### PR TITLE
fix(s3): address Cubic P1 review findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ name = "fakecloud"
 version = "0.1.1"
 dependencies = [
  "axum",
+ "chrono",
  "clap",
  "fakecloud-aws",
  "fakecloud-core",
@@ -1325,6 +1326,8 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-lambda",
+ "fakecloud-logs",
  "http 1.4.0",
  "parking_lot",
  "reqwest",
@@ -1415,6 +1418,7 @@ dependencies = [
  "crc32fast",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-kms",
  "http 1.4.0",
  "md-5",
  "parking_lot",
@@ -1495,6 +1499,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-secretsmanager",
  "http 1.4.0",
  "md5",
  "parking_lot",

--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -1384,3 +1384,302 @@ async fn s3_copy_object_within_bucket() {
     let body = resp.body.collect().await.unwrap().into_bytes();
     assert_eq!(body.as_ref(), b"hello copy");
 }
+
+// ---- P1 Bug Fix Regression Tests ----
+
+/// Regression: ListObjectsV2 with delimiter and many prefixes must not panic
+/// due to bounds check on continuation token / prefix slicing.
+#[tokio::test]
+async fn s3_list_objects_v2_delimiter_many_prefixes() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("delim-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // Create objects under several prefixes
+    for i in 0..5 {
+        client
+            .put_object()
+            .bucket("delim-bucket")
+            .key(format!("prefix{i}/file.txt"))
+            .body(ByteStream::from_static(b"data"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // First page: max-keys=2 to force pagination
+    let page1 = client
+        .list_objects_v2()
+        .bucket("delim-bucket")
+        .delimiter("/")
+        .max_keys(2)
+        .send()
+        .await
+        .unwrap();
+    assert!(page1.is_truncated().unwrap_or(false));
+    assert_eq!(page1.common_prefixes().len(), 2);
+    let token = page1.next_continuation_token().unwrap().to_string();
+
+    // Second page using continuation token — this previously could panic
+    let page2 = client
+        .list_objects_v2()
+        .bucket("delim-bucket")
+        .delimiter("/")
+        .max_keys(2)
+        .continuation_token(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page2.common_prefixes().len(), 2);
+
+    // Third page: should have 1 remaining prefix
+    if page2.is_truncated().unwrap_or(false) {
+        let token2 = page2.next_continuation_token().unwrap().to_string();
+        let page3 = client
+            .list_objects_v2()
+            .bucket("delim-bucket")
+            .delimiter("/")
+            .max_keys(2)
+            .continuation_token(&token2)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(page3.common_prefixes().len(), 1);
+    }
+}
+
+/// Regression: CompleteMultipartUpload with wrong ETag returns InvalidPart error.
+#[tokio::test]
+async fn s3_complete_multipart_wrong_etag_returns_error() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("mpu-etag-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("mpu-etag-bucket")
+        .key("test.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    // Upload a part
+    let part = client
+        .upload_part()
+        .bucket("mpu-etag-bucket")
+        .key("test.bin")
+        .upload_id(&upload_id)
+        .part_number(1)
+        .body(ByteStream::from_static(b"part1data"))
+        .send()
+        .await
+        .unwrap();
+    let _real_etag = part.e_tag().unwrap().to_string();
+
+    // Complete with a wrong ETag — should fail with InvalidPart
+    use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+    let bad_part = CompletedPart::builder()
+        .part_number(1)
+        .e_tag("\"0000000000000000000000000000dead\"")
+        .build();
+    let result = client
+        .complete_multipart_upload()
+        .bucket("mpu-etag-bucket")
+        .key("test.bin")
+        .upload_id(&upload_id)
+        .multipart_upload(CompletedMultipartUpload::builder().parts(bad_part).build())
+        .send()
+        .await;
+    assert!(result.is_err(), "Expected InvalidPart error for wrong ETag");
+    let err_str = format!("{:?}", result.unwrap_err());
+    assert!(
+        err_str.contains("InvalidPart") || err_str.contains("could not be found"),
+        "Error should mention InvalidPart, got: {err_str}"
+    );
+}
+
+/// Regression: AbortMultipartUpload with wrong key returns NoSuchUpload error.
+#[tokio::test]
+async fn s3_abort_multipart_wrong_key_returns_error() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("mpu-abort-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("mpu-abort-bucket")
+        .key("correct-key.txt")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    // Abort with the wrong key — should fail
+    let result = client
+        .abort_multipart_upload()
+        .bucket("mpu-abort-bucket")
+        .key("wrong-key.txt")
+        .upload_id(&upload_id)
+        .send()
+        .await;
+    assert!(
+        result.is_err(),
+        "Expected NoSuchUpload error when aborting with wrong key"
+    );
+
+    // Abort with the correct key — should succeed
+    client
+        .abort_multipart_upload()
+        .bucket("mpu-abort-bucket")
+        .key("correct-key.txt")
+        .upload_id(&upload_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+/// Regression: CopyObject rejects a delete marker as copy source.
+#[tokio::test]
+async fn s3_copy_object_rejects_delete_marker_source() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("copy-dm-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // Enable versioning
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "put-bucket-versioning",
+            "--bucket",
+            "copy-dm-bucket",
+            "--versioning-configuration",
+            "Status=Enabled",
+        ])
+        .await;
+    assert!(output.success(), "versioning: {}", output.stderr_text());
+
+    // Put an object, then delete it to create a delete marker
+    client
+        .put_object()
+        .bucket("copy-dm-bucket")
+        .key("source.txt")
+        .body(ByteStream::from_static(b"hello"))
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_object()
+        .bucket("copy-dm-bucket")
+        .key("source.txt")
+        .send()
+        .await
+        .unwrap();
+
+    // Copy from the (now delete-marked) source should fail
+    let result = client
+        .copy_object()
+        .bucket("copy-dm-bucket")
+        .key("dest.txt")
+        .copy_source("copy-dm-bucket/source.txt")
+        .send()
+        .await;
+    assert!(
+        result.is_err(),
+        "Expected copy from delete marker to fail, but it succeeded"
+    );
+}
+
+/// Regression: Deleting a specific version that doesn't exist must not affect
+/// the current object.
+#[tokio::test]
+async fn s3_delete_specific_version_preserves_current_object() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("ver-del-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // Enable versioning
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "put-bucket-versioning",
+            "--bucket",
+            "ver-del-bucket",
+            "--versioning-configuration",
+            "Status=Enabled",
+        ])
+        .await;
+    assert!(output.success());
+
+    // Put an object (creates a real version)
+    client
+        .put_object()
+        .bucket("ver-del-bucket")
+        .key("keep-me.txt")
+        .body(ByteStream::from_static(b"important data"))
+        .send()
+        .await
+        .unwrap();
+
+    // Delete a non-existent version ID — must not affect the current object
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "delete-object",
+            "--bucket",
+            "ver-del-bucket",
+            "--key",
+            "keep-me.txt",
+            "--version-id",
+            "nonexistent-version-id-12345",
+        ])
+        .await;
+    // The delete may succeed (noop) or fail, but the object must still be readable
+    let _ = output;
+
+    // The current object must still be intact
+    let get = client
+        .get_object()
+        .bucket("ver-del-bucket")
+        .key("keep-me.txt")
+        .send()
+        .await
+        .unwrap();
+    let body = get.body.collect().await.unwrap().into_bytes();
+    assert_eq!(
+        body.as_ref(),
+        b"important data",
+        "Current object was corrupted by deleting a non-existent version"
+    );
+}

--- a/crates/fakecloud-s3/src/service.rs
+++ b/crates/fakecloud-s3/src/service.rs
@@ -1532,9 +1532,13 @@ impl S3Service {
 
             // Handle delimiter-based grouping
             if !delimiter.is_empty() {
+                if prefix.len() > key.len() {
+                    continue;
+                }
                 let suffix = &key[prefix.len()..];
                 if let Some(pos) = suffix.find(&delimiter) {
-                    let cp = format!("{}{}", prefix, &suffix[..=pos]);
+                    let end = (pos + delimiter.len()).min(suffix.len());
+                    let cp = format!("{}{}", prefix, &suffix[..end]);
                     if !common_prefixes.contains(&cp) {
                         if count >= max_keys {
                             is_truncated = true;
@@ -2999,15 +3003,20 @@ impl S3Service {
                 is_dm = versions
                     .iter()
                     .any(|o| vid_matches(o) && o.is_delete_marker);
+                let len_before = versions.len();
                 versions.retain(|o| !vid_matches(o));
-                if let Some(latest) = versions.last() {
-                    if latest.is_delete_marker {
-                        b.objects.remove(key);
+                let removed = len_before != versions.len();
+                // Only update current object if we actually removed a version
+                if removed {
+                    if let Some(latest) = versions.last() {
+                        if latest.is_delete_marker {
+                            b.objects.remove(key);
+                        } else {
+                            b.objects.insert(key.to_string(), latest.clone());
+                        }
                     } else {
-                        b.objects.insert(key.to_string(), latest.clone());
+                        b.objects.remove(key);
                     }
-                } else {
-                    b.objects.remove(key);
                 }
                 if versions.is_empty() {
                     b.object_versions.remove(key);
@@ -3453,6 +3462,11 @@ impl S3Service {
             let obj = resolve_object(sb, src_key, src_version_id.as_ref())?.clone();
             (obj.clone(), obj.version_id.clone())
         };
+
+        // Delete markers cannot be used as copy source
+        if src_obj.is_delete_marker {
+            return Err(no_such_key(src_key));
+        }
 
         // Glacier/Deep Archive: cannot copy unless restored
         if is_frozen(&src_obj) {
@@ -4490,7 +4504,7 @@ impl S3Service {
         let mut md5_digests = Vec::new();
         let mut part_sizes = Vec::new();
 
-        for (part_num, _submitted_etag) in &sorted_parts {
+        for (part_num, submitted_etag) in &sorted_parts {
             let part = upload.parts.get(part_num).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -4498,6 +4512,13 @@ impl S3Service {
                     "One or more of the specified parts could not be found.",
                 )
             })?;
+            if !submitted_etag.is_empty() && submitted_etag != &part.etag {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidPart",
+                    "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not have matched the part's entity tag.",
+                ));
+            }
             combined_data.extend_from_slice(&part.data);
             let part_md5 = Md5::digest(&part.data);
             md5_digests.extend_from_slice(&part_md5);
@@ -4593,7 +4614,7 @@ impl S3Service {
     fn abort_multipart_upload(
         &self,
         bucket: &str,
-        _key: &str,
+        key: &str,
         upload_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut state = self.state.write();
@@ -4602,9 +4623,17 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
 
-        if b.multipart_uploads.remove(upload_id).is_none() {
-            return Err(no_such_upload(upload_id));
+        // Validate upload exists and belongs to the requested key
+        match b.multipart_uploads.get(upload_id) {
+            Some(upload) if upload.key != key => {
+                return Err(no_such_upload(upload_id));
+            }
+            None => {
+                return Err(no_such_upload(upload_id));
+            }
+            _ => {}
         }
+        b.multipart_uploads.remove(upload_id);
 
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
@@ -5745,15 +5774,18 @@ fn resolve_object<'a>(
     if let Some(vid) = version_id {
         // "null" version ID refers to an object with no version_id (pre-versioning)
         if vid == "null" {
-            // Check versions for a pre-versioning object (version_id == None)
+            // Check versions for a pre-versioning object (version_id == None or Some("null"))
             if let Some(versions) = b.object_versions.get(key) {
-                if let Some(obj) = versions.iter().find(|o| o.version_id.is_none()) {
+                if let Some(obj) = versions
+                    .iter()
+                    .find(|o| o.version_id.is_none() || o.version_id.as_deref() == Some("null"))
+                {
                     return Ok(obj);
                 }
             }
             // Also check current object if it has no version_id
             if let Some(obj) = b.objects.get(key) {
-                if obj.version_id.is_none() {
+                if obj.version_id.is_none() || obj.version_id.as_deref() == Some("null") {
                     return Ok(obj);
                 }
             }

--- a/crates/fakecloud-s3/src/service.rs
+++ b/crates/fakecloud-s3/src/service.rs
@@ -4512,7 +4512,7 @@ impl S3Service {
                     "One or more of the specified parts could not be found.",
                 )
             })?;
-            if !submitted_etag.is_empty() && submitted_etag != &part.etag {
+            if submitted_etag != &part.etag {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "InvalidPart",

--- a/crates/fakecloud-s3/src/service.rs
+++ b/crates/fakecloud-s3/src/service.rs
@@ -6658,4 +6658,70 @@ mod tests {
         assert!(origin_matches("https://foo.example.com", "*.example.com"));
         assert!(!origin_matches("https://evil.com", "https://example.com"));
     }
+
+    /// Regression: resolve_object with versionId="null" must match objects
+    /// whose version_id is either None or Some("null").
+    #[test]
+    fn resolve_null_version_matches_both_none_and_null_string() {
+        use crate::state::S3Bucket;
+        use bytes::Bytes;
+        use chrono::Utc;
+
+        let mut b = S3Bucket::new("test", "us-east-1", "owner");
+
+        // Helper to create a minimal S3Object
+        let make_obj = |key: &str, vid: Option<&str>| crate::state::S3Object {
+            key: key.to_string(),
+            data: Bytes::from_static(b"x"),
+            content_type: "text/plain".to_string(),
+            etag: "\"abc\"".to_string(),
+            size: 1,
+            last_modified: Utc::now(),
+            metadata: Default::default(),
+            storage_class: "STANDARD".to_string(),
+            tags: Default::default(),
+            acl_grants: vec![],
+            acl_owner_id: None,
+            parts_count: None,
+            part_sizes: None,
+            sse_algorithm: None,
+            sse_kms_key_id: None,
+            bucket_key_enabled: None,
+            version_id: vid.map(|s| s.to_string()),
+            is_delete_marker: false,
+            content_encoding: None,
+            website_redirect_location: None,
+            restore_ongoing: None,
+            restore_expiry: None,
+            checksum_algorithm: None,
+            checksum_value: None,
+            lock_mode: None,
+            lock_retain_until: None,
+            lock_legal_hold: None,
+        };
+
+        // Object with version_id = Some("null") (pre-versioning migrated)
+        let obj = make_obj("file.txt", Some("null"));
+        b.objects.insert("file.txt".to_string(), obj.clone());
+        b.object_versions.insert("file.txt".to_string(), vec![obj]);
+
+        let null_str = "null".to_string();
+        let result = resolve_object(&b, "file.txt", Some(&null_str));
+        assert!(
+            result.is_ok(),
+            "versionId=null should match version_id=Some(\"null\")"
+        );
+
+        // Object with version_id = None (true pre-versioning)
+        let obj2 = make_obj("file2.txt", None);
+        b.objects.insert("file2.txt".to_string(), obj2.clone());
+        b.object_versions
+            .insert("file2.txt".to_string(), vec![obj2]);
+
+        let result2 = resolve_object(&b, "file2.txt", Some(&null_str));
+        assert!(
+            result2.is_ok(),
+            "versionId=null should match version_id=None"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- **ListObjectsV2 pagination**: Add bounds checking for delimiter-based pagination to prevent panics with out-of-range continuation tokens; fix common prefix computation to include the full delimiter string
- **CompleteMultipartUpload ETag verification**: Verify each submitted part ETag matches the stored part ETag, returning InvalidPart on mismatch
- **AbortMultipartUpload key validation**: Validate that the upload belongs to the requested key before aborting, returning NoSuchUpload on mismatch
- **CopyObject delete markers**: Reject delete markers as copy sources with NoSuchKey error
- **CopyObject versionId=null**: Fix resolve_object to match pre-versioning objects stored with version_id=Some("null") in addition to None
- **Version-specific delete**: Only update the current object entry when a version was actually removed from the version list, preventing incorrect deletion of unrelated objects

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --exclude fakecloud-e2e` passes (all 81 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiple S3 edge cases in `fakecloud-s3` to prevent panics and ensure correct versioning behavior. Adds regression tests covering pagination, multipart, copy-source, and versioning flows.

- **Bug Fixes**
  - ListObjectsV2: add bounds checks for delimiter pagination; include full delimiter in common prefixes.
  - CompleteMultipartUpload: verify submitted part ETags match stored parts; reject empty ETags; return InvalidPart on mismatch.
  - AbortMultipartUpload: ensure upload belongs to the requested key; return NoSuchUpload otherwise.
  - CopyObject: reject delete markers as sources with NoSuchKey.
  - Versioning: treat versionId="null" as pre-versioning (None or "null"); only update current object when a version was actually removed.

<sup>Written for commit de40392fa889e9ac2dee2be051a919404589e55f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

