### PR TITLE
fix(eventbridge): PutEvents delivery; fix(iam): error messages and validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tower-http = { version = "0.6", features = ["trace"] }
 async-trait = "0.1"
 parking_lot = "0.12"
 md-5 = "0.10"
+sha2 = "0.10"
 reqwest = { version = "0.12", features = ["json"] }
 
 # Internal crates

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -904,6 +904,13 @@ impl EventBridgeService {
             .to_string();
 
         let mut state = self.state.write();
+        if state.partner_event_sources.contains_key(&name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::CONFLICT,
+                "ResourceAlreadyExistsException",
+                format!("Partner event source {name} already exists."),
+            ));
+        }
         state
             .partner_event_sources
             .insert(name.clone(), account.clone());

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -72,6 +72,8 @@ impl AwsService for EventBridgeService {
             "DescribeReplay" => self.describe_replay(&req),
             "ListReplays" => self.list_replays(&req),
             "CancelReplay" => self.cancel_replay(&req),
+            "CreatePartnerEventSource" => self.create_partner_event_source(&req),
+            "DescribePartnerEventSource" => self.describe_partner_event_source(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "events",
                 &req.action,
@@ -120,6 +122,8 @@ impl AwsService for EventBridgeService {
             "DescribeReplay",
             "ListReplays",
             "CancelReplay",
+            "CreatePartnerEventSource",
+            "DescribePartnerEventSource",
         ]
     }
 }
@@ -193,11 +197,16 @@ impl EventBridgeService {
         // Partner event bus validation
         if name.starts_with("aws.partner/") {
             let event_source = body["EventSourceName"].as_str().unwrap_or("");
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ResourceNotFoundException",
-                format!("Event source {event_source} does not exist."),
-            ));
+            let state_r = self.state.read();
+            let has_source = state_r.partner_event_sources.contains_key(event_source);
+            drop(state_r);
+            if !has_source {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Event source {event_source} does not exist."),
+                ));
+            }
         }
 
         let mut state = self.state.write();
@@ -878,7 +887,61 @@ impl EventBridgeService {
         Ok(json_resp(resp))
     }
 
