### PR TITLE
fix: achieve 100% conformance on all implemented actions

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,58 +1,58 @@
 {
-  "variants_passed": 26768,
+  "variants_passed": 26931,
   "total_variants": 34856,
   "per_service": {
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "events": {
-      "passed": 1557,
-      "total": 2108
-    },
-    "dynamodb": {
-      "passed": 755,
-      "total": 2123
-    },
-    "logs": {
-      "passed": 1975,
-      "total": 3911
-    },
-    "iam": {
-      "passed": 5940,
-      "total": 5962
-    },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
+    "sts": {
+      "passed": 411,
+      "total": 438
     },
     "sns": {
       "passed": 1027,
       "total": 1027
     },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
+    },
+    "dynamodb": {
+      "passed": 758,
+      "total": 2123
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
+    },
+    "logs": {
+      "passed": 2037,
+      "total": 3911
+    },
     "lambda": {
       "passed": 3347,
       "total": 3347
     },
-    "secretsmanager": {
-      "passed": 847,
-      "total": 852
+    "ssm": {
+      "passed": 1775,
+      "total": 5303
+    },
+    "s3": {
+      "passed": 3620,
+      "total": 3620
+    },
+    "kms": {
+      "passed": 1608,
+      "total": 2196
+    },
+    "events": {
+      "passed": 1565,
+      "total": 2108
     },
     "sqs": {
       "passed": 549,
       "total": 549
-    },
-    "ssm": {
-      "passed": 1740,
-      "total": 5303
-    },
-    "sts": {
-      "passed": 400,
-      "total": 438
-    },
-    "kms": {
-      "passed": 1591,
-      "total": 2196
     }
   }
 }

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -1089,7 +1089,6 @@ impl EventBridgeService {
         let body = parse_body(req);
         validate_required("Entries", &body["Entries"])?;
         validate_optional_string_length("endpointId", body["EndpointId"].as_str(), 1, 50)?;
-        let endpoint_id = body["EndpointId"].as_str();
         let entries = body["Entries"]
             .as_array()
             .ok_or_else(|| missing("Entries"))?;
@@ -1401,13 +1400,10 @@ impl EventBridgeService {
             }
         }
 
