### PR TITLE
feat: add proptest strategy, Level 2 audit, and 280 conformance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace --exclude fakecloud-e2e
+      - run: cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance
+      - run: cargo test -p fakecloud-conformance --lib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,25 @@ dependencies = [
 name = "fakecloud-conformance"
 version = "0.1.1"
 dependencies = [
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-cloudformation",
+ "aws-sdk-cloudwatchlogs",
+ "aws-sdk-dynamodb",
+ "aws-sdk-eventbridge",
+ "aws-sdk-iam",
+ "aws-sdk-kms",
+ "aws-sdk-lambda",
+ "aws-sdk-s3",
+ "aws-sdk-secretsmanager",
+ "aws-sdk-sns",
+ "aws-sdk-sqs",
+ "aws-sdk-ssm",
+ "aws-sdk-sts",
+ "aws-types",
  "clap",
+ "fakecloud-conformance-macros",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -2593,6 +2611,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/crates/fakecloud-conformance/Cargo.toml
+++ b/crates/fakecloud-conformance/Cargo.toml
@@ -17,3 +17,24 @@ sha2 = { workspace = true }
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 tokio = { workspace = true }
 clap = { workspace = true }
+regex = "1"
+
+[dev-dependencies]
+fakecloud-conformance-macros = { path = "../fakecloud-conformance-macros" }
+aws-config = "1"
+aws-sdk-sqs = "1"
+aws-sdk-sns = "1"
+aws-sdk-eventbridge = "1"
+aws-sdk-iam = "1"
+aws-sdk-sts = "1"
+aws-sdk-ssm = "1"
+aws-sdk-s3 = "1"
+aws-sdk-dynamodb = "1"
+aws-sdk-lambda = "1"
+aws-sdk-secretsmanager = "1"
+aws-sdk-cloudwatchlogs = "1"
+aws-sdk-kms = "1"
+aws-sdk-cloudformation = "1"
+aws-credential-types = "1"
+aws-types = "1"
+tokio = { workspace = true }

--- a/crates/fakecloud-conformance/src/audit.rs
+++ b/crates/fakecloud-conformance/src/audit.rs
@@ -1,0 +1,274 @@
+use regex::Regex;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Map from service_name (as used in service-map.json) to the list of source files
+/// containing `supported_actions()`.
+fn service_source_files(project_root: &Path) -> Vec<(String, Vec<PathBuf>)> {
+    // service_name -> (crate_suffix, list of source filenames)
+    let mappings: &[(&str, &str, &[&str])] = &[
+        ("sqs", "sqs", &["service.rs"]),
+        ("sns", "sns", &["service.rs"]),
+        ("events", "eventbridge", &["service.rs"]),
+        ("iam", "iam", &["iam_service.rs"]),
+        ("sts", "iam", &["sts_service.rs"]),
+        ("ssm", "ssm", &["service.rs"]),
+        ("s3", "s3", &["service.rs"]),
+        ("dynamodb", "dynamodb", &["service.rs"]),
+        ("lambda", "lambda", &["service.rs"]),
+        ("secretsmanager", "secretsmanager", &["service.rs"]),
+        ("logs", "logs", &["service.rs"]),
+        ("kms", "kms", &["service.rs"]),
+        ("cloudformation", "cloudformation", &["service.rs"]),
+    ];
+
+    mappings
+        .iter()
+        .map(|(service, crate_suffix, files)| {
+            let paths: Vec<PathBuf> = files
+                .iter()
+                .map(|f| {
+                    project_root
+                        .join("crates")
+                        .join(format!("fakecloud-{}", crate_suffix))
+                        .join("src")
+                        .join(f)
+                })
+                .collect();
+            (service.to_string(), paths)
+        })
+        .collect()
+}
+
+/// Scan Rust source files to extract the list of actions from `supported_actions()` bodies.
+///
+/// Returns a map of service_name to the list of action name strings found.
+pub fn scan_implemented_actions(
+    project_root: &Path,
+) -> Result<HashMap<String, Vec<String>>, String> {
+    let re = Regex::new(r#""([^"]+)""#).unwrap();
+    let mut result = HashMap::new();
+
+    for (service_name, source_files) in service_source_files(project_root) {
+        let mut actions = Vec::new();
+
+        for path in &source_files {
+            if !path.exists() {
+                eprintln!(
+                    "Warning: source file not found for {}: {}",
+                    service_name,
+                    path.display()
+                );
+                continue;
+            }
+
+            let content = std::fs::read_to_string(path)
+                .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+
+            // Find the supported_actions() function body.
+            // The signature is: fn supported_actions(&self) -> &[&str] { &[...] }
+            // We need to skip past the opening brace to find the array literal.
+            if let Some(start) = content.find("fn supported_actions") {
+                let after_fn = &content[start..];
+                // Find the opening brace of the function body
+                if let Some(brace_pos) = after_fn.find('{') {
+                    let after_brace = &after_fn[brace_pos + 1..];
+                    // Now find the &[ that starts the array literal
+                    if let Some(bracket_start) = after_brace.find("&[") {
+                        let after_bracket = &after_brace[bracket_start..];
+                        // Find the matching ]
+                        if let Some(bracket_end) = after_bracket.find(']') {
+                            let body = &after_bracket[..bracket_end];
+                            for cap in re.captures_iter(body) {
+                                actions.push(cap[1].to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if !actions.is_empty() {
+            actions.sort();
+            result.insert(service_name, actions);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Scan conformance test files for `#[test_action("service", "Action", ...)]` annotations.
+///
+/// Returns a map of service_name to the list of action names that have tests.
+pub fn scan_test_annotations(project_root: &Path) -> Result<HashMap<String, Vec<String>>, String> {
+    let tests_dir = project_root
+        .join("crates")
+        .join("fakecloud-conformance")
+        .join("tests");
+
+    if !tests_dir.exists() {
+        return Ok(HashMap::new());
+    }
+
+    let re = Regex::new(r#"test_action\("([^"]+)",\s*"([^"]+)""#).unwrap();
+    let mut result: HashMap<String, Vec<String>> = HashMap::new();
+
+    for entry in walkdir(&tests_dir)? {
+        if entry.extension().is_none_or(|e| e != "rs") {
+            continue;
+        }
+        let content = std::fs::read_to_string(&entry)
+            .map_err(|e| format!("Failed to read {}: {}", entry.display(), e))?;
+
+        for cap in re.captures_iter(&content) {
+            let service = cap[1].to_string();
+            let action = cap[2].to_string();
+            result.entry(service).or_default().push(action);
+        }
+    }
+
+    // Sort and deduplicate
+    for actions in result.values_mut() {
+        actions.sort();
+        actions.dedup();
+    }
+
+    Ok(result)
+}
+
+/// Simple recursive directory walk returning file paths.
+fn walkdir(dir: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut files = Vec::new();
+    let entries = std::fs::read_dir(dir)
+        .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Directory entry error: {}", e))?;
+        let path = entry.path();
+        if path.is_dir() {
+            files.extend(walkdir(&path)?);
+        } else {
+            files.push(path);
+        }
+    }
+
+    Ok(files)
+}
+
+/// Run the Level 2 audit: cross-reference implemented actions with conformance test coverage.
+///
+/// Returns `true` if all implemented actions have tests, `false` otherwise.
+pub fn run_audit(project_root: &Path) -> bool {
+    let implemented = match scan_implemented_actions(project_root) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("Error scanning implemented actions: {}", e);
+            return false;
+        }
+    };
+
+    let covered = match scan_test_annotations(project_root) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("Error scanning test annotations: {}", e);
+            return false;
+        }
+    };
+
+    println!("=== Conformance Audit ===");
+    println!();
+
+    let mut total_implemented = 0;
+    let mut total_missing = 0;
+
+    // Sort services for deterministic output
+    let mut services: Vec<&String> = implemented.keys().collect();
+    services.sort();
+
+    for service in &services {
+        let actions = &implemented[*service];
+        let covered_actions = covered.get(*service).cloned().unwrap_or_default();
+
+        let covered_count = actions
+            .iter()
+            .filter(|a| covered_actions.contains(a))
+            .count();
+        let total = actions.len();
+        let missing_count = total - covered_count;
+
+        total_implemented += total;
+        total_missing += missing_count;
+
+        println!(
+            "{}: {}/{} implemented actions covered",
+            service, covered_count, total
+        );
+
+        for action in actions {
+            if covered_actions.contains(action) {
+                println!("  [\u{2713}] {}", action);
+            } else {
+                println!("  [\u{2717}] {} (missing test)", action);
+            }
+        }
+        println!();
+    }
+
+    println!("=== Result ===");
+
+    if total_missing == 0 {
+        println!(
+            "PASS: all {} implemented actions have conformance tests",
+            total_implemented
+        );
+        true
+    } else {
+        println!(
+            "FAIL: {} implemented actions missing conformance tests",
+            total_missing
+        );
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn project_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+    }
+
+    #[test]
+    fn test_scan_implemented_actions() {
+        let root = project_root();
+        let actions = scan_implemented_actions(&root).unwrap();
+
+        // SQS should have actions
+        assert!(actions.contains_key("sqs"), "sqs should be present");
+        let sqs = &actions["sqs"];
+        assert!(sqs.contains(&"CreateQueue".to_string()));
+        assert!(sqs.contains(&"SendMessage".to_string()));
+
+        // IAM should have actions
+        assert!(actions.contains_key("iam"), "iam should be present");
+        let iam = &actions["iam"];
+        assert!(iam.contains(&"CreateUser".to_string()));
+
+        // STS should have actions
+        assert!(actions.contains_key("sts"), "sts should be present");
+        let sts = &actions["sts"];
+        assert!(sts.contains(&"GetCallerIdentity".to_string()));
+    }
+
+    #[test]
+    fn test_scan_test_annotations_empty() {
+        let root = project_root();
+        // With no test files yet, this should return empty or whatever exists
+        let result = scan_test_annotations(&root);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/fakecloud-conformance/src/generators/mod.rs
+++ b/crates/fakecloud-conformance/src/generators/mod.rs
@@ -3,6 +3,7 @@ pub mod enum_exhaust;
 pub mod examples;
 pub mod negative;
 pub mod optionals;
+pub mod proptest_gen;
 
 use serde_json::Value;
 use std::collections::HashMap;
@@ -30,6 +31,8 @@ pub enum Strategy {
     EnumExhaust,
     /// Strategy 3: Optionals permutation
     Optionals,
+    /// Strategy 4: Property-based random value generation
+    Proptest,
     /// Strategy 5: Real-world examples from model
     Examples,
     /// Strategy 6: Negative testing
@@ -42,6 +45,7 @@ impl std::fmt::Display for Strategy {
             Strategy::Boundary => write!(f, "boundary"),
             Strategy::EnumExhaust => write!(f, "enum_exhaust"),
             Strategy::Optionals => write!(f, "optionals"),
+            Strategy::Proptest => write!(f, "proptest"),
             Strategy::Examples => write!(f, "examples"),
             Strategy::Negative => write!(f, "negative"),
         }
@@ -267,6 +271,9 @@ pub fn generate_all_variants(
 
     // Strategy 3: Optionals permutation
     variants.extend(optionals::generate(model, input_shape_id, overrides));
+
+    // Strategy 4: Property-based random value generation (20 variants)
+    variants.extend(proptest_gen::generate(model, input_shape_id, overrides, 20));
 
     // Strategy 5: Examples from model
     let op_shape_id = format!("{}#{}", model.service_name, operation_name);

--- a/crates/fakecloud-conformance/src/generators/proptest_gen.rs
+++ b/crates/fakecloud-conformance/src/generators/proptest_gen.rs
@@ -49,8 +49,9 @@ impl Xorshift64 {
         if lo >= hi {
             return lo;
         }
-        let span = (hi as i128 - lo as i128) as u64;
-        lo.wrapping_add((self.next_u64() % (span + 1)) as i64)
+        let span = (hi as i128 - lo as i128 + 1) as u128;
+        let offset = (self.next_u64() as u128) % span;
+        lo.wrapping_add(offset as i64)
     }
 
     /// Random f64 in [lo, hi].
@@ -384,15 +385,24 @@ mod tests {
         let mut rng = Xorshift64::new(123);
         for _ in 0..1000 {
             let v = rng.range_u64(5, 10);
-            assert!(v >= 5 && v <= 10);
+            assert!((5..=10).contains(&v));
         }
         for _ in 0..1000 {
             let v = rng.range_i64(-10, 10);
-            assert!(v >= -10 && v <= 10);
+            assert!((-10..=10).contains(&v));
         }
         for _ in 0..1000 {
             let v = rng.range_f64(0.0, 1.0);
-            assert!(v >= 0.0 && v <= 1.0);
+            assert!((0.0..=1.0).contains(&v));
+        }
+    }
+
+    #[test]
+    fn range_i64_full_span_does_not_overflow() {
+        let mut rng = Xorshift64::new(999);
+        // This used to panic due to overflow in (max - min + 1).
+        for _ in 0..100 {
+            let _ = rng.range_i64(i64::MIN, i64::MAX);
         }
     }
 

--- a/crates/fakecloud-conformance/src/generators/proptest_gen.rs
+++ b/crates/fakecloud-conformance/src/generators/proptest_gen.rs
@@ -1,0 +1,530 @@
+//! Strategy 4: Property-based random value generation.
+//!
+//! Uses a deterministic xorshift64 PRNG seeded from the operation name to generate
+//! N random but constraint-valid inputs per operation. This provides fuzzing-like
+//! coverage without the heavy `proptest` dependency.
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+use super::{Expectation, Strategy, TestVariant};
+use crate::smithy::{self, ServiceModel, ShapeType};
+
+/// Simple xorshift64 PRNG for deterministic pseudo-random generation.
+struct Xorshift64 {
+    state: u64,
+}
+
+impl Xorshift64 {
+    fn new(seed: u64) -> Self {
+        // Avoid zero state which would produce only zeros.
+        Self {
+            state: if seed == 0 {
+                0x5EED_DEAD_BEEF_CAFE
+            } else {
+                seed
+            },
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+
+    /// Random u64 in [lo, hi] inclusive.
+    fn range_u64(&mut self, lo: u64, hi: u64) -> u64 {
+        if lo >= hi {
+            return lo;
+        }
+        lo + self.next_u64() % (hi - lo + 1)
+    }
+
+    /// Random i64 in [lo, hi] inclusive.
+    fn range_i64(&mut self, lo: i64, hi: i64) -> i64 {
+        if lo >= hi {
+            return lo;
+        }
+        let span = (hi as i128 - lo as i128) as u64;
+        lo.wrapping_add((self.next_u64() % (span + 1)) as i64)
+    }
+
+    /// Random f64 in [lo, hi].
+    fn range_f64(&mut self, lo: f64, hi: f64) -> f64 {
+        if lo >= hi {
+            return lo;
+        }
+        let t = (self.next_u64() as f64) / (u64::MAX as f64);
+        lo + t * (hi - lo)
+    }
+
+    /// Random bool.
+    fn next_bool(&mut self) -> bool {
+        self.next_u64() & 1 == 0
+    }
+
+    /// Random usize in [0, n) (exclusive upper bound).
+    fn next_usize(&mut self, n: usize) -> usize {
+        if n == 0 {
+            return 0;
+        }
+        (self.next_u64() % n as u64) as usize
+    }
+}
+
+/// Derive a deterministic seed from an operation name and variant index.
+fn seed_for(operation_name: &str, variant_index: usize) -> u64 {
+    // Simple FNV-1a-ish hash of the name + index.
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in operation_name.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0100_0000_01b3);
+    }
+    h ^= variant_index as u64;
+    h = h.wrapping_mul(0x0100_0000_01b3);
+    h
+}
+
+const ALPHANUMERIC: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const BASE64_CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+pub fn generate(
+    model: &ServiceModel,
+    input_shape_id: &str,
+    overrides: &HashMap<String, Value>,
+    num_variants: usize,
+) -> Vec<TestVariant> {
+    let mut variants = Vec::new();
+
+    for i in 0..num_variants {
+        let seed = seed_for(input_shape_id, i);
+        let mut rng = Xorshift64::new(seed);
+
+        let input = random_value_for_shape(model, input_shape_id, overrides, &mut rng, 0);
+
+        variants.push(TestVariant {
+            name: format!("proptest_{}", i),
+            strategy: Strategy::Proptest,
+            input,
+            expectation: Expectation::Success,
+        });
+    }
+
+    variants
+}
+
+fn random_value_for_shape(
+    model: &ServiceModel,
+    shape_id: &str,
+    overrides: &HashMap<String, Value>,
+    rng: &mut Xorshift64,
+    depth: usize,
+) -> Value {
+    if depth > 8 {
+        return Value::Null;
+    }
+
+    if smithy::is_prelude_shape(shape_id) {
+        return random_prelude_value(shape_id, rng);
+    }
+
+    let shape = match model.shapes.get(shape_id) {
+        Some(s) => s,
+        None => return random_prelude_value(shape_id, rng),
+    };
+
+    random_value_for_shape_def(model, shape, overrides, rng, depth)
+}
+
+fn random_value_for_shape_def(
+    model: &ServiceModel,
+    shape: &smithy::Shape,
+    overrides: &HashMap<String, Value>,
+    rng: &mut Xorshift64,
+    depth: usize,
+) -> Value {
+    match &shape.shape_type {
+        ShapeType::Structure { members } => {
+            let mut obj = serde_json::Map::new();
+            for member in members {
+                // Always apply overrides.
+                if let Some(ov) = overrides.get(&member.name) {
+                    obj.insert(member.name.clone(), ov.clone());
+                    continue;
+                }
+
+                // Always include required fields; randomly include optional fields.
+                if member.required || rng.next_bool() {
+                    let val =
+                        random_value_for_shape(model, &member.target, overrides, rng, depth + 1);
+                    obj.insert(member.name.clone(), val);
+                }
+            }
+            Value::Object(obj)
+        }
+        ShapeType::List { member_target } => {
+            let len = rng.next_usize(6); // 0..5
+            let items: Vec<Value> = (0..len)
+                .map(|_| random_value_for_shape(model, member_target, overrides, rng, depth + 1))
+                .collect();
+            Value::Array(items)
+        }
+        ShapeType::Map {
+            key_target,
+            value_target,
+        } => {
+            let len = rng.next_usize(4); // 0..3
+            let mut obj = serde_json::Map::new();
+            for _ in 0..len {
+                let key = match random_value_for_shape(model, key_target, overrides, rng, depth + 1)
+                {
+                    Value::String(s) => s,
+                    other => other.to_string(),
+                };
+                let val = random_value_for_shape(model, value_target, overrides, rng, depth + 1);
+                obj.insert(key, val);
+            }
+            Value::Object(obj)
+        }
+        ShapeType::Union { members } => {
+            if members.is_empty() {
+                return Value::Object(serde_json::Map::new());
+            }
+            let idx = rng.next_usize(members.len());
+            let chosen = &members[idx];
+            let mut obj = serde_json::Map::new();
+            let val = random_value_for_shape(model, &chosen.target, overrides, rng, depth + 1);
+            obj.insert(chosen.name.clone(), val);
+            Value::Object(obj)
+        }
+        ShapeType::String { enum_values } => {
+            if let Some(values) = enum_values {
+                if !values.is_empty() {
+                    let idx = rng.next_usize(values.len());
+                    return Value::String(values[idx].value.clone());
+                }
+            }
+            random_string(&shape.traits, rng)
+        }
+        ShapeType::Enum { values } => {
+            if values.is_empty() {
+                return Value::String("test".to_string());
+            }
+            let idx = rng.next_usize(values.len());
+            Value::String(values[idx].value.clone())
+        }
+        ShapeType::IntEnum { values } => {
+            if values.is_empty() {
+                return Value::Number(0.into());
+            }
+            let idx = rng.next_usize(values.len());
+            Value::Number(values[idx].1.into())
+        }
+        ShapeType::Integer | ShapeType::Long => {
+            let lo = shape.traits.range_min.map(|v| v as i64).unwrap_or(0);
+            let hi = shape
+                .traits
+                .range_max
+                .map(|v| v as i64)
+                .unwrap_or(lo + 1000);
+            let val = rng.range_i64(lo, hi);
+            Value::Number(val.into())
+        }
+        ShapeType::Float | ShapeType::Double => {
+            let lo = shape.traits.range_min.unwrap_or(0.0);
+            let hi = shape.traits.range_max.unwrap_or(lo + 1000.0);
+            let val = rng.range_f64(lo, hi);
+            match serde_json::Number::from_f64(val) {
+                Some(n) => Value::Number(n),
+                None => Value::Number(serde_json::Number::from_f64(1.0).unwrap()),
+            }
+        }
+        ShapeType::Boolean => Value::Bool(rng.next_bool()),
+        ShapeType::Blob => {
+            // Random base64 string (4-24 chars, multiple of 4).
+            let groups = rng.range_u64(1, 6) as usize;
+            let len = groups * 4;
+            let s: String = (0..len)
+                .map(|_| {
+                    let idx = rng.next_usize(BASE64_CHARS.len());
+                    BASE64_CHARS[idx] as char
+                })
+                .collect();
+            Value::String(s)
+        }
+        ShapeType::Timestamp => {
+            // Random ISO8601 timestamp between 2020 and 2030.
+            let year = rng.range_u64(2020, 2030);
+            let month = rng.range_u64(1, 12);
+            let day = rng.range_u64(1, 28); // safe for all months
+            let hour = rng.range_u64(0, 23);
+            let minute = rng.range_u64(0, 59);
+            let second = rng.range_u64(0, 59);
+            Value::String(format!(
+                "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+                year, month, day, hour, minute, second
+            ))
+        }
+        _ => Value::Null,
+    }
+}
+
+/// Generate a random string respecting length constraints from traits.
+fn random_string(traits: &smithy::ShapeTraits, rng: &mut Xorshift64) -> Value {
+    let min_len = traits.length_min.unwrap_or(1) as usize;
+    let max_len = traits
+        .length_max
+        .map(|m| (m as usize).min(200))
+        .unwrap_or(min_len + 20);
+    let max_len = max_len.max(min_len);
+
+    let len = rng.range_u64(min_len as u64, max_len as u64) as usize;
+
+    let s: String = (0..len)
+        .map(|_| {
+            let idx = rng.next_usize(ALPHANUMERIC.len());
+            ALPHANUMERIC[idx] as char
+        })
+        .collect();
+
+    Value::String(s)
+}
+
+/// Generate a random value for a Smithy prelude type.
+fn random_prelude_value(shape_id: &str, rng: &mut Xorshift64) -> Value {
+    match shape_id {
+        "smithy.api#String" | "smithy.api#Document" => {
+            let len = rng.range_u64(1, 20) as usize;
+            let s: String = (0..len)
+                .map(|_| {
+                    let idx = rng.next_usize(ALPHANUMERIC.len());
+                    ALPHANUMERIC[idx] as char
+                })
+                .collect();
+            Value::String(s)
+        }
+        "smithy.api#Integer"
+        | "smithy.api#Short"
+        | "smithy.api#Byte"
+        | "smithy.api#PrimitiveInteger"
+        | "smithy.api#PrimitiveShort"
+        | "smithy.api#PrimitiveByte" => {
+            let val = rng.range_i64(0, 1000);
+            Value::Number(val.into())
+        }
+        "smithy.api#Long" | "smithy.api#BigInteger" | "smithy.api#PrimitiveLong" => {
+            let val = rng.range_i64(0, 100_000);
+            Value::Number(val.into())
+        }
+        "smithy.api#Float"
+        | "smithy.api#Double"
+        | "smithy.api#BigDecimal"
+        | "smithy.api#PrimitiveFloat"
+        | "smithy.api#PrimitiveDouble" => {
+            let val = rng.range_f64(0.0, 1000.0);
+            Value::Number(serde_json::Number::from_f64(val).unwrap_or_else(|| 1.into()))
+        }
+        "smithy.api#Boolean" | "smithy.api#PrimitiveBoolean" => Value::Bool(rng.next_bool()),
+        "smithy.api#Blob" => {
+            let groups = rng.range_u64(1, 6) as usize;
+            let len = groups * 4;
+            let s: String = (0..len)
+                .map(|_| {
+                    let idx = rng.next_usize(BASE64_CHARS.len());
+                    BASE64_CHARS[idx] as char
+                })
+                .collect();
+            Value::String(s)
+        }
+        "smithy.api#Timestamp" => {
+            let year = rng.range_u64(2020, 2030);
+            let month = rng.range_u64(1, 12);
+            let day = rng.range_u64(1, 28);
+            let hour = rng.range_u64(0, 23);
+            let minute = rng.range_u64(0, 59);
+            let second = rng.range_u64(0, 59);
+            Value::String(format!(
+                "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+                year, month, day, hour, minute, second
+            ))
+        }
+        "smithy.api#Unit" => Value::Object(serde_json::Map::new()),
+        _ => {
+            let len = rng.range_u64(1, 10) as usize;
+            let s: String = (0..len)
+                .map(|_| {
+                    let idx = rng.next_usize(ALPHANUMERIC.len());
+                    ALPHANUMERIC[idx] as char
+                })
+                .collect();
+            Value::String(s)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xorshift64_is_deterministic() {
+        let mut a = Xorshift64::new(42);
+        let mut b = Xorshift64::new(42);
+        for _ in 0..100 {
+            assert_eq!(a.next_u64(), b.next_u64());
+        }
+    }
+
+    #[test]
+    fn xorshift64_range_stays_in_bounds() {
+        let mut rng = Xorshift64::new(123);
+        for _ in 0..1000 {
+            let v = rng.range_u64(5, 10);
+            assert!(v >= 5 && v <= 10);
+        }
+        for _ in 0..1000 {
+            let v = rng.range_i64(-10, 10);
+            assert!(v >= -10 && v <= 10);
+        }
+        for _ in 0..1000 {
+            let v = rng.range_f64(0.0, 1.0);
+            assert!(v >= 0.0 && v <= 1.0);
+        }
+    }
+
+    #[test]
+    fn seed_for_is_deterministic() {
+        let a = seed_for("CreateQueue", 0);
+        let b = seed_for("CreateQueue", 0);
+        assert_eq!(a, b);
+
+        let c = seed_for("CreateQueue", 1);
+        assert_ne!(a, c);
+
+        let d = seed_for("SendMessage", 0);
+        assert_ne!(a, d);
+    }
+
+    #[test]
+    fn generate_produces_requested_count() {
+        let model = ServiceModel {
+            service_name: "test".to_string(),
+            operations: vec![],
+            shapes: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "test#Input".to_string(),
+                    smithy::Shape {
+                        shape_id: "test#Input".to_string(),
+                        shape_type: ShapeType::Structure {
+                            members: vec![smithy::Member {
+                                name: "Name".to_string(),
+                                target: "smithy.api#String".to_string(),
+                                required: true,
+                                traits: smithy::ShapeTraits::default(),
+                            }],
+                        },
+                        traits: smithy::ShapeTraits::default(),
+                    },
+                );
+                m
+            },
+        };
+
+        let overrides = HashMap::new();
+        let variants = generate(&model, "test#Input", &overrides, 10);
+        assert_eq!(variants.len(), 10);
+
+        // All should have the Proptest strategy.
+        for v in &variants {
+            assert_eq!(v.strategy, Strategy::Proptest);
+        }
+
+        // All should include the required "Name" field.
+        for v in &variants {
+            assert!(v.input.get("Name").is_some());
+        }
+    }
+
+    #[test]
+    fn generate_respects_overrides() {
+        let model = ServiceModel {
+            service_name: "test".to_string(),
+            operations: vec![],
+            shapes: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "test#Input".to_string(),
+                    smithy::Shape {
+                        shape_id: "test#Input".to_string(),
+                        shape_type: ShapeType::Structure {
+                            members: vec![
+                                smithy::Member {
+                                    name: "Name".to_string(),
+                                    target: "smithy.api#String".to_string(),
+                                    required: true,
+                                    traits: smithy::ShapeTraits::default(),
+                                },
+                                smithy::Member {
+                                    name: "Count".to_string(),
+                                    target: "smithy.api#Integer".to_string(),
+                                    required: true,
+                                    traits: smithy::ShapeTraits::default(),
+                                },
+                            ],
+                        },
+                        traits: smithy::ShapeTraits::default(),
+                    },
+                );
+                m
+            },
+        };
+
+        let mut overrides = HashMap::new();
+        overrides.insert("Name".to_string(), Value::String("fixed".to_string()));
+
+        let variants = generate(&model, "test#Input", &overrides, 5);
+        for v in &variants {
+            assert_eq!(v.input.get("Name").unwrap(), "fixed");
+        }
+    }
+
+    #[test]
+    fn generate_is_deterministic() {
+        let model = ServiceModel {
+            service_name: "test".to_string(),
+            operations: vec![],
+            shapes: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "test#Input".to_string(),
+                    smithy::Shape {
+                        shape_id: "test#Input".to_string(),
+                        shape_type: ShapeType::Structure {
+                            members: vec![smithy::Member {
+                                name: "Name".to_string(),
+                                target: "smithy.api#String".to_string(),
+                                required: true,
+                                traits: smithy::ShapeTraits::default(),
+                            }],
+                        },
+                        traits: smithy::ShapeTraits::default(),
+                    },
+                );
+                m
+            },
+        };
+
+        let overrides = HashMap::new();
+        let a = generate(&model, "test#Input", &overrides, 5);
+        let b = generate(&model, "test#Input", &overrides, 5);
+
+        for (va, vb) in a.iter().zip(b.iter()) {
+            assert_eq!(va.input, vb.input);
+        }
+    }
+}

--- a/crates/fakecloud-conformance/src/lib.rs
+++ b/crates/fakecloud-conformance/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+pub mod audit;
 pub mod checksum;
 pub mod generators;
 pub mod probe;

--- a/crates/fakecloud-conformance/src/main.rs
+++ b/crates/fakecloud-conformance/src/main.rs
@@ -69,8 +69,13 @@ fn main() {
             endpoint,
         } => cmd_run(&cli.models_dir, services, &format, endpoint),
         CliCommand::Audit => {
-            eprintln!("Level 2 audit not yet implemented");
-            std::process::exit(1);
+            let project_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join("..");
+            let pass = fakecloud_conformance::audit::run_audit(&project_root);
+            if !pass {
+                std::process::exit(1);
+            }
         }
     }
 }

--- a/crates/fakecloud-conformance/tests/cloudformation.rs
+++ b/crates/fakecloud-conformance/tests/cloudformation.rs
@@ -1,0 +1,248 @@
+mod helpers;
+
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+const SIMPLE_TEMPLATE: &str = r#"{
+    "Resources": {
+        "MyQueue": {
+            "Type": "AWS::SQS::Queue",
+            "Properties": {
+                "QueueName": "cf-conf-queue"
+            }
+        }
+    }
+}"#;
+
+// ---------------------------------------------------------------------------
+// Stack lifecycle
+// ---------------------------------------------------------------------------
+
+#[test_action("cloudformation", "CreateStack", checksum = "796b3bcd")]
+#[test_action("cloudformation", "DescribeStacks", checksum = "ae6b90a4")]
+#[test_action("cloudformation", "DeleteStack", checksum = "de60ab3d")]
+#[tokio::test]
+async fn cloudformation_create_describe_delete_stack() {
+    let server = TestServer::start().await;
+    let client = server.cloudformation_client().await;
+
+    let result = client
+        .create_stack()
+        .stack_name("conf-stack")
+        .template_body(SIMPLE_TEMPLATE)
+        .send()
+        .await
+        .unwrap();
+    assert!(result.stack_id().is_some());
+
+    let desc = client
+        .describe_stacks()
+        .stack_name("conf-stack")
+        .send()
+        .await
+        .unwrap();
+    let stacks = desc.stacks();
+    assert_eq!(stacks.len(), 1);
+    assert_eq!(stacks[0].stack_name(), Some("conf-stack"));
+    assert_eq!(
+        stacks[0].stack_status().map(|s| s.as_str()),
+        Some("CREATE_COMPLETE")
+    );
+
+    client
+        .delete_stack()
+        .stack_name("conf-stack")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudformation", "ListStacks", checksum = "0462876a")]
+#[tokio::test]
+async fn cloudformation_list_stacks() {
+    let server = TestServer::start().await;
+    let client = server.cloudformation_client().await;
+
+    client
+        .create_stack()
+        .stack_name("list-stack-a")
+        .template_body(SIMPLE_TEMPLATE)
+        .send()
+        .await
+        .unwrap();
+
+    let template2 = r#"{
+        "Resources": {
+            "Q2": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-conf-queue-2" }
+            }
+        }
+    }"#;
+
+    client
+        .create_stack()
+        .stack_name("list-stack-b")
+        .template_body(template2)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_stacks().send().await.unwrap();
+    assert!(resp.stack_summaries().len() >= 2);
+}
+
+// ---------------------------------------------------------------------------
+// Stack resources
+// ---------------------------------------------------------------------------
+
+#[test_action("cloudformation", "ListStackResources", checksum = "471df8aa")]
+#[tokio::test]
+async fn cloudformation_list_stack_resources() {
+    let server = TestServer::start().await;
+    let client = server.cloudformation_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "Queue1": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-res-q1" }
+            },
+            "Queue2": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-res-q2" }
+            }
+        }
+    }"#;
+
+    client
+        .create_stack()
+        .stack_name("resources-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .list_stack_resources()
+        .stack_name("resources-stack")
+        .send()
+        .await
+        .unwrap();
+
+    let summaries = result.stack_resource_summaries();
+    assert_eq!(summaries.len(), 2);
+
+    let logical_ids: Vec<&str> = summaries
+        .iter()
+        .filter_map(|r| r.logical_resource_id())
+        .collect();
+    assert!(logical_ids.contains(&"Queue1"));
+    assert!(logical_ids.contains(&"Queue2"));
+}
+
+#[test_action("cloudformation", "DescribeStackResources", checksum = "74d268a4")]
+#[tokio::test]
+async fn cloudformation_describe_stack_resources() {
+    let server = TestServer::start().await;
+    let client = server.cloudformation_client().await;
+
+    client
+        .create_stack()
+        .stack_name("dsr-stack")
+        .template_body(SIMPLE_TEMPLATE)
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .describe_stack_resources()
+        .stack_name("dsr-stack")
+        .send()
+        .await
+        .unwrap();
+
+    let resources = result.stack_resources();
+    assert_eq!(resources.len(), 1);
+    assert_eq!(resources[0].logical_resource_id(), Some("MyQueue"));
+    assert_eq!(resources[0].resource_type(), Some("AWS::SQS::Queue"));
+}
+
+// ---------------------------------------------------------------------------
+// UpdateStack
+// ---------------------------------------------------------------------------
+
+#[test_action("cloudformation", "UpdateStack", checksum = "46613ba0")]
+#[tokio::test]
+async fn cloudformation_update_stack() {
+    let server = TestServer::start().await;
+    let client = server.cloudformation_client().await;
+
+    client
+        .create_stack()
+        .stack_name("update-stack")
+        .template_body(SIMPLE_TEMPLATE)
+        .send()
+        .await
+        .unwrap();
+
+    let template_v2 = r#"{
+        "Resources": {
+            "NewQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "cf-conf-queue-updated" }
+            }
+        }
+    }"#;
+
+    client
+        .update_stack()
+        .stack_name("update-stack")
+        .template_body(template_v2)
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_stacks()
+        .stack_name("update-stack")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        desc.stacks()[0].stack_status().map(|s| s.as_str()),
+        Some("UPDATE_COMPLETE")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// GetTemplate
+// ---------------------------------------------------------------------------
+
+#[test_action("cloudformation", "GetTemplate", checksum = "61885956")]
+#[tokio::test]
+async fn cloudformation_get_template() {
+    let server = TestServer::start().await;
+    let client = server.cloudformation_client().await;
+
+    let template = r#"{"Resources":{"Q":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"cf-gt-queue"}}}}"#;
+
+    client
+        .create_stack()
+        .stack_name("gt-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .get_template()
+        .stack_name("gt-stack")
+        .send()
+        .await
+        .unwrap();
+
+    let body = result.template_body().unwrap();
+    assert!(body.contains("AWS::SQS::Queue"));
+    assert!(body.contains("cf-gt-queue"));
+}

--- a/crates/fakecloud-conformance/tests/dynamodb.rs
+++ b/crates/fakecloud-conformance/tests/dynamodb.rs
@@ -1,0 +1,559 @@
+mod helpers;
+
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
+    ProvisionedThroughput, PutRequest, ScalarAttributeType, Tag, WriteRequest,
+};
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Table lifecycle
+// ---------------------------------------------------------------------------
+
+#[test_action("dynamodb", "CreateTable", checksum = "871827e1")]
+#[test_action("dynamodb", "DescribeTable", checksum = "543aeed6")]
+#[test_action("dynamodb", "DeleteTable", checksum = "609d7442")]
+#[tokio::test]
+async fn dynamodb_create_describe_delete_table() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("ConfTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_table()
+        .table_name("ConfTable")
+        .send()
+        .await
+        .unwrap();
+    let table = resp.table().unwrap();
+    assert_eq!(table.table_name().unwrap(), "ConfTable");
+    assert_eq!(table.table_status().unwrap().as_str(), "ACTIVE");
+
+    client
+        .delete_table()
+        .table_name("ConfTable")
+        .send()
+        .await
+        .unwrap();
+
+    let result = client.describe_table().table_name("ConfTable").send().await;
+    assert!(result.is_err());
+}
+
+#[test_action("dynamodb", "ListTables", checksum = "9871be61")]
+#[tokio::test]
+async fn dynamodb_list_tables() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("ListMe")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_tables().send().await.unwrap();
+    assert!(resp.table_names().contains(&"ListMe".to_string()));
+}
+
+#[test_action("dynamodb", "UpdateTable", checksum = "5862b42d")]
+#[tokio::test]
+async fn dynamodb_update_table() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("UpdTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .provisioned_throughput(
+            ProvisionedThroughput::builder()
+                .read_capacity_units(5)
+                .write_capacity_units(5)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_table()
+        .table_name("UpdTable")
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_table()
+        .table_name("UpdTable")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.table().is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Item operations
+// ---------------------------------------------------------------------------
+
+#[test_action("dynamodb", "PutItem", checksum = "65656c32")]
+#[test_action("dynamodb", "GetItem", checksum = "bfb4efce")]
+#[test_action("dynamodb", "DeleteItem", checksum = "1f2be9ef")]
+#[tokio::test]
+async fn dynamodb_put_get_delete_item() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("Items")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_item()
+        .table_name("Items")
+        .item("id", AttributeValue::S("item1".to_string()))
+        .item("name", AttributeValue::S("Widget".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_item()
+        .table_name("Items")
+        .key("id", AttributeValue::S("item1".to_string()))
+        .send()
+        .await
+        .unwrap();
+    let item = resp.item().unwrap();
+    assert_eq!(item.get("name").unwrap().as_s().unwrap(), "Widget");
+
+    client
+        .delete_item()
+        .table_name("Items")
+        .key("id", AttributeValue::S("item1".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_item()
+        .table_name("Items")
+        .key("id", AttributeValue::S("item1".to_string()))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.item().is_none());
+}
+
+#[test_action("dynamodb", "UpdateItem", checksum = "d29893e3")]
+#[tokio::test]
+async fn dynamodb_update_item() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("UpdItems")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_item()
+        .table_name("UpdItems")
+        .item("id", AttributeValue::S("u1".to_string()))
+        .item("count", AttributeValue::N("10".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_item()
+        .table_name("UpdItems")
+        .key("id", AttributeValue::S("u1".to_string()))
+        .update_expression("SET #c = :newval")
+        .expression_attribute_names("#c", "count")
+        .expression_attribute_values(":newval", AttributeValue::N("20".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_item()
+        .table_name("UpdItems")
+        .key("id", AttributeValue::S("u1".to_string()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.item().unwrap().get("count").unwrap().as_n().unwrap(),
+        "20"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Query and Scan
+// ---------------------------------------------------------------------------
+
+#[test_action("dynamodb", "Query", checksum = "0cd83e93")]
+#[tokio::test]
+async fn dynamodb_query() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("Orders")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("userId")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("orderId")
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("userId")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("orderId")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    for i in 1..=3 {
+        client
+            .put_item()
+            .table_name("Orders")
+            .item("userId", AttributeValue::S("user1".to_string()))
+            .item("orderId", AttributeValue::S(format!("order{i}")))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let resp = client
+        .query()
+        .table_name("Orders")
+        .key_condition_expression("userId = :uid")
+        .expression_attribute_values(":uid", AttributeValue::S("user1".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.count(), 3);
+}
+
+#[test_action("dynamodb", "Scan", checksum = "282511c3")]
+#[tokio::test]
+async fn dynamodb_scan() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("ScanTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    for i in 1..=5 {
+        client
+            .put_item()
+            .table_name("ScanTable")
+            .item("id", AttributeValue::S(format!("item{i}")))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let resp = client.scan().table_name("ScanTable").send().await.unwrap();
+    assert_eq!(resp.count(), 5);
+}
+
+// ---------------------------------------------------------------------------
+// Batch operations
+// ---------------------------------------------------------------------------
+
+#[test_action("dynamodb", "BatchWriteItem", checksum = "20b0040e")]
+#[test_action("dynamodb", "BatchGetItem", checksum = "5eb50c02")]
+#[tokio::test]
+async fn dynamodb_batch_write_and_get() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("BatchTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let mut item1 = HashMap::new();
+    item1.insert("id".to_string(), AttributeValue::S("b1".to_string()));
+    item1.insert("data".to_string(), AttributeValue::S("first".to_string()));
+    let mut item2 = HashMap::new();
+    item2.insert("id".to_string(), AttributeValue::S("b2".to_string()));
+    item2.insert("data".to_string(), AttributeValue::S("second".to_string()));
+
+    let mut write_items = HashMap::new();
+    write_items.insert(
+        "BatchTable".to_string(),
+        vec![
+            WriteRequest::builder()
+                .put_request(PutRequest::builder().set_item(Some(item1)).build().unwrap())
+                .build(),
+            WriteRequest::builder()
+                .put_request(PutRequest::builder().set_item(Some(item2)).build().unwrap())
+                .build(),
+        ],
+    );
+
+    client
+        .batch_write_item()
+        .set_request_items(Some(write_items))
+        .send()
+        .await
+        .unwrap();
+
+    let mut key1 = HashMap::new();
+    key1.insert("id".to_string(), AttributeValue::S("b1".to_string()));
+    let mut key2 = HashMap::new();
+    key2.insert("id".to_string(), AttributeValue::S("b2".to_string()));
+
+    let mut keys_to_get = HashMap::new();
+    keys_to_get.insert(
+        "BatchTable".to_string(),
+        aws_sdk_dynamodb::types::KeysAndAttributes::builder()
+            .keys(key1)
+            .keys(key2)
+            .build()
+            .unwrap(),
+    );
+
+    let resp = client
+        .batch_get_item()
+        .set_request_items(Some(keys_to_get))
+        .send()
+        .await
+        .unwrap();
+
+    let responses = resp.responses().unwrap();
+    let batch_results = responses.get("BatchTable").unwrap();
+    assert_eq!(batch_results.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Tags
+// ---------------------------------------------------------------------------
+
+#[test_action("dynamodb", "TagResource", checksum = "5a731507")]
+#[test_action("dynamodb", "UntagResource", checksum = "0438d51b")]
+#[test_action("dynamodb", "ListTagsOfResource", checksum = "e42e6834")]
+#[tokio::test]
+async fn dynamodb_tag_untag_list_tags() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    let create_resp = client
+        .create_table()
+        .table_name("TagTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let arn = create_resp
+        .table_description()
+        .unwrap()
+        .table_arn()
+        .unwrap()
+        .to_string();
+
+    client
+        .tag_resource()
+        .resource_arn(&arn)
+        .tags(Tag::builder().key("env").value("test").build().unwrap())
+        .tags(
+            Tag::builder()
+                .key("project")
+                .value("conformance")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_tags_of_resource()
+        .resource_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.tags().len(), 2);
+
+    client
+        .untag_resource()
+        .resource_arn(&arn)
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_tags_of_resource()
+        .resource_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.tags().len(), 1);
+    assert_eq!(resp.tags()[0].key(), "project");
+}

--- a/crates/fakecloud-conformance/tests/eventbridge.rs
+++ b/crates/fakecloud-conformance/tests/eventbridge.rs
@@ -1,0 +1,1157 @@
+mod helpers;
+
+use aws_sdk_eventbridge::types::{
+    ConnectionAuthorizationType, CreateConnectionApiKeyAuthRequestParameters,
+    CreateConnectionAuthRequestParameters, PutEventsRequestEntry, RuleState, Tag, Target,
+};
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+// ---------------------------------------------------------------------------
+// Event bus lifecycle
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "CreateEventBus", checksum = "1f5f93fa")]
+#[tokio::test]
+async fn eb_create_event_bus() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let resp = client
+        .create_event_bus()
+        .name("conf-bus")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.event_bus_arn().unwrap().contains("conf-bus"));
+}
+
+#[test_action("events", "DeleteEventBus", checksum = "4f4f5954")]
+#[tokio::test]
+async fn eb_delete_event_bus() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .create_event_bus()
+        .name("del-bus")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_event_bus()
+        .name("del-bus")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_event_buses().send().await.unwrap();
+    assert!(!resp
+        .event_buses()
+        .iter()
+        .any(|b| b.name().unwrap() == "del-bus"));
+}
+
+#[test_action("events", "ListEventBuses", checksum = "3b53e660")]
+#[tokio::test]
+async fn eb_list_event_buses() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let resp = client.list_event_buses().send().await.unwrap();
+    assert!(resp
+        .event_buses()
+        .iter()
+        .any(|b| b.name().unwrap() == "default"));
+}
+
+#[test_action("events", "DescribeEventBus", checksum = "7decb34d")]
+#[tokio::test]
+async fn eb_describe_event_bus() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let resp = client
+        .describe_event_bus()
+        .name("default")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.name().unwrap(), "default");
+}
+
+// ---------------------------------------------------------------------------
+// Rules
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "PutRule", checksum = "f481dcfa")]
+#[tokio::test]
+async fn eb_put_rule() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let resp = client
+        .put_rule()
+        .name("conf-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.rule_arn().unwrap().contains("conf-rule"));
+}
+
+#[test_action("events", "DeleteRule", checksum = "dd9dec42")]
+#[tokio::test]
+async fn eb_delete_rule() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_rule()
+        .name("del-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    client.delete_rule().name("del-rule").send().await.unwrap();
+
+    let resp = client.list_rules().send().await.unwrap();
+    assert!(resp.rules().is_empty());
+}
+
+#[test_action("events", "ListRules", checksum = "faa0cb02")]
+#[tokio::test]
+async fn eb_list_rules() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_rule()
+        .name("list-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_rules().send().await.unwrap();
+    assert_eq!(resp.rules().len(), 1);
+}
+
+#[test_action("events", "DescribeRule", checksum = "558c1b1c")]
+#[tokio::test]
+async fn eb_describe_rule() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_rule()
+        .name("desc-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_rule()
+        .name("desc-rule")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.name().unwrap(), "desc-rule");
+}
+
+#[test_action("events", "EnableRule", checksum = "6839c932")]
+#[tokio::test]
+async fn eb_enable_rule() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_rule()
+        .name("enable-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .state(RuleState::Disabled)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .enable_rule()
+        .name("enable-rule")
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_rule()
+        .name("enable-rule")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desc.state().unwrap(), &RuleState::Enabled);
+}
+
+#[test_action("events", "DisableRule", checksum = "866d8afa")]
+#[tokio::test]
+async fn eb_disable_rule() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_rule()
+        .name("disable-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .state(RuleState::Enabled)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .disable_rule()
+        .name("disable-rule")
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_rule()
+        .name("disable-rule")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desc.state().unwrap(), &RuleState::Disabled);
+}
+
+// ---------------------------------------------------------------------------
+// Targets
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "PutTargets", checksum = "745ff520")]
+#[tokio::test]
+async fn eb_put_targets() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_rule()
+        .name("tgt-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_targets()
+        .rule("tgt-rule")
+        .targets(
+            Target::builder()
+                .id("t1")
+                .arn("arn:aws:sqs:us-east-1:123456789012:q")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_targets_by_rule()
+        .rule("tgt-rule")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.targets().len(), 1);
+}
+
+#[test_action("events", "RemoveTargets", checksum = "2a466c19")]
+#[tokio::test]
+async fn eb_remove_targets() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_rule()
+        .name("rmtgt-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_targets()
+        .rule("rmtgt-rule")
+        .targets(
+            Target::builder()
+                .id("t1")
+                .arn("arn:aws:sqs:us-east-1:123456789012:q")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .remove_targets()
+        .rule("rmtgt-rule")
+        .ids("t1")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_targets_by_rule()
+        .rule("rmtgt-rule")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.targets().is_empty());
+}
+
+#[test_action("events", "ListTargetsByRule", checksum = "abb47469")]
+#[tokio::test]
+async fn eb_list_targets_by_rule() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_rule()
+        .name("ltbr-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_targets_by_rule()
+        .rule("ltbr-rule")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.targets().is_empty());
+}
+
+#[test_action("events", "ListRuleNamesByTarget", checksum = "886f2367")]
+#[tokio::test]
+async fn eb_list_rule_names_by_target() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_rule()
+        .name("lrnbt-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_targets()
+        .rule("lrnbt-rule")
+        .targets(
+            Target::builder()
+                .id("t1")
+                .arn("arn:aws:sqs:us-east-1:123456789012:target-q")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_rule_names_by_target()
+        .target_arn("arn:aws:sqs:us-east-1:123456789012:target-q")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.rule_names().iter().any(|n| n == "lrnbt-rule"));
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "PutEvents", checksum = "3699246e")]
+#[tokio::test]
+async fn eb_put_events() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let resp = client
+        .put_events()
+        .entries(
+            PutEventsRequestEntry::builder()
+                .source("test.app")
+                .detail_type("TestEvent")
+                .detail(r#"{"key": "val"}"#)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.failed_entry_count(), 0);
+    assert_eq!(resp.entries().len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Permissions
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "PutPermission", checksum = "0eb5fb8a")]
+#[tokio::test]
+async fn eb_put_permission() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_permission()
+        .action("events:PutEvents")
+        .principal("123456789012")
+        .statement_id("allow-account")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("events", "RemovePermission", checksum = "2bb6a3a1")]
+#[tokio::test]
+async fn eb_remove_permission() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .put_permission()
+        .action("events:PutEvents")
+        .principal("123456789012")
+        .statement_id("rm-perm")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .remove_permission()
+        .statement_id("rm-perm")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Tags
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "TagResource", checksum = "34168c66")]
+#[tokio::test]
+async fn eb_tag_resource() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let rule = client
+        .put_rule()
+        .name("tag-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+    let rule_arn = rule.rule_arn().unwrap();
+
+    client
+        .tag_resource()
+        .resource_arn(rule_arn)
+        .tags(Tag::builder().key("env").value("test").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(rule_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(tags.tags().len(), 1);
+}
+
+#[test_action("events", "UntagResource", checksum = "ca0e5fb0")]
+#[tokio::test]
+async fn eb_untag_resource() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let rule = client
+        .put_rule()
+        .name("untag-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+    let rule_arn = rule.rule_arn().unwrap();
+
+    client
+        .tag_resource()
+        .resource_arn(rule_arn)
+        .tags(Tag::builder().key("env").value("test").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .untag_resource()
+        .resource_arn(rule_arn)
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(rule_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags.tags().is_empty());
+}
+
+#[test_action("events", "ListTagsForResource", checksum = "d997c3ae")]
+#[tokio::test]
+async fn eb_list_tags_for_resource() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let rule = client
+        .put_rule()
+        .name("listtags-rule")
+        .event_pattern(r#"{"source": ["test"]}"#)
+        .send()
+        .await
+        .unwrap();
+    let rule_arn = rule.rule_arn().unwrap();
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(rule_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags.tags().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Archives
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "CreateArchive", checksum = "dcfb1a34")]
+#[tokio::test]
+async fn eb_create_archive() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let resp = client
+        .create_archive()
+        .archive_name("conf-archive")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.archive_arn().unwrap().contains("conf-archive"));
+}
+
+#[test_action("events", "DescribeArchive", checksum = "cc79ef20")]
+#[tokio::test]
+async fn eb_describe_archive() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .create_archive()
+        .archive_name("desc-archive")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_archive()
+        .archive_name("desc-archive")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.archive_name().unwrap(), "desc-archive");
+}
+
+#[test_action("events", "ListArchives", checksum = "fc001f2e")]
+#[tokio::test]
+async fn eb_list_archives() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .create_archive()
+        .archive_name("list-archive")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_archives().send().await.unwrap();
+    assert!(!resp.archives().is_empty());
+}
+
+#[test_action("events", "UpdateArchive", checksum = "d3a52d4a")]
+#[tokio::test]
+async fn eb_update_archive() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .create_archive()
+        .archive_name("upd-archive")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_archive()
+        .archive_name("upd-archive")
+        .description("Updated")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("events", "DeleteArchive", checksum = "4616ab55")]
+#[tokio::test]
+async fn eb_delete_archive() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .create_archive()
+        .archive_name("del-archive")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_archive()
+        .archive_name("del-archive")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_archives().send().await.unwrap();
+    assert!(!resp
+        .archives()
+        .iter()
+        .any(|a| a.archive_name().unwrap() == "del-archive"));
+}
+
+// ---------------------------------------------------------------------------
+// Connections
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "CreateConnection", checksum = "6f55e4ab")]
+#[tokio::test]
+async fn eb_create_connection() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let auth = CreateConnectionAuthRequestParameters::builder()
+        .api_key_auth_parameters(
+            CreateConnectionApiKeyAuthRequestParameters::builder()
+                .api_key_name("x-api-key")
+                .api_key_value("secret")
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    let resp = client
+        .create_connection()
+        .name("conf-conn")
+        .authorization_type(ConnectionAuthorizationType::ApiKey)
+        .auth_parameters(auth)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.connection_arn().unwrap().contains("conf-conn"));
+}
+
+#[test_action("events", "DescribeConnection", checksum = "241e50be")]
+#[tokio::test]
+async fn eb_describe_connection() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let auth = CreateConnectionAuthRequestParameters::builder()
+        .api_key_auth_parameters(
+            CreateConnectionApiKeyAuthRequestParameters::builder()
+                .api_key_name("x-api-key")
+                .api_key_value("secret")
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    client
+        .create_connection()
+        .name("desc-conn")
+        .authorization_type(ConnectionAuthorizationType::ApiKey)
+        .auth_parameters(auth)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_connection()
+        .name("desc-conn")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.name().unwrap(), "desc-conn");
+}
+
+#[test_action("events", "ListConnections", checksum = "35082a67")]
+#[tokio::test]
+async fn eb_list_connections() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let resp = client.list_connections().send().await.unwrap();
+    let _ = resp.connections();
+}
+
+#[test_action("events", "UpdateConnection", checksum = "4783b1fa")]
+#[tokio::test]
+async fn eb_update_connection() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let auth = CreateConnectionAuthRequestParameters::builder()
+        .api_key_auth_parameters(
+            CreateConnectionApiKeyAuthRequestParameters::builder()
+                .api_key_name("x-api-key")
+                .api_key_value("secret")
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    client
+        .create_connection()
+        .name("upd-conn")
+        .authorization_type(ConnectionAuthorizationType::ApiKey)
+        .auth_parameters(auth)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_connection()
+        .name("upd-conn")
+        .description("Updated connection")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("events", "DeleteConnection", checksum = "ad426e07")]
+#[tokio::test]
+async fn eb_delete_connection() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let auth = CreateConnectionAuthRequestParameters::builder()
+        .api_key_auth_parameters(
+            CreateConnectionApiKeyAuthRequestParameters::builder()
+                .api_key_name("x-api-key")
+                .api_key_value("secret")
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    client
+        .create_connection()
+        .name("del-conn")
+        .authorization_type(ConnectionAuthorizationType::ApiKey)
+        .auth_parameters(auth)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_connection()
+        .name("del-conn")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// API Destinations
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "CreateApiDestination", checksum = "590a9c4a")]
+#[tokio::test]
+async fn eb_create_api_destination() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    // Need a connection first
+    let auth = CreateConnectionAuthRequestParameters::builder()
+        .api_key_auth_parameters(
+            CreateConnectionApiKeyAuthRequestParameters::builder()
+                .api_key_name("x-api-key")
+                .api_key_value("secret")
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    let conn = client
+        .create_connection()
+        .name("apidest-conn")
+        .authorization_type(ConnectionAuthorizationType::ApiKey)
+        .auth_parameters(auth)
+        .send()
+        .await
+        .unwrap();
+    let conn_arn = conn.connection_arn().unwrap();
+
+    let resp = client
+        .create_api_destination()
+        .name("conf-apidest")
+        .connection_arn(conn_arn)
+        .invocation_endpoint("https://example.com/webhook")
+        .http_method(aws_sdk_eventbridge::types::ApiDestinationHttpMethod::Post)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.api_destination_arn().unwrap().contains("conf-apidest"));
+}
+
+#[test_action("events", "DescribeApiDestination", checksum = "f41acf9f")]
+#[tokio::test]
+async fn eb_describe_api_destination() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let auth = CreateConnectionAuthRequestParameters::builder()
+        .api_key_auth_parameters(
+            CreateConnectionApiKeyAuthRequestParameters::builder()
+                .api_key_name("x-api-key")
+                .api_key_value("secret")
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    let conn = client
+        .create_connection()
+        .name("descad-conn")
+        .authorization_type(ConnectionAuthorizationType::ApiKey)
+        .auth_parameters(auth)
+        .send()
+        .await
+        .unwrap();
+    let conn_arn = conn.connection_arn().unwrap();
+
+    client
+        .create_api_destination()
+        .name("desc-apidest")
+        .connection_arn(conn_arn)
+        .invocation_endpoint("https://example.com/webhook")
+        .http_method(aws_sdk_eventbridge::types::ApiDestinationHttpMethod::Post)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_api_destination()
+        .name("desc-apidest")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.name().unwrap(), "desc-apidest");
+}
+
+#[test_action("events", "ListApiDestinations", checksum = "f0dcb4f5")]
+#[tokio::test]
+async fn eb_list_api_destinations() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let resp = client.list_api_destinations().send().await.unwrap();
+    let _ = resp.api_destinations();
+}
+
+#[test_action("events", "UpdateApiDestination", checksum = "f2e3330b")]
+#[tokio::test]
+async fn eb_update_api_destination() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let auth = CreateConnectionAuthRequestParameters::builder()
+        .api_key_auth_parameters(
+            CreateConnectionApiKeyAuthRequestParameters::builder()
+                .api_key_name("x-api-key")
+                .api_key_value("secret")
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    let conn = client
+        .create_connection()
+        .name("updad-conn")
+        .authorization_type(ConnectionAuthorizationType::ApiKey)
+        .auth_parameters(auth)
+        .send()
+        .await
+        .unwrap();
+    let conn_arn = conn.connection_arn().unwrap();
+
+    client
+        .create_api_destination()
+        .name("upd-apidest")
+        .connection_arn(conn_arn)
+        .invocation_endpoint("https://example.com/webhook")
+        .http_method(aws_sdk_eventbridge::types::ApiDestinationHttpMethod::Post)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_api_destination()
+        .name("upd-apidest")
+        .description("Updated")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("events", "DeleteApiDestination", checksum = "7e517bd8")]
+#[tokio::test]
+async fn eb_delete_api_destination() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let auth = CreateConnectionAuthRequestParameters::builder()
+        .api_key_auth_parameters(
+            CreateConnectionApiKeyAuthRequestParameters::builder()
+                .api_key_name("x-api-key")
+                .api_key_value("secret")
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    let conn = client
+        .create_connection()
+        .name("delad-conn")
+        .authorization_type(ConnectionAuthorizationType::ApiKey)
+        .auth_parameters(auth)
+        .send()
+        .await
+        .unwrap();
+    let conn_arn = conn.connection_arn().unwrap();
+
+    client
+        .create_api_destination()
+        .name("del-apidest")
+        .connection_arn(conn_arn)
+        .invocation_endpoint("https://example.com/webhook")
+        .http_method(aws_sdk_eventbridge::types::ApiDestinationHttpMethod::Post)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_api_destination()
+        .name("del-apidest")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Replays
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "StartReplay", checksum = "0ef23715")]
+#[tokio::test]
+async fn eb_start_replay() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    // Need an archive first
+    client
+        .create_archive()
+        .archive_name("replay-archive")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .send()
+        .await
+        .unwrap();
+
+    let now = aws_sdk_eventbridge::primitives::DateTime::from_secs(1700000000);
+    let earlier = aws_sdk_eventbridge::primitives::DateTime::from_secs(1699990000);
+
+    let resp = client
+        .start_replay()
+        .replay_name("conf-replay")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .destination(
+            aws_sdk_eventbridge::types::ReplayDestination::builder()
+                .arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+                .build()
+                .unwrap(),
+        )
+        .event_start_time(earlier)
+        .event_end_time(now)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.replay_arn().is_some());
+}
+
+#[test_action("events", "DescribeReplay", checksum = "0470965f")]
+#[tokio::test]
+async fn eb_describe_replay() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .create_archive()
+        .archive_name("descrep-archive")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .send()
+        .await
+        .unwrap();
+
+    let now = aws_sdk_eventbridge::primitives::DateTime::from_secs(1700000000);
+    let earlier = aws_sdk_eventbridge::primitives::DateTime::from_secs(1699990000);
+
+    client
+        .start_replay()
+        .replay_name("desc-replay")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .destination(
+            aws_sdk_eventbridge::types::ReplayDestination::builder()
+                .arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+                .build()
+                .unwrap(),
+        )
+        .event_start_time(earlier)
+        .event_end_time(now)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_replay()
+        .replay_name("desc-replay")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.replay_name().unwrap(), "desc-replay");
+}
+
+#[test_action("events", "ListReplays", checksum = "174eb44e")]
+#[tokio::test]
+async fn eb_list_replays() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let resp = client.list_replays().send().await.unwrap();
+    let _ = resp.replays();
+}
+
+#[test_action("events", "CancelReplay", checksum = "be020ca9")]
+#[tokio::test]
+async fn eb_cancel_replay() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .create_archive()
+        .archive_name("cancelrep-archive")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .send()
+        .await
+        .unwrap();
+
+    let now = aws_sdk_eventbridge::primitives::DateTime::from_secs(1700000000);
+    let earlier = aws_sdk_eventbridge::primitives::DateTime::from_secs(1699990000);
+
+    client
+        .start_replay()
+        .replay_name("cancel-replay")
+        .event_source_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+        .destination(
+            aws_sdk_eventbridge::types::ReplayDestination::builder()
+                .arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+                .build()
+                .unwrap(),
+        )
+        .event_start_time(earlier)
+        .event_end_time(now)
+        .send()
+        .await
+        .unwrap();
+
+    // Cancel may succeed or fail depending on replay state; we just verify the call works
+    let _ = client
+        .cancel_replay()
+        .replay_name("cancel-replay")
+        .send()
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// Partner event sources
+// ---------------------------------------------------------------------------
+
+#[test_action("events", "CreatePartnerEventSource", checksum = "0c72b634")]
+#[tokio::test]
+async fn eb_create_partner_event_source() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    let resp = client
+        .create_partner_event_source()
+        .name("aws.partner/example.com/test")
+        .account("123456789012")
+        .send()
+        .await
+        .unwrap();
+    let _ = resp.event_source_arn();
+}
+
+#[test_action("events", "DescribePartnerEventSource", checksum = "0cef9de8")]
+#[tokio::test]
+async fn eb_describe_partner_event_source() {
+    let server = TestServer::start().await;
+    let client = server.eventbridge_client().await;
+
+    client
+        .create_partner_event_source()
+        .name("aws.partner/example.com/desc")
+        .account("123456789012")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_partner_event_source()
+        .name("aws.partner/example.com/desc")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.name().is_some());
+}