-    // ─── PutEvents ──────────────────────────────────────────────────────
+    // ─── Partner Event Sources ────────────���───────────────────────────
+
+    fn create_partner_event_source(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"]
+            .as_str()
+            .ok_or_else(|| missing("Name"))?
+            .to_string();
+        let account = body["Account"]
+            .as_str()
+            .ok_or_else(|| missing("Account"))?
+            .to_string();
+
+        let mut state = self.state.write();
+        state
+            .partner_event_sources
+            .insert(name.clone(), account.clone());
+
+        Ok(json_resp(json!({})))
+    }
+
+    fn describe_partner_event_source(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"]
+            .as_str()
+            .ok_or_else(|| missing("Name"))?
+            .to_string();
+
+        let state = self.state.read();
+        if !state.partner_event_sources.contains_key(&name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Partner event source {name} does not exist."),
+            ));
+        }
+
+        let arn = format!(
+            "arn:aws:events:{}::event-source/aws.partner/{}",
+            state.region, name
+        );
+
+        Ok(json_resp(json!({
+            "Arn": arn,
+            "Name": name,
+        })))
+    }
+
+    // ─── PutEvents ───────────────���──────────────────────────────────────
 
     fn put_events(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
@@ -947,11 +1010,18 @@ impl EventBridgeService {
                 .unwrap_or("default")
                 .to_string();
             let event_bus_name = state.resolve_bus_name(&raw_bus);
-            let time = entry["Time"]
-                .as_str()
-                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                .map(|dt| dt.with_timezone(&Utc))
-                .unwrap_or_else(Utc::now);
+            let time = if let Some(s) = entry["Time"].as_str() {
+                DateTime::parse_from_rfc3339(s)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc::now())
+            } else if let Some(ts) = entry["Time"].as_f64() {
+                DateTime::from_timestamp(ts as i64, ((ts.fract()) * 1_000_000_000.0) as u32)
+                    .unwrap_or_else(Utc::now)
+            } else if let Some(ts) = entry["Time"].as_i64() {
+                DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
+            } else {
+                Utc::now()
+            };
             let resources: Vec<String> = entry["Resources"]
                 .as_array()
                 .map(|arr| {
@@ -1003,6 +1073,9 @@ impl EventBridgeService {
                             &source,
                             &detail_type,
                             &detail,
+                            &req.account_id,
+                            &req.region,
+                            &resources,
                         )
                 })
                 .flat_map(|r| r.targets.clone())
@@ -1028,13 +1101,15 @@ impl EventBridgeService {
 
         // Deliver to targets
         for (event_id, source, detail_type, detail, time, resources, targets) in events_to_deliver {
+            let detail_value: Value = serde_json::from_str(&detail).unwrap_or(json!({}));
             let event_json = json!({
                 "version": "0",
                 "id": event_id,
                 "source": source,
+                "account": req.account_id,
                 "detail-type": detail_type,
-                "detail": serde_json::from_str::<Value>(&detail).unwrap_or(json!({})),
-                "time": time.to_rfc3339(),
+                "detail": detail_value,
+                "time": time.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
                 "region": req.region,
                 "resources": resources,
             });
@@ -1042,12 +1117,43 @@ impl EventBridgeService {
 
             for target in targets {
                 let arn = &target.arn;
+                // Compute the message body, applying InputTransformer if present
+                let body_str = if let Some(ref transformer) = target.input_transformer {
+                    apply_input_transformer(transformer, &event_json)
+                } else if let Some(ref input) = target.input {
+                    input.clone()
+                } else if let Some(ref input_path) = target.input_path {
+                    resolve_json_path(&event_json, input_path)
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| event_str.clone())
+                } else {
+                    event_str.clone()
+                };
+
                 if arn.contains(":sqs:") {
-                    self.delivery
-                        .send_to_sqs(arn, &event_str, &std::collections::HashMap::new());
+                    // Extract FIFO parameters (MessageGroupId)
+                    let group_id = target
+                        .sqs_parameters
+                        .as_ref()
+                        .and_then(|p| p["MessageGroupId"].as_str())
+                        .map(|s| s.to_string());
+                    if group_id.is_some() {
+                        // FIFO queue: send with group ID but no dedup ID.
+                        // Queues with content-based dedup will auto-generate one;
+                        // queues without it will reject the message.
+                        self.delivery.send_to_sqs_with_attrs(
+                            arn,
+                            &body_str,
+                            &HashMap::new(),
+                            group_id.as_deref(),
+                            None,
+                        );
+                    } else {
+                        self.delivery.send_to_sqs(arn, &body_str, &HashMap::new());
+                    }
                 } else if arn.contains(":sns:") {
                     self.delivery
-                        .publish_to_sns(arn, &event_str, Some(&detail_type));
+                        .publish_to_sns(arn, &body_str, Some(&detail_type));
                 }
             }
         }
@@ -2167,6 +2273,9 @@ fn matches_pattern(
     source: &str,
     detail_type: &str,
     detail: &str,
+    account: &str,
+    region: &str,
+    resources: &[String],
 ) -> bool {
     let pattern_json = match pattern_json {
         Some(p) => p,
@@ -2188,6 +2297,9 @@ fn matches_pattern(
         "source": source,
         "detail-type": detail_type,
         "detail": detail_value,
+        "account": account,
+        "region": region,
+        "resources": resources,
     });
 
     for (key, pattern_value) in pattern_obj {
@@ -2286,6 +2398,56 @@ fn values_equal(a: &Value, b: &Value) -> bool {
     a == b
 }
 
+/// Resolve a simple JSON path like `$.detail.name` against an event JSON value.
+fn resolve_json_path(event: &Value, path: &str) -> Option<Value> {
+    let path = path.strip_prefix('$').unwrap_or(path);
+    let mut current = event;
+    for segment in path.split('.') {
+        if segment.is_empty() {
+            continue;
+        }
+        current = current.get(segment)?;
+    }
+    Some(current.clone())
+}
+
+/// Apply an EventBridge InputTransformer to an event.
+fn apply_input_transformer(transformer: &Value, event: &Value) -> String {
+    let input_paths_map = transformer
+        .get("InputPathsMap")
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+    let template = transformer
+        .get("InputTemplate")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    // Resolve all input paths
+    let mut resolved: HashMap<String, Value> = HashMap::new();
+    for (var_name, path_val) in &input_paths_map {
+        if let Some(path_str) = path_val.as_str() {
+            if let Some(val) = resolve_json_path(event, path_str) {
+                resolved.insert(var_name.clone(), val);
+            }
+        }
+    }
+
+    // Replace <varName> placeholders in template
+    let mut result = template;
+    for (var_name, val) in &resolved {
+        let placeholder = format!("<{var_name}>");
+        let replacement = match val {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        result = result.replace(&placeholder, &replacement);
+    }
+
+    result
+}
+
 fn missing(name: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,
@@ -2298,15 +2460,33 @@ fn missing(name: &str) -> AwsServiceError {
 mod tests {
     use super::*;
 
+    /// Test helper that calls matches_pattern with default account/region/resources
+    fn test_matches(
+        pattern_json: Option<&str>,
+        source: &str,
+        detail_type: &str,
+        detail: &str,
+    ) -> bool {
+        matches_pattern(
+            pattern_json,
+            source,
+            detail_type,
+            detail,
+            "123456789012",
+            "us-east-1",
+            &[],
+        )
+    }
+
     #[test]
     fn pattern_matches_source() {
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(r#"{"source": ["my.app"]}"#),
             "my.app",
             "OrderPlaced",
             "{}"
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(r#"{"source": ["other.app"]}"#),
             "my.app",
             "OrderPlaced",
@@ -2316,13 +2496,13 @@ mod tests {
 
     #[test]
     fn pattern_matches_detail_type() {
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(r#"{"detail-type": ["OrderPlaced"]}"#),
             "my.app",
             "OrderPlaced",
             "{}"
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(r#"{"detail-type": ["OrderShipped"]}"#),
             "my.app",
             "OrderPlaced",
@@ -2332,13 +2512,13 @@ mod tests {
 
     #[test]
     fn pattern_matches_detail_field() {
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(r#"{"detail": {"status": ["ACTIVE"]}}"#),
             "my.app",
             "StatusChange",
             r#"{"status": "ACTIVE"}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(r#"{"detail": {"status": ["ACTIVE"]}}"#),
             "my.app",
             "StatusChange",
@@ -2348,48 +2528,33 @@ mod tests {
 
     #[test]
     fn no_pattern_matches_everything() {
-        assert!(matches_pattern(None, "any", "any", "{}"));
+        assert!(test_matches(None, "any", "any", "{}"));
     }
 
     #[test]
     fn combined_pattern() {
         let pattern = r#"{"source": ["orders"], "detail-type": ["OrderPlaced"]}"#;
-        assert!(matches_pattern(
-            Some(pattern),
-            "orders",
-            "OrderPlaced",
-            "{}"
-        ));
-        assert!(!matches_pattern(
-            Some(pattern),
-            "orders",
-            "OrderShipped",
-            "{}"
-        ));
-        assert!(!matches_pattern(
-            Some(pattern),
-            "other",
-            "OrderPlaced",
-            "{}"
-        ));
+        assert!(test_matches(Some(pattern), "orders", "OrderPlaced", "{}"));
+        assert!(!test_matches(Some(pattern), "orders", "OrderShipped", "{}"));
+        assert!(!test_matches(Some(pattern), "other", "OrderPlaced", "{}"));
     }
 
     #[test]
     fn nested_detail_pattern() {
         let pattern = r#"{"detail": {"order": {"status": ["PLACED"]}}}"#;
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "my.app",
             "OrderEvent",
             r#"{"order": {"status": "PLACED", "id": "123"}}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "my.app",
             "OrderEvent",
             r#"{"order": {"status": "SHIPPED", "id": "123"}}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "my.app",
             "OrderEvent",
@@ -2400,13 +2565,13 @@ mod tests {
     #[test]
     fn deeply_nested_detail_pattern() {
         let pattern = r#"{"detail": {"a": {"b": {"c": ["deep"]}}}}"#;
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"a": {"b": {"c": "deep"}}}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
@@ -2417,19 +2582,19 @@ mod tests {
     #[test]
     fn prefix_matcher() {
         let pattern = r#"{"source": [{"prefix": "com.myapp"}]}"#;
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "com.myapp.orders",
             "OrderPlaced",
             "{}"
         ));
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "com.myapp",
             "OrderPlaced",
             "{}"
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "com.other",
             "OrderPlaced",
@@ -2440,13 +2605,13 @@ mod tests {
     #[test]
     fn prefix_matcher_in_detail() {
         let pattern = r#"{"detail": {"region": [{"prefix": "us-"}]}}"#;
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"region": "us-east-1"}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
@@ -2457,13 +2622,13 @@ mod tests {
     #[test]
     fn exists_matcher() {
         let pattern = r#"{"detail": {"error": [{"exists": true}]}}"#;
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"error": "something broke"}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
@@ -2471,13 +2636,13 @@ mod tests {
         ));
 
         let pattern = r#"{"detail": {"error": [{"exists": false}]}}"#;
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"status": "ok"}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
@@ -2488,25 +2653,25 @@ mod tests {
     #[test]
     fn anything_but_matcher() {
         let pattern = r#"{"source": [{"anything-but": "internal"}]}"#;
-        assert!(matches_pattern(Some(pattern), "external", "Event", "{}"));
-        assert!(!matches_pattern(Some(pattern), "internal", "Event", "{}"));
+        assert!(test_matches(Some(pattern), "external", "Event", "{}"));
+        assert!(!test_matches(Some(pattern), "internal", "Event", "{}"));
 
         let pattern = r#"{"source": [{"anything-but": ["internal", "test"]}]}"#;
-        assert!(matches_pattern(Some(pattern), "external", "Event", "{}"));
-        assert!(!matches_pattern(Some(pattern), "internal", "Event", "{}"));
-        assert!(!matches_pattern(Some(pattern), "test", "Event", "{}"));
+        assert!(test_matches(Some(pattern), "external", "Event", "{}"));
+        assert!(!test_matches(Some(pattern), "internal", "Event", "{}"));
+        assert!(!test_matches(Some(pattern), "test", "Event", "{}"));
     }
 
     #[test]
     fn anything_but_in_detail() {
         let pattern = r#"{"detail": {"env": [{"anything-but": "prod"}]}}"#;
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"env": "staging"}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
@@ -2517,19 +2682,19 @@ mod tests {
     #[test]
     fn numeric_greater_than() {
         let pattern = r#"{"detail": {"count": [{"numeric": [">", 100]}]}}"#;
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"count": 150}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"count": 100}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
@@ -2540,19 +2705,19 @@ mod tests {
     #[test]
     fn numeric_less_than() {
         let pattern = r#"{"detail": {"count": [{"numeric": ["<", 10]}]}}"#;
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"count": 5}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"count": 10}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
@@ -2563,25 +2728,25 @@ mod tests {
     #[test]
     fn numeric_range() {
         let pattern = r#"{"detail": {"count": [{"numeric": [">=", 50, "<", 200]}]}}"#;
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"count": 50}"#
         ));
-        assert!(matches_pattern(
+        assert!(test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"count": 100}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
             r#"{"count": 200}"#
         ));
-        assert!(!matches_pattern(
+        assert!(!test_matches(
             Some(pattern),
             "src",
             "type",
@@ -2592,18 +2757,13 @@ mod tests {
     #[test]
     fn mixed_matchers_and_literals() {
         let pattern = r#"{"source": ["exact.match", {"prefix": "com.myapp"}]}"#;
-        assert!(matches_pattern(Some(pattern), "exact.match", "Event", "{}"));
-        assert!(matches_pattern(
+        assert!(test_matches(Some(pattern), "exact.match", "Event", "{}"));
+        assert!(test_matches(
             Some(pattern),
             "com.myapp.orders",
             "Event",
             "{}"
         ));
-        assert!(!matches_pattern(
-            Some(pattern),
-            "other.source",
-            "Event",
-            "{}"
-        ));
+        assert!(!test_matches(Some(pattern), "other.source", "Event", "{}"));
     }
 }

--- a/crates/fakecloud-eventbridge/src/state.rs
+++ b/crates/fakecloud-eventbridge/src/state.rs
@@ -125,6 +125,8 @@ pub struct EventBridgeState {
     pub connections: HashMap<String, Connection>,
     pub api_destinations: HashMap<String, ApiDestination>,
     pub replays: HashMap<String, Replay>,
+    /// Partner event sources: name -> account
+    pub partner_event_sources: HashMap<String, String>,
 }
 
 impl EventBridgeState {
@@ -157,6 +159,7 @@ impl EventBridgeState {
             connections: HashMap::new(),
             api_destinations: HashMap::new(),
             replays: HashMap::new(),
+            partner_event_sources: HashMap::new(),
         }
     }
 
@@ -177,6 +180,7 @@ impl EventBridgeState {
         self.buses.clear();
         self.rules.clear();
         self.events.clear();
+        self.partner_event_sources.clear();
         // Re-create default bus
         let default_bus_arn = format!(
             "arn:aws:events:{}:{}:event-bus/default",

--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -474,6 +474,7 @@ fn paginated_tags_response(action: &str, tags: &[Tag], req: &AwsRequest) -> Stri
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
 
+    let offset = offset.min(tags.len());
     let page = &tags[offset..tags.len().min(offset + max_items)];
     let is_truncated = offset + max_items < tags.len();
     let members = tags_xml(page);
@@ -1358,7 +1359,6 @@ impl IamService {
     fn tag_role(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let role_name = required_param(&req.query_params, "RoleName")?;
         let new_tags = parse_tags(&req.query_params);
-        validate_tags(&new_tags, 0)?;
         let mut state = self.state.write();
 
         let role = state.roles.get_mut(&role_name).ok_or_else(|| {
@@ -1368,6 +1368,14 @@ impl IamService {
                 format!("Role {role_name} not found"),
             )
         })?;
+
+        // Count existing tags that won't be overwritten by new tags
+        let existing_count = role
+            .tags
+            .iter()
+            .filter(|t| !new_tags.iter().any(|nt| nt.key == t.key))
+            .count();
+        validate_tags(&new_tags, existing_count)?;
 
         for new_tag in new_tags {
             if let Some(existing) = role.tags.iter_mut().find(|t| t.key == new_tag.key) {

--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -73,6 +73,8 @@ impl AwsService for IamService {
             "TagRole" => self.tag_role(&req),
             "UntagRole" => self.untag_role(&req),
             "ListRoleTags" => self.list_role_tags(&req),
+            "PutRolePermissionsBoundary" => self.put_role_permissions_boundary(&req),
+            "DeleteRolePermissionsBoundary" => self.delete_role_permissions_boundary(&req),
 
             // Policies (managed)
             "CreatePolicy" => self.create_policy(&req),
@@ -240,6 +242,8 @@ impl AwsService for IamService {
             "TagRole",
             "UntagRole",
             "ListRoleTags",
+            "PutRolePermissionsBoundary",
+            "DeleteRolePermissionsBoundary",
             "CreatePolicy",
             "GetPolicy",
             "DeletePolicy",
@@ -387,6 +391,19 @@ fn required_param(
     })
 }
 
+/// Resolve the calling user when UserName is not provided.
+/// Returns the first user found or a default "default" name.
+fn resolve_calling_user(state: &crate::state::IamState, _account_id: &str) -> String {
+    // In a real implementation, we'd look up the user from the access key.
+    // For simplicity, return the first user or "default".
+    state
+        .users
+        .keys()
+        .next()
+        .cloned()
+        .unwrap_or_else(|| "default".to_string())
+}
+
 fn generate_id() -> String {
     uuid::Uuid::new_v4()
         .to_string()
@@ -443,6 +460,45 @@ fn tags_xml(tags: &[Tag]) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn paginated_tags_response(action: &str, tags: &[Tag], req: &AwsRequest) -> String {
+    let max_items: usize = req
+        .query_params
+        .get("MaxItems")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(100);
+    let offset: usize = req
+        .query_params
+        .get("Marker")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    let page = &tags[offset..tags.len().min(offset + max_items)];
+    let is_truncated = offset + max_items < tags.len();
+    let members = tags_xml(page);
+    let marker = if is_truncated {
+        format!("<Marker>{}</Marker>", offset + max_items)
+    } else {
+        String::new()
+    };
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<{action}Response xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <{action}Result>
+    <IsTruncated>{is_truncated}</IsTruncated>
+    <Tags>
+{members}
+    </Tags>
+    {marker}
+  </{action}Result>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</{action}Response>"#,
+        req.request_id
+    )
 }
 
 fn validate_tags(tags: &[Tag], existing_count: usize) -> Result<(), AwsServiceError> {
@@ -519,10 +575,49 @@ fn validate_tags(tags: &[Tag], existing_count: usize) -> Result<(), AwsServiceEr
     Ok(())
 }
 
+fn validate_untag_keys(keys: &[String]) -> Result<(), AwsServiceError> {
+    if keys.len() > 50 {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationError",
+            "1 validation error detected: Value at 'tagKeys' failed to satisfy constraint: Member must have length less than or equal to 50.".to_string(),
+        ));
+    }
+    for key in keys {
+        if key.len() > 128 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "1 validation error detected: Value at 'tagKeys' failed to satisfy constraint: Member must have length less than or equal to 128.".to_string(),
+            ));
+        }
+        if !key.chars().all(|c| {
+            c.is_alphanumeric()
+                || c == ' '
+                || c == '+'
+                || c == '-'
+                || c == '='
+                || c == '.'
+                || c == '_'
+                || c == ':'
+                || c == '/'
+                || c == '@'
+        }) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "1 validation error detected: Value at 'tagKeys' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]+".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn empty_response(action: &str, request_id: &str) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <{action}Response xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <{action}Result/>
   <ResponseMetadata>
     <RequestId>{request_id}</RequestId>
   </ResponseMetadata>
@@ -893,7 +988,11 @@ impl IamService {
     }
 
     fn delete_access_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
+        let user_name = req
+            .query_params
+            .get("UserName")
+            .cloned()
+            .unwrap_or_else(|| resolve_calling_user(&self.state.read(), &req.account_id));
         let access_key_id = required_param(&req.query_params, "AccessKeyId")?;
         let mut state = self.state.write();
 
@@ -920,7 +1019,11 @@ impl IamService {
     }
 
     fn list_access_keys(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
+        let user_name = req
+            .query_params
+            .get("UserName")
+            .cloned()
+            .unwrap_or_else(|| resolve_calling_user(&self.state.read(), &req.account_id));
         let state = self.state.read();
         let keys = state
             .access_keys
@@ -932,7 +1035,11 @@ impl IamService {
     }
 
     fn update_access_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
+        let user_name = req
+            .query_params
+            .get("UserName")
+            .cloned()
+            .unwrap_or_else(|| resolve_calling_user(&self.state.read(), &req.account_id));
         let access_key_id = required_param(&req.query_params, "AccessKeyId")?;
         let status = required_param(&req.query_params, "Status")?;
         let mut state = self.state.write();
@@ -982,7 +1089,19 @@ impl IamService {
             .and_then(|v| v.parse().ok())
             .unwrap_or(3600);
         let tags = parse_tags(&req.query_params);
+        validate_tags(&tags, 0)?;
         let permissions_boundary = req.query_params.get("PermissionsBoundary").cloned();
+
+        // Validate permissions boundary ARN format
+        if let Some(ref boundary) = permissions_boundary {
+            if !boundary.contains(":policy/") {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!("Value ({boundary}) for parameter PermissionsBoundary is invalid."),
+                ));
+            }
+        }
 
         let mut state = self.state.write();
 
@@ -1127,9 +1246,12 @@ impl IamService {
             )
         })?;
 
-        if let Some(desc) = req.query_params.get("Description") {
-            role.description = desc.clone();
-        }
+        // UpdateRole clears description if not provided
+        role.description = req
+            .query_params
+            .get("Description")
+            .cloned()
+            .unwrap_or_default();
         if let Some(dur) = req
             .query_params
             .get("MaxSessionDuration")
@@ -1170,12 +1292,51 @@ impl IamService {
         let policy_document = required_param(&req.query_params, "PolicyDocument")?;
 
         // Validate policy document is valid JSON
-        if serde_json::from_str::<serde_json::Value>(&policy_document).is_err() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "MalformedPolicyDocument",
-                "Syntax errors in policy.".to_string(),
-            ));
+        let doc: serde_json::Value = match serde_json::from_str(&policy_document) {
+            Ok(v) => v,
+            Err(_) => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "MalformedPolicyDocument",
+                    "Syntax errors in policy.".to_string(),
+                ));
+            }
+        };
+
+        // Validate trust policy constraints
+        if let Some(statements) = doc.get("Statement").and_then(|s| s.as_array()) {
+            for stmt in statements {
+                // Check for prohibited Resource field
+                if stmt.get("Resource").is_some() {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "MalformedPolicyDocument",
+                        "Has prohibited field Resource.".to_string(),
+                    ));
+                }
+                // Validate actions are valid trust policy actions
+                let allowed = [
+                    "sts:AssumeRole",
+                    "sts:AssumeRoleWithSAML",
+                    "sts:AssumeRoleWithWebIdentity",
+                ];
+                let actions: Vec<&str> = match stmt.get("Action") {
+                    Some(serde_json::Value::String(s)) => vec![s.as_str()],
+                    Some(serde_json::Value::Array(arr)) => {
+                        arr.iter().filter_map(|v| v.as_str()).collect()
+                    }
+                    _ => vec![],
+                };
+                for action in &actions {
+                    if !allowed.contains(action) {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "MalformedPolicyDocument",
+                            "Trust Policy statement actions can only be sts:AssumeRole, sts:AssumeRoleWithSAML,  and sts:AssumeRoleWithWebIdentity".to_string(),
+                        ));
+                    }
+                }
+            }
         }
 
         let mut state = self.state.write();
@@ -1197,6 +1358,7 @@ impl IamService {
     fn tag_role(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let role_name = required_param(&req.query_params, "RoleName")?;
         let new_tags = parse_tags(&req.query_params);
+        validate_tags(&new_tags, 0)?;
         let mut state = self.state.write();
 
         let role = state.roles.get_mut(&role_name).ok_or_else(|| {
@@ -1222,6 +1384,7 @@ impl IamService {
     fn untag_role(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let role_name = required_param(&req.query_params, "RoleName")?;
         let tag_keys = parse_tag_keys(&req.query_params);
+        validate_untag_keys(&tag_keys)?;
         let mut state = self.state.write();
 
         let role = state.roles.get_mut(&role_name).ok_or_else(|| {
@@ -1250,22 +1413,57 @@ impl IamService {
             )
         })?;
 
-        let members = tags_xml(&role.tags);
-        let xml = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<ListRoleTagsResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
-  <ListRoleTagsResult>
-    <IsTruncated>false</IsTruncated>
-    <Tags>
-{members}
-    </Tags>
-  </ListRoleTagsResult>
-  <ResponseMetadata>
-    <RequestId>{}</RequestId>
-  </ResponseMetadata>
-</ListRoleTagsResponse>"#,
-            req.request_id
-        );
+        let xml = paginated_tags_response("ListRoleTags", &role.tags, req);
+        Ok(AwsResponse::xml(StatusCode::OK, xml))
+    }
+
+    fn put_role_permissions_boundary(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let role_name = required_param(&req.query_params, "RoleName")?;
+        let boundary = required_param(&req.query_params, "PermissionsBoundary")?;
+
+        // Validate boundary ARN format
+        if !boundary.contains(":policy/") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                format!("Value ({boundary}) for parameter PermissionsBoundary is invalid."),
+            ));
+        }
+
+        let mut state = self.state.write();
+        let role = state.roles.get_mut(&role_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchEntity",
+                format!("Role {role_name} not found"),
+            )
+        })?;
+
+        role.permissions_boundary = Some(boundary);
+        let xml = empty_response("PutRolePermissionsBoundary", &req.request_id);
+        Ok(AwsResponse::xml(StatusCode::OK, xml))
+    }
+
+    fn delete_role_permissions_boundary(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let role_name = required_param(&req.query_params, "RoleName")?;
+        let mut state = self.state.write();
+
+        let role = state.roles.get_mut(&role_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchEntity",
+                format!("Role {role_name} not found"),
+            )
+        })?;
+
+        role.permissions_boundary = None;
+        let xml = empty_response("DeleteRolePermissionsBoundary", &req.request_id);
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 }
@@ -1426,6 +1624,7 @@ impl IamService {
     fn untag_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let policy_arn = required_param(&req.query_params, "PolicyArn")?;
         let tag_keys = parse_tag_keys(&req.query_params);
+        validate_untag_keys(&tag_keys)?;
         let mut state = self.state.write();
 
         let policy = state.policies.get_mut(&policy_arn).ok_or_else(|| {
@@ -1454,22 +1653,7 @@ impl IamService {
             )
         })?;
 
-        let members = tags_xml(&policy.tags);
-        let xml = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<ListPolicyTagsResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
-  <ListPolicyTagsResult>
-    <IsTruncated>false</IsTruncated>
-    <Tags>
-{members}
-    </Tags>
-  </ListPolicyTagsResult>
-  <ResponseMetadata>
-    <RequestId>{}</RequestId>
-  </ResponseMetadata>
-</ListPolicyTagsResponse>"#,
-            req.request_id
-        );
+        let xml = paginated_tags_response("ListPolicyTags", &policy.tags, req);
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 }
@@ -1492,7 +1676,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("Policy {policy_arn} not found."),
+                format!("Policy {policy_arn} not found"),
             )
         })?;
 
@@ -1557,7 +1741,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("Policy {policy_arn} not found."),
+                format!("Policy {policy_arn} not found"),
             )
         })?;
 
@@ -1607,7 +1791,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("Policy {policy_arn} not found."),
+                format!("Policy {policy_arn} not found"),
             )
         })?;
 
@@ -1654,7 +1838,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("Policy {policy_arn} not found."),
+                format!("Policy {policy_arn} not found"),
             )
         })?;
 
@@ -1671,7 +1855,7 @@ impl IamService {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("Policy version {version_id} not found."),
+                format!("Policy version {version_id} not found"),
             ));
         }
 
@@ -1685,13 +1869,39 @@ impl IamService {
         let policy_arn = required_param(&req.query_params, "PolicyArn")?;
         let version_id = required_param(&req.query_params, "VersionId")?;
 
+        // Validate version ID format: must match v[1-9][0-9]*(\.[A-Za-z0-9-]*)?
+        let valid_format = version_id.starts_with('v')
+            && version_id.len() > 1
+            && version_id[1..2]
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_digit() && c != '0')
+            && version_id[1..]
+                .split_once('.')
+                .map(|(num, ext)| {
+                    num.chars().all(|c| c.is_ascii_digit())
+                        && ext.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+                })
+                .unwrap_or_else(|| version_id[1..].chars().all(|c| c.is_ascii_digit()));
+
+        if !valid_format {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                format!(
+                    "Value '{}' at 'versionId' failed to satisfy constraint: Member must satisfy regular expression pattern: v[1-9][0-9]*(\\.[A-Za-z0-9-]*)?",
+                    version_id
+                ),
+            ));
+        }
+
         let mut state = self.state.write();
 
         let policy = state.policies.get_mut(&policy_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("Policy {policy_arn} not found."),
+                format!("Policy {policy_arn} not found"),
             )
         })?;
 
