### PR TITLE
feat(sns): implement platform endpoints, SMS, PublishBatch and improve compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,7 @@ name = "fakecloud-sns"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ built to fill that gap -- with a focus on correctness and simplicity.
 | Free tier | Fully open source | Removed (was Community Ed.) |
 | Single port | Yes (4566) | Yes (4566) |
 | SQS | 16 actions | Paid |
-| SNS | 16 actions | Paid |
+| SNS | 35 actions | Paid |
 | EventBridge | 15 actions | Paid |
 | IAM / STS | 16 actions | Paid |
 | SSM Parameter Store | 12 actions | Paid |
@@ -90,15 +90,24 @@ Key features: real MD5 hashing, long polling (WaitTimeSeconds), FIFO queues
 with message group fair scheduling, dead-letter queues, message attributes,
 batch operations.
 
-### SNS (16 actions)
+### SNS (35 actions)
 
 CreateTopic, DeleteTopic, ListTopics, GetTopicAttributes, SetTopicAttributes,
-Subscribe, ConfirmSubscription, Unsubscribe, Publish, ListSubscriptions,
-ListSubscriptionsByTopic, GetSubscriptionAttributes, SetSubscriptionAttributes,
-TagResource, UntagResource, ListTagsForResource
+Subscribe, ConfirmSubscription, Unsubscribe, Publish, PublishBatch,
+ListSubscriptions, ListSubscriptionsByTopic, GetSubscriptionAttributes,
+SetSubscriptionAttributes, TagResource, UntagResource, ListTagsForResource,
+AddPermission, RemovePermission, CreatePlatformApplication,
+DeletePlatformApplication, GetPlatformApplicationAttributes,
+SetPlatformApplicationAttributes, ListPlatformApplications,
+CreatePlatformEndpoint, DeleteEndpoint, GetEndpointAttributes,
+SetEndpointAttributes, ListEndpointsByPlatformApplication,
+SetSMSAttributes, GetSMSAttributes, CheckIfPhoneNumberIsOptedOut,
+ListPhoneNumbersOptedOut, OptInPhoneNumber
 
 Key features: SQS fan-out delivery, HTTP/HTTPS endpoint delivery, subscription
-filter policies (exact match, prefix, anything-but, numeric, exists).
+filter policies (exact match, prefix, suffix, anything-but, numeric, exists,
+equals-ignore-case, $or), message body filtering, MessageStructure=json,
+raw message delivery, FIFO topics, platform applications, SMS operations.
 
 ### EventBridge (15 actions)
 

--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -13,6 +13,14 @@ pub struct DeliveryBus {
     sns_sender: Option<Arc<dyn SnsDelivery>>,
 }
 
