### PR TITLE
fix(iam): comprehensive edge case fixes (round 6)

### DIFF
--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -463,10 +463,21 @@ fn resolve_calling_user(state: &crate::state::IamState, _account_id: &str) -> St
 }
 
 fn generate_id() -> String {
+    // Generate 16 uppercase hex chars (used with 4-char prefixes like FKIA, AIDA = 20 chars)
     uuid::Uuid::new_v4()
         .to_string()
         .replace('-', "")
         .to_uppercase()[..16]
+        .to_string()
+}
+
+fn generate_long_id() -> String {
+    // Generate 21 uppercase hex chars (used with 3-char prefixes like ASC = 24 chars).
+    // CertificateId requires minimum 24 characters.
+    uuid::Uuid::new_v4()
+        .to_string()
+        .replace('-', "")
+        .to_uppercase()[..21]
         .to_string()
 }
 
@@ -3886,7 +3897,65 @@ impl IamService {
             i += 1;
         }
 
-        let mut state = self.state.write();
+        // Collect validation errors for multi-error response
+        let mut validation_errors: Vec<String> = Vec::new();
+
+        // Check URL length (must be <= 255)
+        if url.len() > 255 {
+            validation_errors.push(
+                "Value at \"url\" failed to satisfy constraint: Member must have length less than or equal to 255".to_string()
+            );
+        }
+
+        // Check thumbprint constraints
+        if thumbprints.len() > 5 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "Thumbprint list must contain fewer than 5 entries.".to_string(),
+            ));
+        }
+        for tp in &thumbprints {
+            if tp.len() != 40 {
+                // AWS always reports both constraints when thumbprint length is wrong
+                validation_errors.push(
+                    "Value at \"thumbprintList\" failed to satisfy constraint: Member must have length less than or equal to 40; Member must have length greater than or equal to 40".to_string()
+                );
+                break;
+            }
+        }
+
+        // Check client ID constraints
+        if client_ids.len() > 100 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "LimitExceeded",
+                "Cannot exceed quota for ClientIdsPerOpenIdConnectProvider: 100".to_string(),
+            ));
+        }
+        for cid in &client_ids {
+            if cid.len() > 255 || cid.is_empty() {
+                // AWS always reports both constraints when client ID length is wrong
+                validation_errors.push(
+                    "Value at \"clientIDList\" failed to satisfy constraint: Member must have length less than or equal to 255; Member must have length greater than or equal to 1".to_string()
+                );
+                break;
+            }
+        }
+
+        if !validation_errors.is_empty() {
+            let count = validation_errors.len();
+            let msg = format!(
+                "{count} validation error{} detected: {}",
+                if count == 1 { "" } else { "s" },
+                validation_errors.join("; ")
+            );
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                msg,
+            ));
+        }
 
         // Validate URL: must start with http:// or https://
         if !url.starts_with("https://") && !url.starts_with("http://") {
@@ -3896,6 +3965,8 @@ impl IamService {
                 "Invalid Open ID Connect Provider URL".to_string(),
             ));
         }
+
+        let mut state = self.state.write();
 
         // Store URL without scheme for responses (AWS behavior)
         let url_without_scheme = url
@@ -3956,7 +4027,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("OpenIDConnect provider not found for arn {arn}"),
+                format!("OpenIDConnect Provider not found for arn {arn}"),
             )
         })?;
 
@@ -4007,13 +4078,8 @@ impl IamService {
         let arn = required_param(&req.query_params, "OpenIDConnectProviderArn")?;
         let mut state = self.state.write();
 
-        if state.oidc_providers.remove(&arn).is_none() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "NoSuchEntity",
-                format!("OpenIDConnect provider not found for arn {arn}"),
-            ));
-        }
+        // AWS silently succeeds when deleting a non-existing OIDC provider
+        state.oidc_providers.remove(&arn);
 
         let xml = empty_response("DeleteOpenIDConnectProvider", &req.request_id);
         Ok(AwsResponse::xml(StatusCode::OK, xml))
@@ -4067,7 +4133,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("OpenIDConnect provider not found for arn {arn}"),
+                format!("OpenIDConnect Provider not found for arn {arn}"),
             )
         })?;
 
@@ -4087,7 +4153,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("OpenIDConnect provider not found for arn {arn}"),
+                format!("OpenIDConnect Provider not found for arn {arn}"),
             )
         })?;
 
@@ -4109,7 +4175,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("OpenIDConnect provider not found for arn {arn}"),
+                format!("OpenIDConnect Provider not found for arn {arn}"),
             )
         })?;
 
@@ -4128,7 +4194,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("OpenIDConnect provider not found for arn {arn}"),
+                format!("OpenIDConnect Provider not found for arn {arn}"),
             )
         })?;
 
@@ -4153,7 +4219,7 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("OpenIDConnect provider not found for arn {arn}"),
+                format!("OpenIDConnect Provider not found for arn {arn}"),
             )
         })?;
 
