### PR TITLE
refactor(sts): remove --default-caller-arn, patch Moto tests instead

### DIFF
--- a/.github/workflows/moto-compat.yml
+++ b/.github/workflows/moto-compat.yml
@@ -56,8 +56,7 @@ jobs:
 
       - name: Start FakeCloud
         run: |
-          FAKECLOUD_DEFAULT_CALLER_ARN="arn:aws:sts::123456789012:user/moto" \
-            ./target/release/fakecloud-server --log-level warn > /tmp/fakecloud.log 2>&1 &
+          ./target/release/fakecloud-server --log-level warn > /tmp/fakecloud.log 2>&1 &
           echo "FAKECLOUD_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for FakeCloud health check

--- a/crates/fakecloud-iam/src/state.rs
+++ b/crates/fakecloud-iam/src/state.rs
@@ -213,8 +213,6 @@ pub struct IamState {
     pub service_linked_role_deletions: HashMap<String, ServiceLinkedRoleDeletion>,
     /// Maps access key ID to the identity that should be returned by GetCallerIdentity.
     pub credential_identities: HashMap<String, CredentialIdentity>,
-    /// Override ARN for GetCallerIdentity when no user/role matches.
-    pub default_caller_arn: Option<String>,
     pub credential_report_generated: bool,
 }
 
@@ -242,7 +240,6 @@ impl IamState {
             virtual_mfa_devices: HashMap::new(),
             service_linked_role_deletions: HashMap::new(),
             credential_identities: HashMap::new(),
-            default_caller_arn: None,
             credential_report_generated: false,
         }
     }

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -114,22 +114,8 @@ impl StsService {
             }
         }
 
-        // Default identity
-        let arn = match &state.default_caller_arn {
-            Some(override_arn) => {
-                // Replace the partition in the override ARN to match the request's region
-                if let Some(rest) = override_arn.strip_prefix("arn:") {
-                    if let Some(pos) = rest.find(':') {
-                        format!("arn:{}{}", partition, &rest[pos..])
-                    } else {
-                        override_arn.clone()
-                    }
-                } else {
-                    override_arn.clone()
-                }
-            }
-            None => format!("arn:{}:iam::{}:root", partition, state.account_id),
-        };
+        // Default identity — matches real AWS root credentials
+        let arn = format!("arn:{}:iam::{}:root", partition, state.account_id);
         let user_id = "FKIAIOSFODNN7EXAMPLE";
         let xml = xml_responses::get_caller_identity_response(
             &state.account_id,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -34,10 +34,6 @@ struct Cli {
     #[arg(long, default_value = "123456789012", env = "FAKECLOUD_ACCOUNT_ID")]
     account_id: String,
 
-    /// Default ARN for GetCallerIdentity when no IAM user/role is matched
-    #[arg(long, env = "FAKECLOUD_DEFAULT_CALLER_ARN")]
-    default_caller_arn: Option<String>,
-
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, default_value = "info", env = "FAKECLOUD_LOG")]
     log_level: String,
@@ -55,9 +51,9 @@ async fn main() {
         .init();
 
     // Shared state
-    let mut iam_init = fakecloud_iam::state::IamState::new(&cli.account_id);
-    iam_init.default_caller_arn = cli.default_caller_arn;
-    let iam_state = Arc::new(parking_lot::RwLock::new(iam_init));
+    let iam_state = Arc::new(parking_lot::RwLock::new(
+        fakecloud_iam::state::IamState::new(&cli.account_id),
+    ));
     let sqs_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_sqs::state::SqsState::new(&cli.account_id, &cli.region, "http://localhost:4566"),
     ));

--- a/tests/compat/moto/patches/sts-hardcoded-credentials.patch
+++ b/tests/compat/moto/patches/sts-hardcoded-credentials.patch
@@ -1,5 +1,5 @@
---- a/tests/test_sts/test_sts.py	2026-04-04 18:26:51
-+++ b/tests/test_sts/test_sts.py	2026-04-04 18:27:25
+--- a/tests/test_sts/test_sts.py	2026-04-04 22:35:31
++++ b/tests/test_sts/test_sts.py	2026-04-04 22:35:24
 @@ -25,14 +25,15 @@
      if not settings.TEST_SERVER_MODE:
          fdate = creds["Expiration"].strftime("%Y-%m-%dT%H:%M:%S.000Z")