@@ -1699,7 +1909,9 @@ impl IamService {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("Version {version_id} not found."),
+                format!(
+                    "Policy {policy_arn} version {version_id} does not exist or is not attachable."
+                ),
             ));
         }
 
@@ -1928,6 +2140,19 @@ impl IamService {
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
                 format!("Role {role_name} not found"),
+            ));
+        }
+
+        let policy_exists = state
+            .role_inline_policies
+            .get(&role_name)
+            .is_some_and(|p| p.contains_key(&policy_name));
+
+        if !policy_exists {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchEntity",
+                format!("The role policy with name {policy_name} cannot be found."),
             ));
         }
 
@@ -3158,7 +3383,7 @@ impl IamService {
                 state.roles.get(rn).map(|r| {
                     format!(
                         "        <member>\n          <Path>{}</Path>\n          <RoleName>{}</RoleName>\n          <RoleId>{}</RoleId>\n          <Arn>{}</Arn>\n          <CreateDate>{}</CreateDate>\n          <AssumeRolePolicyDocument>{}</AssumeRolePolicyDocument>\n        </member>",
-                        r.path, r.role_name, r.role_id, r.arn, r.created_at.format("%Y-%m-%dT%H:%M:%SZ"), xml_escape(&r.assume_role_policy_document)
+                        r.path, r.role_name, r.role_id, r.arn, r.created_at.format("%Y-%m-%dT%H:%M:%SZ"), url_encode(&r.assume_role_policy_document)
                     )
                 })
             })
