### PR TITLE
feat(ci): add Moto test patch infrastructure

### DIFF
--- a/.github/workflows/moto-compat.yml
+++ b/.github/workflows/moto-compat.yml
@@ -81,6 +81,15 @@ jobs:
           echo "# --- Original moto conftest below ---" >> "$MOTO_CONFTEST"
           cat "$MOTO_CONFTEST.orig" >> "$MOTO_CONFTEST"
 
+      - name: Apply Moto test patches
+        run: |
+          for patch in tests/compat/moto/patches/*.patch; do
+            [ -f "$patch" ] || continue
+            echo "Applying $(basename "$patch")"
+            (cd /tmp/moto && git apply "$GITHUB_WORKSPACE/$patch") || \
+              echo "WARNING: Failed to apply $(basename "$patch")"
+          done
+
       - name: Run Moto tests (all services)
         continue-on-error: true
         env:

--- a/tests/compat/moto/patches/sts-hardcoded-credentials.patch
+++ b/tests/compat/moto/patches/sts-hardcoded-credentials.patch
@@ -1,0 +1,63 @@
+# Moto bug: test_get_session_token and test_get_federation_token compare exact
+# hardcoded credential strings outside the `if not TEST_SERVER_MODE` guard.
+# These assertions only pass against Moto's internal mock, not any external server.
+#
+# Additionally, the AccessKeyId assertions use AKIA (long-term IAM key prefix),
+# but GetSessionToken/GetFederationToken return temporary credentials which
+# should use ASIA per AWS convention.
+#
+# This patch wraps the hardcoded comparisons in TEST_SERVER_MODE guards.
+--- a/tests/test_sts/test_sts.py
++++ b/tests/test_sts/test_sts.py
+@@ -25,14 +25,15 @@
+     if not settings.TEST_SERVER_MODE:
+         fdate = creds["Expiration"].strftime("%Y-%m-%dT%H:%M:%S.000Z")
+         assert fdate == "2012-01-01T12:15:03.000Z"
+-    assert creds["SessionToken"] == (
+-        "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrR"
+-        "h3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb"
+-        "4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7"
+-        "b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE"
+-    )
+-    assert creds["AccessKeyId"] == "AKIAIOSFODNN7EXAMPLE"
+-    assert creds["SecretAccessKey"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY"
++    if not settings.TEST_SERVER_MODE:
++        assert creds["SessionToken"] == (
++            "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrR"
++            "h3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb"
++            "4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7"
++            "b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE"
++        )
++        assert creds["AccessKeyId"] == "AKIAIOSFODNN7EXAMPLE"
++        assert creds["SecretAccessKey"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY"
+
+
+ @freeze_time("2012-01-01 12:00:00")
+@@ -49,16 +50,17 @@
+     if not settings.TEST_SERVER_MODE:
+         fdate = creds["Expiration"].strftime("%Y-%m-%dT%H:%M:%S.000Z")
+         assert fdate == "2012-01-01T12:15:03.000Z"
+-    assert creds["SessionToken"] == (
+-        "AQoDYXdzEPT//////////wEXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZ"
+-        "TwdQWLWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI/qkP"
+-        "pKPi/kMcGdQrmGdeehM4IC1NtBmUpp2wUE8phUZampKsburEDy0KPkyQDYwT7W"
+-        "Z0wq5VSXDvp75YU9HFvlRd8Tx6q6fE8YQcHNVXAkiY9q6d+xo0rKwT38xVqr7Z"
+-        "D0u0iPPkUL64lIZbqBAz+scqKmlzm8FDrypNC9Yjc8fPOLn9FX9KSYvKTr4rvx"
+-        "3iSIlTJabIQwj2ICCR/oLxBA=="
+-    )
+-    assert creds["AccessKeyId"] == "AKIAIOSFODNN7EXAMPLE"
+-    assert creds["SecretAccessKey"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY"
++    if not settings.TEST_SERVER_MODE:
++        assert creds["SessionToken"] == (
++            "AQoDYXdzEPT//////////wEXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZ"
++            "TwdQWLWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI/qkP"
++            "pKPi/kMcGdQrmGdeehM4IC1NtBmUpp2wUE8phUZampKsburEDy0KPkyQDYwT7W"
++            "Z0wq5VSXDvp75YU9HFvlRd8Tx6q6fE8YQcHNVXAkiY9q6d+xo0rKwT38xVqr7Z"
++            "D0u0iPPkUL64lIZbqBAz+scqKmlzm8FDrypNC9Yjc8fPOLn9FX9KSYvKTr4rvx"
++            "3iSIlTJabIQwj2ICCR/oLxBA=="
++        )
++        assert creds["AccessKeyId"] == "AKIAIOSFODNN7EXAMPLE"
++        assert creds["SecretAccessKey"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY"
+
+     assert fed_user["Arn"] == (f"arn:aws:sts::{ACCOUNT_ID}:federated-user/{token_name}")
+     assert fed_user["FederatedUserId"] == f"{ACCOUNT_ID}:{token_name}"


### PR DESCRIPTION
## Summary
- Add `tests/compat/moto/patches/` directory for patching upstream Moto test bugs
- Add "Apply Moto test patches" step to CI workflow (runs after cloning Moto, before tests)
- First patch: guard hardcoded STS credential assertions with `TEST_SERVER_MODE` check

### How it works
Patches in `tests/compat/moto/patches/*.patch` are applied to the cloned Moto repo via `git apply`. Each patch file includes a comment header explaining why the patch exists. If a patch fails to apply (e.g. Moto updated the code), CI logs a warning and continues.

### Why
Some Moto tests have assertions that only work against Moto's internal mock (exact hardcoded strings, wrong credential prefixes, etc). Rather than degrading FakeCloud to match these bugs, we patch the tests to be server-mode compatible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CI support to patch upstream `moto` tests before running the compatibility suite. The first patch guards hardcoded STS credential assertions with `TEST_SERVER_MODE` to work with server mode.

- **New Features**
  - Add `tests/compat/moto/patches/` to store `.patch` files with rationale headers.
  - Apply patches via `git apply` in CI after cloning `moto`; on failure, log a warning and continue.
  - STS patch: wrap exact SessionToken/AccessKeyId/SecretAccessKey assertions in `if not TEST_SERVER_MODE`.

<sup>Written for commit cee465f4321d655fdf6572f3873bf480aa6c2bfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

