### PR TITLE
feat: EventBridge/SNS delivery expansion, S3 lifecycle processor

### DIFF
--- a/crates/fakecloud-e2e/tests/eventbridge.rs
+++ b/crates/fakecloud-e2e/tests/eventbridge.rs
@@ -1,6 +1,7 @@
 mod helpers;
 
 use aws_sdk_eventbridge::types::{PutEventsRequestEntry, RuleState, Target};
+use aws_sdk_sqs::types::QueueAttributeName;
 use helpers::TestServer;
 
 #[tokio::test]
@@ -222,4 +223,148 @@ async fn eb_schedule_fires_to_sqs() {
     let event: serde_json::Value = serde_json::from_str(body).unwrap();
     assert_eq!(event["source"], "aws.events");
     assert_eq!(event["detail-type"], "Scheduled Event");
+}
+
+/// Verify EventBridge PutEvents delivers matching events to an SQS target.
+#[tokio::test]
+async fn eb_put_events_delivers_to_sqs_target() {
+    let server = TestServer::start().await;
+    let eb = server.eventbridge_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create SQS queue
+    let queue = sqs
+        .create_queue()
+        .queue_name("eb-delivery-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = attrs
+        .attributes()
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+
+    // Create rule matching "app.orders" source
+    eb.put_rule()
+        .name("delivery-rule")
+        .event_pattern(r#"{"source": ["app.orders"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Add SQS target
+    eb.put_targets()
+        .rule("delivery-rule")
+        .targets(
+            Target::builder()
+                .id("sqs-delivery")
+                .arn(&queue_arn)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Put a matching event
+    let resp = eb
+        .put_events()
+        .entries(
+            PutEventsRequestEntry::builder()
+                .source("app.orders")
+                .detail_type("OrderCreated")
+                .detail(r#"{"orderId": "100"}"#)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.failed_entry_count(), 0);
+
+    // Verify the event was delivered to SQS
+    let msgs = sqs
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(msgs.messages().len(), 1, "expected 1 event in SQS");
+    let body: serde_json::Value = serde_json::from_str(msgs.messages()[0].body().unwrap()).unwrap();
+    assert_eq!(body["source"], "app.orders");
+    assert_eq!(body["detail-type"], "OrderCreated");
+    assert_eq!(body["detail"]["orderId"], "100");
+}
+
+/// Verify EventBridge PutEvents succeeds when targeting Lambda, Logs, and StepFunctions
+/// (stub delivery — no error, event is accepted).
+#[tokio::test]
+async fn eb_put_events_stub_targets_no_error() {
+    let server = TestServer::start().await;
+    let eb = server.eventbridge_client().await;
+
+    // Create rule
+    eb.put_rule()
+        .name("multi-target-rule")
+        .event_pattern(r#"{"source": ["test.stubs"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Add Lambda, Logs, and StepFunctions targets
+    eb.put_targets()
+        .rule("multi-target-rule")
+        .targets(
+            Target::builder()
+                .id("lambda-target")
+                .arn("arn:aws:lambda:us-east-1:123456789012:function:my-func")
+                .build()
+                .unwrap(),
+        )
+        .targets(
+            Target::builder()
+                .id("logs-target")
+                .arn("arn:aws:logs:us-east-1:123456789012:log-group:/aws/events/my-log")
+                .build()
+                .unwrap(),
+        )
+        .targets(
+            Target::builder()
+                .id("sfn-target")
+                .arn("arn:aws:states:us-east-1:123456789012:stateMachine:my-machine")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Put a matching event — should succeed without errors
+    let resp = eb
+        .put_events()
+        .entries(
+            PutEventsRequestEntry::builder()
+                .source("test.stubs")
+                .detail_type("TestEvent")
+                .detail(r#"{"key": "value"}"#)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.failed_entry_count(), 0);
+    assert_eq!(resp.entries().len(), 1);
+    assert!(resp.entries()[0].event_id().is_some());
 }

--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -369,3 +369,99 @@ async fn s3_nested_key_paths() {
     let body = resp.body.collect().await.unwrap().into_bytes();
     assert_eq!(body.as_ref(), b"deep");
 }
+
+/// Verify that S3 lifecycle configuration can be put and retrieved.
+#[tokio::test]
+async fn s3_lifecycle_put_get_delete() {
+    let server = TestServer::start().await;
+
+    // Use AWS CLI for lifecycle operations (SDK lifecycle types are complex)
+    let output = server
+        .aws_cli(&["s3api", "create-bucket", "--bucket", "lifecycle-bucket"])
+        .await;
+    assert!(
+        output.success(),
+        "create bucket failed: {}",
+        output.stderr_text()
+    );
+
+    // Put lifecycle configuration
+    let lifecycle_json = r#"{
+        "Rules": [
+            {
+                "ID": "expire-logs",
+                "Filter": {"Prefix": "logs/"},
+                "Status": "Enabled",
+                "Expiration": {"Days": 30}
+            },
+            {
+                "ID": "archive-data",
+                "Filter": {"Prefix": "data/"},
+                "Status": "Enabled",
+                "Transitions": [
+                    {"Days": 90, "StorageClass": "GLACIER"}
+                ]
+            }
+        ]
+    }"#;
+
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "put-bucket-lifecycle-configuration",
+            "--bucket",
+            "lifecycle-bucket",
+            "--lifecycle-configuration",
+            lifecycle_json,
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "put lifecycle failed: {}",
+        output.stderr_text()
+    );
+
+    // Get lifecycle configuration
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "get-bucket-lifecycle-configuration",
+            "--bucket",
+            "lifecycle-bucket",
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "get lifecycle failed: {}",
+        output.stderr_text()
+    );
+    let json = output.stdout_json();
+    let rules = json["Rules"].as_array().unwrap();
+    assert_eq!(rules.len(), 2);
+
+    // Delete lifecycle configuration
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "delete-bucket-lifecycle",
+            "--bucket",
+            "lifecycle-bucket",
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "delete lifecycle failed: {}",
+        output.stderr_text()
+    );
+
+    // Verify deleted — should fail with NoSuchLifecycleConfiguration
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "get-bucket-lifecycle-configuration",
+            "--bucket",
+            "lifecycle-bucket",
+        ])
+        .await;
+    assert!(!output.success(), "expected error after lifecycle deletion");
+}

--- a/crates/fakecloud-e2e/tests/sns.rs
+++ b/crates/fakecloud-e2e/tests/sns.rs
@@ -1,5 +1,6 @@
 mod helpers;
 
+use aws_sdk_sqs::types::QueueAttributeName;
 use helpers::TestServer;
 
 #[tokio::test]
@@ -188,4 +189,138 @@ async fn sns_fifo_topic_creation() {
         attributes.get("FifoTopic").map(|s| s.as_str()),
         Some("true")
     );
+}
+
+/// Publish to SNS topic with SQS subscriber and verify delivery.
+#[tokio::test]
+async fn sns_publish_delivers_to_sqs_subscriber() {
+    let server = TestServer::start().await;
+    let sns = server.sns_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create SQS queue
+    let queue = sqs
+        .create_queue()
+        .queue_name("sns-delivery-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = attrs
+        .attributes()
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+
+    // Create topic and subscribe SQS
+    let topic = sns
+        .create_topic()
+        .name("delivery-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&queue_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Publish
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("delivery test message")
+        .subject("Test Subject")
+        .send()
+        .await
+        .unwrap();
+
+    // Verify delivery
+    let msgs = sqs
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(msgs.messages().len(), 1, "expected 1 message in SQS");
+    let body = msgs.messages()[0].body().unwrap();
+    let envelope: serde_json::Value = serde_json::from_str(body).unwrap();
+    assert_eq!(envelope["Type"], "Notification");
+    assert_eq!(envelope["Message"], "delivery test message");
+    assert_eq!(envelope["TopicArn"], topic_arn);
+}
+
+/// Subscribing Lambda/email/sms protocols should succeed (stub delivery).
+#[tokio::test]
+async fn sns_subscribe_lambda_email_sms() {
+    let server = TestServer::start().await;
+    let sns = server.sns_client().await;
+
+    let topic = sns.create_topic().name("stub-topic").send().await.unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    // Subscribe Lambda
+    let resp = sns
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("lambda")
+        .endpoint("arn:aws:lambda:us-east-1:123456789012:function:my-func")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.subscription_arn().is_some());
+
+    // Subscribe email
+    let resp = sns
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("email")
+        .endpoint("user@example.com")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.subscription_arn().is_some());
+
+    // Subscribe SMS
+    let resp = sns
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sms")
+        .endpoint("+15551234567")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.subscription_arn().is_some());
+
+    // Publish to the topic — should not error despite stub targets
+    let resp = sns
+        .publish()
+        .topic_arn(&topic_arn)
+        .message("message to all subscribers")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.message_id().is_some());
+
+    // Verify all subscriptions are listed
+    let subs = sns
+        .list_subscriptions_by_topic()
+        .topic_arn(&topic_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(subs.subscriptions().len(), 3);
 }

--- a/crates/fakecloud-eventbridge/Cargo.toml
+++ b/crates/fakecloud-eventbridge/Cargo.toml
@@ -19,4 +19,5 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+reqwest = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -218,6 +218,65 @@ impl Scheduler {
                 } else if arn.contains(":sns:") {
                     self.delivery
                         .publish_to_sns(arn, &event_str, Some("Scheduled Event"));
+                } else if arn.contains(":lambda:") {
+                    tracing::info!(
+                        function_arn = %arn,
+                        payload = %event_str,
+                        "Scheduler delivering to Lambda function (stub)"
+                    );
+                    let mut state = self.state.write();
+                    state
+                        .lambda_invocations
+                        .push(crate::state::LambdaInvocation {
+                            function_arn: arn.clone(),
+                            payload: event_str.clone(),
+                            timestamp: now,
+                        });
+                } else if arn.contains(":logs:") {
+                    tracing::info!(
+                        log_group_arn = %arn,
+                        payload = %event_str,
+                        "Scheduler delivering to CloudWatch Logs (stub)"
+                    );
+                    let mut state = self.state.write();
+                    state.log_deliveries.push(crate::state::LogDelivery {
+                        log_group_arn: arn.clone(),
+                        payload: event_str.clone(),
+                        timestamp: now,
+                    });
+                } else if arn.contains(":states:") {
+                    tracing::info!(
+                        state_machine_arn = %arn,
+                        payload = %event_str,
+                        "Scheduler delivering to Step Functions (stub)"
+                    );
+                    let mut state = self.state.write();
+                    state
+                        .step_function_executions
+                        .push(crate::state::StepFunctionExecution {
+                            state_machine_arn: arn.clone(),
+                            payload: event_str.clone(),
+                            timestamp: now,
+                        });
+                } else if arn.starts_with("https://") || arn.starts_with("http://") {
+                    let url = arn.clone();
+                    let payload = event_str.clone();
+                    tokio::spawn(async move {
+                        let client = reqwest::Client::new();
+                        let result = client
+                            .post(&url)
+                            .header("Content-Type", "application/json")
+                            .body(payload)
+                            .send()
+                            .await;
+                        if let Err(e) = result {
+                            tracing::warn!(
+                                endpoint = %url,
+                                error = %e,
+                                "Scheduler HTTP target delivery failed"
+                            );
+                        }
+                    });
                 }
             }
         }

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -1178,6 +1178,66 @@ impl EventBridgeService {
                 } else if arn.contains(":sns:") {
                     self.delivery
                         .publish_to_sns(arn, &body_str, Some(&detail_type));
+                } else if arn.contains(":lambda:") {
+                    tracing::info!(
+                        function_arn = %arn,
+                        payload = %body_str,
+                        "EventBridge delivering to Lambda function (stub)"
+                    );
+                    let mut state = self.state.write();
+                    state
+                        .lambda_invocations
+                        .push(crate::state::LambdaInvocation {
+                            function_arn: arn.clone(),
+                            payload: body_str.clone(),
+                            timestamp: Utc::now(),
+                        });
+                } else if arn.contains(":logs:") {
+                    tracing::info!(
+                        log_group_arn = %arn,
+                        payload = %body_str,
+                        "EventBridge delivering to CloudWatch Logs (stub)"
+                    );
+                    let mut state = self.state.write();
+                    state.log_deliveries.push(crate::state::LogDelivery {
+                        log_group_arn: arn.clone(),
+                        payload: body_str.clone(),
+                        timestamp: Utc::now(),
+                    });
+                } else if arn.contains(":states:") {
+                    tracing::info!(
+                        state_machine_arn = %arn,
+                        payload = %body_str,
+                        "EventBridge delivering to Step Functions (stub)"
+                    );
+                    let mut state = self.state.write();
+                    state
+                        .step_function_executions
+                        .push(crate::state::StepFunctionExecution {
+                            state_machine_arn: arn.clone(),
+                            payload: body_str.clone(),
+                            timestamp: Utc::now(),
+                        });
+                } else if arn.starts_with("https://") || arn.starts_with("http://") {
+                    // HTTP/API destination target — fire-and-forget POST
+                    let url = arn.clone();
+                    let payload = body_str.clone();
+                    tokio::spawn(async move {
+                        let client = reqwest::Client::new();
+                        let result = client
+                            .post(&url)
+                            .header("Content-Type", "application/json")
+                            .body(payload)
+                            .send()
+                            .await;
+                        if let Err(e) = result {
+                            tracing::warn!(
+                                endpoint = %url,
+                                error = %e,
+                                "EventBridge HTTP target delivery failed"
+                            );
+                        }
+                    });
                 }
             }
         }

