### PR TITLE
fix: change default account ID to 123456789012

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 examples/terraform/.terraform/
 examples/terraform/.terraform.lock.hcl
 examples/terraform/terraform.tfstate*
+.claude/worktrees/

--- a/crates/fakecloud-e2e/tests/eventbridge.rs
+++ b/crates/fakecloud-e2e/tests/eventbridge.rs
@@ -73,7 +73,7 @@ async fn eb_put_rule_with_targets() {
         .targets(
             Target::builder()
                 .id("target-1")
-                .arn("arn:aws:sqs:us-east-1:000000000000:my-queue")
+                .arn("arn:aws:sqs:us-east-1:123456789012:my-queue")
                 .build()
                 .unwrap(),
         )
@@ -191,7 +191,7 @@ async fn eb_schedule_fires_to_sqs() {
         .targets(
             Target::builder()
                 .id("sqs-target")
-                .arn("arn:aws:sqs:us-east-1:000000000000:schedule-target")
+                .arn("arn:aws:sqs:us-east-1:123456789012:schedule-target")
                 .build()
                 .unwrap(),
         )

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -8,7 +8,7 @@ async fn sts_get_caller_identity() {
     let client = server.sts_client().await;
 
     let resp = client.get_caller_identity().send().await.unwrap();
-    assert_eq!(resp.account().unwrap(), "000000000000");
+    assert_eq!(resp.account().unwrap(), "123456789012");
     assert!(resp.arn().unwrap().contains("root"));
 }
 
@@ -185,7 +185,7 @@ async fn sts_assume_role_unique_credentials() {
 
     let resp1 = client
         .assume_role()
-        .role_arn("arn:aws:iam::000000000000:role/role-a")
+        .role_arn("arn:aws:iam::123456789012:role/role-a")
         .role_session_name("session-a")
         .send()
         .await
@@ -194,7 +194,7 @@ async fn sts_assume_role_unique_credentials() {
 
     let resp2 = client
         .assume_role()
-        .role_arn("arn:aws:iam::000000000000:role/role-b")
+        .role_arn("arn:aws:iam::123456789012:role/role-b")
         .role_session_name("session-b")
         .send()
         .await
@@ -226,5 +226,5 @@ async fn sts_get_caller_identity_cli() {
         output.stderr_text()
     );
     let json = output.stdout_json();
-    assert_eq!(json["Account"], "000000000000");
+    assert_eq!(json["Account"], "123456789012");
 }

--- a/crates/fakecloud-e2e/tests/multiservice.rs
+++ b/crates/fakecloud-e2e/tests/multiservice.rs
@@ -381,7 +381,7 @@ async fn iam_ssm_sqs_workflow() {
 
     // Verify identity
     let identity = sts.get_caller_identity().send().await.unwrap();
-    assert_eq!(identity.account().unwrap(), "000000000000");
+    assert_eq!(identity.account().unwrap(), "123456789012");
 
     // Create IAM user
     iam.create_user()

--- a/crates/fakecloud-e2e/tests/smoke.rs
+++ b/crates/fakecloud-e2e/tests/smoke.rs
@@ -23,5 +23,5 @@ async fn server_responds_to_cli() {
         output.stderr_text()
     );
     let json = output.stdout_json();
-    assert_eq!(json["Account"], "000000000000");
+    assert_eq!(json["Account"], "123456789012");
 }

--- a/crates/fakecloud-e2e/tests/sns.rs
+++ b/crates/fakecloud-e2e/tests/sns.rs
@@ -62,7 +62,7 @@ async fn sns_subscribe_and_list() {
         .subscribe()
         .topic_arn(&topic_arn)
         .protocol("sqs")
-        .endpoint("arn:aws:sqs:us-east-1:000000000000:my-queue")
+        .endpoint("arn:aws:sqs:us-east-1:123456789012:my-queue")
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -31,7 +31,7 @@ struct Cli {
     region: String,
 
     /// AWS account ID to use
-    #[arg(long, default_value = "000000000000", env = "FAKECLOUD_ACCOUNT_ID")]
+    #[arg(long, default_value = "123456789012", env = "FAKECLOUD_ACCOUNT_ID")]
     account_id: String,
 
     /// Log level (trace, debug, info, warn, error)


### PR DESCRIPTION
## Summary
- Change default account ID from 000000000000 to 123456789012 (AWS standard test account)
- Update all E2E tests to match

Moto tests expect 123456789012 — this was causing widespread test failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default AWS account ID to 123456789012 and updated E2E tests to match. This aligns with Moto’s expected test account and fixes failing tests.

- **Bug Fixes**
  - Updated `fakecloud-server` CLI default for `--account-id` to `123456789012` (still overridable via `FAKECLOUD_ACCOUNT_ID`).
  - Adjusted ARNs and account assertions in E2E tests (IAM, EventBridge, SNS, multiservice, smoke) to use `123456789012`.

<sup>Written for commit 0b2c2e281ca4901f1ed1eefeccfac1807371c887. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

