### PR TITLE
feat: Docker build and CI/CD for GHCR publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+target/
+.git/
+.github/
+examples/
+tests/
+docs/
+*.md
+LICENSE*
+docker-compose*.yml
+.gitignore
+.dockerignore
+.env*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,8 +10,15 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -19,8 +26,61 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.runner }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -44,13 +104,12 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -35,12 +41,16 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
-FROM rust:latest AS builder
+FROM rust:1.85-bookworm AS chef
+RUN cargo install cargo-chef
 WORKDIR /build
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /build/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --bin fakecloud-server
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   fakecloud:
-    image: faiscadev/fakecloud
+    image: ghcr.io/faiscadev/fakecloud:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- Add `.dockerignore` to reduce build context size
- Improve `Dockerfile` with `cargo-chef` for dependency caching and pinned Rust 1.85 (MSRV)
- Add multi-platform builds (amd64 + arm64), GHA layer caching, and `latest` tag to Docker workflow
- Update `docker-compose.yml` to reference `ghcr.io/faiscadev/fakecloud:latest`

## Test plan
- [ ] Merge to main and verify the Docker workflow runs successfully
- [ ] Confirm image is published to `ghcr.io/faiscadev/fakecloud` with `main`, `latest`, and `sha-*` tags
- [ ] Pull and run the image locally: `docker run -p 4566:4566 ghcr.io/faiscadev/fakecloud:latest`
- [ ] Verify `docker compose up` works with the updated compose file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up Docker CI/CD to build and publish multi-arch images to GHCR using native runners for faster builds, with caching and correct tagging. Pins Rust 1.85 and trims Docker build context.

- New Features
  - Multi-arch builds (linux/amd64, linux/arm64) on native runners (ubuntu-24.04, ubuntu-24.04-arm); faster than QEMU.
  - Per-arch images push by digest with per-platform GHA cache; then merged into a single manifest and published.
  - GHCR tags: `latest` (default branch), branch refs, semver, and `sha`.
  - `Dockerfile` uses `cargo-chef` and pins `rust:1.85-bookworm`.
  - `.dockerignore` reduces context; `docker-compose.yml` uses `ghcr.io/faiscadev/fakecloud:latest`.

<sup>Written for commit ebdc7a6ca557cb7e3b6b3199da9a3587e84bc2ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