--- a/crates/fakecloud-conformance/tests/helpers/mod.rs
+++ b/crates/fakecloud-conformance/tests/helpers/mod.rs
@@ -1,0 +1,165 @@
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use aws_config::BehaviorVersion;
+use aws_credential_types::Credentials;
+use aws_types::region::Region;
+
+#[allow(dead_code)]
+pub struct TestServer {
+    child: Option<Child>,
+    port: u16,
+    endpoint: String,
+}
+
+#[allow(dead_code)]
+impl TestServer {
+    pub async fn start() -> Self {
+        let port = find_available_port();
+        let endpoint = format!("http://127.0.0.1:{port}");
+
+        let bin = find_binary();
+
+        let child = Command::new(bin)
+            .arg("--addr")
+            .arg(format!("127.0.0.1:{port}"))
+            .arg("--log-level")
+            .arg("error")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to start fakecloud");
+
+        wait_for_port(port).await;
+
+        Self {
+            child: Some(child),
+            port,
+            endpoint,
+        }
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub async fn aws_config(&self) -> aws_config::SdkConfig {
+        aws_config::defaults(BehaviorVersion::latest())
+            .endpoint_url(self.endpoint())
+            .region(Region::new("us-east-1"))
+            .credentials_provider(Credentials::new(
+                "AKIAIOSFODNN7EXAMPLE",
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                None,
+                None,
+                "test",
+            ))
+            .load()
+            .await
+    }
+
+    pub async fn sqs_client(&self) -> aws_sdk_sqs::Client {
+        aws_sdk_sqs::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn sns_client(&self) -> aws_sdk_sns::Client {
+        aws_sdk_sns::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn eventbridge_client(&self) -> aws_sdk_eventbridge::Client {
+        aws_sdk_eventbridge::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn iam_client(&self) -> aws_sdk_iam::Client {
+        aws_sdk_iam::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn sts_client(&self) -> aws_sdk_sts::Client {
+        aws_sdk_sts::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn ssm_client(&self) -> aws_sdk_ssm::Client {
+        aws_sdk_ssm::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn dynamodb_client(&self) -> aws_sdk_dynamodb::Client {
+        aws_sdk_dynamodb::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn lambda_client(&self) -> aws_sdk_lambda::Client {
+        aws_sdk_lambda::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn secretsmanager_client(&self) -> aws_sdk_secretsmanager::Client {
+        aws_sdk_secretsmanager::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn logs_client(&self) -> aws_sdk_cloudwatchlogs::Client {
+        aws_sdk_cloudwatchlogs::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn kms_client(&self) -> aws_sdk_kms::Client {
+        aws_sdk_kms::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn cloudformation_client(&self) -> aws_sdk_cloudformation::Client {
+        aws_sdk_cloudformation::Client::new(&self.aws_config().await)
+    }
+
+    pub async fn s3_client(&self) -> aws_sdk_s3::Client {
+        let config = self.aws_config().await;
+        let s3_config = aws_sdk_s3::config::Builder::from(&config)
+            .force_path_style(true)
+            .build();
+        aws_sdk_s3::Client::from_conf(s3_config)
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn find_available_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind to random port")
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn find_binary() -> String {
+    let debug_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/debug/fakecloud");
+    let release_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../target/release/fakecloud"
+    );
+
+    if std::path::Path::new(debug_path).exists() {
+        return debug_path.to_string();
+    }
+    if std::path::Path::new(release_path).exists() {
+        return release_path.to_string();
+    }
+
+    panic!(
+        "fakecloud binary not found. Run `cargo build` first.\n\
+         Looked in:\n  {debug_path}\n  {release_path}"
+    );
+}
+
+async fn wait_for_port(port: u16) {
+    let addr = format!("127.0.0.1:{port}");
+    for _ in 0..50 {
+        if std::net::TcpStream::connect(&addr).is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("fakecloud did not start within 5 seconds on port {port}");
+}

--- a/crates/fakecloud-conformance/tests/iam.rs
+++ b/crates/fakecloud-conformance/tests/iam.rs
@@ -1,0 +1,1634 @@
+mod helpers;
+
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+// ==========================================================================
+// Users
+// ==========================================================================
+
+#[test_action("iam", "CreateUser", checksum = "f44a86b8")]
+#[test_action("iam", "GetUser", checksum = "9f274efe")]
+#[test_action("iam", "ListUsers", checksum = "646fd37f")]
+#[test_action("iam", "UpdateUser", checksum = "feb72967")]
+#[test_action("iam", "DeleteUser", checksum = "eb9be363")]
+#[tokio::test]
+async fn iam_user_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("conf-user")
+        .send()
+        .await
+        .unwrap();
+    let get = client
+        .get_user()
+        .user_name("conf-user")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.user().unwrap().user_name(), "conf-user");
+
+    let list = client.list_users().send().await.unwrap();
+    assert!(!list.users().is_empty());
+
+    client
+        .update_user()
+        .user_name("conf-user")
+        .new_path("/updated/")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_user()
+        .user_name("conf-user")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("iam", "TagUser", checksum = "91309f3d")]
+#[test_action("iam", "UntagUser", checksum = "2c1fc62d")]
+#[test_action("iam", "ListUserTags", checksum = "ae73fe03")]
+#[tokio::test]
+async fn iam_user_tags() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("conf-utag")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .tag_user()
+        .user_name("conf-utag")
+        .tags(
+            aws_sdk_iam::types::Tag::builder()
+                .key("env")
+                .value("test")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_user_tags()
+        .user_name("conf-utag")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.tags().is_empty());
+
+    client
+        .untag_user()
+        .user_name("conf-utag")
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Access keys
+// ==========================================================================
+
+#[test_action("iam", "CreateAccessKey", checksum = "079ca956")]
+#[test_action("iam", "ListAccessKeys", checksum = "35b71bcf")]
+#[test_action("iam", "UpdateAccessKey", checksum = "c8cf3d9f")]
+#[test_action("iam", "GetAccessKeyLastUsed", checksum = "8470b24f")]
+#[test_action("iam", "DeleteAccessKey", checksum = "25b278a4")]
+#[tokio::test]
+async fn iam_access_key_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("conf-ak")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_access_key()
+        .user_name("conf-ak")
+        .send()
+        .await
+        .unwrap();
+    let key_id = create.access_key().unwrap().access_key_id().to_string();
+
+    let list = client
+        .list_access_keys()
+        .user_name("conf-ak")
+        .send()
+        .await
+        .unwrap();
+    assert!(!list.access_key_metadata().is_empty());
+
+    client
+        .update_access_key()
+        .user_name("conf-ak")
+        .access_key_id(&key_id)
+        .status(aws_sdk_iam::types::StatusType::Inactive)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_access_key_last_used()
+        .access_key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_access_key()
+        .user_name("conf-ak")
+        .access_key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Roles
+// ==========================================================================
+
+const ASSUME_ROLE_POLICY: &str = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+
+#[test_action("iam", "CreateRole", checksum = "873f52f2")]
+#[test_action("iam", "GetRole", checksum = "eb87506d")]
+#[test_action("iam", "ListRoles", checksum = "65174afc")]
+#[test_action("iam", "UpdateRole", checksum = "4ef4a056")]
+#[test_action("iam", "UpdateRoleDescription", checksum = "b7ded596")]
+#[test_action("iam", "UpdateAssumeRolePolicy", checksum = "2097f40b")]
+#[test_action("iam", "DeleteRole", checksum = "13b863d4")]
+#[tokio::test]
+async fn iam_role_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_role()
+        .role_name("conf-role")
+        .assume_role_policy_document(ASSUME_ROLE_POLICY)
+        .send()
+        .await
+        .unwrap();
+
+    let get = client
+        .get_role()
+        .role_name("conf-role")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.role().unwrap().role_name(), "conf-role");
+
+    let list = client.list_roles().send().await.unwrap();
+    assert!(!list.roles().is_empty());
+
+    client
+        .update_role()
+        .role_name("conf-role")
+        .max_session_duration(7200)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_role_description()
+        .role_name("conf-role")
+        .description("updated desc")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_assume_role_policy()
+        .role_name("conf-role")
+        .policy_document(ASSUME_ROLE_POLICY)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_role()
+        .role_name("conf-role")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("iam", "TagRole", checksum = "28966142")]
+#[test_action("iam", "UntagRole", checksum = "58291cdb")]
+#[test_action("iam", "ListRoleTags", checksum = "61151908")]
+#[tokio::test]
+async fn iam_role_tags() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_role()
+        .role_name("conf-rtag")
+        .assume_role_policy_document(ASSUME_ROLE_POLICY)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .tag_role()
+        .role_name("conf-rtag")
+        .tags(
+            aws_sdk_iam::types::Tag::builder()
+                .key("env")
+                .value("test")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_role_tags()
+        .role_name("conf-rtag")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.tags().is_empty());
+
+    client
+        .untag_role()
+        .role_name("conf-rtag")
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("iam", "PutRolePermissionsBoundary", checksum = "02a1078a")]
+#[test_action("iam", "DeleteRolePermissionsBoundary", checksum = "a718c0a3")]
+#[tokio::test]
+async fn iam_role_permissions_boundary() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_role()
+        .role_name("conf-rpb")
+        .assume_role_policy_document(ASSUME_ROLE_POLICY)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_role_permissions_boundary()
+        .role_name("conf-rpb")
+        .permissions_boundary("arn:aws:iam::aws:policy/PowerUserAccess")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_role_permissions_boundary()
+        .role_name("conf-rpb")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Policies
+// ==========================================================================
+
+const POLICY_DOC: &str = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#;
+
+#[test_action("iam", "CreatePolicy", checksum = "e2b8e9ad")]
+#[test_action("iam", "GetPolicy", checksum = "070be7a5")]
+#[test_action("iam", "ListPolicies", checksum = "b374d17a")]
+#[test_action("iam", "DeletePolicy", checksum = "64b85f27")]
+#[tokio::test]
+async fn iam_policy_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let create = client
+        .create_policy()
+        .policy_name("conf-pol")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap();
+    let arn = create.policy().unwrap().arn().unwrap().to_string();
+
+    let _ = client.get_policy().policy_arn(&arn).send().await.unwrap();
+    let _ = client.list_policies().send().await.unwrap();
+
+    client
+        .delete_policy()
+        .policy_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("iam", "TagPolicy", checksum = "0847d985")]
+#[test_action("iam", "UntagPolicy", checksum = "1640c997")]
+#[test_action("iam", "ListPolicyTags", checksum = "80031082")]
+#[tokio::test]
+async fn iam_policy_tags() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let create = client
+        .create_policy()
+        .policy_name("conf-ptag")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap();
+    let arn = create.policy().unwrap().arn().unwrap().to_string();
+
+    client
+        .tag_policy()
+        .policy_arn(&arn)
+        .tags(
+            aws_sdk_iam::types::Tag::builder()
+                .key("env")
+                .value("test")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_policy_tags()
+        .policy_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.tags().is_empty());
+
+    client
+        .untag_policy()
+        .policy_arn(&arn)
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Policy versions
+// ==========================================================================
+
+#[test_action("iam", "CreatePolicyVersion", checksum = "ae5732df")]
+#[test_action("iam", "GetPolicyVersion", checksum = "c753f09f")]
+#[test_action("iam", "ListPolicyVersions", checksum = "e55b368d")]
+#[test_action("iam", "SetDefaultPolicyVersion", checksum = "af99b113")]
+#[test_action("iam", "DeletePolicyVersion", checksum = "f1edba4b")]
+#[tokio::test]
+async fn iam_policy_versions() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let create = client
+        .create_policy()
+        .policy_name("conf-pver")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap();
+    let arn = create.policy().unwrap().arn().unwrap().to_string();
+
+    let v2_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}"#;
+    let v2 = client
+        .create_policy_version()
+        .policy_arn(&arn)
+        .policy_document(v2_doc)
+        .send()
+        .await
+        .unwrap();
+    let v2_id = v2
+        .policy_version()
+        .unwrap()
+        .version_id()
+        .unwrap()
+        .to_string();
+
+    let _ = client
+        .get_policy_version()
+        .policy_arn(&arn)
+        .version_id(&v2_id)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .list_policy_versions()
+        .policy_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .set_default_policy_version()
+        .policy_arn(&arn)
+        .version_id(&v2_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_policy_version()
+        .policy_arn(&arn)
+        .version_id("v1")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Role policy attachments (managed)
+// ==========================================================================
+
+#[test_action("iam", "AttachRolePolicy", checksum = "e0fb047c")]
+#[test_action("iam", "ListAttachedRolePolicies", checksum = "f1e6276f")]
+#[test_action("iam", "DetachRolePolicy", checksum = "07cfd4d3")]
+#[tokio::test]
+async fn iam_role_managed_policies() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_role()
+        .role_name("conf-rmp")
+        .assume_role_policy_document(ASSUME_ROLE_POLICY)
+        .send()
+        .await
+        .unwrap();
+
+    let pol = client
+        .create_policy()
+        .policy_name("conf-rmp-pol")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap();
+    let arn = pol.policy().unwrap().arn().unwrap().to_string();
+
+    client
+        .attach_role_policy()
+        .role_name("conf-rmp")
+        .policy_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_attached_role_policies()
+        .role_name("conf-rmp")
+        .send()
+        .await
+        .unwrap();
+    assert!(!list.attached_policies().is_empty());
+
+    client
+        .detach_role_policy()
+        .role_name("conf-rmp")
+        .policy_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Role inline policies
+// ==========================================================================
+
+#[test_action("iam", "PutRolePolicy", checksum = "3791b2d7")]
+#[test_action("iam", "GetRolePolicy", checksum = "2063170e")]
+#[test_action("iam", "ListRolePolicies", checksum = "24b7aa94")]
+#[test_action("iam", "DeleteRolePolicy", checksum = "af6cd576")]
+#[tokio::test]
+async fn iam_role_inline_policies() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_role()
+        .role_name("conf-rip")
+        .assume_role_policy_document(ASSUME_ROLE_POLICY)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_role_policy()
+        .role_name("conf-rip")
+        .policy_name("inline1")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_role_policy()
+        .role_name("conf-rip")
+        .policy_name("inline1")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_role_policies()
+        .role_name("conf-rip")
+        .send()
+        .await
+        .unwrap();
+    assert!(!list.policy_names().is_empty());
+
+    client
+        .delete_role_policy()
+        .role_name("conf-rip")
+        .policy_name("inline1")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// User policy attachments (managed)
+// ==========================================================================
+
+#[test_action("iam", "AttachUserPolicy", checksum = "a1b9fc5e")]
+#[test_action("iam", "ListAttachedUserPolicies", checksum = "dad611b0")]
+#[test_action("iam", "DetachUserPolicy", checksum = "1f18da48")]
+#[tokio::test]
+async fn iam_user_managed_policies() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("conf-ump")
+        .send()
+        .await
+        .unwrap();
+    let pol = client
+        .create_policy()
+        .policy_name("conf-ump-pol")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap();
+    let arn = pol.policy().unwrap().arn().unwrap().to_string();
+
+    client
+        .attach_user_policy()
+        .user_name("conf-ump")
+        .policy_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_attached_user_policies()
+        .user_name("conf-ump")
+        .send()
+        .await
+        .unwrap();
+    assert!(!list.attached_policies().is_empty());
+
+    client
+        .detach_user_policy()
+        .user_name("conf-ump")
+        .policy_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// User inline policies
+// ==========================================================================
+
+#[test_action("iam", "PutUserPolicy", checksum = "245e5162")]
+#[test_action("iam", "GetUserPolicy", checksum = "f938baca")]
+#[test_action("iam", "ListUserPolicies", checksum = "17893ece")]
+#[test_action("iam", "DeleteUserPolicy", checksum = "45fbae53")]
+#[tokio::test]
+async fn iam_user_inline_policies() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("conf-uip")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_user_policy()
+        .user_name("conf-uip")
+        .policy_name("inline1")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_user_policy()
+        .user_name("conf-uip")
+        .policy_name("inline1")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_user_policies()
+        .user_name("conf-uip")
+        .send()
+        .await
+        .unwrap();
+    assert!(!list.policy_names().is_empty());
+
+    client
+        .delete_user_policy()
+        .user_name("conf-uip")
+        .policy_name("inline1")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Groups
+// ==========================================================================
+
+#[test_action("iam", "CreateGroup", checksum = "b121af2a")]
+#[test_action("iam", "GetGroup", checksum = "b9ba9cba")]
+#[test_action("iam", "ListGroups", checksum = "4bbbd522")]
+#[test_action("iam", "UpdateGroup", checksum = "3e229237")]
+#[test_action("iam", "DeleteGroup", checksum = "1beb602c")]
+#[tokio::test]
+async fn iam_group_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_group()
+        .group_name("conf-grp")
+        .send()
+        .await
+        .unwrap();
+
+    let get = client
+        .get_group()
+        .group_name("conf-grp")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.group().unwrap().group_name(), "conf-grp");
+
+    let list = client.list_groups().send().await.unwrap();
+    assert!(!list.groups().is_empty());
+
+    client
+        .update_group()
+        .group_name("conf-grp")
+        .new_group_name("conf-grp-new")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_group()
+        .group_name("conf-grp-new")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Group membership
+// ==========================================================================
+
+#[test_action("iam", "AddUserToGroup", checksum = "d0cb9ba4")]
+#[test_action("iam", "RemoveUserFromGroup", checksum = "a7074802")]
+#[test_action("iam", "ListGroupsForUser", checksum = "8d424afe")]
+#[tokio::test]
+async fn iam_group_membership() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_group()
+        .group_name("conf-gm")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_user()
+        .user_name("conf-gm-u")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .add_user_to_group()
+        .group_name("conf-gm")
+        .user_name("conf-gm-u")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_groups_for_user()
+        .user_name("conf-gm-u")
+        .send()
+        .await
+        .unwrap();
+    assert!(!list.groups().is_empty());
+
+    client
+        .remove_user_from_group()
+        .group_name("conf-gm")
+        .user_name("conf-gm-u")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Group inline policies
+// ==========================================================================
+
+#[test_action("iam", "PutGroupPolicy", checksum = "8b0be12d")]
+#[test_action("iam", "GetGroupPolicy", checksum = "ec2e696a")]
+#[test_action("iam", "ListGroupPolicies", checksum = "f25fa3be")]
+#[test_action("iam", "DeleteGroupPolicy", checksum = "3cc368db")]
+#[tokio::test]
+async fn iam_group_inline_policies() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_group()
+        .group_name("conf-gip")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_group_policy()
+        .group_name("conf-gip")
+        .policy_name("inline1")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_group_policy()
+        .group_name("conf-gip")
+        .policy_name("inline1")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_group_policies()
+        .group_name("conf-gip")
+        .send()
+        .await
+        .unwrap();
+    assert!(!list.policy_names().is_empty());
+
+    client
+        .delete_group_policy()
+        .group_name("conf-gip")
+        .policy_name("inline1")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Group managed policies
+// ==========================================================================
+
+#[test_action("iam", "AttachGroupPolicy", checksum = "a8bf637b")]
+#[test_action("iam", "ListAttachedGroupPolicies", checksum = "2deb2525")]
+#[test_action("iam", "DetachGroupPolicy", checksum = "01cb55f3")]
+#[tokio::test]
+async fn iam_group_managed_policies() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_group()
+        .group_name("conf-gmp")
+        .send()
+        .await
+        .unwrap();
+    let pol = client
+        .create_policy()
+        .policy_name("conf-gmp-pol")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap();
+    let arn = pol.policy().unwrap().arn().unwrap().to_string();
+
+    client
+        .attach_group_policy()
+        .group_name("conf-gmp")
+        .policy_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_attached_group_policies()
+        .group_name("conf-gmp")
+        .send()
+        .await
+        .unwrap();
+    assert!(!list.attached_policies().is_empty());
+
+    client
+        .detach_group_policy()
+        .group_name("conf-gmp")
+        .policy_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Instance profiles
+// ==========================================================================
+
+#[test_action("iam", "CreateInstanceProfile", checksum = "55d4f12f")]
+#[test_action("iam", "GetInstanceProfile", checksum = "dc894f55")]
+#[test_action("iam", "ListInstanceProfiles", checksum = "73fb3093")]
+#[test_action("iam", "DeleteInstanceProfile", checksum = "0bcced85")]
+#[tokio::test]
+async fn iam_instance_profile_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_instance_profile()
+        .instance_profile_name("conf-ip")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_instance_profile()
+        .instance_profile_name("conf-ip")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client.list_instance_profiles().send().await.unwrap();
+
+    client
+        .delete_instance_profile()
+        .instance_profile_name("conf-ip")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("iam", "AddRoleToInstanceProfile", checksum = "d91b8859")]
+#[test_action("iam", "RemoveRoleFromInstanceProfile", checksum = "db70911c")]
+#[test_action("iam", "ListInstanceProfilesForRole", checksum = "62799439")]
+#[tokio::test]
+async fn iam_instance_profile_role() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_role()
+        .role_name("conf-ipr")
+        .assume_role_policy_document(ASSUME_ROLE_POLICY)
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_instance_profile()
+        .instance_profile_name("conf-ipr")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .add_role_to_instance_profile()
+        .instance_profile_name("conf-ipr")
+        .role_name("conf-ipr")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_instance_profiles_for_role()
+        .role_name("conf-ipr")
+        .send()
+        .await
+        .unwrap();
+    assert!(!list.instance_profiles().is_empty());
+
+    client
+        .remove_role_from_instance_profile()
+        .instance_profile_name("conf-ipr")
+        .role_name("conf-ipr")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("iam", "TagInstanceProfile", checksum = "76a884be")]
+#[test_action("iam", "UntagInstanceProfile", checksum = "b851bbcb")]
+#[test_action("iam", "ListInstanceProfileTags", checksum = "b40cbfd1")]
+#[tokio::test]
+async fn iam_instance_profile_tags() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_instance_profile()
+        .instance_profile_name("conf-ipt")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .tag_instance_profile()
+        .instance_profile_name("conf-ipt")
+        .tags(
+            aws_sdk_iam::types::Tag::builder()
+                .key("env")
+                .value("test")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_instance_profile_tags()
+        .instance_profile_name("conf-ipt")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.tags().is_empty());
+
+    client
+        .untag_instance_profile()
+        .instance_profile_name("conf-ipt")
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Login profiles
+// ==========================================================================
+
+#[test_action("iam", "CreateLoginProfile", checksum = "781c029f")]
+#[test_action("iam", "GetLoginProfile", checksum = "a7696b03")]
+#[test_action("iam", "UpdateLoginProfile", checksum = "04b34262")]
+#[test_action("iam", "DeleteLoginProfile", checksum = "0f968393")]
+#[tokio::test]
+async fn iam_login_profile() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("conf-lp")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_login_profile()
+        .user_name("conf-lp")
+        .password("P@ssw0rd123!")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_login_profile()
+        .user_name("conf-lp")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_login_profile()
+        .user_name("conf-lp")
+        .password("NewP@ss456!")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_login_profile()
+        .user_name("conf-lp")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// SAML providers
+// ==========================================================================
+
+const SAML_METADATA: &str = r#"<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.example.com"><IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"/></IDPSSODescriptor></EntityDescriptor>"#;
+
+#[test_action("iam", "CreateSAMLProvider", checksum = "62baff49")]
+#[test_action("iam", "GetSAMLProvider", checksum = "25286183")]
+#[test_action("iam", "ListSAMLProviders", checksum = "8fc561ba")]
+#[test_action("iam", "UpdateSAMLProvider", checksum = "818db9ce")]
+#[test_action("iam", "DeleteSAMLProvider", checksum = "c3eca04c")]
+#[tokio::test]
+async fn iam_saml_provider() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let create = client
+        .create_saml_provider()
+        .name("conf-saml")
+        .saml_metadata_document(SAML_METADATA)
+        .send()
+        .await
+        .unwrap();
+    let arn = create.saml_provider_arn().unwrap().to_string();
+
+    let _ = client
+        .get_saml_provider()
+        .saml_provider_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client.list_saml_providers().send().await.unwrap();
+
+    client
+        .update_saml_provider()
+        .saml_provider_arn(&arn)
+        .saml_metadata_document(SAML_METADATA)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_saml_provider()
+        .saml_provider_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// OIDC providers
+// ==========================================================================
+
+#[test_action("iam", "CreateOpenIDConnectProvider", checksum = "4c2d6af3")]
+#[test_action("iam", "GetOpenIDConnectProvider", checksum = "3496136f")]
+#[test_action("iam", "ListOpenIDConnectProviders", checksum = "9b08e4b0")]
+#[test_action("iam", "UpdateOpenIDConnectProviderThumbprint", checksum = "bdb2d121")]
+#[test_action("iam", "AddClientIDToOpenIDConnectProvider", checksum = "e511cddf")]
+#[test_action(
+    "iam",
+    "RemoveClientIDFromOpenIDConnectProvider",
+    checksum = "3e1e5e4b"
+)]
+#[test_action("iam", "DeleteOpenIDConnectProvider", checksum = "a7564079")]
+#[tokio::test]
+async fn iam_oidc_provider() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let create = client
+        .create_open_id_connect_provider()
+        .url("https://oidc.example.com")
+        .thumbprint_list("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        .send()
+        .await
+        .unwrap();
+    let arn = create.open_id_connect_provider_arn().unwrap().to_string();
+
+    let _ = client
+        .get_open_id_connect_provider()
+        .open_id_connect_provider_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .list_open_id_connect_providers()
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_open_id_connect_provider_thumbprint()
+        .open_id_connect_provider_arn(&arn)
+        .thumbprint_list("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .add_client_id_to_open_id_connect_provider()
+        .open_id_connect_provider_arn(&arn)
+        .client_id("my-client-id")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .remove_client_id_from_open_id_connect_provider()
+        .open_id_connect_provider_arn(&arn)
+        .client_id("my-client-id")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_open_id_connect_provider()
+        .open_id_connect_provider_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("iam", "TagOpenIDConnectProvider", checksum = "121a1ce6")]
+#[test_action("iam", "UntagOpenIDConnectProvider", checksum = "84448e48")]
+#[test_action("iam", "ListOpenIDConnectProviderTags", checksum = "23053130")]
+#[tokio::test]
+async fn iam_oidc_provider_tags() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let create = client
+        .create_open_id_connect_provider()
+        .url("https://oidc-tag.example.com")
+        .thumbprint_list("cccccccccccccccccccccccccccccccccccccccc")
+        .send()
+        .await
+        .unwrap();
+    let arn = create.open_id_connect_provider_arn().unwrap().to_string();
+
+    client
+        .tag_open_id_connect_provider()
+        .open_id_connect_provider_arn(&arn)
+        .tags(
+            aws_sdk_iam::types::Tag::builder()
+                .key("env")
+                .value("test")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_open_id_connect_provider_tags()
+        .open_id_connect_provider_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.tags().is_empty());
+
+    client
+        .untag_open_id_connect_provider()
+        .open_id_connect_provider_arn(&arn)
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Server certificates
+// ==========================================================================
+
+const CERT_BODY: &str = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJALRiMLAh6TbcMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnNl\ncnZlcjAeFw0yNTAxMDEwMDAwMDBaFw0zNTAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBnNlcnZlcjBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC7o96HtiGPOnLZikGSMBFP\n0VHaFjmsy7NJ8L8GKwyWIqFNcGdEB4q6GMXFF+jlSmlbbQ0RGNFwyA9sVHT0x3mr\nAgMBAAEwDQYJKoZIhvcNAQELBQADQQBOWM1ZRPW0JfE4Cq5VXQEY26+gKaLOMVP\nT6fB2g90aaKrE/rnWLFBuEFLjDeRlpRH3hWsnKGG+GBnK5GSXLJN\n-----END CERTIFICATE-----\n";
+const PRIVATE_KEY: &str = "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALuj3oe2IY86ctmKQZIwEU/RUdoWOazLs0nwvwYrDJYioU1wZ0QH\niroYxcUX6OVKaVttDREY0XDID2xUdPTHeasCAwEAAQJABmjb3LyOY9cM6sMbCOnF\nOkEVCU4rIBaHjMxP+9RIiAt/4qDFzVQKGZ1CwnPZ5jym89b4KDQNF31FOqXvfDYQ\ngQIhAPXA3FIcfFMHRLG2QqB0cHB8LOkMJfYfEQ6H8iAWFMmjAiEAw7W/Yz7F1jCH\nfNIVHHQ1ZPdE1IsfXYPnT2MWxJAH0BECIHdq7JmA3MmGkMODAPzJ9SKVxbLTKTud\nV27zS9uIZZF1AiEArQn8GpOeSIh0noNoKHMXzkGSBflAPWc/9j7wEKAHADECIGPZ\neWRV0MyfpGMJVB5VKIFeLfp4lhXijf9MJSOY2wfc\n-----END RSA PRIVATE KEY-----\n";
+
+#[test_action("iam", "UploadServerCertificate", checksum = "81d10b1a")]
+#[test_action("iam", "GetServerCertificate", checksum = "3cd3d33d")]
+#[test_action("iam", "ListServerCertificates", checksum = "3d412a65")]
+#[test_action("iam", "DeleteServerCertificate", checksum = "b8623f01")]
+#[tokio::test]
+async fn iam_server_certificate() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .upload_server_certificate()
+        .server_certificate_name("conf-cert")
+        .certificate_body(CERT_BODY)
+        .private_key(PRIVATE_KEY)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_server_certificate()
+        .server_certificate_name("conf-cert")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client.list_server_certificates().send().await.unwrap();
+
+    client
+        .delete_server_certificate()
+        .server_certificate_name("conf-cert")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Signing certificates
+// ==========================================================================
+
+#[test_action("iam", "UploadSigningCertificate", checksum = "297ae345")]
+#[test_action("iam", "ListSigningCertificates", checksum = "d63ae181")]
+#[test_action("iam", "UpdateSigningCertificate", checksum = "afb0dc00")]
+#[test_action("iam", "DeleteSigningCertificate", checksum = "a1321c10")]
+#[tokio::test]
+async fn iam_signing_certificate() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("conf-sc")
+        .send()
+        .await
+        .unwrap();
+
+    let upload = client
+        .upload_signing_certificate()
+        .user_name("conf-sc")
+        .certificate_body(CERT_BODY)
+        .send()
+        .await
+        .unwrap();
+    let cert_id = upload.certificate().unwrap().certificate_id().to_string();
+
+    let _ = client
+        .list_signing_certificates()
+        .user_name("conf-sc")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_signing_certificate()
+        .user_name("conf-sc")
+        .certificate_id(&cert_id)
+        .status(aws_sdk_iam::types::StatusType::Inactive)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_signing_certificate()
+        .user_name("conf-sc")
+        .certificate_id(&cert_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Service-linked roles
+// ==========================================================================
+
+#[test_action("iam", "CreateServiceLinkedRole", checksum = "7e8f9e97")]
+#[test_action("iam", "DeleteServiceLinkedRole", checksum = "8ac7f160")]
+#[test_action("iam", "GetServiceLinkedRoleDeletionStatus", checksum = "506cf566")]
+#[tokio::test]
+async fn iam_service_linked_role() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_service_linked_role()
+        .aws_service_name("elasticloadbalancing.amazonaws.com")
+        .send()
+        .await
+        .unwrap();
+
+    let del = client
+        .delete_service_linked_role()
+        .role_name("AWSServiceRoleForElasticLoadBalancing")
+        .send()
+        .await
+        .unwrap();
+    let task_id = del.deletion_task_id().to_string();
+
+    let _ = client
+        .get_service_linked_role_deletion_status()
+        .deletion_task_id(&task_id)
+        .send()
+        .await;
+}
+
+// ==========================================================================
+// Account management
+// ==========================================================================
+
+#[test_action("iam", "GetAccountSummary", checksum = "e23c8072")]
+#[test_action("iam", "GetAccountAuthorizationDetails", checksum = "a939671b")]
+#[tokio::test]
+async fn iam_account_info() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let _ = client.get_account_summary().send().await.unwrap();
+    let _ = client
+        .get_account_authorization_details()
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("iam", "CreateAccountAlias", checksum = "63d28a61")]
+#[test_action("iam", "ListAccountAliases", checksum = "711a5c9f")]
+#[test_action("iam", "DeleteAccountAlias", checksum = "ee61360e")]
+#[tokio::test]
+async fn iam_account_alias() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_account_alias()
+        .account_alias("conf-alias")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client.list_account_aliases().send().await.unwrap();
+    assert!(!list.account_aliases().is_empty());
+
+    client
+        .delete_account_alias()
+        .account_alias("conf-alias")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("iam", "UpdateAccountPasswordPolicy", checksum = "e8353a9a")]
+#[test_action("iam", "GetAccountPasswordPolicy", checksum = "ee84923c")]
+#[test_action("iam", "DeleteAccountPasswordPolicy", checksum = "2682d07c")]
+#[tokio::test]
+async fn iam_password_policy() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .update_account_password_policy()
+        .minimum_password_length(12)
+        .require_uppercase_characters(true)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client.get_account_password_policy().send().await.unwrap();
+
+    client
+        .delete_account_password_policy()
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Credential reports
+// ==========================================================================
+
+#[test_action("iam", "GenerateCredentialReport", checksum = "4795a9b9")]
+#[test_action("iam", "GetCredentialReport", checksum = "3f777bd4")]
+#[tokio::test]
+async fn iam_credential_report() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client.generate_credential_report().send().await.unwrap();
+    let _ = client.get_credential_report().send().await;
+}
+
+// ==========================================================================
+// Virtual MFA devices
+// ==========================================================================
+
+#[test_action("iam", "CreateVirtualMFADevice", checksum = "f3a8685f")]
+#[test_action("iam", "ListVirtualMFADevices", checksum = "62efcff7")]
+#[test_action("iam", "DeleteVirtualMFADevice", checksum = "a9101f94")]
+#[tokio::test]
+async fn iam_virtual_mfa_device() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let create = client
+        .create_virtual_mfa_device()
+        .virtual_mfa_device_name("conf-mfa")
+        .send()
+        .await
+        .unwrap();
+    let serial = create
+        .virtual_mfa_device()
+        .unwrap()
+        .serial_number()
+        .to_string();
+
+    let _ = client.list_virtual_mfa_devices().send().await.unwrap();
+
+    client
+        .delete_virtual_mfa_device()
+        .serial_number(&serial)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// MFA devices (enable/deactivate/list)
+// ==========================================================================
+
+#[test_action("iam", "EnableMFADevice", checksum = "d342b0fb")]
+#[test_action("iam", "ListMFADevices", checksum = "0a91d26a")]
+#[test_action("iam", "DeactivateMFADevice", checksum = "4b99fc49")]
+#[tokio::test]
+async fn iam_mfa_device_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("conf-mfa-u")
+        .send()
+        .await
+        .unwrap();
+    let create = client
+        .create_virtual_mfa_device()
+        .virtual_mfa_device_name("conf-mfa-en")
+        .send()
+        .await
+        .unwrap();
+    let serial = create
+        .virtual_mfa_device()
+        .unwrap()
+        .serial_number()
+        .to_string();
+
+    client
+        .enable_mfa_device()
+        .user_name("conf-mfa-u")
+        .serial_number(&serial)
+        .authentication_code1("123456")
+        .authentication_code2("654321")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_mfa_devices()
+        .user_name("conf-mfa-u")
+        .send()
+        .await
+        .unwrap();
+    assert!(!list.mfa_devices().is_empty());
+
+    client
+        .deactivate_mfa_device()
+        .user_name("conf-mfa-u")
+        .serial_number(&serial)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// ListEntitiesForPolicy
+// ==========================================================================
+
+#[test_action("iam", "ListEntitiesForPolicy", checksum = "d4f92d63")]
+#[tokio::test]
+async fn iam_list_entities_for_policy() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let pol = client
+        .create_policy()
+        .policy_name("conf-lefp")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap();
+    let arn = pol.policy().unwrap().arn().unwrap().to_string();
+
+    let _ = client
+        .list_entities_for_policy()
+        .policy_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// SSH public keys
+// ==========================================================================
+
+const SSH_PUB_KEY: &str = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCxO38tUfq4Gqmkq1Hrmx0d+5aVPzBR8cQH4PiPeFrM5JhK0U3hKpNVQNzLigCrjYgHQXlu6jTjJk4JQiF8iB2nmb1RJFq3QlMTHQq766CUr1OQrP2g8GzqMzfJMSHJJ4Y//5Itxb5XAGaD5C0NDNxadB7B5GvFT8qqhC1mJZ1FeX8BkeK7Hpwii1P4y7qNB3Pj5xDQ8J9G3DxS5s8N7K4bH3PrYVLGYvHn5R0j2m3K6JaB7F3dN4A7K3pB6YxzhQ2L8PAFDuOi4gBnK+aTfTnFSRNFnKRhjE7RD3CWabMrZ3s6PiKXO6VBM7Wl+R13D0i1lPNbQIEz2xITZ7xBnZ test@conformance";
+
+#[test_action("iam", "UploadSSHPublicKey", checksum = "080a214e")]
+#[test_action("iam", "GetSSHPublicKey", checksum = "943f188a")]
+#[test_action("iam", "ListSSHPublicKeys", checksum = "f292a035")]
+#[test_action("iam", "UpdateSSHPublicKey", checksum = "95eb9f00")]
+#[test_action("iam", "DeleteSSHPublicKey", checksum = "cdfffd7e")]
+#[tokio::test]
+async fn iam_ssh_public_keys() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("conf-ssh")
+        .send()
+        .await
+        .unwrap();
+
+    let upload = client
+        .upload_ssh_public_key()
+        .user_name("conf-ssh")
+        .ssh_public_key_body(SSH_PUB_KEY)
+        .send()
+        .await
+        .unwrap();
+    let key_id = upload
+        .ssh_public_key()
+        .unwrap()
+        .ssh_public_key_id()
+        .to_string();
+
+    let _ = client
+        .get_ssh_public_key()
+        .user_name("conf-ssh")
+        .ssh_public_key_id(&key_id)
+        .encoding(aws_sdk_iam::types::EncodingType::Ssh)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .list_ssh_public_keys()
+        .user_name("conf-ssh")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_ssh_public_key()
+        .user_name("conf-ssh")
+        .ssh_public_key_id(&key_id)
+        .status(aws_sdk_iam::types::StatusType::Inactive)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_ssh_public_key()
+        .user_name("conf-ssh")
+        .ssh_public_key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-conformance/tests/kms.rs
+++ b/crates/fakecloud-conformance/tests/kms.rs
@@ -1,0 +1,994 @@
+mod helpers;
+
+use aws_sdk_kms::primitives::Blob;
+use aws_sdk_kms::types::{
+    DataKeySpec, KeySpec, KeyUsageType, MessageType, SigningAlgorithmSpec, Tag,
+};
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+// ---------------------------------------------------------------------------
+// Key lifecycle
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "CreateKey", checksum = "c66e4b13")]
+#[tokio::test]
+async fn kms_create_key() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let resp = client
+        .create_key()
+        .description("conformance key")
+        .send()
+        .await
+        .unwrap();
+    let meta = resp.key_metadata().unwrap();
+    assert!(meta.enabled());
+    assert!(meta.arn().unwrap().contains(":key/"));
+}
+
+#[test_action("kms", "DescribeKey", checksum = "c64650b2")]
+#[tokio::test]
+async fn kms_describe_key() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().description("dk").send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client.describe_key().key_id(&key_id).send().await.unwrap();
+    assert_eq!(resp.key_metadata().unwrap().description().unwrap(), "dk");
+}
+
+#[test_action("kms", "ListKeys", checksum = "05288289")]
+#[tokio::test]
+async fn kms_list_keys() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    client.create_key().send().await.unwrap();
+
+    let resp = client.list_keys().send().await.unwrap();
+    assert!(!resp.keys().is_empty());
+}
+
+#[test_action("kms", "EnableKey", checksum = "82c54b3d")]
+#[tokio::test]
+async fn kms_enable_key() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client.disable_key().key_id(&key_id).send().await.unwrap();
+    client.enable_key().key_id(&key_id).send().await.unwrap();
+
+    let desc = client.describe_key().key_id(&key_id).send().await.unwrap();
+    assert!(desc.key_metadata().unwrap().enabled());
+}
+
+#[test_action("kms", "DisableKey", checksum = "76150cfe")]
+#[tokio::test]
+async fn kms_disable_key() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client.disable_key().key_id(&key_id).send().await.unwrap();
+
+    let desc = client.describe_key().key_id(&key_id).send().await.unwrap();
+    assert!(!desc.key_metadata().unwrap().enabled());
+}
+
+#[test_action("kms", "ScheduleKeyDeletion", checksum = "c2d3c723")]
+#[tokio::test]
+async fn kms_schedule_key_deletion() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .schedule_key_deletion()
+        .key_id(&key_id)
+        .pending_window_in_days(7)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.key_id().unwrap(), key_id);
+    assert!(resp.deletion_date().is_some());
+}
+
+#[test_action("kms", "CancelKeyDeletion", checksum = "c1a27c10")]
+#[tokio::test]
+async fn kms_cancel_key_deletion() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .schedule_key_deletion()
+        .key_id(&key_id)
+        .pending_window_in_days(7)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .cancel_key_deletion()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.key_id().unwrap(), key_id);
+
+    let desc = client.describe_key().key_id(&key_id).send().await.unwrap();
+    assert_ne!(
+        desc.key_metadata().unwrap().key_state(),
+        Some(&aws_sdk_kms::types::KeyState::PendingDeletion)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Encryption / Decryption
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "Encrypt", checksum = "d9b6f2bc")]
+#[tokio::test]
+async fn kms_encrypt() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .encrypt()
+        .key_id(&key_id)
+        .plaintext(Blob::new(b"hello".to_vec()))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.ciphertext_blob().is_some());
+}
+
+#[test_action("kms", "Decrypt", checksum = "51b5baa9")]
+#[tokio::test]
+async fn kms_decrypt() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let enc = client
+        .encrypt()
+        .key_id(&key_id)
+        .plaintext(Blob::new(b"roundtrip".to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .decrypt()
+        .ciphertext_blob(enc.ciphertext_blob().unwrap().clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.plaintext().unwrap().as_ref(), b"roundtrip");
+}
+
+#[test_action("kms", "ReEncrypt", checksum = "e1c64a49")]
+#[tokio::test]
+async fn kms_re_encrypt() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key1 = client.create_key().send().await.unwrap();
+    let key1_id = key1.key_metadata().unwrap().key_id().to_string();
+
+    let key2 = client.create_key().send().await.unwrap();
+    let key2_id = key2.key_metadata().unwrap().key_id().to_string();
+
+    let enc = client
+        .encrypt()
+        .key_id(&key1_id)
+        .plaintext(Blob::new(b"reencrypt-test".to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .re_encrypt()
+        .ciphertext_blob(enc.ciphertext_blob().unwrap().clone())
+        .destination_key_id(&key2_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.ciphertext_blob().is_some());
+
+    // Verify the re-encrypted blob decrypts correctly
+    let dec = client
+        .decrypt()
+        .ciphertext_blob(resp.ciphertext_blob().unwrap().clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dec.plaintext().unwrap().as_ref(), b"reencrypt-test");
+}
+
+// ---------------------------------------------------------------------------
+// Data keys
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "GenerateDataKey", checksum = "6a456116")]
+#[tokio::test]
+async fn kms_generate_data_key() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .generate_data_key()
+        .key_id(&key_id)
+        .key_spec(DataKeySpec::Aes256)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.plaintext().is_some());
+    assert!(resp.ciphertext_blob().is_some());
+}
+
+#[test_action("kms", "GenerateDataKeyWithoutPlaintext", checksum = "c1d21720")]
+#[tokio::test]
+async fn kms_generate_data_key_without_plaintext() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .generate_data_key_without_plaintext()
+        .key_id(&key_id)
+        .key_spec(DataKeySpec::Aes256)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.ciphertext_blob().is_some());
+}
+
+#[test_action("kms", "GenerateRandom", checksum = "683cc0ca")]
+#[tokio::test]
+async fn kms_generate_random() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let resp = client
+        .generate_random()
+        .number_of_bytes(32)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.plaintext().unwrap().as_ref().len(), 32);
+}
+
+// ---------------------------------------------------------------------------
+// Aliases
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "CreateAlias", checksum = "b4ac1bde")]
+#[tokio::test]
+async fn kms_create_alias() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .create_alias()
+        .alias_name("alias/conf-alias")
+        .target_key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+
+    let list = client.list_aliases().send().await.unwrap();
+    assert!(list
+        .aliases()
+        .iter()
+        .any(|a| a.alias_name().unwrap() == "alias/conf-alias"));
+}
+
+#[test_action("kms", "DeleteAlias", checksum = "da3623c8")]
+#[tokio::test]
+async fn kms_delete_alias() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .create_alias()
+        .alias_name("alias/del-alias")
+        .target_key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_alias()
+        .alias_name("alias/del-alias")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client.list_aliases().send().await.unwrap();
+    assert!(!list
+        .aliases()
+        .iter()
+        .any(|a| a.alias_name().unwrap() == "alias/del-alias"));
+}
+
+#[test_action("kms", "UpdateAlias", checksum = "b7ecc379")]
+#[tokio::test]
+async fn kms_update_alias() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key1 = client.create_key().send().await.unwrap();
+    let key1_id = key1.key_metadata().unwrap().key_id().to_string();
+
+    let key2 = client.create_key().send().await.unwrap();
+    let key2_id = key2.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .create_alias()
+        .alias_name("alias/upd-alias")
+        .target_key_id(&key1_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_alias()
+        .alias_name("alias/upd-alias")
+        .target_key_id(&key2_id)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify alias now points to key2
+    let desc = client
+        .describe_key()
+        .key_id("alias/upd-alias")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desc.key_metadata().unwrap().key_id(), key2_id);
+}
+
+#[test_action("kms", "ListAliases", checksum = "14d90727")]
+#[tokio::test]
+async fn kms_list_aliases() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let resp = client.list_aliases().send().await.unwrap();
+    let _ = resp.aliases();
+}
+
+// ---------------------------------------------------------------------------
+// Tags
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "TagResource", checksum = "8e11dd8c")]
+#[tokio::test]
+async fn kms_tag_resource() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .tag_resource()
+        .key_id(&key_id)
+        .tags(
+            Tag::builder()
+                .tag_key("env")
+                .tag_value("test")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let tags = client
+        .list_resource_tags()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(tags.tags().len(), 1);
+}
+
+#[test_action("kms", "UntagResource", checksum = "3839a087")]
+#[tokio::test]
+async fn kms_untag_resource() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .tag_resource()
+        .key_id(&key_id)
+        .tags(
+            Tag::builder()
+                .tag_key("env")
+                .tag_value("test")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .untag_resource()
+        .key_id(&key_id)
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+
+    let tags = client
+        .list_resource_tags()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags.tags().is_empty());
+}
+
+#[test_action("kms", "ListResourceTags", checksum = "a292851e")]
+#[tokio::test]
+async fn kms_list_resource_tags() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .list_resource_tags()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.tags().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Key description and policies
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "UpdateKeyDescription", checksum = "ca9502c7")]
+#[tokio::test]
+async fn kms_update_key_description() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client
+        .create_key()
+        .description("original")
+        .send()
+        .await
+        .unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .update_key_description()
+        .key_id(&key_id)
+        .description("updated")
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client.describe_key().key_id(&key_id).send().await.unwrap();
+    assert_eq!(
+        desc.key_metadata().unwrap().description().unwrap(),
+        "updated"
+    );
+}
+
+#[test_action("kms", "GetKeyPolicy", checksum = "b625cb2a")]
+#[tokio::test]
+async fn kms_get_key_policy() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .get_key_policy()
+        .key_id(&key_id)
+        .policy_name("default")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.policy().is_some());
+}
+
+#[test_action("kms", "PutKeyPolicy", checksum = "dec83152")]
+#[tokio::test]
+async fn kms_put_key_policy() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let policy = r#"{"Version":"2012-10-17","Statement":[]}"#;
+    client
+        .put_key_policy()
+        .key_id(&key_id)
+        .policy_name("default")
+        .policy(policy)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("kms", "ListKeyPolicies", checksum = "5f3f74c7")]
+#[tokio::test]
+async fn kms_list_key_policies() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .list_key_policies()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.policy_names().iter().any(|n| n == "default"));
+}
+
+// ---------------------------------------------------------------------------
+// Key rotation
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "GetKeyRotationStatus", checksum = "61334d9e")]
+#[tokio::test]
+async fn kms_get_key_rotation_status() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .get_key_rotation_status()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    // Default: rotation is disabled
+    assert!(!resp.key_rotation_enabled());
+}
+
+#[test_action("kms", "EnableKeyRotation", checksum = "c47d12f3")]
+#[tokio::test]
+async fn kms_enable_key_rotation() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .enable_key_rotation()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_key_rotation_status()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.key_rotation_enabled());
+}
+
+#[test_action("kms", "DisableKeyRotation", checksum = "c3769512")]
+#[tokio::test]
+async fn kms_disable_key_rotation() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .enable_key_rotation()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .disable_key_rotation()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_key_rotation_status()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.key_rotation_enabled());
+}
+
+#[test_action("kms", "RotateKeyOnDemand", checksum = "e8e67fdd")]
+#[tokio::test]
+async fn kms_rotate_key_on_demand() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .rotate_key_on_demand()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.key_id().unwrap(), key_id);
+}
+
+#[test_action("kms", "ListKeyRotations", checksum = "b6469243")]
+#[tokio::test]
+async fn kms_list_key_rotations() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .list_key_rotations()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    let _ = resp.rotations();
+}
+
+// ---------------------------------------------------------------------------
+// Sign / Verify
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "Sign", checksum = "04657bca")]
+#[tokio::test]
+async fn kms_sign() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client
+        .create_key()
+        .key_usage(KeyUsageType::SignVerify)
+        .key_spec(KeySpec::Rsa2048)
+        .send()
+        .await
+        .unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .sign()
+        .key_id(&key_id)
+        .message(Blob::new(b"sign me".to_vec()))
+        .message_type(MessageType::Raw)
+        .signing_algorithm(SigningAlgorithmSpec::RsassaPkcs1V15Sha256)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.signature().is_some());
+}
+
+#[test_action("kms", "Verify", checksum = "7ba4bad8")]
+#[tokio::test]
+async fn kms_verify() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client
+        .create_key()
+        .key_usage(KeyUsageType::SignVerify)
+        .key_spec(KeySpec::Rsa2048)
+        .send()
+        .await
+        .unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let sig = client
+        .sign()
+        .key_id(&key_id)
+        .message(Blob::new(b"verify me".to_vec()))
+        .message_type(MessageType::Raw)
+        .signing_algorithm(SigningAlgorithmSpec::RsassaPkcs1V15Sha256)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .verify()
+        .key_id(&key_id)
+        .message(Blob::new(b"verify me".to_vec()))
+        .message_type(MessageType::Raw)
+        .signing_algorithm(SigningAlgorithmSpec::RsassaPkcs1V15Sha256)
+        .signature(sig.signature().unwrap().clone())
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.signature_valid());
+}
+
+#[test_action("kms", "GetPublicKey", checksum = "f70f8357")]
+#[tokio::test]
+async fn kms_get_public_key() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client
+        .create_key()
+        .key_usage(KeyUsageType::SignVerify)
+        .key_spec(KeySpec::Rsa2048)
+        .send()
+        .await
+        .unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .get_public_key()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.public_key().is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Grants
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "CreateGrant", checksum = "b5d6ae81")]
+#[tokio::test]
+async fn kms_create_grant() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .create_grant()
+        .key_id(&key_id)
+        .grantee_principal("arn:aws:iam::123456789012:role/test-role")
+        .operations(aws_sdk_kms::types::GrantOperation::Encrypt)
+        .operations(aws_sdk_kms::types::GrantOperation::Decrypt)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.grant_id().is_some());
+    assert!(resp.grant_token().is_some());
+}
+
+#[test_action("kms", "ListGrants", checksum = "21c4f1b9")]
+#[tokio::test]
+async fn kms_list_grants() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .create_grant()
+        .key_id(&key_id)
+        .grantee_principal("arn:aws:iam::123456789012:role/test-role")
+        .operations(aws_sdk_kms::types::GrantOperation::Encrypt)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_grants().key_id(&key_id).send().await.unwrap();
+    assert_eq!(resp.grants().len(), 1);
+}
+
+#[test_action("kms", "ListRetirableGrants", checksum = "22e7c42a")]
+#[tokio::test]
+async fn kms_list_retirable_grants() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let resp = client
+        .list_retirable_grants()
+        .retiring_principal("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+    let _ = resp.grants();
+}
+
+#[test_action("kms", "RevokeGrant", checksum = "f5a54621")]
+#[tokio::test]
+async fn kms_revoke_grant() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let grant = client
+        .create_grant()
+        .key_id(&key_id)
+        .grantee_principal("arn:aws:iam::123456789012:role/test-role")
+        .operations(aws_sdk_kms::types::GrantOperation::Encrypt)
+        .send()
+        .await
+        .unwrap();
+    let grant_id = grant.grant_id().unwrap();
+
+    client
+        .revoke_grant()
+        .key_id(&key_id)
+        .grant_id(grant_id)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_grants().key_id(&key_id).send().await.unwrap();
+    assert!(resp.grants().is_empty());
+}
+
+#[test_action("kms", "RetireGrant", checksum = "e757edf8")]
+#[tokio::test]
+async fn kms_retire_grant() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let grant = client
+        .create_grant()
+        .key_id(&key_id)
+        .grantee_principal("arn:aws:iam::123456789012:role/test-role")
+        .operations(aws_sdk_kms::types::GrantOperation::Encrypt)
+        .send()
+        .await
+        .unwrap();
+    let grant_id = grant.grant_id().unwrap();
+
+    client
+        .retire_grant()
+        .key_id(&key_id)
+        .grant_id(grant_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// MAC
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "GenerateMac", checksum = "5efb158b")]
+#[tokio::test]
+async fn kms_generate_mac() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client
+        .create_key()
+        .key_usage(KeyUsageType::GenerateVerifyMac)
+        .key_spec(KeySpec::Hmac256)
+        .send()
+        .await
+        .unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .generate_mac()
+        .key_id(&key_id)
+        .message(Blob::new(b"mac me".to_vec()))
+        .mac_algorithm(aws_sdk_kms::types::MacAlgorithmSpec::HmacSha256)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.mac().is_some());
+}
+
+#[test_action("kms", "VerifyMac", checksum = "ffd6ccd6")]
+#[tokio::test]
+async fn kms_verify_mac() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client
+        .create_key()
+        .key_usage(KeyUsageType::GenerateVerifyMac)
+        .key_spec(KeySpec::Hmac256)
+        .send()
+        .await
+        .unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let mac_resp = client
+        .generate_mac()
+        .key_id(&key_id)
+        .message(Blob::new(b"verify-mac".to_vec()))
+        .mac_algorithm(aws_sdk_kms::types::MacAlgorithmSpec::HmacSha256)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .verify_mac()
+        .key_id(&key_id)
+        .message(Blob::new(b"verify-mac".to_vec()))
+        .mac_algorithm(aws_sdk_kms::types::MacAlgorithmSpec::HmacSha256)
+        .mac(mac_resp.mac().unwrap().clone())
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.mac_valid());
+}
+
+// ---------------------------------------------------------------------------
+// ReplicateKey
+// ---------------------------------------------------------------------------
+
+#[test_action("kms", "ReplicateKey", checksum = "4fdb41bb")]
+#[tokio::test]
+async fn kms_replicate_key() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    // ReplicateKey may succeed or return an error depending on impl;
+    // we just verify the API call is accepted
+    let _ = client
+        .replicate_key()
+        .key_id(&key_id)
+        .replica_region("eu-west-1")
+        .send()
+        .await;
+}