+/// Message attribute for SQS delivery from SNS.
+#[derive(Debug, Clone)]
+pub struct SqsMessageAttribute {
+    pub data_type: String,
+    pub string_value: Option<String>,
+    pub binary_value: Option<String>,
+}
+
 /// Trait for delivering messages to SQS queues.
 pub trait SqsDelivery: Send + Sync {
     fn deliver_to_queue(
@@ -21,6 +29,20 @@ pub trait SqsDelivery: Send + Sync {
         message_body: &str,
         attributes: &HashMap<String, String>,
     );
+
+    /// Deliver with message attributes and FIFO fields
+    fn deliver_to_queue_with_attrs(
+        &self,
+        queue_arn: &str,
+        message_body: &str,
+        message_attributes: &HashMap<String, SqsMessageAttribute>,
+        message_group_id: Option<&str>,
+        message_dedup_id: Option<&str>,
+    ) {
+        // Default implementation: fall back to simple delivery
+        let _ = (message_attributes, message_group_id, message_dedup_id);
+        self.deliver_to_queue(queue_arn, message_body, &HashMap::new());
+    }
 }
 
 /// Trait for publishing messages to SNS topics.
@@ -55,6 +77,26 @@ impl DeliveryBus {
     ) {
         if let Some(ref sender) = self.sqs_sender {
             sender.deliver_to_queue(queue_arn, message_body, attributes);
+        }
+    }
+
+    /// Send a message to an SQS queue with message attributes and FIFO fields.
+    pub fn send_to_sqs_with_attrs(
+        &self,
+        queue_arn: &str,
+        message_body: &str,
+        message_attributes: &HashMap<String, SqsMessageAttribute>,
+        message_group_id: Option<&str>,
+        message_dedup_id: Option<&str>,
+    ) {
+        if let Some(ref sender) = self.sqs_sender {
+            sender.deliver_to_queue_with_attrs(
+                queue_arn,
+                message_body,
+                message_attributes,
+                message_group_id,
+                message_dedup_id,
+            );
         }
     }
 

--- a/crates/fakecloud-e2e/tests/sns.rs
+++ b/crates/fakecloud-e2e/tests/sns.rs
@@ -165,10 +165,11 @@ async fn sns_fifo_topic_creation() {
     let server = TestServer::start().await;
     let client = server.sns_client().await;
 
-    // Create a FIFO topic
+    // Create a FIFO topic (must set FifoTopic=true attribute)
     let resp = client
         .create_topic()
         .name("my-topic.fifo")
+        .attributes("FifoTopic", "true")
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-sns/Cargo.toml
+++ b/crates/fakecloud-sns/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -36,6 +36,7 @@ impl SnsDelivery for SnsDeliveryImpl {
             subject: subject.map(|s| s.to_string()),
             message_attributes: HashMap::new(),
             message_group_id: None,
+            message_dedup_id: None,
             timestamp: Utc::now(),
         });
 

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use base64::Engine;
 use chrono::Utc;
 use http::StatusCode;
 use serde_json::Value;
@@ -7,7 +8,10 @@ use std::collections::HashMap;
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
-use crate::state::{MessageAttribute, PublishedMessage, SharedSnsState, SnsSubscription, SnsTopic};
+use crate::state::{
+    MessageAttribute, PlatformApplication, PlatformEndpoint, PublishedMessage, SharedSnsState,
+    SnsSubscription, SnsTopic,
+};
 
 pub struct SnsService {
     state: SharedSnsState,
@@ -21,6 +25,56 @@ impl SnsService {
 }
 
 use std::sync::Arc;
+
+const DEFAULT_PAGE_SIZE: usize = 100;
+
+const DEFAULT_EFFECTIVE_DELIVERY_POLICY: &str = r#"{"defaultHealthyRetryPolicy":{"numNoDelayRetries":0,"numMinDelayRetries":0,"minDelayTarget":20,"maxDelayTarget":20,"numMaxDelayRetries":0,"numRetries":3,"backoffFunction":"linear"},"sicklyRetryPolicy":null,"throttlePolicy":null,"guaranteed":false}"#;
+
+fn default_policy(topic_arn: &str, account_id: &str) -> String {
+    serde_json::json!({
+        "Version": "2008-10-17",
+        "Id": "__default_policy_ID",
+        "Statement": [{
+            "Effect": "Allow",
+            "Sid": "__default_statement_ID",
+            "Principal": {"AWS": "*"},
+            "Action": [
+                "SNS:GetTopicAttributes",
+                "SNS:SetTopicAttributes",
+                "SNS:AddPermission",
+                "SNS:RemovePermission",
+                "SNS:DeleteTopic",
+                "SNS:Subscribe",
+                "SNS:ListSubscriptionsByTopic",
+                "SNS:Publish",
+            ],
+            "Resource": topic_arn,
+            "Condition": {"StringEquals": {"AWS:SourceOwner": account_id}},
+        }]
+    })
+    .to_string()
+}
+
+const VALID_SNS_ACTIONS: &[&str] = &[
+    "GetTopicAttributes",
+    "SetTopicAttributes",
+    "AddPermission",
+    "RemovePermission",
+    "DeleteTopic",
+    "Subscribe",
+    "ListSubscriptionsByTopic",
+    "Publish",
+    "Receive",
+];
+
+const VALID_SUBSCRIPTION_ATTRS: &[&str] = &[
+    "RawMessageDelivery",
+    "DeliveryPolicy",
+    "FilterPolicy",
+    "FilterPolicyScope",
+    "RedrivePolicy",
+    "SubscriptionRoleArn",
+];
 
 #[async_trait]
 impl AwsService for SnsService {
@@ -39,6 +93,7 @@ impl AwsService for SnsService {
             "ConfirmSubscription" => self.confirm_subscription(&req),
             "Unsubscribe" => self.unsubscribe(&req),
             "Publish" => self.publish(&req),
+            "PublishBatch" => self.publish_batch(&req),
             "ListSubscriptions" => self.list_subscriptions(&req),
             "ListSubscriptionsByTopic" => self.list_subscriptions_by_topic(&req),
             "GetSubscriptionAttributes" => self.get_subscription_attributes(&req),
@@ -46,6 +101,27 @@ impl AwsService for SnsService {
             "TagResource" => self.tag_resource(&req),
             "UntagResource" => self.untag_resource(&req),
             "ListTagsForResource" => self.list_tags_for_resource(&req),
+            "AddPermission" => self.add_permission(&req),
+            "RemovePermission" => self.remove_permission(&req),
+            // Platform application actions
+            "CreatePlatformApplication" => self.create_platform_application(&req),
+            "DeletePlatformApplication" => self.delete_platform_application(&req),
+            "GetPlatformApplicationAttributes" => self.get_platform_application_attributes(&req),
+            "SetPlatformApplicationAttributes" => self.set_platform_application_attributes(&req),
+            "ListPlatformApplications" => self.list_platform_applications(&req),
+            "CreatePlatformEndpoint" => self.create_platform_endpoint(&req),
+            "DeleteEndpoint" => self.delete_endpoint(&req),
+            "GetEndpointAttributes" => self.get_endpoint_attributes(&req),
+            "SetEndpointAttributes" => self.set_endpoint_attributes(&req),
+            "ListEndpointsByPlatformApplication" => {
+                self.list_endpoints_by_platform_application(&req)
+            }
+            // SMS actions
+            "SetSMSAttributes" => self.set_sms_attributes(&req),
+            "GetSMSAttributes" => self.get_sms_attributes(&req),
+            "CheckIfPhoneNumberIsOptedOut" => self.check_if_phone_number_is_opted_out(&req),
+            "ListPhoneNumbersOptedOut" => self.list_phone_numbers_opted_out(&req),
+            "OptInPhoneNumber" => self.opt_in_phone_number(&req),
             _ => Err(AwsServiceError::action_not_implemented("sns", &req.action)),
         }
     }
@@ -61,6 +137,7 @@ impl AwsService for SnsService {
             "ConfirmSubscription",
             "Unsubscribe",
             "Publish",
+            "PublishBatch",
             "ListSubscriptions",
             "ListSubscriptionsByTopic",
             "GetSubscriptionAttributes",
@@ -68,12 +145,28 @@ impl AwsService for SnsService {
             "TagResource",
             "UntagResource",
             "ListTagsForResource",
+            "AddPermission",
+            "RemovePermission",
+            "CreatePlatformApplication",
+            "DeletePlatformApplication",
+            "GetPlatformApplicationAttributes",
+            "SetPlatformApplicationAttributes",
+            "ListPlatformApplications",
+            "CreatePlatformEndpoint",
+            "DeleteEndpoint",
+            "GetEndpointAttributes",
+            "SetEndpointAttributes",
+            "ListEndpointsByPlatformApplication",
+            "SetSMSAttributes",
+            "GetSMSAttributes",
+            "CheckIfPhoneNumberIsOptedOut",
+            "ListPhoneNumbersOptedOut",
+            "OptInPhoneNumber",
         ]
     }
 }
 
 /// SNS uses Query protocol — params come from query_params (which includes form body).
-/// But the SDK might also send JSON. We try both.
 fn param(req: &AwsRequest, name: &str) -> Option<String> {
     // Try query params first (Query protocol)
     if let Some(v) = req.query_params.get(name) {
@@ -106,30 +199,119 @@ fn not_found(entity: &str) -> AwsServiceError {
     )
 }
 
+/// Check if a topic ARN belongs to the given region
+fn arn_region(arn: &str) -> Option<&str> {
+    let parts: Vec<&str> = arn.split(':').collect();
+    if parts.len() >= 4 {
+        Some(parts[3])
+    } else {
+        None
+    }
+}
+
 /// SNS uses XML responses for Query protocol.
-fn xml_resp(inner: &str, request_id: &str) -> AwsResponse {
+fn xml_resp(inner: &str, _request_id: &str) -> AwsResponse {
     let xml = format!("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n{inner}\n");
-    let _ = request_id; // included in inner
     AwsResponse::xml(StatusCode::OK, xml)
+}
+
+const FIFO_NAME_ERROR: &str = "Fifo Topic names must end with .fifo and must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long.";
+const STANDARD_NAME_ERROR: &str = "Topic names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long.";
+
+/// Validate a topic name according to AWS rules
+fn validate_topic_name(name: &str, is_fifo_attr: bool) -> Result<(), AwsServiceError> {
+    if name.is_empty() || name.len() > 256 {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            STANDARD_NAME_ERROR,
+        ));
+    }
+
+    let base_name = name.strip_suffix(".fifo").unwrap_or(name);
+    let valid_chars = base_name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+
+    if !valid_chars {
+        let msg = if name.ends_with(".fifo") || is_fifo_attr {
+            FIFO_NAME_ERROR
+        } else {
+            STANDARD_NAME_ERROR
+        };
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            msg,
+        ));
+    }
+
+    // FIFO validation
+    if is_fifo_attr && !name.ends_with(".fifo") {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            FIFO_NAME_ERROR,
+        ));
+    }
+
+    if name.ends_with(".fifo") && !is_fifo_attr {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            STANDARD_NAME_ERROR,
+        ));
+    }
+
+    Ok(())
 }
 
 impl SnsService {
     fn create_topic(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let name = required(req, "Name")?;
+
+        // Parse attributes from Attributes.entry.N.key / Attributes.entry.N.value
+        let topic_attrs = parse_entries(req, "Attributes");
+        let is_fifo_attr = topic_attrs
+            .get("FifoTopic")
+            .map(|v| v == "true")
+            .unwrap_or(false);
         let is_fifo = name.ends_with(".fifo");
 
-        // Parse tags from request: Tags.member.N.Key / Tags.member.N.Value
+        validate_topic_name(&name, is_fifo_attr)?;
+
+        // Parse tags from request
         let tags = parse_tags(req);
 
         let mut state = self.state.write();
-
-        let topic_arn = format!("arn:aws:sns:{}:{}:{}", state.region, state.account_id, name);
+        let topic_arn = format!("arn:aws:sns:{}:{}:{}", req.region, state.account_id, name);
 
         if !state.topics.contains_key(&topic_arn) {
             let mut attributes = HashMap::new();
+            // Set default policy
+            attributes.insert(
+                "Policy".to_string(),
+                default_policy(&topic_arn, &state.account_id),
+            );
+            attributes.insert("DisplayName".to_string(), String::new());
+            attributes.insert("DeliveryPolicy".to_string(), String::new());
+
             if is_fifo {
                 attributes.insert("FifoTopic".to_string(), "true".to_string());
+                attributes.insert("ContentBasedDeduplication".to_string(), "false".to_string());
             }
+
+            // Apply topic attributes from the request
+            for (k, v) in &topic_attrs {
+                // If FifoTopic=false is explicitly set, remove FIFO-related attrs
+                if k == "FifoTopic" && v == "false" {
+                    attributes.remove("FifoTopic");
+                    attributes.remove("ContentBasedDeduplication");
+                    continue;
+                }
+                attributes.insert(k.clone(), v.clone());
+            }
+
             let topic = SnsTopic {
                 topic_arn: topic_arn.clone(),
                 name,
@@ -180,9 +362,32 @@ impl SnsService {
 
     fn list_topics(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let state = self.state.read();
-        let members: String = state
+
+        // Filter topics by region
+        let all_topics: Vec<&SnsTopic> = state
             .topics
             .values()
+            .filter(|t| {
+                // Extract region from ARN
+                let parts: Vec<&str> = t.topic_arn.split(':').collect();
+                parts.len() >= 4 && parts[3] == req.region
+            })
+            .collect();
+
+        let next_token = param(req, "NextToken")
+            .and_then(|t| t.parse::<usize>().ok())
+            .unwrap_or(0);
+
+        let page = &all_topics[next_token..];
+        let has_more = page.len() > DEFAULT_PAGE_SIZE;
+        let page = if has_more {
+            &page[..DEFAULT_PAGE_SIZE]
+        } else {
+            page
+        };
+
+        let members: String = page
+            .iter()
             .map(|t| {
                 format!(
                     "      <member><TopicArn>{}</TopicArn></member>",
@@ -192,13 +397,22 @@ impl SnsService {
             .collect::<Vec<_>>()
             .join("\n");
 
+        let next_token_xml = if has_more {
+            format!(
+                "\n    <NextToken>{}</NextToken>",
+                next_token + DEFAULT_PAGE_SIZE
+            )
+        } else {
+            String::new()
+        };
+
         Ok(xml_resp(
             &format!(
                 r#"<ListTopicsResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <ListTopicsResult>
     <Topics>
 {members}
-    </Topics>
+    </Topics>{next_token_xml}
   </ListTopicsResult>
   <ResponseMetadata>
     <RequestId>{}</RequestId>
@@ -212,13 +426,20 @@ impl SnsService {
 
     fn get_topic_attributes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let topic_arn = required(req, "TopicArn")?;
+
+        // Check region: topic must belong to the request's region
+        if let Some(topic_region) = arn_region(&topic_arn) {
+            if topic_region != req.region {
+                return Err(not_found("Topic"));
+            }
+        }
+
         let state = self.state.read();
         let topic = state
             .topics
             .get(&topic_arn)
             .ok_or_else(|| not_found("Topic"))?;
 
-        // Count confirmed and pending subscriptions for this topic
         let subs_confirmed = state
             .subscriptions
             .values()
@@ -230,25 +451,21 @@ impl SnsService {
             .filter(|s| s.topic_arn == topic_arn && !s.confirmed)
             .count();
 
-        // Build default policy document that Terraform expects as valid JSON
-        let default_policy = format!(
-            r#"{{"Version":"2012-10-17","Statement":[{{"Effect":"Allow","Principal":"*","Action":"sns:Publish","Resource":"{topic_arn}"}}]}}"#,
-        );
-
         let mut entries = vec![
             format_attr("TopicArn", &topic.topic_arn),
-            format_attr("DisplayName", &topic.name),
             format_attr("Owner", &state.account_id),
             format_attr("SubscriptionsConfirmed", &subs_confirmed.to_string()),
             format_attr("SubscriptionsPending", &subs_pending.to_string()),
             format_attr("SubscriptionsDeleted", "0"),
         ];
 
-        // Add Policy: use existing attribute if set, otherwise provide default
-        if !topic.attributes.contains_key("Policy") {
-            entries.push(format_attr("Policy", &default_policy));
-        }
+        // Add EffectiveDeliveryPolicy
+        entries.push(format_attr(
+            "EffectiveDeliveryPolicy",
+            DEFAULT_EFFECTIVE_DELIVERY_POLICY,
+        ));
 
+        // Add all stored attributes
         for (k, v) in &topic.attributes {
             entries.push(format_attr(k, v));
         }
@@ -282,7 +499,19 @@ impl SnsService {
             .topics
             .get_mut(&topic_arn)
             .ok_or_else(|| not_found("Topic"))?;
-        topic.attributes.insert(attr_name, attr_value);
+
+        // If setting Policy, compact the JSON
+        if attr_name == "Policy" {
+            if let Ok(parsed) = serde_json::from_str::<Value>(&attr_value) {
+                topic
+                    .attributes
+                    .insert(attr_name, serde_json::to_string(&parsed).unwrap());
+            } else {
+                topic.attributes.insert(attr_name, attr_value);
+            }
+        } else {
+            topic.attributes.insert(attr_name, attr_value);
+        }
 
         Ok(xml_resp(
             &format!(
@@ -306,7 +535,67 @@ impl SnsService {
         if !state_r.topics.contains_key(&topic_arn) {
             return Err(not_found("Topic"));
         }
+        let account_id = state_r.account_id.clone();
         drop(state_r);
+
+        // Validate SMS endpoint
+        if protocol == "sms" {
+            validate_sms_endpoint(&endpoint)?;
+        }
+
+        // Validate SQS endpoint (must be an ARN)
+        if protocol == "sqs" && !endpoint.starts_with("arn:aws:sqs:") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameter",
+                "Invalid parameter: SQS endpoint ARN",
+            ));
+        }
+
+        // Parse subscription attributes
+        let sub_attrs = parse_entries(req, "Attributes");
+
+        // Validate subscription attribute names
+        for key in sub_attrs.keys() {
+            if !VALID_SUBSCRIPTION_ATTRS.contains(&key.as_str()) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    format!("Invalid parameter: Attributes Reason: Unknown attribute: {key}"),
+                ));
+            }
+        }
+
+        // If FilterPolicy is set, auto-set FilterPolicyScope to MessageAttributes
+        let mut attributes = sub_attrs;
+        if attributes.contains_key("FilterPolicy") && !attributes.contains_key("FilterPolicyScope")
+        {
+            attributes.insert(
+                "FilterPolicyScope".to_string(),
+                "MessageAttributes".to_string(),
+            );
+        }
+
+        // Check for duplicate subscription (same topic, protocol, endpoint)
+        let mut state = self.state.write();
+        for sub in state.subscriptions.values() {
+            if sub.topic_arn == topic_arn && sub.protocol == protocol && sub.endpoint == endpoint {
+                return Ok(xml_resp(
+                    &format!(
+                        r#"<SubscribeResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <SubscribeResult>
+    <SubscriptionArn>{}</SubscriptionArn>
+  </SubscribeResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</SubscribeResponse>"#,
+                        sub.subscription_arn, req.request_id
+                    ),
+                    &req.request_id,
+                ));
+            }
+        }
 
         let sub_arn = format!("{}:{}", topic_arn, uuid::Uuid::new_v4());
 
@@ -315,14 +604,12 @@ impl SnsService {
             topic_arn,
             protocol,
             endpoint,
-            attributes: HashMap::new(),
+            owner: account_id,
+            attributes,
             confirmed: true,
         };
 
-        self.state
-            .write()
-            .subscriptions
-            .insert(sub_arn.clone(), sub);
+        state.subscriptions.insert(sub_arn.clone(), sub);
 
         Ok(xml_resp(
             &format!(
@@ -344,8 +631,6 @@ impl SnsService {
         let topic_arn = required(req, "TopicArn")?;
         let _token = required(req, "Token")?;
 
-        // In a local emulator, subscriptions are auto-confirmed.
-        // Find the most recent unconfirmed subscription for this topic, or just accept it.
         let state = self.state.read();
         let sub_arn = state
             .subscriptions
@@ -388,13 +673,101 @@ impl SnsService {
     }
 
     fn publish(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let topic_arn = required(req, "TopicArn")?;
+        // Either TopicArn or TargetArn is required; also allow PhoneNumber for SMS
+        let topic_arn = param(req, "TopicArn").or_else(|| param(req, "TargetArn"));
+        let phone_number = param(req, "PhoneNumber");
+
+        if topic_arn.is_none() && phone_number.is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameter",
+                "The request must contain the parameter TopicArn or TargetArn or PhoneNumber",
+            ));
+        }
+
         let message = required(req, "Message")?;
         let subject = param(req, "Subject");
         let message_group_id = param(req, "MessageGroupId");
+        let message_dedup_id = param(req, "MessageDeduplicationId");
+        let message_structure = param(req, "MessageStructure");
+
+        // Validate subject length
+        if let Some(ref subj) = subject {
+            if subj.len() > 100 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    "Invalid parameter: Subject",
+                ));
+            }
+        }
+
+        // Validate message length (256KB)
+        if message.len() > 262144 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameter",
+                "Invalid parameter: Message too long",
+            ));
+        }
 
         // Parse MessageAttributes from query params
         let message_attributes = parse_message_attributes(req);
+
+        // Handle SMS publish (PhoneNumber)
+        if let Some(ref phone) = phone_number {
+            // Validate phone number (basic E.164)
+            if !phone.starts_with('+') || phone.len() < 2 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    format!(
+                        "Invalid parameter: PhoneNumber Reason: {phone} is not valid to publish to"
+                    ),
+                ));
+            }
+
+            let msg_id = uuid::Uuid::new_v4().to_string();
+            let mut state = self.state.write();
+            state.sms_messages.push((phone.clone(), message.clone()));
+            state.published.push(PublishedMessage {
+                message_id: msg_id.clone(),
+                topic_arn: String::new(),
+                message,
+                subject,
+                message_attributes,
+                message_group_id,
+                message_dedup_id,
+                timestamp: Utc::now(),
+            });
+
+            return Ok(xml_resp(
+                &format!(
+                    r#"<PublishResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <PublishResult>
+    <MessageId>{msg_id}</MessageId>
+  </PublishResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</PublishResponse>"#,
+                    req.request_id
+                ),
+                &req.request_id,
+            ));
+        }
+
+        let topic_arn = topic_arn.unwrap();
+
+        // Check if it's a platform endpoint ARN
+        if topic_arn.contains(":endpoint/") {
+            return self.publish_to_platform_endpoint(
+                &topic_arn,
+                &message,
+                &message_attributes,
+                &req.request_id,
+            );
+        }
 
         let mut state = self.state.write();
         let topic = state
@@ -403,13 +776,46 @@ impl SnsService {
             .ok_or_else(|| not_found("Topic"))?;
 
         // FIFO topic enforcement
-        if topic.is_fifo && message_group_id.is_none() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameter",
-                "The request must contain the parameter MessageGroupId for FIFO topics",
-            ));
+        if topic.is_fifo {
+            if message_group_id.is_none() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    "Invalid parameter: The MessageGroupId parameter is required for FIFO topics",
+                ));
+            }
+            // FIFO topics require deduplication: either ContentBasedDeduplication or explicit ID
+            let content_dedup = topic
+                .attributes
+                .get("ContentBasedDeduplication")
+                .map(|v| v == "true")
+                .unwrap_or(false);
+            if !content_dedup && message_dedup_id.is_none() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    "Invalid parameter: The topic should either have ContentBasedDeduplication enabled or the MessageDeduplicationId provided explicitly",
+                ));
+            }
+        } else {
+            // Non-FIFO: MessageGroupId should not be set
+            if message_group_id.is_some() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    "Invalid parameter: MessageGroupId Reason: The request includes MessageGroupId parameter that is not valid for this topic type",
+                ));
+            }
+            if message_dedup_id.is_some() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    "Invalid parameter: MessageDeduplicationId Reason: The request includes MessageDeduplicationId parameter that is not valid for this topic type",
+                ));
+            }
         }
