### PR TITLE
fix: SSM/IAM/SNS/SQS/EventBridge remaining fixable failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,6 +1275,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "thiserror",
  "uuid",
@@ -2612,6 +2613,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3126,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ axum = "0.8"
 hyper = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 quick-xml = { version = "0.37", features = ["serialize"] }
 thiserror = "2"
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -598,6 +598,9 @@ impl EventBridgeService {
                 if let Some(ref se) = r.schedule_expression {
                     obj["ScheduleExpression"] = json!(se);
                 }
+                if let Some(ref mb) = r.managed_by {
+                    obj["ManagedBy"] = json!(mb);
+                }
                 obj
             })
             .collect();
@@ -1312,11 +1315,24 @@ impl EventBridgeService {
             "arn:aws:events:{}:{}:rule/{}",
             req.region, state.account_id, rule_name
         );
+        // Merge archive event pattern with replay-name filter
+        let rule_event_pattern = {
+            let mut merged = if let Some(ref ep) = event_pattern {
+                serde_json::from_str::<Value>(ep).unwrap_or_else(|_| json!({}))
+            } else {
+                json!({})
+            };
+            if let Some(obj) = merged.as_object_mut() {
+                obj.insert("replay-name".to_string(), json!([{"exists": false}]));
+            }
+            serde_json::to_string(&merged).unwrap_or_default()
+        };
+
         let archive_rule = EventRule {
             name: rule_name.clone(),
             arn: rule_arn,
             event_bus_name: bus_name.clone(),
-            event_pattern: Some(r#"{"replay-name": [{"exists": false}]}"#.to_string()),
+            event_pattern: Some(rule_event_pattern),
             schedule_expression: None,
             state: "ENABLED".to_string(),
             description: None,

--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -1333,9 +1333,11 @@ impl IamService {
             )
         })?;
 
-        // UpdateRole updates description if provided
+        // UpdateRole: if Description is provided, set it; if absent, clear it
         if let Some(desc) = req.query_params.get("Description") {
             role.description = Some(desc.clone());
+        } else {
+            role.description = None;
         }
         if let Some(dur) = req
             .query_params
@@ -4522,8 +4524,20 @@ impl IamService {
 
         let mut state = self.state.write();
 
-        if let Some(certs) = state.signing_certificates.get_mut(&user_name) {
+        let found = if let Some(certs) = state.signing_certificates.get_mut(&user_name) {
+            let before = certs.len();
             certs.retain(|c| c.certificate_id != certificate_id);
+            certs.len() < before
+        } else {
+            false
+        };
+
+        if !found {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchEntity",
+                format!("The Certificate with id {certificate_id} cannot be found."),
+            ));
         }
 
         let xml = empty_response("DeleteSigningCertificate", &req.request_id);
@@ -5512,6 +5526,14 @@ impl IamService {
         use base64::Engine;
         let state = self.state.read();
 
+        if !state.credential_report_generated {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::GONE,
+                "ReportNotPresent",
+                "Credential report does not exist. Use GenerateCredentialReport to generate one.",
+            ));
+        }
+
         let mut csv = String::from(
             "user,arn,user_creation_time,password_enabled,password_last_used,password_last_changed,password_next_rotation,mfa_active,access_key_1_active,access_key_1_last_rotated,access_key_1_last_used_date,access_key_1_last_used_region,access_key_1_last_used_service,access_key_2_active,access_key_2_last_rotated,access_key_2_last_used_date,access_key_2_last_used_region,access_key_2_last_used_service,cert_1_active,cert_1_last_rotated,cert_2_active,cert_2_last_rotated\n"
         );
@@ -5587,6 +5609,15 @@ impl IamService {
             .unwrap_or_else(|| "/".to_string());
         let tags = parse_tags(&req.query_params);
 
+        // Validate path
+        if !is_valid_iam_path(&path) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "The specified value for path is invalid. It must begin and end with / and contain only alphanumeric characters and/or / characters.",
+            ));
+        }
+
         let mut state = self.state.write();
 
         let serial_number = format!(
@@ -5648,7 +5679,7 @@ impl IamService {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("VirtualMFADevice with serial number {serial_number} not found"),
+                format!("VirtualMFADevice with serial number {serial_number} doesn't exist."),
             ));
         }
 
