### PR TITLE
Fix 31 conformance validation failures in IAM and STS

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -839,6 +839,53 @@ async fn iam_tag_user() {
     assert!(tags.tags().is_empty());
 }
 
+// ---- Input Validation Tests ----
+
+#[tokio::test]
+async fn iam_list_policies_validates_max_items() {
+    let server = TestServer::start().await;
+    let output = server
+        .aws_cli(&["iam", "list-policies", "--max-items", "0"])
+        .await;
+    assert!(
+        !output.success(),
+        "MaxItems=0 should fail validation but got success"
+    );
+}
+
+#[tokio::test]
+async fn iam_list_users_validates_path_prefix() {
+    let server = TestServer::start().await;
+    let output = server
+        .aws_cli(&["iam", "list-users", "--path-prefix", ""])
+        .await;
+    assert!(
+        !output.success(),
+        "Empty PathPrefix should fail validation but got success"
+    );
+}
+
+#[tokio::test]
+async fn sts_assume_role_validates_external_id() {
+    let server = TestServer::start().await;
+    let output = server
+        .aws_cli(&[
+            "sts",
+            "assume-role",
+            "--role-arn",
+            "arn:aws:iam::123456789012:role/test-role",
+            "--role-session-name",
+            "test-session",
+            "--external-id",
+            "x",
+        ])
+        .await;
+    assert!(
+        !output.success(),
+        "1-char ExternalId should fail validation but got success"
+    );
+}
+
 /// Regression: ListVirtualMFADevices should only return virtual MFA devices,
 /// excluding hardware MFA devices created via EnableMFADevice with a non-virtual serial.
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -847,7 +847,9 @@ async fn iam_list_policies_validates_max_items() {
     let client = server.iam_client().await;
     // MaxItems=0 should fail validation (range is 1-1000)
     let result = client.list_policies().max_items(0).send().await;
-    assert!(result.is_err(), "MaxItems=0 should fail validation");
+    let err = result.expect_err("MaxItems=0 should fail validation");
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("ValidationException") || msg.contains("validation"), "Expected validation error, got: {}", msg);
 }
 
 #[tokio::test]
@@ -856,7 +858,9 @@ async fn iam_list_users_validates_path_prefix() {
     let client = server.iam_client().await;
     // Empty PathPrefix should fail validation (min length 1)
     let result = client.list_users().path_prefix("").send().await;
-    assert!(result.is_err(), "Empty PathPrefix should fail validation");
+    let err = result.expect_err("Empty PathPrefix should fail validation");
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("ValidationException") || msg.contains("validation"), "Expected validation error, got: {}", msg);
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -849,7 +849,11 @@ async fn iam_list_policies_validates_max_items() {
     let result = client.list_policies().max_items(0).send().await;
     let err = result.expect_err("MaxItems=0 should fail validation");
     let msg = format!("{:?}", err);
-    assert!(msg.contains("ValidationException") || msg.contains("validation"), "Expected validation error, got: {}", msg);
+    assert!(
+        msg.contains("ValidationException") || msg.contains("validation"),
+        "Expected validation error, got: {}",
+        msg
+    );
 }
 
 #[tokio::test]
