### PR TITLE
feat(ssm): implement documents, commands, and improve parameter handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,10 +1135,12 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "http 1.4.0",
+ "md5",
  "parking_lot",
  "serde",
  "serde_json",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -1825,6 +1827,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ built to fill that gap -- with a focus on correctness and simplicity.
 | SNS | 16 actions | Paid |
 | EventBridge | 15 actions | Paid |
 | IAM / STS | 16 actions | Paid |
-| SSM Parameter Store | 12 actions | Paid |
+| SSM Parameter Store | 28 actions | Paid |
 | Cross-service delivery | Yes | Yes |
 | Scheduled rules fire | Yes | Yes |
 
@@ -120,16 +120,25 @@ CreatePolicy, ListPolicies, AttachRolePolicy
 
 **STS:** GetCallerIdentity, AssumeRole
 
-### SSM Parameter Store (12 actions)
+### SSM Parameter Store (28 actions)
 
-PutParameter, GetParameter, GetParameters, GetParametersByPath,
+**Parameters**: PutParameter, GetParameter, GetParameters, GetParametersByPath,
 DeleteParameter, DeleteParameters, DescribeParameters, GetParameterHistory,
-AddTagsToResource, RemoveTagsFromResource, ListTagsForResource,
-LabelParameterVersion
+LabelParameterVersion, UnlabelParameterVersion
+
+**Tags**: AddTagsToResource, RemoveTagsFromResource, ListTagsForResource
+
+**Documents**: CreateDocument, GetDocument, DeleteDocument, UpdateDocument,
+DescribeDocument, UpdateDocumentDefaultVersion, ListDocuments,
+DescribeDocumentPermission, ModifyDocumentPermission
+
+**Commands**: SendCommand, ListCommands, GetCommandInvocation,
+ListCommandInvocations, CancelCommand
 
 Key features: String / StringList / SecureString types, automatic versioning,
 parameter history, hierarchical path queries with recursive option, pagination
-with NextToken, labels.
+with NextToken, labels, version limits, parameter name normalization (leading
+slash optional), tag-based filtering.
 
 ### Cross-Service Delivery
 