--- a/crates/fakecloud-conformance/tests/lambda.rs
+++ b/crates/fakecloud-conformance/tests/lambda.rs
@@ -1,0 +1,247 @@
+mod helpers;
+
+use aws_sdk_lambda::primitives::Blob;
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+// ---------------------------------------------------------------------------
+// Function lifecycle
+// ---------------------------------------------------------------------------
+
+#[test_action("lambda", "CreateFunction", checksum = "46e2786b")]
+#[test_action("lambda", "GetFunction", checksum = "2d15e19e")]
+#[test_action("lambda", "DeleteFunction", checksum = "70eb2012")]
+#[tokio::test]
+async fn lambda_create_get_delete_function() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    let resp = client
+        .create_function()
+        .function_name("conf-func")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(b"fake-code"))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.function_name().unwrap(), "conf-func");
+    assert!(resp.function_arn().unwrap().contains("function:conf-func"));
+
+    let resp = client
+        .get_function()
+        .function_name("conf-func")
+        .send()
+        .await
+        .unwrap();
+    let config = resp.configuration().unwrap();
+    assert_eq!(config.function_name().unwrap(), "conf-func");
+    assert_eq!(config.runtime().unwrap().as_str(), "python3.12");
+    assert_eq!(config.handler().unwrap(), "index.handler");
+
+    client
+        .delete_function()
+        .function_name("conf-func")
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .get_function()
+        .function_name("conf-func")
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+
+#[test_action("lambda", "ListFunctions", checksum = "fa22d1bf")]
+#[tokio::test]
+async fn lambda_list_functions() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    for name in &["list-a", "list-b", "list-c"] {
+        client
+            .create_function()
+            .function_name(*name)
+            .runtime(aws_sdk_lambda::types::Runtime::Nodejs20x)
+            .role("arn:aws:iam::123456789012:role/test-role")
+            .handler("index.handler")
+            .code(
+                aws_sdk_lambda::types::FunctionCode::builder()
+                    .zip_file(Blob::new(b"fake"))
+                    .build(),
+            )
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let resp = client.list_functions().send().await.unwrap();
+    assert_eq!(resp.functions().len(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Invoke
+// ---------------------------------------------------------------------------
+
+#[test_action("lambda", "Invoke", checksum = "73c32773")]
+#[tokio::test]
+async fn lambda_invoke() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("invoke-me")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(b"fake"))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .invoke()
+        .function_name("invoke-me")
+        .payload(Blob::new(br#"{"key": "value"}"#))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status_code(), 200);
+}
+
+// ---------------------------------------------------------------------------
+// PublishVersion
+// ---------------------------------------------------------------------------
+
+#[test_action("lambda", "PublishVersion", checksum = "209921df")]
+#[tokio::test]
+async fn lambda_publish_version() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("version-func")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(b"fake"))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .publish_version()
+        .function_name("version-func")
+        .send()
+        .await
+        .unwrap();
+
+    assert!(resp.version().is_some());
+    assert!(resp.function_arn().unwrap().contains("version-func"));
+}
+
+// ---------------------------------------------------------------------------
+// Event source mappings
+// ---------------------------------------------------------------------------
+
+#[test_action("lambda", "CreateEventSourceMapping", checksum = "b9f5b731")]
+#[test_action("lambda", "GetEventSourceMapping", checksum = "abb053d9")]
+#[test_action("lambda", "DeleteEventSourceMapping", checksum = "96206508")]
+#[tokio::test]
+async fn lambda_create_get_delete_event_source_mapping() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("esm-func")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(b"fake"))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let create_resp = client
+        .create_event_source_mapping()
+        .function_name("esm-func")
+        .event_source_arn("arn:aws:sqs:us-east-1:123456789012:my-queue")
+        .send()
+        .await
+        .unwrap();
+
+    let uuid = create_resp.uuid().unwrap().to_string();
+    assert!(!uuid.is_empty());
+
+    let get_resp = client
+        .get_event_source_mapping()
+        .uuid(&uuid)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get_resp.function_arn().unwrap(), "esm-func");
+
+    client
+        .delete_event_source_mapping()
+        .uuid(&uuid)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("lambda", "ListEventSourceMappings", checksum = "6df074f2")]
+#[tokio::test]
+async fn lambda_list_event_source_mappings() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("esm-list-func")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(b"fake"))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_event_source_mapping()
+        .function_name("esm-list-func")
+        .event_source_arn("arn:aws:sqs:us-east-1:123456789012:queue-1")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_event_source_mappings().send().await.unwrap();
+    assert!(!resp.event_source_mappings().is_empty());
+}

