### PR TITLE
feat(sts): implement DecodeAuthorizationMessage action

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,46 +1,50 @@
 {
-  "variants_passed": 26931,
+  "variants_passed": 26956,
   "total_variants": 34856,
   "per_service": {
-    "sts": {
-      "passed": 411,
-      "total": 438
+    "s3": {
+      "passed": 3620,
+      "total": 3620
     },
     "sns": {
       "passed": 1027,
       "total": 1027
     },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "dynamodb": {
-      "passed": 758,
-      "total": 2123
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
-    },
-    "logs": {
-      "passed": 2037,
-      "total": 3911
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
+    "sts": {
+      "passed": 436,
+      "total": 438
     },
     "ssm": {
       "passed": 1775,
       "total": 5303
     },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "logs": {
+      "passed": 2037,
+      "total": 3911
+    },
+    "dynamodb": {
+      "passed": 758,
+      "total": 2123
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
+    },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
     },
     "kms": {
       "passed": 1608,
@@ -49,10 +53,6 @@
     "events": {
       "passed": 1565,
       "total": 2108
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
     }
   }
 }

--- a/crates/fakecloud-conformance/tests/sts.rs
+++ b/crates/fakecloud-conformance/tests/sts.rs
@@ -96,3 +96,17 @@ async fn sts_get_access_key_info() {
         .unwrap();
     assert!(resp.account().is_some());
 }
+
+#[test_action("sts", "DecodeAuthorizationMessage", checksum = "4573ceaa")]
+#[tokio::test]
+async fn sts_decode_authorization_message() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let result = client
+        .decode_authorization_message()
+        .encoded_message("encoded-test-message")
+        .send()
+        .await
+        .unwrap();
+    assert!(result.decoded_message().is_some());
+}

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -337,6 +337,28 @@ async fn sts_get_caller_identity_cli() {
     assert_eq!(json["Account"], "123456789012");
 }
 
+#[tokio::test]
+async fn sts_decode_authorization_message() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+
+    let resp = client
+        .decode_authorization_message()
+        .encoded_message("some-encoded-authorization-message")
+        .send()
+        .await
+        .unwrap();
+    let decoded = resp.decoded_message().unwrap();
+    assert!(
+        decoded.contains("allowed"),
+        "decoded message should contain 'allowed', got: {decoded}"
+    );
+    assert!(
+        decoded.contains("matchedStatements"),
+        "decoded message should contain 'matchedStatements', got: {decoded}"
+    );
+}
+
 // ---- IAM Group Tests ----
 
 #[tokio::test]

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -63,6 +63,7 @@ impl AwsService for StsService {
             "GetSessionToken" => self.get_session_token(&req),
             "GetFederationToken" => self.get_federation_token(&req),
             "GetAccessKeyInfo" => self.get_access_key_info(&req),
+            "DecodeAuthorizationMessage" => self.decode_authorization_message(&req),
             _ => Err(AwsServiceError::action_not_implemented("sts", &req.action)),
         }
     }
@@ -76,6 +77,7 @@ impl AwsService for StsService {
             "GetSessionToken",
             "GetFederationToken",
             "GetAccessKeyInfo",
+            "DecodeAuthorizationMessage",
         ]
     }
 }
@@ -579,6 +581,25 @@ impl StsService {
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 
+    fn decode_authorization_message(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let _encoded_message = req.query_params.get("EncodedMessage").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MissingParameter",
+                "The request must contain the parameter EncodedMessage",
+            )
+        })?;
+
+        let decoded_message =
+            r#"{"allowed":true,"explicitDeny":false,"matchedStatements":{"items":[]}}"#;
+        let xml =
+            xml_responses::decode_authorization_message_response(decoded_message, &req.request_id);
+        Ok(AwsResponse::xml(StatusCode::OK, xml))
+    }
+
     fn get_access_key_info(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let access_key_id = req.query_params.get("AccessKeyId").ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -724,6 +745,48 @@ mod tests {
         let id = xml_responses::generate_role_id();
         assert_eq!(id.len(), 21);
         assert!(id.starts_with("AROA"));
+    }
+
+    #[test]
+    fn test_decode_authorization_message() {
+        use crate::state::IamState;
+        use parking_lot::RwLock;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let state: SharedIamState = Arc::new(RwLock::new(IamState::new("123456789012")));
+        let service = StsService::new(state);
+
+        let mut params = HashMap::new();
+        params.insert(
+            "EncodedMessage".to_string(),
+            "some-encoded-message".to_string(),
+        );
+
+        let req = make_test_request(params);
+        let resp = service.decode_authorization_message(&req).unwrap();
+        let body = std::str::from_utf8(&resp.body).unwrap();
+        assert!(body.contains("DecodedMessage"));
+        assert!(body.contains("allowed"));
+        assert!(body.contains("matchedStatements"));
+    }
+
+    #[test]
+    fn test_decode_authorization_message_missing_param() {
+        use crate::state::IamState;
+        use parking_lot::RwLock;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let state: SharedIamState = Arc::new(RwLock::new(IamState::new("123456789012")));
+        let service = StsService::new(state);
+
+        let req = make_test_request(HashMap::new());
+        let result = service.decode_authorization_message(&req);
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        let msg = format!("{:?}", err);
+        assert!(msg.contains("EncodedMessage"));
     }
 
     fn make_test_request(params: std::collections::HashMap<String, String>) -> AwsRequest {

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -810,6 +810,22 @@ pub fn get_federation_token_response(
     )
 }
 
+pub fn decode_authorization_message_response(decoded_message: &str, request_id: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<DecodeAuthorizationMessageResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <DecodeAuthorizationMessageResult>
+    <DecodedMessage>{decoded_message}</DecodedMessage>
+  </DecodeAuthorizationMessageResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</DecodeAuthorizationMessageResponse>"#,
+        decoded_message = xml_escape(decoded_message),
+        request_id = request_id,
+    )
+}
+
 pub fn get_access_key_info_response(account_id: &str, request_id: &str) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- Add `DecodeAuthorizationMessage` STS action that accepts an `EncodedMessage` parameter and returns a stub decoded JSON authorization message
- Add XML response builder `decode_authorization_message_response` following existing patterns
- Add unit tests for success and missing parameter cases, and an E2E test using the STS SDK client

## Test plan
- [x] Unit tests pass (`cargo test -p fakecloud-iam`)
- [x] Clippy clean (`cargo clippy -p fakecloud-iam -- -D warnings`)
- [ ] E2E test `sts_decode_authorization_message` passes against running server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements STS `DecodeAuthorizationMessage` to validate `EncodedMessage` and return a stub decoded JSON payload in the standard STS XML response. Adds unit, E2E, and conformance tests; updates the conformance baseline.

- **New Features**
  - Wire `DecodeAuthorizationMessage` into `StsService`.
  - Add XML builder `decode_authorization_message_response`.
  - Return `MissingParameter` when `EncodedMessage` is missing.
  - Add unit, E2E, and conformance tests (new conformance case); update `conformance-baseline.json`.

<sup>Written for commit d9f634afb322fb0ceddd7f3bbcef00840e842916. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

