### PR TITLE
feat: add conformance ratchet — CI fails if coverage drops

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -26,33 +26,23 @@ jobs:
       - name: Build conformance tool
         run: cargo build -p fakecloud-conformance
 
-      - name: Run conformance probes
-        run: |
-          cargo run -p fakecloud-conformance -- run --format text 2>&1 | tee conformance-report.txt
-          cargo run -p fakecloud-conformance -- run --format json > conformance-report.json
+      - name: Check conformance (fails if coverage drops)
+        run: cargo run -p fakecloud-conformance -- check 2>&1 | tee conformance-report.txt
+
+      - name: Generate JSON report
+        if: always()
+        run: cargo run -p fakecloud-conformance -- run --format json > conformance-report.json 2>/dev/null || true
 
       - name: Post summary
         if: always()
         run: |
           echo '## Conformance Report' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
-          echo '| Service | Handled | Passing | Variants |' >> $GITHUB_STEP_SUMMARY
-          echo '|---------|---------|---------|----------|' >> $GITHUB_STEP_SUMMARY
           if [ -f conformance-report.txt ]; then
-          grep -E "^[a-z].*operations handled" conformance-report.txt | while read -r line; do
-            svc=$(echo "$line" | cut -d: -f1)
-            handled=$(echo "$line" | grep -oP '\d+/\d+ operations handled' | head -1)
-            passing=$(echo "$line" | grep -oP '\d+/\d+ fully passing' | head -1)
-            echo "| $svc | $handled | $passing | |" >> $GITHUB_STEP_SUMMARY
-          done
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            grep -E "^(Conformance|  |Operations|Variants)" conformance-report.txt >> $GITHUB_STEP_SUMMARY || true
+            echo '```' >> $GITHUB_STEP_SUMMARY
           fi
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '**Summary**' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          if [ -f conformance-report.txt ]; then
-          grep -E "^(Operations|Variants):" conformance-report.txt >> $GITHUB_STEP_SUMMARY
-          fi
-          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload report
         if: always()

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Check conformance (fails if coverage drops)
         run: cargo run -p fakecloud-conformance -- check 2>&1 | tee conformance-report.txt
 
+      - name: Audit handwritten tests (fails if implemented action lacks a test)
+        run: cargo run -p fakecloud-conformance -- audit
+
       - name: Generate JSON report
         if: always()
         run: cargo run -p fakecloud-conformance -- run --format json > conformance-report.json 2>/dev/null || true

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,9 +27,11 @@ jobs:
         run: cargo build -p fakecloud-conformance
 
       - name: Check conformance (fails if coverage drops)
+        id: check
         run: cargo run -p fakecloud-conformance -- check 2>&1 | tee conformance-report.txt
 
       - name: Audit handwritten tests (fails if implemented action lacks a test)
+        if: always() && steps.check.outcome != 'skipped'
         run: cargo run -p fakecloud-conformance -- audit
 
       - name: Generate JSON report