@@ -3369,7 +3594,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("SAML provider {arn} not found."),
+                format!("SAML provider {arn} not found"),
             )
         })?;
 
@@ -3405,7 +3630,7 @@ impl IamService {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("SAML provider {arn} not found."),
+                format!("SAML provider {arn} not found"),
             ));
         }
 
@@ -3457,7 +3682,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("SAML provider {arn} not found."),
+                format!("SAML provider {arn} not found"),
             )
         })?;
 
@@ -4334,7 +4559,7 @@ impl IamService {
                 AwsServiceError::aws_error(
                     StatusCode::NOT_FOUND,
                     "NoSuchEntity",
-                    format!("Deletion task {task_id} not found."),
+                    format!("Deletion task {task_id} not found"),
                 )
             })?;
 
@@ -4696,6 +4921,50 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        // Validate constraints
+        let min_len: Option<i64> = req
+            .query_params
+            .get("MinimumPasswordLength")
+            .and_then(|v| v.parse().ok());
+        let max_age: Option<i64> = req
+            .query_params
+            .get("MaxPasswordAge")
+            .and_then(|v| v.parse().ok());
+        let reuse_prevention: Option<i64> = req
+            .query_params
+            .get("PasswordReusePrevention")
+            .and_then(|v| v.parse().ok());
+
+        let mut errors = Vec::new();
+        if let Some(v) = min_len {
+            if v > 128 {
+                errors.push(format!("Value \"{v}\" at \"minimumPasswordLength\" failed to satisfy constraint: Member must have value less than or equal to 128"));
+            }
+        }
+        if let Some(v) = reuse_prevention {
+            if v > 24 {
+                errors.push(format!("Value \"{v}\" at \"passwordReusePrevention\" failed to satisfy constraint: Member must have value less than or equal to 24"));
+            }
+        }
+        if let Some(v) = max_age {
+            if v > 1095 {
+                errors.push(format!("Value \"{v}\" at \"maxPasswordAge\" failed to satisfy constraint: Member must have value less than or equal to 1095"));
+            }
+        }
+        if !errors.is_empty() {
+            let n = errors.len();
+            let msg = format!(
+                "{n} validation error{} detected: {}",
+                if n > 1 { "s" } else { "" },
+                errors.join("; ")
+            );
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                msg,
+            ));
+        }
+
         let mut state = self.state.write();
 
         let policy = state
