### PR TITLE
fix(ci): add missing test deps to Moto workflow

### DIFF
--- a/.github/workflows/moto-compat.yml
+++ b/.github/workflows/moto-compat.yml
@@ -52,7 +52,7 @@ jobs:
           python -m venv /tmp/moto-venv
           source /tmp/moto-venv/bin/activate
           pip install --quiet --upgrade pip
-          pip install --quiet -e "/tmp/moto[all]" pytest pytest-timeout requests flask
+          pip install --quiet -e "/tmp/moto[all]" pytest pytest-timeout requests flask freezegun
 
       - name: Start FakeCloud
         run: |
@@ -106,7 +106,7 @@ jobs:
                 "test_$svc/" \
                 --timeout=30 \
                 -q \
-                --tb=no \
+                --tb=short \
                 --no-header \
                 --ignore-glob="**/test_server.py" \
                 2>&1) > "tests/compat/moto/results/${svc}.log" || true

--- a/.github/workflows/moto-compat.yml
+++ b/.github/workflows/moto-compat.yml
@@ -98,9 +98,12 @@ jobs:
           source /tmp/moto-venv/bin/activate
           mkdir -p tests/compat/moto/results
 
-          for dir in /tmp/moto/tests/test_*; do
+          # Only test services FakeCloud implements
+          SERVICES="sqs sns events iam sts ssm"
+
+          for svc in $SERVICES; do
+            dir="/tmp/moto/tests/test_$svc"
             if [ -d "$dir" ]; then
-              svc=$(basename "$dir" | sed 's/^test_//')
               echo "--- Testing $svc ---"
               (cd /tmp/moto/tests && python -m pytest \
                 "test_$svc/" \


### PR DESCRIPTION
## Summary
- Add `freezegun` to pip install — `moto[all]` doesn't include test dependencies, causing `@freeze_time`-decorated test files to fail collection
- Change `--tb=no` to `--tb=short` so collection errors are visible in logs

Without this fix, services like STS (28 tests), IAM (384 tests), and SQS (172 tests) report near-zero test counts because entire files fail to import.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `freezegun` to the Moto CI workflow and switch pytest to `--tb=short` to surface collection errors, fixing `@freeze_time` imports and restoring accurate test counts (e.g., STS, IAM, SQS).
Limit runs to services FakeCloud implements (`sqs`, `sns`, `events`, `iam`, `sts`, `ssm`) to cut CI time from ~5min to ~1min.

<sup>Written for commit 13e6b5c4ab2bcb6d05f9dc58d782a86b56f737ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