--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,0 +1,58 @@
+{
+  "variants_passed": 26252,
+  "total_variants": 34856,
+  "per_service": {
+    "sts": {
+      "passed": 361,
+      "total": 438
+    },
+    "secretsmanager": {
+      "passed": 737,
+      "total": 852
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "ssm": {
+      "passed": 1619,
+      "total": 5303
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "iam": {
+      "passed": 5929,
+      "total": 5962
+    },
+    "dynamodb": {
+      "passed": 746,
+      "total": 2123
+    },
+    "events": {
+      "passed": 1385,
+      "total": 2108
+    },
+    "kms": {
+      "passed": 1580,
+      "total": 2196
+    },
+    "logs": {
+      "passed": 1932,
+      "total": 3911
+    },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "s3": {
+      "passed": 3620,
+      "total": 3620
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    }
+  }
+}

--- a/crates/fakecloud-conformance/src/audit.rs
+++ b/crates/fakecloud-conformance/src/audit.rs
@@ -110,7 +110,7 @@ pub fn scan_test_annotations(project_root: &Path) -> Result<HashMap<String, Vec<
         return Ok(HashMap::new());
     }
 
-    let re = Regex::new(r#"test_action\("([^"]+)",\s*"([^"]+)""#).unwrap();
+    let re = Regex::new(r#"test_action\(\s*"([^"]+)",\s*"([^"]+)""#).unwrap();
     let mut result: HashMap<String, Vec<String>> = HashMap::new();
 
     for entry in walkdir(&tests_dir)? {

--- a/crates/fakecloud-conformance/src/main.rs
+++ b/crates/fakecloud-conformance/src/main.rs
@@ -55,6 +55,24 @@ enum CliCommand {
     },
     /// Run Level 2 audit: check handwritten test coverage
     Audit,
+    /// Check conformance results against baseline (fails if coverage drops)
+    Check {
+        /// Path to conformance-baseline.json
+        #[arg(long, default_value = "conformance-baseline.json")]
+        baseline: PathBuf,
+        /// Connect to an already-running fakecloud at this endpoint
+        #[arg(long)]
+        endpoint: Option<String>,
+    },
+    /// Update the baseline file with current conformance results
+    UpdateBaseline {
+        /// Path to conformance-baseline.json
+        #[arg(long, default_value = "conformance-baseline.json")]
+        baseline: PathBuf,
+        /// Connect to an already-running fakecloud at this endpoint
+        #[arg(long)]
+        endpoint: Option<String>,
+    },
 }
 
 fn main() {
@@ -76,6 +94,10 @@ fn main() {
             if !pass {
                 std::process::exit(1);
             }
+        }
+        CliCommand::Check { baseline, endpoint } => cmd_check(&cli.models_dir, &baseline, endpoint),
+        CliCommand::UpdateBaseline { baseline, endpoint } => {
+            cmd_update_baseline(&cli.models_dir, &baseline, endpoint)
         }
     }
 }
@@ -134,19 +156,17 @@ fn cmd_checksums(models_dir: &std::path::Path) {
     }
 }
 
-fn cmd_run(
+/// Run probes and return the report data.
+fn run_probes(
     models_dir: &std::path::Path,
     services_filter: Option<String>,
-    format: &str,
     endpoint: Option<String>,
-) {
+) -> report::ConformanceReport {
     let models = load_models(models_dir);
 
     let filter: Option<Vec<String>> =
         services_filter.map(|s| s.split(',').map(|s| s.trim().to_string()).collect());
 
-    // Start fakecloud or connect to existing.
-    // _server holds a ChildGuard that kills the process on drop.
     let (endpoint, _server) = if let Some(ep) = endpoint {
         (ep, None)
     } else {
@@ -244,8 +264,16 @@ fn cmd_run(
         all_results.insert(service_name.clone(), service_results);
     }
 
-    let report_data = report::build_report(all_results, &total_ops_per_service);
+    report::build_report(all_results, &total_ops_per_service)
+}
 
+fn cmd_run(
+    models_dir: &std::path::Path,
+    services_filter: Option<String>,
+    format: &str,
+    endpoint: Option<String>,
+) {
+    let report_data = run_probes(models_dir, services_filter, endpoint);
     match format {
         "json" => report::print_json_report(&report_data),
         _ => report::print_text_report(&report_data),
@@ -316,4 +344,127 @@ fn find_binary() -> String {
         debug_path, release_path
     );
     std::process::exit(1);
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct Baseline {
+    variants_passed: usize,
+    total_variants: usize,
+    per_service: HashMap<String, ServiceBaseline>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct ServiceBaseline {
+    passed: usize,
+    total: usize,
+}
+
+fn cmd_check(
+    models_dir: &std::path::Path,
+    baseline_path: &std::path::Path,
+    endpoint: Option<String>,
+) {
+    let baseline_content = std::fs::read_to_string(baseline_path).unwrap_or_else(|e| {
+        eprintln!("Failed to read baseline {}: {}", baseline_path.display(), e);
+        std::process::exit(1);
+    });
+    let baseline: Baseline = serde_json::from_str(&baseline_content).unwrap_or_else(|e| {
+        eprintln!("Failed to parse baseline: {}", e);
+        std::process::exit(1);
+    });
+
+    let report_data = run_probes(models_dir, None, endpoint);
+
+    report::print_text_report(&report_data);
+
+    // Check per-service ratchet
+    let mut regressions = Vec::new();
+
+    for svc in &report_data.services {
+        let current_passed: usize = svc.operations.iter().map(|o| o.passed).sum();
+
+        if let Some(svc_baseline) = baseline.per_service.get(&svc.service_name) {
+            if current_passed < svc_baseline.passed {
+                regressions.push(format!(
+                    "{}: {} → {} variants passing (was {}, lost {})",
+                    svc.service_name,
+                    svc_baseline.passed,
+                    current_passed,
+                    svc_baseline.passed,
+                    svc_baseline.passed - current_passed,
+                ));
+            }
+        }
+    }
+
+    // Check overall ratchet
+    let current_total_passed = report_data.summary.variants_passed;
+    if current_total_passed < baseline.variants_passed {
+        regressions.push(format!(
+            "overall: {} → {} variants passing (lost {})",
+            baseline.variants_passed,
+            current_total_passed,
+            baseline.variants_passed - current_total_passed,
+        ));
+    }
+
+    if regressions.is_empty() {
+        println!("\nConformance check PASSED (no regressions)");
+        println!(
+            "  baseline: {}/{} ({:.1}%)",
+            baseline.variants_passed,
+            baseline.total_variants,
+            baseline.variants_passed as f64 / baseline.total_variants as f64 * 100.0,
+        );
+        println!(
+            "  current:  {}/{} ({:.1}%)",
+            report_data.summary.variants_passed,
+            report_data.summary.total_variants,
+            report_data.summary.variants_passed as f64 / report_data.summary.total_variants as f64
+                * 100.0,
+        );
+    } else {
+        eprintln!("\nConformance check FAILED — coverage dropped:");
+        for r in &regressions {
+            eprintln!("  {}", r);
+        }
+        eprintln!("\nTo update the baseline after intentional changes:");
+        eprintln!("  cargo run -p fakecloud-conformance -- update-baseline");
+        std::process::exit(1);
+    }
+}
+
+fn cmd_update_baseline(
+    models_dir: &std::path::Path,
+    baseline_path: &std::path::Path,
+    endpoint: Option<String>,
+) {
+    let report_data = run_probes(models_dir, None, endpoint);
+
+    let mut per_service = HashMap::new();
+    for svc in &report_data.services {
+        let passed: usize = svc.operations.iter().map(|o| o.passed).sum();
+        let total: usize = svc.operations.iter().map(|o| o.total_variants).sum();
+        per_service.insert(svc.service_name.clone(), ServiceBaseline { passed, total });
+    }
+
+    let baseline = Baseline {
+        variants_passed: report_data.summary.variants_passed,
+        total_variants: report_data.summary.total_variants,
+        per_service,
+    };
+
+    let json = serde_json::to_string_pretty(&baseline).unwrap();
+    std::fs::write(baseline_path, format!("{}\n", json)).unwrap_or_else(|e| {
+        eprintln!("Failed to write baseline: {}", e);
+        std::process::exit(1);
+    });
+
+    println!("Baseline updated: {}", baseline_path.display());
+    println!(
+        "  {}/{} variants passing ({:.1}%)",
+        baseline.variants_passed,
+        baseline.total_variants,
+        baseline.variants_passed as f64 / baseline.total_variants as f64 * 100.0,
+    );
 }

--- a/crates/fakecloud-conformance/src/main.rs
+++ b/crates/fakecloud-conformance/src/main.rs
@@ -380,20 +380,30 @@ fn cmd_check(
     // Check per-service ratchet
     let mut regressions = Vec::new();
 
-    for svc in &report_data.services {
-        let current_passed: usize = svc.operations.iter().map(|o| o.passed).sum();
+    // Build a map of current results for lookup
+    let current_by_service: HashMap<&str, usize> = report_data
+        .services
+        .iter()
+        .map(|svc| {
+            let passed: usize = svc.operations.iter().map(|o| o.passed).sum();
+            (svc.service_name.as_str(), passed)
+        })
+        .collect();
 
-        if let Some(svc_baseline) = baseline.per_service.get(&svc.service_name) {
-            if current_passed < svc_baseline.passed {
-                regressions.push(format!(
-                    "{}: {} → {} variants passing (was {}, lost {})",
-                    svc.service_name,
-                    svc_baseline.passed,
-                    current_passed,
-                    svc_baseline.passed,
-                    svc_baseline.passed - current_passed,
-                ));
-            }
+    for (svc_name, svc_baseline) in &baseline.per_service {
+        let current_passed = current_by_service
+            .get(svc_name.as_str())
+            .copied()
+            .unwrap_or(0);
+        if current_passed < svc_baseline.passed {
+            regressions.push(format!(
+                "{}: {} → {} variants passing (was {}, lost {})",
+                svc_name,
+                svc_baseline.passed,
+                current_passed,
+                svc_baseline.passed,
+                svc_baseline.passed - current_passed,
+            ));
         }
     }
 

--- a/crates/fakecloud-s3/src/service.rs
+++ b/crates/fakecloud-s3/src/service.rs
@@ -489,7 +489,7 @@ impl AwsService for S3Service {
             "DeleteBucketEncryption",
             "PutBucketLifecycleConfiguration",
             "GetBucketLifecycleConfiguration",
-            "DeleteBucketLifecycleConfiguration",
+            "DeleteBucketLifecycle",
             "PutBucketLogging",
             "GetBucketLogging",
             "PutBucketPolicy",


### PR DESCRIPTION
## Summary

- Add `check` subcommand that compares conformance results against a checked-in baseline
- CI fails if any service's variant pass count drops (ratchet — can only go up)
- Add `update-baseline` subcommand to update the baseline after intentional changes
- Baseline file: `conformance-baseline.json` (26,252/34,856 variants, 75.3%)

## Test plan

- [x] `cargo run -p fakecloud-conformance -- check` passes against current baseline
- [x] `cargo test -p fakecloud-conformance --lib` — 26 tests pass
- [x] `cargo clippy -p fakecloud-conformance -- -D warnings` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a conformance ratchet to `fakecloud-conformance` that fails CI if coverage regresses, including per-service checks and missing-service detection. Also wire a Level 2 audit into CI to block untested implemented actions, and ensure it runs even if the conformance check fails.

- **New Features**
  - `check`: compares results to `conformance-baseline.json` and fails on any drop; prints a concise summary.
  - `update-baseline`: regenerates the baseline from current results.
  - Baseline added at repo root with 26,252/34,856 variants passing (75.3%).
  - CI runs `check` and `audit`, and always publishes a JSON report and a text summary.

- **Bug Fixes**
  - Ratchet detects services missing from current results and fails CI accordingly.
  - CI always runs the audit step; audit regex now matches multi-line `test_action` annotations.
  - Align S3 action name with the Smithy model: `DeleteBucketLifecycle`.

<sup>Written for commit 22f0ad31eaca0b8b092473ef2e2f3e4228fbdbbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

