### PR TITLE
feat(cloudformation): implement basic CloudFormation service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ cargo fmt --check                        # format check
 - `fakecloud` — binary entry point (clap CLI, Axum server)
 - `fakecloud-core` — AwsService trait, ServiceRegistry, request dispatch, protocol parsing
 - `fakecloud-aws` — shared AWS types (ARNs, error builders, SigV4 parser)
-- `fakecloud-{sqs,sns,eventbridge,iam,ssm,dynamodb,lambda,secretsmanager,s3,logs,kms}` — individual service implementations
+- `fakecloud-{sqs,sns,eventbridge,iam,ssm,dynamodb,lambda,secretsmanager,s3,logs,kms,cloudformation}` — individual service implementations
 - `fakecloud-e2e` — E2E tests using aws-sdk-rust and AWS CLI
 
 ## Conventions
@@ -38,7 +38,7 @@ cargo fmt --check                        # format check
 - CLI tests use `aws` CLI binary via TestServer::aws_cli()
 
 ### AWS Protocol Notes
-- Query protocol (SQS, SNS, IAM, STS): form-encoded body, `Action` param, XML responses
+- Query protocol (SQS, SNS, IAM, STS, CloudFormation): form-encoded body, `Action` param, XML responses
 - JSON protocol (SSM, EventBridge, DynamoDB, Secrets Manager, CloudWatch Logs, KMS): JSON body, `X-Amz-Target` header, JSON responses
 - REST protocol (S3, Lambda): HTTP method + path-based routing, XML/JSON responses
 - SigV4 signatures are parsed for routing but never validated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cloudformation"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4687fe4ff3ed2764592177371a4a52348201dbea1e38eaed33a0cd7f3e303f74"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-cloudwatchlogs"
 version = "1.125.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1247,7 @@ dependencies = [
  "chrono",
  "clap",
  "fakecloud-aws",
+ "fakecloud-cloudformation",
  "fakecloud-core",
  "fakecloud-dynamodb",
  "fakecloud-eventbridge",
@@ -1255,6 +1281,32 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "fakecloud-cloudformation"
+version = "0.1.1"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "fakecloud-aws",
+ "fakecloud-core",
+ "fakecloud-dynamodb",
+ "fakecloud-eventbridge",
+ "fakecloud-iam",
+ "fakecloud-logs",
+ "fakecloud-s3",
+ "fakecloud-sns",
+ "fakecloud-sqs",
+ "fakecloud-ssm",
+ "http 1.4.0",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tracing",
  "uuid",
 ]
 
@@ -1299,6 +1351,7 @@ version = "0.1.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
+ "aws-sdk-cloudformation",
  "aws-sdk-cloudwatchlogs",
  "aws-sdk-dynamodb",
  "aws-sdk-eventbridge",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,7 @@ name = "fakecloud-cloudformation"
 version = "0.1.1"
 dependencies = [
  "async-trait",
+ "bytes",
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/fakecloud-secretsmanager",
     "crates/fakecloud-logs",
     "crates/fakecloud-kms",
+    "crates/fakecloud-cloudformation",
     "crates/fakecloud-e2e",
 ]
 resolver = "2"
@@ -69,3 +70,4 @@ fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.1.1" }
 fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.1.1" }
 fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.1.1" }
 fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.1.1" }
+fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.1.1" }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ alternatives have emerged since then. Here's how they compare:
 | Language | Rust | Python | Java (Quarkus Native) | Python |
 | Auth required | No | Yes (account + token) | No | No |
 | Commercial use | Free | Paid plans only | Free | Free |
-| AWS services | 9 | 80+ | 25 | 38 |
+| AWS services | 10 | 80+ | 25 | 38 |
 | Cross-service delivery | Yes | Yes | Yes | Yes |
 | Scheduled rules fire | Yes | Yes | -- | -- |
 
@@ -338,6 +338,21 @@ Key features: fake envelope encryption (base64-encoded with key ID prefix),
 key enable/disable/deletion scheduling, alias resolution for all operations,
 data key generation.
 
+### CloudFormation (8 actions)
+
+CreateStack, DeleteStack, DescribeStacks, ListStacks, ListStackResources,
+DescribeStackResources, UpdateStack, GetTemplate
+
+Key features: JSON and YAML template parsing, resource provisioning into
+existing services (SQS, SNS, SSM, IAM, S3, EventBridge, DynamoDB, CloudWatch
+Logs), stack update with diff-based resource create/delete, parameter and
+tag support, Ref/Fn::Sub/Fn::Join intrinsic function resolution.
+
+Supported resource types: AWS::SQS::Queue, AWS::SNS::Topic,
+AWS::SNS::Subscription, AWS::SSM::Parameter, AWS::IAM::Role,
+AWS::IAM::Policy, AWS::S3::Bucket, AWS::Events::Rule,
+AWS::DynamoDB::Table, AWS::Logs::LogGroup.
+
 ### Cross-Service Integration
 
 FakeCloud implements real cross-service message delivery and background