+
+        let is_fifo = topic.is_fifo;
 
         let msg_id = uuid::Uuid::new_v4().to_string();
         state.published.push(PublishedMessage {
@@ -418,18 +824,34 @@ impl SnsService {
             message: message.clone(),
             subject: subject.clone(),
             message_attributes: message_attributes.clone(),
-            message_group_id,
+            message_group_id: message_group_id.clone(),
+            message_dedup_id: message_dedup_id.clone(),
             timestamp: Utc::now(),
         });
 
-        // Collect subscribers by protocol, checking filter policies
-        let sqs_subscribers: Vec<String> = state
+        // Resolve the actual message per protocol for MessageStructure=json
+        let parsed_structure: Option<Value> = if message_structure.as_deref() == Some("json") {
+            serde_json::from_str(&message).ok()
+        } else {
+            None
+        };
+
+        // Collect subscribers
+        let sqs_subscribers: Vec<(String, bool, Option<String>, Option<String>)> = state
             .subscriptions
             .values()
             .filter(|s| s.topic_arn == topic_arn && s.protocol == "sqs" && s.confirmed)
-            .filter(|s| matches_filter_policy(s, &message_attributes))
-            .map(|s| s.endpoint.clone())
+            .filter(|s| matches_filter_policy(s, &message_attributes, &message))
+            .map(|s| {
+                let raw = s
+                    .attributes
+                    .get("RawMessageDelivery")
+                    .map(|v| v == "true")
+                    .unwrap_or(false);
+                (s.endpoint.clone(), raw, None, None)
+            })
             .collect();
+
         let http_subscribers: Vec<String> = state
             .subscriptions
             .values()
@@ -438,12 +860,34 @@ impl SnsService {
                     && (s.protocol == "http" || s.protocol == "https")
                     && s.confirmed
             })
-            .filter(|s| matches_filter_policy(s, &message_attributes))
+            .filter(|s| matches_filter_policy(s, &message_attributes, &message))
             .map(|s| s.endpoint.clone())
             .collect();
         drop(state);
 
