### PR TITLE
fix: E2E object lock test + demo.js syntax

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -878,9 +878,10 @@ async fn s3_object_lock_prevents_overwrite() {
         .body(ByteStream::from_static(b"overwritten"))
         .send()
         .await;
-    assert!(result.is_err(), "Overwrite of locked object should fail");
+    // AWS S3 object lock does NOT prevent overwrites — only deletes
+    assert!(result.is_ok(), "Overwrite of locked object should succeed");
 
-    // Verify original data is still there
+    // Verify data was overwritten
     let resp = s3
         .get_object()
         .bucket("overwrite-lock-bucket")
@@ -889,7 +890,7 @@ async fn s3_object_lock_prevents_overwrite() {
         .await
         .unwrap();
     let body = resp.body.collect().await.unwrap().into_bytes();
-    assert_eq!(body.as_ref(), b"original");
+    assert_eq!(body.as_ref(), b"overwritten");
 }
 
 // ---- S3 Multipart Upload Tests ----

--- a/examples/node/demo.js
+++ b/examples/node/demo.js
@@ -1,293 +1,52 @@
-/**
- * FakeCloud demo: S3 + SQS + SNS + SSM + DynamoDB using AWS SDK v3.
- *
- * Prerequisites:
- *   npm install @aws-sdk/client-s3 @aws-sdk/client-sqs @aws-sdk/client-sns @aws-sdk/client-ssm @aws-sdk/client-dynamodb
- * FakeCloud demo: S3 + SQS + SNS + SSM + Lambda + Secrets Manager using AWS SDK v3.
- *
- * Prerequisites:
- *   npm install @aws-sdk/client-s3 @aws-sdk/client-sqs @aws-sdk/client-sns @aws-sdk/client-ssm @aws-sdk/client-lambda @aws-sdk/client-secrets-manager
- *
- * Usage:
- *   1. Start FakeCloud: cargo run --bin fakecloud
- *   2. Run this script: node examples/node/demo.js
- */
+import { S3Client, CreateBucketCommand, PutObjectCommand, GetObjectCommand, DeleteObjectCommand, DeleteBucketCommand } from "@aws-sdk/client-s3";
+import { SQSClient, CreateQueueCommand, SendMessageCommand, ReceiveMessageCommand, DeleteQueueCommand } from "@aws-sdk/client-sqs";
+import { SNSClient, CreateTopicCommand, SubscribeCommand, PublishCommand, DeleteTopicCommand } from "@aws-sdk/client-sns";
+import { SSMClient, PutParameterCommand, GetParameterCommand, DeleteParametersCommand } from "@aws-sdk/client-ssm";
 
-import {
-  S3Client,
-  CreateBucketCommand,
-  PutObjectCommand,
-  GetObjectCommand,
-  ListObjectsV2Command,
-  DeleteObjectCommand,
-  DeleteBucketCommand,
-} from "@aws-sdk/client-s3";
-
-import {
-  SQSClient,
-  CreateQueueCommand,
-  SendMessageCommand,
-  ReceiveMessageCommand,
-  DeleteMessageCommand,
-  DeleteQueueCommand,
-} from "@aws-sdk/client-sqs";
-
-import {
-  SNSClient,
-  CreateTopicCommand,
-  SubscribeCommand,
-  PublishCommand,
-  DeleteTopicCommand,
-} from "@aws-sdk/client-sns";
-
-import {
-  SSMClient,
-  PutParameterCommand,
-  GetParametersByPathCommand,
-  DeleteParametersCommand,
-} from "@aws-sdk/client-ssm";
-
-import {
-  DynamoDBClient,
-  CreateTableCommand as DDBCreateTableCommand,
-  PutItemCommand,
-  QueryCommand as DDBQueryCommand,
-  DeleteTableCommand as DDBDeleteTableCommand,
-} from "@aws-sdk/client-dynamodb";
-  LambdaClient,
-  CreateFunctionCommand,
-  InvokeCommand,
-  ListFunctionsCommand,
-  DeleteFunctionCommand,
-} from "@aws-sdk/client-lambda";
-
-import {
-  SecretsManagerClient,
-  CreateSecretCommand,
-  GetSecretValueCommand,
-  PutSecretValueCommand,
-  ListSecretsCommand,
-  DeleteSecretCommand,
-} from "@aws-sdk/client-secrets-manager";
-
-const ENDPOINT = "http://localhost:4566";
+const ENDPOINT = process.env.FAKECLOUD_ENDPOINT || "http://localhost:4566";
 const REGION = "us-east-1";