-        let mut resp = json!({
+        let resp = json!({
             "FailedEntryCount": failed_count,
             "Entries": result_entries,
         });
-        if let Some(eid) = endpoint_id {
-            resp["EndpointId"] = json!(eid);
-        }
 
         Ok(json_resp(resp))
     }
@@ -3675,8 +3671,9 @@ mod tests {
     // -- PutEvents EndpointId tests --
 
     #[test]
-    fn put_events_returns_endpoint_id() {
+    fn put_events_never_includes_endpoint_id_in_response() {
         let svc = make_service();
+        // Even when EndpointId is provided in the request, it must not appear in the response
         let req = make_request(
             "PutEvents",
             json!({
@@ -3691,30 +3688,11 @@ mod tests {
         );
         let resp = svc.put_events(&req).unwrap();
         let body: Value = serde_json::from_slice(&resp.body).unwrap();
-        assert_eq!(body["EndpointId"].as_str().unwrap(), "my-endpoint.abc123");
-        assert_eq!(body["FailedEntryCount"], 0);
-    }
-
-    #[test]
-    fn put_events_omits_endpoint_id_when_not_provided() {
-        let svc = make_service();
-        let req = make_request(
-            "PutEvents",
-            json!({
-                "Entries": [{
-                    "Source": "my.source",
-                    "DetailType": "MyType",
-                    "Detail": "{}",
-                    "EventBusName": "default"
-                }]
-            }),
-        );
-        let resp = svc.put_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
         assert!(
             !body.as_object().unwrap().contains_key("EndpointId"),
-            "EndpointId should be omitted when not provided"
+            "EndpointId should never be in the PutEvents response"
         );
+        assert_eq!(body["FailedEntryCount"], 0);
     }
 
     // -- ListArchives pagination tests --

--- a/crates/fakecloud-logs/src/service.rs
+++ b/crates/fakecloud-logs/src/service.rs
@@ -156,6 +156,16 @@ fn body_json(req: &AwsRequest) -> Value {
     serde_json::from_slice(&req.body).unwrap_or(Value::Null)
 }
 
+/// Build a delivery destination configuration JSON object, ensuring
+/// `destinationResourceArn` is always present as a string (Smithy requirement).
+fn dd_config_json(config: &std::collections::HashMap<String, String>) -> Value {
+    let mut m: serde_json::Map<String, Value> =
+        config.iter().map(|(k, v)| (k.clone(), json!(v))).collect();
+    m.entry("destinationResourceArn".to_string())
+        .or_insert_with(|| json!(""));
+    Value::Object(m)
+}
+
 fn generate_sequence_token() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let nanos = SystemTime::now()
@@ -2584,10 +2594,12 @@ impl LogsService {
         state.delivery_destinations.insert(name.clone(), dd);
 
         // Build the configuration object for the response, preserving existing fields
-        // and omitting destinationResourceArn when not set (Smithy shape requires string, not null)
+        // and always including destinationResourceArn (Smithy shape requires string, not null)
         let config_resp = {
-            let c: serde_json::Map<String, Value> =
+            let mut c: serde_json::Map<String, Value> =
                 config.iter().map(|(k, v)| (k.clone(), json!(v))).collect();
+            c.entry("destinationResourceArn".to_string())
+                .or_insert_with(|| json!(""));
             Value::Object(c)
         };
 
@@ -2635,7 +2647,7 @@ impl LogsService {
         let mut obj = json!({
             "name": dd.name,
             "arn": dd.arn,
-            "deliveryDestinationConfiguration": dd.delivery_destination_configuration,
+            "deliveryDestinationConfiguration": dd_config_json(&dd.delivery_destination_configuration),
         });
         if let Some(ref fmt) = dd.output_format {
             obj["outputFormat"] = json!(fmt);
@@ -2663,7 +2675,7 @@ impl LogsService {
                 let mut obj = json!({
                     "name": dd.name,
                     "arn": dd.arn,
-                    "deliveryDestinationConfiguration": dd.delivery_destination_configuration,
+                    "deliveryDestinationConfiguration": dd_config_json(&dd.delivery_destination_configuration),
                 });
                 if let Some(ref fmt) = dd.output_format {
                     obj["outputFormat"] = json!(fmt);
@@ -3389,7 +3401,7 @@ impl LogsService {
             1,
             256,
         )?;
-        validate_optional_string_length("clientToken", body["clientToken"].as_str(), 1, 128)?;
+        validate_optional_string_length("clientToken", body["clientToken"].as_str(), 36, 128)?;
         validate_optional_enum_value(
             "queryLanguage",
             &body["queryLanguage"],
@@ -3871,7 +3883,7 @@ mod tests {
     // ---- extract_log_group_from_arn ----
 
     #[test]
-    fn put_delivery_destination_omits_null_destination_resource_arn() {
+    fn put_delivery_destination_includes_empty_destination_resource_arn() {
         let svc = make_service();
         let req = make_request(
             "PutDeliveryDestination",
@@ -3883,13 +3895,11 @@ mod tests {
         let resp = svc.put_delivery_destination(&req).unwrap();
         let body: Value = serde_json::from_slice(&resp.body).unwrap();
         let config = &body["deliveryDestination"]["deliveryDestinationConfiguration"];
-        // destinationResourceArn should be absent (not null) when not provided
-        assert!(
-            !config
-                .as_object()
-                .unwrap()
-                .contains_key("destinationResourceArn"),
-            "destinationResourceArn should be omitted when not set, not returned as null"
+        // destinationResourceArn should always be present as a string (Smithy requirement)
+        assert_eq!(
+            config["destinationResourceArn"].as_str().unwrap(),
+            "",
+            "destinationResourceArn should be an empty string when not set"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fix 26 remaining conformance failures to achieve 0 failures on all implemented actions
- EventBridge: remove EndpointId from PutEvents response (not in Smithy output shape)
- Logs: include destinationResourceArn as string in PutDeliveryDestination, fix clientToken bounds (36-128)
- Conformance: 26,931/26,931 implemented variants passing (100%)
- Overall: 77.3% (remaining 23% are unimplemented operations)

## Test plan

- [x] `cargo run -p fakecloud-conformance -- run` shows 0 failures on implemented actions
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the last 26 conformance failures to reach 100% pass rate on all implemented actions (26,931/26,931). Overall conformance is now 77.3%, with the remainder unimplemented.

- **Bug Fixes**
  - EventBridge `PutEvents`: never return `EndpointId` in the response.
  - Logs `PutDeliveryDestination`: always include `destinationResourceArn` as a string in `deliveryDestinationConfiguration` (empty string when unset).
  - Logs `PutQueryDefinition`: enforce `clientToken` length 36–128.
  - Logs: validate `deliveryDestinationType` against the allowed enum.

<sup>Written for commit fe0c163cc1a8b0ac3b042b717b886bcaa976f740. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

