### PR TITLE
fix(logs): add missing input validations for 44 conformance failures

### DIFF
--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -412,10 +412,7 @@ async fn logs_put_metric_filter_requires_filter_pattern() {
         ])
         .await;
     // The CLI should fail because filterPattern is required
-    assert!(
-        !result.success(),
-        "omitting filterPattern should fail"
-    );
+    assert!(!result.success(), "omitting filterPattern should fail");
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -377,6 +377,48 @@ async fn logs_describe_groups_with_prefix() {
 }
 
 #[tokio::test]
+async fn logs_describe_log_groups_validates_limit() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    let result = client.describe_log_groups().limit(0).send().await;
+    assert!(result.is_err(), "limit=0 should be rejected");
+}
+
+#[tokio::test]
+async fn logs_put_metric_filter_requires_filter_pattern() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    // Create the log group first
+    client
+        .create_log_group()
+        .log_group_name("/test/metric-filter")
+        .send()
+        .await
+        .unwrap();
+
+    // Omit filterPattern via CLI (the SDK may enforce required fields locally)
+    let result = server
+        .aws_cli(&[
+            "logs",
+            "put-metric-filter",
+            "--log-group-name",
+            "/test/metric-filter",
+            "--filter-name",
+            "test-filter",
+            "--metric-transformations",
+            "metricName=TestMetric,metricNamespace=TestNS,metricValue=1",
+        ])
+        .await;
+    // The CLI should fail because filterPattern is required
+    assert!(
+        !result.success(),
+        "omitting filterPattern should fail"
+    );
+}
+
+#[tokio::test]
 async fn logs_put_events_to_nonexistent_stream_fails() {
     let server = TestServer::start().await;
     let client = server.logs_client().await;

--- a/crates/fakecloud-logs/src/service.rs
+++ b/crates/fakecloud-logs/src/service.rs
@@ -282,15 +282,13 @@ impl LogsService {
             0,
             512,
         )?;
-
-        // Validate limit
-        if limit > 50 {
-            return Err(validation_error(
-                "limit",
-                &limit.to_string(),
-                "Member must have value less than or equal to 50",
-            ));
-        }
+        validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
+        validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
+        validate_optional_enum_value(
+            "logGroupClass",
+            &body["logGroupClass"],
+            &["STANDARD", "INFREQUENT_ACCESS", "DELIVERY"],
+        )?;
 
         let state = self.state.read();
         let mut groups: Vec<&LogGroup> = state
@@ -1642,6 +1640,7 @@ impl LogsService {
                 )
             })?
             .to_string();
+        validate_required("filterPattern", &body["filterPattern"])?;
         let filter_pattern = body["filterPattern"].as_str().unwrap_or("").to_string();
         let log_group_name = body["logGroupName"]
             .as_str()