@@ -5811,6 +5842,30 @@ impl IamService {
         );
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
+}
+
+/// Validate an IAM path: must start and end with `/`, contain only valid chars, no `//`.
+fn is_valid_iam_path(path: &str) -> bool {
+    if !path.starts_with('/') || !path.ends_with('/') {
+        return false;
+    }
+    if path.contains("//") {
+        return false;
+    }
+    if path.len() > 512 {
+        return false;
+    }
+    path.chars().all(|c| {
+        c.is_alphanumeric()
+            || c == '/'
+            || c == '-'
+            || c == '_'
+            || c == '.'
+            || c == '+'
+            || c == '='
+            || c == '@'
+            || c == ','
+    })
 }
 
 // ========= ListEntitiesForPolicy =========

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -294,12 +294,7 @@ pub fn list_roles_response(roles: &[IamRole], request_id: &str) -> String {
     let members: String = roles
         .iter()
         .map(|r| {
-            let tags_section = if r.tags.is_empty() {
-                String::new()
-            } else {
-                let tags_members = tags_xml(&r.tags);
-                format!("\n        <Tags>\n{tags_members}\n        </Tags>")
-            };
+            // ListRoles does NOT include Tags, PermissionsBoundary, or RoleLastUsed
             let description_section = match &r.description {
                 Some(desc) => format!("\n        <Description>{}</Description>", xml_escape(desc)),
                 None => String::new(),
@@ -312,7 +307,7 @@ pub fn list_roles_response(roles: &[IamRole], request_id: &str) -> String {
         <Arn>{arn}</Arn>
         <CreateDate>{date}</CreateDate>
         <AssumeRolePolicyDocument>{policy}</AssumeRolePolicyDocument>{description_section}
-        <MaxSessionDuration>{max_session}</MaxSessionDuration>{tags_section}
+        <MaxSessionDuration>{max_session}</MaxSessionDuration>
       </member>"#,
                 path = r.path,
                 name = r.role_name,
@@ -351,12 +346,7 @@ pub fn list_roles_response_paginated(
     let members: String = roles
         .iter()
         .map(|r| {
-            let tags_section = if r.tags.is_empty() {
-                String::new()
-            } else {
-                let tags_members = tags_xml(&r.tags);
-                format!("\n        <Tags>\n{tags_members}\n        </Tags>")
-            };
+            // ListRoles does NOT include Tags, PermissionsBoundary, or RoleLastUsed
             let description_section = match &r.description {
                 Some(desc) => format!("\n        <Description>{}</Description>", xml_escape(desc)),
                 None => String::new(),
@@ -369,7 +359,7 @@ pub fn list_roles_response_paginated(
         <Arn>{arn}</Arn>
         <CreateDate>{date}</CreateDate>
         <AssumeRolePolicyDocument>{policy}</AssumeRolePolicyDocument>{description_section}
-        <MaxSessionDuration>{max_session}</MaxSessionDuration>{tags_section}
+        <MaxSessionDuration>{max_session}</MaxSessionDuration>
       </member>"#,
                 path = r.path,
                 name = r.role_name,
@@ -499,6 +489,15 @@ pub fn get_policy_response(policy: &IamPolicy, request_id: &str) -> String {
         format!("\n      <Tags>\n{tags_members}\n      </Tags>")
     };
 
+    let description_section = if policy.description.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\n      <Description>{}</Description>",
+            xml_escape(&policy.description)
+        )
+    };
+
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <GetPolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
@@ -511,8 +510,7 @@ pub fn get_policy_response(policy: &IamPolicy, request_id: &str) -> String {
       <DefaultVersionId>{default_version}</DefaultVersionId>
       <AttachmentCount>{attachment_count}</AttachmentCount>
       <IsAttachable>true</IsAttachable>
-      <CreateDate>{date}</CreateDate>
-      <Description>{description}</Description>{tags_section}
+      <CreateDate>{date}</CreateDate>{description_section}{tags_section}
     </Policy>
   </GetPolicyResult>
   <ResponseMetadata>
@@ -526,7 +524,6 @@ pub fn get_policy_response(policy: &IamPolicy, request_id: &str) -> String {
         default_version = policy.default_version_id,
         attachment_count = policy.attachment_count,
         date = policy.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
-        description = xml_escape(&policy.description),
     )
 }
 

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -560,7 +560,7 @@ impl SnsService {
                     StatusCode::BAD_REQUEST,
                     "InvalidParameter",
                     format!(
-                        "Invalid parameter: Endpoint Reason: Endpoint does not exist for endpoint arn {endpoint}"
+                        "Invalid parameter: Endpoint Reason: Endpoint does not exist for endpoint arn{endpoint}"
                     ),
                 ));
             }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -560,7 +560,7 @@ impl SnsService {
                     StatusCode::BAD_REQUEST,
                     "InvalidParameter",
                     format!(
-                        "Invalid parameter: Endpoint Reason: Endpoint does not exist for endpoint arn{endpoint}"
+                        "Invalid parameter: Endpoint Reason: Endpoint does not exist for endpoint {endpoint}"
                     ),
                 ));
             }

--- a/crates/fakecloud-ssm/Cargo.toml
+++ b/crates/fakecloud-ssm/Cargo.toml
@@ -16,5 +16,6 @@ sha2 = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-ssm/src/service.rs
+++ b/crates/fakecloud-ssm/src/service.rs
@@ -209,16 +209,21 @@ fn convert_document_content(content: &str, from_format: &str, to_format: &str) -
         return content.to_string();
     }
 
-    // Try to parse as JSON regardless of declared format
-    // (most content round-trips through JSON in tests)
-    if to_format == "JSON" {
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(content) {
-            return serde_json::to_string(&val).unwrap_or_else(|_| content.to_string());
-        }
-    }
+    // Parse the content from its source format
+    let parsed: Option<serde_json::Value> = match from_format {
+        "YAML" => serde_yaml::from_str(content).ok(),
+        _ => serde_json::from_str(content).ok(),
+    };
 
-    // Return content as-is for other conversions
-    content.to_string()
+    if let Some(val) = parsed {
+        match to_format {
+            "JSON" => serde_json::to_string(&val).unwrap_or_else(|_| content.to_string()),
+            "YAML" => serde_yaml::to_string(&val).unwrap_or_else(|_| content.to_string()),
+            _ => content.to_string(),
+        }
+    } else {
+        content.to_string()
+    }
 }
 
 fn param_arn(region: &str, account_id: &str, name: &str) -> String {
@@ -591,6 +596,15 @@ impl SsmService {
         let raw_name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
 
+        // Check for Secrets Manager references - require WithDecryption=true
+        if raw_name.starts_with("/aws/reference/secretsmanager/") && !with_decryption {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "WithDecryption flag must be True for retrieving a Secret Manager secret.",
+            ));
+        }
+
         let state = self.state.read();
 
         // Handle ARN-style names directly (they contain many colons)
@@ -608,8 +622,9 @@ impl SsmService {
             return Err(param_not_found(&n));
         }
 
-        // Try looking up by name or by ARN
-        let param = resolve_param_by_name_or_arn(&state, base_name)?;
+        // Try looking up by name or by ARN - use raw_name in error for full context
+        let param = resolve_param_by_name_or_arn(&state, base_name)
+            .map_err(|_| param_not_found(raw_name))?;
 
         match selector {
             ParamSelector::None => Ok(json_resp(json!({
@@ -848,10 +863,18 @@ impl SsmService {
         };
 
         let is_root = path == "/";
+        let targets_aws = path.starts_with("/aws/") || path.starts_with("/aws");
 
         let all_params: Vec<&SsmParameter> = state
             .parameters
             .values()
+            .filter(|p| {
+                // Exclude /aws/ prefix params unless path explicitly targets them
+                if !targets_aws && p.name.starts_with("/aws/") {
+                    return false;
+                }
+                true
+            })
             .filter(|p| {
                 if is_root {
                     if recursive {
@@ -963,9 +986,41 @@ impl SsmService {
         }
 
         let state = self.state.read();
+
+        // Check if any filter explicitly targets /aws/ prefix paths
+        let targets_aws_prefix = param_filters.as_ref().is_some_and(|filters| {
+            filters.iter().any(|f| {
+                let key = f["Key"].as_str().unwrap_or("");
+                if key == "Path" {
+                    f["Values"].as_array().is_some_and(|vals| {
+                        vals.iter()
+                            .any(|v| v.as_str().is_some_and(|s| s.starts_with("/aws")))
+                    })
+                } else if key == "Name" {
+                    f["Values"].as_array().is_some_and(|vals| {
+                        vals.iter().any(|v| {
+                            v.as_str().is_some_and(|s| {
+                                let n = s.strip_prefix('/').unwrap_or(s);
+                                n.starts_with("aws/") || n.starts_with("aws")
+                            })
+                        })
+                    })
+                } else {
+                    false
+                }
+            })
+        });
+
         let all_params: Vec<&SsmParameter> = state
             .parameters
             .values()
+            .filter(|p| {
+                // Exclude /aws/ prefix params from user queries unless explicitly targeted
+                if !targets_aws_prefix && p.name.starts_with("/aws/") {
+                    return false;
+                }
+                true
+            })
             .filter(|p| apply_parameter_filters(p, param_filters.as_ref()))
             .filter(|p| apply_old_filters(p, old_filters.as_ref()))
             .collect();
@@ -1538,7 +1593,7 @@ impl SsmService {
 
         let doc = SsmDocument {
             name: name.clone(),
-            content,
+            content: content.clone(),
             document_type: doc_type.clone(),
             document_format: doc_format.clone(),
             target_type: target_type.clone(),
@@ -1555,24 +1610,33 @@ impl SsmService {
 
         state.documents.insert(name.clone(), doc);
 
-        Ok(json_resp(json!({
-            "DocumentDescription": {
-                "Name": name,
-                "DocumentType": doc_type,
-                "DocumentFormat": doc_format,
-                "TargetType": target_type,
-                "DocumentVersion": "1",
-                "LatestVersion": "1",
-                "DefaultVersion": "1",
-                "Status": "Active",
-                "CreatedDate": now.timestamp_millis() as f64 / 1000.0,
-                "Owner": state.account_id,
-                "SchemaVersion": "2.2",
-                "PlatformTypes": ["Linux", "MacOS", "Windows"],
-                "Hash": content_hash,
-                "HashType": "Sha256",
-            }
-        })))
+        let (doc_description, schema_ver, doc_params) =
+            extract_document_metadata(&content, &doc_format);
+
+        let mut desc_json = json!({
+            "Name": name,
+            "DocumentType": doc_type,
+            "DocumentFormat": doc_format,
+            "TargetType": target_type,
+            "DocumentVersion": "1",
+            "LatestVersion": "1",
+            "DefaultVersion": "1",
+            "Status": "Active",
+            "CreatedDate": now.timestamp_millis() as f64 / 1000.0,
+            "Owner": state.account_id,
+            "SchemaVersion": schema_ver.as_deref().unwrap_or("2.2"),
+            "PlatformTypes": ["Linux", "MacOS", "Windows"],
+            "Hash": content_hash,
+            "HashType": "Sha256",
+        });
+        if let Some(d) = doc_description {
+            desc_json["Description"] = json!(d);
+        }
+        if !doc_params.is_empty() {
+            desc_json["Parameters"] = json!(doc_params);
+        }
+
+        Ok(json_resp(json!({ "DocumentDescription": desc_json })))
     }
 
     fn get_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1655,10 +1719,45 @@ impl SsmService {
     fn delete_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let doc_version = body["DocumentVersion"].as_str();
+        let version_name = body["VersionName"].as_str();
 
         let mut state = self.state.write();
-        if state.documents.remove(name).is_none() {
-            return Err(doc_not_found(name));
+
+        if doc_version.is_some() || version_name.is_some() {
+            // Deleting a specific version
+            let doc = state
+                .documents
+                .get_mut(name)
+                .ok_or_else(|| doc_not_found(name))?;
+
+            // Find the target version
+            let target_ver = if let Some(vn) = version_name {
+                doc.versions
+                    .iter()
+                    .find(|v| v.version_name.as_deref() == Some(vn))
+                    .map(|v| v.document_version.clone())
+            } else {
+                doc_version.map(|v| v.to_string())
+            };
+
+            if let Some(ver) = target_ver {
+                if ver == doc.default_version {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidDocumentOperation",
+                        "Default version of the document can't be deleted.",
+                    ));
+                }
+                doc.versions.retain(|v| v.document_version != ver);
+            } else {
+                return Err(doc_not_found(name));
+            }
+        } else {
+            // Delete the entire document
+            if state.documents.remove(name).is_none() {
+                return Err(doc_not_found(name));
+            }
         }
 
         Ok(json_resp(json!({})))
@@ -1673,6 +1772,7 @@ impl SsmService {
             .to_string();
         let version_name = body["VersionName"].as_str().map(|s| s.to_string());
         let doc_format = body["DocumentFormat"].as_str();
+        let target_version = body["DocumentVersion"].as_str();
 
         let mut state = self.state.write();
         let doc = state
@@ -1680,8 +1780,55 @@ impl SsmService {
             .get_mut(name)
             .ok_or_else(|| doc_not_found(name))?;
 
+        // Validate target version exists (if specified and not $LATEST)
+        if let Some(ver) = target_version {
+            if ver != "$LATEST" && !doc.versions.iter().any(|v| v.document_version == ver) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidDocument",
+                    "The document version is not valid or does not exist.",
+                ));
+            }
+        }
+
+        // Check for duplicate content
+        let new_hash = format!("{:x}", Sha256::digest(content.as_bytes()));
+        for v in &doc.versions {
+            let existing_hash = format!("{:x}", Sha256::digest(v.content.as_bytes()));
+            if new_hash == existing_hash {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "DuplicateDocumentContent",
+                    "The content of the association document matches another \
+                     document. Change the content of the document and try again.",
+                ));
+            }
+        }
+
+        // Check for duplicate version name
+        if let Some(ref vn) = version_name {
+            if doc
+                .versions
+                .iter()
+                .any(|v| v.version_name.as_deref() == Some(vn))
+            {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "DuplicateDocumentVersionName",
+                    format!(
+                        "The specified version name is a duplicate. \
+                         Specify a unique version name, and try again. \
+                         Version name: {vn}."
+                    ),
+                ));
+            }
+        }
+
         let new_version_num = (doc.versions.len() + 1).to_string();
         let format = doc_format.unwrap_or(&doc.document_format).to_string();
+
+        let (doc_description, schema_ver, doc_params) =
+            extract_document_metadata(&content, &format);
 
         let version = SsmDocumentVersion {
             content: content.clone(),
@@ -1697,20 +1844,26 @@ impl SsmService {
         doc.latest_version = new_version_num.clone();
         doc.content = content;
 
-        Ok(json_resp(json!({
-            "DocumentDescription": {
-                "Name": doc.name,
-                "DocumentType": doc.document_type,
-                "DocumentFormat": format,
-                "DocumentVersion": new_version_num,
-                "LatestVersion": doc.latest_version,
-                "DefaultVersion": doc.default_version,
-                "Status": "Active",
-                "CreatedDate": doc.created_date.timestamp_millis() as f64 / 1000.0,
-                "Owner": doc.owner,
-                "SchemaVersion": "2.2",
-            }
-        })))
+        let mut desc_json = json!({
+            "Name": doc.name,
+            "DocumentType": doc.document_type,
+            "DocumentFormat": format,
+            "DocumentVersion": new_version_num,
+            "LatestVersion": doc.latest_version,
+            "DefaultVersion": doc.default_version,
+            "Status": "Active",
+            "CreatedDate": doc.created_date.timestamp_millis() as f64 / 1000.0,
+            "Owner": doc.owner,
+            "SchemaVersion": schema_ver.as_deref().unwrap_or("2.2"),
+        });
+        if let Some(d) = doc_description {
+            desc_json["Description"] = json!(d);
+        }
+        if !doc_params.is_empty() {
+            desc_json["Parameters"] = json!(doc_params);
+        }
+
+        Ok(json_resp(json!({ "DocumentDescription": desc_json })))
     }
 
     fn describe_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1723,24 +1876,46 @@ impl SsmService {
             .get(name)
             .ok_or_else(|| doc_not_found(name))?;
 
-        Ok(json_resp(json!({
-            "Document": {
-                "Name": doc.name,
-                "DocumentType": doc.document_type,
-                "DocumentFormat": doc.document_format,
-                "TargetType": doc.target_type,
-                "DocumentVersion": doc.default_version,
-                "LatestVersion": doc.latest_version,
-                "DefaultVersion": doc.default_version,
-                "Status": doc.status,
-                "CreatedDate": doc.created_date.timestamp_millis() as f64 / 1000.0,
-                "Owner": doc.owner,
-                "SchemaVersion": "2.2",
-                "PlatformTypes": ["Linux", "MacOS", "Windows"],
-                "Hash": format!("{:x}", Sha256::digest(doc.content.as_bytes())),
-                "HashType": "Sha256",
+        let (doc_description, schema_ver, doc_params) =
+            extract_document_metadata(&doc.content, &doc.document_format);
+
+        let mut desc_json = json!({
+            "Name": doc.name,
+            "DocumentType": doc.document_type,
+            "DocumentFormat": doc.document_format,
+            "TargetType": doc.target_type,
+            "DocumentVersion": doc.default_version,
+            "LatestVersion": doc.latest_version,
+            "DefaultVersion": doc.default_version,
+            "Status": doc.status,
+            "CreatedDate": doc.created_date.timestamp_millis() as f64 / 1000.0,
+            "Owner": doc.owner,
+            "SchemaVersion": schema_ver.as_deref().unwrap_or("2.2"),
+            "PlatformTypes": ["Linux", "MacOS", "Windows"],
+            "Hash": format!("{:x}", Sha256::digest(doc.content.as_bytes())),
+            "HashType": "Sha256",
+        });
+        if let Some(d) = doc_description {
+            desc_json["Description"] = json!(d);
+        }
+        if !doc_params.is_empty() {
+            desc_json["Parameters"] = json!(doc_params);
+        }
+        if let Some(ref vn) = doc.version_name {
+            desc_json["VersionName"] = json!(vn);
+        }
+        // Find default version name
+        if let Some(ver) = doc
+            .versions
+            .iter()
+            .find(|v| v.document_version == doc.default_version)
+        {
+            if let Some(ref vn) = ver.version_name {
+                desc_json["DefaultVersionName"] = json!(vn);
             }
-        })))
+        }
+
+        Ok(json_resp(json!({ "Document": desc_json })))
     }
 
     fn update_document_default_version(
@@ -1771,12 +1946,22 @@ impl SsmService {
             v.is_default_version = v.document_version == version;
         }
 
-        Ok(json_resp(json!({
-            "Description": {
-                "Name": name,
-                "DefaultVersion": version,
-            }
-        })))
+        // Find version name for the new default version
+        let version_name = doc
+            .versions
+            .iter()
+            .find(|v| v.document_version == version)
+            .and_then(|v| v.version_name.clone());
+
+        let mut desc = json!({
+            "Name": name,
+            "DefaultVersion": version,
+        });
+        if let Some(vn) = version_name {
+            desc["DefaultVersionName"] = json!(vn);
+        }
+
+        Ok(json_resp(json!({ "Description": desc })))
     }
 
     fn list_documents(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1815,6 +2000,8 @@ impl SsmService {
         let mut resp = json!({ "DocumentIdentifiers": result });
         if has_more {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        } else {
+            resp["NextToken"] = json!("");
         }
 
         Ok(json_resp(resp))
@@ -2895,12 +3082,12 @@ impl SsmService {
 
         let mut state = self.state.write();
 
-        // Check baseline exists
+        // Check baseline exists (AWS returns "Maintenance window" in this error, not "Patch baseline")
         if !state.patch_baselines.contains_key(&baseline_id) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "DoesNotExistException",
-                format!("Patch baseline {baseline_id} does not exist"),
+                format!("Maintenance window {baseline_id} does not exist"),
             ));
         }
 
@@ -3215,11 +3402,11 @@ fn validate_parameter_filters(filters: &[Value]) -> Result<(), AwsServiceError> 
         }
     }
 
-    // Check for missing values
+    // Check for missing values (tag: filters are allowed without values - means "tag exists")
     for filter in filters {
         let key = filter["Key"].as_str().unwrap_or("");
         let values = filter["Values"].as_array();
-        if values.is_none() || values.is_some_and(|v| v.is_empty()) {
+        if !key.starts_with("tag:") && (values.is_none() || values.is_some_and(|v| v.is_empty())) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationException",
@@ -3383,9 +3570,23 @@ fn apply_parameter_filters(param: &SsmParameter, filters: Option<&Vec<Value>>) -
 
         let matches = match key {
             "Name" => match option {
-                "BeginsWith" => values.iter().any(|v| param.name.starts_with(v)),
+                "BeginsWith" => values.iter().any(|v| {
+                    param.name.starts_with(v) || {
+                        // Normalize: /foo matches foo, foo matches /foo
+                        let normalized_v = v.strip_prefix('/').unwrap_or(v);
+                        let normalized_name = param.name.strip_prefix('/').unwrap_or(&param.name);
+                        normalized_name.starts_with(normalized_v)
+                    }
+                }),
                 "Contains" => values.iter().any(|v| param.name.contains(v)),
-                "Equals" => values.iter().any(|v| param.name == *v),
+                "Equals" => values.iter().any(|v| {
+                    param.name == *v || {
+                        // Normalize: /foo matches foo, foo matches /foo
+                        let normalized_v = v.strip_prefix('/').unwrap_or(v);
+                        let normalized_name = param.name.strip_prefix('/').unwrap_or(&param.name);
+                        normalized_name == normalized_v
+                    }
+                }),
                 _ => true,
             },
             "Path" => {
@@ -3439,11 +3640,22 @@ fn apply_parameter_filters(param: &SsmParameter, filters: Option<&Vec<Value>>) -
                 }
             }
             "KeyId" => {
-                if values.is_empty() {
-                    param.key_id.is_some()
+                // For SecureString params without explicit KeyId, default is alias/aws/ssm
+                let effective_key_id = if param.param_type == "SecureString" {
+                    Some(
+                        param
+                            .key_id
+                            .as_deref()
+                            .unwrap_or("alias/aws/ssm")
+                            .to_string(),
+                    )
                 } else {
-                    param
-                        .key_id
+                    param.key_id.clone()
+                };
+                if values.is_empty() {
+                    effective_key_id.is_some()
+                } else {
+                    effective_key_id
                         .as_ref()
                         .is_some_and(|kid| values.contains(&kid.as_str()))
                 }
@@ -3589,4 +3801,60 @@ fn mw_not_found(id: &str) -> AwsServiceError {
         "DoesNotExistException",
         format!("Maintenance window {id} does not exist"),
     )
+}
+
+/// Parse a document content string (JSON or YAML) and extract metadata fields.
+/// Returns (description, schema_version, parameters_json).
+fn extract_document_metadata(
+    content: &str,
+    format: &str,
+) -> (Option<String>, Option<String>, Vec<Value>) {
+    let parsed: Option<Value> = match format {
+        "YAML" => serde_yaml::from_str(content).ok(),
+        _ => serde_json::from_str(content).ok(),
+    };
+
+    let parsed = match parsed {
+        Some(v) => v,
+        None => return (None, None, Vec::new()),
+    };
+
+    let description = parsed
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let schema_version = parsed
+        .get("schemaVersion")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let parameters = if let Some(params_obj) = parsed.get("parameters").and_then(|v| v.as_object())
+    {
+        params_obj
+            .iter()
+            .map(|(name, def)| {
+                let mut param = json!({ "Name": name });
+                if let Some(t) = def.get("type").and_then(|v| v.as_str()) {
+                    param["Type"] = json!(t);
+                }
+                if let Some(d) = def.get("description").and_then(|v| v.as_str()) {
+                    param["Description"] = json!(d);
+                }
+                if let Some(dv) = def.get("default") {
+                    let default_str = match dv {
+                        Value::String(s) => s.clone(),
+                        Value::Number(n) => n.to_string(),
+                        Value::Bool(b) => if *b { "True" } else { "False" }.to_string(),
+                        other => serde_json::to_string(other).unwrap_or_default(),
+                    };
+                    param["DefaultValue"] = json!(default_str);
+                }
+                param
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    (description, schema_version, parameters)
 }

--- a/crates/fakecloud-ssm/src/service.rs
+++ b/crates/fakecloud-ssm/src/service.rs
@@ -1750,6 +1750,16 @@ impl SsmService {
                     ));
                 }
                 doc.versions.retain(|v| v.document_version != ver);
+                // Update latest_version if we deleted the latest
+                if doc.latest_version == ver {
+                    doc.latest_version = doc
+                        .versions
+                        .iter()
+                        .filter_map(|v| v.document_version.parse::<u64>().ok())
+                        .max()
+                        .map(|n| n.to_string())
+                        .unwrap_or_else(|| "1".to_string());
+                }
             } else {
                 return Err(doc_not_found(name));
             }


### PR DESCRIPTION
## Summary
- **SSM**: Filter `/aws/service/*` default params from user queries, fix parameter version/label error messages, add document content parsing (Description, Parameters, SchemaVersion), fix YAML-to-JSON conversion, add duplicate content validation for UpdateDocument, version-specific DeleteDocument, KeyId and Name filter normalization, tag existence filters, patch baseline error message
- **IAM**: Fix UpdateRole Description clearing, credential report generation check, signing certificate deletion error, virtual MFA device path validation and error messages, policy Description omission when empty, remove Tags/PermissionsBoundary/RoleLastUsed from ListRoles
- **SNS**: Fix "arnarn" double-arn bug in deleted platform endpoint error message
- **EventBridge**: Add ManagedBy field to ListRules response, merge archive event patterns with replay-name filter

## Test plan
- [ ] `cargo fmt --check && cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo test --workspace --exclude fakecloud-e2e` passes
- [ ] SSM moto test suite shows improvement on DescribeParameters, GetParametersByPath, document ops, patch baseline, and secretsmanager reference tests
- [ ] IAM moto test suite shows improvement on UpdateRole, credential report, signing cert, MFA device, and ListRoles attribute tests
- [ ] SNS moto test suite shows improvement on platform endpoint error format
- [ ] EventBridge moto test suite shows improvement on archive rule listing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AWS-compat issues across SSM, IAM, SNS, and EventBridge to reduce moto test failures and align error/response shapes. Adds YAML parsing for SSM documents and tightens filtering, versioning, and validation.

- **Bug Fixes**
  - SSM (parameters): Filter `/aws/*` defaults from DescribeParameters/GetParametersByPath unless explicitly targeted; require WithDecryption for `/aws/reference/secretsmanager/*`; normalize Name/KeyId/tag filters (tag existence allowed, SecureString defaults KeyId to `alias/aws/ssm`); use raw selector in version/label errors; always return NextToken in ListDocuments; use AWS “Maintenance window … does not exist” text.
  - SSM (documents): Parse Description/Parameters/SchemaVersion, support YAML↔JSON conversion; block duplicate content and version names; support versioned DeleteDocument with default-version protection and update LatestVersion when deleting the latest; include DefaultVersionName in default-version updates and return VersionName/DefaultVersionName where applicable.
  - IAM: UpdateRole clears Description when omitted; validate CreateVirtualMFADevice path; fix DeleteVirtualMFADevice and DeleteSigningCertificate errors; require GenerateCredentialReport before GetCredentialReport; omit empty Description in GetPolicy; drop Tags/PermissionsBoundary/RoleLastUsed from ListRoles.
  - SNS: Fix double-arn in deleted platform endpoint and subscription error messages (remove stray space before ARN).
  - EventBridge: Add ManagedBy in ListRules and merge archive event patterns with the replay-name filter.

- **Dependencies**
  - Add `serde_yaml` for SSM document YAML parsing.

<sup>Written for commit c24c4d6f454a5a4ff4547cb2f43947b4b2e4fc78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

