### PR TITLE
fix: address unaddressed Cubic review comments

### DIFF
--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -1495,12 +1495,14 @@ impl IamService {
         let tags = parse_tags(&req.query_params);
         validate_tags(&tags, 0)?;
 
+        let partition = partition_for_region(&req.region);
+        let effective_account = self.effective_account_id(req);
+
         let mut state = self.state.write();
 
-        let partition = partition_for_region(&req.region);
         let arn = format!(
             "arn:{}:iam::{}:policy{}{}",
-            partition, state.account_id, path, policy_name
+            partition, effective_account, path, policy_name
         );
 
         // Check for duplicate policy ARN

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -386,6 +386,7 @@ impl SnsService {
         let next_token = param(req, "NextToken")
             .and_then(|t| t.parse::<usize>().ok())
             .unwrap_or(0);
+        let next_token = next_token.min(all_topics.len());
 
         let page = &all_topics[next_token..];
         let has_more = page.len() > DEFAULT_PAGE_SIZE;
@@ -1310,6 +1311,7 @@ impl SnsService {
         let next_token = param(req, "NextToken")
             .and_then(|t| t.parse::<usize>().ok())
             .unwrap_or(0);
+        let next_token = next_token.min(all_subs.len());
 
         let page = &all_subs[next_token..];
         let has_more = page.len() > DEFAULT_PAGE_SIZE;
@@ -1368,6 +1370,7 @@ impl SnsService {
         let next_token = param(req, "NextToken")
             .and_then(|t| t.parse::<usize>().ok())
             .unwrap_or(0);
+        let next_token = next_token.min(all_subs.len());
 
         let page = &all_subs[next_token..];
         let has_more = page.len() > DEFAULT_PAGE_SIZE;

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -501,6 +501,19 @@ impl SqsService {
             attributes.insert("FifoThroughputLimit".to_string(), "perQueue".to_string());
         }
 
+        // Validate DelaySeconds (0–900 inclusive)
+        if let Some(ds) = new_attributes.get("DelaySeconds") {
+            if let Ok(d) = ds.parse::<i64>() {
+                if !(0..=900).contains(&d) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidAttributeValue",
+                        "Invalid value for the parameter DelaySeconds.".to_string(),
+                    ));
+                }
+            }
+        }
+
         // Validate MaximumMessageSize before inserting
         if let Some(mms) = new_attributes.get("MaximumMessageSize") {
             if let Ok(size) = mms.parse::<u64>() {
@@ -954,9 +967,9 @@ impl SqsService {
             ));
         }
 
-        // Validate delay seconds (max 900 = 15 minutes)
+        // Validate delay seconds (0–900 inclusive)
         if let Some(d) = val_as_i64(&body["DelaySeconds"]) {
-            if d > 900 {
+            if !(0..=900).contains(&d) {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "InvalidParameterValue",
@@ -1588,6 +1601,21 @@ impl SqsService {
             .get_mut(&resolved_url)
             .ok_or_else(queue_not_found)?;
 
+        // Validate DelaySeconds (0–900 inclusive) before applying
+        if let Some(attrs) = body["Attributes"].as_object() {
+            if let Some(ds) = attrs.get("DelaySeconds").and_then(|v| v.as_str()) {
+                if let Ok(d) = ds.parse::<i64>() {
+                    if !(0..=900).contains(&d) {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidAttributeValue",
+                            "Invalid value for the parameter DelaySeconds.".to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+
         if let Some(attrs) = body["Attributes"].as_object() {
             for (k, v) in attrs {
                 if let Some(s) = v.as_str() {
@@ -1776,9 +1804,9 @@ impl SqsService {
                 continue;
             }
 
-            // Per-entry delay validation (max 900 seconds)
+            // Per-entry delay validation (0–900 seconds)
             if let Some(d) = val_as_i64(&entry["DelaySeconds"]) {
-                if d > 900 {
+                if !(0..=900).contains(&d) {
                     failed.push(json!({
                         "Id": id,
                         "SenderFault": true,

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -443,7 +443,7 @@ impl SqsService {
         if let Some(attrs) = body["Attributes"].as_object() {
             for (k, v) in attrs {
                 if let Some(s) = v.as_str() {
-                    new_attributes.insert(k.clone(), s.to_string());
+                    new_attributes.insert(k.trim().to_string(), s.to_string());
                 }
             }
         }

--- a/crates/fakecloud-ssm/src/service.rs
+++ b/crates/fakecloud-ssm/src/service.rs
@@ -1443,7 +1443,7 @@ impl SsmService {
                 "SchemaVersion": "2.2",
                 "PlatformTypes": ["Linux", "MacOS", "Windows"],
                 "Hash": format!("{:x}", md5::compute(b"placeholder")),
-                "HashType": "Sha256",
+                "HashType": "Md5",
             }
         })))
     }
@@ -1611,7 +1611,7 @@ impl SsmService {
                 "SchemaVersion": "2.2",
                 "PlatformTypes": ["Linux", "MacOS", "Windows"],
                 "Hash": format!("{:x}", md5::compute(b"placeholder")),
-                "HashType": "Sha256",
+                "HashType": "Md5",
             }
         })))
     }


### PR DESCRIPTION
## Summary

- **SSM HashType mismatch**: Changed `HashType` from `"Sha256"` to `"Md5"` in `create_document` and `describe_document` to match the actual MD5 hash computation
- **SQS DelaySeconds negative values**: Added `< 0` validation for `DelaySeconds` in `SendMessage`, `SendMessageBatch`, `CreateQueue`, and `SetQueueAttributes` (AWS requires 0-900 inclusive)
- **SNS NextToken panic**: Clamped `next_token` to list length before slicing in `list_topics`, `list_subscriptions`, and `list_subscriptions_by_topic` to prevent out-of-bounds panics
- **IAM CreatePolicy account ID**: Use `effective_account_id(req)` instead of `state.account_id` in `CreatePolicy` ARN, matching the pattern used by `CreateUser`

## Test plan

- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo test --workspace` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes correctness gaps across `fakecloud-ssm`, `fakecloud-sqs`, `fakecloud-sns`, and `fakecloud-iam` to better match AWS behavior and prevent edge-case crashes.

- **Bug Fixes**
  - `fakecloud-ssm`: Set Document `HashType` to "Md5" in `create_document` and `describe_document`.
  - `fakecloud-sqs`: Trim attribute keys before validation in `CreateQueue`. Validate `DelaySeconds` is 0–900 in `CreateQueue`, `SetQueueAttributes`, `SendMessage`, and `SendMessageBatch`.
  - `fakecloud-sns`: Clamp `NextToken` to list length in `list_topics`, `list_subscriptions`, and `list_subscriptions_by_topic`.
  - `fakecloud-iam`: Build `CreatePolicy` ARNs with `effective_account_id(req)`.

<sup>Written for commit fbb0b788b83cd5197e6ee8970bc33079b9d3442f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