@@ -88,12 +88,39 @@
      assert len(creds["SecretAccessKey"]) == 40
  
      assert user["Arn"] == (
-@@ -664,7 +666,7 @@
+@@ -663,8 +665,11 @@
+ def test_get_caller_identity_with_default_credentials(region, partition):
      identity = boto3.client("sts", region_name=region).get_caller_identity()
  
-     assert identity["Arn"] == f"arn:{partition}:sts::{ACCOUNT_ID}:user/moto"
+-    assert identity["Arn"] == f"arn:{partition}:sts::{ACCOUNT_ID}:user/moto"
 -    assert identity["UserId"] == "AKIAIOSFODNN7EXAMPLE"
++    if not settings.TEST_SERVER_MODE:
++        assert identity["Arn"] == f"arn:{partition}:sts::{ACCOUNT_ID}:user/moto"
++    else:
++        assert f":{ACCOUNT_ID}:" in identity["Arn"]
 +    assert len(identity["UserId"]) == 20
      assert identity["Account"] == str(ACCOUNT_ID)
  
  
+@@ -769,12 +774,15 @@
+     resp = client.get_caller_identity()
+     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+ 
+-    if region == "us-west-2":
+-        assert resp["Arn"] == f"arn:aws:sts::{ACCOUNT_ID}:user/moto"
+-    if region == "cn-northwest-1":
+-        assert resp["Arn"] == f"arn:aws-cn:sts::{ACCOUNT_ID}:user/moto"
+-    if region == "us-isob-east-1":
+-        assert resp["Arn"] == f"arn:aws-iso-b:sts::{ACCOUNT_ID}:user/moto"
++    if not settings.TEST_SERVER_MODE:
++        if region == "us-west-2":
++            assert resp["Arn"] == f"arn:aws:sts::{ACCOUNT_ID}:user/moto"
++        if region == "cn-northwest-1":
++            assert resp["Arn"] == f"arn:aws-cn:sts::{ACCOUNT_ID}:user/moto"
++        if region == "us-isob-east-1":
++            assert resp["Arn"] == f"arn:aws-iso-b:sts::{ACCOUNT_ID}:user/moto"
++    else:
++        assert f":{ACCOUNT_ID}:" in resp["Arn"]
+ 
+ 
+ @mock_aws


### PR DESCRIPTION
## Summary
- Remove `--default-caller-arn` CLI flag and `FAKECLOUD_DEFAULT_CALLER_ARN` env var
- Always return `arn:{partition}:iam::{account}:root` for default GetCallerIdentity (correct AWS behavior)
- Expand STS Moto patch to guard `user/moto` ARN assertions with `TEST_SERVER_MODE`
- Remove env var from CI workflow

The flag was a hack to match Moto's convention. Now that we have patch infrastructure, patching is how we handle Moto-specific assertions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the `--default-caller-arn` flag and `FAKECLOUD_DEFAULT_CALLER_ARN` env var. STS GetCallerIdentity now returns the AWS-correct `arn:{partition}:iam::{account}:root`, and Moto tests are patched to accept this in server mode.

- **Refactors**
  - Always return root ARN in GetCallerIdentity; remove the default-caller override from IAM state.
  - Patch Moto to guard `user/moto` ARN assertions with `TEST_SERVER_MODE` and accept any valid ARN in server mode.
  - Remove the env var from the CI workflow.

- **Migration**
  - Stop using `--default-caller-arn` and `FAKECLOUD_DEFAULT_CALLER_ARN`.
  - If tests expect `user/moto` in server mode, update them to allow the root ARN or use the provided Moto patch.

<sup>Written for commit bab9f526105f0250406072d92292e737e3b73516. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