@@ -1657,6 +1656,12 @@ impl LogsService {
         validate_string_length("filterName", &filter_name, 1, 512)?;
         validate_string_length("logGroupName", &log_group_name, 1, 512)?;
         validate_optional_string_length("filterPattern", Some(&filter_pattern), 0, 1024)?;
+        validate_optional_string_length(
+            "fieldSelectionCriteria",
+            body["fieldSelectionCriteria"].as_str(),
+            0,
+            2000,
+        )?;
 
         let transformations_json = body["metricTransformations"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -1721,6 +1726,8 @@ impl LogsService {
         validate_optional_string_length("logGroupName", log_group_name, 1, 512)?;
         validate_optional_string_length("metricName", metric_name, 0, 255)?;
         validate_optional_string_length("metricNamespace", metric_namespace, 0, 255)?;
+        validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
+        validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
 
         let state = self.state.read();
         let filters: Vec<Value> = state
@@ -1881,7 +1888,14 @@ impl LogsService {
     }
 
     fn describe_resource_policies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let _body = body_json(req);
+        let body = body_json(req);
+        validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
+        validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
+        validate_optional_enum_value(
+            "policyScope",
+            &body["policyScope"],
+            &["ACCOUNT", "RESOURCE"],
+        )?;
         let state = self.state.read();
 
         let mut policies: Vec<Value> = state
@@ -1966,6 +1980,8 @@ impl LogsService {
             .to_string();
 
         validate_string_length("destinationName", &destination_name, 1, 512)?;
+        validate_string_length("targetArn", &target_arn, 1, 2048)?;
+        validate_string_length("roleArn", &role_arn, 1, 2048)?;
 
         let tags: std::collections::HashMap<String, String> = body["tags"]
             .as_object()
@@ -2025,6 +2041,8 @@ impl LogsService {
             1,
             512,
         )?;
+        validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
+        validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
 
         let state = self.state.read();
         let destinations: Vec<Value> = state
@@ -2095,6 +2113,8 @@ impl LogsService {
                 "accessPolicy is required",
             )
         })?;
+
+        validate_string_length("accessPolicy", policy, 1, 5120)?;
 
         let mut state = self.state.write();
         let dest = state.destinations.get_mut(name).ok_or_else(|| {
@@ -2227,6 +2247,26 @@ impl LogsService {
         let status_filter = body["status"].as_str();
 
         validate_optional_string_length("logGroupName", log_group_name, 1, 512)?;
+        validate_optional_range_i64("maxResults", body["maxResults"].as_i64(), 1, 1000)?;
+        validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
+        validate_optional_enum_value(
+            "status",
+            &body["status"],
+            &[
+                "Scheduled",
+                "Running",
+                "Complete",
+                "Failed",
+                "Cancelled",
+                "Timeout",
+                "Unknown",
+            ],
+        )?;
+        validate_optional_enum_value(
+            "queryLanguage",
+            &body["queryLanguage"],
+            &["CWLI", "SQL", "PPL"],
+        )?;
 
         let state = self.state.read();
         let queries: Vec<Value> = state
@@ -2351,6 +2391,20 @@ impl LogsService {
         let task_id_filter = body["taskId"].as_str();
 
         validate_optional_string_length("taskId", task_id_filter, 1, 512)?;
+        validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
+        validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
+        validate_optional_enum_value(
+            "statusCode",
+            &body["statusCode"],
+            &[
+                "CANCELLED",
+                "COMPLETED",
+                "FAILED",
+                "PENDING",
+                "PENDING_CANCEL",
+                "RUNNING",
+            ],
+        )?;
 
         let state = self.state.read();
 
@@ -2451,6 +2505,12 @@ impl LogsService {
             .to_string();
 
         validate_string_length("name", &name, 1, 60)?;
+
+        validate_optional_enum_value(
+            "deliveryDestinationType",
+            &body["deliveryDestinationType"],
+            &["S3", "CWL", "FH", "XRAY"],
+        )?;
 
         let output_format = body["outputFormat"].as_str().map(|s| s.to_string());
 
@@ -2591,8 +2651,12 @@ impl LogsService {
 
     fn describe_delivery_destinations(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
+        validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
+
         let state = self.state.read();
         let dds: Vec<Value> = state
             .delivery_destinations
@@ -2930,7 +2994,11 @@ impl LogsService {
         ))
     }
 
-    fn describe_delivery_sources(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    fn describe_delivery_sources(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
+        validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
+
         let state = self.state.read();
         let sources: Vec<Value> = state
             .delivery_sources
@@ -3155,7 +3223,11 @@ impl LogsService {
         ))
     }
 
-    fn describe_deliveries(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    fn describe_deliveries(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
+        validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
+
         let state = self.state.read();
         let deliveries: Vec<Value> = state
             .deliveries
@@ -3319,6 +3391,12 @@ impl LogsService {
             1,
             256,
         )?;
+        validate_optional_string_length("clientToken", body["clientToken"].as_str(), 1, 128)?;
+        validate_optional_enum_value(
+            "queryLanguage",
+            &body["queryLanguage"],
+            &["CWLI", "SQL", "PPL"],
+        )?;
 
         let now = Utc::now().timestamp_millis();
 
@@ -3351,6 +3429,13 @@ impl LogsService {
             body["queryDefinitionNamePrefix"].as_str(),
             1,
             255,
+        )?;
+        validate_optional_range_i64("maxResults", body["maxResults"].as_i64(), 1, 1000)?;
+        validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
+        validate_optional_enum_value(
+            "queryLanguage",
+            &body["queryLanguage"],
+            &["CWLI", "SQL", "PPL"],
         )?;
 
         let state = self.state.read();


### PR DESCRIPTION
## Summary
- Add `validate_optional_range_i64` and `validate_optional_string_length` for limit/nextToken on all 10 Describe* operations (DescribeDeliveries, DescribeDeliveryDestinations, DescribeDeliverySources, DescribeDestinations, DescribeExportTasks, DescribeLogGroups, DescribeMetricFilters, DescribeQueries, DescribeQueryDefinitions, DescribeResourcePolicies)
- Add enum validation for logGroupClass, statusCode, queryLanguage, status, policyScope, and deliveryDestinationType across 7 operations
- Add `validate_required` for filterPattern in PutMetricFilter
- Add string length checks for roleArn/targetArn (PutDestination), accessPolicy (PutDestinationPolicy), clientToken (PutQueryDefinition), fieldSelectionCriteria (PutMetricFilter)
- Add E2E tests for limit validation on DescribeLogGroups and required filterPattern on PutMetricFilter

## Test plan
- [x] `cargo build -p fakecloud-logs` passes
- [x] `cargo test -p fakecloud-logs` — all 15 unit tests pass
- [x] `cargo clippy -p fakecloud-logs -- -D warnings` — clean
- [x] `cargo test -p fakecloud-e2e --test logs -- --list` — 12 tests compile (2 new)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing input validation across Logs APIs to resolve 44 conformance failures. Fixes pagination and enum checks in Describe* calls and enforces required/length rules in write APIs.

- **Bug Fixes**
  - Validate pagination on Describe* operations: `limit` (1–50) for DescribeDeliveries, DescribeDeliveryDestinations, DescribeDeliverySources, DescribeDestinations, DescribeExportTasks, DescribeLogGroups, DescribeMetricFilters, DescribeResourcePolicies; `maxResults` (1–1000) for DescribeQueries and DescribeQueryDefinitions; `nextToken` (1–2048) on all.
  - Add enum checks for `logGroupClass`, `statusCode`, `queryLanguage`, `status`, `policyScope`, `deliveryDestinationType`.
  - Enforce required `filterPattern` in PutMetricFilter; add length checks for `fieldSelectionCriteria`.
  - Add length checks: `roleArn`/`targetArn` (PutDestination), `accessPolicy` (PutDestinationPolicy), `clientToken` (PutQueryDefinition).
  - E2E tests in `fakecloud-e2e` for DescribeLogGroups limit validation and required `filterPattern` in PutMetricFilter; unit tests updated in `fakecloud-logs`.

<sup>Written for commit 86059d937d030364ba7df3220fb104fde6a2556b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

