### PR TITLE
feat(s3): implement bucket configuration operations

### DIFF
--- a/crates/fakecloud-s3/src/service.rs
+++ b/crates/fakecloud-s3/src/service.rs
@@ -6,7 +6,7 @@ use md5::{Digest, Md5};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
-use crate::state::{S3Bucket, S3Object, SharedS3State};
+use crate::state::{MultipartUpload, S3Bucket, S3Object, SharedS3State};
 
 pub struct S3Service {
     state: SharedS3State,
@@ -25,7 +25,6 @@ impl AwsService for S3Service {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        // S3 REST routing: method + path segments + query params
         let bucket = req.path_segments.first().map(|s| s.as_str());
         let key = if req.path_segments.len() > 1 {
             Some(req.path_segments[1..].join("/"))
@@ -34,36 +33,13 @@ impl AwsService for S3Service {
         };
 
         match (&req.method, bucket, key.as_deref()) {
-            // ListBuckets: GET /
             (&Method::GET, None, None) => self.list_buckets(&req),
 
-            // Bucket-level operations (no key)
-            (&Method::PUT, Some(b), None) => {
-                if req.query_params.contains_key("tagging") {
-                    self.put_bucket_tagging(&req, b)
-                } else {
-                    self.create_bucket(&req, b)
-                }
-            }
-            (&Method::DELETE, Some(b), None) => {
-                if req.query_params.contains_key("tagging") {
-                    self.delete_bucket_tagging(&req, b)
-                } else {
-                    self.delete_bucket(&req, b)
-                }
-            }
+            (&Method::PUT, Some(b), None) => self.route_put_bucket(&req, b),
+            (&Method::DELETE, Some(b), None) => self.route_delete_bucket(&req, b),
             (&Method::HEAD, Some(b), None) => self.head_bucket(b),
-            (&Method::GET, Some(b), None) => {
-                if req.query_params.contains_key("tagging") {
-                    self.get_bucket_tagging(&req, b)
-                } else if req.query_params.contains_key("location") {
-                    self.get_bucket_location(b)
-                } else {
-                    self.list_objects_v2(&req, b)
-                }
-            }
+            (&Method::GET, Some(b), None) => self.route_get_bucket(&req, b),
 
-            // Object-level operations
             (&Method::PUT, Some(b), Some(k)) => {
                 if req.headers.contains_key("x-amz-copy-source") {
                     self.copy_object(&req, b, k)
@@ -75,9 +51,11 @@ impl AwsService for S3Service {
             (&Method::DELETE, Some(b), Some(k)) => self.delete_object(b, k),
             (&Method::HEAD, Some(b), Some(k)) => self.head_object(b, k),
 
-            // POST /{bucket}?delete — batch delete
             (&Method::POST, Some(b), None) if req.query_params.contains_key("delete") => {
                 self.delete_objects(&req, b)
+            }
+            (&Method::POST, Some(b), Some(k)) if req.query_params.contains_key("uploads") => {
+                self.create_multipart_upload(&req, b, k)
             }
 
             _ => Err(AwsServiceError::aws_error(
@@ -95,6 +73,7 @@ impl AwsService for S3Service {
             "DeleteBucket",
             "HeadBucket",
             "ListObjectsV2",
+            "ListObjects",
             "PutObject",
             "GetObject",
             "DeleteObject",
@@ -105,7 +84,146 @@ impl AwsService for S3Service {
             "GetBucketTagging",
             "PutBucketTagging",
             "DeleteBucketTagging",
+            "GetBucketVersioning",
+            "PutBucketVersioning",
+            "GetBucketEncryption",
+            "PutBucketEncryption",
+            "DeleteBucketEncryption",
+            "GetBucketLifecycleConfiguration",
+            "PutBucketLifecycleConfiguration",
+            "DeleteBucketLifecycle",
+            "GetBucketPolicy",
+            "PutBucketPolicy",
+            "DeleteBucketPolicy",
+            "GetBucketCors",
+            "PutBucketCors",
+            "DeleteBucketCors",
+            "GetBucketAcl",
+            "PutBucketAcl",
+            "GetBucketNotificationConfiguration",
+            "PutBucketNotificationConfiguration",
+            "GetBucketLogging",
+            "PutBucketLogging",
+            "GetBucketWebsite",
+            "PutBucketWebsite",
+            "DeleteBucketWebsite",
+            "GetBucketAccelerateConfiguration",
+            "PutBucketAccelerateConfiguration",
+            "GetPublicAccessBlock",
+            "PutPublicAccessBlock",
+            "DeletePublicAccessBlock",
+            "GetObjectLockConfiguration",
+            "PutObjectLockConfiguration",
+            "ListObjectVersions",
+            "CreateMultipartUpload",
         ]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Routing helpers
+// ---------------------------------------------------------------------------
+impl S3Service {
+    fn route_put_bucket(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        if req.query_params.contains_key("tagging") {
+            self.put_bucket_tagging(req, bucket)
+        } else if req.query_params.contains_key("versioning") {
+            self.put_bucket_versioning(req, bucket)
+        } else if req.query_params.contains_key("encryption") {
+            self.put_bucket_encryption(req, bucket)
+        } else if req.query_params.contains_key("lifecycle") {
+            self.put_bucket_lifecycle(req, bucket)
+        } else if req.query_params.contains_key("policy") {
+            self.put_bucket_policy(req, bucket)
+        } else if req.query_params.contains_key("cors") {
+            self.put_bucket_cors(req, bucket)
+        } else if req.query_params.contains_key("acl") {
+            self.put_bucket_acl(req, bucket)
+        } else if req.query_params.contains_key("notification") {
+            self.put_bucket_notification(req, bucket)
+        } else if req.query_params.contains_key("logging") {
+            self.put_bucket_logging(req, bucket)
+        } else if req.query_params.contains_key("website") {
+            self.put_bucket_website(req, bucket)
+        } else if req.query_params.contains_key("accelerate") {
+            self.put_bucket_accelerate(req, bucket)
+        } else if req.query_params.contains_key("publicAccessBlock") {
+            self.put_public_access_block(req, bucket)
+        } else if req.query_params.contains_key("object-lock") {
+            self.put_object_lock_config(req, bucket)
+        } else {
+            self.create_bucket(req, bucket)
+        }
+    }
+
+    fn route_get_bucket(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        if req.query_params.contains_key("tagging") {
+            self.get_bucket_tagging(req, bucket)
+        } else if req.query_params.contains_key("location") {
+            self.get_bucket_location(bucket)
+        } else if req.query_params.contains_key("versioning") {
+            self.get_bucket_versioning(bucket)
+        } else if req.query_params.contains_key("encryption") {
+            self.get_bucket_encryption(bucket)
+        } else if req.query_params.contains_key("lifecycle") {
+            self.get_bucket_lifecycle(bucket)
+        } else if req.query_params.contains_key("policy") {
+            self.get_bucket_policy(bucket)
+        } else if req.query_params.contains_key("cors") {
+            self.get_bucket_cors(bucket)
+        } else if req.query_params.contains_key("acl") {
+            self.get_bucket_acl(req, bucket)
+        } else if req.query_params.contains_key("notification") {
+            self.get_bucket_notification(bucket)
+        } else if req.query_params.contains_key("logging") {
+            self.get_bucket_logging(bucket)
+        } else if req.query_params.contains_key("website") {
+            self.get_bucket_website(bucket)
+        } else if req.query_params.contains_key("accelerate") {
+            self.get_bucket_accelerate(bucket)
+        } else if req.query_params.contains_key("publicAccessBlock") {
+            self.get_public_access_block(bucket)
+        } else if req.query_params.contains_key("object-lock") {
+            self.get_object_lock_config(bucket)
+        } else if req.query_params.contains_key("versions") {
+            self.list_object_versions(req, bucket)
+        } else if req.query_params.get("list-type").map(|s| s.as_str()) == Some("2") {
+            self.list_objects_v2(req, bucket)
+        } else {
+            self.list_objects(req, bucket)
+        }
+    }
+
+    fn route_delete_bucket(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        if req.query_params.contains_key("tagging") {
+            self.delete_bucket_tagging(req, bucket)
+        } else if req.query_params.contains_key("encryption") {
+            self.delete_bucket_encryption(bucket)
+        } else if req.query_params.contains_key("lifecycle") {
+            self.delete_bucket_lifecycle(bucket)
+        } else if req.query_params.contains_key("policy") {
+            self.delete_bucket_policy(bucket)
+        } else if req.query_params.contains_key("cors") {
+            self.delete_bucket_cors(bucket)
+        } else if req.query_params.contains_key("website") {
+            self.delete_bucket_website(bucket)
+        } else if req.query_params.contains_key("publicAccessBlock") {
+            self.delete_public_access_block(bucket)
+        } else {
+            self.delete_bucket(req, bucket)
+        }
     }
 }
 
@@ -189,12 +307,7 @@ impl S3Service {
             ));
         }
         state.buckets.remove(bucket);
-        Ok(AwsResponse {
-            status: StatusCode::NO_CONTENT,
-            content_type: "application/xml".to_string(),
-            body: Bytes::new(),
-            headers: HeaderMap::new(),
-        })
+        Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
     fn head_bucket(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
@@ -206,12 +319,7 @@ impl S3Service {
                 format!("The specified bucket does not exist: {bucket}"),
             ));
         }
-        Ok(AwsResponse {
-            status: StatusCode::OK,
-            content_type: "application/xml".to_string(),
-            body: Bytes::new(),
-            headers: HeaderMap::new(),
-        })
+        Ok(empty_response(StatusCode::OK))
     }
 
     fn get_bucket_location(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
@@ -228,6 +336,682 @@ impl S3Service {
         let body = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
              <LocationConstraint xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">{loc}</LocationConstraint>"
+        );
+        Ok(AwsResponse::xml(StatusCode::OK, body))
+    }
+
+    // ---- Versioning ----
+
+    fn put_bucket_versioning(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("");
+        let status = extract_xml_value(body_str, "Status");
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.versioning_status = status;
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_bucket_versioning(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        let status_xml = match &b.versioning_status {
+            Some(s) => format!("<Status>{s}</Status>"),
+            None => String::new(),
+        };
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <VersioningConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             {status_xml}\
+             </VersioningConfiguration>"
+        );
+        Ok(AwsResponse::xml(StatusCode::OK, body))
+    }
+
+    // ---- Encryption ----
+
+    fn put_bucket_encryption(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.encryption_config = Some(body_str);
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_bucket_encryption(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        match &b.encryption_config {
+            Some(config) => Ok(AwsResponse::xml(StatusCode::OK, config.clone())),
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ServerSideEncryptionConfigurationNotFoundError",
+                "The server side encryption configuration was not found",
+            )),
+        }
+    }
+
+    fn delete_bucket_encryption(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.encryption_config = None;
+        Ok(empty_response(StatusCode::NO_CONTENT))
+    }
+
+    // ---- Lifecycle ----
+
+    fn put_bucket_lifecycle(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.lifecycle_config = Some(body_str);
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_bucket_lifecycle(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        match &b.lifecycle_config {
+            Some(config) => Ok(AwsResponse::xml(StatusCode::OK, config.clone())),
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchLifecycleConfiguration",
+                "The lifecycle configuration does not exist",
+            )),
+        }
+    }
+
+    fn delete_bucket_lifecycle(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.lifecycle_config = None;
+        Ok(empty_response(StatusCode::NO_CONTENT))
+    }
+
+    // ---- Policy ----
+
+    fn put_bucket_policy(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.policy = Some(body_str);
+        Ok(empty_response(StatusCode::NO_CONTENT))
+    }
+
+    fn get_bucket_policy(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        match &b.policy {
+            Some(policy) => Ok(AwsResponse {
+                status: StatusCode::OK,
+                content_type: "application/json".to_string(),
+                body: Bytes::from(policy.clone()),
+                headers: HeaderMap::new(),
+            }),
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchBucketPolicy",
+                "The bucket policy does not exist",
+            )),
+        }
+    }
+
+    fn delete_bucket_policy(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.policy = None;
+        Ok(empty_response(StatusCode::NO_CONTENT))
+    }
+
+    // ---- CORS ----
+
+    fn put_bucket_cors(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.cors_config = Some(body_str);
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_bucket_cors(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        match &b.cors_config {
+            Some(config) => Ok(AwsResponse::xml(StatusCode::OK, config.clone())),
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchCORSConfiguration",
+                "The CORS configuration does not exist",
+            )),
+        }
+    }
+
+    fn delete_bucket_cors(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.cors_config = None;
+        Ok(empty_response(StatusCode::NO_CONTENT))
+    }
+
+    // ---- ACL ----
+
+    fn put_bucket_acl(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        if body_str.is_empty() {
+            let canned = req
+                .headers
+                .get("x-amz-acl")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("private")
+                .to_string();
+            b.acl = Some(canned);
+        } else {
+            b.acl = Some(body_str);
+        }
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_bucket_acl(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let _b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        let owner_id = &req.account_id;
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <AccessControlPolicy xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Owner><ID>{owner_id}</ID><DisplayName>{owner_id}</DisplayName></Owner>\
+             <AccessControlList>\
+             <Grant>\
+             <Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"CanonicalUser\">\
+             <ID>{owner_id}</ID><DisplayName>{owner_id}</DisplayName>\
+             </Grantee>\
+             <Permission>FULL_CONTROL</Permission>\
+             </Grant>\
+             </AccessControlList>\
+             </AccessControlPolicy>"
+        );
+        Ok(AwsResponse::xml(StatusCode::OK, body))
+    }
+
+    // ---- Notification ----
+
+    fn put_bucket_notification(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.notification_config = Some(body_str);
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_bucket_notification(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        let body = match &b.notification_config {
+            Some(config) => config.clone(),
+            None => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+                     <NotificationConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+                     </NotificationConfiguration>"
+                .to_string(),
+        };
+        Ok(AwsResponse::xml(StatusCode::OK, body))
+    }
+
+    // ---- Logging ----
+
+    fn put_bucket_logging(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.logging_config = Some(body_str);
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_bucket_logging(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        let body = match &b.logging_config {
+            Some(config) => config.clone(),
+            None => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+                     <BucketLoggingStatus xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+                     </BucketLoggingStatus>"
+                .to_string(),
+        };
+        Ok(AwsResponse::xml(StatusCode::OK, body))
+    }
+
+    // ---- Website ----
+
+    fn put_bucket_website(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.website_config = Some(body_str);
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_bucket_website(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        match &b.website_config {
+            Some(config) => Ok(AwsResponse::xml(StatusCode::OK, config.clone())),
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchWebsiteConfiguration",
+                "The specified bucket does not have a website configuration",
+            )),
+        }
+    }
+
+    fn delete_bucket_website(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.website_config = None;
+        Ok(empty_response(StatusCode::NO_CONTENT))
+    }
+
+    // ---- Accelerate ----
+
+    fn put_bucket_accelerate(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("");
+        let status = extract_xml_value(body_str, "Status");
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.accelerate_status = status;
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_bucket_accelerate(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        let status_xml = match &b.accelerate_status {
+            Some(s) => format!("<Status>{s}</Status>"),
+            None => String::new(),
+        };
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <AccelerateConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             {status_xml}\
+             </AccelerateConfiguration>"
+        );
+        Ok(AwsResponse::xml(StatusCode::OK, body))
+    }
+
+    // ---- PublicAccessBlock ----
+
+    fn put_public_access_block(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.public_access_block = Some(body_str);
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_public_access_block(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        match &b.public_access_block {
+            Some(config) => Ok(AwsResponse::xml(StatusCode::OK, config.clone())),
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchPublicAccessBlockConfiguration",
+                "The public access block configuration was not found",
+            )),
+        }
+    }
+
+    fn delete_public_access_block(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.public_access_block = None;
+        Ok(empty_response(StatusCode::NO_CONTENT))
+    }
+
+    // ---- ObjectLockConfiguration ----
+
+    fn put_object_lock_config(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.object_lock_config = Some(body_str);
+        Ok(empty_response(StatusCode::OK))
+    }
+
+    fn get_object_lock_config(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        match &b.object_lock_config {
+            Some(config) => Ok(AwsResponse::xml(StatusCode::OK, config.clone())),
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ObjectLockConfigurationNotFoundError",
+                "Object Lock configuration does not exist for this bucket",
+            )),
+        }
+    }
+
+    // ---- Tagging ----
+
+    fn get_bucket_tagging(
+        &self,
+        _req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        if b.tags.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchTagSet",
+                "The TagSet does not exist",
+            ));
+        }
+        let mut tags_xml = String::new();
+        for (k, v) in &b.tags {
+            tags_xml.push_str(&format!(
+                "<Tag><Key>{}</Key><Value>{}</Value></Tag>",
+                xml_escape(k),
+                xml_escape(v),
+            ));
+        }
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <TagSet>{tags_xml}</TagSet></Tagging>"
+        );
+        Ok(AwsResponse::xml(StatusCode::OK, body))
+    }
+
+    fn put_bucket_tagging(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("");
+        let tags = parse_tagging_xml(body_str);
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.tags = tags;
+        Ok(empty_response(StatusCode::NO_CONTENT))
+    }
+
+    fn delete_bucket_tagging(
+        &self,
+        _req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let mut state = self.state.write();
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.tags.clear();
+        Ok(empty_response(StatusCode::NO_CONTENT))
+    }
+
+    // ---- List operations ----
+
+    fn list_objects(&self, req: &AwsRequest, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+
+        let prefix = req.query_params.get("prefix").cloned().unwrap_or_default();
+        let delimiter = req
+            .query_params
+            .get("delimiter")
+            .cloned()
+            .unwrap_or_default();
+        let max_keys: usize = req
+            .query_params
+            .get("max-keys")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1000);
+        let marker = req.query_params.get("marker").cloned().unwrap_or_default();
+
+        let mut contents = String::new();
+        let mut common_prefixes: Vec<String> = Vec::new();
+        let mut count = 0;
+        let mut is_truncated = false;
+        let mut last_key = String::new();
+
+        for (key, obj) in &b.objects {
+            if !key.starts_with(&prefix) {
+                continue;
+            }
+            if !marker.is_empty() && key.as_str() <= marker.as_str() {
+                continue;
+            }
+
+            if !delimiter.is_empty() {
+                let suffix = &key[prefix.len()..];
+                if let Some(pos) = suffix.find(&delimiter) {
+                    let cp = format!("{}{}", prefix, &suffix[..=pos]);
+                    if !common_prefixes.contains(&cp) {
+                        if count >= max_keys {
+                            is_truncated = true;
+                            break;
+                        }
+                        common_prefixes.push(cp);
+                        last_key = key.clone();
+                        count += 1;
+                    }
+                    continue;
+                }
+            }
+
+            if count >= max_keys {
+                is_truncated = true;
+                break;
+            }
+
+            contents.push_str(&format!(
+                "<Contents>\
+                 <Key>{}</Key>\
+                 <LastModified>{}</LastModified>\
+                 <ETag>&quot;{}&quot;</ETag>\
+                 <Size>{}</Size>\
+                 <StorageClass>{}</StorageClass>\
+                 </Contents>",
+                xml_escape(key),
+                obj.last_modified.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
+                obj.etag,
+                obj.size,
+                obj.storage_class,
+            ));
+            last_key = key.clone();
+            count += 1;
+        }
+
+        let mut common_prefixes_xml = String::new();
+        for cp in &common_prefixes {
+            common_prefixes_xml.push_str(&format!(
+                "<CommonPrefixes><Prefix>{}</Prefix></CommonPrefixes>",
+                xml_escape(cp),
+            ));
+        }
+
+        let next_marker = if is_truncated {
+            format!("<NextMarker>{}</NextMarker>", xml_escape(&last_key))
+        } else {
+            String::new()
+        };
+
+        let marker_xml = if !marker.is_empty() {
+            format!("<Marker>{}</Marker>", xml_escape(&marker))
+        } else {
+            "<Marker/>".to_string()
+        };
+
+        let delimiter_xml = if !delimiter.is_empty() {
+            format!("<Delimiter>{}</Delimiter>", xml_escape(&delimiter))
+        } else {
+            String::new()
+        };
+
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Name>{bucket}</Name>\
+             <Prefix>{prefix}</Prefix>\
+             {marker_xml}\
+             <MaxKeys>{max_keys}</MaxKeys>\
+             {delimiter_xml}\
+             <IsTruncated>{is_truncated}</IsTruncated>\
+             {next_marker}\
+             {contents}\
+             {common_prefixes_xml}\
+             </ListBucketResult>",
+            prefix = xml_escape(&prefix),
         );
         Ok(AwsResponse::xml(StatusCode::OK, body))
     }
