### PR TITLE
fix: conftest reset endpoint bug

### DIFF
--- a/tests/compat/moto/conftest.py
+++ b/tests/compat/moto/conftest.py
@@ -8,7 +8,7 @@ boto3.client/resource to point at FakeCloud instead of mocking internally.
 Environment variables set by run.sh:
     TEST_SERVER_MODE=true
     TEST_SERVER_MODE_ENDPOINT=http://localhost:4566
-    MOTO_CALL_RESET_API=false  (FakeCloud doesn't have /moto-api/reset)
+    MOTO_CALL_RESET_API=false
     AWS_DEFAULT_REGION=us-east-1
     AWS_ACCESS_KEY_ID=testing
     AWS_SECRET_ACCESS_KEY=testing
@@ -31,13 +31,13 @@ FAKECLOUD_ENDPOINT = os.environ.get(
 def _fakecloud_reset():
     """Try to reset FakeCloud state before each test.
 
-    Attempts /_fakecloud/reset first, then /moto-api/reset.
-    If neither exists, logs a warning and continues.
+    Attempts /_reset first, then /moto-api/reset.
+    Continues silently if neither endpoint is available.
     """
-    for path in ("/_fakecloud/reset", "/moto-api/reset"):
+    for path in ("/_reset", "/moto-api/reset"):
         try:
             resp = requests.post(f"{FAKECLOUD_ENDPOINT}{path}", timeout=2)
-            if resp.status_code < 500:
+            if resp.ok:
                 break
         except requests.exceptions.RequestException:
             pass


### PR DESCRIPTION
## Summary
- Fix conftest `_fakecloud_reset` fixture: check `resp.ok` instead of `resp.status_code < 500`
- Use `/_reset` instead of `/_fakecloud/reset` as first path

The old logic would `break` on a 400/404 from the fallback handler, never reaching `/moto-api/reset`. This caused state to bleed between tests, making all services show baseline-level pass rates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the FakeCloud test reset fixture to try `/_reset` first (then `/moto-api/reset`) and only treat the call as successful when `resp.ok`. This prevents breaking on 400/404 fallbacks and stops state from bleeding between tests.

<sup>Written for commit d71f797b91a62679489b6ce59a8b6da1e34c3928. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