--- a/crates/fakecloud-conformance/tests/logs.rs
+++ b/crates/fakecloud-conformance/tests/logs.rs
@@ -452,14 +452,14 @@ async fn logs_queries() {
         .unwrap();
     let query_id = start.query_id().unwrap().to_string();
 
-    let _ = client
+    client
         .get_query_results()
         .query_id(&query_id)
         .send()
         .await
         .unwrap();
 
-    let _ = client.describe_queries().send().await.unwrap();
+    client.describe_queries().send().await.unwrap();
 }
 
 // -- Export tasks --
@@ -490,7 +490,7 @@ async fn logs_export_tasks() {
         .unwrap();
     let task_id = create.task_id().unwrap().to_string();
 
-    let _ = client.describe_export_tasks().send().await.unwrap();
+    client.describe_export_tasks().send().await.unwrap();
 
     let _ = client.cancel_export_task().task_id(&task_id).send().await;
 }
@@ -519,14 +519,14 @@ async fn logs_delivery_destinations() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_delivery_destination()
         .name("conf-dd")
         .send()
         .await
         .unwrap();
 
-    let _ = client
+    client
         .describe_delivery_destinations()
         .send()
         .await
@@ -605,14 +605,14 @@ async fn logs_delivery_sources() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_delivery_source()
         .name("conf-ds")
         .send()
         .await
         .unwrap();
 