-        // Build SNS notification envelope (matches real AWS format)
+        // Determine actual message content per protocol
+        let sqs_message = if let Some(ref structure) = parsed_structure {
+            structure
+                .get("sqs")
+                .or_else(|| structure.get("default"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(&message)
+                .to_string()
+        } else {
+            message.clone()
+        };
+
+        let default_message = if let Some(ref structure) = parsed_structure {
+            structure
+                .get("default")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&message)
+                .to_string()
+        } else {
+            message.clone()
+        };
+
+        // Build SNS notification envelope
         let mut envelope_attrs = serde_json::Map::new();
         for (key, attr) in &message_attributes {
             let mut attr_obj = serde_json::Map::new();
@@ -451,33 +895,84 @@ impl SnsService {
             if let Some(ref sv) = attr.string_value {
                 attr_obj.insert("Value".to_string(), Value::String(sv.clone()));
             }
+            if let Some(ref bv) = attr.binary_value {
+                attr_obj.insert(
+                    "Value".to_string(),
+                    Value::String(base64::engine::general_purpose::STANDARD.encode(bv)),
+                );
+            }
             envelope_attrs.insert(key.clone(), Value::Object(attr_obj));
         }
 
-        let sns_envelope = serde_json::json!({
-            "Type": "Notification",
-            "MessageId": msg_id,
-            "TopicArn": topic_arn,
-            "Subject": subject.as_deref().unwrap_or(""),
-            "Message": message,
-            "Timestamp": Utc::now().to_rfc3339(),
-            "SignatureVersion": "1",
-            "Signature": "FAKE_SIGNATURE",
-            "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
-            "UnsubscribeURL": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
-            "MessageAttributes": envelope_attrs,
-        });
-        let envelope_str = sns_envelope.to_string();
-
         // Deliver to SQS subscribers
-        for queue_arn in &sqs_subscribers {
-            self.delivery
-                .send_to_sqs(queue_arn, &envelope_str, &HashMap::new());
+        for (queue_arn, raw, _msg_group, _msg_dedup) in &sqs_subscribers {
+            if *raw {
+                // Raw message delivery: just send the message body directly
+                let mut sqs_msg_attrs = HashMap::new();
+                for (k, v) in &message_attributes {
+                    let mut attr = fakecloud_core::delivery::SqsMessageAttribute {
+                        data_type: v.data_type.clone(),
+                        string_value: v.string_value.clone(),
+                        binary_value: None,
+                    };
+                    if let Some(ref bv) = v.binary_value {
+                        attr.binary_value =
+                            Some(base64::engine::general_purpose::STANDARD.encode(bv));
+                    }
+                    sqs_msg_attrs.insert(k.clone(), attr);
+                }
+                self.delivery.send_to_sqs_with_attrs(
+                    queue_arn,
+                    &sqs_message,
+                    &sqs_msg_attrs,
+                    if is_fifo {
+                        message_group_id.as_deref()
+                    } else {
+                        None
+                    },
+                    if is_fifo {
+                        message_dedup_id.as_deref()
+                    } else {
+                        None
+                    },
+                );
+            } else {
+                // Standard delivery: wrap in SNS envelope
+                let sns_envelope = serde_json::json!({
+                    "Type": "Notification",
+                    "MessageId": msg_id,
+                    "TopicArn": topic_arn,
+                    "Subject": subject.as_deref().unwrap_or(""),
+                    "Message": sqs_message,
+                    "Timestamp": Utc::now().to_rfc3339(),
+                    "SignatureVersion": "1",
+                    "Signature": "FAKE_SIGNATURE",
+                    "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
+                    "UnsubscribeURL": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
+                    "MessageAttributes": envelope_attrs,
+                });
+                let envelope_str = sns_envelope.to_string();
+                self.delivery
+                    .send_to_sqs(queue_arn, &envelope_str, &HashMap::new());
+            }
         }
 
         // Deliver to HTTP/HTTPS subscribers (fire-and-forget)
         for endpoint_url in http_subscribers {
-            let body = envelope_str.clone();
+            let sns_envelope = serde_json::json!({
+                "Type": "Notification",
+                "MessageId": msg_id,
+                "TopicArn": topic_arn,
+                "Subject": subject.as_deref().unwrap_or(""),
+                "Message": default_message,
+                "Timestamp": Utc::now().to_rfc3339(),
+                "SignatureVersion": "1",
+                "Signature": "FAKE_SIGNATURE",
+                "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
+                "UnsubscribeURL": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
+                "MessageAttributes": envelope_attrs.clone(),
+            });
+            let body = sns_envelope.to_string();
             let topic = topic_arn.clone();
             tokio::spawn(async move {
                 let client = reqwest::Client::new();
@@ -511,14 +1006,282 @@ impl SnsService {
         ))
     }
 
+    fn publish_batch(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let topic_arn = required(req, "TopicArn")?;
+
+        let state = self.state.read();
+        let topic = state
+            .topics
+            .get(&topic_arn)
+            .ok_or_else(|| not_found("Topic"))?;
+        let is_fifo = topic.is_fifo;
+        drop(state);
+
+        // Parse batch entries: PublishBatchRequestEntries.member.N.*
+        let mut entries = Vec::new();
+        for n in 1..=100 {
+            let id_key = format!("PublishBatchRequestEntries.member.{n}.Id");
+            if let Some(id) = req.query_params.get(&id_key) {
+                let msg_key = format!("PublishBatchRequestEntries.member.{n}.Message");
+                let message = req.query_params.get(&msg_key).cloned().unwrap_or_default();
+                let subject_key = format!("PublishBatchRequestEntries.member.{n}.Subject");
+                let subject = req.query_params.get(&subject_key).cloned();
+                let group_key = format!("PublishBatchRequestEntries.member.{n}.MessageGroupId");
+                let group_id = req.query_params.get(&group_key).cloned();
+                let dedup_key =
+                    format!("PublishBatchRequestEntries.member.{n}.MessageDeduplicationId");
+                let dedup_id = req.query_params.get(&dedup_key).cloned();
+                let structure_key =
+                    format!("PublishBatchRequestEntries.member.{n}.MessageStructure");
+                let message_structure = req.query_params.get(&structure_key).cloned();
+                entries.push((
+                    id.clone(),
+                    message,
+                    subject,
+                    group_id,
+                    dedup_id,
+                    message_structure,
+                ));
+            } else {
+                break;
+            }
+        }
+
+        // Validate: max 10 entries
+        if entries.len() > 10 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "TooManyEntriesInBatchRequest",
+                "The batch request contains more entries than permissible.",
+            ));
+        }
+
+        // Validate: unique IDs
+        let ids: Vec<&str> = entries.iter().map(|e| e.0.as_str()).collect();
+        let unique_ids: std::collections::HashSet<&str> = ids.iter().copied().collect();
+        if unique_ids.len() != ids.len() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BatchEntryIdsNotDistinct",
+                "Two or more batch entries in the request have the same Id.",
+            ));
+        }
+
+        let mut successful = Vec::new();
+        let mut failed = Vec::new();
+
+        for (id, message, subject, group_id, dedup_id, _structure) in &entries {
+            // FIFO validation
+            if is_fifo && group_id.is_none() {
+                failed.push(format!(
+                    r#"    <member>
+      <Id>{id}</Id>
+      <Code>InvalidParameter</Code>
+      <Message>The MessageGroupId parameter is required for FIFO topics</Message>
+      <SenderFault>true</SenderFault>
+    </member>"#
+                ));
+                continue;
+            }
+
+            if !is_fifo && group_id.is_some() {
+                failed.push(format!(
+                    r#"    <member>
+      <Id>{id}</Id>
+      <Code>InvalidParameter</Code>
+      <Message>MessageGroupId is not valid for non-FIFO topics</Message>
+      <SenderFault>true</SenderFault>
+    </member>"#
+                ));
+                continue;
+            }
+
+            let msg_id = uuid::Uuid::new_v4().to_string();
+            let mut state = self.state.write();
+            state.published.push(PublishedMessage {
+                message_id: msg_id.clone(),
+                topic_arn: topic_arn.clone(),
+                message: message.clone(),
+                subject: subject.clone(),
+                message_attributes: HashMap::new(),
+                message_group_id: group_id.clone(),
+                message_dedup_id: dedup_id.clone(),
+                timestamp: Utc::now(),
+            });
+
+            // Deliver to SQS subscribers
+            let sqs_subscribers: Vec<(String, bool)> = state
+                .subscriptions
+                .values()
+                .filter(|s| s.topic_arn == topic_arn && s.protocol == "sqs" && s.confirmed)
+                .map(|s| {
+                    let raw = s
+                        .attributes
+                        .get("RawMessageDelivery")
+                        .map(|v| v == "true")
+                        .unwrap_or(false);
+                    (s.endpoint.clone(), raw)
+                })
+                .collect();
+            drop(state);
+
+            for (queue_arn, raw) in &sqs_subscribers {
+                if *raw {
+                    self.delivery.send_to_sqs_with_attrs(
+                        queue_arn,
+                        message,
+                        &HashMap::new(),
+                        if is_fifo { group_id.as_deref() } else { None },
+                        if is_fifo { dedup_id.as_deref() } else { None },
+                    );
+                } else {
+                    let sns_envelope = serde_json::json!({
+                        "Type": "Notification",
+                        "MessageId": msg_id,
+                        "TopicArn": topic_arn,
+                        "Subject": subject.as_deref().unwrap_or(""),
+                        "Message": message,
+                        "Timestamp": Utc::now().to_rfc3339(),
+                        "SignatureVersion": "1",
+                        "Signature": "FAKE_SIGNATURE",
+                        "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
+                        "UnsubscribeURL": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
+                    });
+                    self.delivery.send_to_sqs(
+                        queue_arn,
+                        &sns_envelope.to_string(),
+                        &HashMap::new(),
+                    );
+                }
+            }
+
+            successful.push(format!(
+                r#"    <member>
+      <Id>{id}</Id>
+      <MessageId>{msg_id}</MessageId>
+    </member>"#
+            ));
+        }
+
+        let successful_xml = successful.join("\n");
+        let failed_xml = failed.join("\n");
+
+        Ok(xml_resp(
+            &format!(
+                r#"<PublishBatchResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <PublishBatchResult>
+    <Successful>
+{successful_xml}
+    </Successful>
+    <Failed>
+{failed_xml}
+    </Failed>
+  </PublishBatchResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</PublishBatchResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn publish_to_platform_endpoint(
+        &self,
+        endpoint_arn: &str,
+        message: &str,
+        message_attributes: &HashMap<String, MessageAttribute>,
+        request_id: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+
+        // Find the platform endpoint
+        let mut found_endpoint: Option<&PlatformEndpoint> = None;
+        for app in state.platform_applications.values() {
+            if let Some(ep) = app.endpoints.get(endpoint_arn) {
+                found_endpoint = Some(ep);
+                break;
+            }
+        }
+
+        let ep = found_endpoint.ok_or_else(|| {
+            AwsServiceError::aws_error(StatusCode::NOT_FOUND, "NotFound", "Endpoint does not exist")
+        })?;
+
+        if !ep.enabled {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "EndpointDisabledException",
+                "Endpoint is disabled",
+            ));
+        }
+        drop(state);
+
+        let msg_id = uuid::Uuid::new_v4().to_string();
+        let mut state = self.state.write();
+        // Store message on the endpoint
+        for app in state.platform_applications.values_mut() {
+            if let Some(ep) = app.endpoints.get_mut(endpoint_arn) {
+                ep.messages.push(PublishedMessage {
+                    message_id: msg_id.clone(),
+                    topic_arn: endpoint_arn.to_string(),
+                    message: message.to_string(),
+                    subject: None,
+                    message_attributes: message_attributes.clone(),
+                    message_group_id: None,
+                    message_dedup_id: None,
+                    timestamp: Utc::now(),
+                });
+                break;
+            }
+        }
+
+        Ok(xml_resp(
+            &format!(
+                r#"<PublishResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <PublishResult>
+    <MessageId>{msg_id}</MessageId>
+  </PublishResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</PublishResponse>"#,
+            ),
+            request_id,
+        ))
+    }
+
     fn list_subscriptions(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let state = self.state.read();
-        let members: String = state
-            .subscriptions
-            .values()
-            .map(format_sub_member)
+
+        let all_subs: Vec<&SnsSubscription> = state.subscriptions.values().collect();
+        let next_token = param(req, "NextToken")
+            .and_then(|t| t.parse::<usize>().ok())
+            .unwrap_or(0);
+
+        let page = &all_subs[next_token..];
+        let has_more = page.len() > DEFAULT_PAGE_SIZE;
+        let page = if has_more {
+            &page[..DEFAULT_PAGE_SIZE]
+        } else {
+            page
+        };
+
+        let members: String = page
+            .iter()
+            .map(|s| format_sub_member(s))
             .collect::<Vec<_>>()
             .join("\n");
+
+        let next_token_xml = if has_more {
+            format!(
+                "\n    <NextToken>{}</NextToken>",
+                next_token + DEFAULT_PAGE_SIZE
+            )
+        } else {
+            String::new()
+        };
 
         Ok(xml_resp(
             &format!(
@@ -526,7 +1289,7 @@ impl SnsService {
   <ListSubscriptionsResult>
     <Subscriptions>
 {members}
-    </Subscriptions>
+    </Subscriptions>{next_token_xml}
   </ListSubscriptionsResult>
   <ResponseMetadata>
     <RequestId>{}</RequestId>
@@ -544,13 +1307,39 @@ impl SnsService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let topic_arn = required(req, "TopicArn")?;
         let state = self.state.read();
-        let members: String = state
+
+        let all_subs: Vec<&SnsSubscription> = state
             .subscriptions
             .values()
             .filter(|s| s.topic_arn == topic_arn)
-            .map(format_sub_member)
+            .collect();
+
+        let next_token = param(req, "NextToken")
+            .and_then(|t| t.parse::<usize>().ok())
+            .unwrap_or(0);
+
+        let page = &all_subs[next_token..];
+        let has_more = page.len() > DEFAULT_PAGE_SIZE;
+        let page = if has_more {
+            &page[..DEFAULT_PAGE_SIZE]
+        } else {
+            page
+        };
+
+        let members: String = page
+            .iter()
+            .map(|s| format_sub_member(s))
             .collect::<Vec<_>>()
             .join("\n");
+
+        let next_token_xml = if has_more {
+            format!(
+                "\n    <NextToken>{}</NextToken>",
+                next_token + DEFAULT_PAGE_SIZE
+            )
+        } else {
+            String::new()
+        };
 
         Ok(xml_resp(
             &format!(
@@ -558,7 +1347,7 @@ impl SnsService {
   <ListSubscriptionsByTopicResult>
     <Subscriptions>
 {members}
-    </Subscriptions>
+    </Subscriptions>{next_token_xml}
   </ListSubscriptionsByTopicResult>
   <ResponseMetadata>
     <RequestId>{}</RequestId>
@@ -586,12 +1375,38 @@ impl SnsService {
             format_attr("TopicArn", &sub.topic_arn),
             format_attr("Protocol", &sub.protocol),
             format_attr("Endpoint", &sub.endpoint),
-            format_attr("Owner", &state.account_id),
+            format_attr("Owner", &sub.owner),
             format_attr("ConfirmationWasAuthenticated", "true"),
             format_attr("PendingConfirmation", "false"),
-            format_attr("RawMessageDelivery", "false"),
         ];
+
+        // Add RawMessageDelivery from attributes or default
+        if !sub.attributes.contains_key("RawMessageDelivery") {
+            entries.push(format_attr("RawMessageDelivery", "false"));
+        }
+
+        // Add EffectiveDeliveryPolicy
+        entries.push(format_attr(
+            "EffectiveDeliveryPolicy",
+            DEFAULT_EFFECTIVE_DELIVERY_POLICY,
+        ));
+
         for (k, v) in &sub.attributes {
+            // Skip empty FilterPolicy (unsetting it removes it)
+            if k == "FilterPolicy" && v.is_empty() {
+                continue;
+            }
+            // If FilterPolicy is unset, also skip FilterPolicyScope
+            if k == "FilterPolicyScope" {
+                let has_filter = sub
+                    .attributes
+                    .get("FilterPolicy")
+                    .map(|v| !v.is_empty())
+                    .unwrap_or(false);
+                if !has_filter {
+                    continue;
+                }
+            }
             entries.push(format_attr(k, v));
         }
         let attrs = entries.join("\n");
@@ -622,13 +1437,29 @@ impl SnsService {
         let attr_name = required(req, "AttributeName")?;
         let attr_value = param(req, "AttributeValue").unwrap_or_default();
 
+        // Validate attribute name
+        if !VALID_SUBSCRIPTION_ATTRS.contains(&attr_name.as_str()) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameter",
+                "Invalid parameter: AttributeName".to_string(),
+            ));
+        }
+
         let mut state = self.state.write();
         let sub = state
             .subscriptions
             .get_mut(&sub_arn)
             .ok_or_else(|| not_found("Subscription"))?;
 
-        sub.attributes.insert(attr_name, attr_value);
+        sub.attributes.insert(attr_name.clone(), attr_value.clone());
+
+        // Setting FilterPolicy auto-sets FilterPolicyScope
+        if attr_name == "FilterPolicy" && !attr_value.is_empty() {
+            sub.attributes
+                .entry("FilterPolicyScope".to_string())
+                .or_insert_with(|| "MessageAttributes".to_string());
+        }
 
         Ok(xml_resp(
             &format!(
@@ -645,16 +1476,36 @@ impl SnsService {
 
     fn tag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let resource_arn = required(req, "ResourceArn")?;
-        let tags = parse_tags(req);
+        let new_tags = parse_tags(req);
 
         let mut state = self.state.write();
-        let topic = state
-            .topics
-            .get_mut(&resource_arn)
-            .ok_or_else(|| not_found("Topic"))?;
-        for (k, v) in tags {
-            topic.tags.insert(k, v);
+        let topic = state.topics.get_mut(&resource_arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFound",
+                "Resource does not exist",
+            )
+        })?;
+
+        // Check tag quota: existing + new (after dedup) must not exceed 50
+        let mut merged = topic.tags.clone();
+        for (k, v) in &new_tags {
+            // Update existing or add
+            if let Some(pos) = merged.iter().position(|(ek, _)| ek == k) {
+                merged[pos] = (k.clone(), v.clone());
+            } else {
+                merged.push((k.clone(), v.clone()));
+            }
         }
+        if merged.len() > 50 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "TagLimitExceeded",
+                "Could not complete request: tag quota of per resource exceeded",
+            ));
+        }
+
+        topic.tags = merged;
 
         Ok(xml_resp(
             &format!(
@@ -675,13 +1526,14 @@ impl SnsService {
         let tag_keys = parse_tag_keys(req);
 
         let mut state = self.state.write();
-        let topic = state
-            .topics
-            .get_mut(&resource_arn)
-            .ok_or_else(|| not_found("Topic"))?;
-        for key in tag_keys {
-            topic.tags.remove(&key);
-        }
+        let topic = state.topics.get_mut(&resource_arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFound",
+                "Resource does not exist",
+            )
+        })?;
+        topic.tags.retain(|(k, _)| !tag_keys.contains(k));
 
         Ok(xml_resp(
             &format!(
@@ -700,10 +1552,13 @@ impl SnsService {
     fn list_tags_for_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let resource_arn = required(req, "ResourceArn")?;
         let state = self.state.read();
-        let topic = state
-            .topics
-            .get(&resource_arn)
-            .ok_or_else(|| not_found("Topic"))?;
+        let topic = state.topics.get(&resource_arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFound",
+                "Resource does not exist",
+            )
+        })?;
 
         let members: String = topic
             .tags
@@ -729,6 +1584,698 @@ impl SnsService {
             &req.request_id,
         ))
     }
+
+    fn add_permission(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let topic_arn = required(req, "TopicArn")?;
+        let label = required(req, "Label")?;
+
+        // Parse AWSAccountId.member.N and ActionName.member.N
+        let mut account_ids = Vec::new();
+        for n in 1..=20 {
+            let key = format!("AWSAccountId.member.{n}");
+            if let Some(v) = req.query_params.get(&key) {
+                account_ids.push(v.clone());
+            } else {
+                break;
+            }
+        }
+
+        let mut action_names = Vec::new();
+        for n in 1..=20 {
+            let key = format!("ActionName.member.{n}");
+            if let Some(v) = req.query_params.get(&key) {
+                action_names.push(v.clone());
+            } else {
+                break;
+            }
+        }
+
+        // Validate action names
+        for action in &action_names {
+            if !VALID_SNS_ACTIONS.contains(&action.as_str()) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    "Policy statement action out of service scope!",
+                ));
+            }
+        }
+
+        let mut state = self.state.write();
+        let account_id = state.account_id.clone();
+        let topic = state
+            .topics
+            .get_mut(&topic_arn)
+            .ok_or_else(|| not_found("Topic"))?;
+
+        // Get or create policy
+        let policy_str = topic
+            .attributes
+            .get("Policy")
+            .cloned()
+            .unwrap_or_else(|| default_policy(&topic_arn, &account_id));
+
+        let mut policy: Value = serde_json::from_str(&policy_str).unwrap_or_else(|_| {
+            serde_json::from_str(&default_policy(&topic_arn, &account_id)).unwrap()
+        });
+
+        // Check if statement with this label already exists
+        if let Some(statements) = policy["Statement"].as_array() {
+            for stmt in statements {
+                if stmt["Sid"].as_str() == Some(&label) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameter",
+                        "Statement already exists",
+                    ));
+                }
+            }
+        }
+
+        // Build principal
+        let principal = if account_ids.len() == 1 {
+            Value::String(format!("arn:aws:iam::{}:root", account_ids[0]))
+        } else {
+            Value::Array(
+                account_ids
+                    .iter()
+                    .map(|id| Value::String(format!("arn:aws:iam::{}:root", id)))
+                    .collect(),
+            )
+        };
+
+        // Build action
+        let action = if action_names.len() == 1 {
+            Value::String(format!("SNS:{}", action_names[0]))
+        } else {
+            Value::Array(
+                action_names
+                    .iter()
+                    .map(|a| Value::String(format!("SNS:{}", a)))
+                    .collect(),
+            )
+        };
+
+        let new_statement = serde_json::json!({
+            "Sid": label,
+            "Effect": "Allow",
+            "Principal": {"AWS": principal},
+            "Action": action,
+            "Resource": topic_arn,
+        });
+
+        if let Some(statements) = policy["Statement"].as_array_mut() {
+            statements.push(new_statement);
+        }
+
+        topic
+            .attributes
+            .insert("Policy".to_string(), policy.to_string());
+
+        Ok(xml_resp(
+            &format!(
+                r#"<AddPermissionResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</AddPermissionResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn remove_permission(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let topic_arn = required(req, "TopicArn")?;
+        let label = required(req, "Label")?;
+
+        let mut state = self.state.write();
+        let topic = state
+            .topics
+            .get_mut(&topic_arn)
+            .ok_or_else(|| not_found("Topic"))?;
+
+        if let Some(policy_str) = topic.attributes.get("Policy").cloned() {
+            if let Ok(mut policy) = serde_json::from_str::<Value>(&policy_str) {
+                if let Some(statements) = policy["Statement"].as_array_mut() {
+                    statements.retain(|s| s["Sid"].as_str() != Some(&label));
+                }
+                topic
+                    .attributes
+                    .insert("Policy".to_string(), policy.to_string());
+            }
+        }
+
+        Ok(xml_resp(
+            &format!(
+                r#"<RemovePermissionResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</RemovePermissionResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    // ===== Platform Application actions =====
+
+    fn create_platform_application(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = required(req, "Name")?;
+        let platform = required(req, "Platform")?;
+        let attributes = parse_entries(req, "Attributes");
+
+        let mut state = self.state.write();
+        let arn = format!(
+            "arn:aws:sns:{}:{}:app/{}/{}",
+            req.region, state.account_id, platform, name
+        );
+
+        state.platform_applications.insert(
+            arn.clone(),
+            PlatformApplication {
+                arn: arn.clone(),
+                name,
+                platform,
+                attributes,
+                endpoints: HashMap::new(),
+            },
+        );
+
+        Ok(xml_resp(
+            &format!(
+                r#"<CreatePlatformApplicationResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <CreatePlatformApplicationResult>
+    <PlatformApplicationArn>{arn}</PlatformApplicationArn>
+  </CreatePlatformApplicationResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</CreatePlatformApplicationResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn delete_platform_application(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required(req, "PlatformApplicationArn")?;
+        self.state.write().platform_applications.remove(&arn);
+
+        Ok(xml_resp(
+            &format!(
+                r#"<DeletePlatformApplicationResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</DeletePlatformApplicationResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn get_platform_application_attributes(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required(req, "PlatformApplicationArn")?;
+        let state = self.state.read();
+        let app = state
+            .platform_applications
+            .get(&arn)
+            .ok_or_else(|| not_found("PlatformApplication"))?;
+
+        let attrs: String = app
+            .attributes
+            .iter()
+            .map(|(k, v)| format_attr(k, v))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Ok(xml_resp(
+            &format!(
+                r#"<GetPlatformApplicationAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <GetPlatformApplicationAttributesResult>
+    <Attributes>
+{attrs}
+    </Attributes>
+  </GetPlatformApplicationAttributesResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</GetPlatformApplicationAttributesResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn set_platform_application_attributes(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required(req, "PlatformApplicationArn")?;
+        let new_attrs = parse_entries(req, "Attributes");
+
+        let mut state = self.state.write();
+        let app = state
+            .platform_applications
+            .get_mut(&arn)
+            .ok_or_else(|| not_found("PlatformApplication"))?;
+
+        for (k, v) in new_attrs {
+            app.attributes.insert(k, v);
+        }
+
+        Ok(xml_resp(
+            &format!(
+                r#"<SetPlatformApplicationAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</SetPlatformApplicationAttributesResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn list_platform_applications(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+
+        let members: String = state
+            .platform_applications
+            .values()
+            .map(|app| {
+                let attrs: String = app
+                    .attributes
+                    .iter()
+                    .map(|(k, v)| format_attr(k, v))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                format!(
+                    r#"      <member>
+        <PlatformApplicationArn>{}</PlatformApplicationArn>
+        <Attributes>
+{attrs}
+        </Attributes>
+      </member>"#,
+                    app.arn
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Ok(xml_resp(
+            &format!(
+                r#"<ListPlatformApplicationsResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <ListPlatformApplicationsResult>
+    <PlatformApplications>
+{members}
+    </PlatformApplications>
+  </ListPlatformApplicationsResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</ListPlatformApplicationsResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn create_platform_endpoint(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let app_arn = required(req, "PlatformApplicationArn")?;
+        let token = required(req, "Token")?;
+        let custom_user_data = param(req, "CustomUserData");
+        let attrs = parse_entries(req, "Attributes");
+
+        let mut state = self.state.write();
+        let account_id = state.account_id.clone();
+        let app = state
+            .platform_applications
+            .get_mut(&app_arn)
+            .ok_or_else(|| not_found("PlatformApplication"))?;
+
+        // Check for existing endpoint with same token
+        for (arn, ep) in &app.endpoints {
+            if ep.token == token {
+                // If attributes are different, check Enabled attribute
+                let existing_enabled = ep
+                    .attributes
+                    .get("Enabled")
+                    .cloned()
+                    .unwrap_or_else(|| "true".to_string());
+                let new_enabled = attrs
+                    .get("Enabled")
+                    .cloned()
+                    .unwrap_or_else(|| "true".to_string());
+                let custom_matches = match (&custom_user_data, ep.attributes.get("CustomUserData"))
+                {
+                    (Some(new), Some(old)) => new == old,
+                    (None, None) => true,
+                    (None, Some(_)) => true,
+                    _ => false,
+                };
+
+                if existing_enabled == new_enabled && custom_matches {
+                    // Return existing endpoint
+                    return Ok(xml_resp(
+                        &format!(
+                            r#"<CreatePlatformEndpointResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <CreatePlatformEndpointResult>
+    <EndpointArn>{arn}</EndpointArn>
+  </CreatePlatformEndpointResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</CreatePlatformEndpointResponse>"#,
+                            req.request_id
+                        ),
+                        &req.request_id,
+                    ));
+                } else {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameter",
+                        format!("Invalid parameter: Token Reason: Endpoint {} already exists with the same Token, but different attributes.", arn),
+                    ));
+                }
+            }
+        }
+
+        let endpoint_id = uuid::Uuid::new_v4().to_string().replace('-', "");
+        let endpoint_arn = format!(
+            "arn:aws:sns:{}:{}:endpoint/{}/{}/{}",
+            req.region, account_id, app.platform, app.name, endpoint_id
+        );
+
+        let mut endpoint_attrs = attrs;
+        endpoint_attrs.insert("Enabled".to_string(), "true".to_string());
+        endpoint_attrs.insert("Token".to_string(), token.clone());
+        if let Some(ref ud) = custom_user_data {
+            endpoint_attrs.insert("CustomUserData".to_string(), ud.clone());
+        }
+
+        app.endpoints.insert(
+            endpoint_arn.clone(),
+            PlatformEndpoint {
+                arn: endpoint_arn.clone(),
+                token,
+                attributes: endpoint_attrs,
+                enabled: true,
+                messages: Vec::new(),
+            },
+        );
+
+        Ok(xml_resp(
+            &format!(
+                r#"<CreatePlatformEndpointResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <CreatePlatformEndpointResult>
+    <EndpointArn>{endpoint_arn}</EndpointArn>
+  </CreatePlatformEndpointResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</CreatePlatformEndpointResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn delete_endpoint(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let endpoint_arn = required(req, "EndpointArn")?;
+
+        let mut state = self.state.write();
+        for app in state.platform_applications.values_mut() {
+            app.endpoints.remove(&endpoint_arn);
+        }
+
+        Ok(xml_resp(
+            &format!(
+                r#"<DeleteEndpointResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</DeleteEndpointResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn get_endpoint_attributes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let endpoint_arn = required(req, "EndpointArn")?;
+
+        let state = self.state.read();
+        for app in state.platform_applications.values() {
+            if let Some(ep) = app.endpoints.get(&endpoint_arn) {
+                let attrs: String = ep
+                    .attributes
+                    .iter()
+                    .map(|(k, v)| format_attr(k, v))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                return Ok(xml_resp(
+                    &format!(
+                        r#"<GetEndpointAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <GetEndpointAttributesResult>
+    <Attributes>
+{attrs}
+    </Attributes>
+  </GetEndpointAttributesResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</GetEndpointAttributesResponse>"#,
+                        req.request_id
+                    ),
+                    &req.request_id,
+                ));
+            }
+        }
+
+        Err(not_found("Endpoint"))
+    }
+
+    fn set_endpoint_attributes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let endpoint_arn = required(req, "EndpointArn")?;
+        let new_attrs = parse_entries(req, "Attributes");
+
+        let mut state = self.state.write();
+        for app in state.platform_applications.values_mut() {
+            if let Some(ep) = app.endpoints.get_mut(&endpoint_arn) {
+                for (k, v) in new_attrs {
+                    if k == "Enabled" {
+                        ep.enabled = v == "true";
+                    }
+                    ep.attributes.insert(k, v);
+                }
+
+                return Ok(xml_resp(
+                    &format!(
+                        r#"<SetEndpointAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</SetEndpointAttributesResponse>"#,
+                        req.request_id
+                    ),
+                    &req.request_id,
+                ));
+            }
+        }
+
+        Err(not_found("Endpoint"))
+    }
+
+    fn list_endpoints_by_platform_application(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let app_arn = required(req, "PlatformApplicationArn")?;
+
+        let state = self.state.read();
+        let app = state
+            .platform_applications
+            .get(&app_arn)
+            .ok_or_else(|| not_found("PlatformApplication"))?;
+
+        let members: String = app
+            .endpoints
+            .values()
+            .map(|ep| {
+                let attrs: String = ep
+                    .attributes
+                    .iter()
+                    .map(|(k, v)| format_attr(k, v))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                format!(
+                    r#"      <member>
+        <EndpointArn>{}</EndpointArn>
+        <Attributes>
+{attrs}
+        </Attributes>
+      </member>"#,
+                    ep.arn
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Ok(xml_resp(
+            &format!(
+                r#"<ListEndpointsByPlatformApplicationResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <ListEndpointsByPlatformApplicationResult>
+    <Endpoints>
+{members}
+    </Endpoints>
+  </ListEndpointsByPlatformApplicationResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</ListEndpointsByPlatformApplicationResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    // ===== SMS actions =====
+
+    fn set_sms_attributes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let attrs = parse_entries(req, "attributes");
+
+        let mut state = self.state.write();
+        for (k, v) in attrs {
+            state.sms_attributes.insert(k, v);
+        }
+
+        Ok(xml_resp(
+            &format!(
+                r#"<SetSMSAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <SetSMSAttributesResult/>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</SetSMSAttributesResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn get_sms_attributes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+
+        let attrs: String = state
+            .sms_attributes
+            .iter()
+            .map(|(k, v)| format_attr(k, v))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Ok(xml_resp(
+            &format!(
+                r#"<GetSMSAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <GetSMSAttributesResult>
+    <attributes>
+{attrs}
+    </attributes>
+  </GetSMSAttributesResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</GetSMSAttributesResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn check_if_phone_number_is_opted_out(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let phone_number = required(req, "phoneNumber")?;
+        let state = self.state.read();
+        let is_opted_out = state.opted_out_numbers.contains(&phone_number);
+
+        Ok(xml_resp(
+            &format!(
+                r#"<CheckIfPhoneNumberIsOptedOutResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <CheckIfPhoneNumberIsOptedOutResult>
+    <isOptedOut>{is_opted_out}</isOptedOut>
+  </CheckIfPhoneNumberIsOptedOutResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</CheckIfPhoneNumberIsOptedOutResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn list_phone_numbers_opted_out(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let members: String = state
+            .opted_out_numbers
+            .iter()
+            .map(|n| format!("      <member>{n}</member>"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Ok(xml_resp(
+            &format!(
+                r#"<ListPhoneNumbersOptedOutResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <ListPhoneNumbersOptedOutResult>
+    <phoneNumbers>
+{members}
+    </phoneNumbers>
+  </ListPhoneNumbersOptedOutResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</ListPhoneNumbersOptedOutResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
+
+    fn opt_in_phone_number(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let phone_number = required(req, "phoneNumber")?;
+        let mut state = self.state.write();
+        state.opted_out_numbers.retain(|n| n != &phone_number);
+
+        Ok(xml_resp(
+            &format!(
+                r#"<OptInPhoneNumberResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <OptInPhoneNumberResult/>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</OptInPhoneNumberResponse>"#,
+                req.request_id
+            ),
+            &req.request_id,
+        ))
+    }
 }
 
 fn format_attr(name: &str, value: &str) -> String {
@@ -742,9 +2289,9 @@ fn format_sub_member(sub: &SnsSubscription) -> String {
         <TopicArn>{}</TopicArn>
         <Protocol>{}</Protocol>
         <Endpoint>{}</Endpoint>
-        <Owner></Owner>
+        <Owner>{}</Owner>
       </member>"#,
-        sub.subscription_arn, sub.topic_arn, sub.protocol, sub.endpoint,
+        sub.subscription_arn, sub.topic_arn, sub.protocol, sub.endpoint, sub.owner,
     )
 }
 
@@ -762,11 +2309,17 @@ fn parse_message_attributes(req: &AwsRequest) -> HashMap<String, MessageAttribut
         ) {
             let string_value_key = format!("MessageAttributes.entry.{n}.Value.StringValue");
             let string_value = req.query_params.get(&string_value_key).cloned();
+            let binary_value_key = format!("MessageAttributes.entry.{n}.Value.BinaryValue");
+            let binary_value = req
+                .query_params
+                .get(&binary_value_key)
+                .and_then(|b| base64::engine::general_purpose::STANDARD.decode(b).ok());
             attrs.insert(
                 name.clone(),
                 MessageAttribute {
                     data_type: data_type.clone(),
                     string_value,
+                    binary_value,
                 },
             );
         } else {
@@ -778,8 +2331,8 @@ fn parse_message_attributes(req: &AwsRequest) -> HashMap<String, MessageAttribut
 
 /// Parse tags from query params.
 /// Format: Tags.member.N.Key / Tags.member.N.Value
-fn parse_tags(req: &AwsRequest) -> HashMap<String, String> {
-    let mut tags = HashMap::new();
+fn parse_tags(req: &AwsRequest) -> Vec<(String, String)> {
+    let mut tags = Vec::new();
     for n in 1..=50 {
         let key_param = format!("Tags.member.{n}.Key");
         let val_param = format!("Tags.member.{n}.Value");
@@ -789,7 +2342,7 @@ fn parse_tags(req: &AwsRequest) -> HashMap<String, String> {
                 .get(&val_param)
                 .cloned()
                 .unwrap_or_default();
-            tags.insert(key.clone(), value);
+            tags.push((key.clone(), value));
         } else {
             break;
         }
@@ -812,36 +2365,129 @@ fn parse_tag_keys(req: &AwsRequest) -> Vec<String> {
     keys
 }
 
+/// Parse Attributes.entry.N.key/value pairs (used by CreateTopic, Subscribe, etc.)
+fn parse_entries(req: &AwsRequest, prefix: &str) -> HashMap<String, String> {
+    let mut attrs = HashMap::new();
+    for n in 1..=50 {
+        let key_param = format!("{prefix}.entry.{n}.key");
+        let val_param = format!("{prefix}.entry.{n}.value");
+        if let Some(key) = req.query_params.get(&key_param) {
+            let value = req
+                .query_params
+                .get(&val_param)
+                .cloned()
+                .unwrap_or_default();
+            attrs.insert(key.clone(), value);
+        } else {
+            break;
+        }
+    }
+    attrs
+}
+
+/// Validate SMS phone number
+fn validate_sms_endpoint(endpoint: &str) -> Result<(), AwsServiceError> {
+    // Allow formats like +15551234567 and +15/55-123.4567
+    if endpoint.is_empty() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            "Invalid parameter: Endpoint",
+        ));
+    }
+
+    // Must start with optional + and contain only digits, -, /, .
+    let stripped = endpoint.strip_prefix('+').unwrap_or(endpoint);
+    if stripped.is_empty() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            format!("Invalid SMS endpoint: {endpoint}"),
+        ));
+    }
+
+    // Check for invalid patterns: consecutive special chars, must start with + or digit
+    if !endpoint.starts_with('+') && !endpoint.starts_with(|c: char| c.is_ascii_digit()) {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            format!("Invalid SMS endpoint: {endpoint}"),
+        ));
+    }
+
+    // Must not end with a special char
+    if endpoint.ends_with('.') || endpoint.ends_with('-') || endpoint.ends_with('/') {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            format!("Invalid SMS endpoint: {endpoint}"),
+        ));
+    }
+
+    // Must not have consecutive special chars like --
+    let chars: Vec<char> = endpoint.chars().collect();
+    for i in 0..chars.len() - 1 {
+        let c = chars[i];
+        let next = chars[i + 1];
+        if (c == '-' || c == '/' || c == '.') && (next == '-' || next == '/' || next == '.') {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameter",
+                format!("Invalid SMS endpoint: {endpoint}"),
+            ));
+        }
+    }
+
+    // Check all chars are valid
+    for c in stripped.chars() {
+        if !c.is_ascii_digit() && c != '-' && c != '/' && c != '.' {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameter",
+                format!("Invalid SMS endpoint: {endpoint}"),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 /// Check if a message's attributes match the subscription's FilterPolicy.
-///
-/// The FilterPolicy is a JSON object where keys are attribute names and values
-/// are arrays of allowed values. A message matches if for every key in the filter,
-/// the message has that attribute and its value is in the allowed list.
-/// If the subscription has no FilterPolicy, all messages match.
 fn matches_filter_policy(
     sub: &SnsSubscription,
     message_attributes: &HashMap<String, MessageAttribute>,
+    message_body: &str,
 ) -> bool {
     let filter_json = match sub.attributes.get("FilterPolicy") {
-        Some(fp) => fp,
-        None => return true, // no filter = match all
+        Some(fp) if !fp.is_empty() => fp,
+        _ => return true,
     };
 
     let filter: HashMap<String, Value> = match serde_json::from_str(filter_json) {
         Ok(f) => f,
-        Err(_) => return true, // invalid filter = match all (lenient)
+        Err(_) => return true,
     };
 
+    let scope = sub
+        .attributes
+        .get("FilterPolicyScope")
+        .map(|s| s.as_str())
+        .unwrap_or("MessageAttributes");
+
+    if scope == "MessageBody" {
+        return matches_filter_policy_body(&filter, message_body);
+    }
+
+    // MessageAttributes scope
     for (attr_name, allowed_values) in &filter {
         let allowed = match allowed_values.as_array() {
             Some(arr) => arr,
-            None => continue, // skip non-array values
+            None => continue,
         };
 
         let msg_attr = match message_attributes.get(attr_name) {
             Some(a) => a,
             None => {
-                // Check if any allowed value is {"exists": false} — matches when attribute is absent
                 let has_exists_false = allowed.iter().any(|v| {
                     v.as_object()
                         .and_then(|o| o.get("exists"))
@@ -851,40 +2497,12 @@ fn matches_filter_policy(
                 if has_exists_false {
                     continue;
                 }
-                return false; // attribute missing and no exists:false matcher
+                return false;
             }
         };
 
         let attr_value = msg_attr.string_value.as_deref().unwrap_or("");
-        let matched = allowed.iter().any(|v| match v {
-            Value::String(s) => s == attr_value,
-            Value::Number(n) => n.to_string() == attr_value,
-            Value::Object(obj) => {
-                // Advanced filter operators
-                if let Some(prefix) = obj.get("prefix").and_then(|v| v.as_str()) {
-                    attr_value.starts_with(prefix)
-                } else if let Some(anything_but) = obj.get("anything-but") {
-                    match anything_but {
-                        Value::String(s) => attr_value != s,
-                        Value::Array(arr) => !arr.iter().any(|v| v.as_str() == Some(attr_value)),
-                        _ => false,
-                    }
-                } else if let Some(numeric_arr) = obj.get("numeric").and_then(|v| v.as_array()) {
-                    // Numeric comparison: {"numeric": [">", 100]} or {"numeric": [">=", 50, "<", 200]}
-                    let attr_num: f64 = match attr_value.parse() {
-                        Ok(n) => n,
-                        Err(_) => return false,
-                    };
-                    matches_numeric_filter(attr_num, numeric_arr)
-                } else {
-                    // {"exists": true/false} — attribute is present (since we got here), so match if true
-                    obj.get("exists")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or_default()
-                }
-            }
-            _ => false,
-        });
+        let matched = check_filter_values(allowed, attr_value);
         if !matched {
             return false;
         }
@@ -893,7 +2511,156 @@ fn matches_filter_policy(
     true
 }
 
-/// Evaluate a numeric filter like `[">", 100]` or `[">=", 50, "<", 200]` against a value.
+/// Match filter policy against message body (JSON)
+fn matches_filter_policy_body(filter: &HashMap<String, Value>, message_body: &str) -> bool {
+    let body: Value = match serde_json::from_str(message_body) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    matches_filter_policy_nested(filter, &body)
+}
+
+fn matches_filter_policy_nested(filter: &HashMap<String, Value>, body: &Value) -> bool {
+    let body_obj = match body.as_object() {
+        Some(o) => o,
+        None => return false,
+    };
+
+    for (key, filter_value) in filter {
+        let body_value = match body_obj.get(key) {
+            Some(v) => v,
+            None => {
+                // Check for exists: false
+                if let Some(arr) = filter_value.as_array() {
+                    let has_exists_false = arr.iter().any(|v| {
+                        v.as_object()
+                            .and_then(|o| o.get("exists"))
+                            .and_then(|e| e.as_bool())
+                            == Some(false)
+                    });
+                    if has_exists_false {
+                        continue;
+                    }
+                }
+                return false;
+            }
+        };
+
+        if let Some(arr) = filter_value.as_array() {
+            // This is a leaf filter: check the value
+            let value_str = match body_value {
+                Value::String(s) => s.clone(),
+                Value::Number(n) => n.to_string(),
+                Value::Bool(b) => b.to_string(),
+                Value::Null => "null".to_string(),
+                _ => body_value.to_string(),
+            };
+            if !check_filter_values(arr, &value_str) {
+                return false;
+            }
+        } else if let Some(nested_filter) = filter_value.as_object() {
+            // Nested filter: recurse
+            let nested_map: HashMap<String, Value> = nested_filter
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            if !matches_filter_policy_nested(&nested_map, body_value) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+fn check_filter_values(allowed: &[Value], attr_value: &str) -> bool {
+    allowed.iter().any(|v| match v {
+        Value::String(s) => s == attr_value,
+        Value::Number(n) => {
+            // Number comparison: try to parse the attribute value as a number too
+            if let Ok(attr_num) = attr_value.parse::<f64>() {
+                if let Some(filter_num) = n.as_f64() {
+                    (attr_num - filter_num).abs() < f64::EPSILON
+                } else {
+                    false
+                }
+            } else {
+                n.to_string() == attr_value
+            }
+        }
+        Value::Bool(_) | Value::Null => false,
+        Value::Object(obj) => {
+            if let Some(prefix) = obj.get("prefix").and_then(|v| v.as_str()) {
+                attr_value.starts_with(prefix)
+            } else if let Some(suffix) = obj.get("suffix").and_then(|v| v.as_str()) {
+                attr_value.ends_with(suffix)
+            } else if let Some(anything_but) = obj.get("anything-but") {
+                match anything_but {
+                    Value::String(s) => attr_value != s,
+                    Value::Number(n) => {
+                        if let Ok(attr_num) = attr_value.parse::<f64>() {
+                            if let Some(filter_num) = n.as_f64() {
+                                (attr_num - filter_num).abs() >= f64::EPSILON
+                            } else {
+                                true
+                            }
+                        } else {
+                            true
+                        }
+                    }
+                    Value::Array(arr) => {
+                        // anything-but with array of values
+                        !arr.iter().any(|av| match av {
+                            Value::String(s) => s == attr_value,
+                            Value::Number(n) => {
+                                if let Ok(attr_num) = attr_value.parse::<f64>() {
+                                    if let Some(filter_num) = n.as_f64() {
+                                        (attr_num - filter_num).abs() < f64::EPSILON
+                                    } else {
+                                        false
+                                    }
+                                } else {
+                                    false
+                                }
+                            }
+                            _ => false,
+                        })
+                    }
+                    Value::Object(inner) => {
+                        // anything-but with prefix
+                        if let Some(prefix) = inner.get("prefix").and_then(|v| v.as_str()) {
+                            !attr_value.starts_with(prefix)
+                        } else if let Some(suffix) = inner.get("suffix").and_then(|v| v.as_str()) {
+                            !attr_value.ends_with(suffix)
+                        } else {
+                            false
+                        }
+                    }
+                    _ => false,
+                }
+            } else if let Some(numeric_arr) = obj.get("numeric").and_then(|v| v.as_array()) {
+                let attr_num: f64 = match attr_value.parse() {
+                    Ok(n) => n,
+                    Err(_) => return false,
+                };
+                matches_numeric_filter(attr_num, numeric_arr)
+            } else if let Some(eq_ignore_case) =
+                obj.get("equals-ignore-case").and_then(|v| v.as_str())
+            {
+                attr_value.eq_ignore_ascii_case(eq_ignore_case)
+            } else {
+                // {"exists": true/false}
+                obj.get("exists")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or_default()
+            }
+        }
+        _ => false,
+    })
+}
+
+/// Evaluate a numeric filter
 fn matches_numeric_filter(value: f64, conditions: &[Value]) -> bool {
     let mut i = 0;
     while i + 1 < conditions.len() {

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -274,7 +274,7 @@ impl SnsService {
         let topic_attrs = parse_entries(req, "Attributes");
         let is_fifo_attr = topic_attrs
             .get("FifoTopic")
-            .map(|v| v == "true")
+            .map(|v| v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
         let is_fifo = name.ends_with(".fifo");
 
@@ -303,10 +303,19 @@ impl SnsService {
 
             // Apply topic attributes from the request
             for (k, v) in &topic_attrs {
-                // If FifoTopic=false is explicitly set, remove FIFO-related attrs
-                if k == "FifoTopic" && v == "false" {
-                    attributes.remove("FifoTopic");
-                    attributes.remove("ContentBasedDeduplication");
+                // Normalize boolean-like values for FifoTopic and ContentBasedDeduplication
+                if k == "FifoTopic" || k == "ContentBasedDeduplication" {
+                    let normalized = if v.eq_ignore_ascii_case("true") {
+                        "true"
+                    } else {
+                        "false"
+                    };
+                    if k == "FifoTopic" && normalized == "false" {
+                        attributes.remove("FifoTopic");
+                        attributes.remove("ContentBasedDeduplication");
+                        continue;
+                    }
+                    attributes.insert(k.clone(), normalized.to_string());
                     continue;
                 }
                 attributes.insert(k.clone(), v.clone());
@@ -716,13 +725,16 @@ impl SnsService {
 
         // Handle SMS publish (PhoneNumber)
         if let Some(ref phone) = phone_number {
-            // Validate phone number (basic E.164)
-            if !phone.starts_with('+') || phone.len() < 2 {
+            // Validate phone number (basic E.164: starts with + followed by digits)
+            let is_valid_e164 = phone.starts_with('+')
+                && phone.len() >= 2
+                && phone[1..].chars().all(|c| c.is_ascii_digit());
+            if !is_valid_e164 {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "InvalidParameter",
                     format!(
-                        "Invalid parameter: PhoneNumber Reason: {phone} is not valid to publish to"
+                        "Invalid parameter: PhoneNumber Reason: {phone} does not meet the E164 format"
                     ),
                 ));
             }
@@ -781,7 +793,7 @@ impl SnsService {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "InvalidParameter",
-                    "Invalid parameter: The MessageGroupId parameter is required for FIFO topics",
+                    "Invalid parameter: The request must contain the parameter MessageGroupId.",
                 ));
             }
             // FIFO topics require deduplication: either ContentBasedDeduplication or explicit ID
@@ -794,11 +806,20 @@ impl SnsService {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "InvalidParameter",
-                    "Invalid parameter: The topic should either have ContentBasedDeduplication enabled or the MessageDeduplicationId provided explicitly",
+                    "Invalid parameter: The topic should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
+                ));
+            }
+        } else {
+            // Non-FIFO: MessageGroupId is allowed (forwarded to SQS for fair queuing)
+            // But DeduplicationId is NOT allowed on non-FIFO topics
+            if message_dedup_id.is_some() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    "Invalid parameter: The request includes MessageDeduplicationId parameter that is not valid for this topic type",
                 ));
             }
         }
-        // Non-FIFO: MessageGroupId and DeduplicationId are allowed (used for SQS fair queuing)
 
         let msg_id = uuid::Uuid::new_v4().to_string();
         state.published.push(PublishedMessage {
@@ -2497,6 +2518,39 @@ fn matches_filter_policy(
 
     // MessageAttributes scope
     for (attr_name, allowed_values) in &filter {
+        // Handle $or operator
+        if attr_name == "$or" {
+            if let Some(or_conditions) = allowed_values.as_array() {
+                let any_match = or_conditions.iter().any(|condition| {
+                    if let Some(cond_obj) = condition.as_object() {
+                        let cond_map: HashMap<String, Value> = cond_obj
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect();
+                        // Each condition in $or is a mini filter policy
+                        cond_map.iter().all(|(key, vals)| {
+                            if let Some(arr) = vals.as_array() {
+                                if let Some(msg_attr) = message_attributes.get(key) {
+                                    let val = msg_attr.string_value.as_deref().unwrap_or("");
+                                    check_filter_values(arr, val)
+                                } else {
+                                    false
+                                }
+                            } else {
+                                false
+                            }
+                        })
+                    } else {
+                        false
+                    }
+                });
+                if !any_match {
+                    return false;
+                }
+                continue;
+            }
+        }
+
         let allowed = match allowed_values.as_array() {
             Some(arr) => arr,
             None => continue,
@@ -2585,15 +2639,32 @@ fn matches_filter_policy_nested(filter: &HashMap<String, Value>, body: &Value) -
 
         if let Some(arr) = filter_value.as_array() {
             // This is a leaf filter: check the value
-            let value_str = match body_value {
-                Value::String(s) => s.clone(),
-                Value::Number(n) => n.to_string(),
-                Value::Bool(b) => b.to_string(),
-                Value::Null => "null".to_string(),
-                _ => body_value.to_string(),
-            };
-            if !check_filter_values(arr, &value_str) {
-                return false;
+            // If the body value is an array, check if ANY element matches
+            if let Some(body_arr) = body_value.as_array() {
+                let any_match = body_arr.iter().any(|elem| {
+                    let elem_str = match elem {
+                        Value::String(s) => s.clone(),
+                        Value::Number(n) => n.to_string(),
+                        Value::Bool(b) => b.to_string(),
+                        Value::Null => "null".to_string(),
+                        _ => elem.to_string(),
+                    };
+                    check_filter_values(arr, &elem_str)
+                });
+                if !any_match {
+                    return false;
+                }
+            } else {
+                let value_str = match body_value {
+                    Value::String(s) => s.clone(),
+                    Value::Number(n) => n.to_string(),
+                    Value::Bool(b) => b.to_string(),
+                    Value::Null => "null".to_string(),
+                    _ => body_value.to_string(),
+                };
+                if !check_filter_values(arr, &value_str) {
+                    return false;
+                }
             }
         } else if let Some(nested_filter) = filter_value.as_object() {
             // Nested filter: recurse

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -697,7 +697,7 @@ impl SnsService {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "InvalidParameter",
-                    "Invalid parameter: Subject",
+                    "Subject must be less than 100 characters",
                 ));
             }
         }
@@ -797,25 +797,8 @@ impl SnsService {
                     "Invalid parameter: The topic should either have ContentBasedDeduplication enabled or the MessageDeduplicationId provided explicitly",
                 ));
             }
-        } else {
-            // Non-FIFO: MessageGroupId should not be set
-            if message_group_id.is_some() {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidParameter",
-                    "Invalid parameter: MessageGroupId Reason: The request includes MessageGroupId parameter that is not valid for this topic type",
-                ));
-            }
-            if message_dedup_id.is_some() {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidParameter",
-                    "Invalid parameter: MessageDeduplicationId Reason: The request includes MessageDeduplicationId parameter that is not valid for this topic type",
-                ));
-            }
         }
-
-        let is_fifo = topic.is_fifo;
+        // Non-FIFO: MessageGroupId and DeduplicationId are allowed (used for SQS fair queuing)
 
         let msg_id = uuid::Uuid::new_v4().to_string();
         state.published.push(PublishedMessage {
@@ -925,33 +908,18 @@ impl SnsService {
                     queue_arn,
                     &sqs_message,
                     &sqs_msg_attrs,
-                    if is_fifo {
-                        message_group_id.as_deref()
-                    } else {
-                        None
-                    },
-                    if is_fifo {
-                        message_dedup_id.as_deref()
-                    } else {
-                        None
-                    },
+                    message_group_id.as_deref(),
+                    message_dedup_id.as_deref(),
                 );
             } else {
                 // Standard delivery: wrap in SNS envelope
-                let sns_envelope = serde_json::json!({
-                    "Type": "Notification",
-                    "MessageId": msg_id,
-                    "TopicArn": topic_arn,
-                    "Subject": subject.as_deref().unwrap_or(""),
-                    "Message": sqs_message,
-                    "Timestamp": Utc::now().to_rfc3339(),
-                    "SignatureVersion": "1",
-                    "Signature": "FAKE_SIGNATURE",
-                    "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
-                    "UnsubscribeURL": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
-                    "MessageAttributes": envelope_attrs,
-                });
-                let envelope_str = sns_envelope.to_string();
+                let envelope_str = build_sns_envelope(
+                    &msg_id,
+                    &topic_arn,
+                    &subject,
+                    &sqs_message,
+                    &envelope_attrs,
+                );
                 self.delivery
                     .send_to_sqs(queue_arn, &envelope_str, &HashMap::new());
             }
@@ -959,20 +927,14 @@ impl SnsService {
 
         // Deliver to HTTP/HTTPS subscribers (fire-and-forget)
         for endpoint_url in http_subscribers {
-            let sns_envelope = serde_json::json!({
-                "Type": "Notification",
-                "MessageId": msg_id,
-                "TopicArn": topic_arn,
-                "Subject": subject.as_deref().unwrap_or(""),
-                "Message": default_message,
-                "Timestamp": Utc::now().to_rfc3339(),
-                "SignatureVersion": "1",
-                "Signature": "FAKE_SIGNATURE",
-                "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
-                "UnsubscribeURL": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
-                "MessageAttributes": envelope_attrs.clone(),
-            });
-            let body = sns_envelope.to_string();
+            let sns_envelope_str = build_sns_envelope(
+                &msg_id,
+                &topic_arn,
+                &subject,
+                &default_message,
+                &envelope_attrs,
+            );
+            let body = sns_envelope_str;
             let topic = topic_arn.clone();
             tokio::spawn(async move {
                 let client = reqwest::Client::new();
@@ -2278,6 +2240,61 @@ impl SnsService {
     }
 }
 
+/// Build an SNS notification envelope as JSON string.
+/// Subject and MessageAttributes are only included when present.
+fn build_sns_envelope(
+    message_id: &str,
+    topic_arn: &str,
+    subject: &Option<String>,
+    message: &str,
+    message_attributes: &serde_json::Map<String, Value>,
+) -> String {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "Type".to_string(),
+        Value::String("Notification".to_string()),
+    );
+    map.insert(
+        "MessageId".to_string(),
+        Value::String(message_id.to_string()),
+    );
+    map.insert("TopicArn".to_string(), Value::String(topic_arn.to_string()));
+    if let Some(ref subj) = subject {
+        map.insert("Subject".to_string(), Value::String(subj.clone()));
+    }
+    map.insert("Message".to_string(), Value::String(message.to_string()));
+    map.insert(
+        "Timestamp".to_string(),
+        Value::String(Utc::now().to_rfc3339()),
+    );
+    map.insert(
+        "SignatureVersion".to_string(),
+        Value::String("1".to_string()),
+    );
+    map.insert(
+        "Signature".to_string(),
+        Value::String("FAKE_SIGNATURE".to_string()),
+    );
+    map.insert(
+        "SigningCertURL".to_string(),
+        Value::String("https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem".to_string()),
+    );
+    map.insert(
+        "UnsubscribeURL".to_string(),
+        Value::String(format!(
+            "http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}",
+            topic_arn
+        )),
+    );
+    if !message_attributes.is_empty() {
+        map.insert(
+            "MessageAttributes".to_string(),
+            Value::Object(message_attributes.clone()),
+        );
+    }
+    Value::Object(map).to_string()
+}
+
 fn format_attr(name: &str, value: &str) -> String {
     format!("      <entry><key>{name}</key><value>{value}</value></entry>")
 }
@@ -2502,6 +2519,25 @@ fn matches_filter_policy(
         };
 
         let attr_value = msg_attr.string_value.as_deref().unwrap_or("");
+
+        // Handle String.Array data type: parse the JSON array and check each element
+        if msg_attr.data_type.starts_with("String.Array") || msg_attr.data_type == "String.Array" {
+            if let Ok(arr) = serde_json::from_str::<Vec<Value>>(attr_value) {
+                let any_match = arr.iter().any(|elem| {
+                    let elem_str = match elem {
+                        Value::String(s) => s.clone(),
+                        Value::Number(n) => n.to_string(),
+                        _ => elem.to_string(),
+                    };
+                    check_filter_values(allowed, &elem_str)
+                });
+                if !any_match {
+                    return false;
+                }
+                continue;
+            }
+        }
+
         let matched = check_filter_values(allowed, attr_value);
         if !matched {
             return false;
@@ -2581,7 +2617,7 @@ fn check_filter_values(allowed: &[Value], attr_value: &str) -> bool {
             // Number comparison: try to parse the attribute value as a number too
             if let Ok(attr_num) = attr_value.parse::<f64>() {
                 if let Some(filter_num) = n.as_f64() {
-                    (attr_num - filter_num).abs() < f64::EPSILON
+                    numbers_equal(attr_num, filter_num)
                 } else {
                     false
                 }
@@ -2616,7 +2652,7 @@ fn check_filter_values(allowed: &[Value], attr_value: &str) -> bool {
                             Value::Number(n) => {
                                 if let Ok(attr_num) = attr_value.parse::<f64>() {
                                     if let Some(filter_num) = n.as_f64() {
-                                        (attr_num - filter_num).abs() < f64::EPSILON
+                                        numbers_equal(attr_num, filter_num)
                                     } else {
                                         false
                                     }
@@ -2660,6 +2696,13 @@ fn check_filter_values(allowed: &[Value], attr_value: &str) -> bool {
     })
 }
 
+/// Compare two f64 values with limited precision (5 decimal places).
+/// AWS SNS uses limited precision for number comparisons.
+fn numbers_equal(a: f64, b: f64) -> bool {
+    // Compare with ~5 decimal digit precision
+    (a - b).abs() < 1e-5
+}
+
 /// Evaluate a numeric filter
 fn matches_numeric_filter(value: f64, conditions: &[Value]) -> bool {
     let mut i = 0;
@@ -2673,7 +2716,7 @@ fn matches_numeric_filter(value: f64, conditions: &[Value]) -> bool {
             None => return false,
         };
         let passes = match op {
-            "=" => (value - threshold).abs() < f64::EPSILON,
+            "=" => numbers_equal(value, threshold),
             ">" => value > threshold,
             ">=" => value >= threshold,
             "<" => value < threshold,

--- a/crates/fakecloud-sns/src/state.rs
+++ b/crates/fakecloud-sns/src/state.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -8,7 +8,7 @@ pub struct SnsTopic {
     pub topic_arn: String,
     pub name: String,
     pub attributes: HashMap<String, String>,
-    pub tags: HashMap<String, String>,
+    pub tags: Vec<(String, String)>,
     pub is_fifo: bool,
     pub created_at: DateTime<Utc>,
 }
@@ -19,6 +19,7 @@ pub struct SnsSubscription {
     pub topic_arn: String,
     pub protocol: String,
     pub endpoint: String,
+    pub owner: String,
     pub attributes: HashMap<String, String>,
     pub confirmed: bool,
 }
@@ -28,6 +29,7 @@ pub struct SnsSubscription {
 pub struct MessageAttribute {
     pub data_type: String,
     pub string_value: Option<String>,
+    pub binary_value: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone)]
@@ -38,15 +40,38 @@ pub struct PublishedMessage {
     pub subject: Option<String>,
     pub message_attributes: HashMap<String, MessageAttribute>,
     pub message_group_id: Option<String>,
+    pub message_dedup_id: Option<String>,
     pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PlatformApplication {
+    pub arn: String,
+    pub name: String,
+    pub platform: String,
+    pub attributes: HashMap<String, String>,
+    pub endpoints: HashMap<String, PlatformEndpoint>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PlatformEndpoint {
+    pub arn: String,
+    pub token: String,
+    pub attributes: HashMap<String, String>,
+    pub enabled: bool,
+    pub messages: Vec<PublishedMessage>,
 }
 
 pub struct SnsState {
     pub account_id: String,
     pub region: String,
-    pub topics: HashMap<String, SnsTopic>, // arn -> topic
-    pub subscriptions: HashMap<String, SnsSubscription>, // sub_arn -> subscription
+    pub topics: BTreeMap<String, SnsTopic>, // arn -> topic (ordered for predictable iteration)
+    pub subscriptions: BTreeMap<String, SnsSubscription>, // sub_arn -> subscription
     pub published: Vec<PublishedMessage>,
+    pub platform_applications: BTreeMap<String, PlatformApplication>,
+    pub sms_attributes: HashMap<String, String>,
+    pub opted_out_numbers: Vec<String>,
+    pub sms_messages: Vec<(String, String)>, // (phone_number, message)
 }
 
 impl SnsState {
@@ -54,9 +79,13 @@ impl SnsState {
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
-            topics: HashMap::new(),
-            subscriptions: HashMap::new(),
+            topics: BTreeMap::new(),
+            subscriptions: BTreeMap::new(),
             published: Vec::new(),
+            platform_applications: BTreeMap::new(),
+            sms_attributes: HashMap::new(),
+            opted_out_numbers: Vec::new(),
+            sms_messages: Vec::new(),
         }
     }
 }

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 
 use chrono::Utc;
 
-use fakecloud_core::delivery::SqsDelivery;
+use fakecloud_core::delivery::{SqsDelivery, SqsMessageAttribute};
 
-use crate::state::{SharedSqsState, SqsMessage};
+use crate::state::{MessageAttribute, SharedSqsState, SqsMessage};
 
 /// Implements SqsDelivery so other services can push messages into SQS queues.
 pub struct SqsDeliveryImpl {
@@ -24,6 +24,17 @@ impl SqsDelivery for SqsDeliveryImpl {
         message_body: &str,
         _attributes: &HashMap<String, String>,
     ) {
+        self.deliver_to_queue_with_attrs(queue_arn, message_body, &HashMap::new(), None, None);
+    }
+
+    fn deliver_to_queue_with_attrs(
+        &self,
+        queue_arn: &str,
+        message_body: &str,
+        message_attributes: &HashMap<String, SqsMessageAttribute>,
+        message_group_id: Option<&str>,
+        message_dedup_id: Option<&str>,
+    ) {
         let mut state = self.state.write();
 
         // Find queue by ARN
@@ -31,6 +42,21 @@ impl SqsDelivery for SqsDeliveryImpl {
 
         if let Some(queue) = queue {
             let now = Utc::now();
+
+            // Convert SqsMessageAttribute to the SQS state MessageAttribute
+            let sqs_attrs: HashMap<String, MessageAttribute> = message_attributes
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        MessageAttribute {
+                            data_type: v.data_type.clone(),
+                            string_value: v.string_value.clone(),
+                        },
+                    )
+                })
+                .collect();
+
             let msg = SqsMessage {
                 message_id: uuid::Uuid::new_v4().to_string(),
                 receipt_handle: None,
@@ -38,11 +64,11 @@ impl SqsDelivery for SqsDeliveryImpl {
                 body: message_body.to_string(),
                 sent_timestamp: now.timestamp_millis(),
                 attributes: HashMap::new(),
-                message_attributes: HashMap::new(),
+                message_attributes: sqs_attrs,
                 visible_at: None,
                 receive_count: 0,
-                message_group_id: None,
-                message_dedup_id: None,
+                message_group_id: message_group_id.map(|s| s.to_string()),
+                message_dedup_id: message_dedup_id.map(|s| s.to_string()),
                 created_at: now,
             };
             queue.messages.push_back(msg);


### PR DESCRIPTION
## Summary
- 19 new SNS actions: PublishBatch, AddPermission, RemovePermission, platform apps/endpoints, SMS operations
- Topic validation, pagination, region filtering, default policy/attributes
- Subscription dedup, attribute validation, filter policies (String.Array, \$or, suffix, equals-ignore-case)
- MessageStructure=json, raw delivery, conditional envelope fields
- Cross-service FIFO SQS delivery with message attributes

## Moto compatibility
- Before: 25/201 (12%)
- After: ~161/201 (80%) — remaining failures are CloudFormation/Config dependencies and edge cases