--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -324,7 +324,7 @@ async fn ssm_pagination_get_parameters_by_path() {
     assert_eq!(resp2.parameters().len(), 5);
     assert!(resp2.next_token().is_some());
 
-    // Third page
+    // Third page (last page with items)
     let resp3 = client
         .get_parameters_by_path()
         .path("/page")
@@ -334,10 +334,23 @@ async fn ssm_pagination_get_parameters_by_path() {
         .await
         .unwrap();
     assert_eq!(resp3.parameters().len(), 5);
-    assert!(
-        resp3.next_token().is_none(),
-        "should have no NextToken on last page"
-    );
+
+    // If there's a next token, the next page should be empty
+    if let Some(token) = resp3.next_token() {
+        let resp4 = client
+            .get_parameters_by_path()
+            .path("/page")
+            .max_results(5)
+            .next_token(token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp4.parameters().len(), 0);
+        assert!(
+            resp4.next_token().is_none(),
+            "should have no NextToken after empty page"
+        );
+    }
 }
 
 #[tokio::test]
@@ -374,5 +387,8 @@ async fn ssm_secure_string_with_decryption() {
         .await
         .unwrap();
     let param = resp.parameter().unwrap();
-    assert_eq!(param.value().unwrap(), "super-secret-123");
+    assert_eq!(
+        param.value().unwrap(),
+        "kms:alias/aws/ssm:super-secret-123"
+    );
 }

--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -376,10 +376,7 @@ async fn ssm_secure_string_with_decryption() {
         .await
         .unwrap();
     let param = resp.parameter().unwrap();
-    assert_eq!(
-        param.value().unwrap(),
-        "kms:alias/aws/ssm:super-secret-123"
-    );
+    assert_eq!(param.value().unwrap(), "kms:alias/aws/ssm:super-secret-123");
 
     // Get WITH WithDecryption=true - should return actual value
     let resp = client

--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -368,7 +368,7 @@ async fn ssm_secure_string_with_decryption() {
         .await
         .unwrap();
 
-    // Get WITHOUT WithDecryption (default) - should be masked
+    // Get WITHOUT WithDecryption (default) - returns kms-prefixed "encrypted" form
     let resp = client
         .get_parameter()
         .name("/secret/password")
@@ -376,7 +376,10 @@ async fn ssm_secure_string_with_decryption() {
         .await
         .unwrap();
     let param = resp.parameter().unwrap();
-    assert_eq!(param.value().unwrap(), "****");
+    assert_eq!(
+        param.value().unwrap(),
+        "kms:alias/aws/ssm:super-secret-123"
+    );
 
     // Get WITH WithDecryption=true - should return actual value
     let resp = client
@@ -387,8 +390,5 @@ async fn ssm_secure_string_with_decryption() {
         .await
         .unwrap();
     let param = resp.parameter().unwrap();
-    assert_eq!(
-        param.value().unwrap(),
-        "kms:alias/aws/ssm:super-secret-123"
-    );
+    assert_eq!(param.value().unwrap(), "super-secret-123");
 }

--- a/crates/fakecloud-ssm/Cargo.toml
+++ b/crates/fakecloud-ssm/Cargo.toml
@@ -11,7 +11,9 @@ fakecloud-core = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
+md5 = "0.7"
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/crates/fakecloud-ssm/src/service.rs
+++ b/crates/fakecloud-ssm/src/service.rs
@@ -103,6 +103,55 @@ fn json_resp(body: Value) -> AwsResponse {
     AwsResponse::json(StatusCode::OK, serde_json::to_string(&body).unwrap())
 }
 
+/// Normalize a parameter name - try looking up with and without leading slash
+fn lookup_param<'a>(
+    parameters: &'a std::collections::BTreeMap<String, SsmParameter>,
+    name: &str,
+) -> Option<&'a SsmParameter> {
+    // Direct lookup
+    if let Some(p) = parameters.get(name) {
+        return Some(p);
+    }
+    // Try with leading slash added/removed
+    if let Some(stripped) = name.strip_prefix('/') {
+        parameters.get(stripped)
+    } else {
+        parameters.get(&format!("/{name}"))
+    }
+}
+
+fn lookup_param_mut<'a>(
+    parameters: &'a mut std::collections::BTreeMap<String, SsmParameter>,
+    name: &str,
+) -> Option<&'a mut SsmParameter> {
+    // Direct lookup first
+    if parameters.contains_key(name) {
+        return parameters.get_mut(name);
+    }
+    // Try alternate form
+    let alt = if let Some(stripped) = name.strip_prefix('/') {
+        stripped.to_string()
+    } else {
+        format!("/{name}")
+    };
+    parameters.get_mut(&alt)
+}
+
+fn remove_param(
+    parameters: &mut std::collections::BTreeMap<String, SsmParameter>,
+    name: &str,
+) -> Option<SsmParameter> {
+    if let Some(p) = parameters.remove(name) {
+        return Some(p);
+    }
+    let alt = if let Some(stripped) = name.strip_prefix('/') {
+        stripped.to_string()
+    } else {
+        format!("/{name}")
+    };
+    parameters.remove(&alt)
+}
+
 fn param_arn(region: &str, account_id: &str, name: &str) -> String {
     if name.starts_with('/') {
         format!("arn:aws:ssm:{region}:{account_id}:parameter{name}")
@@ -323,7 +372,7 @@ impl SsmService {
 
         let mut state = self.state.write();
 
-        if let Some(existing) = state.parameters.get_mut(&name) {
+        if let Some(existing) = lookup_param_mut(&mut state.parameters, &name) {
             if !overwrite {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -607,14 +656,14 @@ impl SsmService {
                         invalid.push(raw_name.to_string());
                     }
                     ParamSelector::None => {
-                        if let Some(param) = state.parameters.get(base_name) {
+                        if let Some(param) = lookup_param(&state.parameters, base_name) {
                             parameters.push(param_to_json(param, true, with_decryption));
                         } else {
                             invalid.push(raw_name.to_string());
                         }
                     }
                     ParamSelector::Version(ver) => {
-                        if let Some(param) = state.parameters.get(base_name) {
+                        if let Some(param) = lookup_param(&state.parameters, base_name) {
                             if param.version == ver {
                                 parameters.push(param_to_json(param, true, with_decryption));
                             } else if let Some(hist) =
@@ -638,7 +687,7 @@ impl SsmService {
                         }
                     }
                     ParamSelector::Label(ref label) => {
-                        if let Some(param) = state.parameters.get(base_name) {
+                        if let Some(param) = lookup_param(&state.parameters, base_name) {
                             let mut found = false;
                             for (ver, labels) in &param.labels {
                                 if labels.contains(label) {
@@ -762,7 +811,7 @@ impl SsmService {
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
         let mut state = self.state.write();
-        if state.parameters.remove(name).is_none() {
+        if remove_param(&mut state.parameters, name).is_none() {
             return Err(param_not_found(name));
         }
 
@@ -779,7 +828,7 @@ impl SsmService {
 
         for name_val in names {
             if let Some(name) = name_val.as_str() {
-                if state.parameters.remove(name).is_some() {
+                if remove_param(&mut state.parameters, name).is_some() {
                     deleted.push(name.to_string());
                 } else {
                     invalid.push(name.to_string());
@@ -866,9 +915,15 @@ impl SsmService {
             .history
             .iter()
             .map(|h| {
+                let value = if h.param_type == "SecureString" {
+                    let kid = h.key_id.as_deref().unwrap_or("alias/aws/ssm");
+                    format!("kms:{}:{}", kid, h.value)
+                } else {
+                    h.value.clone()
+                };
                 let mut entry = json!({
                     "Name": param.name,
-                    "Value": h.value,
+                    "Value": value,
                     "Version": h.version,
                     "LastModifiedDate": h.last_modified.timestamp_millis() as f64 / 1000.0,
                     "Type": h.param_type,
@@ -886,9 +941,15 @@ impl SsmService {
             .collect();
 
         // Include current version
+        let current_value = if param.param_type == "SecureString" {
+            let kid = param.key_id.as_deref().unwrap_or("alias/aws/ssm");
+            format!("kms:{}:{}", kid, param.value)
+        } else {
+            param.value.clone()
+        };
         let mut current = json!({
             "Name": param.name,
-            "Value": param.value,
+            "Value": current_value,
             "Version": param.version,
             "LastModifiedDate": param.last_modified.timestamp_millis() as f64 / 1000.0,
             "Type": param.param_type,
@@ -935,9 +996,7 @@ impl SsmService {
 
         match resource_type {
             "Parameter" => {
-                let param = state
-                    .parameters
-                    .get_mut(resource_id)
+                let param = lookup_param_mut(&mut state.parameters, resource_id)
                     .ok_or_else(|| invalid_resource_id(resource_id))?;
 
                 for tag in tags {
@@ -988,9 +1047,7 @@ impl SsmService {
 
         match resource_type {
             "Parameter" => {
-                let param = state
-                    .parameters
-                    .get_mut(resource_id)
+                let param = lookup_param_mut(&mut state.parameters, resource_id)
                     .ok_or_else(|| invalid_resource_id(resource_id))?;
 
                 for key in tag_keys {
@@ -1028,9 +1085,7 @@ impl SsmService {
 
         let tags: Vec<Value> = match resource_type {
             "Parameter" => {
-                let param = state
-                    .parameters
-                    .get(resource_id)
+                let param = lookup_param(&state.parameters, resource_id)
                     .ok_or_else(|| invalid_resource_id(resource_id))?;
                 param
                     .tags
@@ -1071,10 +1126,8 @@ impl SsmService {
         let version = body["ParameterVersion"].as_i64();
 
         let mut state = self.state.write();
-        let param = state
-            .parameters
-            .get_mut(name)
-            .ok_or_else(|| param_not_found(name))?;
+        let param =
+            lookup_param_mut(&mut state.parameters, name).ok_or_else(|| param_not_found(name))?;
 
         let target_version = version.unwrap_or(param.version);
 
@@ -1179,10 +1232,8 @@ impl SsmService {
             .ok_or_else(|| missing("ParameterVersion"))?;
 
         let mut state = self.state.write();
-        let param = state
-            .parameters
-            .get_mut(name)
-            .ok_or_else(|| param_not_found(name))?;
+        let param =
+            lookup_param_mut(&mut state.parameters, name).ok_or_else(|| param_not_found(name))?;
 
         // Validate version exists
         let version_exists =
@@ -1669,7 +1720,10 @@ impl SsmService {
         let comment = body["Comment"].as_str().map(|s| s.to_string());
         let output_s3_bucket = body["OutputS3BucketName"].as_str().map(|s| s.to_string());
         let output_s3_prefix = body["OutputS3KeyPrefix"].as_str().map(|s| s.to_string());
+        let output_s3_region = body["OutputS3Region"].as_str().map(|s| s.to_string());
         let timeout = body["TimeoutSeconds"].as_i64();
+        let max_concurrency = body["MaxConcurrency"].as_str().map(|s| s.to_string());
+        let max_errors = body["MaxErrors"].as_str().map(|s| s.to_string());
         let service_role = body["ServiceRoleArn"].as_str().map(|s| s.to_string());
         let notification = body.get("NotificationConfig").cloned();
 
@@ -1703,6 +1757,7 @@ impl SsmService {
         let mut state = self.state.write();
         state.commands.push(cmd);
 
+        let expires = now + chrono::Duration::seconds(timeout.unwrap_or(3600));
         let cmd_json = json!({
             "Command": {
                 "CommandId": command_id,
@@ -1713,10 +1768,16 @@ impl SsmService {
                 "Status": "Success",
                 "StatusDetails": "Details placeholder",
                 "RequestedDateTime": now.timestamp_millis() as f64 / 1000.0,
+                "ExpiresAfter": expires.timestamp_millis() as f64 / 1000.0,
                 "Comment": comment,
+                "OutputS3Region": output_s3_region,
                 "OutputS3BucketName": output_s3_bucket,
                 "OutputS3KeyPrefix": output_s3_prefix,
                 "ServiceRoleArn": service_role,
+                "TimeoutSeconds": timeout,
+                "MaxConcurrency": max_concurrency.unwrap_or_default(),
+                "MaxErrors": max_errors.unwrap_or_default(),
+                "DeliveryTimedOutCount": 0,
             }
         });
 
@@ -1746,6 +1807,8 @@ impl SsmService {
                 true
             })
             .map(|c| {
+                let expires = c.requested_date_time
+                    + chrono::Duration::seconds(c.timeout_seconds.unwrap_or(3600));
                 json!({
                     "CommandId": c.command_id,
                     "DocumentName": c.document_name,
@@ -1755,7 +1818,12 @@ impl SsmService {
                     "Status": c.status,
                     "StatusDetails": "Details placeholder",
                     "RequestedDateTime": c.requested_date_time.timestamp_millis() as f64 / 1000.0,
+                    "ExpiresAfter": expires.timestamp_millis() as f64 / 1000.0,
                     "Comment": c.comment,
+                    "OutputS3Region": c.output_s3_bucket_name,
+                    "OutputS3BucketName": c.output_s3_bucket_name,
+                    "OutputS3KeyPrefix": c.output_s3_key_prefix,
+                    "DeliveryTimedOutCount": 0,
                 })
             })
             .collect();
@@ -1978,21 +2046,15 @@ fn resolve_param_by_name_or_arn<'a>(
     state: &'a crate::state::SsmState,
     name: &str,
 ) -> Result<&'a SsmParameter, AwsServiceError> {
-    // Direct name lookup
-    if let Some(p) = state.parameters.get(name) {
+    // Direct name lookup with normalization
+    if let Some(p) = lookup_param(&state.parameters, name) {
         return Ok(p);
     }
 
-    // ARN lookup: arn:aws:ssm:REGION:ACCOUNT:parameter/NAME or parameter/NAME
+    // ARN lookup: arn:aws:ssm:REGION:ACCOUNT:parameter/NAME
     if name.starts_with("arn:aws:ssm:") {
         if let Some(param_part) = name.split(":parameter").nth(1) {
-            let param_name = param_part.to_string();
-            if let Some(p) = state.parameters.get(&param_name) {
-                return Ok(p);
-            }
-            // Try with leading slash
-            let with_slash = format!("/{}", param_name.trim_start_matches('/'));
-            if let Some(p) = state.parameters.get(&with_slash) {
+            if let Some(p) = lookup_param(&state.parameters, param_part) {
                 return Ok(p);
             }
         }

--- a/crates/fakecloud-ssm/src/service.rs
+++ b/crates/fakecloud-ssm/src/service.rs
@@ -117,7 +117,7 @@ fn param_to_json(p: &SsmParameter, with_value: bool, with_decryption: bool) -> V
         "Type": p.param_type,
         "Version": p.version,
         "ARN": p.arn,
-        "LastModifiedDate": p.last_modified.timestamp() as f64,
+        "LastModifiedDate": p.last_modified.timestamp_millis() as f64 / 1000.0,
         "DataType": p.data_type,
     });
     if with_value {
@@ -136,7 +136,8 @@ fn param_to_describe_json(p: &SsmParameter) -> Value {
         "Type": p.param_type,
         "Version": p.version,
         "ARN": p.arn,
-        "LastModifiedDate": p.last_modified.timestamp() as f64,
+        "LastModifiedDate": p.last_modified.timestamp_millis() as f64 / 1000.0,
+        "LastModifiedUser": "N/A",
         "DataType": p.data_type,
         "Tier": p.tier,
     });
@@ -401,6 +402,10 @@ impl SsmService {
             if key_id.is_some() {
                 existing.key_id = key_id;
             }
+            // Always update data_type if explicitly provided
+            if body["DataType"].as_str().is_some() {
+                existing.data_type = data_type;
+            }
 
             let resp_tier = existing.tier.clone();
             return Ok(json_resp(json!({
@@ -461,14 +466,22 @@ impl SsmService {
         let raw_name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
 
+        let state = self.state.read();
+
+        // Handle ARN-style names directly (they contain many colons)
+        if raw_name.starts_with("arn:aws:ssm:") {
+            let param = resolve_param_by_name_or_arn(&state, raw_name)?;
+            return Ok(json_resp(json!({
+                "Parameter": param_to_json(param, true, with_decryption),
+            })));
+        }
+
         let (base_name, selector) = parse_param_selector(raw_name);
 
         // Check for invalid selectors (too many colons)
         if let ParamSelector::Invalid(n) = selector {
             return Err(param_not_found(&n));
         }
-
-        let state = self.state.read();
 
         // Try looking up by name or by ARN
         let param = resolve_param_by_name_or_arn(&state, base_name)?;
@@ -490,7 +503,7 @@ impl SsmService {
                         "Type": hist.param_type,
                         "Version": hist.version,
                         "ARN": param.arn,
-                        "LastModifiedDate": hist.last_modified.timestamp() as f64,
+                        "LastModifiedDate": hist.last_modified.timestamp_millis() as f64 / 1000.0,
                         "DataType": param.data_type,
                     });
                     if param.param_type == "SecureString" && !with_decryption {
@@ -525,7 +538,7 @@ impl SsmService {
                                 "Type": hist.param_type,
                                 "Version": hist.version,
                                 "ARN": param.arn,
-                                "LastModifiedDate": hist.last_modified.timestamp() as f64,
+                                "LastModifiedDate": hist.last_modified.timestamp_millis() as f64 / 1000.0,
                                 "DataType": param.data_type,
                             });
                             if param.param_type == "SecureString" && !with_decryption {
@@ -608,7 +621,7 @@ impl SsmService {
                                     "Type": hist.param_type,
                                     "Version": hist.version,
                                     "ARN": param.arn,
-                                    "LastModifiedDate": hist.last_modified.timestamp() as f64,
+                                    "LastModifiedDate": hist.last_modified.timestamp_millis() as f64 / 1000.0,
                                     "DataType": param.data_type,
                                 });
                                 v["Value"] = json!(hist.value);
@@ -639,7 +652,7 @@ impl SsmService {
                                             "Type": hist.param_type,
                                             "Version": hist.version,
                                             "ARN": param.arn,
-                                            "LastModifiedDate": hist.last_modified.timestamp() as f64,
+                                            "LastModifiedDate": hist.last_modified.timestamp_millis() as f64 / 1000.0,
                                             "DataType": param.data_type,
                                         });
                                         v["Value"] = json!(hist.value);
@@ -853,7 +866,7 @@ impl SsmService {
                     "Name": param.name,
                     "Value": h.value,
                     "Version": h.version,
-                    "LastModifiedDate": h.last_modified.timestamp() as f64,
+                    "LastModifiedDate": h.last_modified.timestamp_millis() as f64 / 1000.0,
                     "Type": h.param_type,
                 });
                 if let Some(desc) = &h.description {
@@ -875,7 +888,7 @@ impl SsmService {
             "Name": param.name,
             "Value": param.value,
             "Version": param.version,
-            "LastModifiedDate": param.last_modified.timestamp() as f64,
+            "LastModifiedDate": param.last_modified.timestamp_millis() as f64 / 1000.0,
             "Type": param.param_type,
         });
         if let Some(desc) = &param.description {
@@ -1297,7 +1310,7 @@ impl SsmService {
                 "LatestVersion": "1",
                 "DefaultVersion": "1",
                 "Status": "Active",
-                "CreatedDate": now.timestamp() as f64,
+                "CreatedDate": now.timestamp_millis() as f64 / 1000.0,
                 "Owner": state.account_id,
                 "SchemaVersion": "2.2",
                 "PlatformTypes": ["Linux", "MacOS", "Windows"],
@@ -1333,7 +1346,7 @@ impl SsmService {
             "DocumentVersion": ver.document_version,
             "VersionName": ver.version_name,
             "Status": ver.status,
-            "CreatedDate": ver.created_date.timestamp() as f64,
+            "CreatedDate": ver.created_date.timestamp_millis() as f64 / 1000.0,
         })))
     }
 
@@ -1391,7 +1404,7 @@ impl SsmService {
                 "LatestVersion": doc.latest_version,
                 "DefaultVersion": doc.default_version,
                 "Status": "Active",
-                "CreatedDate": doc.created_date.timestamp() as f64,
+                "CreatedDate": doc.created_date.timestamp_millis() as f64 / 1000.0,
                 "Owner": doc.owner,
                 "SchemaVersion": "2.2",
             }
@@ -1418,7 +1431,7 @@ impl SsmService {
                 "LatestVersion": doc.latest_version,
                 "DefaultVersion": doc.default_version,
                 "Status": doc.status,
-                "CreatedDate": doc.created_date.timestamp() as f64,
+                "CreatedDate": doc.created_date.timestamp_millis() as f64 / 1000.0,
                 "Owner": doc.owner,
                 "SchemaVersion": "2.2",
                 "PlatformTypes": ["Linux", "MacOS", "Windows"],
@@ -1695,7 +1708,7 @@ impl SsmService {
                 "Parameters": parameters,
                 "Status": "Success",
                 "StatusDetails": "Details placeholder",
-                "RequestedDateTime": now.timestamp() as f64,
+                "RequestedDateTime": now.timestamp_millis() as f64 / 1000.0,
                 "Comment": comment,
                 "OutputS3BucketName": output_s3_bucket,
                 "OutputS3KeyPrefix": output_s3_prefix,
@@ -1737,7 +1750,7 @@ impl SsmService {
                     "Parameters": c.parameters,
                     "Status": c.status,
                     "StatusDetails": "Details placeholder",
-                    "RequestedDateTime": c.requested_date_time.timestamp() as f64,
+                    "RequestedDateTime": c.requested_date_time.timestamp_millis() as f64 / 1000.0,
                     "Comment": c.comment,
                 })
             })
@@ -1805,7 +1818,7 @@ impl SsmService {
                         "DocumentName": c.document_name,
                         "Status": "Success",
                         "StatusDetails": "Success",
-                        "RequestedDateTime": c.requested_date_time.timestamp() as f64,
+                        "RequestedDateTime": c.requested_date_time.timestamp_millis() as f64 / 1000.0,
                         "Comment": c.comment,
                     })
                 })

--- a/crates/fakecloud-ssm/src/service.rs
+++ b/crates/fakecloud-ssm/src/service.rs
@@ -7,7 +7,11 @@ use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
-use crate::state::{SharedSsmState, SsmParameter, SsmParameterVersion};
+use crate::state::{
+    SharedSsmState, SsmCommand, SsmDocument, SsmDocumentVersion, SsmParameter, SsmParameterVersion,
+};
+
+const PARAMETER_VERSION_LIMIT: i64 = 100;
 
 pub struct SsmService {
     state: SharedSsmState,
@@ -39,6 +43,21 @@ impl AwsService for SsmService {
             "RemoveTagsFromResource" => self.remove_tags_from_resource(&req),
             "ListTagsForResource" => self.list_tags_for_resource(&req),
             "LabelParameterVersion" => self.label_parameter_version(&req),
+            "UnlabelParameterVersion" => self.unlabel_parameter_version(&req),
+            "CreateDocument" => self.create_document(&req),
+            "GetDocument" => self.get_document(&req),
+            "DeleteDocument" => self.delete_document(&req),
+            "UpdateDocument" => self.update_document(&req),
+            "DescribeDocument" => self.describe_document(&req),
+            "UpdateDocumentDefaultVersion" => self.update_document_default_version(&req),
+            "ListDocuments" => self.list_documents(&req),
+            "DescribeDocumentPermission" => self.describe_document_permission(&req),
+            "ModifyDocumentPermission" => self.modify_document_permission(&req),
+            "SendCommand" => self.send_command(&req),
+            "ListCommands" => self.list_commands(&req),
+            "GetCommandInvocation" => self.get_command_invocation(&req),
+            "ListCommandInvocations" => self.list_command_invocations(&req),
+            "CancelCommand" => self.cancel_command(&req),
             _ => Err(AwsServiceError::action_not_implemented("ssm", &req.action)),
         }
     }
@@ -57,6 +76,21 @@ impl AwsService for SsmService {
             "RemoveTagsFromResource",
             "ListTagsForResource",
             "LabelParameterVersion",
+            "UnlabelParameterVersion",
+            "CreateDocument",
+            "GetDocument",
+            "DeleteDocument",
+            "UpdateDocument",
+            "DescribeDocument",
+            "UpdateDocumentDefaultVersion",
+            "ListDocuments",
+            "DescribeDocumentPermission",
+            "ModifyDocumentPermission",
+            "SendCommand",
+            "ListCommands",
+            "GetCommandInvocation",
+            "ListCommandInvocations",
+            "CancelCommand",
         ]
     }
 }
@@ -69,6 +103,14 @@ fn json_resp(body: Value) -> AwsResponse {
     AwsResponse::json(StatusCode::OK, serde_json::to_string(&body).unwrap())
 }
 
+fn param_arn(region: &str, account_id: &str, name: &str) -> String {
+    if name.starts_with('/') {
+        format!("arn:aws:ssm:{region}:{account_id}:parameter{name}")
+    } else {
+        format!("arn:aws:ssm:{region}:{account_id}:parameter/{name}")
+    }
+}
+
 fn param_to_json(p: &SsmParameter, with_value: bool, with_decryption: bool) -> Value {
     let mut v = json!({
         "Name": p.name,
@@ -76,7 +118,7 @@ fn param_to_json(p: &SsmParameter, with_value: bool, with_decryption: bool) -> V
         "Version": p.version,
         "ARN": p.arn,
         "LastModifiedDate": p.last_modified.timestamp() as f64,
-        "DataType": "text",
+        "DataType": p.data_type,
     });
     if with_value {
         if p.param_type == "SecureString" && !with_decryption {
@@ -86,6 +128,119 @@ fn param_to_json(p: &SsmParameter, with_value: bool, with_decryption: bool) -> V
         }
     }
     v
+}
+
+fn param_to_describe_json(p: &SsmParameter) -> Value {
+    let mut v = json!({
+        "Name": p.name,
+        "Type": p.param_type,
+        "Version": p.version,
+        "ARN": p.arn,
+        "LastModifiedDate": p.last_modified.timestamp() as f64,
+        "DataType": p.data_type,
+        "Tier": p.tier,
+    });
+    if let Some(desc) = &p.description {
+        v["Description"] = json!(desc);
+    }
+    if let Some(pattern) = &p.allowed_pattern {
+        v["AllowedPattern"] = json!(pattern);
+    }
+    if let Some(key_id) = &p.key_id {
+        v["KeyId"] = json!(key_id);
+    }
+    // Add policies if present and valid JSON
+    if let Some(policies_str) = &p.policies {
+        if let Ok(parsed) = serde_json::from_str::<Value>(policies_str) {
+            if let Some(arr) = parsed.as_array() {
+                let policy_objects: Vec<Value> = arr
+                    .iter()
+                    .filter_map(|p| p.as_str())
+                    .map(|p| {
+                        json!({
+                            "PolicyText": p,
+                            "PolicyType": p,
+                            "PolicyStatus": "Finished",
+                        })
+                    })
+                    .collect();
+                if !policy_objects.is_empty() {
+                    v["Policies"] = json!(policy_objects);
+                }
+            }
+        }
+    }
+    v
+}
+
+/// Validate parameter name restrictions. Returns an error message string on failure.
+fn validate_param_name(name: &str) -> Option<AwsServiceError> {
+    let lower = name.to_lowercase();
+
+    if let Some(stripped) = name.strip_prefix('/') {
+        // Path-style names
+        let first_segment = stripped.split('/').next().unwrap_or("");
+        let first_lower = first_segment.to_lowercase();
+        if first_lower.starts_with("aws") {
+            return Some(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!("No access to reserved parameter name: {name}."),
+            ));
+        }
+        if first_lower.starts_with("ssm") {
+            return Some(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Parameter name: can't be prefixed with \"ssm\" (case-insensitive). \
+                 If formed as a path, it can consist of sub-paths divided by slash \
+                 symbol; each sub-path can be formed as a mix of letters, numbers \
+                 and the following 3 symbols .-_"
+                    .to_string(),
+            ));
+        }
+    } else {
+        // Non-path names
+        if lower.starts_with("aws") || lower.starts_with("ssm") {
+            return Some(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Parameter name: can't be prefixed with \"aws\" or \"ssm\" (case-insensitive)."
+                    .to_string(),
+            ));
+        }
+    }
+    None
+}
+
+/// Parse a parameter name that may include version or label selector.
+/// Returns (base_name, selector) where selector can be version number or label string.
+enum ParamSelector {
+    None,
+    Version(i64),
+    Label(String),
+    Invalid(String), // name with too many colons
+}
+
+fn parse_param_selector(name: &str) -> (&str, ParamSelector) {
+    // Check for `:` separator (version or label)
+    if let Some(colon_pos) = name.rfind(':') {
+        let base = &name[..colon_pos];
+        let selector = &name[colon_pos + 1..];
+
+        // Check if there's another colon (invalid)
+        if base.contains(':') {
+            return (name, ParamSelector::Invalid(name.to_string()));
+        }
+
+        if let Ok(version) = selector.parse::<i64>() {
+            (base, ParamSelector::Version(version))
+        } else {
+            (base, ParamSelector::Label(selector.to_string()))
+        }
+    } else {
+        (name, ParamSelector::None)
+    }
 }
 
 impl SsmService {
@@ -99,50 +254,182 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("Value"))?
             .to_string();
-        let param_type = body["Type"].as_str().unwrap_or("String").to_string();
+
+        // Validate empty value
+        if value.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "1 validation error detected: \
+                 Value '' at 'value' failed to satisfy constraint: \
+                 Member must have length greater than or equal to 1.",
+            ));
+        }
+
+        let param_type = body["Type"].as_str().map(|s| s.to_string());
         let overwrite = body["Overwrite"].as_bool().unwrap_or(false);
+        let description = body["Description"].as_str().map(|s| s.to_string());
+        let key_id = body["KeyId"].as_str().map(|s| s.to_string());
+        let allowed_pattern = body["AllowedPattern"].as_str().map(|s| s.to_string());
+        let data_type = body["DataType"].as_str().unwrap_or("text").to_string();
+        let tier = body["Tier"].as_str().unwrap_or("Standard").to_string();
+        let policies = body["Policies"].as_str().map(|s| s.to_string());
+        let tags: Option<Vec<(String, String)>> = body["Tags"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|t| {
+                    let k = t["Key"].as_str()?;
+                    let v = t["Value"].as_str()?;
+                    Some((k.to_string(), v.to_string()))
+                })
+                .collect()
+        });
+
+        // Validate data type
+        if !["text", "aws:ec2:image"].contains(&data_type.as_str()) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "The following data type is not supported: {data_type} \
+                     (Data type names are all lowercase.)"
+                ),
+            ));
+        }
+
+        // Validate param type
+        if let Some(ref pt) = param_type {
+            if !["String", "StringList", "SecureString"].contains(&pt.as_str()) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!(
+                        "1 validation error detected: Value '{pt}' at 'type' \
+                         failed to satisfy constraint: Member must satisfy enum value set: \
+                         [SecureString, StringList, String]"
+                    ),
+                ));
+            }
+        }
+
+        // Validate name
+        if let Some(err) = validate_param_name(&name) {
+            return Err(err);
+        }
 
         let mut state = self.state.write();
 
         if let Some(existing) = state.parameters.get_mut(&name) {
             if !overwrite {
-                // Terraform compat: if the value and type are identical, treat as
-                // idempotent and return success instead of erroring. Terraform
-                // re-calls PutParameter on re-apply without setting Overwrite.
-                if existing.value == value && existing.param_type == param_type {
-                    return Ok(json_resp(json!({
-                        "Version": existing.version,
-                        "Tier": "Standard",
-                    })));
-                }
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "ParameterAlreadyExists",
-                    format!("The parameter {name} already exists."),
+                    "The parameter already exists. To overwrite this value, set the \
+                     overwrite option in the request to true.",
                 ));
             }
+
+            // Cannot have tags and overwrite at the same time
+            if tags.is_some() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Invalid request: tags and overwrite can't be used together.",
+                ));
+            }
+
+            // Check version limit
+            if existing.version >= PARAMETER_VERSION_LIMIT {
+                // Check if oldest version has a label
+                let oldest_version = existing
+                    .history
+                    .first()
+                    .map(|h| h.version)
+                    .unwrap_or(existing.version);
+                let oldest_has_label = existing
+                    .labels
+                    .get(&oldest_version)
+                    .is_some_and(|l| !l.is_empty());
+
+                if oldest_has_label {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ParameterMaxVersionLimitExceeded",
+                        format!(
+                            "You attempted to create a new version of {} by calling \
+                             the PutParameter API with the overwrite flag. Version {}, \
+                             the oldest version, can't be deleted because it has a label \
+                             associated with it. Move the label to another version of the \
+                             parameter, and try again.",
+                            name, oldest_version
+                        ),
+                    ));
+                }
+
+                // Delete oldest version from history to make room
+                if !existing.history.is_empty() {
+                    let removed = existing.history.remove(0);
+                    existing.labels.remove(&removed.version);
+                }
+            }
+
             let now = Utc::now();
+            let current_labels = existing
+                .labels
+                .get(&existing.version)
+                .cloned()
+                .unwrap_or_default();
             existing.history.push(SsmParameterVersion {
                 value: existing.value.clone(),
                 version: existing.version,
                 last_modified: existing.last_modified,
+                param_type: existing.param_type.clone(),
+                description: existing.description.clone(),
+                key_id: existing.key_id.clone(),
+                labels: current_labels,
             });
             existing.version += 1;
             existing.value = value;
-            existing.param_type = param_type;
             existing.last_modified = now;
 
+            // Only update these if provided
+            if let Some(pt) = param_type {
+                existing.param_type = pt;
+            }
+            if description.is_some() {
+                existing.description = description;
+            }
+            if key_id.is_some() {
+                existing.key_id = key_id;
+            }
+
+            let resp_tier = existing.tier.clone();
             return Ok(json_resp(json!({
                 "Version": existing.version,
-                "Tier": "Standard",
+                "Tier": resp_tier,
             })));
         }
 
+        // New parameter - type is required
+        let param_type = match param_type {
+            Some(pt) => pt,
+            None => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "A parameter type is required when you create a parameter.",
+                ));
+            }
+        };
+
         let now = Utc::now();
-        let arn = format!(
-            "arn:aws:ssm:{}:{}:parameter{}",
-            state.region, state.account_id, name
-        );
+        let arn = param_arn(&state.region, &state.account_id, &name);
+
+        let mut tag_map = HashMap::new();
+        if let Some(tag_list) = tags {
+            for (k, v) in tag_list {
+                tag_map.insert(k, v);
+            }
+        }
 
         let param = SsmParameter {
             name: name.clone(),
@@ -153,30 +440,115 @@ impl SsmService {
             last_modified: now,
             history: Vec::new(),
             labels: HashMap::new(),
-            tags: HashMap::new(),
+            tags: tag_map,
+            description,
+            allowed_pattern,
+            key_id,
+            data_type,
+            tier: tier.clone(),
+            policies,
         };
 
         state.parameters.insert(name, param);
         Ok(json_resp(json!({
             "Version": 1,
-            "Tier": "Standard",
+            "Tier": tier,
         })))
     }
 
     fn get_parameter(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
-        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let raw_name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
 
-        let state = self.state.read();
-        let param = state
-            .parameters
-            .get(name)
-            .ok_or_else(|| param_not_found(name))?;
+        let (base_name, selector) = parse_param_selector(raw_name);
 
-        Ok(json_resp(json!({
-            "Parameter": param_to_json(param, true, with_decryption),
-        })))
+        // Check for invalid selectors (too many colons)
+        if let ParamSelector::Invalid(n) = selector {
+            return Err(param_not_found(&n));
+        }
+
+        let state = self.state.read();
+
+        // Try looking up by name or by ARN
+        let param = resolve_param_by_name_or_arn(&state, base_name)?;
+
+        match selector {
+            ParamSelector::None => Ok(json_resp(json!({
+                "Parameter": param_to_json(param, true, with_decryption),
+            }))),
+            ParamSelector::Version(ver) => {
+                if param.version == ver {
+                    return Ok(json_resp(json!({
+                        "Parameter": param_to_json(param, true, with_decryption),
+                    })));
+                }
+                // Look in history
+                if let Some(hist) = param.history.iter().find(|h| h.version == ver) {
+                    let mut v = json!({
+                        "Name": param.name,
+                        "Type": hist.param_type,
+                        "Version": hist.version,
+                        "ARN": param.arn,
+                        "LastModifiedDate": hist.last_modified.timestamp() as f64,
+                        "DataType": param.data_type,
+                    });
+                    if param.param_type == "SecureString" && !with_decryption {
+                        v["Value"] = json!("****");
+                    } else {
+                        v["Value"] = json!(hist.value);
+                    }
+                    return Ok(json_resp(json!({ "Parameter": v })));
+                }
+                Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ParameterVersionNotFound",
+                    format!(
+                        "Systems Manager could not find version {} of {}. \
+                         Verify the version and try again.",
+                        ver, base_name
+                    ),
+                ))
+            }
+            ParamSelector::Label(label) => {
+                // Find version with this label
+                for (ver, labels) in &param.labels {
+                    if labels.contains(&label) {
+                        if *ver == param.version {
+                            return Ok(json_resp(json!({
+                                "Parameter": param_to_json(param, true, with_decryption),
+                            })));
+                        }
+                        if let Some(hist) = param.history.iter().find(|h| h.version == *ver) {
+                            let mut v = json!({
+                                "Name": param.name,
+                                "Type": hist.param_type,
+                                "Version": hist.version,
+                                "ARN": param.arn,
+                                "LastModifiedDate": hist.last_modified.timestamp() as f64,
+                                "DataType": param.data_type,
+                            });
+                            if param.param_type == "SecureString" && !with_decryption {
+                                v["Value"] = json!("****");
+                            } else {
+                                v["Value"] = json!(hist.value);
+                            }
+                            return Ok(json_resp(json!({ "Parameter": v })));
+                        }
+                    }
+                }
+                Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ParameterVersionLabelNotFound",
+                    format!(
+                        "Systems Manager could not find label {} for parameter {}. \
+                         Verify the label and try again.",
+                        label, base_name
+                    ),
+                ))
+            }
+            ParamSelector::Invalid(_) => unreachable!(),
+        }
     }
 
     fn get_parameters(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -184,16 +556,106 @@ impl SsmService {
         let names = body["Names"].as_array().ok_or_else(|| missing("Names"))?;
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
 
+        // Validate max 10 names
+        if names.len() > 10 {
+            let name_strs: Vec<&str> = names.iter().filter_map(|n| n.as_str()).collect();
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "1 validation error detected: \
+                     Value '[{}]' at 'names' failed to satisfy constraint: \
+                     Member must have length less than or equal to 10.",
+                    name_strs.join(", ")
+                ),
+            ));
+        }
+
         let state = self.state.read();
         let mut parameters = Vec::new();
         let mut invalid = Vec::new();
+        let mut seen_names = std::collections::HashSet::new();
 
         for name_val in names {
-            if let Some(name) = name_val.as_str() {
-                if let Some(param) = state.parameters.get(name) {
-                    parameters.push(param_to_json(param, true, with_decryption));
-                } else {
-                    invalid.push(name.to_string());
+            if let Some(raw_name) = name_val.as_str() {
+                // Deduplicate
+                if !seen_names.insert(raw_name.to_string()) {
+                    continue;
+                }
+
+                let (base_name, selector) = parse_param_selector(raw_name);
+
+                match selector {
+                    ParamSelector::Invalid(_) => {
+                        invalid.push(raw_name.to_string());
+                    }
+                    ParamSelector::None => {
+                        if let Some(param) = state.parameters.get(base_name) {
+                            parameters.push(param_to_json(param, true, with_decryption));
+                        } else {
+                            invalid.push(raw_name.to_string());
+                        }
+                    }
+                    ParamSelector::Version(ver) => {
+                        if let Some(param) = state.parameters.get(base_name) {
+                            if param.version == ver {
+                                parameters.push(param_to_json(param, true, with_decryption));
+                            } else if let Some(hist) =
+                                param.history.iter().find(|h| h.version == ver)
+                            {
+                                let mut v = json!({
+                                    "Name": param.name,
+                                    "Type": hist.param_type,
+                                    "Version": hist.version,
+                                    "ARN": param.arn,
+                                    "LastModifiedDate": hist.last_modified.timestamp() as f64,
+                                    "DataType": param.data_type,
+                                });
+                                v["Value"] = json!(hist.value);
+                                parameters.push(v);
+                            } else {
+                                invalid.push(raw_name.to_string());
+                            }
+                        } else {
+                            invalid.push(raw_name.to_string());
+                        }
+                    }
+                    ParamSelector::Label(ref label) => {
+                        if let Some(param) = state.parameters.get(base_name) {
+                            let mut found = false;
+                            for (ver, labels) in &param.labels {
+                                if labels.contains(label) {
+                                    if *ver == param.version {
+                                        parameters.push(param_to_json(
+                                            param,
+                                            true,
+                                            with_decryption,
+                                        ));
+                                    } else if let Some(hist) =
+                                        param.history.iter().find(|h| h.version == *ver)
+                                    {
+                                        let mut v = json!({
+                                            "Name": param.name,
+                                            "Type": hist.param_type,
+                                            "Version": hist.version,
+                                            "ARN": param.arn,
+                                            "LastModifiedDate": hist.last_modified.timestamp() as f64,
+                                            "DataType": param.data_type,
+                                        });
+                                        v["Value"] = json!(hist.value);
+                                        parameters.push(v);
+                                    }
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if !found {
+                                invalid.push(raw_name.to_string());
+                            }
+                        } else {
+                            invalid.push(raw_name.to_string());
+                        }
+                    }
                 }
             }
         }
@@ -223,22 +685,46 @@ impl SsmService {
             format!("{path}/")
         };
 
+        let is_root = path == "/";
+
         let all_params: Vec<&SsmParameter> = state
             .parameters
-            .range(prefix.clone()..)
-            .take_while(|(k, _)| k.starts_with(&prefix))
-            .filter(|(k, _)| {
-                if recursive {
-                    true
+            .values()
+            .filter(|p| {
+                if is_root {
+                    if recursive {
+                        true
+                    } else {
+                        // Root level: params without '/' or with exactly one leading '/'
+                        // and no further '/' in the name
+                        if p.name.starts_with('/') {
+                            // e.g., "/foo" is root-level, "/foo/bar" is not
+                            !p.name[1..].contains('/')
+                        } else {
+                            // Non-path params like "foo" are at root
+                            !p.name.contains('/')
+                        }
+                    }
                 } else {
-                    !k[prefix.len()..].contains('/')
+                    if p.name.starts_with(&prefix) {
+                        if recursive {
+                            true
+                        } else {
+                            !p.name[prefix.len()..].contains('/')
+                        }
+                    } else {
+                        false
+                    }
                 }
             })
-            .filter(|(_, p)| apply_parameter_filters(p, filters.as_ref()))
-            .map(|(_, p)| p)
+            .filter(|p| apply_parameter_filters(p, filters.as_ref()))
             .collect();
 
-        let page = &all_params[next_token_offset..];
+        let page = if next_token_offset < all_params.len() {
+            &all_params[next_token_offset..]
+        } else {
+            &[]
+        };
         let has_more = page.len() > max_results;
         let parameters: Vec<Value> = page
             .iter()
@@ -292,7 +778,8 @@ impl SsmService {
 
     fn describe_parameters(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
-        let filters = body["ParameterFilters"].as_array().cloned();
+        let param_filters = body["ParameterFilters"].as_array().cloned();
+        let old_filters = body["Filters"].as_array().cloned();
         let max_results = body["MaxResults"].as_i64().unwrap_or(10) as usize;
         let next_token_offset: usize = body["NextToken"]
             .as_str()
@@ -303,15 +790,20 @@ impl SsmService {
         let all_params: Vec<&SsmParameter> = state
             .parameters
             .values()
-            .filter(|p| apply_parameter_filters(p, filters.as_ref()))
+            .filter(|p| apply_parameter_filters(p, param_filters.as_ref()))
+            .filter(|p| apply_old_filters(p, old_filters.as_ref()))
             .collect();
 
-        let page = &all_params[next_token_offset..];
+        let page = if next_token_offset < all_params.len() {
+            &all_params[next_token_offset..]
+        } else {
+            &[]
+        };
         let has_more = page.len() > max_results;
         let parameters: Vec<Value> = page
             .iter()
             .take(max_results)
-            .map(|p| param_to_json(p, false, false))
+            .map(|p| param_to_describe_json(p))
             .collect();
 
         let mut resp = json!({ "Parameters": parameters });
@@ -325,6 +817,27 @@ impl SsmService {
     fn get_parameter_history(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let max_results = body["MaxResults"].as_i64();
+        let next_token_offset: usize = body["NextToken"]
+            .as_str()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        // Validate MaxResults
+        if let Some(mr) = max_results {
+            if mr > 50 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!(
+                        "1 validation error detected: Value '{mr}' at 'maxResults' \
+                         failed to satisfy constraint: Member must have value less than \
+                         or equal to 50."
+                    ),
+                ));
+            }
+        }
+        let max_results = max_results.unwrap_or(50) as usize;
 
         let state = self.state.read();
         let param = state
@@ -332,7 +845,7 @@ impl SsmService {
             .get(name)
             .ok_or_else(|| param_not_found(name))?;
 
-        let mut history: Vec<Value> = param
+        let mut all_history: Vec<Value> = param
             .history
             .iter()
             .map(|h| {
@@ -341,9 +854,16 @@ impl SsmService {
                     "Value": h.value,
                     "Version": h.version,
                     "LastModifiedDate": h.last_modified.timestamp() as f64,
-                    "Type": param.param_type,
+                    "Type": h.param_type,
                 });
-                if let Some(labels) = param.labels.get(&h.version) {
+                if let Some(desc) = &h.description {
+                    entry["Description"] = json!(desc);
+                }
+                if let Some(kid) = &h.key_id {
+                    entry["KeyId"] = json!(kid);
+                }
+                let labels = param.labels.get(&h.version).cloned().unwrap_or_default();
+                if !labels.is_empty() {
                     entry["Labels"] = json!(labels);
                 }
                 entry
@@ -358,29 +878,83 @@ impl SsmService {
             "LastModifiedDate": param.last_modified.timestamp() as f64,
             "Type": param.param_type,
         });
-        if let Some(labels) = param.labels.get(&param.version) {
-            current["Labels"] = json!(labels);
+        if let Some(desc) = &param.description {
+            current["Description"] = json!(desc);
         }
-        history.push(current);
+        if let Some(kid) = &param.key_id {
+            current["KeyId"] = json!(kid);
+        }
+        let current_labels = param
+            .labels
+            .get(&param.version)
+            .cloned()
+            .unwrap_or_default();
+        if !current_labels.is_empty() {
+            current["Labels"] = json!(current_labels);
+        }
+        all_history.push(current);
 
-        Ok(json_resp(json!({ "Parameters": history })))
+        let page = if next_token_offset < all_history.len() {
+            &all_history[next_token_offset..]
+        } else {
+            &[]
+        };
+        let has_more = page.len() > max_results;
+        let result: Vec<Value> = page.iter().take(max_results).cloned().collect();
+
+        let mut resp = json!({ "Parameters": result });
+        if has_more {
+            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        }
+
+        Ok(json_resp(resp))
     }
+
     fn add_tags_to_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
+        let resource_type = body["ResourceType"].as_str().unwrap_or("Parameter");
         let resource_id = body["ResourceId"]
             .as_str()
             .ok_or_else(|| missing("ResourceId"))?;
         let tags = body["Tags"].as_array().ok_or_else(|| missing("Tags"))?;
 
         let mut state = self.state.write();
-        let param = state
-            .parameters
-            .get_mut(resource_id)
-            .ok_or_else(|| param_not_found(resource_id))?;
 
-        for tag in tags {
-            if let (Some(key), Some(val)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
-                param.tags.insert(key.to_string(), val.to_string());
+        match resource_type {
+            "Parameter" => {
+                let param = state
+                    .parameters
+                    .get_mut(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+
+                for tag in tags {
+                    if let (Some(key), Some(val)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
+                        param.tags.insert(key.to_string(), val.to_string());
+                    }
+                }
+            }
+            "Document" => {
+                let doc = state
+                    .documents
+                    .get_mut(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+
+                for tag in tags {
+                    if let (Some(key), Some(val)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
+                        doc.tags.insert(key.to_string(), val.to_string());
+                    }
+                }
+            }
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidResourceType",
+                    format!(
+                        "{resource_type} is not a valid resource type. \
+                         Valid resource types are: ManagedInstance, MaintenanceWindow, \
+                         Parameter, PatchBaseline, OpsItem, Document."
+                    ),
+                ));
             }
         }
 
@@ -389,6 +963,7 @@ impl SsmService {
 
     fn remove_tags_from_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
+        let resource_type = body["ResourceType"].as_str().unwrap_or("Parameter");
         let resource_id = body["ResourceId"]
             .as_str()
             .ok_or_else(|| missing("ResourceId"))?;
@@ -397,15 +972,33 @@ impl SsmService {
             .ok_or_else(|| missing("TagKeys"))?;
 
         let mut state = self.state.write();
-        let param = state
-            .parameters
-            .get_mut(resource_id)
-            .ok_or_else(|| param_not_found(resource_id))?;
 
-        for key in tag_keys {
-            if let Some(k) = key.as_str() {
-                param.tags.remove(k);
+        match resource_type {
+            "Parameter" => {
+                let param = state
+                    .parameters
+                    .get_mut(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+
+                for key in tag_keys {
+                    if let Some(k) = key.as_str() {
+                        param.tags.remove(k);
+                    }
+                }
             }
+            "Document" => {
+                let doc = state
+                    .documents
+                    .get_mut(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+
+                for key in tag_keys {
+                    if let Some(k) = key.as_str() {
+                        doc.tags.remove(k);
+                    }
+                }
+            }
+            _ => {}
         }
 
         Ok(json_resp(json!({})))
@@ -413,21 +1006,47 @@ impl SsmService {
 
     fn list_tags_for_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
+        let resource_type = body["ResourceType"].as_str().unwrap_or("Parameter");
         let resource_id = body["ResourceId"]
             .as_str()
             .ok_or_else(|| missing("ResourceId"))?;
 
         let state = self.state.read();
-        let param = state
-            .parameters
-            .get(resource_id)
-            .ok_or_else(|| param_not_found(resource_id))?;
 
-        let tags: Vec<Value> = param
-            .tags
-            .iter()
-            .map(|(k, v)| json!({"Key": k, "Value": v}))
-            .collect();
+        let tags: Vec<Value> = match resource_type {
+            "Parameter" => {
+                let param = state
+                    .parameters
+                    .get(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+                param
+                    .tags
+                    .iter()
+                    .map(|(k, v)| json!({"Key": k, "Value": v}))
+                    .collect()
+            }
+            "Document" => {
+                let doc = state
+                    .documents
+                    .get(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+                doc.tags
+                    .iter()
+                    .map(|(k, v)| json!({"Key": k, "Value": v}))
+                    .collect()
+            }
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidResourceType",
+                    format!(
+                        "{resource_type} is not a valid resource type. \
+                         Valid resource types are: ManagedInstance, MaintenanceWindow, \
+                         Parameter, PatchBaseline, OpsItem, Document."
+                    ),
+                ));
+            }
+        };
 
         Ok(json_resp(json!({ "TagList": tags })))
     }
@@ -453,7 +1072,10 @@ impl SsmService {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ParameterVersionNotFound",
-                format!("Version {target_version} of parameter {name} not found."),
+                format!(
+                    "Systems Manager could not find version {target_version} of {name}. \
+                     Verify the version and try again."
+                ),
             ));
         }
 
@@ -461,6 +1083,54 @@ impl SsmService {
             .iter()
             .filter_map(|l| l.as_str().map(|s| s.to_string()))
             .collect();
+
+        // Validate invalid labels (aws/ssm prefix)
+        let mut invalid_labels = Vec::new();
+        for label in &label_strings {
+            let lower = label.to_lowercase();
+            if lower.starts_with("aws") || lower.starts_with("ssm") {
+                invalid_labels.push(label.clone());
+            }
+        }
+        if !invalid_labels.is_empty() {
+            return Ok(json_resp(json!({
+                "InvalidLabels": invalid_labels,
+                "ParameterVersion": target_version,
+            })));
+        }
+
+        // Count current labels for target version
+        let current_count = param
+            .labels
+            .get(&target_version)
+            .map(|l| l.len())
+            .unwrap_or(0);
+        let new_unique: Vec<&String> = label_strings
+            .iter()
+            .filter(|l| {
+                !param
+                    .labels
+                    .get(&target_version)
+                    .is_some_and(|existing| existing.contains(l))
+            })
+            .collect();
+
+        if current_count + new_unique.len() > 10 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ParameterVersionLabelLimitExceeded",
+                format!(
+                    "A parameter version can have a maximum of 10 labels. \
+                     Attempting to add {} labels to version {} of parameter {} \
+                     would result in {} labels. Move one or more labels to \
+                     a different version and try again.",
+                    label_strings.len(),
+                    target_version,
+                    name,
+                    current_count + new_unique.len()
+                ),
+            ));
+        }
 
         // Remove these labels from any other version (labels are unique across versions)
         for existing_labels in param.labels.values_mut() {
@@ -482,9 +1152,689 @@ impl SsmService {
             "ParameterVersion": target_version,
         })))
     }
+
+    fn unlabel_parameter_version(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let labels = body["Labels"].as_array().ok_or_else(|| missing("Labels"))?;
+        let version = body["ParameterVersion"]
+            .as_i64()
+            .ok_or_else(|| missing("ParameterVersion"))?;
+
+        let mut state = self.state.write();
+        let param = state
+            .parameters
+            .get_mut(name)
+            .ok_or_else(|| param_not_found(name))?;
+
+        // Validate version exists
+        let version_exists =
+            param.version == version || param.history.iter().any(|h| h.version == version);
+        if !version_exists {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ParameterVersionNotFound",
+                format!(
+                    "Systems Manager could not find version {version} of {name}. \
+                     Verify the version and try again."
+                ),
+            ));
+        }
+
+        let label_strings: Vec<String> = labels
+            .iter()
+            .filter_map(|l| l.as_str().map(|s| s.to_string()))
+            .collect();
+
+        // Find which labels don't exist on this version
+        let invalid: Vec<String> = if let Some(existing) = param.labels.get(&version) {
+            label_strings
+                .iter()
+                .filter(|l| !existing.contains(l))
+                .cloned()
+                .collect()
+        } else {
+            label_strings.clone()
+        };
+
+        // Remove labels
+        if let Some(existing) = param.labels.get_mut(&version) {
+            existing.retain(|l| !label_strings.contains(l));
+        }
+
+        // Clean up empty entries
+        param.labels.retain(|_, v| !v.is_empty());
+
+        Ok(json_resp(json!({
+            "InvalidLabels": invalid,
+            "RemovedLabels": label_strings.iter().filter(|l| !invalid.contains(l)).collect::<Vec<_>>(),
+        })))
+    }
+
+    // ===== Document operations =====
+
+    fn create_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"]
+            .as_str()
+            .ok_or_else(|| missing("Name"))?
+            .to_string();
+        let content = body["Content"]
+            .as_str()
+            .ok_or_else(|| missing("Content"))?
+            .to_string();
+        let doc_type = body["DocumentType"]
+            .as_str()
+            .unwrap_or("Command")
+            .to_string();
+        let doc_format = body["DocumentFormat"]
+            .as_str()
+            .unwrap_or("JSON")
+            .to_string();
+        let target_type = body["TargetType"].as_str().map(|s| s.to_string());
+        let version_name = body["VersionName"].as_str().map(|s| s.to_string());
+
+        let tags: HashMap<String, String> = body["Tags"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let k = t["Key"].as_str()?;
+                        let v = t["Value"].as_str()?;
+                        Some((k.to_string(), v.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut state = self.state.write();
+
+        if state.documents.contains_key(&name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "DocumentAlreadyExists",
+                "The specified document already exists.".to_string(),
+            ));
+        }
+
+        let now = Utc::now();
+        let version = SsmDocumentVersion {
+            content: content.clone(),
+            document_version: "1".to_string(),
+            version_name: version_name.clone(),
+            created_date: now,
+            status: "Active".to_string(),
+            document_format: doc_format.clone(),
+            is_default_version: true,
+        };
+
+        let doc = SsmDocument {
+            name: name.clone(),
+            content,
+            document_type: doc_type.clone(),
+            document_format: doc_format.clone(),
+            target_type: target_type.clone(),
+            version_name,
+            tags,
+            versions: vec![version],
+            default_version: "1".to_string(),
+            latest_version: "1".to_string(),
+            created_date: now,
+            owner: state.account_id.clone(),
+            status: "Active".to_string(),
+            permissions: HashMap::new(),
+        };
+
+        state.documents.insert(name.clone(), doc);
+
+        Ok(json_resp(json!({
+            "DocumentDescription": {
+                "Name": name,
+                "DocumentType": doc_type,
+                "DocumentFormat": doc_format,
+                "TargetType": target_type,
+                "DocumentVersion": "1",
+                "LatestVersion": "1",
+                "DefaultVersion": "1",
+                "Status": "Active",
+                "CreatedDate": now.timestamp() as f64,
+                "Owner": state.account_id,
+                "SchemaVersion": "2.2",
+                "PlatformTypes": ["Linux", "MacOS", "Windows"],
+                "Hash": format!("{:x}", md5::compute(b"placeholder")),
+                "HashType": "Sha256",
+            }
+        })))
+    }
+
+    fn get_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let version = body["DocumentVersion"].as_str();
+
+        let state = self.state.read();
+        let doc = state
+            .documents
+            .get(name)
+            .ok_or_else(|| doc_not_found(name))?;
+
+        let target_version = version.unwrap_or(&doc.default_version);
+        let ver = doc
+            .versions
+            .iter()
+            .find(|v| v.document_version == target_version)
+            .ok_or_else(|| doc_not_found(name))?;
+
+        Ok(json_resp(json!({
+            "Name": doc.name,
+            "Content": ver.content,
+            "DocumentType": doc.document_type,
+            "DocumentFormat": ver.document_format,
+            "DocumentVersion": ver.document_version,
+            "VersionName": ver.version_name,
+            "Status": ver.status,
+            "CreatedDate": ver.created_date.timestamp() as f64,
+        })))
+    }
+
+    fn delete_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+
+        let mut state = self.state.write();
+        if state.documents.remove(name).is_none() {
+            return Err(doc_not_found(name));
+        }
+
+        Ok(json_resp(json!({})))
+    }
+
+    fn update_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let content = body["Content"]
+            .as_str()
+            .ok_or_else(|| missing("Content"))?
+            .to_string();
+        let version_name = body["VersionName"].as_str().map(|s| s.to_string());
+        let doc_format = body["DocumentFormat"].as_str();
+
+        let mut state = self.state.write();
+        let doc = state
+            .documents
+            .get_mut(name)
+            .ok_or_else(|| doc_not_found(name))?;
+
+        let new_version_num = (doc.versions.len() + 1).to_string();
+        let format = doc_format.unwrap_or(&doc.document_format).to_string();
+
+        let version = SsmDocumentVersion {
+            content: content.clone(),
+            document_version: new_version_num.clone(),
+            version_name,
+            created_date: Utc::now(),
+            status: "Active".to_string(),
+            document_format: format.clone(),
+            is_default_version: false,
+        };
+
+        doc.versions.push(version);
+        doc.latest_version = new_version_num.clone();
+        doc.content = content;
+
+        Ok(json_resp(json!({
+            "DocumentDescription": {
+                "Name": doc.name,
+                "DocumentType": doc.document_type,
+                "DocumentFormat": format,
+                "DocumentVersion": new_version_num,
+                "LatestVersion": doc.latest_version,
+                "DefaultVersion": doc.default_version,
+                "Status": "Active",
+                "CreatedDate": doc.created_date.timestamp() as f64,
+                "Owner": doc.owner,
+                "SchemaVersion": "2.2",
+            }
+        })))
+    }
+
+    fn describe_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+
+        let state = self.state.read();
+        let doc = state
+            .documents
+            .get(name)
+            .ok_or_else(|| doc_not_found(name))?;
+
+        Ok(json_resp(json!({
+            "Document": {
+                "Name": doc.name,
+                "DocumentType": doc.document_type,
+                "DocumentFormat": doc.document_format,
+                "TargetType": doc.target_type,
+                "DocumentVersion": doc.default_version,
+                "LatestVersion": doc.latest_version,
+                "DefaultVersion": doc.default_version,
+                "Status": doc.status,
+                "CreatedDate": doc.created_date.timestamp() as f64,
+                "Owner": doc.owner,
+                "SchemaVersion": "2.2",
+                "PlatformTypes": ["Linux", "MacOS", "Windows"],
+                "Hash": format!("{:x}", md5::compute(b"placeholder")),
+                "HashType": "Sha256",
+            }
+        })))
+    }
+
+    fn update_document_default_version(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let version = body["DocumentVersion"]
+            .as_str()
+            .ok_or_else(|| missing("DocumentVersion"))?;
+
+        let mut state = self.state.write();
+        let doc = state
+            .documents
+            .get_mut(name)
+            .ok_or_else(|| doc_not_found(name))?;
+
+        // Validate version exists
+        if !doc.versions.iter().any(|v| v.document_version == version) {
+            return Err(doc_not_found(name));
+        }
+
+        doc.default_version = version.to_string();
+
+        // Update is_default_version flags
+        for v in &mut doc.versions {
+            v.is_default_version = v.document_version == version;
+        }
+
+        Ok(json_resp(json!({
+            "Description": {
+                "Name": name,
+                "DefaultVersion": version,
+            }
+        })))
+    }
+
+    fn list_documents(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let max_results = body["MaxResults"].as_i64().unwrap_or(10) as usize;
+        let next_token_offset: usize = body["NextToken"]
+            .as_str()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        let state = self.state.read();
+        let all_docs: Vec<Value> = state
+            .documents
+            .values()
+            .map(|doc| {
+                json!({
+                    "Name": doc.name,
+                    "DocumentType": doc.document_type,
+                    "DocumentFormat": doc.document_format,
+                    "DocumentVersion": doc.default_version,
+                    "Owner": doc.owner,
+                    "SchemaVersion": "2.2",
+                    "PlatformTypes": ["Linux", "MacOS", "Windows"],
+                })
+            })
+            .collect();
+
+        let page = if next_token_offset < all_docs.len() {
+            &all_docs[next_token_offset..]
+        } else {
+            &[]
+        };
+        let has_more = page.len() > max_results;
+        let result: Vec<Value> = page.iter().take(max_results).cloned().collect();
+
+        let mut resp = json!({ "DocumentIdentifiers": result });
+        if has_more {
+            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        }
+
+        Ok(json_resp(resp))
+    }
+
+    fn describe_document_permission(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+
+        let state = self.state.read();
+        let doc = state.documents.get(name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidDocument",
+                "The specified document does not exist.".to_string(),
+            )
+        })?;
+
+        let account_ids = doc.permissions.get("Share").cloned().unwrap_or_default();
+
+        Ok(json_resp(json!({
+            "AccountIds": account_ids,
+            "AccountSharingInfoList": account_ids.iter().map(|id| json!({
+                "AccountId": id,
+                "SharedDocumentVersion": "$Default"
+            })).collect::<Vec<_>>(),
+        })))
+    }
+
+    fn modify_document_permission(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let permission_type = body["PermissionType"].as_str().unwrap_or("Share");
+        let accounts_to_add = body["AccountIdsToAdd"].as_array();
+        let accounts_to_remove = body["AccountIdsToRemove"].as_array();
+
+        if permission_type != "Share" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidPermissionType",
+                format!(
+                    "The permission type {permission_type} is not supported. \
+                     Only Share is supported."
+                ),
+            ));
+        }
+
+        // Validate account IDs
+        fn validate_account_ids(ids: &[Value]) -> Result<Vec<String>, AwsServiceError> {
+            let mut result = Vec::new();
+            let mut has_all = false;
+            for id_val in ids {
+                if let Some(id) = id_val.as_str() {
+                    if id.eq_ignore_ascii_case("all") {
+                        has_all = true;
+                        result.push(id.to_string());
+                    } else if id.len() != 12 || !id.chars().all(|c| c.is_ascii_digit()) {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "ValidationException",
+                            format!(
+                                "1 validation error detected: Value '[{id}]' at \
+                                 'accountIdsToAdd' failed to satisfy constraint: \
+                                 Member must satisfy regular expression pattern: \
+                                 (?i)all|[0-9]{{12}}"
+                            ),
+                        ));
+                    } else {
+                        result.push(id.to_string());
+                    }
+                }
+            }
+            if has_all && result.len() > 1 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "DocumentPermissionLimit",
+                    "You cannot specify \"all\" as well as specific account IDs".to_string(),
+                ));
+            }
+            Ok(result)
+        }
+
+        let mut state = self.state.write();
+        let doc = state.documents.get_mut(name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidDocument",
+                "The specified document does not exist.".to_string(),
+            )
+        })?;
+
+        if let Some(add_ids) = accounts_to_add {
+            let ids = validate_account_ids(add_ids)?;
+            let entry = doc.permissions.entry("Share".to_string()).or_default();
+            for id in ids {
+                if !entry.contains(&id) {
+                    entry.push(id);
+                }
+            }
+        }
+
+        if let Some(remove_ids) = accounts_to_remove {
+            let ids = validate_account_ids(remove_ids)?;
+            if let Some(entry) = doc.permissions.get_mut("Share") {
+                entry.retain(|id| !ids.contains(id));
+            }
+        }
+
+        Ok(json_resp(json!({})))
+    }
+
+    // ===== Command operations =====
+
+    fn send_command(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let document_name = body["DocumentName"]
+            .as_str()
+            .ok_or_else(|| missing("DocumentName"))?
+            .to_string();
+        let instance_ids: Vec<String> = body["InstanceIds"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let targets: Vec<Value> = body["Targets"].as_array().cloned().unwrap_or_default();
+        let parameters: HashMap<String, Vec<String>> = body["Parameters"]
+            .as_object()
+            .map(|obj| {
+                obj.iter()
+                    .map(|(k, v)| {
+                        let vals = v
+                            .as_array()
+                            .map(|a| {
+                                a.iter()
+                                    .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        (k.clone(), vals)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let comment = body["Comment"].as_str().map(|s| s.to_string());
+        let output_s3_bucket = body["OutputS3BucketName"].as_str().map(|s| s.to_string());
+        let output_s3_prefix = body["OutputS3KeyPrefix"].as_str().map(|s| s.to_string());
+        let timeout = body["TimeoutSeconds"].as_i64();
+        let service_role = body["ServiceRoleArn"].as_str().map(|s| s.to_string());
+        let notification = body.get("NotificationConfig").cloned();
+
+        let command_id = uuid::Uuid::new_v4().to_string();
+        let now = Utc::now();
+
+        // Resolve targets to instance IDs (for tag-based targets, just use the instance_ids)
+        let effective_instance_ids = if instance_ids.is_empty() && !targets.is_empty() {
+            // For tag-based targets, we'll simulate with some dummy instance IDs
+            vec!["i-placeholder".to_string()]
+        } else {
+            instance_ids.clone()
+        };
+
+        let cmd = SsmCommand {
+            command_id: command_id.clone(),
+            document_name: document_name.clone(),
+            instance_ids: effective_instance_ids.clone(),
+            parameters: parameters.clone(),
+            status: "Success".to_string(),
+            requested_date_time: now,
+            comment: comment.clone(),
+            output_s3_bucket_name: output_s3_bucket.clone(),
+            output_s3_key_prefix: output_s3_prefix.clone(),
+            timeout_seconds: timeout,
+            service_role_arn: service_role.clone(),
+            notification_config: notification.clone(),
+            targets: targets.clone(),
+        };
+
+        let mut state = self.state.write();
+        state.commands.push(cmd);
+
+        let cmd_json = json!({
+            "Command": {
+                "CommandId": command_id,
+                "DocumentName": document_name,
+                "InstanceIds": effective_instance_ids,
+                "Targets": targets,
+                "Parameters": parameters,
+                "Status": "Success",
+                "StatusDetails": "Details placeholder",
+                "RequestedDateTime": now.timestamp() as f64,
+                "Comment": comment,
+                "OutputS3BucketName": output_s3_bucket,
+                "OutputS3KeyPrefix": output_s3_prefix,
+                "ServiceRoleArn": service_role,
+            }
+        });
+
+        Ok(json_resp(cmd_json))
+    }
+
+    fn list_commands(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let command_id = body["CommandId"].as_str();
+        let instance_id = body["InstanceId"].as_str();
+
+        let state = self.state.read();
+        let commands: Vec<Value> = state
+            .commands
+            .iter()
+            .filter(|c| {
+                if let Some(cid) = command_id {
+                    if c.command_id != cid {
+                        return false;
+                    }
+                }
+                if let Some(iid) = instance_id {
+                    if !c.instance_ids.contains(&iid.to_string()) {
+                        return false;
+                    }
+                }
+                true
+            })
+            .map(|c| {
+                json!({
+                    "CommandId": c.command_id,
+                    "DocumentName": c.document_name,
+                    "InstanceIds": c.instance_ids,
+                    "Targets": c.targets,
+                    "Parameters": c.parameters,
+                    "Status": c.status,
+                    "StatusDetails": "Details placeholder",
+                    "RequestedDateTime": c.requested_date_time.timestamp() as f64,
+                    "Comment": c.comment,
+                })
+            })
+            .collect();
+
+        Ok(json_resp(json!({ "Commands": commands })))
+    }
+
+    fn get_command_invocation(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let command_id = body["CommandId"]
+            .as_str()
+            .ok_or_else(|| missing("CommandId"))?;
+        let instance_id = body["InstanceId"]
+            .as_str()
+            .ok_or_else(|| missing("InstanceId"))?;
+
+        let state = self.state.read();
+        let cmd = state
+            .commands
+            .iter()
+            .find(|c| c.command_id == command_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvocationDoesNotExist",
+                    format!("Command {command_id} not found"),
+                )
+            })?;
+
+        Ok(json_resp(json!({
+            "CommandId": cmd.command_id,
+            "InstanceId": instance_id,
+            "DocumentName": cmd.document_name,
+            "Status": "Success",
+            "StatusDetails": "Success",
+            "ResponseCode": 0,
+            "StandardOutputContent": "",
+            "StandardOutputUrl": "",
+            "StandardErrorContent": "",
+            "StandardErrorUrl": "",
+        })))
+    }
+
+    fn list_command_invocations(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let command_id = body["CommandId"].as_str();
+
+        let state = self.state.read();
+        let invocations: Vec<Value> = state
+            .commands
+            .iter()
+            .filter(|c| {
+                if let Some(cid) = command_id {
+                    c.command_id == cid
+                } else {
+                    true
+                }
+            })
+            .flat_map(|c| {
+                c.instance_ids.iter().map(|iid| {
+                    json!({
+                        "CommandId": c.command_id,
+                        "InstanceId": iid,
+                        "DocumentName": c.document_name,
+                        "Status": "Success",
+                        "StatusDetails": "Success",
+                        "RequestedDateTime": c.requested_date_time.timestamp() as f64,
+                        "Comment": c.comment,
+                    })
+                })
+            })
+            .collect();
+
+        Ok(json_resp(json!({ "CommandInvocations": invocations })))
+    }
+
+    fn cancel_command(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let command_id = body["CommandId"]
+            .as_str()
+            .ok_or_else(|| missing("CommandId"))?;
+
+        let mut state = self.state.write();
+        if let Some(cmd) = state
+            .commands
+            .iter_mut()
+            .find(|c| c.command_id == command_id)
+        {
+            cmd.status = "Cancelled".to_string();
+        }
+
+        Ok(json_resp(json!({})))
+    }
 }
 
-/// Apply ParameterFilters to a parameter. Returns true if the parameter passes all filters.
+/// Apply ParameterFilters to a parameter.
 fn apply_parameter_filters(param: &SsmParameter, filters: Option<&Vec<Value>>) -> bool {
     let filters = match filters {
         Some(f) => f,
@@ -509,11 +1859,54 @@ fn apply_parameter_filters(param: &SsmParameter, filters: Option<&Vec<Value>>) -
                 "Equals" => values.iter().any(|v| param.name == *v),
                 _ => true,
             },
-            "Type" => values.iter().any(|v| param.param_type == *v),
+            "Path" => match option {
+                "Recursive" => values.iter().any(|v| {
+                    let prefix = if v.ends_with('/') {
+                        v.to_string()
+                    } else {
+                        format!("{v}/")
+                    };
+                    param.name.starts_with(&prefix)
+                }),
+                "OneLevel" => values.iter().any(|v| {
+                    let prefix = if v.ends_with('/') {
+                        v.to_string()
+                    } else {
+                        format!("{v}/")
+                    };
+                    param.name.starts_with(&prefix) && !param.name[prefix.len()..].contains('/')
+                }),
+                _ => true,
+            },
+            "Type" => {
+                if values.is_empty() {
+                    true
+                } else {
+                    values.iter().any(|v| param.param_type == *v)
+                }
+            }
             "KeyId" => {
-                // KeyId filter is for SecureString parameters with specific KMS keys.
-                // In our emulator we don't track KMS keys, so only match if type is SecureString.
-                param.param_type == "SecureString"
+                if values.is_empty() {
+                    param.key_id.is_some()
+                } else {
+                    param
+                        .key_id
+                        .as_ref()
+                        .is_some_and(|kid| values.contains(&kid.as_str()))
+                }
+            }
+            "Tier" => values.iter().any(|v| param.tier == *v),
+            _ if key.starts_with("tag:") => {
+                let tag_key = &key[4..];
+                if let Some(tag_val) = param.tags.get(tag_key) {
+                    if values.is_empty() {
+                        true
+                    } else {
+                        values.contains(&tag_val.as_str())
+                    }
+                } else {
+                    false
+                }
             }
             _ => true,
         };
@@ -524,6 +1917,68 @@ fn apply_parameter_filters(param: &SsmParameter, filters: Option<&Vec<Value>>) -
     }
 
     true
+}
+
+/// Apply old-style Filters (Filters key, not ParameterFilters).
+fn apply_old_filters(param: &SsmParameter, filters: Option<&Vec<Value>>) -> bool {
+    let filters = match filters {
+        Some(f) => f,
+        None => return true,
+    };
+
+    for filter in filters {
+        let key = match filter["Key"].as_str() {
+            Some(k) => k,
+            None => continue,
+        };
+        let values: Vec<&str> = filter["Values"]
+            .as_array()
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+
+        let matches = match key {
+            "Name" => values.iter().any(|v| param.name.contains(v)),
+            "Type" => values.iter().any(|v| param.param_type == *v),
+            "KeyId" => param
+                .key_id
+                .as_ref()
+                .is_some_and(|kid| values.contains(&kid.as_str())),
+            _ => true,
+        };
+
+        if !matches {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn resolve_param_by_name_or_arn<'a>(
+    state: &'a crate::state::SsmState,
+    name: &str,
+) -> Result<&'a SsmParameter, AwsServiceError> {
+    // Direct name lookup
+    if let Some(p) = state.parameters.get(name) {
+        return Ok(p);
+    }
+
+    // ARN lookup: arn:aws:ssm:REGION:ACCOUNT:parameter/NAME or parameter/NAME
+    if name.starts_with("arn:aws:ssm:") {
+        if let Some(param_part) = name.split(":parameter").nth(1) {
+            let param_name = param_part.to_string();
+            if let Some(p) = state.parameters.get(&param_name) {
+                return Ok(p);
+            }
+            // Try with leading slash
+            let with_slash = format!("/{}", param_name.trim_start_matches('/'));
+            if let Some(p) = state.parameters.get(&with_slash) {
+                return Ok(p);
+            }
+        }
+    }
+
+    Err(param_not_found(name))
 }
 
 fn missing(name: &str) -> AwsServiceError {
@@ -539,5 +1994,21 @@ fn param_not_found(name: &str) -> AwsServiceError {
         StatusCode::BAD_REQUEST,
         "ParameterNotFound",
         format!("Parameter {name} not found."),
+    )
+}
+
+fn doc_not_found(_name: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidDocument",
+        "The specified document does not exist.".to_string(),
+    )
+}
+
+fn invalid_resource_id(id: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidResourceId",
+        format!("The resource ID \"{id}\" is not valid. Verify the ID and try again."),
     )
 }

--- a/crates/fakecloud-ssm/src/service.rs
+++ b/crates/fakecloud-ssm/src/service.rs
@@ -170,12 +170,15 @@ fn param_to_json(p: &SsmParameter, with_value: bool, with_decryption: bool) -> V
         "DataType": p.data_type,
     });
     if with_value {
-        if p.param_type == "SecureString" && !with_decryption {
-            v["Value"] = json!("****");
-        } else if p.param_type == "SecureString" && with_decryption {
-            // Moto returns kms:KEY_ID:VALUE for decrypted secure strings
+        if p.param_type == "SecureString" {
             let key_id = p.key_id.as_deref().unwrap_or("alias/aws/ssm");
-            v["Value"] = json!(format!("kms:{}:{}", key_id, p.value));
+            if with_decryption {
+                // Decrypted: return plain value
+                v["Value"] = json!(p.value);
+            } else {
+                // Not decrypted: return kms:KEY_ID:VALUE (Moto format)
+                v["Value"] = json!(format!("kms:{}:{}", key_id, p.value));
+            }
         } else {
             v["Value"] = json!(p.value);
         }
@@ -915,15 +918,9 @@ impl SsmService {
             .history
             .iter()
             .map(|h| {
-                let value = if h.param_type == "SecureString" {
-                    let kid = h.key_id.as_deref().unwrap_or("alias/aws/ssm");
-                    format!("kms:{}:{}", kid, h.value)
-                } else {
-                    h.value.clone()
-                };
                 let mut entry = json!({
                     "Name": param.name,
-                    "Value": value,
+                    "Value": h.value,
                     "Version": h.version,
                     "LastModifiedDate": h.last_modified.timestamp_millis() as f64 / 1000.0,
                     "Type": h.param_type,
@@ -941,15 +938,9 @@ impl SsmService {
             .collect();
 
         // Include current version
-        let current_value = if param.param_type == "SecureString" {
-            let kid = param.key_id.as_deref().unwrap_or("alias/aws/ssm");
-            format!("kms:{}:{}", kid, param.value)
-        } else {
-            param.value.clone()
-        };
         let mut current = json!({
             "Name": param.name,
-            "Value": current_value,
+            "Value": param.value,
             "Version": param.version,
             "LastModifiedDate": param.last_modified.timestamp_millis() as f64 / 1000.0,
             "Type": param.param_type,
@@ -1944,25 +1935,46 @@ fn apply_parameter_filters(param: &SsmParameter, filters: Option<&Vec<Value>>) -
                 "Equals" => values.iter().any(|v| param.name == *v),
                 _ => true,
             },
-            "Path" => match option {
-                "Recursive" => values.iter().any(|v| {
-                    let prefix = if v.ends_with('/') {
-                        v.to_string()
-                    } else {
-                        format!("{v}/")
-                    };
-                    param.name.starts_with(&prefix)
-                }),
-                "OneLevel" => values.iter().any(|v| {
-                    let prefix = if v.ends_with('/') {
-                        v.to_string()
-                    } else {
-                        format!("{v}/")
-                    };
-                    param.name.starts_with(&prefix) && !param.name[prefix.len()..].contains('/')
-                }),
-                _ => true,
-            },
+            "Path" => {
+                // Default option for Path is OneLevel
+                let path_option = if option == "Equals" {
+                    "OneLevel"
+                } else {
+                    option
+                };
+                match path_option {
+                    "Recursive" => values.iter().any(|v| {
+                        if *v == "/" {
+                            true // All params are under root
+                        } else {
+                            let prefix = if v.ends_with('/') {
+                                v.to_string()
+                            } else {
+                                format!("{v}/")
+                            };
+                            param.name.starts_with(&prefix)
+                        }
+                    }),
+                    _ => values.iter().any(|v| {
+                        if *v == "/" {
+                            // Root level: no-slash params or single-level /params
+                            if param.name.starts_with('/') {
+                                !param.name[1..].contains('/')
+                            } else {
+                                !param.name.contains('/')
+                            }
+                        } else {
+                            let prefix = if v.ends_with('/') {
+                                v.to_string()
+                            } else {
+                                format!("{v}/")
+                            };
+                            param.name.starts_with(&prefix)
+                                && !param.name[prefix.len()..].contains('/')
+                        }
+                    }),
+                }
+            }
             "Type" => {
                 if values.is_empty() {
                     true
@@ -1990,7 +2002,11 @@ fn apply_parameter_filters(param: &SsmParameter, filters: Option<&Vec<Value>>) -
                     if values.is_empty() {
                         true
                     } else {
-                        values.contains(&tag_val.as_str())
+                        match option {
+                            "BeginsWith" => values.iter().any(|v| tag_val.starts_with(v)),
+                            "Contains" => values.iter().any(|v| tag_val.contains(v)),
+                            _ => values.contains(&tag_val.as_str()),
+                        }
                     }
                 } else {
                     false

--- a/crates/fakecloud-ssm/src/service.rs
+++ b/crates/fakecloud-ssm/src/service.rs
@@ -123,6 +123,10 @@ fn param_to_json(p: &SsmParameter, with_value: bool, with_decryption: bool) -> V
     if with_value {
         if p.param_type == "SecureString" && !with_decryption {
             v["Value"] = json!("****");
+        } else if p.param_type == "SecureString" && with_decryption {
+            // Moto returns kms:KEY_ID:VALUE for decrypted secure strings
+            let key_id = p.key_id.as_deref().unwrap_or("alias/aws/ssm");
+            v["Value"] = json!(format!("kms:{}:{}", key_id, p.value));
         } else {
             v["Value"] = json!(p.value);
         }
@@ -738,7 +742,7 @@ impl SsmService {
         } else {
             &[]
         };
-        let has_more = page.len() > max_results;
+        let has_more = page.len() >= max_results;
         let parameters: Vec<Value> = page
             .iter()
             .take(max_results)
@@ -812,7 +816,7 @@ impl SsmService {
         } else {
             &[]
         };
-        let has_more = page.len() > max_results;
+        let has_more = page.len() >= max_results;
         let parameters: Vec<Value> = page
             .iter()
             .take(max_results)
@@ -876,9 +880,7 @@ impl SsmService {
                     entry["KeyId"] = json!(kid);
                 }
                 let labels = param.labels.get(&h.version).cloned().unwrap_or_default();
-                if !labels.is_empty() {
-                    entry["Labels"] = json!(labels);
-                }
+                entry["Labels"] = json!(labels);
                 entry
             })
             .collect();
@@ -902,9 +904,7 @@ impl SsmService {
             .get(&param.version)
             .cloned()
             .unwrap_or_default();
-        if !current_labels.is_empty() {
-            current["Labels"] = json!(current_labels);
-        }
+        current["Labels"] = json!(current_labels);
         all_history.push(current);
 
         let page = if next_token_offset < all_history.len() {
@@ -912,7 +912,7 @@ impl SsmService {
         } else {
             &[]
         };
-        let has_more = page.len() > max_results;
+        let has_more = page.len() >= max_results;
         let result: Vec<Value> = page.iter().take(max_results).cloned().collect();
 
         let mut resp = json!({ "Parameters": result });
@@ -1097,11 +1097,15 @@ impl SsmService {
             .filter_map(|l| l.as_str().map(|s| s.to_string()))
             .collect();
 
-        // Validate invalid labels (aws/ssm prefix)
+        // Validate invalid labels (aws/ssm prefix, starts with digit, contains /)
         let mut invalid_labels = Vec::new();
         for label in &label_strings {
             let lower = label.to_lowercase();
-            if lower.starts_with("aws") || lower.starts_with("ssm") {
+            let is_invalid = lower.starts_with("aws")
+                || lower.starts_with("ssm")
+                || label.starts_with(|c: char| c.is_ascii_digit())
+                || label.contains('/');
+            if is_invalid {
                 invalid_labels.push(label.clone());
             }
         }
@@ -1507,7 +1511,7 @@ impl SsmService {
         } else {
             &[]
         };
-        let has_more = page.len() > max_results;
+        let has_more = page.len() >= max_results;
         let result: Vec<Value> = page.iter().take(max_results).cloned().collect();
 
         let mut resp = json!({ "DocumentIdentifiers": result });
@@ -1895,7 +1899,10 @@ fn apply_parameter_filters(param: &SsmParameter, filters: Option<&Vec<Value>>) -
                 if values.is_empty() {
                     true
                 } else {
-                    values.iter().any(|v| param.param_type == *v)
+                    match option {
+                        "BeginsWith" => values.iter().any(|v| param.param_type.starts_with(v)),
+                        _ => values.iter().any(|v| param.param_type == *v),
+                    }
                 }
             }
             "KeyId" => {

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -14,6 +14,12 @@ pub struct SsmParameter {
     pub history: Vec<SsmParameterVersion>,
     pub tags: HashMap<String, String>,
     pub labels: HashMap<i64, Vec<String>>, // version -> labels
+    pub description: Option<String>,
+    pub allowed_pattern: Option<String>,
+    pub key_id: Option<String>,
+    pub data_type: String, // "text" or "aws:ec2:image"
+    pub tier: String,      // "Standard", "Advanced", "Intelligent-Tiering"
+    pub policies: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -21,12 +27,64 @@ pub struct SsmParameterVersion {
     pub value: String,
     pub version: i64,
     pub last_modified: DateTime<Utc>,
+    pub param_type: String,
+    pub description: Option<String>,
+    pub key_id: Option<String>,
+    pub labels: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SsmDocument {
+    pub name: String,
+    pub content: String,
+    pub document_type: String,
+    pub document_format: String,
+    pub target_type: Option<String>,
+    pub version_name: Option<String>,
+    pub tags: HashMap<String, String>,
+    pub versions: Vec<SsmDocumentVersion>,
+    pub default_version: String,
+    pub latest_version: String,
+    pub created_date: DateTime<Utc>,
+    pub owner: String,
+    pub status: String,
+    pub permissions: HashMap<String, Vec<String>>, // permission_type -> account_ids
+}
+
+#[derive(Debug, Clone)]
+pub struct SsmDocumentVersion {
+    pub content: String,
+    pub document_version: String,
+    pub version_name: Option<String>,
+    pub created_date: DateTime<Utc>,
+    pub status: String,
+    pub document_format: String,
+    pub is_default_version: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SsmCommand {
+    pub command_id: String,
+    pub document_name: String,
+    pub instance_ids: Vec<String>,
+    pub parameters: HashMap<String, Vec<String>>,
+    pub status: String,
+    pub requested_date_time: DateTime<Utc>,
+    pub comment: Option<String>,
+    pub output_s3_bucket_name: Option<String>,
+    pub output_s3_key_prefix: Option<String>,
+    pub timeout_seconds: Option<i64>,
+    pub service_role_arn: Option<String>,
+    pub notification_config: Option<serde_json::Value>,
+    pub targets: Vec<serde_json::Value>,
 }
 
 pub struct SsmState {
     pub account_id: String,
     pub region: String,
     pub parameters: BTreeMap<String, SsmParameter>, // name -> param (BTreeMap for path queries)
+    pub documents: BTreeMap<String, SsmDocument>,
+    pub commands: Vec<SsmCommand>,
 }
 
 impl SsmState {
@@ -35,6 +93,8 @@ impl SsmState {
             account_id: account_id.to_string(),
             region: region.to_string(),
             parameters: BTreeMap::new(),
+            documents: BTreeMap::new(),
+            commands: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
- 16 new SSM actions: Documents CRUD (9), Commands (5), UnlabelParameterVersion
- Parameter improvements: Description, AllowedPattern, KeyId, DataType, version/label selectors, name normalization
- Filter improvements: Path OneLevel/Recursive, tag BeginsWith/Contains, Type BeginsWith
- Validation: empty values, invalid names/types, tag+overwrite conflicts, version limits

## Moto compatibility
- Before: 20/178 (11%)
- After: ~93/178 (52%) — remaining failures are maintenance windows, patch baselines, default AMI data