--- a/crates/fakecloud-eventbridge/src/state.rs
+++ b/crates/fakecloud-eventbridge/src/state.rs
@@ -115,6 +115,30 @@ pub struct Replay {
     pub replay_end_time: Option<DateTime<Utc>>,
 }
 
+/// A recorded Lambda invocation from EventBridge delivery.
+#[derive(Debug, Clone)]
+pub struct LambdaInvocation {
+    pub function_arn: String,
+    pub payload: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+/// A recorded CloudWatch Logs delivery from EventBridge.
+#[derive(Debug, Clone)]
+pub struct LogDelivery {
+    pub log_group_arn: String,
+    pub payload: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+/// A recorded Step Functions invocation from EventBridge delivery.
+#[derive(Debug, Clone)]
+pub struct StepFunctionExecution {
+    pub state_machine_arn: String,
+    pub payload: String,
+    pub timestamp: DateTime<Utc>,
+}
+
 pub struct EventBridgeState {
     pub account_id: String,
     pub region: String,
@@ -127,6 +151,12 @@ pub struct EventBridgeState {
     pub replays: HashMap<String, Replay>,
     /// Partner event sources: name -> account
     pub partner_event_sources: HashMap<String, String>,
+    /// Recorded Lambda invocations (stub deliveries).
+    pub lambda_invocations: Vec<LambdaInvocation>,
+    /// Recorded CloudWatch Logs deliveries (stub deliveries).
+    pub log_deliveries: Vec<LogDelivery>,
+    /// Recorded Step Functions executions (stub deliveries).
+    pub step_function_executions: Vec<StepFunctionExecution>,
 }
 
 impl EventBridgeState {
@@ -160,6 +190,9 @@ impl EventBridgeState {
             api_destinations: HashMap::new(),
             replays: HashMap::new(),
             partner_event_sources: HashMap::new(),
+            lambda_invocations: Vec::new(),
+            log_deliveries: Vec::new(),
+            step_function_executions: Vec::new(),
         }
     }
 
@@ -181,6 +214,9 @@ impl EventBridgeState {
         self.rules.clear();
         self.events.clear();
         self.partner_event_sources.clear();
+        self.lambda_invocations.clear();
+        self.log_deliveries.clear();
+        self.step_function_executions.clear();
         // Re-create default bus
         let default_bus_arn = format!(
             "arn:aws:events:{}:{}:event-bus/default",

--- a/crates/fakecloud-s3/Cargo.toml
+++ b/crates/fakecloud-s3/Cargo.toml
@@ -19,6 +19,7 @@ parking_lot = { workspace = true }
 percent-encoding = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }

--- a/crates/fakecloud-s3/src/lib.rs
+++ b/crates/fakecloud-s3/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod lifecycle;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-s3/src/lifecycle.rs
+++ b/crates/fakecloud-s3/src/lifecycle.rs
@@ -1,0 +1,445 @@
+use std::time::Duration;
+
+use chrono::{NaiveDate, Utc};
+
+use crate::state::SharedS3State;
+
+/// Background task that processes S3 lifecycle rules.
+///
+/// Every 60 seconds, iterates all buckets with lifecycle configurations,
+/// parses the lifecycle XML, and:
+/// - Deletes objects matching expiration rules (by Days or Date)
+/// - Updates storage class for objects matching transition rules
+pub struct LifecycleProcessor {
+    state: SharedS3State,
+}
+
+impl LifecycleProcessor {
+    pub fn new(state: SharedS3State) -> Self {
+        Self { state }
+    }
+
+    pub async fn run(self) {
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
+
+        loop {
+            interval.tick().await;
+            self.tick();
+        }
+    }
+
+    fn tick(&self) {
+        let now = Utc::now();
+        let today = now.date_naive();
+
+        // Collect bucket names and their lifecycle configs (to avoid holding lock during processing)
+        let bucket_configs: Vec<(String, String)> = {
+            let state = self.state.read();
+            state
+                .buckets
+                .values()
+                .filter_map(|b| {
+                    b.lifecycle_config
+                        .as_ref()
+                        .map(|cfg| (b.name.clone(), cfg.clone()))
+                })
+                .collect()
+        };
+
+        for (bucket_name, config_xml) in bucket_configs {
+            let rules = match parse_lifecycle_rules(&config_xml) {
+                Some(r) => r,
+                None => continue,
+            };
+
+            for rule in &rules {
+                if rule.status != "Enabled" {
+                    continue;
+                }
+
+                self.process_rule(&bucket_name, rule, today);
+            }
+        }
+    }
+
+    fn process_rule(&self, bucket_name: &str, rule: &LifecycleRule, today: NaiveDate) {
+        let mut state = self.state.write();
+        let bucket = match state.buckets.get_mut(bucket_name) {
+            Some(b) => b,
+            None => return,
+        };
+
+        // Collect keys to expire
+        let mut keys_to_delete: Vec<String> = Vec::new();
+        // Collect keys to transition (key, new_storage_class)
+        let mut keys_to_transition: Vec<(String, String)> = Vec::new();
+
+        for (key, obj) in bucket.objects.iter() {
+            // Check prefix filter
+            if let Some(ref prefix) = rule.prefix {
+                if !prefix.is_empty() && !key.starts_with(prefix) {
+                    continue;
+                }
+            }
+
+            // Check tag filter
+            if let Some(ref tag_filter) = rule.tag_filter {
+                let matches = obj
+                    .tags
+                    .get(&tag_filter.key)
+                    .map(|v| v == &tag_filter.value)
+                    .unwrap_or(false);
+                if !matches {
+                    continue;
+                }
+            }
+
+            // Check expiration by Days
+            if let Some(days) = rule.expiration_days {
+                let age = today
+                    .signed_duration_since(obj.last_modified.date_naive())
+                    .num_days();
+                if age >= days as i64 {
+                    keys_to_delete.push(key.clone());
+                    continue;
+                }
+            }
+
+            // Check expiration by Date
+            if let Some(ref date) = rule.expiration_date {
+                if &today >= date {
+                    keys_to_delete.push(key.clone());
+                    continue;
+                }
+            }
+
+            // Check transition by Days
+            for transition in &rule.transitions {
+                let should_transition = if let Some(days) = transition.days {
+                    let age = today
+                        .signed_duration_since(obj.last_modified.date_naive())
+                        .num_days();
+                    age >= days as i64
+                } else if let Some(ref date) = transition.date {
+                    &today >= date
+                } else {
+                    false
+                };
+
+                if should_transition && obj.storage_class != transition.storage_class {
+                    keys_to_transition.push((key.clone(), transition.storage_class.clone()));
+                    break; // Only apply first matching transition
+                }
+            }
+        }
+
+        // Apply deletions
+        if !keys_to_delete.is_empty() {
+            tracing::info!(
+                bucket = %bucket_name,
+                count = keys_to_delete.len(),
+                "S3 lifecycle: expiring objects"
+            );
+            for key in &keys_to_delete {
+                bucket.objects.remove(key);
+            }
+        }
+
+        // Apply transitions
+        if !keys_to_transition.is_empty() {
+            tracing::info!(
+                bucket = %bucket_name,
+                count = keys_to_transition.len(),
+                "S3 lifecycle: transitioning object storage classes"
+            );
+            for (key, new_class) in &keys_to_transition {
+                if let Some(obj) = bucket.objects.get_mut(key) {
+                    obj.storage_class = new_class.clone();
+                }
+            }
+        }
+    }
+}
+
+/// A parsed lifecycle rule.
+struct LifecycleRule {
+    status: String,
+    prefix: Option<String>,
+    tag_filter: Option<TagFilter>,
+    expiration_days: Option<u32>,
+    expiration_date: Option<NaiveDate>,
+    transitions: Vec<Transition>,
+}
+
+struct TagFilter {
+    key: String,
+    value: String,
+}
+
+struct Transition {
+    days: Option<u32>,
+    date: Option<NaiveDate>,
+    storage_class: String,
+}
+
+/// Parse lifecycle configuration XML into rules.
+fn parse_lifecycle_rules(xml: &str) -> Option<Vec<LifecycleRule>> {
+    let mut rules = Vec::new();
+    let mut remaining = xml;
+
+    while let Some(rule_start) = remaining.find("<Rule>") {
+        let after = &remaining[rule_start + 6..];
+        let rule_end = after.find("</Rule>")?;
+        let rule_body = &after[..rule_end];
+
+        let status = extract_tag(rule_body, "Status").unwrap_or_default();
+
+        // Parse prefix — can be at rule level or inside <Filter>
+        let prefix = if let Some(filter_body) = extract_block(rule_body, "Filter") {
+            // Check for <Prefix> inside Filter
+            let filter_prefix = extract_tag(filter_body, "Prefix");
+            // Also check for <And><Prefix> pattern
+            if filter_prefix.is_some() {
+                filter_prefix
+            } else if let Some(and_body) = extract_block(filter_body, "And") {
+                extract_tag(and_body, "Prefix")
+            } else {
+                None
+            }
+        } else {
+            extract_tag(rule_body, "Prefix")
+        };
+
+        // Parse tag filter from <Filter><Tag> or <Filter><And><Tag>
+        let tag_filter = if let Some(filter_body) = extract_block(rule_body, "Filter") {
+            parse_tag_filter(filter_body)
+        } else {
+            None
+        };
+
+        // Parse expiration
+        let (expiration_days, expiration_date) =
+            if let Some(exp_body) = extract_block(rule_body, "Expiration") {
+                let days = extract_tag(exp_body, "Days").and_then(|s| s.parse::<u32>().ok());
+                let date = extract_tag(exp_body, "Date").and_then(|s| parse_date(&s));
+                (days, date)
+            } else {
+                (None, None)
+            };
+
+        // Parse transitions
+        let mut transitions = Vec::new();
+        let mut trans_remaining = rule_body;
+        while let Some(t_start) = trans_remaining.find("<Transition>") {
+            let t_after = &trans_remaining[t_start + 12..];
+            if let Some(t_end) = t_after.find("</Transition>") {
+                let t_body = &t_after[..t_end];
+                let days = extract_tag(t_body, "Days").and_then(|s| s.parse::<u32>().ok());
+                let date = extract_tag(t_body, "Date").and_then(|s| parse_date(&s));
+                let storage_class =
+                    extract_tag(t_body, "StorageClass").unwrap_or_else(|| "GLACIER".to_string());
+                transitions.push(Transition {
+                    days,
+                    date,
+                    storage_class,
+                });
+                trans_remaining = &t_after[t_end + 13..];
+            } else {
+                break;
+            }
+        }
+
+        rules.push(LifecycleRule {
+            status,
+            prefix,
+            tag_filter,
+            expiration_days,
+            expiration_date,
+            transitions,
+        });
+
+        remaining = &after[rule_end + 7..];
+    }
+
+    Some(rules)
+}
+
+/// Extract text content of a simple XML tag, e.g. `<Days>30</Days>` -> "30".
+fn extract_tag(body: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = body.find(&open)?;
+    let content_start = start + open.len();
+    let end = body[content_start..].find(&close)?;
+    Some(body[content_start..content_start + end].trim().to_string())
+}
+
+/// Extract the body of a block element, e.g. `<Filter>...</Filter>` -> "...".
+fn extract_block<'a>(body: &'a str, tag: &str) -> Option<&'a str> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = body.find(&open)?;
+    let content_start = start + open.len();
+    let end = body[content_start..].find(&close)?;
+    Some(&body[content_start..content_start + end])
+}
+
+fn parse_tag_filter(filter_body: &str) -> Option<TagFilter> {
+    // Try direct <Tag> inside <Filter>
+    if let Some(tag_body) = extract_block(filter_body, "Tag") {
+        let key = extract_tag(tag_body, "Key")?;
+        let value = extract_tag(tag_body, "Value").unwrap_or_default();
+        return Some(TagFilter { key, value });
+    }
+    // Try <And><Tag> inside <Filter>
+    if let Some(and_body) = extract_block(filter_body, "And") {
+        if let Some(tag_body) = extract_block(and_body, "Tag") {
+            let key = extract_tag(tag_body, "Key")?;
+            let value = extract_tag(tag_body, "Value").unwrap_or_default();
+            return Some(TagFilter { key, value });
+        }
+    }
+    None
+}
+
+/// Parse a date string like "2024-01-01" or "2024-01-01T00:00:00.000Z".
+fn parse_date(s: &str) -> Option<NaiveDate> {
+    // Try YYYY-MM-DD first
+    if let Ok(d) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        return Some(d);
+    }
+    // Try ISO 8601 with time
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(dt.date_naive());
+    }
+    // Try with T and Z suffix
+    if let Some(date_part) = s.split('T').next() {
+        if let Ok(d) = NaiveDate::parse_from_str(date_part, "%Y-%m-%d") {
+            return Some(d);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_expiration_days_rule() {
+        let xml = r#"<LifecycleConfiguration>
+            <Rule>
+                <Filter><Prefix>logs/</Prefix></Filter>
+                <Status>Enabled</Status>
+                <Expiration><Days>30</Days></Expiration>
+            </Rule>
+        </LifecycleConfiguration>"#;
+
+        let rules = parse_lifecycle_rules(xml).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].status, "Enabled");
+        assert_eq!(rules[0].prefix.as_deref(), Some("logs/"));
+        assert_eq!(rules[0].expiration_days, Some(30));
+    }
+
+    #[test]
+    fn parse_expiration_date_rule() {
+        let xml = r#"<LifecycleConfiguration>
+            <Rule>
+                <Filter><Prefix></Prefix></Filter>
+                <Status>Enabled</Status>
+                <Expiration><Date>2024-06-01</Date></Expiration>
+            </Rule>
+        </LifecycleConfiguration>"#;
+
+        let rules = parse_lifecycle_rules(xml).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(
+            rules[0].expiration_date,
+            Some(NaiveDate::from_ymd_opt(2024, 6, 1).unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_transition_rule() {
+        let xml = r#"<LifecycleConfiguration>
+            <Rule>
+                <Filter><Prefix>archive/</Prefix></Filter>
+                <Status>Enabled</Status>
+                <Transition>
+                    <Days>90</Days>
+                    <StorageClass>GLACIER</StorageClass>
+                </Transition>
+                <Transition>
+                    <Days>365</Days>
+                    <StorageClass>DEEP_ARCHIVE</StorageClass>
+                </Transition>
+            </Rule>
+        </LifecycleConfiguration>"#;
+
+        let rules = parse_lifecycle_rules(xml).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].transitions.len(), 2);
+        assert_eq!(rules[0].transitions[0].days, Some(90));
+        assert_eq!(rules[0].transitions[0].storage_class, "GLACIER");
+        assert_eq!(rules[0].transitions[1].days, Some(365));
+        assert_eq!(rules[0].transitions[1].storage_class, "DEEP_ARCHIVE");
+    }
+
+    #[test]
+    fn parse_disabled_rule() {
+        let xml = r#"<LifecycleConfiguration>
+            <Rule>
+                <Filter><Prefix></Prefix></Filter>
+                <Status>Disabled</Status>
+                <Expiration><Days>1</Days></Expiration>
+            </Rule>
+        </LifecycleConfiguration>"#;
+
+        let rules = parse_lifecycle_rules(xml).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].status, "Disabled");
+    }
+
+    #[test]
+    fn parse_tag_filter_rule() {
+        let xml = r#"<LifecycleConfiguration>
+            <Rule>
+                <Filter>
+                    <Tag><Key>env</Key><Value>test</Value></Tag>
+                </Filter>
+                <Status>Enabled</Status>
+                <Expiration><Days>7</Days></Expiration>
+            </Rule>
+        </LifecycleConfiguration>"#;
+
+        let rules = parse_lifecycle_rules(xml).unwrap();
+        assert_eq!(rules.len(), 1);
+        let tag = rules[0].tag_filter.as_ref().unwrap();
+        assert_eq!(tag.key, "env");
+        assert_eq!(tag.value, "test");
+    }
+
+    #[test]
+    fn parse_multiple_rules() {
+        let xml = r#"<LifecycleConfiguration>
+            <Rule>
+                <Filter><Prefix>a/</Prefix></Filter>
+                <Status>Enabled</Status>
+                <Expiration><Days>10</Days></Expiration>
+            </Rule>
+            <Rule>
+                <Filter><Prefix>b/</Prefix></Filter>
+                <Status>Enabled</Status>
+                <Expiration><Days>20</Days></Expiration>
+            </Rule>
+        </LifecycleConfiguration>"#;
+
+        let rules = parse_lifecycle_rules(xml).unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].prefix.as_deref(), Some("a/"));
+        assert_eq!(rules[0].expiration_days, Some(10));
+        assert_eq!(rules[1].prefix.as_deref(), Some("b/"));
+        assert_eq!(rules[1].expiration_days, Some(20));
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -204,6 +204,9 @@ impl ResetState {
             eb.api_destinations.clear();
             eb.replays.clear();
             eb.buses.retain(|name, _| name == "default");
+            eb.lambda_invocations.clear();
+            eb.log_deliveries.clear();
+            eb.step_function_executions.clear();
         }
         self.ssm.write().reset();
         self.s3.write().reset();

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -117,7 +117,11 @@ async fn main() {
     registry.register(Arc::new(IamService::new(iam_state.clone())));
     registry.register(Arc::new(StsService::new(iam_state)));
     registry.register(Arc::new(SsmService::new(ssm_state)));
-    registry.register(Arc::new(S3Service::new(s3_state)));
+    registry.register(Arc::new(S3Service::new(s3_state.clone())));
+
+    // Spawn the S3 lifecycle processor as a background task
+    let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state);
+    tokio::spawn(lifecycle_processor.run());
 
     let services: Vec<&str> = registry.service_names();
     tracing::info!(services = ?services, "registered services");

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -48,6 +48,78 @@ impl SnsDelivery for SnsDeliveryImpl {
             .map(|s| s.endpoint.clone())
             .collect();
 
+        // Collect Lambda, email, and SMS subscribers
+        let lambda_subscribers: Vec<String> = state
+            .subscriptions
+            .values()
+            .filter(|s| s.topic_arn == topic_arn && s.protocol == "lambda" && s.confirmed)
+            .map(|s| s.endpoint.clone())
+            .collect();
+
+        let email_subscribers: Vec<String> = state
+            .subscriptions
+            .values()
+            .filter(|s| {
+                s.topic_arn == topic_arn
+                    && (s.protocol == "email" || s.protocol == "email-json")
+                    && s.confirmed
+            })
+            .map(|s| s.endpoint.clone())
+            .collect();
+
+        let sms_subscribers: Vec<String> = state
+            .subscriptions
+            .values()
+            .filter(|s| s.topic_arn == topic_arn && s.protocol == "sms" && s.confirmed)
+            .map(|s| s.endpoint.clone())
+            .collect();
+
+        // Store Lambda invocations
+        let now = Utc::now();
+        for function_arn in &lambda_subscribers {
+            tracing::info!(
+                function_arn = %function_arn,
+                topic_arn = %topic_arn,
+                "SNS cross-service delivering to Lambda (stub)"
+            );
+            state
+                .lambda_invocations
+                .push(crate::state::LambdaInvocation {
+                    function_arn: function_arn.clone(),
+                    message: message.to_string(),
+                    subject: subject.map(|s| s.to_string()),
+                    timestamp: now,
+                });
+        }
+
+        // Store email deliveries
+        for email_address in &email_subscribers {
+            tracing::info!(
+                email = %email_address,
+                topic_arn = %topic_arn,
+                "SNS cross-service delivering to email (stub)"
+            );
+            state.sent_emails.push(crate::state::SentEmail {
+                email_address: email_address.clone(),
+                message: message.to_string(),
+                subject: subject.map(|s| s.to_string()),
+                topic_arn: topic_arn.to_string(),
+                timestamp: now,
+            });
+        }
+
+        // Store SMS deliveries
+        for phone_number in &sms_subscribers {
+            tracing::info!(
+                phone_number = %phone_number,
+                topic_arn = %topic_arn,
+                "SNS cross-service delivering to SMS (stub)"
+            );
+            state
+                .sms_messages
+                .push((phone_number.clone(), message.to_string()));
+        }
+
         // Drop the lock before calling into SQS delivery
         drop(state);
 

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -909,6 +909,35 @@ impl SnsService {
             .filter(|s| matches_filter_policy(s, &message_attributes, &message))
             .map(|s| s.endpoint.clone())
             .collect();
+
+        let lambda_subscribers: Vec<String> = state
+            .subscriptions
+            .values()
+            .filter(|s| s.topic_arn == topic_arn && s.protocol == "lambda" && s.confirmed)
+            .filter(|s| matches_filter_policy(s, &message_attributes, &message))
+            .map(|s| s.endpoint.clone())
+            .collect();
+
+        let email_subscribers: Vec<String> = state
+            .subscriptions
+            .values()
+            .filter(|s| {
+                s.topic_arn == topic_arn
+                    && (s.protocol == "email" || s.protocol == "email-json")
+                    && s.confirmed
+            })
+            .filter(|s| matches_filter_policy(s, &message_attributes, &message))
+            .map(|s| s.endpoint.clone())
+            .collect();
+
+        let sms_subscribers: Vec<String> = state
+            .subscriptions
+            .values()
+            .filter(|s| s.topic_arn == topic_arn && s.protocol == "sms" && s.confirmed)
+            .filter(|s| matches_filter_policy(s, &message_attributes, &message))
+            .map(|s| s.endpoint.clone())
+            .collect();
+
         drop(state);
 
         // Determine actual message content per protocol
@@ -1013,6 +1042,63 @@ impl SnsService {
                     tracing::warn!(endpoint = %endpoint_url, error = %e, "SNS HTTP delivery failed");
                 }
             });