@@ -381,7 +396,7 @@ curl http://localhost:4566/_fakecloud/health
 {
   "status": "ok",
   "version": "0.1.0",
-  "services": ["sqs", "sns", "events", "iam", "sts", "ssm", "lambda", "secretsmanager", "logs", "kms", "s3"]
+  "services": ["cloudformation", "sqs", "sns", "events", "iam", "sts", "ssm", "lambda", "secretsmanager", "logs", "kms", "s3"]
 }
 ```
 
@@ -405,10 +420,11 @@ FakeCloud is organized as a Cargo workspace:
 | `fakecloud-s3` | S3 implementation |
 | `fakecloud-logs` | CloudWatch Logs implementation |
 | `fakecloud-kms` | KMS implementation |
+| `fakecloud-cloudformation` | CloudFormation implementation |
 | `fakecloud-e2e` | End-to-end tests using aws-sdk-rust |
 
 Protocol handling:
-- **Query protocol** (SQS, SNS, IAM, STS): form-encoded body, `Action` parameter, XML responses
+- **Query protocol** (SQS, SNS, IAM, STS, CloudFormation): form-encoded body, `Action` parameter, XML responses
 - **JSON protocol** (SSM, EventBridge, DynamoDB, CloudWatch Logs, KMS): JSON body, `X-Amz-Target` header, JSON responses
 - **REST protocol** (S3): HTTP method + path-based routing, XML responses
 - **JSON protocol** (SSM, EventBridge, Secrets Manager, CloudWatch Logs, KMS): JSON body, `X-Amz-Target` header, JSON responses

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "fakecloud-cloudformation"
+description = "CloudFormation implementation for FakeCloud"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+version.workspace = true
+
+[dependencies]
+fakecloud-aws = { workspace = true }
+fakecloud-core = { workspace = true }
+fakecloud-sqs = { workspace = true }
+fakecloud-sns = { workspace = true }
+fakecloud-ssm = { workspace = true }
+fakecloud-iam = { workspace = true }
+fakecloud-s3 = { workspace = true }
+fakecloud-eventbridge = { workspace = true }
+fakecloud-dynamodb = { workspace = true }
+fakecloud-logs = { workspace = true }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+http = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+tracing = { workspace = true }

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -28,3 +28,6 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+bytes = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/lib.rs
+++ b/crates/fakecloud-cloudformation/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod resource_provisioner;
+pub mod service;
+pub mod state;
+pub mod template;
+pub mod xml_responses;

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -191,6 +191,12 @@ impl ResourceProvisioner {
             .ok_or("SNS Subscription requires Endpoint")?;
 
         let mut state = self.sns_state.write();
+
+        // Validate that the topic exists
+        if !state.topics.contains_key(topic_arn) {
+            return Err(format!("Topic ARN does not exist: {topic_arn}"));
+        }
+
         let sub_arn = format!("{}:{}", topic_arn, Uuid::new_v4());
 
         let subscription = SnsSubscription {
@@ -446,10 +452,23 @@ impl ResourceProvisioner {
             .unwrap_or("default");
 
         let mut state = self.eventbridge_state.write();
-        let arn = format!(
-            "arn:aws:events:{}:{}:rule/{}/{}",
-            state.region, state.account_id, event_bus_name, rule_name
-        );
+
+        // Validate that the event bus exists
+        if !state.buses.contains_key(event_bus_name) {
+            return Err(format!("Event bus does not exist: {event_bus_name}"));
+        }
+
+        let arn = if event_bus_name == "default" {
+            format!(
+                "arn:aws:events:{}:{}:rule/{}",
+                state.region, state.account_id, rule_name
+            )
+        } else {
+            format!(
+                "arn:aws:events:{}:{}:rule/{}/{}",
+                state.region, state.account_id, event_bus_name, rule_name
+            )
+        };
 
         let rule = EventRule {
             name: rule_name.to_string(),
@@ -677,5 +696,180 @@ impl ResourceProvisioner {
             state.log_groups.remove(&name);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn make_provisioner() -> ResourceProvisioner {
+        ResourceProvisioner {
+            sqs_state: Arc::new(RwLock::new(fakecloud_sqs::state::SqsState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ))),
+            sns_state: Arc::new(RwLock::new(fakecloud_sns::state::SnsState::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+            ssm_state: Arc::new(RwLock::new(fakecloud_ssm::state::SsmState::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+            iam_state: Arc::new(RwLock::new(fakecloud_iam::state::IamState::new(
+                "123456789012",
+            ))),
+            s3_state: Arc::new(RwLock::new(fakecloud_s3::state::S3State::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+            eventbridge_state: Arc::new(RwLock::new(
+                fakecloud_eventbridge::state::EventBridgeState::new("123456789012", "us-east-1"),
+            )),
+            dynamodb_state: Arc::new(RwLock::new(fakecloud_dynamodb::state::DynamoDbState::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+            logs_state: Arc::new(RwLock::new(fakecloud_logs::state::LogsState::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+        }
+    }
+
+    fn make_resource(
+        resource_type: &str,
+        logical_id: &str,
+        props: serde_json::Value,
+    ) -> ResourceDefinition {
+        ResourceDefinition {
+            logical_id: logical_id.to_string(),
+            resource_type: resource_type.to_string(),
+            properties: props,
+        }
+    }
+
+    #[test]
+    fn sns_subscription_rejects_nonexistent_topic() {
+        let prov = make_provisioner();
+        let resource = make_resource(
+            "AWS::SNS::Subscription",
+            "MySub",
+            serde_json::json!({
+                "TopicArn": "arn:aws:sns:us-east-1:123456789012:NonExistent",
+                "Protocol": "sqs",
+                "Endpoint": "arn:aws:sqs:us-east-1:123456789012:my-queue"
+            }),
+        );
+        let result = prov.create_resource(&resource);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("does not exist"));
+    }
+
+    #[test]
+    fn sns_subscription_succeeds_when_topic_exists() {
+        let prov = make_provisioner();
+        // First create the topic
+        let topic = make_resource(
+            "AWS::SNS::Topic",
+            "MyTopic",
+            serde_json::json!({ "TopicName": "my-topic" }),
+        );
+        let topic_result = prov.create_resource(&topic);
+        assert!(topic_result.is_ok());
+        let topic_arn = topic_result.unwrap().physical_id;
+
+        // Now create subscription referencing that topic
+        let sub = make_resource(
+            "AWS::SNS::Subscription",
+            "MySub",
+            serde_json::json!({
+                "TopicArn": topic_arn,
+                "Protocol": "sqs",
+                "Endpoint": "arn:aws:sqs:us-east-1:123456789012:my-queue"
+            }),
+        );
+        let result = prov.create_resource(&sub);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn eventbridge_rule_arn_default_bus_omits_bus_name() {
+        let prov = make_provisioner();
+        let resource = make_resource(
+            "AWS::Events::Rule",
+            "MyRule",
+            serde_json::json!({
+                "Name": "my-rule",
+                "ScheduleExpression": "rate(1 hour)"
+            }),
+        );
+        let result = prov.create_resource(&resource).unwrap();
+        // For default bus, ARN should be rule/<name> without /default/
+        assert_eq!(
+            result.physical_id,
+            "arn:aws:events:us-east-1:123456789012:rule/my-rule"
+        );
+        assert!(!result.physical_id.contains("rule/default/"));
+    }
+
+    #[test]
+    fn eventbridge_rule_arn_custom_bus_includes_bus_name() {
+        let prov = make_provisioner();
+        // Create a custom bus first
+        {
+            let mut state = prov.eventbridge_state.write();
+            state.buses.insert(
+                "custom-bus".to_string(),
+                fakecloud_eventbridge::state::EventBus {
+                    name: "custom-bus".to_string(),
+                    arn: "arn:aws:events:us-east-1:123456789012:event-bus/custom-bus".to_string(),
+                    policy: None,
+                    creation_time: Utc::now(),
+                    last_modified_time: Utc::now(),
+                    description: None,
+                    kms_key_identifier: None,
+                    dead_letter_config: None,
+                    tags: HashMap::new(),
+                },
+            );
+        }
+        let resource = make_resource(
+            "AWS::Events::Rule",
+            "MyRule",
+            serde_json::json!({
+                "Name": "my-rule",
+                "EventBusName": "custom-bus",
+                "ScheduleExpression": "rate(1 hour)"
+            }),
+        );
+        let result = prov.create_resource(&resource).unwrap();
+        assert_eq!(
+            result.physical_id,
+            "arn:aws:events:us-east-1:123456789012:rule/custom-bus/my-rule"
+        );
+    }
+
+    #[test]
+    fn eventbridge_rule_rejects_nonexistent_bus() {
+        let prov = make_provisioner();
+        let resource = make_resource(
+            "AWS::Events::Rule",
+            "MyRule",
+            serde_json::json!({
+                "Name": "my-rule",
+                "EventBusName": "nonexistent-bus",
+                "ScheduleExpression": "rate(1 hour)"
+            }),
+        );
+        let result = prov.create_resource(&resource);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("does not exist"));
     }
 }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -1,0 +1,681 @@
+use chrono::Utc;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use fakecloud_dynamodb::state::{
+    AttributeDefinition, DynamoTable, KeySchemaElement, ProvisionedThroughput, SharedDynamoDbState,
+};
+use fakecloud_eventbridge::state::{EventRule, SharedEventBridgeState};
+use fakecloud_iam::state::{IamPolicy, IamRole, PolicyVersion, SharedIamState};
+use fakecloud_logs::state::SharedLogsState;
+use fakecloud_s3::state::{S3Bucket, SharedS3State};
+use fakecloud_sns::state::{SharedSnsState, SnsSubscription, SnsTopic};
+use fakecloud_sqs::state::{SharedSqsState, SqsQueue};
+use fakecloud_ssm::state::{SharedSsmState, SsmParameter};
+
+use crate::state::StackResource;
+use crate::template::ResourceDefinition;
+
+/// Holds references to all service states so CloudFormation can provision resources.
+pub struct ResourceProvisioner {
+    pub sqs_state: SharedSqsState,
+    pub sns_state: SharedSnsState,
+    pub ssm_state: SharedSsmState,
+    pub iam_state: SharedIamState,
+    pub s3_state: SharedS3State,
+    pub eventbridge_state: SharedEventBridgeState,
+    pub dynamodb_state: SharedDynamoDbState,
+    pub logs_state: SharedLogsState,
+    pub account_id: String,
+    pub region: String,
+}
+
+impl ResourceProvisioner {
+    /// Create a resource and return the StackResource with physical ID.
+    pub fn create_resource(&self, resource: &ResourceDefinition) -> Result<StackResource, String> {
+        let result = match resource.resource_type.as_str() {
+            "AWS::SQS::Queue" => self.create_sqs_queue(resource),
+            "AWS::SNS::Topic" => self.create_sns_topic(resource),
+            "AWS::SNS::Subscription" => self.create_sns_subscription(resource),
+            "AWS::SSM::Parameter" => self.create_ssm_parameter(resource),
+            "AWS::IAM::Role" => self.create_iam_role(resource),
+            "AWS::IAM::Policy" => self.create_iam_policy(resource),
+            "AWS::S3::Bucket" => self.create_s3_bucket(resource),
+            "AWS::Events::Rule" => self.create_eventbridge_rule(resource),
+            "AWS::DynamoDB::Table" => self.create_dynamodb_table(resource),
+            "AWS::Logs::LogGroup" => self.create_log_group(resource),
+            other => Err(format!("Unsupported resource type: {other}")),
+        };
+
+        result.map(|physical_id| StackResource {
+            logical_id: resource.logical_id.clone(),
+            physical_id,
+            resource_type: resource.resource_type.clone(),
+            status: "CREATE_COMPLETE".to_string(),
+        })
+    }
+
+    /// Delete a previously created resource.
+    pub fn delete_resource(&self, resource: &StackResource) -> Result<(), String> {
+        match resource.resource_type.as_str() {
+            "AWS::SQS::Queue" => self.delete_sqs_queue(&resource.physical_id),
+            "AWS::SNS::Topic" => self.delete_sns_topic(&resource.physical_id),
+            "AWS::SNS::Subscription" => self.delete_sns_subscription(&resource.physical_id),
+            "AWS::SSM::Parameter" => self.delete_ssm_parameter(&resource.physical_id),
+            "AWS::IAM::Role" => self.delete_iam_role(&resource.physical_id),
+            "AWS::IAM::Policy" => self.delete_iam_policy(&resource.physical_id),
+            "AWS::S3::Bucket" => self.delete_s3_bucket(&resource.physical_id),
+            "AWS::Events::Rule" => self.delete_eventbridge_rule(&resource.physical_id),
+            "AWS::DynamoDB::Table" => self.delete_dynamodb_table(&resource.physical_id),
+            "AWS::Logs::LogGroup" => self.delete_log_group(&resource.physical_id),
+            other => Err(format!("Unsupported resource type: {other}")),
+        }
+    }
+
+    // --- SQS ---
+
+    fn create_sqs_queue(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let queue_name = props
+            .get("QueueName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id);
+
+        let mut state = self.sqs_state.write();
+        let queue_url = format!("http://localhost:4566/{}/{}", state.account_id, queue_name);
+        let arn = format!(
+            "arn:aws:sqs:{}:{}:{}",
+            state.region, state.account_id, queue_name
+        );
+
+        let is_fifo = queue_name.ends_with(".fifo");
+        let mut attributes = HashMap::new();
+        if let Some(obj) = props.as_object() {
+            for (k, v) in obj {
+                if k != "QueueName" {
+                    if let Some(s) = v.as_str() {
+                        attributes.insert(k.clone(), s.to_string());
+                    } else if let Some(n) = v.as_i64() {
+                        attributes.insert(k.clone(), n.to_string());
+                    }
+                }
+            }
+        }
+
+        let queue = SqsQueue {
+            queue_name: queue_name.to_string(),
+            queue_url: queue_url.clone(),
+            arn,
+            created_at: Utc::now(),
+            messages: std::collections::VecDeque::new(),
+            inflight: Vec::new(),
+            attributes,
+            is_fifo,
+            dedup_cache: HashMap::new(),
+            redrive_policy: None,
+            tags: HashMap::new(),
+            next_sequence_number: 0,
+            permission_labels: Vec::new(),
+            receipt_handle_map: HashMap::new(),
+        };
+
+        state
+            .name_to_url
+            .insert(queue_name.to_string(), queue_url.clone());
+        state.queues.insert(queue_url.clone(), queue);
+
+        Ok(queue_url)
+    }
+
+    fn delete_sqs_queue(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.sqs_state.write();
+        if let Some(queue) = state.queues.remove(physical_id) {
+            state.name_to_url.remove(&queue.queue_name);
+        }
+        Ok(())
+    }
+
+    // --- SNS ---
+
+    fn create_sns_topic(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let topic_name = props
+            .get("TopicName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id);
+
+        let mut state = self.sns_state.write();
+        let topic_arn = format!(
+            "arn:aws:sns:{}:{}:{}",
+            state.region, state.account_id, topic_name
+        );
+
+        let topic = SnsTopic {
+            topic_arn: topic_arn.clone(),
+            name: topic_name.to_string(),
+            attributes: HashMap::new(),
+            tags: Vec::new(),
+            is_fifo: topic_name.ends_with(".fifo"),
+            created_at: Utc::now(),
+        };
+
+        state.topics.insert(topic_arn.clone(), topic);
+        Ok(topic_arn)
+    }
+
+    fn delete_sns_topic(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.sns_state.write();
+        state.topics.remove(physical_id);
+        // Also remove subscriptions for this topic
+        state
+            .subscriptions
+            .retain(|_, sub| sub.topic_arn != physical_id);
+        Ok(())
+    }
+
+    // --- SNS Subscription ---
+
+    fn create_sns_subscription(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let topic_arn = props
+            .get("TopicArn")
+            .and_then(|v| v.as_str())
+            .ok_or("SNS Subscription requires TopicArn")?;
+        let protocol = props
+            .get("Protocol")
+            .and_then(|v| v.as_str())
+            .ok_or("SNS Subscription requires Protocol")?;
+        let endpoint = props
+            .get("Endpoint")
+            .and_then(|v| v.as_str())
+            .ok_or("SNS Subscription requires Endpoint")?;
+
+        let mut state = self.sns_state.write();
+        let sub_arn = format!("{}:{}", topic_arn, Uuid::new_v4());
+
+        let subscription = SnsSubscription {
+            subscription_arn: sub_arn.clone(),
+            topic_arn: topic_arn.to_string(),
+            protocol: protocol.to_string(),
+            endpoint: endpoint.to_string(),
+            owner: state.account_id.clone(),
+            attributes: HashMap::new(),
+            confirmed: true,
+        };
+
+        state.subscriptions.insert(sub_arn.clone(), subscription);
+        Ok(sub_arn)
+    }
+
+    fn delete_sns_subscription(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.sns_state.write();
+        state.subscriptions.remove(physical_id);
+        Ok(())
+    }
+
+    // --- SSM ---
+
+    fn create_ssm_parameter(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("SSM Parameter requires Name")?;
+        let value = props
+            .get("Value")
+            .and_then(|v| v.as_str())
+            .ok_or("SSM Parameter requires Value")?;
+        let param_type = props
+            .get("Type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("String");
+
+        let mut state = self.ssm_state.write();
+        let arn = format!(
+            "arn:aws:ssm:{}:{}:parameter{}",
+            state.region,
+            state.account_id,
+            if name.starts_with('/') {
+                name.to_string()
+            } else {
+                format!("/{name}")
+            }
+        );
+
+        let parameter = SsmParameter {
+            name: name.to_string(),
+            value: value.to_string(),
+            param_type: param_type.to_string(),
+            version: 1,
+            arn: arn.clone(),
+            last_modified: Utc::now(),
+            history: Vec::new(),
+            tags: HashMap::new(),
+            labels: HashMap::new(),
+            description: props
+                .get("Description")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            allowed_pattern: None,
+            key_id: None,
+            data_type: "text".to_string(),
+            tier: "Standard".to_string(),
+            policies: None,
+        };
+
+        state.parameters.insert(name.to_string(), parameter);
+        Ok(name.to_string())
+    }
+
+    fn delete_ssm_parameter(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.ssm_state.write();
+        state.parameters.remove(physical_id);
+        Ok(())
+    }
+
+    // --- IAM Role ---
+
+    fn create_iam_role(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let role_name = props
+            .get("RoleName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id);
+
+        let assume_role_policy = props
+            .get("AssumeRolePolicyDocument")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap().to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            })
+            .unwrap_or_default();
+
+        let path = props.get("Path").and_then(|v| v.as_str()).unwrap_or("/");
+
+        let mut state = self.iam_state.write();
+        let role_id = format!(
+            "FKIA{}",
+            &Uuid::new_v4().to_string().replace('-', "").to_uppercase()[..16]
+        );
+        let arn = format!(
+            "arn:aws:iam::{}:role{}{}",
+            state.account_id,
+            if path == "/" { "/" } else { path },
+            role_name
+        );
+
+        let role = IamRole {
+            role_name: role_name.to_string(),
+            role_id,
+            arn: arn.clone(),
+            path: path.to_string(),
+            assume_role_policy_document: assume_role_policy,
+            created_at: Utc::now(),
+            description: props
+                .get("Description")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            max_session_duration: 3600,
+            tags: Vec::new(),
+            permissions_boundary: None,
+        };
+
+        state.roles.insert(role_name.to_string(), role);
+        Ok(arn)
+    }
+
+    fn delete_iam_role(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.iam_state.write();
+        // physical_id is the ARN; find the role name
+        let role_name = state
+            .roles
+            .iter()
+            .find(|(_, r)| r.arn == physical_id)
+            .map(|(name, _)| name.clone());
+        if let Some(name) = role_name {
+            state.roles.remove(&name);
+            state.role_policies.remove(&name);
+            state.role_inline_policies.remove(&name);
+        }
+        Ok(())
+    }
+
+    // --- IAM Policy ---
+
+    fn create_iam_policy(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let policy_name = props
+            .get("PolicyName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id);
+
+        let policy_document = props
+            .get("PolicyDocument")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap().to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            })
+            .unwrap_or_default();
+
+        let path = props.get("Path").and_then(|v| v.as_str()).unwrap_or("/");
+
+        let mut state = self.iam_state.write();
+        let policy_id = format!(
+            "FSIA{}",
+            &Uuid::new_v4().to_string().replace('-', "").to_uppercase()[..16]
+        );
+        let arn = format!(
+            "arn:aws:iam::{}:policy{}{}",
+            state.account_id,
+            if path == "/" { "/" } else { path },
+            policy_name
+        );
+
+        let now = Utc::now();
+        let policy = IamPolicy {
+            policy_name: policy_name.to_string(),
+            policy_id,
+            arn: arn.clone(),
+            path: path.to_string(),
+            description: props
+                .get("Description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            created_at: now,
+            tags: Vec::new(),
+            default_version_id: "v1".to_string(),
+            versions: vec![PolicyVersion {
+                version_id: "v1".to_string(),
+                document: policy_document,
+                is_default: true,
+                created_at: now,
+            }],
+            next_version_num: 2,
+            attachment_count: 0,
+        };
+
+        state.policies.insert(arn.clone(), policy);
+        Ok(arn)
+    }
+
+    fn delete_iam_policy(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.iam_state.write();
+        state.policies.remove(physical_id);
+        Ok(())
+    }
+
+    // --- S3 ---
+
+    fn create_s3_bucket(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let bucket_name = props
+            .get("BucketName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id);
+
+        let mut state = self.s3_state.write();
+        let bucket = S3Bucket::new(bucket_name, &state.region, &state.account_id);
+        state.buckets.insert(bucket_name.to_string(), bucket);
+        Ok(bucket_name.to_string())
+    }
+
+    fn delete_s3_bucket(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.s3_state.write();
+        state.buckets.remove(physical_id);
+        Ok(())
+    }
+
+    // --- EventBridge ---
+
+    fn create_eventbridge_rule(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let rule_name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id);
+        let event_bus_name = props
+            .get("EventBusName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("default");
+
+        let mut state = self.eventbridge_state.write();
+        let arn = format!(
+            "arn:aws:events:{}:{}:rule/{}/{}",
+            state.region, state.account_id, event_bus_name, rule_name
+        );
+
+        let rule = EventRule {
+            name: rule_name.to_string(),
+            arn: arn.clone(),
+            event_bus_name: event_bus_name.to_string(),
+            event_pattern: props.get("EventPattern").map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap().to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            }),
+            schedule_expression: props
+                .get("ScheduleExpression")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            state: props
+                .get("State")
+                .and_then(|v| v.as_str())
+                .unwrap_or("ENABLED")
+                .to_string(),
+            description: props
+                .get("Description")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            role_arn: props
+                .get("RoleArn")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            managed_by: None,
+            created_by: None,
+            targets: Vec::new(),
+            tags: HashMap::new(),
+            last_fired: None,
+        };
+
+        state
+            .rules
+            .insert((event_bus_name.to_string(), rule_name.to_string()), rule);
+        Ok(arn)
+    }
+
+    fn delete_eventbridge_rule(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.eventbridge_state.write();
+        // physical_id is the ARN; find the rule key
+        let key = state
+            .rules
+            .iter()
+            .find(|(_, r)| r.arn == physical_id)
+            .map(|(k, _)| k.clone());
+        if let Some(k) = key {
+            state.rules.remove(&k);
+        }
+        Ok(())
+    }
+
+    // --- DynamoDB ---
+
+    fn create_dynamodb_table(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let table_name = props
+            .get("TableName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id);
+
+        let mut key_schema = Vec::new();
+        if let Some(ks) = props.get("KeySchema").and_then(|v| v.as_array()) {
+            for item in ks {
+                let attr_name = item
+                    .get("AttributeName")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let key_type = item
+                    .get("KeyType")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("HASH")
+                    .to_string();
+                key_schema.push(KeySchemaElement {
+                    attribute_name: attr_name,
+                    key_type,
+                });
+            }
+        }
+
+        let mut attribute_definitions = Vec::new();
+        if let Some(defs) = props.get("AttributeDefinitions").and_then(|v| v.as_array()) {
+            for item in defs {
+                let attr_name = item
+                    .get("AttributeName")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let attr_type = item
+                    .get("AttributeType")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("S")
+                    .to_string();
+                attribute_definitions.push(AttributeDefinition {
+                    attribute_name: attr_name,
+                    attribute_type: attr_type,
+                });
+            }
+        }
+
+        let billing_mode = props
+            .get("BillingMode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("PAY_PER_REQUEST")
+            .to_string();
+
+        let provisioned_throughput = if billing_mode == "PROVISIONED" {
+            if let Some(pt) = props.get("ProvisionedThroughput") {
+                ProvisionedThroughput {
+                    read_capacity_units: pt
+                        .get("ReadCapacityUnits")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(5),
+                    write_capacity_units: pt
+                        .get("WriteCapacityUnits")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(5),
+                }
+            } else {
+                ProvisionedThroughput {
+                    read_capacity_units: 5,
+                    write_capacity_units: 5,
+                }
+            }
+        } else {
+            ProvisionedThroughput {
+                read_capacity_units: 0,
+                write_capacity_units: 0,
+            }
+        };
+
+        let mut state = self.dynamodb_state.write();
+        let arn = format!(
+            "arn:aws:dynamodb:{}:{}:table/{}",
+            state.region, state.account_id, table_name
+        );
+
+        let table = DynamoTable {
+            name: table_name.to_string(),
+            arn: arn.clone(),
+            key_schema,
+            attribute_definitions,
+            provisioned_throughput,
+            items: Vec::new(),
+            gsi: Vec::new(),
+            lsi: Vec::new(),
+            tags: HashMap::new(),
+            created_at: Utc::now(),
+            status: "ACTIVE".to_string(),
+            item_count: 0,
+            size_bytes: 0,
+            billing_mode,
+        };
+
+        state.tables.insert(table_name.to_string(), table);
+        Ok(arn)
+    }
+
+    fn delete_dynamodb_table(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.dynamodb_state.write();
+        // physical_id is the ARN; find the table name
+        let table_name = state
+            .tables
+            .iter()
+            .find(|(_, t)| t.arn == physical_id)
+            .map(|(name, _)| name.clone());
+        if let Some(name) = table_name {
+            state.tables.remove(&name);
+        }
+        Ok(())
+    }
+
+    // --- CloudWatch Logs ---
+
+    fn create_log_group(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let log_group_name = props
+            .get("LogGroupName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id);
+
+        let retention_in_days = props
+            .get("RetentionInDays")
+            .and_then(|v| v.as_i64())
+            .map(|v| v as i32);
+
+        let mut state = self.logs_state.write();
+        let arn = format!(
+            "arn:aws:logs:{}:{}:log-group:{}:*",
+            state.region, state.account_id, log_group_name
+        );
+
+        let log_group = fakecloud_logs::state::LogGroup {
+            name: log_group_name.to_string(),
+            arn: arn.clone(),
+            creation_time: Utc::now().timestamp_millis(),
+            retention_in_days,
+            kms_key_id: None,
+            stored_bytes: 0,
+            log_streams: HashMap::new(),
+            tags: HashMap::new(),
+            subscription_filters: Vec::new(),
+        };
+
+        state
+            .log_groups
+            .insert(log_group_name.to_string(), log_group);
+        Ok(arn)
+    }
+
+    fn delete_log_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.logs_state.write();
+        // physical_id is the ARN; find the log group name
+        let name = state
+            .log_groups
+            .iter()
+            .find(|(_, g)| g.arn == physical_id)
+            .map(|(name, _)| name.clone());
+        if let Some(name) = name {
+            state.log_groups.remove(&name);
+        }
+        Ok(())
+    }
+}

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -157,27 +157,77 @@ impl CloudFormationService {
         let tags = Self::extract_tags(&params);
         let parameters = Self::extract_parameters(&params);
 
+        // First pass: parse to get resource definitions (without physical ID resolution)
         let parsed = template::parse_template(template_body, &parameters).map_err(|e| {
             AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
         })?;
 
         let provisioner = self.provisioner();
         let mut resources = Vec::new();
+        let mut physical_ids: HashMap<String, String> = HashMap::new();
 
-        for resource_def in &parsed.resources {
-            match provisioner.create_resource(resource_def) {
-                Ok(stack_resource) => resources.push(stack_resource),
-                Err(e) => {
-                    // Rollback: delete all resources created so far
-                    for r in &resources {
-                        let _ = provisioner.delete_resource(r);
+        // Create resources incrementally, re-resolving Refs with known physical IDs.
+        // Use multi-pass to handle dependency ordering (resources may reference each
+        // other via Ref, and JSON object key order is not guaranteed).
+        let mut pending: Vec<&template::ResourceDefinition> = parsed.resources.iter().collect();
+        let max_passes = pending.len() + 1;
+        for _ in 0..max_passes {
+            if pending.is_empty() {
+                break;
+            }
+            let mut still_pending = Vec::new();
+            let mut made_progress = false;
+
+            for resource_def in pending {
+                let resolved_def = template::resolve_resource_properties(
+                    resource_def,
+                    template_body,
+                    &parameters,
+                    &physical_ids,
+                )
+                .map_err(|e| {
+                    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
+                })?;
+
+                match provisioner.create_resource(&resolved_def) {
+                    Ok(stack_resource) => {
+                        physical_ids.insert(
+                            stack_resource.logical_id.clone(),
+                            stack_resource.physical_id.clone(),
+                        );
+                        resources.push(stack_resource);
+                        made_progress = true;
                     }
-                    return Err(AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "ValidationError",
-                        format!("Failed to create resource {}: {e}", resource_def.logical_id),
-                    ));
+                    Err(_) => {
+                        still_pending.push(resource_def);
+                    }
                 }
+            }
+
+            pending = still_pending;
+            if !made_progress && !pending.is_empty() {
+                // No progress made — report the first failure
+                let resource_def = pending[0];
+                let resolved_def = template::resolve_resource_properties(
+                    resource_def,
+                    template_body,
+                    &parameters,
+                    &physical_ids,
+                )
+                .unwrap_or_else(|_| resource_def.clone());
+                let err = provisioner.create_resource(&resolved_def).unwrap_err();
+                // Rollback
+                for r in &resources {
+                    let _ = provisioner.delete_resource(r);
+                }
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!(
+                        "Failed to create resource {}: {err}",
+                        resource_def.logical_id
+                    ),
+                ));
             }
         }
 
@@ -432,16 +482,50 @@ impl CloudFormationService {
             .resources
             .retain(|r| new_logical_ids.contains(&r.logical_id));
 
+        // Build physical ID map from existing resources
+        let mut physical_ids: HashMap<String, String> = stack
+            .resources
+            .iter()
+            .map(|r| (r.logical_id.clone(), r.physical_id.clone()))
+            .collect();
+
         // Create new resources
+        let mut update_failed = false;
+        let mut update_error_msg = String::new();
         for resource_def in &parsed.resources {
             if !old_logical_ids.contains(&resource_def.logical_id) {
-                match provisioner.create_resource(resource_def) {
-                    Ok(stack_resource) => stack.resources.push(stack_resource),
+                let resolved_def = match template::resolve_resource_properties(
+                    resource_def,
+                    template_body,
+                    &new_parameters,
+                    &physical_ids,
+                ) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        update_failed = true;
+                        update_error_msg = format!(
+                            "Failed to resolve resource {}: {e}",
+                            resource_def.logical_id
+                        );
+                        continue;
+                    }
+                };
+                match provisioner.create_resource(&resolved_def) {
+                    Ok(stack_resource) => {
+                        physical_ids.insert(
+                            stack_resource.logical_id.clone(),
+                            stack_resource.physical_id.clone(),
+                        );
+                        stack.resources.push(stack_resource);
+                    }
                     Err(e) => {
                         tracing::warn!(
                             "Failed to create resource {} during update: {e}",
                             resource_def.logical_id
                         );
+                        update_failed = true;
+                        update_error_msg =
+                            format!("Failed to create resource {}: {e}", resource_def.logical_id);
                     }
                 }
             }
@@ -449,13 +533,25 @@ impl CloudFormationService {
 
         let stack_id = stack.stack_id.clone();
         stack.template = template_body.clone();
-        stack.status = "UPDATE_COMPLETE".to_string();
+        stack.status = if update_failed {
+            "UPDATE_FAILED".to_string()
+        } else {
+            "UPDATE_COMPLETE".to_string()
+        };
         stack.parameters = new_parameters;
         if !new_tags.is_empty() {
             stack.tags = new_tags;
         }
         stack.updated_at = Some(Utc::now());
         stack.description = parsed.description;
+
+        if update_failed {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                update_error_msg,
+            ));
+        }
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -528,5 +624,155 @@ impl AwsService for CloudFormationService {
             "UpdateStack",
             "GetTemplate",
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::CloudFormationState;
+    use http::HeaderMap;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn make_service() -> CloudFormationService {
+        let cf_state = Arc::new(RwLock::new(CloudFormationState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        CloudFormationService::new(
+            cf_state,
+            Arc::new(RwLock::new(fakecloud_sqs::state::SqsState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ))),
+            Arc::new(RwLock::new(fakecloud_sns::state::SnsState::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+            Arc::new(RwLock::new(fakecloud_ssm::state::SsmState::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+            Arc::new(RwLock::new(fakecloud_iam::state::IamState::new(
+                "123456789012",
+            ))),
+            Arc::new(RwLock::new(fakecloud_s3::state::S3State::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+            Arc::new(RwLock::new(
+                fakecloud_eventbridge::state::EventBridgeState::new("123456789012", "us-east-1"),
+            )),
+            Arc::new(RwLock::new(fakecloud_dynamodb::state::DynamoDbState::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+            Arc::new(RwLock::new(fakecloud_logs::state::LogsState::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+        )
+    }
+
+    fn make_request(action: &str, params: HashMap<String, String>) -> AwsRequest {
+        AwsRequest {
+            service: "cloudformation".to_string(),
+            action: action.to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test-request-id".to_string(),
+            headers: HeaderMap::new(),
+            query_params: params,
+            body: bytes::Bytes::new(),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+        }
+    }
+
+    #[test]
+    fn update_stack_sets_failed_status_on_resource_error() {
+        let svc = make_service();
+
+        // Create a stack with just a queue
+        let mut create_params = HashMap::new();
+        create_params.insert("StackName".to_string(), "test-stack".to_string());
+        create_params.insert(
+            "TemplateBody".to_string(),
+            r#"{"Resources":{"MyQueue":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"q1"}}}}"#.to_string(),
+        );
+        let req = make_request("CreateStack", create_params);
+        let result = svc.create_stack(&req);
+        assert!(result.is_ok());
+
+        // Update stack adding an SNS subscription with a non-existent topic
+        let mut update_params = HashMap::new();
+        update_params.insert("StackName".to_string(), "test-stack".to_string());
+        update_params.insert(
+            "TemplateBody".to_string(),
+            r#"{"Resources":{"MyQueue":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"q1"}},"BadSub":{"Type":"AWS::SNS::Subscription","Properties":{"TopicArn":"arn:aws:sns:us-east-1:123456789012:nope","Protocol":"sqs","Endpoint":"arn:aws:sqs:us-east-1:123456789012:q1"}}}}"#.to_string(),
+        );
+        let req = make_request("UpdateStack", update_params);
+        let result = svc.update_stack(&req);
+
+        // Should return an error
+        assert!(result.is_err());
+
+        // Stack status should be UPDATE_FAILED
+        let state = svc.state.read();
+        let stack = state.stacks.get("test-stack").unwrap();
+        assert_eq!(stack.status, "UPDATE_FAILED");
+    }
+
+    #[test]
+    fn create_stack_resolves_ref_to_physical_id() {
+        let svc = make_service();
+
+        // Template where subscription Refs the topic
+        let template = r#"{
+            "Resources": {
+                "MyTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": { "TopicName": "ref-test-topic" }
+                },
+                "MySub": {
+                    "Type": "AWS::SNS::Subscription",
+                    "Properties": {
+                        "TopicArn": { "Ref": "MyTopic" },
+                        "Protocol": "sqs",
+                        "Endpoint": "arn:aws:sqs:us-east-1:123456789012:some-queue"
+                    }
+                }
+            }
+        }"#;
+
+        let mut params = HashMap::new();
+        params.insert("StackName".to_string(), "ref-stack".to_string());
+        params.insert("TemplateBody".to_string(), template.to_string());
+        let req = make_request("CreateStack", params);
+        let result = svc.create_stack(&req);
+        assert!(result.is_ok(), "CreateStack failed: {:?}", result.err());
+
+        // Verify both resources were created
+        let state = svc.state.read();
+        let stack = state.stacks.get("ref-stack").unwrap();
+        assert_eq!(stack.resources.len(), 2);
+        assert_eq!(stack.status, "CREATE_COMPLETE");
+
+        // The subscription's physical ID should be an ARN (not just "MyTopic")
+        let sub = stack
+            .resources
+            .iter()
+            .find(|r| r.logical_id == "MySub")
+            .unwrap();
+        assert!(
+            sub.physical_id.contains("ref-test-topic"),
+            "Subscription physical ID should reference the topic ARN, got: {}",
+            sub.physical_id
+        );
     }
 }

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -1,0 +1,532 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use http::StatusCode;
+use std::collections::HashMap;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_dynamodb::state::SharedDynamoDbState;
+use fakecloud_eventbridge::state::SharedEventBridgeState;
+use fakecloud_iam::state::SharedIamState;
+use fakecloud_logs::state::SharedLogsState;
+use fakecloud_s3::state::SharedS3State;
+use fakecloud_sns::state::SharedSnsState;
+use fakecloud_sqs::state::SharedSqsState;
+use fakecloud_ssm::state::SharedSsmState;
+
+use crate::resource_provisioner::ResourceProvisioner;
+use crate::state::{SharedCloudFormationState, Stack};
+use crate::template;
+use crate::xml_responses;
+
+pub struct CloudFormationService {
+    state: SharedCloudFormationState,
+    sqs_state: SharedSqsState,
+    sns_state: SharedSnsState,
+    ssm_state: SharedSsmState,
+    iam_state: SharedIamState,
+    s3_state: SharedS3State,
+    eventbridge_state: SharedEventBridgeState,
+    dynamodb_state: SharedDynamoDbState,
+    logs_state: SharedLogsState,
+}
+
+impl CloudFormationService {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        state: SharedCloudFormationState,
+        sqs_state: SharedSqsState,
+        sns_state: SharedSnsState,
+        ssm_state: SharedSsmState,
+        iam_state: SharedIamState,
+        s3_state: SharedS3State,
+        eventbridge_state: SharedEventBridgeState,
+        dynamodb_state: SharedDynamoDbState,
+        logs_state: SharedLogsState,
+    ) -> Self {
+        Self {
+            state,
+            sqs_state,
+            sns_state,
+            ssm_state,
+            iam_state,
+            s3_state,
+            eventbridge_state,
+            dynamodb_state,
+            logs_state,
+        }
+    }
+
+    fn provisioner(&self) -> ResourceProvisioner {
+        let cf_state = self.state.read();
+        ResourceProvisioner {
+            sqs_state: self.sqs_state.clone(),
+            sns_state: self.sns_state.clone(),
+            ssm_state: self.ssm_state.clone(),
+            iam_state: self.iam_state.clone(),
+            s3_state: self.s3_state.clone(),
+            eventbridge_state: self.eventbridge_state.clone(),
+            dynamodb_state: self.dynamodb_state.clone(),
+            logs_state: self.logs_state.clone(),
+            account_id: cf_state.account_id.clone(),
+            region: cf_state.region.clone(),
+        }
+    }
+
+    fn get_param(req: &AwsRequest, key: &str) -> Option<String> {
+        // Check query params first (for Query protocol)
+        if let Some(v) = req.query_params.get(key) {
+            return Some(v.clone());
+        }
+        // Then check form-encoded body
+        let body_params = fakecloud_core::protocol::parse_query_body(&req.body);
+        body_params.get(key).cloned()
+    }
+
+    fn get_all_params(req: &AwsRequest) -> HashMap<String, String> {
+        let mut params = req.query_params.clone();
+        let body_params = fakecloud_core::protocol::parse_query_body(&req.body);
+        for (k, v) in body_params {
+            params.entry(k).or_insert(v);
+        }
+        params
+    }
+
+    fn extract_tags(params: &HashMap<String, String>) -> HashMap<String, String> {
+        let mut tags = HashMap::new();
+        for i in 1.. {
+            let key_param = format!("Tags.member.{i}.Key");
+            let value_param = format!("Tags.member.{i}.Value");
+            match (params.get(&key_param), params.get(&value_param)) {
+                (Some(k), Some(v)) => {
+                    tags.insert(k.clone(), v.clone());
+                }
+                _ => break,
+            }
+        }
+        tags
+    }
+
+    fn extract_parameters(params: &HashMap<String, String>) -> HashMap<String, String> {
+        let mut result = HashMap::new();
+        for i in 1.. {
+            let key_param = format!("Parameters.member.{i}.ParameterKey");
+            let value_param = format!("Parameters.member.{i}.ParameterValue");
+            match (params.get(&key_param), params.get(&value_param)) {
+                (Some(k), Some(v)) => {
+                    result.insert(k.clone(), v.clone());
+                }
+                _ => break,
+            }
+        }
+        result
+    }
+
+    fn create_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let params = Self::get_all_params(req);
+
+        let stack_name = params.get("StackName").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "StackName is required",
+            )
+        })?;
+
+        let template_body = params.get("TemplateBody").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "TemplateBody is required",
+            )
+        })?;
+
+        // Check if stack already exists and is not deleted
+        {
+            let state = self.state.read();
+            if let Some(existing) = state.stacks.get(stack_name.as_str()) {
+                if existing.status != "DELETE_COMPLETE" {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "AlreadyExistsException",
+                        format!("Stack [{stack_name}] already exists"),
+                    ));
+                }
+            }
+        }
+
+        let tags = Self::extract_tags(&params);
+        let parameters = Self::extract_parameters(&params);
+
+        let parsed = template::parse_template(template_body, &parameters).map_err(|e| {
+            AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
+        })?;
+
+        let provisioner = self.provisioner();
+        let mut resources = Vec::new();
+
+        for resource_def in &parsed.resources {
+            match provisioner.create_resource(resource_def) {
+                Ok(stack_resource) => resources.push(stack_resource),
+                Err(e) => {
+                    // Rollback: delete all resources created so far
+                    for r in &resources {
+                        let _ = provisioner.delete_resource(r);
+                    }
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationError",
+                        format!("Failed to create resource {}: {e}", resource_def.logical_id),
+                    ));
+                }
+            }
+        }
+
+        let stack_id = {
+            let state = self.state.read();
+            format!(
+                "arn:aws:cloudformation:{}:{}:stack/{}/{}",
+                state.region,
+                state.account_id,
+                stack_name,
+                uuid::Uuid::new_v4()
+            )
+        };
+
+        let stack = Stack {
+            name: stack_name.clone(),
+            stack_id: stack_id.clone(),
+            template: template_body.clone(),
+            status: "CREATE_COMPLETE".to_string(),
+            resources,
+            parameters,
+            tags,
+            created_at: Utc::now(),
+            updated_at: None,
+            description: parsed.description,
+        };
+
+        {
+            let mut state = self.state.write();
+            state.stacks.insert(stack_name.clone(), stack);
+        }
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_responses::create_stack_response(&stack_id, &req.request_id),
+        ))
+    }
+
+    fn delete_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let stack_name = Self::get_param(req, "StackName").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "StackName is required",
+            )
+        })?;
+
+        let provisioner = self.provisioner();
+
+        let mut state = self.state.write();
+
+        // Find stack by name or stack ID
+        let stack = state.stacks.values_mut().find(|s| {
+            (s.name == stack_name || s.stack_id == stack_name) && s.status != "DELETE_COMPLETE"
+        });
+
+        if let Some(stack) = stack {
+            // Delete resources in reverse order
+            let resources: Vec<_> = stack.resources.clone();
+            for resource in resources.iter().rev() {
+                let _ = provisioner.delete_resource(resource);
+            }
+            stack.status = "DELETE_COMPLETE".to_string();
+            stack.resources.clear();
+        }
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_responses::delete_stack_response(&req.request_id),
+        ))
+    }
+
+    fn describe_stacks(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let stack_name = Self::get_param(req, "StackName");
+
+        let state = self.state.read();
+        let stacks: Vec<Stack> = if let Some(ref name) = stack_name {
+            state
+                .stacks
+                .values()
+                .filter(|s| {
+                    (s.name == *name || s.stack_id == *name) && s.status != "DELETE_COMPLETE"
+                })
+                .cloned()
+                .collect()
+        } else {
+            state
+                .stacks
+                .values()
+                .filter(|s| s.status != "DELETE_COMPLETE")
+                .cloned()
+                .collect()
+        };
+
+        if let Some(ref name) = stack_name {
+            if stacks.is_empty() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!("Stack with id {name} does not exist"),
+                ));
+            }
+        }
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_responses::describe_stacks_response(&stacks, &req.request_id),
+        ))
+    }
+
+    fn list_stacks(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let stacks: Vec<Stack> = state.stacks.values().cloned().collect();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_responses::list_stacks_response(&stacks, &req.request_id),
+        ))
+    }
+
+    fn list_stack_resources(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let stack_name = Self::get_param(req, "StackName").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "StackName is required",
+            )
+        })?;
+
+        let state = self.state.read();
+        let stack = state
+            .stacks
+            .values()
+            .find(|s| {
+                (s.name == stack_name || s.stack_id == stack_name) && s.status != "DELETE_COMPLETE"
+            })
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!("Stack [{stack_name}] does not exist"),
+                )
+            })?;
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_responses::list_stack_resources_response(&stack.resources, &req.request_id),
+        ))
+    }
+
+    fn describe_stack_resources(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let stack_name = Self::get_param(req, "StackName").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "StackName is required",
+            )
+        })?;
+
+        let state = self.state.read();
+        let stack = state
+            .stacks
+            .values()
+            .find(|s| {
+                (s.name == stack_name || s.stack_id == stack_name) && s.status != "DELETE_COMPLETE"
+            })
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!("Stack [{stack_name}] does not exist"),
+                )
+            })?;
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_responses::describe_stack_resources_response(
+                &stack.resources,
+                &stack.name,
+                &req.request_id,
+            ),
+        ))
+    }
+
+    fn update_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let params = Self::get_all_params(req);
+
+        let stack_name = params.get("StackName").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "StackName is required",
+            )
+        })?;
+
+        let template_body = params.get("TemplateBody").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "TemplateBody is required",
+            )
+        })?;
+
+        let new_parameters = Self::extract_parameters(&params);
+        let new_tags = Self::extract_tags(&params);
+
+        let parsed = template::parse_template(template_body, &new_parameters).map_err(|e| {
+            AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
+        })?;
+
+        let provisioner = self.provisioner();
+
+        let mut state = self.state.write();
+        let stack = state
+            .stacks
+            .values_mut()
+            .find(|s| {
+                (s.name == *stack_name || s.stack_id == *stack_name)
+                    && s.status != "DELETE_COMPLETE"
+            })
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!("Stack [{stack_name}] does not exist"),
+                )
+            })?;
+
+        // Determine which resources to add and remove
+        let old_logical_ids: std::collections::HashSet<String> = stack
+            .resources
+            .iter()
+            .map(|r| r.logical_id.clone())
+            .collect();
+        let new_logical_ids: std::collections::HashSet<String> = parsed
+            .resources
+            .iter()
+            .map(|r| r.logical_id.clone())
+            .collect();
+
+        // Delete resources that are no longer in the template
+        let to_remove: Vec<_> = stack
+            .resources
+            .iter()
+            .filter(|r| !new_logical_ids.contains(&r.logical_id))
+            .cloned()
+            .collect();
+        for resource in &to_remove {
+            let _ = provisioner.delete_resource(resource);
+        }
+        stack
+            .resources
+            .retain(|r| new_logical_ids.contains(&r.logical_id));
+
+        // Create new resources
+        for resource_def in &parsed.resources {
+            if !old_logical_ids.contains(&resource_def.logical_id) {
+                match provisioner.create_resource(resource_def) {
+                    Ok(stack_resource) => stack.resources.push(stack_resource),
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to create resource {} during update: {e}",
+                            resource_def.logical_id
+                        );
+                    }
+                }
+            }
+        }
+
+        let stack_id = stack.stack_id.clone();
+        stack.template = template_body.clone();
+        stack.status = "UPDATE_COMPLETE".to_string();
+        stack.parameters = new_parameters;
+        if !new_tags.is_empty() {
+            stack.tags = new_tags;
+        }
+        stack.updated_at = Some(Utc::now());
+        stack.description = parsed.description;
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_responses::update_stack_response(&stack_id, &req.request_id),
+        ))
+    }
+
+    fn get_template(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let stack_name = Self::get_param(req, "StackName").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "StackName is required",
+            )
+        })?;
+
+        let state = self.state.read();
+        let stack = state
+            .stacks
+            .values()
+            .find(|s| {
+                (s.name == stack_name || s.stack_id == stack_name) && s.status != "DELETE_COMPLETE"
+            })
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!("Stack [{stack_name}] does not exist"),
+                )
+            })?;
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_responses::get_template_response(&stack.template, &req.request_id),
+        ))
+    }
+}
+
+#[async_trait]
+impl AwsService for CloudFormationService {
+    fn service_name(&self) -> &str {
+        "cloudformation"
+    }
+
+    async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        match req.action.as_str() {
+            "CreateStack" => self.create_stack(&req),
+            "DeleteStack" => self.delete_stack(&req),
+            "DescribeStacks" => self.describe_stacks(&req),
+            "ListStacks" => self.list_stacks(&req),
+            "ListStackResources" => self.list_stack_resources(&req),
+            "DescribeStackResources" => self.describe_stack_resources(&req),
+            "UpdateStack" => self.update_stack(&req),
+            "GetTemplate" => self.get_template(&req),
+            _ => Err(AwsServiceError::action_not_implemented(
+                "cloudformation",
+                &req.action,
+            )),
+        }
+    }
+
+    fn supported_actions(&self) -> &[&str] {
+        &[
+            "CreateStack",
+            "DeleteStack",
+            "DescribeStacks",
+            "ListStacks",
+            "ListStackResources",
+            "DescribeStackResources",
+            "UpdateStack",
+            "GetTemplate",
+        ]
+    }
+}

--- a/crates/fakecloud-cloudformation/src/state.rs
+++ b/crates/fakecloud-cloudformation/src/state.rs
@@ -1,0 +1,48 @@
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct StackResource {
+    pub logical_id: String,
+    pub physical_id: String,
+    pub resource_type: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Stack {
+    pub name: String,
+    pub stack_id: String,
+    pub template: String,
+    pub status: String,
+    pub resources: Vec<StackResource>,
+    pub parameters: HashMap<String, String>,
+    pub tags: HashMap<String, String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub description: Option<String>,
+}
+
+pub struct CloudFormationState {
+    pub account_id: String,
+    pub region: String,
+    pub stacks: HashMap<String, Stack>,
+}
+
+impl CloudFormationState {
+    pub fn new(account_id: &str, region: &str) -> Self {
+        Self {
+            account_id: account_id.to_string(),
+            region: region.to_string(),
+            stacks: HashMap::new(),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.stacks.clear();
+    }
+}
+
+pub type SharedCloudFormationState = Arc<RwLock<CloudFormationState>>;

--- a/crates/fakecloud-cloudformation/src/template.rs
+++ b/crates/fakecloud-cloudformation/src/template.rs
@@ -16,10 +16,31 @@ pub struct ResourceDefinition {
     pub properties: Value,
 }
 
+/// Known pseudo-references that should be passed through as-is.
+const PSEUDO_REFS: &[&str] = &[
+    "AWS::AccountId",
+    "AWS::NotificationARNs",
+    "AWS::NoValue",
+    "AWS::Partition",
+    "AWS::Region",
+    "AWS::StackId",
+    "AWS::StackName",
+    "AWS::URLSuffix",
+];
+
 /// Parse a CloudFormation template from a string (JSON or YAML).
 pub fn parse_template(
     template_body: &str,
     parameters: &HashMap<String, String>,
+) -> Result<ParsedTemplate, String> {
+    parse_template_with_physical_ids(template_body, parameters, &HashMap::new())
+}
+
+/// Parse a CloudFormation template, resolving Refs using known physical resource IDs.
+pub fn parse_template_with_physical_ids(
+    template_body: &str,
+    parameters: &HashMap<String, String>,
+    resource_physical_ids: &HashMap<String, String>,
 ) -> Result<ParsedTemplate, String> {
     let value: Value = if template_body.trim_start().starts_with('{') {
         serde_json::from_str(template_body).map_err(|e| format!("Invalid JSON template: {e}"))?
@@ -51,7 +72,12 @@ pub fn parse_template(
             .unwrap_or(Value::Object(serde_json::Map::new()));
 
         // Resolve Ref and parameter substitutions in properties
-        let resolved = resolve_refs(&properties, parameters, resources_obj);
+        let resolved = resolve_refs(
+            &properties,
+            parameters,
+            resources_obj,
+            resource_physical_ids,
+        );
 
         resources.push(ResourceDefinition {
             logical_id: logical_id.clone(),
@@ -66,20 +92,69 @@ pub fn parse_template(
     })
 }
 
+/// Re-resolve a single resource definition's properties with updated physical IDs.
+pub fn resolve_resource_properties(
+    resource: &ResourceDefinition,
+    template_body: &str,
+    parameters: &HashMap<String, String>,
+    resource_physical_ids: &HashMap<String, String>,
+) -> Result<ResourceDefinition, String> {
+    let value: Value = if template_body.trim_start().starts_with('{') {
+        serde_json::from_str(template_body).map_err(|e| format!("Invalid JSON template: {e}"))?
+    } else {
+        serde_yaml::from_str(template_body).map_err(|e| format!("Invalid YAML template: {e}"))?
+    };
+
+    let resources_obj = value
+        .get("Resources")
+        .and_then(|v| v.as_object())
+        .ok_or("Template must contain a Resources section")?;
+
+    let raw_props = resources_obj
+        .get(&resource.logical_id)
+        .and_then(|r| r.get("Properties"))
+        .cloned()
+        .unwrap_or(Value::Object(serde_json::Map::new()));
+
+    let resolved = resolve_refs(&raw_props, parameters, resources_obj, resource_physical_ids);
+
+    Ok(ResourceDefinition {
+        logical_id: resource.logical_id.clone(),
+        resource_type: resource.resource_type.clone(),
+        properties: resolved,
+    })
+}
+
 /// Resolve { "Ref": "param_name" } and { "Fn::GetAtt": [...] } in property values.
 fn resolve_refs(
     value: &Value,
     parameters: &HashMap<String, String>,
     _resources: &serde_json::Map<String, Value>,
+    resource_physical_ids: &HashMap<String, String>,
 ) -> Value {
     match value {
         Value::Object(map) => {
             if let Some(ref_val) = map.get("Ref") {
                 if let Some(ref_name) = ref_val.as_str() {
+                    // 1. Check explicit parameters first
                     if let Some(param_val) = parameters.get(ref_name) {
                         return Value::String(param_val.clone());
                     }
-                    // If it references another resource, return logical ID as placeholder
+                    // 2. Check already-provisioned resource physical IDs
+                    if let Some(physical_id) = resource_physical_ids.get(ref_name) {
+                        return Value::String(physical_id.clone());
+                    }
+                    // 3. Allow pseudo-references to pass through as the ref name
+                    if PSEUDO_REFS.contains(&ref_name) {
+                        return Value::String(ref_name.to_string());
+                    }
+                    // 4. If it's a known logical resource in the template but not yet
+                    //    provisioned, return the logical ID (will be resolved later
+                    //    during incremental provisioning)
+                    if _resources.contains_key(ref_name) {
+                        return Value::String(ref_name.to_string());
+                    }
+                    // 5. Unknown ref — return as-is (could be a default parameter)
                     return Value::String(ref_name.to_string());
                 }
             }
@@ -91,7 +166,12 @@ fn resolve_refs(
                             let resolved_parts: Vec<String> = parts
                                 .iter()
                                 .map(|p| {
-                                    let resolved = resolve_refs(p, parameters, _resources);
+                                    let resolved = resolve_refs(
+                                        p,
+                                        parameters,
+                                        _resources,
+                                        resource_physical_ids,
+                                    );
                                     match resolved {
                                         Value::String(s) => s,
                                         other => other.to_string(),
@@ -109,19 +189,26 @@ fn resolve_refs(
                     for (k, v) in parameters {
                         result = result.replace(&format!("${{{k}}}"), v);
                     }
+                    // Also substitute resource physical IDs in Fn::Sub
+                    for (k, v) in resource_physical_ids {
+                        result = result.replace(&format!("${{{k}}}"), v);
+                    }
                     return Value::String(result);
                 }
             }
             // Recurse into object
             let mut new_map = serde_json::Map::new();
             for (k, v) in map {
-                new_map.insert(k.clone(), resolve_refs(v, parameters, _resources));
+                new_map.insert(
+                    k.clone(),
+                    resolve_refs(v, parameters, _resources, resource_physical_ids),
+                );
             }
             Value::Object(new_map)
         }
         Value::Array(arr) => Value::Array(
             arr.iter()
-                .map(|v| resolve_refs(v, parameters, _resources))
+                .map(|v| resolve_refs(v, parameters, _resources, resource_physical_ids))
                 .collect(),
         ),
         other => other.clone(),
@@ -186,6 +273,140 @@ Resources:
         assert_eq!(
             parsed.resources[0].properties["QueueName"],
             Value::String("resolved-queue".to_string())
+        );
+    }
+
+    #[test]
+    fn ref_resolves_physical_id_over_logical_id() {
+        let template = r#"{
+            "Resources": {
+                "MyTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": "my-topic"
+                    }
+                },
+                "MySub": {
+                    "Type": "AWS::SNS::Subscription",
+                    "Properties": {
+                        "TopicArn": { "Ref": "MyTopic" },
+                        "Protocol": "sqs",
+                        "Endpoint": "arn:aws:sqs:us-east-1:123456789012:q"
+                    }
+                }
+            }
+        }"#;
+
+        let mut physical_ids = HashMap::new();
+        physical_ids.insert(
+            "MyTopic".to_string(),
+            "arn:aws:sns:us-east-1:123456789012:my-topic".to_string(),
+        );
+
+        let parsed =
+            parse_template_with_physical_ids(template, &HashMap::new(), &physical_ids).unwrap();
+        let sub = parsed
+            .resources
+            .iter()
+            .find(|r| r.logical_id == "MySub")
+            .unwrap();
+        assert_eq!(
+            sub.properties["TopicArn"],
+            Value::String("arn:aws:sns:us-east-1:123456789012:my-topic".to_string())
+        );
+    }
+
+    #[test]
+    fn ref_without_physical_id_returns_logical_id_for_known_resource() {
+        let template = r#"{
+            "Resources": {
+                "MyTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": "my-topic"
+                    }
+                },
+                "MySub": {
+                    "Type": "AWS::SNS::Subscription",
+                    "Properties": {
+                        "TopicArn": { "Ref": "MyTopic" },
+                        "Protocol": "sqs",
+                        "Endpoint": "arn:aws:sqs:us-east-1:123456789012:q"
+                    }
+                }
+            }
+        }"#;
+
+        // No physical IDs yet — logical ID returned for known resources
+        let parsed = parse_template(template, &HashMap::new()).unwrap();
+        let sub = parsed
+            .resources
+            .iter()
+            .find(|r| r.logical_id == "MySub")
+            .unwrap();
+        assert_eq!(
+            sub.properties["TopicArn"],
+            Value::String("MyTopic".to_string())
+        );
+    }
+
+    #[test]
+    fn pseudo_ref_passes_through() {
+        let template = r#"{
+            "Resources": {
+                "MyQueue": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {
+                        "QueueName": { "Ref": "AWS::StackName" }
+                    }
+                }
+            }
+        }"#;
+
+        let parsed = parse_template(template, &HashMap::new()).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["QueueName"],
+            Value::String("AWS::StackName".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_sub_resolves_physical_ids() {
+        let template = r#"{
+            "Resources": {
+                "MyTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": "my-topic"
+                    }
+                },
+                "MyParam": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Name": "/app/topic",
+                        "Type": "String",
+                        "Value": { "Fn::Sub": "Topic is ${MyTopic}" }
+                    }
+                }
+            }
+        }"#;
+
+        let mut physical_ids = HashMap::new();
+        physical_ids.insert(
+            "MyTopic".to_string(),
+            "arn:aws:sns:us-east-1:123456789012:my-topic".to_string(),
+        );
+
+        let parsed =
+            parse_template_with_physical_ids(template, &HashMap::new(), &physical_ids).unwrap();
+        let param = parsed
+            .resources
+            .iter()
+            .find(|r| r.logical_id == "MyParam")
+            .unwrap();
+        assert_eq!(
+            param.properties["Value"],
+            Value::String("Topic is arn:aws:sns:us-east-1:123456789012:my-topic".to_string())
         );
     }
 }

--- a/crates/fakecloud-cloudformation/src/template.rs
+++ b/crates/fakecloud-cloudformation/src/template.rs
@@ -1,0 +1,191 @@
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// A parsed CloudFormation template.
+#[derive(Debug, Clone)]
+pub struct ParsedTemplate {
+    pub description: Option<String>,
+    pub resources: Vec<ResourceDefinition>,
+}
+
+/// A single resource from the template.
+#[derive(Debug, Clone)]
+pub struct ResourceDefinition {
+    pub logical_id: String,
+    pub resource_type: String,
+    pub properties: Value,
+}
+
+/// Parse a CloudFormation template from a string (JSON or YAML).
+pub fn parse_template(
+    template_body: &str,
+    parameters: &HashMap<String, String>,
+) -> Result<ParsedTemplate, String> {
+    let value: Value = if template_body.trim_start().starts_with('{') {
+        serde_json::from_str(template_body).map_err(|e| format!("Invalid JSON template: {e}"))?
+    } else {
+        serde_yaml::from_str(template_body).map_err(|e| format!("Invalid YAML template: {e}"))?
+    };
+
+    let description = value
+        .get("Description")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let resources_obj = value
+        .get("Resources")
+        .and_then(|v| v.as_object())
+        .ok_or("Template must contain a Resources section")?;
+
+    let mut resources = Vec::new();
+    for (logical_id, resource) in resources_obj {
+        let resource_type = resource
+            .get("Type")
+            .and_then(|v| v.as_str())
+            .ok_or(format!("Resource {logical_id} must have a Type property"))?
+            .to_string();
+
+        let properties = resource
+            .get("Properties")
+            .cloned()
+            .unwrap_or(Value::Object(serde_json::Map::new()));
+
+        // Resolve Ref and parameter substitutions in properties
+        let resolved = resolve_refs(&properties, parameters, resources_obj);
+
+        resources.push(ResourceDefinition {
+            logical_id: logical_id.clone(),
+            resource_type,
+            properties: resolved,
+        });
+    }
+
+    Ok(ParsedTemplate {
+        description,
+        resources,
+    })
+}
+
+/// Resolve { "Ref": "param_name" } and { "Fn::GetAtt": [...] } in property values.
+fn resolve_refs(
+    value: &Value,
+    parameters: &HashMap<String, String>,
+    _resources: &serde_json::Map<String, Value>,
+) -> Value {
+    match value {
+        Value::Object(map) => {
+            if let Some(ref_val) = map.get("Ref") {
+                if let Some(ref_name) = ref_val.as_str() {
+                    if let Some(param_val) = parameters.get(ref_name) {
+                        return Value::String(param_val.clone());
+                    }
+                    // If it references another resource, return logical ID as placeholder
+                    return Value::String(ref_name.to_string());
+                }
+            }
+            if let Some(join_val) = map.get("Fn::Join") {
+                if let Some(arr) = join_val.as_array() {
+                    if arr.len() == 2 {
+                        let delimiter = arr[0].as_str().unwrap_or("");
+                        if let Some(parts) = arr[1].as_array() {
+                            let resolved_parts: Vec<String> = parts
+                                .iter()
+                                .map(|p| {
+                                    let resolved = resolve_refs(p, parameters, _resources);
+                                    match resolved {
+                                        Value::String(s) => s,
+                                        other => other.to_string(),
+                                    }
+                                })
+                                .collect();
+                            return Value::String(resolved_parts.join(delimiter));
+                        }
+                    }
+                }
+            }
+            if let Some(sub_val) = map.get("Fn::Sub") {
+                if let Some(s) = sub_val.as_str() {
+                    let mut result = s.to_string();
+                    for (k, v) in parameters {
+                        result = result.replace(&format!("${{{k}}}"), v);
+                    }
+                    return Value::String(result);
+                }
+            }
+            // Recurse into object
+            let mut new_map = serde_json::Map::new();
+            for (k, v) in map {
+                new_map.insert(k.clone(), resolve_refs(v, parameters, _resources));
+            }
+            Value::Object(new_map)
+        }
+        Value::Array(arr) => Value::Array(
+            arr.iter()
+                .map(|v| resolve_refs(v, parameters, _resources))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_json_template() {
+        let template = r#"{
+            "Resources": {
+                "MyQueue": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {
+                        "QueueName": "test-queue"
+                    }
+                }
+            }
+        }"#;
+
+        let parsed = parse_template(template, &HashMap::new()).unwrap();
+        assert_eq!(parsed.resources.len(), 1);
+        assert_eq!(parsed.resources[0].logical_id, "MyQueue");
+        assert_eq!(parsed.resources[0].resource_type, "AWS::SQS::Queue");
+    }
+
+    #[test]
+    fn parse_yaml_template() {
+        let template = r#"
+Resources:
+  MyTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: test-topic
+"#;
+
+        let parsed = parse_template(template, &HashMap::new()).unwrap();
+        assert_eq!(parsed.resources.len(), 1);
+        assert_eq!(parsed.resources[0].logical_id, "MyTopic");
+        assert_eq!(parsed.resources[0].resource_type, "AWS::SNS::Topic");
+    }
+
+    #[test]
+    fn resolve_ref_parameters() {
+        let template = r#"{
+            "Resources": {
+                "MyQueue": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {
+                        "QueueName": { "Ref": "QueueNameParam" }
+                    }
+                }
+            }
+        }"#;
+
+        let mut params = HashMap::new();
+        params.insert("QueueNameParam".to_string(), "resolved-queue".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["QueueName"],
+            Value::String("resolved-queue".to_string())
+        );
+    }
+}

--- a/crates/fakecloud-cloudformation/src/xml_responses.rs
+++ b/crates/fakecloud-cloudformation/src/xml_responses.rs
@@ -1,0 +1,256 @@
+use crate::state::{Stack, StackResource};
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+pub fn create_stack_response(stack_id: &str, request_id: &str) -> String {
+    format!(
+        r#"<CreateStackResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <CreateStackResult>
+    <StackId>{stack_id}</StackId>
+  </CreateStackResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</CreateStackResponse>"#,
+        stack_id = xml_escape(stack_id),
+        request_id = xml_escape(request_id),
+    )
+}
+
+pub fn update_stack_response(stack_id: &str, request_id: &str) -> String {
+    format!(
+        r#"<UpdateStackResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <UpdateStackResult>
+    <StackId>{stack_id}</StackId>
+  </UpdateStackResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</UpdateStackResponse>"#,
+        stack_id = xml_escape(stack_id),
+        request_id = xml_escape(request_id),
+    )
+}
+
+pub fn delete_stack_response(request_id: &str) -> String {
+    format!(
+        r#"<DeleteStackResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</DeleteStackResponse>"#,
+        request_id = xml_escape(request_id),
+    )
+}
+
+pub fn describe_stacks_response(stacks: &[Stack], request_id: &str) -> String {
+    let members: String = stacks
+        .iter()
+        .map(stack_member_xml)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"<DescribeStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <DescribeStacksResult>
+    <Stacks>
+{members}
+    </Stacks>
+  </DescribeStacksResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</DescribeStacksResponse>"#,
+        request_id = xml_escape(request_id),
+    )
+}
+
+fn stack_member_xml(stack: &Stack) -> String {
+    let tags_xml = if stack.tags.is_empty() {
+        String::new()
+    } else {
+        let tags: String = stack
+            .tags
+            .iter()
+            .map(|(k, v)| {
+                format!(
+                    "          <member>\n            <Key>{}</Key>\n            <Value>{}</Value>\n          </member>",
+                    xml_escape(k),
+                    xml_escape(v),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("\n        <Tags>\n{tags}\n        </Tags>")
+    };
+
+    let params_xml = if stack.parameters.is_empty() {
+        String::new()
+    } else {
+        let params: String = stack
+            .parameters
+            .iter()
+            .map(|(k, v)| {
+                format!(
+                    "          <member>\n            <ParameterKey>{}</ParameterKey>\n            <ParameterValue>{}</ParameterValue>\n          </member>",
+                    xml_escape(k),
+                    xml_escape(v),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("\n        <Parameters>\n{params}\n        </Parameters>")
+    };
+
+    let description_xml = stack
+        .description
+        .as_ref()
+        .map(|d| format!("\n        <Description>{}</Description>", xml_escape(d)))
+        .unwrap_or_default();
+
+    format!(
+        r#"      <member>
+        <StackName>{name}</StackName>
+        <StackId>{id}</StackId>
+        <StackStatus>{status}</StackStatus>
+        <CreationTime>{created}</CreationTime>{description_xml}{tags_xml}{params_xml}
+      </member>"#,
+        name = xml_escape(&stack.name),
+        id = xml_escape(&stack.stack_id),
+        status = xml_escape(&stack.status),
+        created = stack.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
+    )
+}
+
+pub fn list_stacks_response(stacks: &[Stack], request_id: &str) -> String {
+    let summaries: String = stacks
+        .iter()
+        .map(|s| {
+            format!(
+                r#"      <member>
+        <StackName>{name}</StackName>
+        <StackId>{id}</StackId>
+        <StackStatus>{status}</StackStatus>
+        <CreationTime>{created}</CreationTime>
+      </member>"#,
+                name = xml_escape(&s.name),
+                id = xml_escape(&s.stack_id),
+                status = xml_escape(&s.status),
+                created = s.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"<ListStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <ListStacksResult>
+    <StackSummaries>
+{summaries}
+    </StackSummaries>
+  </ListStacksResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</ListStacksResponse>"#,
+        request_id = xml_escape(request_id),
+    )
+}
+
+pub fn list_stack_resources_response(resources: &[StackResource], request_id: &str) -> String {
+    let summaries: String = resources
+        .iter()
+        .map(stack_resource_summary_xml)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"<ListStackResourcesResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <ListStackResourcesResult>
+    <StackResourceSummaries>
+{summaries}
+    </StackResourceSummaries>
+  </ListStackResourcesResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</ListStackResourcesResponse>"#,
+        request_id = xml_escape(request_id),
+    )
+}
+
+fn stack_resource_summary_xml(resource: &StackResource) -> String {
+    format!(
+        r#"      <member>
+        <LogicalResourceId>{logical_id}</LogicalResourceId>
+        <PhysicalResourceId>{physical_id}</PhysicalResourceId>
+        <ResourceType>{resource_type}</ResourceType>
+        <ResourceStatus>{status}</ResourceStatus>
+      </member>"#,
+        logical_id = xml_escape(&resource.logical_id),
+        physical_id = xml_escape(&resource.physical_id),
+        resource_type = xml_escape(&resource.resource_type),
+        status = xml_escape(&resource.status),
+    )
+}
+
+pub fn describe_stack_resources_response(
+    resources: &[StackResource],
+    stack_name: &str,
+    request_id: &str,
+) -> String {
+    let members: String = resources
+        .iter()
+        .map(|r| {
+            format!(
+                r#"      <member>
+        <StackName>{stack_name}</StackName>
+        <LogicalResourceId>{logical_id}</LogicalResourceId>
+        <PhysicalResourceId>{physical_id}</PhysicalResourceId>
+        <ResourceType>{resource_type}</ResourceType>
+        <ResourceStatus>{status}</ResourceStatus>
+      </member>"#,
+                stack_name = xml_escape(stack_name),
+                logical_id = xml_escape(&r.logical_id),
+                physical_id = xml_escape(&r.physical_id),
+                resource_type = xml_escape(&r.resource_type),
+                status = xml_escape(&r.status),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"<DescribeStackResourcesResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <DescribeStackResourcesResult>
+    <StackResources>
+{members}
+    </StackResources>
+  </DescribeStackResourcesResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</DescribeStackResourcesResponse>"#,
+        request_id = xml_escape(request_id),
+    )
+}
+
+pub fn get_template_response(template_body: &str, request_id: &str) -> String {
+    format!(
+        r#"<GetTemplateResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <GetTemplateResult>
+    <TemplateBody>{template_body}</TemplateBody>
+  </GetTemplateResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</GetTemplateResponse>"#,
+        template_body = xml_escape(template_body),
+        request_id = xml_escape(request_id),
+    )
+}

--- a/crates/fakecloud-e2e/Cargo.toml
+++ b/crates/fakecloud-e2e/Cargo.toml
@@ -24,6 +24,7 @@ aws-sdk-lambda = "1"
 aws-sdk-secretsmanager = "1"
 aws-sdk-cloudwatchlogs = "1"
 aws-sdk-kms = "1"
+aws-sdk-cloudformation = "1"
 aws-credential-types = "1"
 aws-types = "1"
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/fakecloud-e2e/tests/cloudformation.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation.rs
@@ -1,0 +1,453 @@
+mod helpers;
+
+use helpers::TestServer;
+
+#[tokio::test]
+async fn cloudformation_create_stack_with_sqs_queue() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+    let sqs_client = server.sqs_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {
+                    "QueueName": "cf-test-queue"
+                }
+            }
+        }
+    }"#;
+
+    let result = cf_client
+        .create_stack()
+        .stack_name("test-sqs-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(result.stack_id().is_some());
+
+    // Verify the queue was actually created
+    let queues = sqs_client.list_queues().send().await.unwrap();
+    let urls = queues.queue_urls();
+    assert!(
+        urls.iter().any(|u| u.contains("cf-test-queue")),
+        "Queue cf-test-queue should exist, got: {urls:?}"
+    );
+}
+
+#[tokio::test]
+async fn cloudformation_create_stack_with_sns_topic_and_subscription() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+    let sns_client = server.sns_client().await;
+    let sqs_client = server.sqs_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "MyTopic": {
+                "Type": "AWS::SNS::Topic",
+                "Properties": {
+                    "TopicName": "cf-test-topic"
+                }
+            },
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {
+                    "QueueName": "cf-sub-queue"
+                }
+            },
+            "MySub": {
+                "Type": "AWS::SNS::Subscription",
+                "Properties": {
+                    "TopicArn": "arn:aws:sns:us-east-1:123456789012:cf-test-topic",
+                    "Protocol": "sqs",
+                    "Endpoint": "arn:aws:sqs:us-east-1:123456789012:cf-sub-queue"
+                }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("test-sns-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify topic was created
+    let topics = sns_client.list_topics().send().await.unwrap();
+    let topic_arns: Vec<String> = topics
+        .topics()
+        .iter()
+        .filter_map(|t| t.topic_arn().map(|s| s.to_string()))
+        .collect();
+    assert!(
+        topic_arns.iter().any(|a| a.contains("cf-test-topic")),
+        "Topic cf-test-topic should exist, got: {topic_arns:?}"
+    );
+
+    // Verify queue was created
+    let queues = sqs_client.list_queues().send().await.unwrap();
+    assert!(queues
+        .queue_urls()
+        .iter()
+        .any(|u| u.contains("cf-sub-queue")));
+
+    // Verify subscription was created
+    let subs = sns_client.list_subscriptions().send().await.unwrap();
+    assert!(
+        subs.subscriptions().iter().any(|s| {
+            s.topic_arn()
+                .map(|a| a.contains("cf-test-topic"))
+                .unwrap_or(false)
+        }),
+        "Subscription should exist"
+    );
+}
+
+#[tokio::test]
+async fn cloudformation_delete_stack_removes_resources() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+    let sqs_client = server.sqs_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {
+                    "QueueName": "cf-delete-queue"
+                }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("delete-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify queue exists
+    let queues = sqs_client.list_queues().send().await.unwrap();
+    assert!(queues
+        .queue_urls()
+        .iter()
+        .any(|u| u.contains("cf-delete-queue")));
+
+    // Delete the stack
+    cf_client
+        .delete_stack()
+        .stack_name("delete-stack")
+        .send()
+        .await
+        .unwrap();
+
+    // Verify queue is gone
+    let queues = sqs_client.list_queues().send().await.unwrap();
+    assert!(
+        !queues
+            .queue_urls()
+            .iter()
+            .any(|u| u.contains("cf-delete-queue")),
+        "Queue should be deleted after stack deletion"
+    );
+}
+
+#[tokio::test]
+async fn cloudformation_describe_stacks() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+
+    let template = r#"{
+        "Description": "Test stack description",
+        "Resources": {
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {
+                    "QueueName": "cf-describe-queue"
+                }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("describe-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    let result = cf_client
+        .describe_stacks()
+        .stack_name("describe-stack")
+        .send()
+        .await
+        .unwrap();
+
+    let stacks = result.stacks();
+    assert_eq!(stacks.len(), 1);
+    let stack = &stacks[0];
+    assert_eq!(stack.stack_name(), Some("describe-stack"));
+    assert_eq!(
+        stack.stack_status().map(|s| s.as_str()),
+        Some("CREATE_COMPLETE")
+    );
+}
+
+#[tokio::test]
+async fn cloudformation_list_stacks() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "Q1": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-list-q1" }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("list-stack-1")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    let template2 = r#"{
+        "Resources": {
+            "Q2": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-list-q2" }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("list-stack-2")
+        .template_body(template2)
+        .send()
+        .await
+        .unwrap();
+
+    let result = cf_client.list_stacks().send().await.unwrap();
+    let summaries = result.stack_summaries();
+    assert!(summaries.len() >= 2);
+}
+
+#[tokio::test]
+async fn cloudformation_list_stack_resources() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "Queue1": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-res-q1" }
+            },
+            "Queue2": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-res-q2" }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("resources-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    let result = cf_client
+        .list_stack_resources()
+        .stack_name("resources-stack")
+        .send()
+        .await
+        .unwrap();
+
+    let summaries = result.stack_resource_summaries();
+    assert_eq!(summaries.len(), 2);
+
+    let logical_ids: Vec<&str> = summaries
+        .iter()
+        .filter_map(|r| r.logical_resource_id())
+        .collect();
+    assert!(logical_ids.contains(&"Queue1"));
+    assert!(logical_ids.contains(&"Queue2"));
+}
+
+#[tokio::test]
+async fn cloudformation_create_stack_with_s3_bucket() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+    let s3_client = server.s3_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "MyBucket": {
+                "Type": "AWS::S3::Bucket",
+                "Properties": {
+                    "BucketName": "cf-test-bucket"
+                }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("s3-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify the bucket was created
+    let buckets = s3_client.list_buckets().send().await.unwrap();
+    let bucket_names: Vec<&str> = buckets.buckets().iter().filter_map(|b| b.name()).collect();
+    assert!(
+        bucket_names.contains(&"cf-test-bucket"),
+        "Bucket cf-test-bucket should exist, got: {bucket_names:?}"
+    );
+}
+
+#[tokio::test]
+async fn cloudformation_describe_stack_resources() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-dsr-queue" }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("dsr-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    let result = cf_client
+        .describe_stack_resources()
+        .stack_name("dsr-stack")
+        .send()
+        .await
+        .unwrap();
+
+    let resources = result.stack_resources();
+    assert_eq!(resources.len(), 1);
+    assert_eq!(resources[0].logical_resource_id(), Some("MyQueue"));
+    assert_eq!(resources[0].resource_type(), Some("AWS::SQS::Queue"));
+}
+
+#[tokio::test]
+async fn cloudformation_get_template() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+
+    let template = r#"{"Resources":{"Q":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"cf-gt-queue"}}}}"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("gt-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    let result = cf_client
+        .get_template()
+        .stack_name("gt-stack")
+        .send()
+        .await
+        .unwrap();
+
+    let body = result.template_body().unwrap();
+    assert!(body.contains("AWS::SQS::Queue"));
+    assert!(body.contains("cf-gt-queue"));
+}
+
+#[tokio::test]
+async fn cloudformation_update_stack() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+    let sqs_client = server.sqs_client().await;
+
+    let template_v1 = r#"{
+        "Resources": {
+            "Queue1": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-update-q1" }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("update-stack")
+        .template_body(template_v1)
+        .send()
+        .await
+        .unwrap();
+
+    // Update: remove Queue1, add Queue2
+    let template_v2 = r#"{
+        "Resources": {
+            "Queue2": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-update-q2" }
+            }
+        }
+    }"#;
+
+    cf_client
+        .update_stack()
+        .stack_name("update-stack")
+        .template_body(template_v2)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify Queue1 is gone and Queue2 exists
+    let queues = sqs_client.list_queues().send().await.unwrap();
+    let urls = queues.queue_urls();
+    assert!(
+        !urls.iter().any(|u| u.contains("cf-update-q1")),
+        "Queue1 should be removed after update"
+    );
+    assert!(
+        urls.iter().any(|u| u.contains("cf-update-q2")),
+        "Queue2 should exist after update"
+    );
+
+    // Verify status is UPDATE_COMPLETE
+    let desc = cf_client
+        .describe_stacks()
+        .stack_name("update-stack")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        desc.stacks()[0].stack_status().map(|s| s.as_str()),
+        Some("UPDATE_COMPLETE")
+    );
+}

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -122,6 +122,11 @@ impl TestServer {
         aws_sdk_kms::Client::new(&self.aws_config().await)
     }
 
+    /// Create a CloudFormation client.
+    pub async fn cloudformation_client(&self) -> aws_sdk_cloudformation::Client {
+        aws_sdk_cloudformation::Client::new(&self.aws_config().await)
+    }
+
     /// Create an S3 client (path-style addressing for single-endpoint emulator).
     pub async fn s3_client(&self) -> aws_sdk_s3::Client {
         let config = self.aws_config().await;

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -25,6 +25,7 @@ fakecloud-lambda = { workspace = true }
 fakecloud-secretsmanager = { workspace = true }
 fakecloud-logs = { workspace = true }
 fakecloud-kms = { workspace = true }
+fakecloud-cloudformation = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -13,6 +13,7 @@ use fakecloud_core::registry::ServiceRegistry;
 mod sqs_lambda_poller;
 use sqs_lambda_poller::SqsLambdaPoller;
 
+use fakecloud_cloudformation::service::CloudFormationService;
 use fakecloud_dynamodb::service::DynamoDbService;
 use fakecloud_eventbridge::service::EventBridgeService;
 use fakecloud_iam::iam_service::IamService;
@@ -96,6 +97,9 @@ async fn main() {
     let kms_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_kms::state::KmsState::new(&cli.account_id, &cli.region),
     ));
+    let cloudformation_state = Arc::new(parking_lot::RwLock::new(
+        fakecloud_cloudformation::state::CloudFormationState::new(&cli.account_id, &cli.region),
+    ));
 
     // Cross-service delivery bus
     // Step 1: SQS delivery (SNS and EventBridge can push messages into SQS queues)
@@ -138,10 +142,22 @@ async fn main() {
         s3: s3_state.clone(),
         logs: logs_state.clone(),
         kms: kms_state.clone(),
+        cloudformation: cloudformation_state.clone(),
     };
 
     // Register services
     let mut registry = ServiceRegistry::new();
+    registry.register(Arc::new(CloudFormationService::new(
+        cloudformation_state,
+        sqs_state.clone(),
+        sns_state.clone(),
+        ssm_state.clone(),
+        iam_state.clone(),
+        s3_state.clone(),
+        eb_state.clone(),
+        dynamodb_state.clone(),
+        logs_state.clone(),
+    )));
     registry.register(Arc::new(SqsService::new(sqs_state.clone())));
     registry.register(Arc::new(SnsService::new(sns_state, delivery_for_sns)));
     registry.register(Arc::new(
@@ -267,6 +283,7 @@ struct ResetState {
     s3: fakecloud_s3::state::SharedS3State,
     logs: fakecloud_logs::state::SharedLogsState,
     kms: fakecloud_kms::state::SharedKmsState,
+    cloudformation: fakecloud_cloudformation::state::SharedCloudFormationState,
 }
 
 impl ResetState {
@@ -299,6 +316,7 @@ impl ResetState {
         self.s3.write().reset();
         self.logs.write().reset();
         self.kms.write().reset();
+        self.cloudformation.write().reset();
         tracing::info!("state reset via reset API");
         axum::Json(serde_json::json!({"status": "ok"}))
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -371,7 +371,7 @@
           </tr>
           <tr>
             <td>AWS services</td>
-            <td>11</td>
+            <td>12</td>
             <td>80+</td>
             <td>25</td>
             <td>38</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -284,8 +284,8 @@
       </div>
       <div class="feature">
         <div class="label">Coverage</div>
-        <h3>11 AWS services</h3>
-        <p>S3, SQS, SNS, EventBridge, IAM/STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS. The services local dev actually needs.</p>
+        <h3>12 AWS services</h3>
+        <p>S3, SQS, SNS, EventBridge, IAM/STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation. The services local dev actually needs.</p>
       </div>
       <div class="feature">
         <div class="label">Tested</div>
@@ -444,6 +444,10 @@
       <div class="service">
         <div class="name">KMS (stub)</div>
         <div class="proto">JSON protocol</div>
+      </div>
+      <div class="service">
+        <div class="name">CloudFormation</div>
+        <div class="proto">Query protocol</div>
       </div>
     </div>
   </div>

--- a/tests/compat/moto/services.txt
+++ b/tests/compat/moto/services.txt
@@ -1,2 +1,2 @@
-sqs sns events iam sts ssm s3 dynamodb logs kms
-sqs sns events iam sts ssm s3 awslambda secretsmanager logs kms
+sqs sns events iam sts ssm s3 dynamodb logs kms cloudformation
+sqs sns events iam sts ssm s3 awslambda secretsmanager logs kms cloudformation


### PR DESCRIPTION
## Summary

- Add `fakecloud-cloudformation` crate with 8 CloudFormation actions: CreateStack, DeleteStack, DescribeStacks, ListStacks, ListStackResources, DescribeStackResources, UpdateStack, GetTemplate
- Support provisioning 10 resource types (SQS::Queue, SNS::Topic, SNS::Subscription, SSM::Parameter, IAM::Role, IAM::Policy, S3::Bucket, Events::Rule, DynamoDB::Table, Logs::LogGroup) by directly manipulating other service states
- Stack updates perform diff-based resource create/delete; templates support JSON and YAML with Ref/Fn::Sub/Fn::Join intrinsic function resolution

## Test plan

- [x] 10 E2E tests covering all major features:
  - Create stack with SQS queue, verify queue exists
  - Create stack with SNS topic + subscription, verify both
  - Delete stack, verify resources removed
  - DescribeStacks, ListStacks, ListStackResources, DescribeStackResources
  - Create stack with S3 bucket, verify bucket exists
  - GetTemplate returns stored template
  - UpdateStack adds/removes resources correctly
- [x] 3 unit tests for template parsing (JSON, YAML, Ref resolution)
- [x] `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace --exclude fakecloud-e2e` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a basic CloudFormation service for stack create/update/delete that provisions real resources in FakeCloud, enabling local IaC via Query endpoints. Also fixes validation, dependency resolution, and update error handling.

- **New Features**
  - Added `fakecloud-cloudformation` with 8 actions: CreateStack, UpdateStack, DeleteStack, DescribeStacks, DescribeStackResources, ListStacks, ListStackResources, GetTemplate.
  - Provisions resources across SQS, SNS (Topic/Subscription), SSM Parameter, IAM Role/Policy, S3 Bucket, EventBridge Rule, DynamoDB Table, and Logs LogGroup.
  - Supports JSON/YAML templates with Ref, Fn::Sub, Fn::Join; parameters and tags; diff-based UpdateStack; GetTemplate returns the stored template.
  - Registered in `fakecloud-server`; health/docs updated; E2E tests cover major flows.

- **Bug Fixes**
  - Validate `TopicArn` and `EventBusName` before creating SNS subscriptions and EventBridge rules; fixed default bus rule ARN to use rule/<name>.
  - Multi-pass dependency resolution to map Refs to physical IDs during incremental resource creation.
  - Propagate resource creation errors in UpdateStack and set stack status to UPDATE_FAILED.

<sup>Written for commit d805f750ddb417ddea9fa9d3b4f9456c4fbf79e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