@@ -860,7 +864,11 @@ async fn iam_list_users_validates_path_prefix() {
     let result = client.list_users().path_prefix("").send().await;
     let err = result.expect_err("Empty PathPrefix should fail validation");
     let msg = format!("{:?}", err);
-    assert!(msg.contains("ValidationException") || msg.contains("validation"), "Expected validation error, got: {}", msg);
+    assert!(
+        msg.contains("ValidationException") || msg.contains("validation"),
+        "Expected validation error, got: {}",
+        msg
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -844,25 +844,19 @@ async fn iam_tag_user() {
 #[tokio::test]
 async fn iam_list_policies_validates_max_items() {
     let server = TestServer::start().await;
-    let output = server
-        .aws_cli(&["iam", "list-policies", "--max-items", "0"])
-        .await;
-    assert!(
-        !output.success(),
-        "MaxItems=0 should fail validation but got success"
-    );
+    let client = server.iam_client().await;
+    // MaxItems=0 should fail validation (range is 1-1000)
+    let result = client.list_policies().max_items(0).send().await;
+    assert!(result.is_err(), "MaxItems=0 should fail validation");
 }
 
 #[tokio::test]
 async fn iam_list_users_validates_path_prefix() {
     let server = TestServer::start().await;
-    let output = server
-        .aws_cli(&["iam", "list-users", "--path-prefix", ""])
-        .await;
-    assert!(
-        !output.success(),
-        "Empty PathPrefix should fail validation but got success"
-    );
+    let client = server.iam_client().await;
+    // Empty PathPrefix should fail validation (min length 1)
+    let result = client.list_users().path_prefix("").send().await;
+    assert!(result.is_err(), "Empty PathPrefix should fail validation");
 }
 
 #[tokio::test]

--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -879,6 +879,27 @@ impl IamService {
     }
 
     fn list_users(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        validate_optional_string_length(
+            "pathPrefix",
+            req.query_params.get("PathPrefix").map(|s| s.as_str()),
+            1,
+            512,
+        )?;
+        validate_optional_string_length(
+            "marker",
+            req.query_params.get("Marker").map(|s| s.as_str()),
+            1,
+            320,
+        )?;
+        validate_optional_range_i64(
+            "maxItems",
+            req.query_params
+                .get("MaxItems")
+                .and_then(|v| v.parse::<i64>().ok()),
+            1,
+            1000,
+        )?;
+
         let state = self.state.read();
         let path_prefix = req.query_params.get("PathPrefix").cloned();
         let mut users: Vec<IamUser> = state.users.values().cloned().collect();
@@ -1158,6 +1179,12 @@ impl IamService {
 
     fn list_access_keys(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         validate_optional_string_length(
+            "userName",
+            req.query_params.get("UserName").map(|s| s.as_str()),
+            1,
+            128,
+        )?;
+        validate_optional_string_length(
             "marker",
             req.query_params.get("Marker").map(|s| s.as_str()),
             1,
@@ -1418,6 +1445,20 @@ impl IamService {
             req.query_params.get("Marker").map(|s| s.as_str()),
             1,
             320,
+        )?;
+        validate_optional_string_length(
+            "pathPrefix",
+            req.query_params.get("PathPrefix").map(|s| s.as_str()),
+            1,
+            512,
+        )?;
+        validate_optional_range_i64(
+            "maxItems",
+            req.query_params
+                .get("MaxItems")
+                .and_then(|v| v.parse::<i64>().ok()),
+            1,
+            1000,
         )?;
         let state = self.state.read();
         let path_prefix = req.query_params.get("PathPrefix").cloned();
@@ -1836,6 +1877,39 @@ impl IamService {
     }
 
     fn list_policies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        validate_optional_string_length(
+            "pathPrefix",
+            req.query_params.get("PathPrefix").map(|s| s.as_str()),
+            1,
+            512,
+        )?;
+        validate_optional_string_length(
+            "marker",
+            req.query_params.get("Marker").map(|s| s.as_str()),
+            1,
+            320,
+        )?;
+        validate_optional_range_i64(
+            "maxItems",
+            req.query_params
+                .get("MaxItems")
+                .and_then(|v| v.parse::<i64>().ok()),
+            1,
+            1000,
+        )?;
+        validate_optional_enum(
+            "scope",
+            req.query_params.get("Scope").map(|s| s.as_str()),
+            &["All", "AWS", "Local"],
+        )?;
+        validate_optional_enum(
+            "policyUsageFilter",
+            req.query_params
+                .get("PolicyUsageFilter")
+                .map(|s| s.as_str()),
+            &["PermissionsPolicy", "PermissionsBoundary"],
+        )?;
+
         let state = self.state.read();
         let path_prefix = req.query_params.get("PathPrefix").cloned();
         let scope = req.query_params.get("Scope").cloned();

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -187,6 +187,30 @@ impl StsService {
             validate_range_i64("durationSeconds", v, 900, 43200)?;
         }
 
+        // Validate optional ExternalId
+        validate_optional_string_length(
+            "externalId",
+            req.query_params.get("ExternalId").map(|s| s.as_str()),
+            2,
+            1224,
+        )?;
+
+        // Validate optional Policy
+        validate_optional_string_length(
+            "policy",
+            req.query_params.get("Policy").map(|s| s.as_str()),
+            1,
+            2048,
+        )?;
+
+        // Validate optional SourceIdentity
+        validate_optional_string_length(
+            "sourceIdentity",
+            req.query_params.get("SourceIdentity").map(|s| s.as_str()),
+            2,
+            64,
+        )?;
+
         // Validate and accept optional MFA SerialNumber
         validate_optional_string_length(
             "serialNumber",
@@ -291,6 +315,22 @@ impl StsService {
         validate_string_length("webIdentityToken", web_identity_token, 4, 20000)?;
         let _web_identity_token = web_identity_token.clone();
 
+        // Validate optional Policy
+        validate_optional_string_length(
+            "policy",
+            req.query_params.get("Policy").map(|s| s.as_str()),
+            1,
+            2048,
+        )?;
+
+        // Validate optional ProviderId
+        validate_optional_string_length(
+            "providerId",
+            req.query_params.get("ProviderId").map(|s| s.as_str()),
+            4,
+            2048,
+        )?;
+
         // Validate optional DurationSeconds (used below for expiration)
         if let Some(ds) = req.query_params.get("DurationSeconds") {
             let v = ds.parse::<i64>().map_err(|_| {
@@ -377,6 +417,14 @@ impl StsService {
             )
         })?;
         validate_string_length("sAMLAssertion", saml_assertion, 4, 100000)?;
+
+        // Validate optional Policy
+        validate_optional_string_length(
+            "policy",
+            req.query_params.get("Policy").map(|s| s.as_str()),
+            1,
+            2048,
+        )?;
 
         // Validate optional DurationSeconds (used below for expiration)
         if let Some(ds) = req.query_params.get("DurationSeconds") {


### PR DESCRIPTION
## Summary
- Add missing input validation for 20 IAM actions (ListAccessKeys, ListPolicies, ListRoles, ListUsers) covering UserName, Marker, MaxItems, PathPrefix, Scope, and PolicyUsageFilter constraints
- Add missing input validation for 11 STS actions (AssumeRole, AssumeRoleWithSAML, AssumeRoleWithWebIdentity) covering ExternalId, Policy, SourceIdentity, and ProviderId constraints
- Add 3 E2E tests verifying validation errors for MaxItems=0, empty PathPrefix, and 1-char ExternalId

## Test plan
- [x] `cargo build -p fakecloud-iam` passes
- [x] `cargo test -p fakecloud-iam` passes (21 unit tests)
- [x] `cargo clippy -p fakecloud-iam -- -D warnings` clean
- [x] `cargo test -p fakecloud-e2e --test iam -- --list` shows 27 tests (24 existing + 3 new)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing input validation for IAM List* and STS Assume* calls to match AWS. Fixes 31 conformance failures by returning ValidationException instead of HTTP 200 on bad inputs.

- **Bug Fixes**
  - IAM: `ListAccessKeys`, `ListPolicies`, `ListRoles`, `ListUsers` validate `UserName`, `Marker`, `MaxItems`, `PathPrefix`, `Scope`, `PolicyUsageFilter`.
  - STS: `AssumeRole`, `AssumeRoleWithSAML`, `AssumeRoleWithWebIdentity` validate `ExternalId`, `Policy`, `SourceIdentity`, `ProviderId`.
  - E2E: switch to SDK-based tests; assert ValidationException for `MaxItems=0`, empty `PathPrefix`, and 1-char `ExternalId`.

<sup>Written for commit f1dcdf80368b19918afd5abc1a60cf01c271f75a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