+        }
+
+        // Deliver to Lambda subscribers (stub — log and store)
+        if !lambda_subscribers.is_empty() {
+            let now = Utc::now();
+            let mut state = self.state.write();
+            for function_arn in lambda_subscribers {
+                tracing::info!(
+                    function_arn = %function_arn,
+                    message = %default_message,
+                    topic_arn = %topic_arn,
+                    "SNS delivering to Lambda function (stub)"
+                );
+                state
+                    .lambda_invocations
+                    .push(crate::state::LambdaInvocation {
+                        function_arn,
+                        message: default_message.clone(),
+                        subject: subject.clone(),
+                        timestamp: now,
+                    });
+            }
+        }
+
+        // Deliver to email subscribers (stub — log and store)
+        if !email_subscribers.is_empty() {
+            let now = Utc::now();
+            let mut state = self.state.write();
+            for email_address in email_subscribers {
+                tracing::info!(
+                    email = %email_address,
+                    topic_arn = %topic_arn,
+                    "SNS delivering to email (stub)"
+                );
+                state.sent_emails.push(crate::state::SentEmail {
+                    email_address,
+                    message: default_message.clone(),
+                    subject: subject.clone(),
+                    topic_arn: topic_arn.clone(),
+                    timestamp: now,
+                });
+            }
+        }
+
+        // Deliver to SMS subscribers (stub — log and store)
+        if !sms_subscribers.is_empty() {
+            let mut state = self.state.write();
+            for phone_number in sms_subscribers {
+                tracing::info!(
+                    phone_number = %phone_number,
+                    topic_arn = %topic_arn,
+                    "SNS delivering to SMS (stub)"
+                );
+                state
+                    .sms_messages
+                    .push((phone_number, default_message.clone()));
+            }
         }
 
         Ok(xml_resp(

--- a/crates/fakecloud-sns/src/state.rs
+++ b/crates/fakecloud-sns/src/state.rs
@@ -62,6 +62,25 @@ pub struct PlatformEndpoint {
     pub messages: Vec<PublishedMessage>,
 }
 
+/// A recorded Lambda invocation from SNS delivery.
+#[derive(Debug, Clone)]
+pub struct LambdaInvocation {
+    pub function_arn: String,
+    pub message: String,
+    pub subject: Option<String>,
+    pub timestamp: DateTime<Utc>,
+}
+
+/// A recorded email delivery from SNS (stub).
+#[derive(Debug, Clone)]
+pub struct SentEmail {
+    pub email_address: String,
+    pub message: String,
+    pub subject: Option<String>,
+    pub topic_arn: String,
+    pub timestamp: DateTime<Utc>,
+}
+
 pub struct SnsState {
     pub account_id: String,
     pub region: String,
@@ -72,6 +91,10 @@ pub struct SnsState {
     pub sms_attributes: HashMap<String, String>,
     pub opted_out_numbers: Vec<String>,
     pub sms_messages: Vec<(String, String)>, // (phone_number, message)
+    /// Recorded Lambda invocations (stub deliveries).
+    pub lambda_invocations: Vec<LambdaInvocation>,
+    /// Recorded email deliveries (stub — not actually sent).
+    pub sent_emails: Vec<SentEmail>,
 }
 
 impl SnsState {
@@ -86,6 +109,8 @@ impl SnsState {
             sms_attributes: HashMap::new(),
             opted_out_numbers: Vec::new(),
             sms_messages: Vec::new(),
+            lambda_invocations: Vec::new(),
+            sent_emails: Vec::new(),
         }
     }
 
@@ -97,6 +122,8 @@ impl SnsState {
         self.sms_attributes.clear();
         self.opted_out_numbers.clear();
         self.sms_messages.clear();
+        self.lambda_invocations.clear();
+        self.sent_emails.clear();
     }
 
     /// Seed default opt-out phone numbers.


### PR DESCRIPTION
## Summary
- **EventBridge**: Expanded PutEvents and scheduler delivery to support Lambda, CloudWatch Logs, Step Functions (stub — log and store invocations), and HTTP/API destination targets (fire-and-forget POST via reqwest).
- **SNS**: Expanded publish delivery to fan out to Lambda, email, and SMS subscriptions (stub — log and store in state). Works through both direct publish and cross-service (EventBridge -> SNS) delivery paths.
- **S3**: Added `LifecycleProcessor` background task that runs every 60 seconds, parses lifecycle XML configs, and applies expiration (delete) and transition (storage class change) rules based on Days/Date with prefix/tag filters.

## Test plan
- [ ] Unit tests pass for lifecycle XML parsing (6 tests in `fakecloud-s3`)
- [ ] All existing workspace unit tests continue to pass
- [ ] E2E: EventBridge PutEvents delivers to SQS target
- [ ] E2E: EventBridge PutEvents with Lambda/Logs/StepFunctions stub targets succeeds without error
- [ ] E2E: SNS publish delivers to SQS subscriber
- [ ] E2E: SNS subscribe with Lambda/email/sms protocols and publish succeeds
- [ ] E2E: S3 lifecycle configuration put/get/delete round-trip

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands EventBridge and SNS delivery targets and adds an S3 lifecycle background processor. This broadens cross-service fan-out and enables automatic object expiration and storage-class transitions.

- **New Features**
  - EventBridge: PutEvents and scheduler now support Lambda, CloudWatch Logs, and Step Functions (stub: log and store), plus HTTP/API destinations via fire-and-forget POST.
  - SNS: Publish now fans out to Lambda, email, and SMS subscriptions (stub: log and store), in both direct publish and EventBridge→SNS paths.
  - S3: Added `LifecycleProcessor` running every 60s to parse lifecycle XML and apply Expiration (Days/Date) and Transition rules with prefix/tag filters.

- **Dependencies**
  - Added `reqwest` to `fakecloud-eventbridge` for HTTP targets.
  - Added `tokio` to `fakecloud-s3` to run the background lifecycle task.

<sup>Written for commit 1f39237fa76a281367accf7cb3737c5d70cafc25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