@@ -277,7 +1061,6 @@ impl S3Service {
                 continue;
             }
 
-            // Handle delimiter-based grouping
             if !delimiter.is_empty() {
                 let suffix = &key[prefix.len()..];
                 if let Some(pos) = suffix.find(&delimiter) {
@@ -359,9 +1142,9 @@ impl S3Service {
         Ok(AwsResponse::xml(StatusCode::OK, body))
     }
 
-    fn get_bucket_tagging(
+    fn list_object_versions(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let state = self.state.read();
@@ -369,68 +1152,121 @@ impl S3Service {
             .buckets
             .get(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        if b.tags.is_empty() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "NoSuchTagSet",
-                "The TagSet does not exist",
+
+        let prefix = req.query_params.get("prefix").cloned().unwrap_or_default();
+        let max_keys: usize = req
+            .query_params
+            .get("max-keys")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1000);
+
+        let mut versions_xml = String::new();
+        let mut count = 0;
+        let mut is_truncated = false;
+
+        for (key, obj) in &b.objects {
+            if !key.starts_with(&prefix) {
+                continue;
+            }
+            if count >= max_keys {
+                is_truncated = true;
+                break;
+            }
+            versions_xml.push_str(&format!(
+                "<Version>\
+                 <Key>{}</Key>\
+                 <VersionId>null</VersionId>\
+                 <IsLatest>true</IsLatest>\
+                 <LastModified>{}</LastModified>\
+                 <ETag>&quot;{}&quot;</ETag>\
+                 <Size>{}</Size>\
+                 <StorageClass>{}</StorageClass>\
+                 </Version>",
+                xml_escape(key),
+                obj.last_modified.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
+                obj.etag,
+                obj.size,
+                obj.storage_class,
             ));
+            count += 1;
         }
-        let mut tags_xml = String::new();
-        for (k, v) in &b.tags {
-            tags_xml.push_str(&format!(
-                "<Tag><Key>{}</Key><Value>{}</Value></Tag>",
-                xml_escape(k),
-                xml_escape(v),
-            ));
-        }
+
         let body = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-             <Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
-             <TagSet>{tags_xml}</TagSet></Tagging>"
+             <ListVersionsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Name>{bucket}</Name>\
+             <Prefix>{prefix}</Prefix>\
+             <MaxKeys>{max_keys}</MaxKeys>\
+             <IsTruncated>{is_truncated}</IsTruncated>\
+             {versions_xml}\
+             </ListVersionsResult>",
+            prefix = xml_escape(&prefix),
         );
         Ok(AwsResponse::xml(StatusCode::OK, body))
     }
 
-    fn put_bucket_tagging(
+    // ---- CreateMultipartUpload ----
+
+    fn create_multipart_upload(
         &self,
         req: &AwsRequest,
         bucket: &str,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let body_str = std::str::from_utf8(&req.body).unwrap_or("");
-        let tags = parse_tagging_xml(body_str);
-
-        let mut state = self.state.write();
-        let b = state
-            .buckets
-            .get_mut(bucket)
-            .ok_or_else(|| no_such_bucket(bucket))?;
-        b.tags = tags;
-        Ok(AwsResponse {
-            status: StatusCode::NO_CONTENT,
-            content_type: "application/xml".to_string(),
-            body: Bytes::new(),
-            headers: HeaderMap::new(),
-        })
-    }
-
-    fn delete_bucket_tagging(
-        &self,
-        _req: &AwsRequest,
-        bucket: &str,
+        key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut state = self.state.write();
-        let b = state
-            .buckets
-            .get_mut(bucket)
-            .ok_or_else(|| no_such_bucket(bucket))?;
-        b.tags.clear();
-        Ok(AwsResponse {
-            status: StatusCode::NO_CONTENT,
-            content_type: "application/xml".to_string(),
-            body: Bytes::new(),
-            headers: HeaderMap::new(),
-        })
+        if !state.buckets.contains_key(bucket) {
+            return Err(no_such_bucket(bucket));
+        }
+
+        let content_type = req
+            .headers
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("binary/octet-stream")
+            .to_string();
+        let storage_class = req
+            .headers
+            .get("x-amz-storage-class")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let metadata = extract_user_metadata(&req.headers);
+
+        let upload_id = format!(
+            "{:x}",
+            Md5::digest(
+                format!(
+                    "{}/{}/{}",
+                    bucket,
+                    key,
+                    Utc::now().timestamp_nanos_opt().unwrap_or(0)
+                )
+                .as_bytes()
+            )
+        );
+
+        let upload = MultipartUpload {
+            upload_id: upload_id.clone(),
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            parts: std::collections::HashMap::new(),
+            initiated: Utc::now(),
+            storage_class,
+            metadata,
+            content_type,
+        };
+        state.multipart_uploads.insert(upload_id.clone(), upload);
+
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Bucket>{}</Bucket>\
+             <Key>{}</Key>\
+             <UploadId>{upload_id}</UploadId>\
+             </InitiateMultipartUploadResult>",
+            xml_escape(bucket),
+            xml_escape(key),
+        );
+        Ok(AwsResponse::xml(StatusCode::OK, body))
     }
 }
 
@@ -525,14 +1361,8 @@ impl S3Service {
             .buckets
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        // S3 returns 204 even if the key doesn't exist
         b.objects.remove(key);
-        Ok(AwsResponse {
-            status: StatusCode::NO_CONTENT,
-            content_type: "application/xml".to_string(),
-            body: Bytes::new(),
-            headers: HeaderMap::new(),
-        })
+        Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
     fn head_object(&self, bucket: &str, key: &str) -> Result<AwsResponse, AwsServiceError> {
@@ -581,7 +1411,6 @@ impl S3Service {
                 )
             })?;
 
-        // Decode percent-encoded source and strip leading /
         let decoded = percent_encoding::percent_decode_str(copy_source)
             .decode_utf8_lossy()
             .to_string();
@@ -596,7 +1425,6 @@ impl S3Service {
 
         let mut state = self.state.write();
 
-        // Read source object
         let src_obj = {
             let sb = state
                 .buckets
@@ -611,7 +1439,6 @@ impl S3Service {
         let etag = src_obj.etag.clone();
         let last_modified = Utc::now();
 
-        // Write to destination
         let db = state
             .buckets
             .get_mut(dest_bucket)
@@ -689,6 +1516,15 @@ fn no_such_key(key: &str) -> AwsServiceError {
     )
 }
 
+fn empty_response(status: StatusCode) -> AwsResponse {
+    AwsResponse {
+        status,
+        content_type: "application/xml".to_string(),
+        body: Bytes::new(),
+        headers: HeaderMap::new(),
+    }
+}
+
 fn compute_md5(data: &[u8]) -> String {
     let digest = Md5::digest(data);
     format!("{:x}", digest)
@@ -718,17 +1554,14 @@ fn is_valid_bucket_name(name: &str) -> bool {
     if name.len() < 3 || name.len() > 63 {
         return false;
     }
-    // Must start and end with alphanumeric
     let bytes = name.as_bytes();
     if !bytes[0].is_ascii_alphanumeric() || !bytes[bytes.len() - 1].is_ascii_alphanumeric() {
         return false;
     }
-    // Only lowercase letters, digits, hyphens, dots
     name.chars()
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '.')
 }
 
-/// Minimal XML parser for `<Delete><Object><Key>...</Key></Object>...</Delete>`.
 fn parse_delete_objects_xml(xml: &str) -> Vec<String> {
     let mut keys = Vec::new();
     let mut remaining = xml;
@@ -744,7 +1577,6 @@ fn parse_delete_objects_xml(xml: &str) -> Vec<String> {
     keys
 }
 
-/// Minimal XML parser for `<Tagging><TagSet><Tag><Key>k</Key><Value>v</Value></Tag>...`.
 fn parse_tagging_xml(xml: &str) -> std::collections::HashMap<String, String> {
     let mut tags = std::collections::HashMap::new();
     let mut remaining = xml;

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -17,6 +17,26 @@ pub struct S3Object {
 }
 
 #[derive(Debug, Clone)]
+pub struct MultipartUpload {
+    pub upload_id: String,
+    pub bucket: String,
+    pub key: String,
+    pub parts: HashMap<i32, UploadPart>,
+    pub initiated: DateTime<Utc>,
+    pub storage_class: Option<String>,
+    pub metadata: HashMap<String, String>,
+    pub content_type: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct UploadPart {
+    pub part_number: i32,
+    pub data: Bytes,
+    pub etag: String,
+    pub last_modified: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
 pub struct S3Bucket {
     pub name: String,
     pub creation_date: DateTime<Utc>,
@@ -24,6 +44,20 @@ pub struct S3Bucket {
     /// Objects keyed by their full key path.
     pub objects: BTreeMap<String, S3Object>,
     pub tags: HashMap<String, String>,
+    /// Versioning status: None = never enabled, Some("Enabled"), Some("Suspended")
+    pub versioning_status: Option<String>,
+    /// Raw XML configs stored as Option<String>
+    pub encryption_config: Option<String>,
+    pub lifecycle_config: Option<String>,
+    pub policy: Option<String>,
+    pub cors_config: Option<String>,
+    pub acl: Option<String>,
+    pub notification_config: Option<String>,
+    pub logging_config: Option<String>,
+    pub website_config: Option<String>,
+    pub accelerate_status: Option<String>,
+    pub public_access_block: Option<String>,
+    pub object_lock_config: Option<String>,
 }
 
 impl S3Bucket {
@@ -34,6 +68,18 @@ impl S3Bucket {
             region: region.to_string(),
             objects: BTreeMap::new(),
             tags: HashMap::new(),
+            versioning_status: None,
+            encryption_config: None,
+            lifecycle_config: None,
+            policy: None,
+            cors_config: None,
+            acl: None,
+            notification_config: None,
+            logging_config: None,
+            website_config: None,
+            accelerate_status: None,
+            public_access_block: None,
+            object_lock_config: None,
         }
     }
 }
@@ -42,6 +88,8 @@ pub struct S3State {
     pub account_id: String,
     pub region: String,
     pub buckets: HashMap<String, S3Bucket>,
+    /// In-progress multipart uploads keyed by upload_id
+    pub multipart_uploads: HashMap<String, MultipartUpload>,
 }
 
 impl S3State {
@@ -50,11 +98,13 @@ impl S3State {
             account_id: account_id.to_string(),
             region: region.to_string(),
             buckets: HashMap::new(),
+            multipart_uploads: HashMap::new(),
         }
     }
 
     pub fn reset(&mut self) {
         self.buckets.clear();
+        self.multipart_uploads.clear();
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix S3 bucket-level query param routing so PUT/GET/DELETE with params like `?versioning`, `?encryption`, `?cors` dispatch to correct handlers instead of falling through to `create_bucket`/`delete_bucket`/`list_objects`
- Add 12 bucket configuration operations (versioning, encryption, lifecycle, policy, CORS, ACL, notification, logging, website, accelerate, public access block, object lock)
- Add ListObjectVersions, ListObjects v1, and CreateMultipartUpload stub
- Add MultipartUpload and UploadPart types to state

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --exclude fakecloud-e2e` passes
- [ ] Run Moto S3 test suite to verify routing fixes resolve BucketAlreadyOwnedByYou errors on config operations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes S3 bucket-level routing for query-param operations and adds bucket configuration APIs, plus ListObjects v1, ListObjectVersions, and CreateMultipartUpload support in `fakecloud-s3`.

- **New Features**
  - Added 12 bucket configuration APIs: versioning, encryption, lifecycle, policy, CORS, ACL, notification, logging, website, accelerate, public access block, object lock.
  - Implemented ListObjects v1 and ListObjectVersions; added CreateMultipartUpload and in-memory tracking via MultipartUpload and UploadPart.

- **Bug Fixes**
  - Corrected routing for bucket-level PUT/GET/DELETE with params (e.g., ?versioning, ?encryption, ?cors) so they hit the right handlers instead of create/delete/list, preventing BucketAlreadyOwnedByYou errors.

<sup>Written for commit 96973040f2a057e755471e0a748cb7e150ce7cf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