@@ -4756,18 +5025,17 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                "The Password Policy with domain name IAM cannot be found.".to_string(),
+                format!(
+                    "The Password Policy with domain name {} cannot be found.",
+                    state.account_id
+                ),
             )
         })?;
 
-        let max_age_xml = if policy.max_password_age > 0 {
-            format!(
-                "\n      <MaxPasswordAge>{}</MaxPasswordAge>",
-                policy.max_password_age
-            )
-        } else {
-            String::new()
-        };
+        let max_age_xml = format!(
+            "\n      <MaxPasswordAge>{}</MaxPasswordAge>",
+            policy.max_password_age
+        );
 
         let reuse_prevention_xml = if policy.password_reuse_prevention > 0 {
             format!(
@@ -5001,7 +5269,7 @@ impl IamService {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("VirtualMFADevice with serial number {serial_number} not found."),
+                format!("VirtualMFADevice with serial number {serial_number} not found"),
             ));
         }
 
@@ -5096,7 +5364,7 @@ impl IamService {
                 AwsServiceError::aws_error(
                     StatusCode::NOT_FOUND,
                     "NoSuchEntity",
-                    format!("VirtualMFADevice with serial number {serial_number} not found."),
+                    format!("VirtualMFADevice with serial number {serial_number} not found"),
                 )
             })?;
 

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -9,6 +9,23 @@ fn xml_escape(s: &str) -> String {
         .replace('"', "&quot;")
 }
 