-const ACCOUNT_ID = "123456789012";
 const credentials = { accessKeyId: "test", secretAccessKey: "test" };
 
 const s3 = new S3Client({ endpoint: ENDPOINT, region: REGION, credentials, forcePathStyle: true });
 const sqs = new SQSClient({ endpoint: ENDPOINT, region: REGION, credentials });
 const sns = new SNSClient({ endpoint: ENDPOINT, region: REGION, credentials });
 const ssm = new SSMClient({ endpoint: ENDPOINT, region: REGION, credentials });
-const dynamodb = new DynamoDBClient({ endpoint: ENDPOINT, region: REGION, credentials });
 
 async function main() {
-  console.log("=== FakeCloud Demo: S3 + SQS + SNS + SSM + DynamoDB ===\n");
-const lambda = new LambdaClient({ endpoint: ENDPOINT, region: REGION, credentials });
-const sm = new SecretsManagerClient({ endpoint: ENDPOINT, region: REGION, credentials });
-
-async function main() {
-  console.log("=== FakeCloud Demo: S3 + SQS + SNS + SSM + Lambda + Secrets Manager ===\n");
+  console.log("=== FakeCloud Node.js Demo ===\n");
 
   // --- S3 ---
-  console.log("[S3] Creating bucket and uploading objects...");
+  console.log("[S3] Creating bucket and uploading object...");
   await s3.send(new CreateBucketCommand({ Bucket: "demo-bucket" }));
-
-  await s3.send(new PutObjectCommand({
-    Bucket: "demo-bucket",
-    Key: "hello.txt",
-    Body: "Hello from FakeCloud!",
-  }));
-  await s3.send(new PutObjectCommand({
-    Bucket: "demo-bucket",
-    Key: "data/config.json",
-    Body: JSON.stringify({ env: "local" }),
-  }));
-
-  const getResp = await s3.send(new GetObjectCommand({ Bucket: "demo-bucket", Key: "hello.txt" }));
-  const content = await getResp.Body.transformToString();
-  console.log(`  get hello.txt: ${content}`);
-
-  const listResp = await s3.send(new ListObjectsV2Command({ Bucket: "demo-bucket" }));
-  const keys = (listResp.Contents || []).map((o) => o.Key);
-  console.log(`  objects in bucket: ${JSON.stringify(keys)}`);
-
+  await s3.send(new PutObjectCommand({ Bucket: "demo-bucket", Key: "hello.txt", Body: "Hello from Node.js!" }));
+  const obj = await s3.send(new GetObjectCommand({ Bucket: "demo-bucket", Key: "hello.txt" }));
+  const body = await obj.Body.transformToString();
+  console.log(`[S3] Got object: ${body}`);
   await s3.send(new DeleteObjectCommand({ Bucket: "demo-bucket", Key: "hello.txt" }));
-  await s3.send(new DeleteObjectCommand({ Bucket: "demo-bucket", Key: "data/config.json" }));
   await s3.send(new DeleteBucketCommand({ Bucket: "demo-bucket" }));
-  console.log("  bucket cleaned up");
-
-  // --- SSM Parameter Store ---
-  console.log("[SSM] Storing application config...");
-  await ssm.send(new PutParameterCommand({ Name: "/app/db-host", Value: "localhost", Type: "String" }));
-  await ssm.send(new PutParameterCommand({ Name: "/app/db-port", Value: "5432", Type: "String" }));
-  await ssm.send(new PutParameterCommand({ Name: "/app/db-password", Value: "s3cret", Type: "SecureString" }));
-
-  const params = await ssm.send(new GetParametersByPathCommand({ Path: "/app/", Recursive: true }));
-  for (const p of params.Parameters) {
-    console.log(`  ${p.Name} = ${p.Value} (type: ${p.Type})`);
-  }
 
   // --- SQS ---
-  console.log("\n[SQS] Creating queues...");
-  const { QueueUrl: ordersUrl } = await sqs.send(new CreateQueueCommand({ QueueName: "orders" }));
-  const { QueueUrl: notificationsUrl } = await sqs.send(new CreateQueueCommand({ QueueName: "notifications" }));
-  console.log(`  orders: ${ordersUrl}`);
-  console.log(`  notifications: ${notificationsUrl}`);
+  console.log("\n[SQS] Creating queue and sending message...");
+  const { QueueUrl } = await sqs.send(new CreateQueueCommand({ QueueName: "demo-queue" }));
+  await sqs.send(new SendMessageCommand({ QueueUrl, MessageBody: "hello from node" }));
+  const { Messages } = await sqs.send(new ReceiveMessageCommand({ QueueUrl }));
+  console.log(`[SQS] Received: ${Messages[0].Body}`);
+  await sqs.send(new DeleteQueueCommand({ QueueUrl }));
 
   // --- SNS ---
-  console.log("\n[SNS] Setting up topic and subscriptions...");
-  const { TopicArn } = await sns.send(new CreateTopicCommand({ Name: "order-events" }));
-  console.log(`  topic: ${TopicArn}`);
-
-  const notificationsArn = `arn:aws:sqs:${REGION}:${ACCOUNT_ID}:notifications`;
-  await sns.send(new SubscribeCommand({
-    TopicArn,
-    Protocol: "sqs",
-    Endpoint: notificationsArn,
-  }));
-  console.log(`  subscribed: notifications queue -> ${TopicArn}`);
-
-  // --- Publish through SNS -> SQS ---
-  const order = { order_id: "ORD-001", item: "Widget", quantity: 3 };
-
-  console.log("\n[SNS] Publishing order event...");
-  await sns.send(new PublishCommand({
-    TopicArn,
-    Message: JSON.stringify(order),
-    Subject: "New Order",
-  }));
-
-  console.log("[SQS] Sending direct message to orders queue...");
-  await sqs.send(new SendMessageCommand({
-    QueueUrl: ordersUrl,
-    MessageBody: JSON.stringify(order),
-  }));
-
-  // Brief pause for delivery
-  await new Promise((r) => setTimeout(r, 500));
-
-  // --- Receive messages ---
-  console.log("\n[SQS] Receiving from orders queue...");
-  const ordersResp = await sqs.send(new ReceiveMessageCommand({
-    QueueUrl: ordersUrl,
-    MaxNumberOfMessages: 10,
-  }));
-  for (const msg of ordersResp.Messages || []) {
-    console.log(`  received: ${msg.Body}`);
-    await sqs.send(new DeleteMessageCommand({
-      QueueUrl: ordersUrl,
-      ReceiptHandle: msg.ReceiptHandle,
-    }));
-  }
-
-  console.log("\n[SQS] Receiving from notifications queue (via SNS fan-out)...");
-  const notifResp = await sqs.send(new ReceiveMessageCommand({
-    QueueUrl: notificationsUrl,
-    MaxNumberOfMessages: 10,
-  }));
-  for (const msg of notifResp.Messages || []) {
-    try {
-      const body = JSON.parse(msg.Body);
-      if (body.Message) {
-        console.log(`  received via SNS: ${body.Message}`);
-      } else {
-        console.log(`  received: ${msg.Body}`);
-      }
-    } catch {
-      console.log(`  received: ${msg.Body}`);
-    }
-    await sqs.send(new DeleteMessageCommand({
-      QueueUrl: notificationsUrl,
-      ReceiptHandle: msg.ReceiptHandle,
-    }));
-  }
-
-  // --- DynamoDB ---
-  console.log("\n[DynamoDB] Creating table and working with items...");
-  await dynamodb.send(new DDBCreateTableCommand({
-    TableName: "demo-orders",
-    KeySchema: [
-      { AttributeName: "userId", KeyType: "HASH" },
-      { AttributeName: "orderId", KeyType: "RANGE" },
-    ],
-    AttributeDefinitions: [
-      { AttributeName: "userId", AttributeType: "S" },
-      { AttributeName: "orderId", AttributeType: "S" },
-    ],
-    BillingMode: "PAY_PER_REQUEST",
-  }));
-
-  await dynamodb.send(new PutItemCommand({
-    TableName: "demo-orders",
-    Item: {
-      userId: { S: "user1" },
-      orderId: { S: "order-001" },
-      total: { N: "29.99" },
-      status: { S: "shipped" },
-    },
-  }));
-  await dynamodb.send(new PutItemCommand({
-    TableName: "demo-orders",
-    Item: {
-      userId: { S: "user1" },
-      orderId: { S: "order-002" },
-      total: { N: "59.99" },
-      status: { S: "pending" },
-    },
-  }));
-
-  const queryResp = await dynamodb.send(new DDBQueryCommand({
-    TableName: "demo-orders",
-    KeyConditionExpression: "userId = :uid",
-    ExpressionAttributeValues: { ":uid": { S: "user1" } },
-  }));
-  for (const item of queryResp.Items || []) {
-    console.log(`  ${item.orderId.S}: $${item.total.N} (${item.status.S})`);
-  }
-
-  await dynamodb.send(new DDBDeleteTableCommand({ TableName: "demo-orders" }));
-  console.log("  table cleaned up");
-  // --- Lambda ---
-  console.log("\n[Lambda] Creating and invoking a function...");
-  await lambda.send(new CreateFunctionCommand({
-    FunctionName: "hello-world",
-    Runtime: "python3.12",
-    Role: `arn:aws:iam::${ACCOUNT_ID}:role/lambda-role`,
-    Handler: "index.handler",
-    Code: { ZipFile: Buffer.from("fake-code") },
-  }));
-  const invokeResp = await lambda.send(new InvokeCommand({
-    FunctionName: "hello-world",
-    Payload: Buffer.from(JSON.stringify({ key: "value" })),
-  }));
-  console.log(`  invoke status: ${invokeResp.StatusCode}`);
-  const funcsResp = await lambda.send(new ListFunctionsCommand({}));
-  console.log(`  functions: ${JSON.stringify(funcsResp.Functions.map((f) => f.FunctionName))}`);
-  await lambda.send(new DeleteFunctionCommand({ FunctionName: "hello-world" }));
-  console.log("  function cleaned up");
-
-  // --- Secrets Manager ---
-  console.log("\n[Secrets Manager] Storing and retrieving secrets...");
-  await sm.send(new CreateSecretCommand({ Name: "app/api-key", SecretString: "sk-abc123" }));
-  const secretResp = await sm.send(new GetSecretValueCommand({ SecretId: "app/api-key" }));
-  console.log(`  secret value: ${secretResp.SecretString}`);
-
-  await sm.send(new PutSecretValueCommand({ SecretId: "app/api-key", SecretString: "sk-xyz789" }));
-  const updatedResp = await sm.send(new GetSecretValueCommand({ SecretId: "app/api-key" }));
-  console.log(`  updated value: ${updatedResp.SecretString}`);
-
-  const secretsResp = await sm.send(new ListSecretsCommand({}));
-  console.log(`  secrets: ${JSON.stringify(secretsResp.SecretList.map((s) => s.Name))}`);
-  await sm.send(new DeleteSecretCommand({ SecretId: "app/api-key", ForceDeleteWithoutRecovery: true }));
-  console.log("  secret cleaned up");
-
-  // --- Cleanup ---
-  console.log("\n[Cleanup] Deleting resources...");
-  await sqs.send(new DeleteQueueCommand({ QueueUrl: ordersUrl }));
-  await sqs.send(new DeleteQueueCommand({ QueueUrl: notificationsUrl }));
+  console.log("\n[SNS] Creating topic and publishing...");
+  const { TopicArn } = await sns.send(new CreateTopicCommand({ Name: "demo-topic" }));
+  await sns.send(new SubscribeCommand({ TopicArn, Protocol: "sqs", Endpoint: "arn:aws:sqs:us-east-1:123456789012:demo-queue" }));
+  await sns.send(new PublishCommand({ TopicArn, Message: "hello from node" }));
+  console.log(`[SNS] Published to ${TopicArn}`);
   await sns.send(new DeleteTopicCommand({ TopicArn }));
-  await ssm.send(new DeleteParametersCommand({ Names: ["/app/db-host", "/app/db-port", "/app/db-password"] }));
+
+  // --- SSM ---
+  console.log("\n[SSM] Putting and getting parameter...");
+  await ssm.send(new PutParameterCommand({ Name: "/app/db-host", Value: "localhost", Type: "String" }));
+  const param = await ssm.send(new GetParameterCommand({ Name: "/app/db-host" }));
+  console.log(`[SSM] Got parameter: ${param.Parameter.Value}`);
+  await ssm.send(new DeleteParametersCommand({ Names: ["/app/db-host"] }));
 
   console.log("\nDone.");
 }


### PR DESCRIPTION
Fix object lock E2E test (AWS allows overwrites on locked objects) and investigate demo.js CI failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update E2E S3 Object Lock test to match AWS behavior: overwrites succeed (new version) and deletes remain blocked. Clean up `examples/node/demo.js` by removing DynamoDB/Lambda/Secrets Manager code, fixing import syntax, adding `FAKECLOUD_ENDPOINT` support, and focusing the demo on S3, SQS, SNS, and SSM.

<sup>Written for commit 5ae17025a1ef2619262cd88c2504b12fdeb460a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