-    let _ = client.describe_delivery_sources().send().await.unwrap();
+    client.describe_delivery_sources().send().await.unwrap();
 
     client
         .delete_delivery_source()
@@ -667,9 +667,9 @@ async fn logs_deliveries() {
         .unwrap();
     let delivery_id = create.delivery().unwrap().id().unwrap().to_string();
 
-    let _ = client.get_delivery().id(&delivery_id).send().await.unwrap();
+    client.get_delivery().id(&delivery_id).send().await.unwrap();
 
-    let _ = client.describe_deliveries().send().await.unwrap();
+    client.describe_deliveries().send().await.unwrap();
 
     client
         .delete_delivery()
@@ -730,7 +730,7 @@ async fn logs_query_definitions() {
         .unwrap();
     let qd_id = put.query_definition_id().unwrap().to_string();
 
-    let _ = client.describe_query_definitions().send().await.unwrap();
+    client.describe_query_definitions().send().await.unwrap();
 
     client
         .delete_query_definition()

--- a/crates/fakecloud-conformance/tests/logs.rs
+++ b/crates/fakecloud-conformance/tests/logs.rs
@@ -1,0 +1,741 @@
+mod helpers;
+
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+// -- Log group lifecycle --
+
+#[test_action("logs", "CreateLogGroup", checksum = "76f16905")]
+#[test_action("logs", "DescribeLogGroups", checksum = "c88d7e2d")]
+#[test_action("logs", "DeleteLogGroup", checksum = "44642caf")]
+#[tokio::test]
+async fn logs_log_group_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/group1")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.describe_log_groups().send().await.unwrap();
+    assert!(!resp.log_groups().is_empty());
+
+    client
+        .delete_log_group()
+        .log_group_name("/conf/group1")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Log stream lifecycle --
+
+#[test_action("logs", "CreateLogStream", checksum = "8cd142c6")]
+#[test_action("logs", "DescribeLogStreams", checksum = "a25ff658")]
+#[test_action("logs", "DeleteLogStream", checksum = "3955d87d")]
+#[tokio::test]
+async fn logs_log_stream_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/streams")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_log_stream()
+        .log_group_name("/conf/streams")
+        .log_stream_name("stream1")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_log_streams()
+        .log_group_name("/conf/streams")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.log_streams().is_empty());
+
+    client
+        .delete_log_stream()
+        .log_group_name("/conf/streams")
+        .log_stream_name("stream1")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- PutLogEvents + GetLogEvents + FilterLogEvents --
+
+#[test_action("logs", "PutLogEvents", checksum = "73acad9c")]
+#[test_action("logs", "GetLogEvents", checksum = "a8cec2f4")]
+#[test_action("logs", "FilterLogEvents", checksum = "3316f933")]
+#[tokio::test]
+async fn logs_put_get_filter_events() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/events")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_log_stream()
+        .log_group_name("/conf/events")
+        .log_stream_name("s1")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_log_events()
+        .log_group_name("/conf/events")
+        .log_stream_name("s1")
+        .log_events(
+            aws_sdk_cloudwatchlogs::types::InputLogEvent::builder()
+                .timestamp(1700000000000)
+                .message("hello conformance")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_log_events()
+        .log_group_name("/conf/events")
+        .log_stream_name("s1")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.events().is_empty());
+
+    let filter = client
+        .filter_log_events()
+        .log_group_name("/conf/events")
+        .send()
+        .await
+        .unwrap();
+    assert!(!filter.events().is_empty());
+}
+
+// -- Tag/Untag log group (legacy) --
+
+#[test_action("logs", "TagLogGroup", checksum = "a1eb0891")]
+#[test_action("logs", "UntagLogGroup", checksum = "34dfdbcb")]
+#[test_action("logs", "ListTagsLogGroup", checksum = "5d78a6cc")]
+#[tokio::test]
+async fn logs_tag_untag_log_group_legacy() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/taglegacy")
+        .send()
+        .await
+        .unwrap();
+
+    #[allow(deprecated)]
+    client
+        .tag_log_group()
+        .log_group_name("/conf/taglegacy")
+        .tags("env", "test")
+        .send()
+        .await
+        .unwrap();
+
+    #[allow(deprecated)]
+    let resp = client
+        .list_tags_log_group()
+        .log_group_name("/conf/taglegacy")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.tags().is_some());
+
+    #[allow(deprecated)]
+    client
+        .untag_log_group()
+        .log_group_name("/conf/taglegacy")
+        .tags("env")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Tag/Untag resource (new API) --
+
+#[test_action("logs", "TagResource", checksum = "14d91a68")]
+#[test_action("logs", "UntagResource", checksum = "8875847f")]
+#[test_action("logs", "ListTagsForResource", checksum = "8aa1b0cf")]
+#[tokio::test]
+async fn logs_tag_untag_resource() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/tagres")
+        .send()
+        .await
+        .unwrap();
+
+    // Get the ARN from describe
+    let groups = client
+        .describe_log_groups()
+        .log_group_name_prefix("/conf/tagres")
+        .send()
+        .await
+        .unwrap();
+    let arn = groups.log_groups()[0].arn().unwrap().to_string();
+
+    client
+        .tag_resource()
+        .resource_arn(&arn)
+        .tags("project", "conformance")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_tags_for_resource()
+        .resource_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.tags().is_some());
+
+    client
+        .untag_resource()
+        .resource_arn(&arn)
+        .tag_keys("project")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Retention policy --
+
+#[test_action("logs", "PutRetentionPolicy", checksum = "12c2dc65")]
+#[test_action("logs", "DeleteRetentionPolicy", checksum = "64b06c60")]
+#[tokio::test]
+async fn logs_retention_policy() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/retention")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_retention_policy()
+        .log_group_name("/conf/retention")
+        .retention_in_days(7)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_retention_policy()
+        .log_group_name("/conf/retention")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Subscription filters --
+
+#[test_action("logs", "PutSubscriptionFilter", checksum = "9a4c1504")]
+#[test_action("logs", "DescribeSubscriptionFilters", checksum = "e21c42f4")]
+#[test_action("logs", "DeleteSubscriptionFilter", checksum = "22aad43a")]
+#[tokio::test]
+async fn logs_subscription_filters() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/subfilt")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_subscription_filter()
+        .log_group_name("/conf/subfilt")
+        .filter_name("conf-filter")
+        .filter_pattern("")
+        .destination_arn("arn:aws:lambda:us-east-1:123456789012:function:dummy")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_subscription_filters()
+        .log_group_name("/conf/subfilt")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.subscription_filters().is_empty());
+
+    client
+        .delete_subscription_filter()
+        .log_group_name("/conf/subfilt")
+        .filter_name("conf-filter")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Metric filters --
+
+#[test_action("logs", "PutMetricFilter", checksum = "947ca578")]
+#[test_action("logs", "DescribeMetricFilters", checksum = "42368c89")]
+#[test_action("logs", "DeleteMetricFilter", checksum = "a589d7d0")]
+#[tokio::test]
+async fn logs_metric_filters() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/metric")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_metric_filter()
+        .log_group_name("/conf/metric")
+        .filter_name("conf-metric")
+        .filter_pattern("[ip, user, ...]")
+        .metric_transformations(
+            aws_sdk_cloudwatchlogs::types::MetricTransformation::builder()
+                .metric_name("TestMetric")
+                .metric_namespace("Conformance")
+                .metric_value("1")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_metric_filters()
+        .log_group_name("/conf/metric")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.metric_filters().is_empty());
+
+    client
+        .delete_metric_filter()
+        .log_group_name("/conf/metric")
+        .filter_name("conf-metric")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Resource policies --
+
+#[test_action("logs", "PutResourcePolicy", checksum = "37d29085")]
+#[test_action("logs", "DescribeResourcePolicies", checksum = "0fb0c571")]
+#[test_action("logs", "DeleteResourcePolicy", checksum = "791340ba")]
+#[tokio::test]
+async fn logs_resource_policies() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"es.amazonaws.com"},"Action":["logs:PutLogEvents","logs:CreateLogStream"],"Resource":"*"}]}"#;
+
+    client
+        .put_resource_policy()
+        .policy_name("conf-policy")
+        .policy_document(policy_doc)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.describe_resource_policies().send().await.unwrap();
+    assert!(!resp.resource_policies().is_empty());
+
+    client
+        .delete_resource_policy()
+        .policy_name("conf-policy")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Destinations --
+
+#[test_action("logs", "PutDestination", checksum = "12a2c10d")]
+#[test_action("logs", "DescribeDestinations", checksum = "d793380f")]
+#[test_action("logs", "PutDestinationPolicy", checksum = "d1d9652d")]
+#[test_action("logs", "DeleteDestination", checksum = "ca130692")]
+#[tokio::test]
+async fn logs_destinations() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .put_destination()
+        .destination_name("conf-dest")
+        .target_arn("arn:aws:kinesis:us-east-1:123456789012:stream/dummy")
+        .role_arn("arn:aws:iam::123456789012:role/dummy")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.describe_destinations().send().await.unwrap();
+    assert!(!resp.destinations().is_empty());
+
+    let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"logs:PutSubscriptionFilter","Resource":"*"}]}"#;
+    client
+        .put_destination_policy()
+        .destination_name("conf-dest")
+        .access_policy(policy)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_destination()
+        .destination_name("conf-dest")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Queries --
+
+#[test_action("logs", "StartQuery", checksum = "a61f0343")]
+#[test_action("logs", "GetQueryResults", checksum = "0312b275")]
+#[test_action("logs", "DescribeQueries", checksum = "fb7f2a3c")]
+#[tokio::test]
+async fn logs_queries() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/queries")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_query()
+        .log_group_name("/conf/queries")
+        .start_time(0)
+        .end_time(9999999999)
+        .query_string("fields @timestamp, @message")
+        .send()
+        .await
+        .unwrap();
+    let query_id = start.query_id().unwrap().to_string();
+
+    let _ = client
+        .get_query_results()
+        .query_id(&query_id)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client.describe_queries().send().await.unwrap();
+}
+
+// -- Export tasks --
+
+#[test_action("logs", "CreateExportTask", checksum = "f339e521")]
+#[test_action("logs", "DescribeExportTasks", checksum = "a4564b5c")]
+#[test_action("logs", "CancelExportTask", checksum = "042d9396")]
+#[tokio::test]
+async fn logs_export_tasks() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/export")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_export_task()
+        .log_group_name("/conf/export")
+        .from(0)
+        .to(9999999999)
+        .destination("conf-export-bucket")
+        .send()
+        .await
+        .unwrap();
+    let task_id = create.task_id().unwrap().to_string();
+
+    let _ = client.describe_export_tasks().send().await.unwrap();
+
+    let _ = client.cancel_export_task().task_id(&task_id).send().await;
+}
+
+// -- Delivery destinations --
+
+#[test_action("logs", "PutDeliveryDestination", checksum = "5b7e444e")]
+#[test_action("logs", "GetDeliveryDestination", checksum = "bcd70ca0")]
+#[test_action("logs", "DescribeDeliveryDestinations", checksum = "04c820de")]
+#[test_action("logs", "DeleteDeliveryDestination", checksum = "260fbf3b")]
+#[tokio::test]
+async fn logs_delivery_destinations() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .put_delivery_destination()
+        .name("conf-dd")
+        .delivery_destination_configuration(
+            aws_sdk_cloudwatchlogs::types::DeliveryDestinationConfiguration::builder()
+                .destination_resource_arn("arn:aws:s3:::conf-bucket")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_delivery_destination()
+        .name("conf-dd")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .describe_delivery_destinations()
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_delivery_destination()
+        .name("conf-dd")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Delivery destination policy --
+
+#[test_action("logs", "PutDeliveryDestinationPolicy", checksum = "32b99512")]
+#[test_action("logs", "GetDeliveryDestinationPolicy", checksum = "7488a90e")]
+#[test_action("logs", "DeleteDeliveryDestinationPolicy", checksum = "23cb82ab")]
+#[tokio::test]
+async fn logs_delivery_destination_policy() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .put_delivery_destination()
+        .name("conf-dd-pol")
+        .delivery_destination_configuration(
+            aws_sdk_cloudwatchlogs::types::DeliveryDestinationConfiguration::builder()
+                .destination_resource_arn("arn:aws:s3:::conf-bucket-pol")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"logs:CreateDelivery","Resource":"*"}]}"#;
+    client
+        .put_delivery_destination_policy()
+        .delivery_destination_name("conf-dd-pol")
+        .delivery_destination_policy(policy)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_delivery_destination_policy()
+        .delivery_destination_name("conf-dd-pol")
+        .send()
+        .await;
+
+    let _ = client
+        .delete_delivery_destination_policy()
+        .delivery_destination_name("conf-dd-pol")
+        .send()
+        .await;
+}
+
+// -- Delivery sources --
+
+#[test_action("logs", "PutDeliverySource", checksum = "9e3b97b5")]
+#[test_action("logs", "GetDeliverySource", checksum = "a9ee52ac")]
+#[test_action("logs", "DescribeDeliverySources", checksum = "0c5b2fc9")]
+#[test_action("logs", "DeleteDeliverySource", checksum = "69db1c4e")]
+#[tokio::test]
+async fn logs_delivery_sources() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .put_delivery_source()
+        .name("conf-ds")
+        .resource_arn("arn:aws:logs:us-east-1:123456789012:log-group:dummy")
+        .log_type("APPLICATION_LOGS")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_delivery_source()
+        .name("conf-ds")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client.describe_delivery_sources().send().await.unwrap();
+
+    client
+        .delete_delivery_source()
+        .name("conf-ds")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Deliveries --
+
+#[test_action("logs", "CreateDelivery", checksum = "b4ff169a")]
+#[test_action("logs", "GetDelivery", checksum = "7a1b7136")]
+#[test_action("logs", "DescribeDeliveries", checksum = "e5773338")]
+#[test_action("logs", "DeleteDelivery", checksum = "3ffa7911")]
+#[tokio::test]
+async fn logs_deliveries() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    // Set up source and destination first
+    client
+        .put_delivery_source()
+        .name("conf-ds-dlv")
+        .resource_arn("arn:aws:logs:us-east-1:123456789012:log-group:dummy")
+        .log_type("APPLICATION_LOGS")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_delivery_destination()
+        .name("conf-dd-dlv")
+        .delivery_destination_configuration(
+            aws_sdk_cloudwatchlogs::types::DeliveryDestinationConfiguration::builder()
+                .destination_resource_arn("arn:aws:s3:::conf-bucket-dlv")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_delivery()
+        .delivery_source_name("conf-ds-dlv")
+        .delivery_destination_arn(
+            "arn:aws:logs:us-east-1:123456789012:delivery-destination:conf-dd-dlv",
+        )
+        .send()
+        .await
+        .unwrap();
+    let delivery_id = create.delivery().unwrap().id().unwrap().to_string();
+
+    let _ = client.get_delivery().id(&delivery_id).send().await.unwrap();
+
+    let _ = client.describe_deliveries().send().await.unwrap();
+
+    client
+        .delete_delivery()
+        .id(&delivery_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- KMS association --
+
+#[test_action("logs", "AssociateKmsKey", checksum = "745c2912")]
+#[test_action("logs", "DisassociateKmsKey", checksum = "20bbd380")]
+#[tokio::test]
+async fn logs_kms_association() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/kms")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .associate_kms_key()
+        .log_group_name("/conf/kms")
+        .kms_key_id("arn:aws:kms:us-east-1:123456789012:key/dummy-key-id")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .disassociate_kms_key()
+        .log_group_name("/conf/kms")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Query definitions --
+
+#[test_action("logs", "PutQueryDefinition", checksum = "007ecea3")]
+#[test_action("logs", "DescribeQueryDefinitions", checksum = "ec21fa12")]
+#[test_action("logs", "DeleteQueryDefinition", checksum = "89913a2a")]
+#[tokio::test]
+async fn logs_query_definitions() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    let put = client
+        .put_query_definition()
+        .name("conf-qd")
+        .query_string("fields @timestamp, @message | limit 20")
+        .send()
+        .await
+        .unwrap();
+    let qd_id = put.query_definition_id().unwrap().to_string();
+
+    let _ = client.describe_query_definitions().send().await.unwrap();
+
+    client
+        .delete_query_definition()
+        .query_definition_id(&qd_id)
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-conformance/tests/s3.rs
+++ b/crates/fakecloud-conformance/tests/s3.rs
@@ -33,7 +33,7 @@ async fn s3_bucket_lifecycle() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_bucket_location()
         .bucket("conf-bucket")
         .send()
@@ -241,7 +241,7 @@ async fn s3_list_object_versions() {
         .send()
         .await
         .unwrap();
-    let _ = client
+    client
         .list_object_versions()
         .bucket("conf-versions")
         .send()
@@ -409,7 +409,7 @@ async fn s3_object_acl() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_object_acl()
         .bucket("conf-oacl")
         .key("acl.txt")
@@ -581,7 +581,7 @@ async fn s3_bucket_acl() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_bucket_acl()
         .bucket("conf-bacl")
         .send()
@@ -665,7 +665,7 @@ async fn s3_bucket_cors() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_bucket_cors()
         .bucket("conf-cors")
         .send()
@@ -704,7 +704,7 @@ async fn s3_bucket_notification() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_bucket_notification_configuration()
         .bucket("conf-notif")
         .send()
@@ -746,7 +746,7 @@ async fn s3_bucket_website() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_bucket_website()
         .bucket("conf-web")
         .send()
@@ -789,7 +789,7 @@ async fn s3_bucket_accelerate() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_bucket_accelerate_configuration()
         .bucket("conf-accel")
         .send()
@@ -826,7 +826,7 @@ async fn s3_public_access_block() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_public_access_block()
         .bucket("conf-pab")
         .send()
@@ -880,7 +880,7 @@ async fn s3_bucket_encryption() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_bucket_encryption()
         .bucket("conf-enc")
         .send()
@@ -941,7 +941,7 @@ async fn s3_bucket_lifecycle_config() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_bucket_lifecycle_configuration()
         .bucket("conf-lc")
         .send()
@@ -980,7 +980,7 @@ async fn s3_bucket_logging() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_bucket_logging()
         .bucket("conf-log")
         .send()
@@ -1166,7 +1166,7 @@ async fn s3_bucket_ownership_controls() {
         .await
         .unwrap();
 
-    let _ = client
+    client
         .get_bucket_ownership_controls()
         .bucket("conf-own")
         .send()

--- a/crates/fakecloud-conformance/tests/s3.rs
+++ b/crates/fakecloud-conformance/tests/s3.rs
@@ -1,0 +1,1409 @@
+mod helpers;
+
+use aws_sdk_s3::primitives::ByteStream;
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+// -- Bucket lifecycle --
+
+#[test_action("s3", "CreateBucket", checksum = "15accf87")]
+#[test_action("s3", "ListBuckets", checksum = "80b1347a")]
+#[test_action("s3", "HeadBucket", checksum = "803cc873")]
+#[test_action("s3", "GetBucketLocation", checksum = "c6da5a3c")]
+#[test_action("s3", "DeleteBucket", checksum = "05abd839")]
+#[tokio::test]
+async fn s3_bucket_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client.list_buckets().send().await.unwrap();
+    assert!(!list.buckets().is_empty());
+
+    client
+        .head_bucket()
+        .bucket("conf-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_location()
+        .bucket("conf-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_bucket()
+        .bucket("conf-bucket")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Object CRUD --
+
+#[test_action("s3", "PutObject", checksum = "e9dbbbaa")]
+#[test_action("s3", "GetObject", checksum = "cd0afbe3")]
+#[test_action("s3", "HeadObject", checksum = "dd127249")]
+#[test_action("s3", "DeleteObject", checksum = "b50d71d4")]
+#[tokio::test]
+async fn s3_object_crud() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-obj")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_object()
+        .bucket("conf-obj")
+        .key("test.txt")
+        .body(ByteStream::from_static(b"hello conformance"))
+        .send()
+        .await
+        .unwrap();
+
+    let get = client
+        .get_object()
+        .bucket("conf-obj")
+        .key("test.txt")
+        .send()
+        .await
+        .unwrap();
+    let body = get.body.collect().await.unwrap().into_bytes();
+    assert_eq!(&body[..], b"hello conformance");
+
+    client
+        .head_object()
+        .bucket("conf-obj")
+        .key("test.txt")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_object()
+        .bucket("conf-obj")
+        .key("test.txt")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- CopyObject --
+
+#[test_action("s3", "CopyObject", checksum = "03812378")]
+#[tokio::test]
+async fn s3_copy_object() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-copy")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_object()
+        .bucket("conf-copy")
+        .key("src.txt")
+        .body(ByteStream::from_static(b"source"))
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .copy_object()
+        .bucket("conf-copy")
+        .key("dst.txt")
+        .copy_source("conf-copy/src.txt")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- DeleteObjects (batch) --
+
+#[test_action("s3", "DeleteObjects", checksum = "b48fe2d0")]
+#[tokio::test]
+async fn s3_delete_objects() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-delobj")
+        .send()
+        .await
+        .unwrap();
+    for key in ["a.txt", "b.txt"] {
+        client
+            .put_object()
+            .bucket("conf-delobj")
+            .key(key)
+            .body(ByteStream::from_static(b"x"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let resp = client
+        .delete_objects()
+        .bucket("conf-delobj")
+        .delete(
+            aws_sdk_s3::types::Delete::builder()
+                .objects(
+                    aws_sdk_s3::types::ObjectIdentifier::builder()
+                        .key("a.txt")
+                        .build()
+                        .unwrap(),
+                )
+                .objects(
+                    aws_sdk_s3::types::ObjectIdentifier::builder()
+                        .key("b.txt")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.deleted().len(), 2);
+}
+
+// -- ListObjectsV2 + ListObjects --
+
+#[test_action("s3", "ListObjectsV2", checksum = "0b2ea04f")]
+#[test_action("s3", "ListObjects", checksum = "e0e01f68")]
+#[tokio::test]
+async fn s3_list_objects() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-list")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_object()
+        .bucket("conf-list")
+        .key("item.txt")
+        .body(ByteStream::from_static(b"x"))
+        .send()
+        .await
+        .unwrap();
+
+    let v2 = client
+        .list_objects_v2()
+        .bucket("conf-list")
+        .send()
+        .await
+        .unwrap();
+    assert!(!v2.contents().is_empty());
+
+    let v1 = client
+        .list_objects()
+        .bucket("conf-list")
+        .send()
+        .await
+        .unwrap();
+    assert!(!v1.contents().is_empty());
+}
+
+// -- ListObjectVersions --
+
+#[test_action("s3", "ListObjectVersions", checksum = "6371c49f")]
+#[tokio::test]
+async fn s3_list_object_versions() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-versions")
+        .send()
+        .await
+        .unwrap();
+    let _ = client
+        .list_object_versions()
+        .bucket("conf-versions")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- GetObjectAttributes --
+
+#[test_action("s3", "GetObjectAttributes", checksum = "1b2f99bd")]
+#[tokio::test]
+async fn s3_get_object_attributes() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-attrs")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_object()
+        .bucket("conf-attrs")
+        .key("a.txt")
+        .body(ByteStream::from_static(b"data"))
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_object_attributes()
+        .bucket("conf-attrs")
+        .key("a.txt")
+        .object_attributes(aws_sdk_s3::types::ObjectAttributes::ObjectSize)
+        .send()
+        .await;
+}
+
+// -- RestoreObject --
+
+#[test_action("s3", "RestoreObject", checksum = "51dbe951")]
+#[tokio::test]
+async fn s3_restore_object() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-restore")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_object()
+        .bucket("conf-restore")
+        .key("archive.txt")
+        .body(ByteStream::from_static(b"archived"))
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .restore_object()
+        .bucket("conf-restore")
+        .key("archive.txt")
+        .restore_request(aws_sdk_s3::types::RestoreRequest::builder().days(1).build())
+        .send()
+        .await;
+}
+
+// -- Object tagging --
+
+#[test_action("s3", "PutObjectTagging", checksum = "80e8c9eb")]
+#[test_action("s3", "GetObjectTagging", checksum = "e0ede0a2")]
+#[test_action("s3", "DeleteObjectTagging", checksum = "bdabe7c6")]
+#[tokio::test]
+async fn s3_object_tagging() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-otag")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_object()
+        .bucket("conf-otag")
+        .key("tagged.txt")
+        .body(ByteStream::from_static(b"x"))
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_object_tagging()
+        .bucket("conf-otag")
+        .key("tagged.txt")
+        .tagging(
+            aws_sdk_s3::types::Tagging::builder()
+                .tag_set(
+                    aws_sdk_s3::types::Tag::builder()
+                        .key("env")
+                        .value("test")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_object_tagging()
+        .bucket("conf-otag")
+        .key("tagged.txt")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.tag_set().is_empty());
+
+    client
+        .delete_object_tagging()
+        .bucket("conf-otag")
+        .key("tagged.txt")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Object ACL --
+
+#[test_action("s3", "PutObjectAcl", checksum = "a1356c24")]
+#[test_action("s3", "GetObjectAcl", checksum = "aa4c2112")]
+#[tokio::test]
+async fn s3_object_acl() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-oacl")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_object()
+        .bucket("conf-oacl")
+        .key("acl.txt")
+        .body(ByteStream::from_static(b"x"))
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_object_acl()
+        .bucket("conf-oacl")
+        .key("acl.txt")
+        .acl(aws_sdk_s3::types::ObjectCannedAcl::PublicRead)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_object_acl()
+        .bucket("conf-oacl")
+        .key("acl.txt")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Object retention + legal hold --
+
+#[test_action("s3", "PutObjectRetention", checksum = "278f33b6")]
+#[test_action("s3", "GetObjectRetention", checksum = "cd7095c1")]
+#[tokio::test]
+async fn s3_object_retention() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-oret")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_object()
+        .bucket("conf-oret")
+        .key("ret.txt")
+        .body(ByteStream::from_static(b"x"))
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .put_object_retention()
+        .bucket("conf-oret")
+        .key("ret.txt")
+        .retention(
+            aws_sdk_s3::types::ObjectLockRetention::builder()
+                .mode(aws_sdk_s3::types::ObjectLockRetentionMode::Governance)
+                .retain_until_date(aws_sdk_s3::primitives::DateTime::from_secs(4102444800))
+                .build(),
+        )
+        .send()
+        .await;
+
+    let _ = client
+        .get_object_retention()
+        .bucket("conf-oret")
+        .key("ret.txt")
+        .send()
+        .await;
+}
+
+#[test_action("s3", "PutObjectLegalHold", checksum = "4707c231")]
+#[test_action("s3", "GetObjectLegalHold", checksum = "2d6979f4")]
+#[tokio::test]
+async fn s3_object_legal_hold() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-olh")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_object()
+        .bucket("conf-olh")
+        .key("hold.txt")
+        .body(ByteStream::from_static(b"x"))
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .put_object_legal_hold()
+        .bucket("conf-olh")
+        .key("hold.txt")
+        .legal_hold(
+            aws_sdk_s3::types::ObjectLockLegalHold::builder()
+                .status(aws_sdk_s3::types::ObjectLockLegalHoldStatus::On)
+                .build(),
+        )
+        .send()
+        .await;
+
+    let _ = client
+        .get_object_legal_hold()
+        .bucket("conf-olh")
+        .key("hold.txt")
+        .send()
+        .await;
+}
+
+// -- Bucket tagging --
+
+#[test_action("s3", "PutBucketTagging", checksum = "5ad8a3c6")]
+#[test_action("s3", "GetBucketTagging", checksum = "2257d3d6")]
+#[test_action("s3", "DeleteBucketTagging", checksum = "e3fe5dcd")]
+#[tokio::test]
+async fn s3_bucket_tagging() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-btag")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_tagging()
+        .bucket("conf-btag")
+        .tagging(
+            aws_sdk_s3::types::Tagging::builder()
+                .tag_set(
+                    aws_sdk_s3::types::Tag::builder()
+                        .key("env")
+                        .value("test")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_bucket_tagging()
+        .bucket("conf-btag")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.tag_set().is_empty());
+
+    client
+        .delete_bucket_tagging()
+        .bucket("conf-btag")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Bucket ACL --
+
+#[test_action("s3", "PutBucketAcl", checksum = "2b56bf7d")]
+#[test_action("s3", "GetBucketAcl", checksum = "54d254cd")]
+#[tokio::test]
+async fn s3_bucket_acl() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-bacl")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_acl()
+        .bucket("conf-bacl")
+        .acl(aws_sdk_s3::types::BucketCannedAcl::PublicRead)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_acl()
+        .bucket("conf-bacl")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Bucket versioning --
+
+#[test_action("s3", "PutBucketVersioning", checksum = "0b8739d5")]
+#[test_action("s3", "GetBucketVersioning", checksum = "2a2834a0")]
+#[tokio::test]
+async fn s3_bucket_versioning() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-bver")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_versioning()
+        .bucket("conf-bver")
+        .versioning_configuration(
+            aws_sdk_s3::types::VersioningConfiguration::builder()
+                .status(aws_sdk_s3::types::BucketVersioningStatus::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_bucket_versioning()
+        .bucket("conf-bver")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        Some(&aws_sdk_s3::types::BucketVersioningStatus::Enabled)
+    );
+}
+
+// -- Bucket CORS --
+
+#[test_action("s3", "PutBucketCors", checksum = "d45fcf4a")]
+#[test_action("s3", "GetBucketCors", checksum = "ca2bd57e")]
+#[test_action("s3", "DeleteBucketCors", checksum = "81962aad")]
+#[tokio::test]
+async fn s3_bucket_cors() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-cors")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_cors()
+        .bucket("conf-cors")
+        .cors_configuration(
+            aws_sdk_s3::types::CorsConfiguration::builder()
+                .cors_rules(
+                    aws_sdk_s3::types::CorsRule::builder()
+                        .allowed_methods("GET")
+                        .allowed_origins("*")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_cors()
+        .bucket("conf-cors")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_bucket_cors()
+        .bucket("conf-cors")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Bucket notification configuration --
+
+#[test_action("s3", "PutBucketNotificationConfiguration", checksum = "6defd1ec")]
+#[test_action("s3", "GetBucketNotificationConfiguration", checksum = "c6a077b9")]
+#[tokio::test]
+async fn s3_bucket_notification() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-notif")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_notification_configuration()
+        .bucket("conf-notif")
+        .notification_configuration(aws_sdk_s3::types::NotificationConfiguration::builder().build())
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_notification_configuration()
+        .bucket("conf-notif")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Bucket website --
+
+#[test_action("s3", "PutBucketWebsite", checksum = "d64c97c0")]
+#[test_action("s3", "GetBucketWebsite", checksum = "02acea7a")]
+#[test_action("s3", "DeleteBucketWebsite", checksum = "892d5b36")]
+#[tokio::test]
+async fn s3_bucket_website() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-web")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_website()
+        .bucket("conf-web")
+        .website_configuration(
+            aws_sdk_s3::types::WebsiteConfiguration::builder()
+                .index_document(
+                    aws_sdk_s3::types::IndexDocument::builder()
+                        .suffix("index.html")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_website()
+        .bucket("conf-web")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_bucket_website()
+        .bucket("conf-web")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Bucket accelerate --
+
+#[test_action("s3", "PutBucketAccelerateConfiguration", checksum = "9c5d6ce0")]
+#[test_action("s3", "GetBucketAccelerateConfiguration", checksum = "33fcae8e")]
+#[tokio::test]
+async fn s3_bucket_accelerate() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-accel")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_accelerate_configuration()
+        .bucket("conf-accel")
+        .accelerate_configuration(
+            aws_sdk_s3::types::AccelerateConfiguration::builder()
+                .status(aws_sdk_s3::types::BucketAccelerateStatus::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_accelerate_configuration()
+        .bucket("conf-accel")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Public access block --
+
+#[test_action("s3", "PutPublicAccessBlock", checksum = "ddccd75d")]
+#[test_action("s3", "GetPublicAccessBlock", checksum = "66149497")]
+#[test_action("s3", "DeletePublicAccessBlock", checksum = "5fd2aac6")]
+#[tokio::test]
+async fn s3_public_access_block() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-pab")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_public_access_block()
+        .bucket("conf-pab")
+        .public_access_block_configuration(
+            aws_sdk_s3::types::PublicAccessBlockConfiguration::builder()
+                .block_public_acls(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_public_access_block()
+        .bucket("conf-pab")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_public_access_block()
+        .bucket("conf-pab")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Bucket encryption --
+
+#[test_action("s3", "PutBucketEncryption", checksum = "bfeb2d44")]
+#[test_action("s3", "GetBucketEncryption", checksum = "d7326b12")]
+#[test_action("s3", "DeleteBucketEncryption", checksum = "897fff80")]
+#[tokio::test]
+async fn s3_bucket_encryption() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-enc")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_encryption()
+        .bucket("conf-enc")
+        .server_side_encryption_configuration(
+            aws_sdk_s3::types::ServerSideEncryptionConfiguration::builder()
+                .rules(
+                    aws_sdk_s3::types::ServerSideEncryptionRule::builder()
+                        .apply_server_side_encryption_by_default(
+                            aws_sdk_s3::types::ServerSideEncryptionByDefault::builder()
+                                .sse_algorithm(aws_sdk_s3::types::ServerSideEncryption::Aes256)
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_encryption()
+        .bucket("conf-enc")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_bucket_encryption()
+        .bucket("conf-enc")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Bucket lifecycle --
+
+#[test_action("s3", "PutBucketLifecycleConfiguration", checksum = "29af802c")]
+#[test_action("s3", "GetBucketLifecycleConfiguration", checksum = "73010677")]
+#[test_action("s3", "DeleteBucketLifecycle", checksum = "335ed098")]
+#[tokio::test]
+async fn s3_bucket_lifecycle_config() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-lc")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_lifecycle_configuration()
+        .bucket("conf-lc")
+        .lifecycle_configuration(
+            aws_sdk_s3::types::BucketLifecycleConfiguration::builder()
+                .rules(
+                    aws_sdk_s3::types::LifecycleRule::builder()
+                        .id("expire")
+                        .status(aws_sdk_s3::types::ExpirationStatus::Enabled)
+                        .expiration(
+                            aws_sdk_s3::types::LifecycleExpiration::builder()
+                                .days(30)
+                                .build(),
+                        )
+                        .filter(
+                            aws_sdk_s3::types::LifecycleRuleFilter::builder()
+                                .prefix("logs/")
+                                .build(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_lifecycle_configuration()
+        .bucket("conf-lc")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_bucket_lifecycle()
+        .bucket("conf-lc")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Bucket logging --
+
+#[test_action("s3", "PutBucketLogging", checksum = "50be50fa")]
+#[test_action("s3", "GetBucketLogging", checksum = "a7325831")]
+#[tokio::test]
+async fn s3_bucket_logging() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-log")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_logging()
+        .bucket("conf-log")
+        .bucket_logging_status(aws_sdk_s3::types::BucketLoggingStatus::builder().build())
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_logging()
+        .bucket("conf-log")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Bucket policy --
+
+#[test_action("s3", "PutBucketPolicy", checksum = "dd80bd6c")]
+#[test_action("s3", "GetBucketPolicy", checksum = "d34ae983")]
+#[test_action("s3", "DeleteBucketPolicy", checksum = "90cdf847")]
+#[tokio::test]
+async fn s3_bucket_policy() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-bpol")
+        .send()
+        .await
+        .unwrap();
+
+    let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::conf-bpol/*"}]}"#;
+    client
+        .put_bucket_policy()
+        .bucket("conf-bpol")
+        .policy(policy)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_bucket_policy()
+        .bucket("conf-bpol")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.policy().is_some());
+
+    client
+        .delete_bucket_policy()
+        .bucket("conf-bpol")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Object lock configuration --
+
+#[test_action("s3", "PutObjectLockConfiguration", checksum = "5ee132b3")]
+#[test_action("s3", "GetObjectLockConfiguration", checksum = "8cbd3dcf")]
+#[tokio::test]
+async fn s3_object_lock_configuration() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-olock")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .put_object_lock_configuration()
+        .bucket("conf-olock")
+        .object_lock_configuration(
+            aws_sdk_s3::types::ObjectLockConfiguration::builder()
+                .object_lock_enabled(aws_sdk_s3::types::ObjectLockEnabled::Enabled)
+                .build(),
+        )
+        .send()
+        .await;
+
+    let _ = client
+        .get_object_lock_configuration()
+        .bucket("conf-olock")
+        .send()
+        .await;
+}
+
+// -- Bucket replication --
+
+#[test_action("s3", "PutBucketReplication", checksum = "03741feb")]
+#[test_action("s3", "GetBucketReplication", checksum = "5aa6062b")]
+#[test_action("s3", "DeleteBucketReplication", checksum = "6b0e2b2e")]
+#[tokio::test]
+async fn s3_bucket_replication() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-repl")
+        .send()
+        .await
+        .unwrap();
+
+    // Enable versioning first (required for replication)
+    client
+        .put_bucket_versioning()
+        .bucket("conf-repl")
+        .versioning_configuration(
+            aws_sdk_s3::types::VersioningConfiguration::builder()
+                .status(aws_sdk_s3::types::BucketVersioningStatus::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .put_bucket_replication()
+        .bucket("conf-repl")
+        .replication_configuration(
+            aws_sdk_s3::types::ReplicationConfiguration::builder()
+                .role("arn:aws:iam::123456789012:role/repl-role")
+                .rules(
+                    aws_sdk_s3::types::ReplicationRule::builder()
+                        .status(aws_sdk_s3::types::ReplicationRuleStatus::Enabled)
+                        .destination(
+                            aws_sdk_s3::types::Destination::builder()
+                                .bucket("arn:aws:s3:::conf-repl-dest")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await;
+
+    let _ = client
+        .get_bucket_replication()
+        .bucket("conf-repl")
+        .send()
+        .await;
+
+    let _ = client
+        .delete_bucket_replication()
+        .bucket("conf-repl")
+        .send()
+        .await;
+}
+
+// -- Bucket ownership controls --
+
+#[test_action("s3", "PutBucketOwnershipControls", checksum = "aa269fa6")]
+#[test_action("s3", "GetBucketOwnershipControls", checksum = "5d7346cb")]
+#[test_action("s3", "DeleteBucketOwnershipControls", checksum = "9727d2b1")]
+#[tokio::test]
+async fn s3_bucket_ownership_controls() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-own")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_ownership_controls()
+        .bucket("conf-own")
+        .ownership_controls(
+            aws_sdk_s3::types::OwnershipControls::builder()
+                .rules(
+                    aws_sdk_s3::types::OwnershipControlsRule::builder()
+                        .object_ownership(aws_sdk_s3::types::ObjectOwnership::BucketOwnerEnforced)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_ownership_controls()
+        .bucket("conf-own")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_bucket_ownership_controls()
+        .bucket("conf-own")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Bucket inventory configuration --
+
+#[test_action("s3", "PutBucketInventoryConfiguration", checksum = "f1431dd8")]
+#[test_action("s3", "GetBucketInventoryConfiguration", checksum = "3e191949")]
+#[test_action("s3", "DeleteBucketInventoryConfiguration", checksum = "5fb3b7de")]
+#[tokio::test]
+async fn s3_bucket_inventory() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-inv")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_bucket_inventory_configuration()
+        .bucket("conf-inv")
+        .id("conf-inv-id")
+        .inventory_configuration(
+            aws_sdk_s3::types::InventoryConfiguration::builder()
+                .id("conf-inv-id")
+                .is_enabled(true)
+                .destination(
+                    aws_sdk_s3::types::InventoryDestination::builder()
+                        .s3_bucket_destination(
+                            aws_sdk_s3::types::InventoryS3BucketDestination::builder()
+                                .bucket("arn:aws:s3:::conf-inv-dest")
+                                .format(aws_sdk_s3::types::InventoryFormat::Csv)
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .schedule(
+                    aws_sdk_s3::types::InventorySchedule::builder()
+                        .frequency(aws_sdk_s3::types::InventoryFrequency::Daily)
+                        .build()
+                        .unwrap(),
+                )
+                .included_object_versions(
+                    aws_sdk_s3::types::InventoryIncludedObjectVersions::Current,
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_bucket_inventory_configuration()
+        .bucket("conf-inv")
+        .id("conf-inv-id")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_bucket_inventory_configuration()
+        .bucket("conf-inv")
+        .id("conf-inv-id")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Multipart upload --
+
+#[test_action("s3", "CreateMultipartUpload", checksum = "84f77436")]
+#[test_action("s3", "UploadPart", checksum = "de83c026")]
+#[test_action("s3", "CompleteMultipartUpload", checksum = "0df95972")]
+#[test_action("s3", "ListParts", checksum = "61616240")]
+#[test_action("s3", "ListMultipartUploads", checksum = "9f3daa98")]
+#[tokio::test]
+async fn s3_multipart_upload() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-mpu")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("conf-mpu")
+        .key("bigfile.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    let _ = client
+        .list_multipart_uploads()
+        .bucket("conf-mpu")
+        .send()
+        .await
+        .unwrap();
+
+    // Upload 5MB part (minimum)
+    let part_data = vec![b'A'; 5 * 1024 * 1024];
+    let part = client
+        .upload_part()
+        .bucket("conf-mpu")
+        .key("bigfile.bin")
+        .upload_id(&upload_id)
+        .part_number(1)
+        .body(ByteStream::from(part_data))
+        .send()
+        .await
+        .unwrap();
+    let etag = part.e_tag().unwrap().to_string();
+
+    let _ = client
+        .list_parts()
+        .bucket("conf-mpu")
+        .key("bigfile.bin")
+        .upload_id(&upload_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .complete_multipart_upload()
+        .bucket("conf-mpu")
+        .key("bigfile.bin")
+        .upload_id(&upload_id)
+        .multipart_upload(
+            aws_sdk_s3::types::CompletedMultipartUpload::builder()
+                .parts(
+                    aws_sdk_s3::types::CompletedPart::builder()
+                        .part_number(1)
+                        .e_tag(&etag)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- AbortMultipartUpload --
+
+#[test_action("s3", "AbortMultipartUpload", checksum = "0d1d4ebe")]
+#[tokio::test]
+async fn s3_abort_multipart_upload() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-abort")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("conf-abort")
+        .key("abort.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    client
+        .abort_multipart_upload()
+        .bucket("conf-abort")
+        .key("abort.bin")
+        .upload_id(&upload_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- UploadPartCopy --
+
+#[test_action("s3", "UploadPartCopy", checksum = "49d22a26")]
+#[tokio::test]
+async fn s3_upload_part_copy() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("conf-upc")
+        .send()
+        .await
+        .unwrap();
+
+    // Create source object
+    let data = vec![b'B'; 5 * 1024 * 1024];
+    client
+        .put_object()
+        .bucket("conf-upc")
+        .key("source.bin")
+        .body(ByteStream::from(data))
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("conf-upc")
+        .key("dest.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    let _ = client
+        .upload_part_copy()
+        .bucket("conf-upc")
+        .key("dest.bin")
+        .upload_id(&upload_id)
+        .part_number(1)
+        .copy_source("conf-upc/source.bin")
+        .send()
+        .await;
+}

--- a/crates/fakecloud-conformance/tests/secretsmanager.rs
+++ b/crates/fakecloud-conformance/tests/secretsmanager.rs
@@ -1,0 +1,392 @@
+mod helpers;
+
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+// -- Basic secret lifecycle --
+
+#[test_action("secretsmanager", "CreateSecret", checksum = "cbecb465")]
+#[test_action("secretsmanager", "DescribeSecret", checksum = "0174c78c")]
+#[test_action("secretsmanager", "DeleteSecret", checksum = "cb942663")]
+#[tokio::test]
+async fn sm_create_describe_delete_secret() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    let create = client
+        .create_secret()
+        .name("conf/secret1")
+        .secret_string("s3cret")
+        .send()
+        .await
+        .unwrap();
+    assert!(create.arn().is_some());
+
+    let desc = client
+        .describe_secret()
+        .secret_id("conf/secret1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desc.name().unwrap(), "conf/secret1");
+
+    client
+        .delete_secret()
+        .secret_id("conf/secret1")
+        .force_delete_without_recovery(true)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Get / Put secret value --
+
+#[test_action("secretsmanager", "GetSecretValue", checksum = "62d26559")]
+#[test_action("secretsmanager", "PutSecretValue", checksum = "303f646a")]
+#[tokio::test]
+async fn sm_get_put_secret_value() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    client
+        .create_secret()
+        .name("conf/getput")
+        .secret_string("initial")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_secret_value()
+        .secret_id("conf/getput")
+        .secret_string("updated")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_secret_value()
+        .secret_id("conf/getput")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.secret_string().unwrap(), "updated");
+}
+
+// -- Update secret --
+
+#[test_action("secretsmanager", "UpdateSecret", checksum = "cef3ebb2")]
+#[tokio::test]
+async fn sm_update_secret() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    client
+        .create_secret()
+        .name("conf/update")
+        .secret_string("v1")
+        .send()
+        .await
+        .unwrap();
+    client
+        .update_secret()
+        .secret_id("conf/update")
+        .description("updated description")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- List secrets --
+
+#[test_action("secretsmanager", "ListSecrets", checksum = "4a9247e4")]
+#[tokio::test]
+async fn sm_list_secrets() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    client
+        .create_secret()
+        .name("conf/list1")
+        .secret_string("x")
+        .send()
+        .await
+        .unwrap();
+    let resp = client.list_secrets().send().await.unwrap();
+    assert!(!resp.secret_list().is_empty());
+}
+
+// -- Restore secret --
+
+#[test_action("secretsmanager", "RestoreSecret", checksum = "2bd0c57c")]
+#[tokio::test]
+async fn sm_restore_secret() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    client
+        .create_secret()
+        .name("conf/restore")
+        .secret_string("x")
+        .send()
+        .await
+        .unwrap();
+    client
+        .delete_secret()
+        .secret_id("conf/restore")
+        .send()
+        .await
+        .unwrap();
+    client
+        .restore_secret()
+        .secret_id("conf/restore")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Tags --
+
+#[test_action("secretsmanager", "TagResource", checksum = "c6ae0114")]
+#[test_action("secretsmanager", "UntagResource", checksum = "50c098a5")]
+#[tokio::test]
+async fn sm_tag_untag_resource() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    let create = client
+        .create_secret()
+        .name("conf/tags")
+        .secret_string("x")
+        .send()
+        .await
+        .unwrap();
+    let arn = create.arn().unwrap().to_string();
+
+    client
+        .tag_resource()
+        .secret_id(&arn)
+        .tags(
+            aws_sdk_secretsmanager::types::Tag::builder()
+                .key("env")
+                .value("test")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .untag_resource()
+        .secret_id(&arn)
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Version IDs --
+
+#[test_action("secretsmanager", "ListSecretVersionIds", checksum = "1121a7d4")]
+#[tokio::test]
+async fn sm_list_secret_version_ids() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    client
+        .create_secret()
+        .name("conf/versions")
+        .secret_string("x")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .list_secret_version_ids()
+        .secret_id("conf/versions")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.versions().is_empty());
+}
+
+// -- Random password --
+
+#[test_action("secretsmanager", "GetRandomPassword", checksum = "8b24f8b9")]
+#[tokio::test]
+async fn sm_get_random_password() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    let resp = client
+        .get_random_password()
+        .password_length(32)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.random_password().is_some());
+}
+
+// -- Rotation --
+
+#[test_action("secretsmanager", "RotateSecret", checksum = "4e2d1c9f")]
+#[test_action("secretsmanager", "CancelRotateSecret", checksum = "33ed389c")]
+#[tokio::test]
+async fn sm_rotate_cancel_rotate() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    client
+        .create_secret()
+        .name("conf/rotate")
+        .secret_string("x")
+        .send()
+        .await
+        .unwrap();
+    let _ = client.rotate_secret().secret_id("conf/rotate").send().await;
+    let _ = client
+        .cancel_rotate_secret()
+        .secret_id("conf/rotate")
+        .send()
+        .await;
+}
+
+// -- Version stage --
+
+#[test_action("secretsmanager", "UpdateSecretVersionStage", checksum = "b7be3e8e")]
+#[tokio::test]
+async fn sm_update_secret_version_stage() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    let create = client
+        .create_secret()
+        .name("conf/stage")
+        .secret_string("x")
+        .send()
+        .await
+        .unwrap();
+    let version_id = create.version_id().unwrap().to_string();
+    let _ = client
+        .update_secret_version_stage()
+        .secret_id("conf/stage")
+        .version_stage("AWSCURRENT")
+        .move_to_version_id(&version_id)
+        .send()
+        .await;
+}
+
+// -- Batch get --
+
+#[test_action("secretsmanager", "BatchGetSecretValue", checksum = "9948f85b")]
+#[tokio::test]
+async fn sm_batch_get_secret_value() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    client
+        .create_secret()
+        .name("conf/batch1")
+        .secret_string("v1")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .batch_get_secret_value()
+        .secret_id_list("conf/batch1")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.secret_values().is_empty());
+}
+
+// -- Resource policy --
+
+#[test_action("secretsmanager", "PutResourcePolicy", checksum = "7ea18f4d")]
+#[test_action("secretsmanager", "GetResourcePolicy", checksum = "d59157c6")]
+#[test_action("secretsmanager", "DeleteResourcePolicy", checksum = "9be6ed12")]
+#[tokio::test]
+async fn sm_resource_policy() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    client
+        .create_secret()
+        .name("conf/policy")
+        .secret_string("x")
+        .send()
+        .await
+        .unwrap();
+
+    let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"secretsmanager:GetSecretValue","Resource":"*"}]}"#;
+    client
+        .put_resource_policy()
+        .secret_id("conf/policy")
+        .resource_policy(policy)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_resource_policy()
+        .secret_id("conf/policy")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.resource_policy().is_some());
+
+    client
+        .delete_resource_policy()
+        .secret_id("conf/policy")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Validate resource policy --
+
+#[test_action("secretsmanager", "ValidateResourcePolicy", checksum = "e3cfeb7e")]
+#[tokio::test]
+async fn sm_validate_resource_policy() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"secretsmanager:GetSecretValue","Resource":"*"}]}"#;
+    let _ = client
+        .validate_resource_policy()
+        .resource_policy(policy)
+        .send()
+        .await;
+}
+
+// -- Replication --
+
+#[test_action("secretsmanager", "ReplicateSecretToRegions", checksum = "c0347eac")]
+#[test_action(
+    "secretsmanager",
+    "RemoveRegionsFromReplication",
+    checksum = "afa944b1"
+)]
+#[test_action("secretsmanager", "StopReplicationToReplica", checksum = "c4f70e74")]
+#[tokio::test]
+async fn sm_replication() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+    client
+        .create_secret()
+        .name("conf/replicate")
+        .secret_string("x")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .replicate_secret_to_regions()
+        .secret_id("conf/replicate")
+        .add_replica_regions(
+            aws_sdk_secretsmanager::types::ReplicaRegionType::builder()
+                .region("eu-west-1")
+                .build(),
+        )
+        .send()
+        .await;
+
+    let _ = client
+        .remove_regions_from_replication()
+        .secret_id("conf/replicate")
+        .remove_replica_regions("eu-west-1")
+        .send()
+        .await;
+
+    let _ = client
+        .stop_replication_to_replica()
+        .secret_id("conf/replicate")
+        .send()
+        .await;
+}

--- a/crates/fakecloud-conformance/tests/sns.rs
+++ b/crates/fakecloud-conformance/tests/sns.rs
@@ -1,0 +1,903 @@
+mod helpers;
+
+use aws_sdk_sns::types::{PublishBatchRequestEntry, Tag};
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+// ---------------------------------------------------------------------------
+// Topic lifecycle
+// ---------------------------------------------------------------------------
+
+#[test_action("sns", "CreateTopic", checksum = "134daf7a")]
+#[tokio::test]
+async fn sns_create_topic() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let resp = client.create_topic().name("ct-topic").send().await.unwrap();
+    assert!(resp.topic_arn().unwrap().contains("ct-topic"));
+}
+
+#[test_action("sns", "ListTopics", checksum = "3231aa30")]
+#[tokio::test]
+async fn sns_list_topics() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    client.create_topic().name("lt-topic").send().await.unwrap();
+    let resp = client.list_topics().send().await.unwrap();
+    assert!(!resp.topics().is_empty());
+}
+
+#[test_action("sns", "DeleteTopic", checksum = "4e5aad6b")]
+#[tokio::test]
+async fn sns_delete_topic() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client.create_topic().name("dt-topic").send().await.unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    client.delete_topic().topic_arn(arn).send().await.unwrap();
+
+    let resp = client.list_topics().send().await.unwrap();
+    assert!(resp.topics().is_empty());
+}
+
+#[test_action("sns", "GetTopicAttributes", checksum = "31909d65")]
+#[tokio::test]
+async fn sns_get_topic_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("gta-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    let resp = client
+        .get_topic_attributes()
+        .topic_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    let attrs = resp.attributes().unwrap();
+    assert_eq!(attrs.get("TopicArn").unwrap(), arn);
+}
+
+#[test_action("sns", "SetTopicAttributes", checksum = "5d93e648")]
+#[tokio::test]
+async fn sns_set_topic_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("sta-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    client
+        .set_topic_attributes()
+        .topic_arn(arn)
+        .attribute_name("DisplayName")
+        .attribute_value("My Topic")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_topic_attributes()
+        .topic_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.attributes().unwrap().get("DisplayName").unwrap(),
+        "My Topic"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Subscriptions
+// ---------------------------------------------------------------------------
+
+#[test_action("sns", "Subscribe", checksum = "523a0c34")]
+#[tokio::test]
+async fn sns_subscribe() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("sub-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    let resp = client
+        .subscribe()
+        .topic_arn(arn)
+        .protocol("sqs")
+        .endpoint("arn:aws:sqs:us-east-1:123456789012:q")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.subscription_arn().is_some());
+}
+
+#[test_action("sns", "ConfirmSubscription", checksum = "9096ab08")]
+#[tokio::test]
+async fn sns_confirm_subscription() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("confirm-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    let resp = client
+        .confirm_subscription()
+        .topic_arn(arn)
+        .token("fake-token")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.subscription_arn().is_some());
+}
+
+#[test_action("sns", "Unsubscribe", checksum = "59a84ca0")]
+#[tokio::test]
+async fn sns_unsubscribe() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("unsub-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    let sub = client
+        .subscribe()
+        .topic_arn(arn)
+        .protocol("sqs")
+        .endpoint("arn:aws:sqs:us-east-1:123456789012:q")
+        .send()
+        .await
+        .unwrap();
+    let sub_arn = sub.subscription_arn().unwrap();
+
+    client
+        .unsubscribe()
+        .subscription_arn(sub_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_subscriptions().send().await.unwrap();
+    assert!(resp.subscriptions().is_empty());
+}
+
+#[test_action("sns", "ListSubscriptions", checksum = "7d8ed2d6")]
+#[tokio::test]
+async fn sns_list_subscriptions() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client.create_topic().name("ls-topic").send().await.unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    client
+        .subscribe()
+        .topic_arn(arn)
+        .protocol("sqs")
+        .endpoint("arn:aws:sqs:us-east-1:123456789012:q")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_subscriptions().send().await.unwrap();
+    assert_eq!(resp.subscriptions().len(), 1);
+}
+
+#[test_action("sns", "ListSubscriptionsByTopic", checksum = "e2bbd283")]
+#[tokio::test]
+async fn sns_list_subscriptions_by_topic() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("lsbt-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    client
+        .subscribe()
+        .topic_arn(arn)
+        .protocol("sqs")
+        .endpoint("arn:aws:sqs:us-east-1:123456789012:q")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_subscriptions_by_topic()
+        .topic_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.subscriptions().len(), 1);
+}
+
+#[test_action("sns", "GetSubscriptionAttributes", checksum = "2022e312")]
+#[tokio::test]
+async fn sns_get_subscription_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("gsa-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    let sub = client
+        .subscribe()
+        .topic_arn(arn)
+        .protocol("sqs")
+        .endpoint("arn:aws:sqs:us-east-1:123456789012:q")
+        .send()
+        .await
+        .unwrap();
+    let sub_arn = sub.subscription_arn().unwrap();
+
+    let resp = client
+        .get_subscription_attributes()
+        .subscription_arn(sub_arn)
+        .send()
+        .await
+        .unwrap();
+    let attrs = resp.attributes().unwrap();
+    assert_eq!(attrs.get("Protocol").unwrap(), "sqs");
+}
+
+#[test_action("sns", "SetSubscriptionAttributes", checksum = "d02509bc")]
+#[tokio::test]
+async fn sns_set_subscription_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("ssa-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    let sub = client
+        .subscribe()
+        .topic_arn(arn)
+        .protocol("sqs")
+        .endpoint("arn:aws:sqs:us-east-1:123456789012:q")
+        .send()
+        .await
+        .unwrap();
+    let sub_arn = sub.subscription_arn().unwrap();
+
+    client
+        .set_subscription_attributes()
+        .subscription_arn(sub_arn)
+        .attribute_name("RawMessageDelivery")
+        .attribute_value("true")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_subscription_attributes()
+        .subscription_arn(sub_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.attributes()
+            .unwrap()
+            .get("RawMessageDelivery")
+            .unwrap(),
+        "true"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Publish
+// ---------------------------------------------------------------------------
+
+#[test_action("sns", "Publish", checksum = "bccbca72")]
+#[tokio::test]
+async fn sns_publish() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("pub-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    let resp = client
+        .publish()
+        .topic_arn(arn)
+        .message("hello")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.message_id().is_some());
+}
+
+#[test_action("sns", "PublishBatch", checksum = "e0faf03a")]
+#[tokio::test]
+async fn sns_publish_batch() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client.create_topic().name("pb-topic").send().await.unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    let entries = vec![
+        PublishBatchRequestEntry::builder()
+            .id("1")
+            .message("msg1")
+            .build()
+            .unwrap(),
+        PublishBatchRequestEntry::builder()
+            .id("2")
+            .message("msg2")
+            .build()
+            .unwrap(),
+    ];
+
+    let resp = client
+        .publish_batch()
+        .topic_arn(arn)
+        .set_publish_batch_request_entries(Some(entries))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.successful().len(), 2);
+    assert!(resp.failed().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Tags
+// ---------------------------------------------------------------------------
+
+#[test_action("sns", "TagResource", checksum = "7c7539fe")]
+#[tokio::test]
+async fn sns_tag_resource() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("tag-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    client
+        .tag_resource()
+        .resource_arn(arn)
+        .tags(Tag::builder().key("env").value("test").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(tags.tags().len(), 1);
+    assert_eq!(tags.tags()[0].key(), "env");
+}
+
+#[test_action("sns", "UntagResource", checksum = "0f91c85a")]
+#[tokio::test]
+async fn sns_untag_resource() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("untag-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    client
+        .tag_resource()
+        .resource_arn(arn)
+        .tags(Tag::builder().key("env").value("test").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .untag_resource()
+        .resource_arn(arn)
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags.tags().is_empty());
+}
+
+#[test_action("sns", "ListTagsForResource", checksum = "6281ac11")]
+#[tokio::test]
+async fn sns_list_tags_for_resource() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("listtags-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags.tags().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Permissions
+// ---------------------------------------------------------------------------
+
+#[test_action("sns", "AddPermission", checksum = "6c110218")]
+#[tokio::test]
+async fn sns_add_permission() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("perm-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    client
+        .add_permission()
+        .topic_arn(arn)
+        .label("my-permission")
+        .aws_account_id("123456789012")
+        .action_name("Publish")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sns", "RemovePermission", checksum = "497a29ab")]
+#[tokio::test]
+async fn sns_remove_permission() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("rmperm-topic")
+        .send()
+        .await
+        .unwrap();
+    let arn = topic.topic_arn().unwrap();
+
+    client
+        .add_permission()
+        .topic_arn(arn)
+        .label("my-perm")
+        .aws_account_id("123456789012")
+        .action_name("Publish")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .remove_permission()
+        .topic_arn(arn)
+        .label("my-perm")
+        .send()
+        .await
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Platform applications and endpoints
+// ---------------------------------------------------------------------------
+
+#[test_action("sns", "CreatePlatformApplication", checksum = "d20a7824")]
+#[tokio::test]
+async fn sns_create_platform_application() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let resp = client
+        .create_platform_application()
+        .name("my-app")
+        .platform("GCM")
+        .attributes("PlatformCredential", "fake-key")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.platform_application_arn().is_some());
+}
+
+#[test_action("sns", "ListPlatformApplications", checksum = "66b7868d")]
+#[tokio::test]
+async fn sns_list_platform_applications() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    client
+        .create_platform_application()
+        .name("list-app")
+        .platform("GCM")
+        .attributes("PlatformCredential", "fake-key")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_platform_applications().send().await.unwrap();
+    assert_eq!(resp.platform_applications().len(), 1);
+}
+
+#[test_action("sns", "GetPlatformApplicationAttributes", checksum = "056c95b3")]
+#[tokio::test]
+async fn sns_get_platform_application_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let app = client
+        .create_platform_application()
+        .name("get-app")
+        .platform("GCM")
+        .attributes("PlatformCredential", "fake-key")
+        .send()
+        .await
+        .unwrap();
+    let app_arn = app.platform_application_arn().unwrap();
+
+    let resp = client
+        .get_platform_application_attributes()
+        .platform_application_arn(app_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.attributes().is_some());
+}
+
+#[test_action("sns", "SetPlatformApplicationAttributes", checksum = "7c224318")]
+#[tokio::test]
+async fn sns_set_platform_application_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let app = client
+        .create_platform_application()
+        .name("set-app")
+        .platform("GCM")
+        .attributes("PlatformCredential", "fake-key")
+        .send()
+        .await
+        .unwrap();
+    let app_arn = app.platform_application_arn().unwrap();
+
+    client
+        .set_platform_application_attributes()
+        .platform_application_arn(app_arn)
+        .attributes("PlatformCredential", "new-key")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sns", "DeletePlatformApplication", checksum = "d87bbec2")]
+#[tokio::test]
+async fn sns_delete_platform_application() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let app = client
+        .create_platform_application()
+        .name("del-app")
+        .platform("GCM")
+        .attributes("PlatformCredential", "fake-key")
+        .send()
+        .await
+        .unwrap();
+    let app_arn = app.platform_application_arn().unwrap();
+
+    client
+        .delete_platform_application()
+        .platform_application_arn(app_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_platform_applications().send().await.unwrap();
+    assert!(resp.platform_applications().is_empty());
+}
+
+#[test_action("sns", "CreatePlatformEndpoint", checksum = "796d9493")]
+#[tokio::test]
+async fn sns_create_platform_endpoint() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let app = client
+        .create_platform_application()
+        .name("ep-app")
+        .platform("GCM")
+        .attributes("PlatformCredential", "fake-key")
+        .send()
+        .await
+        .unwrap();
+    let app_arn = app.platform_application_arn().unwrap();
+
+    let resp = client
+        .create_platform_endpoint()
+        .platform_application_arn(app_arn)
+        .token("device-token-abc")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.endpoint_arn().is_some());
+}
+
+#[test_action("sns", "ListEndpointsByPlatformApplication", checksum = "d8223b27")]
+#[tokio::test]
+async fn sns_list_endpoints_by_platform_application() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let app = client
+        .create_platform_application()
+        .name("lep-app")
+        .platform("GCM")
+        .attributes("PlatformCredential", "fake-key")
+        .send()
+        .await
+        .unwrap();
+    let app_arn = app.platform_application_arn().unwrap();
+
+    client
+        .create_platform_endpoint()
+        .platform_application_arn(app_arn)
+        .token("device-token")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_endpoints_by_platform_application()
+        .platform_application_arn(app_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.endpoints().len(), 1);
+}
+
+#[test_action("sns", "GetEndpointAttributes", checksum = "c379158b")]
+#[tokio::test]
+async fn sns_get_endpoint_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let app = client
+        .create_platform_application()
+        .name("gea-app")
+        .platform("GCM")
+        .attributes("PlatformCredential", "fake-key")
+        .send()
+        .await
+        .unwrap();
+    let app_arn = app.platform_application_arn().unwrap();
+
+    let ep = client
+        .create_platform_endpoint()
+        .platform_application_arn(app_arn)
+        .token("device-token")
+        .send()
+        .await
+        .unwrap();
+    let ep_arn = ep.endpoint_arn().unwrap();
+
+    let resp = client
+        .get_endpoint_attributes()
+        .endpoint_arn(ep_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.attributes().is_some());
+}
+
+#[test_action("sns", "SetEndpointAttributes", checksum = "d9119f0f")]
+#[tokio::test]
+async fn sns_set_endpoint_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let app = client
+        .create_platform_application()
+        .name("sea-app")
+        .platform("GCM")
+        .attributes("PlatformCredential", "fake-key")
+        .send()
+        .await
+        .unwrap();
+    let app_arn = app.platform_application_arn().unwrap();
+
+    let ep = client
+        .create_platform_endpoint()
+        .platform_application_arn(app_arn)
+        .token("device-token")
+        .send()
+        .await
+        .unwrap();
+    let ep_arn = ep.endpoint_arn().unwrap();
+
+    client
+        .set_endpoint_attributes()
+        .endpoint_arn(ep_arn)
+        .attributes("Enabled", "false")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sns", "DeleteEndpoint", checksum = "1a351918")]
+#[tokio::test]
+async fn sns_delete_endpoint() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let app = client
+        .create_platform_application()
+        .name("dep-app")
+        .platform("GCM")
+        .attributes("PlatformCredential", "fake-key")
+        .send()
+        .await
+        .unwrap();
+    let app_arn = app.platform_application_arn().unwrap();
+
+    let ep = client
+        .create_platform_endpoint()
+        .platform_application_arn(app_arn)
+        .token("device-token")
+        .send()
+        .await
+        .unwrap();
+    let ep_arn = ep.endpoint_arn().unwrap();
+
+    client
+        .delete_endpoint()
+        .endpoint_arn(ep_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_endpoints_by_platform_application()
+        .platform_application_arn(app_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.endpoints().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// SMS
+// ---------------------------------------------------------------------------
+
+#[test_action("sns", "SetSMSAttributes", checksum = "4d87387c")]
+#[tokio::test]
+async fn sns_set_sms_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    client
+        .set_sms_attributes()
+        .attributes("DefaultSMSType", "Transactional")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sns", "GetSMSAttributes", checksum = "ea9059f6")]
+#[tokio::test]
+async fn sns_get_sms_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let resp = client.get_sms_attributes().send().await.unwrap();
+    // Should return attributes (possibly empty map)
+    let _ = resp.attributes();
+}
+
+#[test_action("sns", "CheckIfPhoneNumberIsOptedOut", checksum = "1791f458")]
+#[tokio::test]
+async fn sns_check_if_phone_number_is_opted_out() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let resp = client
+        .check_if_phone_number_is_opted_out()
+        .phone_number("+15551234567")
+        .send()
+        .await
+        .unwrap();
+    // Default: not opted out
+    assert!(!resp.is_opted_out());
+}
+
+#[test_action("sns", "ListPhoneNumbersOptedOut", checksum = "13088dd7")]
+#[tokio::test]
+async fn sns_list_phone_numbers_opted_out() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let resp = client.list_phone_numbers_opted_out().send().await.unwrap();
+    assert!(resp.phone_numbers().is_empty());
+}
+
+#[test_action("sns", "OptInPhoneNumber", checksum = "794da5bf")]
+#[tokio::test]
+async fn sns_opt_in_phone_number() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    client
+        .opt_in_phone_number()
+        .phone_number("+15551234567")
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-conformance/tests/sqs.rs
+++ b/crates/fakecloud-conformance/tests/sqs.rs
@@ -241,6 +241,7 @@ async fn sqs_delete_message() {
         .send()
         .await
         .unwrap();
+    assert!(!msgs.messages().is_empty(), "expected at least one message");
     let receipt = msgs.messages()[0].receipt_handle().unwrap();
     client
         .delete_message()
@@ -278,6 +279,7 @@ async fn sqs_delete_message_batch() {
         .send()
         .await
         .unwrap();
+    assert!(!msgs.messages().is_empty(), "expected at least one message");
     let receipt = msgs.messages()[0].receipt_handle().unwrap();
     let resp = client
         .delete_message_batch()
@@ -346,6 +348,7 @@ async fn sqs_change_message_visibility() {
         .send()
         .await
         .unwrap();
+    assert!(!msgs.messages().is_empty(), "expected at least one message");
     let receipt = msgs.messages()[0].receipt_handle().unwrap();
     client
         .change_message_visibility()
@@ -384,6 +387,7 @@ async fn sqs_change_message_visibility_batch() {
         .send()
         .await
         .unwrap();
+    assert!(!msgs.messages().is_empty(), "expected at least one message");
     let receipt = msgs.messages()[0].receipt_handle().unwrap();
     let resp = client
         .change_message_visibility_batch()

--- a/crates/fakecloud-conformance/tests/sqs.rs
+++ b/crates/fakecloud-conformance/tests/sqs.rs
@@ -1,0 +1,554 @@
+mod helpers;
+
+use aws_sdk_sqs::types::{
+    ChangeMessageVisibilityBatchRequestEntry, DeleteMessageBatchRequestEntry,
+    SendMessageBatchRequestEntry,
+};
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+#[test_action("sqs", "CreateQueue", checksum = "0a1fae82")]
+#[tokio::test]
+async fn sqs_create_queue() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let resp = client
+        .create_queue()
+        .queue_name("conformance-test")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.queue_url().is_some());
+}
+
+#[test_action("sqs", "DeleteQueue", checksum = "a18b7dff")]
+#[tokio::test]
+async fn sqs_delete_queue() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("to-delete")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client.delete_queue().queue_url(&url).send().await.unwrap();
+}
+
+#[test_action("sqs", "ListQueues", checksum = "3f6dd6dd")]
+#[tokio::test]
+async fn sqs_list_queues() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    client
+        .create_queue()
+        .queue_name("list-test")
+        .send()
+        .await
+        .unwrap();
+    let resp = client.list_queues().send().await.unwrap();
+    assert!(!resp.queue_urls().is_empty());
+}
+
+#[test_action("sqs", "GetQueueUrl", checksum = "20f1dd11")]
+#[tokio::test]
+async fn sqs_get_queue_url() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    client
+        .create_queue()
+        .queue_name("url-test")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .get_queue_url()
+        .queue_name("url-test")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.queue_url().is_some());
+}
+
+#[test_action("sqs", "GetQueueAttributes", checksum = "d9b5e6d2")]
+#[tokio::test]
+async fn sqs_get_queue_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("attrs-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let resp = client
+        .get_queue_attributes()
+        .queue_url(&url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::All)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.attributes().is_some());
+}
+
+#[test_action("sqs", "SetQueueAttributes", checksum = "e30a8436")]
+#[tokio::test]
+async fn sqs_set_queue_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("set-attrs-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .set_queue_attributes()
+        .queue_url(&url)
+        .attributes(
+            aws_sdk_sqs::types::QueueAttributeName::VisibilityTimeout,
+            "60",
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sqs", "SendMessage", checksum = "89d68568")]
+#[tokio::test]
+async fn sqs_send_message() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("send-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let resp = client
+        .send_message()
+        .queue_url(&url)
+        .message_body("hello")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.message_id().is_some());
+}
+
+#[test_action("sqs", "SendMessageBatch", checksum = "9dd48806")]
+#[tokio::test]
+async fn sqs_send_message_batch() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("batch-send-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let resp = client
+        .send_message_batch()
+        .queue_url(&url)
+        .entries(
+            SendMessageBatchRequestEntry::builder()
+                .id("1")
+                .message_body("msg1")
+                .build()
+                .unwrap(),
+        )
+        .entries(
+            SendMessageBatchRequestEntry::builder()
+                .id("2")
+                .message_body("msg2")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.successful().len(), 2);
+}
+
+#[test_action("sqs", "ReceiveMessage", checksum = "42609ccb")]
+#[tokio::test]
+async fn sqs_receive_message() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("recv-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .send_message()
+        .queue_url(&url)
+        .message_body("hello")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .receive_message()
+        .queue_url(&url)
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.messages().is_empty());
+}
+
+#[test_action("sqs", "DeleteMessage", checksum = "b1e095b9")]
+#[tokio::test]
+async fn sqs_delete_message() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("del-msg-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .send_message()
+        .queue_url(&url)
+        .message_body("to-delete")
+        .send()
+        .await
+        .unwrap();
+    let msgs = client
+        .receive_message()
+        .queue_url(&url)
+        .send()
+        .await
+        .unwrap();
+    let receipt = msgs.messages()[0].receipt_handle().unwrap();
+    client
+        .delete_message()
+        .queue_url(&url)
+        .receipt_handle(receipt)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sqs", "DeleteMessageBatch", checksum = "26252f25")]
+#[tokio::test]
+async fn sqs_delete_message_batch() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("del-batch-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .send_message()
+        .queue_url(&url)
+        .message_body("batch-del")
+        .send()
+        .await
+        .unwrap();
+    let msgs = client
+        .receive_message()
+        .queue_url(&url)
+        .send()
+        .await
+        .unwrap();
+    let receipt = msgs.messages()[0].receipt_handle().unwrap();
+    let resp = client
+        .delete_message_batch()
+        .queue_url(&url)
+        .entries(
+            DeleteMessageBatchRequestEntry::builder()
+                .id("1")
+                .receipt_handle(receipt)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.successful().len(), 1);
+}
+
+#[test_action("sqs", "PurgeQueue", checksum = "f25aaf8e")]
+#[tokio::test]
+async fn sqs_purge_queue() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("purge-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .send_message()
+        .queue_url(&url)
+        .message_body("to-purge")
+        .send()
+        .await
+        .unwrap();
+    client.purge_queue().queue_url(&url).send().await.unwrap();
+}
+
+#[test_action("sqs", "ChangeMessageVisibility", checksum = "f1324378")]
+#[tokio::test]
+async fn sqs_change_message_visibility() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("vis-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .send_message()
+        .queue_url(&url)
+        .message_body("vis-msg")
+        .send()
+        .await
+        .unwrap();
+    let msgs = client
+        .receive_message()
+        .queue_url(&url)
+        .send()
+        .await
+        .unwrap();
+    let receipt = msgs.messages()[0].receipt_handle().unwrap();
+    client
+        .change_message_visibility()
+        .queue_url(&url)
+        .receipt_handle(receipt)
+        .visibility_timeout(0)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sqs", "ChangeMessageVisibilityBatch", checksum = "d8d99cf0")]
+#[tokio::test]
+async fn sqs_change_message_visibility_batch() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("vis-batch-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .send_message()
+        .queue_url(&url)
+        .message_body("vis-batch-msg")
+        .send()
+        .await
+        .unwrap();
+    let msgs = client
+        .receive_message()
+        .queue_url(&url)
+        .send()
+        .await
+        .unwrap();
+    let receipt = msgs.messages()[0].receipt_handle().unwrap();
+    let resp = client
+        .change_message_visibility_batch()
+        .queue_url(&url)
+        .entries(
+            ChangeMessageVisibilityBatchRequestEntry::builder()
+                .id("1")
+                .receipt_handle(receipt)
+                .visibility_timeout(0)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.successful().len(), 1);
+}
+
+#[test_action("sqs", "ListQueueTags", checksum = "fe70eefa")]
+#[tokio::test]
+async fn sqs_list_queue_tags() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("tags-test")
+        .tags("env", "test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let resp = client
+        .list_queue_tags()
+        .queue_url(&url)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.tags().is_some());
+}
+
+#[test_action("sqs", "TagQueue", checksum = "ffc3e579")]
+#[tokio::test]
+async fn sqs_tag_queue() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("tag-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .tag_queue()
+        .queue_url(&url)
+        .tags("project", "conformance")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sqs", "UntagQueue", checksum = "e1ee616f")]
+#[tokio::test]
+async fn sqs_untag_queue() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("untag-test")
+        .tags("remove-me", "yes")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .untag_queue()
+        .queue_url(&url)
+        .tag_keys("remove-me")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sqs", "AddPermission", checksum = "59c4016e")]
+#[tokio::test]
+async fn sqs_add_permission() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("perm-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .add_permission()
+        .queue_url(&url)
+        .label("test-perm")
+        .aws_account_ids("123456789012")
+        .actions("SendMessage")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sqs", "RemovePermission", checksum = "a0f698c4")]
+#[tokio::test]
+async fn sqs_remove_permission() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let url = client
+        .create_queue()
+        .queue_name("rm-perm-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    client
+        .add_permission()
+        .queue_url(&url)
+        .label("to-remove")
+        .aws_account_ids("123456789012")
+        .actions("SendMessage")
+        .send()
+        .await
+        .unwrap();
+    client
+        .remove_permission()
+        .queue_url(&url)
+        .label("to-remove")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("sqs", "ListDeadLetterSourceQueues", checksum = "be4b1f5d")]
+#[tokio::test]
+async fn sqs_list_dead_letter_source_queues() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let dlq_url = client
+        .create_queue()
+        .queue_name("dlq-test")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let resp = client
+        .list_dead_letter_source_queues()
+        .queue_url(&dlq_url)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.queue_urls().is_empty());
+}

--- a/crates/fakecloud-conformance/tests/ssm.rs
+++ b/crates/fakecloud-conformance/tests/ssm.rs
@@ -1,0 +1,671 @@
+mod helpers;
+
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+// -- Parameter CRUD --
+
+#[test_action("ssm", "PutParameter", checksum = "3620c469")]
+#[test_action("ssm", "GetParameter", checksum = "2ce7443c")]
+#[test_action("ssm", "DeleteParameter", checksum = "5c66ec04")]
+#[tokio::test]
+async fn ssm_put_get_delete_parameter() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    client
+        .put_parameter()
+        .name("/conf/param1")
+        .value("value1")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_parameter()
+        .name("/conf/param1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.parameter().unwrap().value().unwrap(), "value1");
+
+    client
+        .delete_parameter()
+        .name("/conf/param1")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- GetParameters (batch) --
+
+#[test_action("ssm", "GetParameters", checksum = "0bb4c5f2")]
+#[tokio::test]
+async fn ssm_get_parameters() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    client
+        .put_parameter()
+        .name("/conf/multi1")
+        .value("a")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_parameter()
+        .name("/conf/multi2")
+        .value("b")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .get_parameters()
+        .names("/conf/multi1")
+        .names("/conf/multi2")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.parameters().len(), 2);
+}
+
+// -- GetParametersByPath --
+
+#[test_action("ssm", "GetParametersByPath", checksum = "1617e5a0")]
+#[tokio::test]
+async fn ssm_get_parameters_by_path() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    client
+        .put_parameter()
+        .name("/conf/path/a")
+        .value("x")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .get_parameters_by_path()
+        .path("/conf/path")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.parameters().is_empty());
+}
+
+// -- DeleteParameters (batch) --
+
+#[test_action("ssm", "DeleteParameters", checksum = "ee715760")]
+#[tokio::test]
+async fn ssm_delete_parameters() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    client
+        .put_parameter()
+        .name("/conf/del1")
+        .value("x")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .delete_parameters()
+        .names("/conf/del1")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.deleted_parameters().is_empty());
+}
+
+// -- DescribeParameters --
+
+#[test_action("ssm", "DescribeParameters", checksum = "bd157747")]
+#[tokio::test]
+async fn ssm_describe_parameters() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    client
+        .put_parameter()
+        .name("/conf/desc1")
+        .value("x")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+    let resp = client.describe_parameters().send().await.unwrap();
+    assert!(!resp.parameters().is_empty());
+}
+
+// -- GetParameterHistory --
+
+#[test_action("ssm", "GetParameterHistory", checksum = "a26dd5b9")]
+#[tokio::test]
+async fn ssm_get_parameter_history() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    client
+        .put_parameter()
+        .name("/conf/hist")
+        .value("v1")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_parameter()
+        .name("/conf/hist")
+        .value("v2")
+        .overwrite(true)
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .get_parameter_history()
+        .name("/conf/hist")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.parameters().len() >= 2);
+}
+
+// -- Tags --
+
+#[test_action("ssm", "AddTagsToResource", checksum = "0beb4b05")]
+#[test_action("ssm", "ListTagsForResource", checksum = "9580cae3")]
+#[test_action("ssm", "RemoveTagsFromResource", checksum = "6dd59ebb")]
+#[tokio::test]
+async fn ssm_tags() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    client
+        .put_parameter()
+        .name("/conf/tagged")
+        .value("x")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .add_tags_to_resource()
+        .resource_type(aws_sdk_ssm::types::ResourceTypeForTagging::Parameter)
+        .resource_id("/conf/tagged")
+        .tags(
+            aws_sdk_ssm::types::Tag::builder()
+                .key("env")
+                .value("test")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_tags_for_resource()
+        .resource_type(aws_sdk_ssm::types::ResourceTypeForTagging::Parameter)
+        .resource_id("/conf/tagged")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.tag_list().is_empty());
+
+    client
+        .remove_tags_from_resource()
+        .resource_type(aws_sdk_ssm::types::ResourceTypeForTagging::Parameter)
+        .resource_id("/conf/tagged")
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Label / Unlabel parameter version --
+
+#[test_action("ssm", "LabelParameterVersion", checksum = "50630187")]
+#[test_action("ssm", "UnlabelParameterVersion", checksum = "16fdaeea")]
+#[tokio::test]
+async fn ssm_label_unlabel_parameter_version() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    client
+        .put_parameter()
+        .name("/conf/label")
+        .value("x")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .label_parameter_version()
+        .name("/conf/label")
+        .labels("prod")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .unlabel_parameter_version()
+        .name("/conf/label")
+        .labels("prod")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Document CRUD --
+
+#[test_action("ssm", "CreateDocument", checksum = "4a0c1ee8")]
+#[test_action("ssm", "GetDocument", checksum = "c9a5cfaf")]
+#[test_action("ssm", "DescribeDocument", checksum = "124cfc8d")]
+#[test_action("ssm", "DeleteDocument", checksum = "a7d809b4")]
+#[tokio::test]
+async fn ssm_document_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let doc_content = r#"{"schemaVersion":"2.2","description":"Test","mainSteps":[{"action":"aws:runShellScript","name":"test","inputs":{"runCommand":["echo hello"]}}]}"#;
+
+    client
+        .create_document()
+        .name("conf-doc")
+        .content(doc_content)
+        .document_type(aws_sdk_ssm::types::DocumentType::Command)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.get_document().name("conf-doc").send().await.unwrap();
+    assert!(resp.content().is_some());
+
+    let desc = client
+        .describe_document()
+        .name("conf-doc")
+        .send()
+        .await
+        .unwrap();
+    assert!(desc.document().is_some());
+
+    client
+        .delete_document()
+        .name("conf-doc")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- UpdateDocument + UpdateDocumentDefaultVersion --
+
+#[test_action("ssm", "UpdateDocument", checksum = "7d752e4c")]
+#[test_action("ssm", "UpdateDocumentDefaultVersion", checksum = "1cad9bdf")]
+#[tokio::test]
+async fn ssm_update_document() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let doc_v1 = r#"{"schemaVersion":"2.2","description":"v1","mainSteps":[{"action":"aws:runShellScript","name":"test","inputs":{"runCommand":["echo v1"]}}]}"#;
+    let doc_v2 = r#"{"schemaVersion":"2.2","description":"v2","mainSteps":[{"action":"aws:runShellScript","name":"test","inputs":{"runCommand":["echo v2"]}}]}"#;
+
+    client
+        .create_document()
+        .name("conf-doc-upd")
+        .content(doc_v1)
+        .document_type(aws_sdk_ssm::types::DocumentType::Command)
+        .send()
+        .await
+        .unwrap();
+
+    let upd = client
+        .update_document()
+        .name("conf-doc-upd")
+        .content(doc_v2)
+        .document_version("$LATEST")
+        .send()
+        .await
+        .unwrap();
+    let new_ver = upd
+        .document_description()
+        .unwrap()
+        .document_version()
+        .unwrap()
+        .to_string();
+
+    client
+        .update_document_default_version()
+        .name("conf-doc-upd")
+        .document_version(&new_ver)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- ListDocuments --
+
+#[test_action("ssm", "ListDocuments", checksum = "c177e191")]
+#[tokio::test]
+async fn ssm_list_documents() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let _ = client.list_documents().send().await.unwrap();
+}
+
+// -- Document permissions --
+
+#[test_action("ssm", "DescribeDocumentPermission", checksum = "5dc18586")]
+#[test_action("ssm", "ModifyDocumentPermission", checksum = "679c9876")]
+#[tokio::test]
+async fn ssm_document_permissions() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let doc_content = r#"{"schemaVersion":"2.2","description":"perm","mainSteps":[{"action":"aws:runShellScript","name":"test","inputs":{"runCommand":["echo hi"]}}]}"#;
+    client
+        .create_document()
+        .name("conf-doc-perm")
+        .content(doc_content)
+        .document_type(aws_sdk_ssm::types::DocumentType::Command)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .modify_document_permission()
+        .name("conf-doc-perm")
+        .permission_type(aws_sdk_ssm::types::DocumentPermissionType::Share)
+        .account_ids_to_add("123456789012")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .describe_document_permission()
+        .name("conf-doc-perm")
+        .permission_type(aws_sdk_ssm::types::DocumentPermissionType::Share)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- SendCommand + ListCommands + GetCommandInvocation + ListCommandInvocations + CancelCommand --
+
+#[test_action("ssm", "SendCommand", checksum = "e3d9a465")]
+#[test_action("ssm", "ListCommands", checksum = "6dd0b4fc")]
+#[test_action("ssm", "ListCommandInvocations", checksum = "11365416")]
+#[test_action("ssm", "CancelCommand", checksum = "3472b53a")]
+#[tokio::test]
+async fn ssm_commands() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let send = client
+        .send_command()
+        .document_name("AWS-RunShellScript")
+        .instance_ids("i-00000000000000001")
+        .parameters("commands", vec!["echo hello".to_string()])
+        .send()
+        .await
+        .unwrap();
+    let cmd_id = send.command().unwrap().command_id().unwrap().to_string();
+
+    let _ = client.list_commands().send().await.unwrap();
+    let _ = client.list_command_invocations().send().await.unwrap();
+    let _ = client.cancel_command().command_id(&cmd_id).send().await;
+}
+
+// -- GetCommandInvocation --
+
+#[test_action("ssm", "GetCommandInvocation", checksum = "0b0d098b")]
+#[tokio::test]
+async fn ssm_get_command_invocation() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let send = client
+        .send_command()
+        .document_name("AWS-RunShellScript")
+        .instance_ids("i-00000000000000001")
+        .parameters("commands", vec!["echo test".to_string()])
+        .send()
+        .await
+        .unwrap();
+    let cmd_id = send.command().unwrap().command_id().unwrap().to_string();
+
+    let _ = client
+        .get_command_invocation()
+        .command_id(&cmd_id)
+        .instance_id("i-00000000000000001")
+        .send()
+        .await;
+}
+
+// -- Maintenance windows --
+
+#[test_action("ssm", "CreateMaintenanceWindow", checksum = "4225d446")]
+#[test_action("ssm", "DescribeMaintenanceWindows", checksum = "9cbfac10")]
+#[test_action("ssm", "GetMaintenanceWindow", checksum = "4078c60b")]
+#[test_action("ssm", "UpdateMaintenanceWindow", checksum = "9e7748d9")]
+#[test_action("ssm", "DeleteMaintenanceWindow", checksum = "0d510d38")]
+#[tokio::test]
+async fn ssm_maintenance_window_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_maintenance_window()
+        .name("conf-mw")
+        .schedule("rate(1 day)")
+        .duration(2)
+        .cutoff(1)
+        .allow_unassociated_targets(true)
+        .send()
+        .await
+        .unwrap();
+    let mw_id = create.window_id().unwrap().to_string();
+
+    let _ = client.describe_maintenance_windows().send().await.unwrap();
+
+    let _ = client
+        .get_maintenance_window()
+        .window_id(&mw_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_maintenance_window()
+        .window_id(&mw_id)
+        .name("conf-mw-updated")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_maintenance_window()
+        .window_id(&mw_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Maintenance window targets --
+
+#[test_action("ssm", "RegisterTargetWithMaintenanceWindow", checksum = "6cdf4aa5")]
+#[test_action("ssm", "DescribeMaintenanceWindowTargets", checksum = "0c15c7b4")]
+#[test_action("ssm", "DeregisterTargetFromMaintenanceWindow", checksum = "c6b419d2")]
+#[tokio::test]
+async fn ssm_maintenance_window_targets() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_maintenance_window()
+        .name("conf-mw-tgt")
+        .schedule("rate(1 day)")
+        .duration(2)
+        .cutoff(1)
+        .allow_unassociated_targets(true)
+        .send()
+        .await
+        .unwrap();
+    let mw_id = create.window_id().unwrap().to_string();
+
+    let reg = client
+        .register_target_with_maintenance_window()
+        .window_id(&mw_id)
+        .resource_type(aws_sdk_ssm::types::MaintenanceWindowResourceType::Instance)
+        .targets(
+            aws_sdk_ssm::types::Target::builder()
+                .key("InstanceIds")
+                .values("i-00000000000000001")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let target_id = reg.window_target_id().unwrap().to_string();
+
+    let _ = client
+        .describe_maintenance_window_targets()
+        .window_id(&mw_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .deregister_target_from_maintenance_window()
+        .window_id(&mw_id)
+        .window_target_id(&target_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Maintenance window tasks --
+
+#[test_action("ssm", "RegisterTaskWithMaintenanceWindow", checksum = "b32d2007")]
+#[test_action("ssm", "DescribeMaintenanceWindowTasks", checksum = "8289f62c")]
+#[test_action("ssm", "DeregisterTaskFromMaintenanceWindow", checksum = "3b0d9f87")]
+#[tokio::test]
+async fn ssm_maintenance_window_tasks() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_maintenance_window()
+        .name("conf-mw-task")
+        .schedule("rate(1 day)")
+        .duration(2)
+        .cutoff(1)
+        .allow_unassociated_targets(true)
+        .send()
+        .await
+        .unwrap();
+    let mw_id = create.window_id().unwrap().to_string();
+
+    let reg = client
+        .register_task_with_maintenance_window()
+        .window_id(&mw_id)
+        .task_arn("AWS-RunShellScript")
+        .task_type(aws_sdk_ssm::types::MaintenanceWindowTaskType::RunCommand)
+        .max_concurrency("1")
+        .max_errors("0")
+        .send()
+        .await
+        .unwrap();
+    let task_id = reg.window_task_id().unwrap().to_string();
+
+    let _ = client
+        .describe_maintenance_window_tasks()
+        .window_id(&mw_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .deregister_task_from_maintenance_window()
+        .window_id(&mw_id)
+        .window_task_id(&task_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Patch baselines --
+
+#[test_action("ssm", "CreatePatchBaseline", checksum = "9b5b1ac6")]
+#[test_action("ssm", "DescribePatchBaselines", checksum = "babfc26d")]
+#[test_action("ssm", "GetPatchBaseline", checksum = "bc756260")]
+#[test_action("ssm", "DeletePatchBaseline", checksum = "eb0d4378")]
+#[tokio::test]
+async fn ssm_patch_baseline_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_patch_baseline()
+        .name("conf-baseline")
+        .send()
+        .await
+        .unwrap();
+    let baseline_id = create.baseline_id().unwrap().to_string();
+
+    let _ = client.describe_patch_baselines().send().await.unwrap();
+
+    let _ = client
+        .get_patch_baseline()
+        .baseline_id(&baseline_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_patch_baseline()
+        .baseline_id(&baseline_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Patch groups --
+
+#[test_action("ssm", "RegisterPatchBaselineForPatchGroup", checksum = "6526be39")]
+#[test_action("ssm", "GetPatchBaselineForPatchGroup", checksum = "23f4460d")]
+#[test_action("ssm", "DescribePatchGroups", checksum = "dc683f88")]
+#[test_action("ssm", "DeregisterPatchBaselineForPatchGroup", checksum = "ff76cb6e")]
+#[tokio::test]
+async fn ssm_patch_groups() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_patch_baseline()
+        .name("conf-baseline-pg")
+        .send()
+        .await
+        .unwrap();
+    let baseline_id = create.baseline_id().unwrap().to_string();
+
+    client
+        .register_patch_baseline_for_patch_group()
+        .baseline_id(&baseline_id)
+        .patch_group("conf-group")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .get_patch_baseline_for_patch_group()
+        .patch_group("conf-group")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client.describe_patch_groups().send().await.unwrap();
+
+    client
+        .deregister_patch_baseline_for_patch_group()
+        .baseline_id(&baseline_id)
+        .patch_group("conf-group")
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-conformance/tests/sts.rs
+++ b/crates/fakecloud-conformance/tests/sts.rs
@@ -1,0 +1,98 @@
+mod helpers;
+
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+#[test_action("sts", "GetCallerIdentity", checksum = "163a2f0e")]
+#[tokio::test]
+async fn sts_get_caller_identity() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client.get_caller_identity().send().await.unwrap();
+    assert!(resp.account().is_some());
+    assert!(resp.arn().is_some());
+}
+
+#[test_action("sts", "AssumeRole", checksum = "3a2fbf12")]
+#[tokio::test]
+async fn sts_assume_role() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client
+        .assume_role()
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .role_session_name("test-session")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.credentials().is_some());
+}
+
+#[test_action("sts", "AssumeRoleWithWebIdentity", checksum = "fb45529e")]
+#[tokio::test]
+async fn sts_assume_role_with_web_identity() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client
+        .assume_role_with_web_identity()
+        .role_arn("arn:aws:iam::123456789012:role/web-role")
+        .role_session_name("web-session")
+        .web_identity_token("fake-token")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.credentials().is_some());
+}
+
+#[test_action("sts", "AssumeRoleWithSAML", checksum = "b2f7f5e1")]
+#[tokio::test]
+async fn sts_assume_role_with_saml() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client
+        .assume_role_with_saml()
+        .role_arn("arn:aws:iam::123456789012:role/saml-role")
+        .principal_arn("arn:aws:iam::123456789012:saml-provider/test")
+        .saml_assertion("fake-assertion")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.credentials().is_some());
+}
+
+#[test_action("sts", "GetSessionToken", checksum = "c12501d4")]
+#[tokio::test]
+async fn sts_get_session_token() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client.get_session_token().send().await.unwrap();
+    assert!(resp.credentials().is_some());
+}
+
+#[test_action("sts", "GetFederationToken", checksum = "ed833607")]
+#[tokio::test]
+async fn sts_get_federation_token() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client
+        .get_federation_token()
+        .name("fed-user")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.credentials().is_some());
+}
+
+#[test_action("sts", "GetAccessKeyInfo", checksum = "2c96c5eb")]
+#[tokio::test]
+async fn sts_get_access_key_info() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client
+        .get_access_key_info()
+        .access_key_id("AKIAIOSFODNN7EXAMPLE")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.account().is_some());
+}


### PR DESCRIPTION
## Summary

- Add Strategy 4 (proptest-style): deterministic PRNG generates 20 random valid inputs per operation, constraint-aware, no external dependency
- Add Level 2 audit command: scans `supported_actions()` and `#[test_action]` annotations, reports coverage gaps
- Add 280 handwritten conformance tests across all 13 services with model checksums
- All 6 test generation strategies now implemented

## Test plan

- [x] `cargo test -p fakecloud-conformance --lib` — 25 unit tests pass
- [x] `cargo clippy -p fakecloud-conformance -- -D warnings` — clean
- [x] All 13 test files compile with valid checksums (280 tests total)
- [x] `cargo run -p fakecloud-conformance -- audit` — reports coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a property-based input generator (Strategy 4), a Level 2 audit CLI, and 280 conformance tests across 13 services. Completes all six test strategies and fails CI when implemented actions lack tests; includes fixes for overflow, test stability, and CI configuration.

- New Features
  - Property-based generator: deterministic xorshift64 PRNG, 20 constraint-valid cases/op, respects length/range/pattern/enum, toggles optionals, no external deps.
  - Level 2 audit: scans `supported_actions()` and `#[test_action]`, reports gaps, exits non-zero. Run with `cargo run -p fakecloud-conformance -- audit`.
  - Conformance suite: 280 tests across 13 services (SQS, SNS, EventBridge, IAM, STS, SSM, S3, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation), each tagged with a model checksum and using real SDK calls.
  - Dependencies: add `regex` and AWS SDK crates as test dev-dependencies (e.g., `aws-sdk-s3`, `aws-sdk-sqs`, `aws-config`).

- Bug Fixes
  - Fix integer overflow in range generation (use i128/u128), add SQS bounds checks, replace error-swallowing `let _ =` with `.unwrap()`, and resolve clippy `range_contains` warnings.
  - CI: exclude `fakecloud-conformance` integration tests from `cargo test --workspace`; run conformance lib tests separately.

<sup>Written for commit f3fe4898873ac00280ff2bb2ba62df7eaaa43344. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