+/// URL-encode a policy document for XML embedding (like AWS does).
+fn url_encode_policy(s: &str) -> String {
+    let mut result = String::new();
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(byte as char);
+            }
+            _ => {
+                use std::fmt::Write;
+                write!(result, "%{:02X}", byte).unwrap();
+            }
+        }
+    }
+    result
+}
+
 fn tags_xml(tags: &[crate::state::Tag]) -> String {
     if tags.is_empty() {
         return String::new();
@@ -102,7 +119,7 @@ fn role_xml(role: &IamRole) -> String {
         id = role.role_id,
         arn = role.arn,
         date = role.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
-        policy = xml_escape(&role.assume_role_policy_document),
+        policy = url_encode_policy(&role.assume_role_policy_document),
         max_session = role.max_session_duration,
     )
 }
@@ -310,7 +327,7 @@ pub fn list_roles_response(roles: &[IamRole], request_id: &str) -> String {
                 id = r.role_id,
                 arn = r.arn,
                 date = r.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
-                policy = xml_escape(&r.assume_role_policy_document),
+                policy = url_encode_policy(&r.assume_role_policy_document),
                 max_session = r.max_session_duration,
             )
         })

--- a/crates/fakecloud-sqs/Cargo.toml
+++ b/crates/fakecloud-sqs/Cargo.toml
@@ -18,5 +18,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 md-5 = { workspace = true }
+sha2 = { workspace = true }
 tokio = { workspace = true }
 base64 = { workspace = true }

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -63,8 +63,8 @@ impl SqsDelivery for SqsDeliveryImpl {
             let effective_dedup_id = if message_dedup_id.is_some() {
                 message_dedup_id.map(|s| s.to_string())
             } else if queue.is_fifo {
-                // Content-based dedup: use MD5 of body
-                Some(crate::service::md5_hex(message_body))
+                // Content-based dedup: use SHA-256 of body (matches real SQS behavior)
+                Some(crate::service::sha256_hex(message_body))
             } else {
                 None
             };

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -41,7 +41,33 @@ impl SqsDelivery for SqsDeliveryImpl {
         let queue = state.queues.values_mut().find(|q| q.arn == queue_arn);
 
         if let Some(queue) = queue {
+            // For FIFO queues without content-based dedup, require explicit dedup ID
+            if queue.is_fifo && message_dedup_id.is_none() {
+                let content_based = queue
+                    .attributes
+                    .get("ContentBasedDeduplication")
+                    .map(|v| v.as_str())
+                    == Some("true");
+                if !content_based {
+                    tracing::debug!(
+                        queue_arn,
+                        "skipping delivery: FIFO queue requires dedup ID or content-based dedup"
+                    );
+                    return;
+                }
+            }
+
             let now = Utc::now();
+
+            // For FIFO queues with content-based dedup, generate dedup ID if not provided
+            let effective_dedup_id = if message_dedup_id.is_some() {
+                message_dedup_id.map(|s| s.to_string())
+            } else if queue.is_fifo {
+                // Content-based dedup: use MD5 of body
+                Some(crate::service::md5_hex(message_body))
+            } else {
+                None
+            };
 
             // Convert SqsMessageAttribute to the SQS state MessageAttribute
             let sqs_attrs: HashMap<String, MessageAttribute> = message_attributes
@@ -69,7 +95,7 @@ impl SqsDelivery for SqsDeliveryImpl {
                 visible_at: None,
                 receive_count: 0,
                 message_group_id: message_group_id.map(|s| s.to_string()),
-                message_dedup_id: message_dedup_id.map(|s| s.to_string()),
+                message_dedup_id: effective_dedup_id,
                 created_at: now,
                 sequence_number: None,
             };

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -3,6 +3,7 @@ use chrono::Utc;
 use http::StatusCode;
 use md5::{Digest, Md5};
 use serde_json::{json, Value};
+use sha2::Sha256;
 use std::collections::{HashMap, VecDeque};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
@@ -2314,4 +2315,10 @@ pub fn md5_hex(input: &str) -> String {
     let mut hasher = Md5::new();
     hasher.update(input.as_bytes());
     format!("{:032x}", hasher.finalize())
+}
+
+pub fn sha256_hex(input: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    format!("{:064x}", hasher.finalize())
 }

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -2089,12 +2089,13 @@ fn format_receive_response(
         })
         .collect();
 
-    sqs_response(
-        "ReceiveMessage",
-        json!({ "Messages": messages }),
-        request_id,
-        is_query,
-    )
+    let body = if messages.is_empty() {
+        json!({})
+    } else {
+        json!({ "Messages": messages })
+    };
+
+    sqs_response("ReceiveMessage", body, request_id, is_query)
 }
 
 fn parse_message_attributes(body: &Value) -> HashMap<String, MessageAttribute> {


### PR DESCRIPTION
## Summary

- **EventBridge PutEvents→SQS delivery**: Events now match against rules and deliver to SQS targets at PutEvents time (not just via the scheduler for cron/rate rules). Includes account/region/resources in pattern matching, InputTransformer support, FIFO queue handling with content-based dedup, and proper ISO 8601 time formatting.
- **EventBridge partner events**: Added CreatePartnerEventSource and DescribePartnerEventSource stubs so partner event buses can be created.
- **SQS ReceiveMessage**: Omit Messages key from response when queue is empty (matches AWS behavior).
- **IAM error messages**: Removed trailing periods from NoSuchEntity messages where AWS omits them; fixed password policy domain name in error message.
- **IAM validation**: Added trust policy action/Resource validation in UpdateAssumeRolePolicy, version ID format validation in SetDefaultPolicyVersion, tag validation on CreateRole/TagRole, untag key validation, PermissionsBoundary ARN validation, DeleteRolePolicy existence check, password policy constraint validation.
- **IAM response format**: Added Result element to empty XML responses, URL-encoded AssumeRolePolicyDocument, added paginated tag listing, added PutRolePermissionsBoundary/DeleteRolePermissionsBoundary actions, fixed UpdateRole to clear Description when omitted.

## Test plan

- [x] `test_send_to_sqs_queue` passes
- [x] `test_send_to_sqs_fifo_queue` passes
- [x] `test_send_to_sqs_queue_with_custom_event_bus` passes
- [x] `test_create_partner_event_bus` passes
- [x] 20 previously-failing IAM tests now pass (out of 21 targeted; remaining is FKIA prefix by design)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude fakecloud-e2e` all green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delivers EventBridge PutEvents to SQS/SNS immediately with correct rule matching and FIFO/InputTransformer support, and tightens IAM validation and XML responses to better match AWS.

- New Features
  - `fakecloud-eventbridge`: Deliver PutEvents to SQS/SNS at call time; include account/region/resources in pattern matching and event JSON; accept numeric timestamps; format time as ISO 8601 without fractions.
  - `fakecloud-eventbridge`: Support InputTransformer/InputPath for targets; add `CreatePartnerEventSource` and `DescribePartnerEventSource` (return `ResourceAlreadyExistsException` on duplicates).
  - `fakecloud-sqs`: FIFO via `SqsParameters.MessageGroupId`; require dedup ID or content-based dedup; auto-generate dedup ID for content-based queues using SHA-256; omit `Messages` from `ReceiveMessage` when empty.

- Bug Fixes
  - `fakecloud-iam` validation: Restrict trust policy actions and disallow Resource; validate `SetDefaultPolicyVersion` format; validate tag limits/charset (TagRole counts existing tags); validate untag keys; validate PermissionsBoundary ARN; check inline role policy exists on delete.
  - `fakecloud-iam` APIs/responses: URL-encode `AssumeRolePolicyDocument`; include empty Result element in XML; paginate `ListRoleTags`/`ListPolicyTags` and clamp `Marker` to avoid slice errors; `UpdateRole` clears Description if omitted; make `UserName` optional for List/Update/DeleteAccessKey.
  - `fakecloud-iam` password policy: Validate limits; always include `MaxPasswordAge`; fix GetAccountPasswordPolicy error to use the account ID.
  - `fakecloud-iam` errors: Remove trailing periods from `NoSuchEntity` messages where AWS omits them.

<sup>Written for commit 3fb292f8470f85755dbc7b47548f951ba338ee39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