@@ -4171,26 +4237,11 @@ impl IamService {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
-                format!("OpenIDConnect provider not found for arn {arn}"),
+                format!("OpenIDConnect Provider not found for arn {arn}"),
             )
         })?;
 
-        let members = tags_xml(&provider.tags);
-        let xml = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<ListOpenIDConnectProviderTagsResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
-  <ListOpenIDConnectProviderTagsResult>
-    <IsTruncated>false</IsTruncated>
-    <Tags>
-{members}
-    </Tags>
-  </ListOpenIDConnectProviderTagsResult>
-  <ResponseMetadata>
-    <RequestId>{}</RequestId>
-  </ResponseMetadata>
-</ListOpenIDConnectProviderTagsResponse>"#,
-            req.request_id
-        );
+        let xml = paginated_tags_response("ListOpenIDConnectProviderTags", &provider.tags, req);
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 }
@@ -4385,6 +4436,15 @@ impl IamService {
         let user_name = required_param(&req.query_params, "UserName")?;
         let certificate_body = required_param(&req.query_params, "CertificateBody")?;
 
+        // Validate certificate body looks like a PEM certificate
+        if !certificate_body.contains("-----BEGIN CERTIFICATE-----") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MalformedCertificate",
+                "Certificate body is malformed.".to_string(),
+            ));
+        }
+
         let mut state = self.state.write();
 
         if !state.users.contains_key(&user_name) {
@@ -4403,12 +4463,12 @@ impl IamService {
             return Err(AwsServiceError::aws_error(
                 StatusCode::CONFLICT,
                 "LimitExceeded",
-                "Cannot exceed quota for SigningCertificatesPerUser: 2".to_string(),
+                "Cannot exceed quota for CertificatesPerUser: 2".to_string(),
             ));
         }
 
         let cert = SigningCertificate {
-            certificate_id: format!("ASC{}", generate_id()),
+            certificate_id: format!("ASC{}", generate_long_id()),
             user_name: user_name.clone(),
             certificate_body,
             status: "Active".to_string(),

--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -1032,8 +1032,33 @@ impl IamService {
 
 impl IamService {
     fn create_access_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
         let mut state = self.state.write();
+
+        // UserName is optional; if not specified, infer from the caller's access key
+        let user_name = match req.query_params.get("UserName") {
+            Some(name) => name.clone(),
+            None => {
+                // Look up user by access key ID from the request credentials
+                let access_key_id = req.access_key_id.as_deref().unwrap_or("");
+                state
+                    .access_keys
+                    .iter()
+                    .find_map(|(user, keys)| {
+                        if keys.iter().any(|k| k.access_key_id == access_key_id) {
+                            Some(user.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "MissingParameter",
+                            "The request must contain the parameter UserName".to_string(),
+                        )
+                    })?
+            }
+        };
 
         if !state.users.contains_key(&user_name) {
             return Err(AwsServiceError::aws_error(

--- a/crates/fakecloud-iam/src/policy_validation.rs
+++ b/crates/fakecloud-iam/src/policy_validation.rs
@@ -490,7 +490,11 @@ fn validate_arn(resource: &str) -> Result<(), String> {
             );
         }
         // 3 or 4 parts: valid (e.g., "arn:aws:fdsasf" or "arn:aws:s3:fdsasf")
+        // but reject if service (parts[2]) is empty (e.g., "arn:aws::fdsasf")
         if parts.len() >= 3 && parts.len() <= 4 {
+            if parts[2].is_empty() {
+                return Err("The policy failed legacy parsing".to_string());
+            }
             return Ok(());
         }
         // 5 parts: legacy parsing error (e.g., "arn:aws:s3::example_bucket")
@@ -568,8 +572,12 @@ fn validate_condition_structure(val: &Value) -> Result<(), String> {
             _ => return Err("Syntax errors in policy.".to_string()),
         };
 
+        // AWS accepts unknown condition operators when their inner object is empty
         if !is_valid_condition_operator(op_key) {
-            return Err("Syntax errors in policy.".to_string());
+            if !inner_obj.is_empty() {
+                return Err("Syntax errors in policy.".to_string());
+            }
+            continue;
         }
 
         for (_cond_key, cond_val) in inner_obj {
@@ -687,11 +695,6 @@ fn is_valid_date_value(s: &str) -> bool {
     // YYYY-MM-DDThh:mm:ss.sssZ
     // YYYY-MM-DDThh:mm:ss+HH:MM or +HH
 
-    // Must start with YYYY-
-    if s.len() < 4 {
-        return false;
-    }
-
     // Find the 'T' or 't' separator
     let t_pos = s.find(['T', 't']);
 
@@ -699,11 +702,20 @@ fn is_valid_date_value(s: &str) -> bool {
         let date_part = &s[..t_idx];
         let time_part = &s[t_idx + 1..];
 
+        // AWS accepts short numeric prefixes before T (e.g. "01T") as valid date values
+        if date_part.chars().all(|c| c.is_ascii_digit()) && !date_part.is_empty() {
+            return is_valid_time_part(time_part);
+        }
+
         if !is_valid_date_part(date_part) {
             return false;
         }
 
         return is_valid_time_part(time_part);
+    }
+
+    if s.len() < 4 {
+        return false;
     }
 
     // No time part, just a date

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -154,19 +154,14 @@ pub fn list_users_response(users: &[IamUser], request_id: &str) -> String {
     let members: String = users
         .iter()
         .map(|u| {
-            let tags_section = if u.tags.is_empty() {
-                String::new()
-            } else {
-                let tags_members = tags_xml(&u.tags);
-                format!("\n        <Tags>\n{tags_members}\n        </Tags>")
-            };
+            // ListUsers never includes Tags or PermissionsBoundary (AWS behavior)
             format!(
                 r#"      <member>
         <Path>{path}</Path>
         <UserName>{name}</UserName>
         <UserId>{id}</UserId>
         <Arn>{arn}</Arn>
-        <CreateDate>{date}</CreateDate>{tags_section}
+        <CreateDate>{date}</CreateDate>
       </member>"#,
                 path = u.path,
                 name = u.user_name,
@@ -436,12 +431,7 @@ pub fn list_policies_response(policies: &[IamPolicy], request_id: &str) -> Strin
     let members: String = policies
         .iter()
         .map(|p| {
-            let tags_section = if p.tags.is_empty() {
-                String::new()
-            } else {
-                let tags_members = tags_xml(&p.tags);
-                format!("\n        <Tags>\n{tags_members}\n        </Tags>")
-            };
+            // ListPolicies never includes Tags or Description (AWS behavior)
             format!(
                 r#"      <member>
         <PolicyName>{name}</PolicyName>
@@ -451,7 +441,7 @@ pub fn list_policies_response(policies: &[IamPolicy], request_id: &str) -> Strin
         <DefaultVersionId>{default_version}</DefaultVersionId>
         <AttachmentCount>{attachment_count}</AttachmentCount>
         <IsAttachable>true</IsAttachable>
-        <CreateDate>{date}</CreateDate>{tags_section}
+        <CreateDate>{date}</CreateDate>
       </member>"#,
                 name = p.policy_name,
                 id = p.policy_id,
@@ -482,8 +472,9 @@ pub fn list_policies_response(policies: &[IamPolicy], request_id: &str) -> Strin
 }
 
 pub fn get_policy_response(policy: &IamPolicy, request_id: &str) -> String {
+    // GetPolicy always includes Tags, even if empty (AWS behavior)
     let tags_section = if policy.tags.is_empty() {
-        String::new()
+        "\n      <Tags/>".to_string()
     } else {
         let tags_members = tags_xml(&policy.tags);
         format!("\n      <Tags>\n{tags_members}\n      </Tags>")


### PR DESCRIPTION
## Summary

- Fix signing certificate ID length (CertificateId min 24 chars) and body validation
- Fix OIDC provider operations: error messages, silent delete, tag pagination, input validation
- Fix ListUsers/ListPolicies to not include Tags; GetPolicy to always include Tags
- Fix policy validation: accept unknown condition operators with empty values, short date prefixes, reject empty service ARNs
- Support CreateAccessKey without UserName (infer from caller credentials)
- Apply Moto patch for FKIA access key prefix

## Test results

**Before:** 55 failed, 317 passed, 13 skipped
**After:** 36 failed, 336 passed, 13 skipped

**19 tests fixed.** Remaining 36 failures:
- 31 CloudFormation tests (needs CloudFormation service)
- 2 Config tests (needs Config service)
- 1 EC2 integration test (needs EC2 service)
- 1 STS role tracking test (needs assume-role last-used tracking)
- 1 AccountSummary PolicyVersionsInUse counting difference

## Test plan

- [x] `cargo fmt --all && cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace --exclude fakecloud-e2e`
- [x] Full Moto IAM test suite with reset API enabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings IAM edge-case behavior in line with AWS to improve Moto compatibility. Focuses on OIDC provider validation and errors, access key creation without `UserName`, signing certificate correctness, policy parsing, and tag presence in list/get responses.

- **Bug Fixes**
  - OIDC provider: add URL/client ID/thumbprint validation with aggregated errors; correct error strings; silent delete; paginate `ListOpenIDConnectProviderTags`.
  - `CreateAccessKey`: support calls without `UserName` by inferring from caller credentials.
  - Signing certificates: enforce PEM body; use 24+ char `CertificateId` (`ASC` + long ID); fix quota message to "CertificatesPerUser".
  - Policy validation: allow unknown condition operators when empty; accept short numeric date prefixes (e.g., "01T"); reject ARNs with empty service.
  - Responses: `ListUsers` and `ListPolicies` no longer include Tags; `GetPolicy` always includes Tags (even when empty).
  - Compatibility: apply FKIA access key prefix patch; fixes 19 Moto IAM tests (now 336 passed, 36 failed).

<sup>Written for commit af5c902c24f2c62e1a1b3fa2ea7de50be010c2a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

