### PR TITLE
feat(ssm): implement 38 missing SSM operations

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,46 +1,14 @@
 {
-  "variants_passed": 27758,
+  "variants_passed": 29113,
   "total_variants": 34856,
   "per_service": {
-    "kms": {
-      "passed": 1905,
-      "total": 2196
-    },
-    "ssm": {
-      "passed": 1775,
-      "total": 5303
-    },
     "s3": {
       "passed": 3620,
       "total": 3620
     },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "logs": {
-      "passed": 2037,
-      "total": 3911
-    },
-    "events": {
-      "passed": 2070,
-      "total": 2108
-    },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "dynamodb": {
-      "passed": 758,
-      "total": 2123
-    },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
+    "kms": {
+      "passed": 1905,
+      "total": 2196
     },
     "secretsmanager": {
       "passed": 852,
@@ -50,9 +18,41 @@
       "passed": 549,
       "total": 549
     },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "dynamodb": {
+      "passed": 1079,
+      "total": 2123
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
+    },
+    "logs": {
+      "passed": 2037,
+      "total": 3911
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "ssm": {
+      "passed": 2801,
+      "total": 5303
+    },
     "sts": {
       "passed": 436,
       "total": 438
+    },
+    "events": {
+      "passed": 2078,
+      "total": 2108
     }
   }
 }

--- a/crates/fakecloud-conformance/tests/ssm.rs
+++ b/crates/fakecloud-conformance/tests/ssm.rs
@@ -669,3 +669,550 @@ async fn ssm_patch_groups() {
         .await
         .unwrap();
 }
+
+// -- Association lifecycle --
+
+#[test_action("ssm", "CreateAssociation", checksum = "507ad141")]
+#[test_action("ssm", "DescribeAssociation", checksum = "2ffc2f3f")]
+#[test_action("ssm", "UpdateAssociation", checksum = "2febcaea")]
+#[test_action("ssm", "ListAssociations", checksum = "373868d2")]
+#[test_action("ssm", "ListAssociationVersions", checksum = "6d4e7407")]
+#[test_action("ssm", "DeleteAssociation", checksum = "89e9a7ab")]
+#[tokio::test]
+async fn ssm_association_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_association()
+        .name("AWS-RunShellScript")
+        .targets(
+            aws_sdk_ssm::types::Target::builder()
+                .key("InstanceIds")
+                .values("i-00000000000000001")
+                .build(),
+        )
+        .schedule_expression("rate(1 hour)")
+        .association_name("conf-assoc")
+        .send()
+        .await
+        .unwrap();
+    let assoc_id = create
+        .association_description()
+        .unwrap()
+        .association_id()
+        .unwrap()
+        .to_string();
+
+    let _ = client
+        .describe_association()
+        .association_id(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_association()
+        .association_id(&assoc_id)
+        .association_name("conf-assoc-updated")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client.list_associations().send().await.unwrap();
+
+    let _ = client
+        .list_association_versions()
+        .association_id(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_association()
+        .association_id(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- UpdateAssociationStatus --
+
+#[test_action("ssm", "UpdateAssociationStatus", checksum = "1668b3f6")]
+#[tokio::test]
+async fn ssm_update_association_status() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_association()
+        .name("AWS-RunShellScript")
+        .instance_id("i-00000000000000001")
+        .send()
+        .await
+        .unwrap();
+    let _assoc_id = create
+        .association_description()
+        .unwrap()
+        .association_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .update_association_status()
+        .name("AWS-RunShellScript")
+        .instance_id("i-00000000000000001")
+        .association_status(
+            aws_sdk_ssm::types::AssociationStatus::builder()
+                .name(aws_sdk_ssm::types::AssociationStatusName::Success)
+                .date(aws_sdk_ssm::primitives::DateTime::from_secs(0))
+                .message("ok")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- StartAssociationsOnce --
+
+#[test_action("ssm", "StartAssociationsOnce", checksum = "7f3c858a")]
+#[tokio::test]
+async fn ssm_start_associations_once() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_association()
+        .name("AWS-RunShellScript")
+        .targets(
+            aws_sdk_ssm::types::Target::builder()
+                .key("InstanceIds")
+                .values("i-00000000000000001")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let assoc_id = create
+        .association_description()
+        .unwrap()
+        .association_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .start_associations_once()
+        .association_ids(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- CreateAssociationBatch --
+
+#[test_action("ssm", "CreateAssociationBatch", checksum = "d64a58de")]
+#[tokio::test]
+async fn ssm_create_association_batch() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let entry = aws_sdk_ssm::types::CreateAssociationBatchRequestEntry::builder()
+        .name("AWS-RunShellScript")
+        .targets(
+            aws_sdk_ssm::types::Target::builder()
+                .key("InstanceIds")
+                .values("i-00000000000000001")
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    let resp = client
+        .create_association_batch()
+        .entries(entry)
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.successful().is_empty());
+}
+
+// -- DescribeAssociationExecutions + Targets --
+
+#[test_action("ssm", "DescribeAssociationExecutions", checksum = "6b36f591")]
+#[tokio::test]
+async fn ssm_describe_association_executions() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_association()
+        .name("AWS-RunShellScript")
+        .targets(
+            aws_sdk_ssm::types::Target::builder()
+                .key("InstanceIds")
+                .values("i-00000000000000001")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let assoc_id = create
+        .association_description()
+        .unwrap()
+        .association_id()
+        .unwrap()
+        .to_string();
+
+    let resp = client
+        .describe_association_executions()
+        .association_id(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.association_executions().is_empty());
+}
+
+#[test_action("ssm", "DescribeAssociationExecutionTargets", checksum = "10258e0d")]
+#[tokio::test]
+async fn ssm_describe_association_execution_targets() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_association()
+        .name("AWS-RunShellScript")
+        .targets(
+            aws_sdk_ssm::types::Target::builder()
+                .key("InstanceIds")
+                .values("i-00000000000000001")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let assoc_id = create
+        .association_description()
+        .unwrap()
+        .association_id()
+        .unwrap()
+        .to_string();
+
+    let resp = client
+        .describe_association_execution_targets()
+        .association_id(&assoc_id)
+        .execution_id("fake-execution-id")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.association_execution_targets().is_empty());
+}
+
+// -- OpsItems --
+
+#[test_action("ssm", "CreateOpsItem", checksum = "48b1d2b8")]
+#[test_action("ssm", "GetOpsItem", checksum = "649a65f9")]
+#[test_action("ssm", "UpdateOpsItem", checksum = "43879dd9")]
+#[test_action("ssm", "DescribeOpsItems", checksum = "3a284cc4")]
+#[test_action("ssm", "DeleteOpsItem", checksum = "f705d8f4")]
+#[tokio::test]
+async fn ssm_ops_item_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create = client
+        .create_ops_item()
+        .title("Conf OpsItem")
+        .source("conf-test")
+        .send()
+        .await
+        .unwrap();
+    let ops_item_id = create.ops_item_id().unwrap().to_string();
+
+    let get = client
+        .get_ops_item()
+        .ops_item_id(&ops_item_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.ops_item().unwrap().title().unwrap(), "Conf OpsItem");
+
+    client
+        .update_ops_item()
+        .ops_item_id(&ops_item_id)
+        .title("Updated Conf OpsItem")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client.describe_ops_items().send().await.unwrap();
+
+    client
+        .delete_ops_item()
+        .ops_item_id(&ops_item_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Document extras --
+
+#[test_action("ssm", "ListDocumentVersions", checksum = "aadc01d4")]
+#[tokio::test]
+async fn ssm_list_document_versions() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let doc_content = r#"{"schemaVersion":"2.2","description":"ver","mainSteps":[{"action":"aws:runShellScript","name":"test","inputs":{"runCommand":["echo hi"]}}]}"#;
+
+    client
+        .create_document()
+        .name("conf-doc-ver")
+        .content(doc_content)
+        .document_type(aws_sdk_ssm::types::DocumentType::Command)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_document_versions()
+        .name("conf-doc-ver")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.document_versions().is_empty());
+}
+
+#[test_action("ssm", "ListDocumentMetadataHistory", checksum = "c6bdd053")]
+#[tokio::test]
+async fn ssm_list_document_metadata_history() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let doc_content = r#"{"schemaVersion":"2.2","description":"meta","mainSteps":[{"action":"aws:runShellScript","name":"test","inputs":{"runCommand":["echo hi"]}}]}"#;
+
+    client
+        .create_document()
+        .name("conf-doc-meta")
+        .content(doc_content)
+        .document_type(aws_sdk_ssm::types::DocumentType::Command)
+        .send()
+        .await
+        .unwrap();
+
+    let _ = client
+        .list_document_metadata_history()
+        .name("conf-doc-meta")
+        .metadata(aws_sdk_ssm::types::DocumentMetadataEnum::DocumentReviews)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ssm", "UpdateDocumentMetadata", checksum = "9e4be7a5")]
+#[tokio::test]
+async fn ssm_update_document_metadata() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let doc_content = r#"{"schemaVersion":"2.2","description":"updmeta","mainSteps":[{"action":"aws:runShellScript","name":"test","inputs":{"runCommand":["echo hi"]}}]}"#;
+
+    client
+        .create_document()
+        .name("conf-doc-updmeta")
+        .content(doc_content)
+        .document_type(aws_sdk_ssm::types::DocumentType::Command)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_document_metadata()
+        .name("conf-doc-updmeta")
+        .document_reviews(
+            aws_sdk_ssm::types::DocumentReviews::builder()
+                .action(aws_sdk_ssm::types::DocumentReviewAction::Approve)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Resource policies --
+
+#[test_action("ssm", "PutResourcePolicy", checksum = "7ee6b0bd")]
+#[test_action("ssm", "GetResourcePolicies", checksum = "303e2bb5")]
+#[test_action("ssm", "DeleteResourcePolicy", checksum = "df09409d")]
+#[tokio::test]
+async fn ssm_resource_policies() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // First create a parameter to use as resource
+    client
+        .put_parameter()
+        .name("/conf/policy-test")
+        .value("x")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+
+    let put = client
+        .put_resource_policy()
+        .resource_arn("arn:aws:ssm:us-east-1:123456789012:parameter/conf/policy-test")
+        .policy(r#"{"Version":"2012-10-17","Statement":[]}"#)
+        .send()
+        .await
+        .unwrap();
+    let policy_id = put.policy_id().unwrap().to_string();
+    let policy_hash = put.policy_hash().unwrap().to_string();
+
+    let get = client
+        .get_resource_policies()
+        .resource_arn("arn:aws:ssm:us-east-1:123456789012:parameter/conf/policy-test")
+        .send()
+        .await
+        .unwrap();
+    assert!(!get.policies().is_empty());
+
+    client
+        .delete_resource_policy()
+        .resource_arn("arn:aws:ssm:us-east-1:123456789012:parameter/conf/policy-test")
+        .policy_id(&policy_id)
+        .policy_hash(&policy_hash)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Stubs --
+
+#[test_action("ssm", "GetConnectionStatus", checksum = "5ceb276b")]
+#[tokio::test]
+async fn ssm_get_connection_status() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let resp = client
+        .get_connection_status()
+        .target("i-00000000000000001")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        Some(&aws_sdk_ssm::types::ConnectionStatus::Connected)
+    );
+}
+
+#[test_action("ssm", "GetCalendarState", checksum = "ead1c10e")]
+#[tokio::test]
+async fn ssm_get_calendar_state() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let _ = client
+        .get_calendar_state()
+        .calendar_names("arn:aws:ssm:us-east-1:123456789012:document/cal")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ssm", "DescribePatchGroupState", checksum = "6ff4c75a")]
+#[tokio::test]
+async fn ssm_describe_patch_group_state() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let _ = client
+        .describe_patch_group_state()
+        .patch_group("conf-group")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ssm", "DescribePatchProperties", checksum = "79e19b9c")]
+#[tokio::test]
+async fn ssm_describe_patch_properties() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let _ = client
+        .describe_patch_properties()
+        .operating_system(aws_sdk_ssm::types::OperatingSystem::Windows)
+        .property(aws_sdk_ssm::types::PatchProperty::Product)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ssm", "GetDefaultPatchBaseline", checksum = "e52823f7")]
+#[tokio::test]
+async fn ssm_get_default_patch_baseline() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let resp = client.get_default_patch_baseline().send().await.unwrap();
+    assert!(resp.baseline_id().is_some());
+}
+
+#[test_action("ssm", "RegisterDefaultPatchBaseline", checksum = "5b5ac699")]
+#[tokio::test]
+async fn ssm_register_default_patch_baseline() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // Create a baseline to register
+    let create = client
+        .create_patch_baseline()
+        .name("conf-default-bl")
+        .send()
+        .await
+        .unwrap();
+    let baseline_id = create.baseline_id().unwrap().to_string();
+
+    client
+        .register_default_patch_baseline()
+        .baseline_id(&baseline_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ssm", "DescribeAvailablePatches", checksum = "2d7c2b66")]
+#[tokio::test]
+async fn ssm_describe_available_patches() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+    let resp = client.describe_available_patches().send().await.unwrap();
+    assert!(resp.patches().is_empty());
+}
+
+#[test_action("ssm", "GetServiceSetting", checksum = "3419aa2b")]
+#[test_action("ssm", "UpdateServiceSetting", checksum = "ea87e0e0")]
+#[test_action("ssm", "ResetServiceSetting", checksum = "cfad6810")]
+#[tokio::test]
+async fn ssm_service_settings() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let _ = client
+        .get_service_setting()
+        .setting_id("/ssm/parameter-store/high-throughput-enabled")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_service_setting()
+        .setting_id("/ssm/parameter-store/high-throughput-enabled")
+        .setting_value("true")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .reset_service_setting()
+        .setting_id("/ssm/parameter-store/high-throughput-enabled")
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -721,3 +721,352 @@ async fn ssm_remove_tags_invalid_resource_type() {
         "expected error for invalid resource type, but got success"
     );
 }
+
+// =====================================================================
+// Associations
+// =====================================================================
+
+#[tokio::test]
+async fn ssm_association_crud() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // Create
+    let create_resp = client
+        .create_association()
+        .name("AWS-RunShellScript")
+        .targets(
+            aws_sdk_ssm::types::Target::builder()
+                .key("InstanceIds")
+                .values("i-00000000000000001")
+                .build(),
+        )
+        .schedule_expression("rate(1 hour)")
+        .association_name("e2e-assoc")
+        .send()
+        .await
+        .unwrap();
+    let assoc_desc = create_resp.association_description().unwrap();
+    let assoc_id = assoc_desc.association_id().unwrap().to_string();
+    assert_eq!(assoc_desc.name().unwrap(), "AWS-RunShellScript");
+
+    // Describe
+    let desc = client
+        .describe_association()
+        .association_id(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        desc.association_description()
+            .unwrap()
+            .association_name()
+            .unwrap(),
+        "e2e-assoc"
+    );
+
+    // List
+    let list = client.list_associations().send().await.unwrap();
+    assert!(!list.associations().is_empty());
+
+    // Update
+    client
+        .update_association()
+        .association_id(&assoc_id)
+        .association_name("updated-assoc")
+        .send()
+        .await
+        .unwrap();
+
+    // List versions
+    let versions = client
+        .list_association_versions()
+        .association_id(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(versions.association_versions().len() >= 2);
+
+    // Delete
+    client
+        .delete_association()
+        .association_id(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify deleted
+    let result = client
+        .describe_association()
+        .association_id(&assoc_id)
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn ssm_association_batch_and_start() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // Batch create
+    let entry1 = aws_sdk_ssm::types::CreateAssociationBatchRequestEntry::builder()
+        .name("AWS-RunShellScript")
+        .targets(
+            aws_sdk_ssm::types::Target::builder()
+                .key("InstanceIds")
+                .values("i-001")
+                .build(),
+        )
+        .build()
+        .unwrap();
+    let entry2 = aws_sdk_ssm::types::CreateAssociationBatchRequestEntry::builder()
+        .name("AWS-RunShellScript")
+        .targets(
+            aws_sdk_ssm::types::Target::builder()
+                .key("InstanceIds")
+                .values("i-002")
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    let batch_resp = client
+        .create_association_batch()
+        .entries(entry1)
+        .entries(entry2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(batch_resp.successful().len(), 2);
+
+    // StartAssociationsOnce
+    let assoc_id = batch_resp.successful()[0]
+        .association_id()
+        .unwrap()
+        .to_string();
+    let _ = client
+        .start_associations_once()
+        .association_ids(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn ssm_association_executions_empty() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let create_resp = client
+        .create_association()
+        .name("AWS-RunShellScript")
+        .targets(
+            aws_sdk_ssm::types::Target::builder()
+                .key("InstanceIds")
+                .values("i-00000000000000001")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let assoc_id = create_resp
+        .association_description()
+        .unwrap()
+        .association_id()
+        .unwrap()
+        .to_string();
+
+    let execs = client
+        .describe_association_executions()
+        .association_id(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(execs.association_executions().is_empty());
+}
+
+// =====================================================================
+// OpsItems
+// =====================================================================
+
+#[tokio::test]
+async fn ssm_ops_item_crud() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // Create
+    let create_resp = client
+        .create_ops_item()
+        .title("E2E Test OpsItem")
+        .source("e2e-test")
+        .description("A test ops item for E2E tests")
+        .send()
+        .await
+        .unwrap();
+    let ops_item_id = create_resp.ops_item_id().unwrap().to_string();
+
+    // Get
+    let get_resp = client
+        .get_ops_item()
+        .ops_item_id(&ops_item_id)
+        .send()
+        .await
+        .unwrap();
+    let item = get_resp.ops_item().unwrap();
+    assert_eq!(item.title().unwrap(), "E2E Test OpsItem");
+    assert_eq!(
+        item.status(),
+        Some(&aws_sdk_ssm::types::OpsItemStatus::Open)
+    );
+
+    // Update
+    client
+        .update_ops_item()
+        .ops_item_id(&ops_item_id)
+        .title("Updated OpsItem")
+        .status(aws_sdk_ssm::types::OpsItemStatus::Resolved)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify update
+    let get_resp = client
+        .get_ops_item()
+        .ops_item_id(&ops_item_id)
+        .send()
+        .await
+        .unwrap();
+    let item = get_resp.ops_item().unwrap();
+    assert_eq!(item.title().unwrap(), "Updated OpsItem");
+
+    // Describe
+    let desc = client.describe_ops_items().send().await.unwrap();
+    assert!(!desc.ops_item_summaries().is_empty());
+
+    // Delete
+    client
+        .delete_ops_item()
+        .ops_item_id(&ops_item_id)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify deleted
+    let result = client.get_ops_item().ops_item_id(&ops_item_id).send().await;
+    assert!(result.is_err());
+}
+
+// =====================================================================
+// Document extras
+// =====================================================================
+
+#[tokio::test]
+async fn ssm_list_document_versions() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let doc_content = r#"{"schemaVersion":"2.2","description":"test","mainSteps":[{"action":"aws:runShellScript","name":"test","inputs":{"runCommand":["echo hi"]}}]}"#;
+
+    client
+        .create_document()
+        .name("e2e-doc-ver")
+        .content(doc_content)
+        .document_type(aws_sdk_ssm::types::DocumentType::Command)
+        .send()
+        .await
+        .unwrap();
+
+    let versions = client
+        .list_document_versions()
+        .name("e2e-doc-ver")
+        .send()
+        .await
+        .unwrap();
+    assert!(!versions.document_versions().is_empty());
+}
+
+// =====================================================================
+// Stubs
+// =====================================================================
+
+#[tokio::test]
+async fn ssm_get_connection_status() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let resp = client
+        .get_connection_status()
+        .target("i-00000000000000001")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        Some(&aws_sdk_ssm::types::ConnectionStatus::Connected)
+    );
+}
+
+#[tokio::test]
+async fn ssm_get_calendar_state() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let resp = client
+        .get_calendar_state()
+        .calendar_names("arn:aws:ssm:us-east-1:123456789012:document/cal")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.state(), Some(&aws_sdk_ssm::types::CalendarState::Open));
+}
+
+#[tokio::test]
+async fn ssm_service_settings() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // Get default
+    let resp = client
+        .get_service_setting()
+        .setting_id("/ssm/parameter-store/high-throughput-enabled")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.service_setting().is_some());
+
+    // Update
+    client
+        .update_service_setting()
+        .setting_id("/ssm/parameter-store/high-throughput-enabled")
+        .setting_value("true")
+        .send()
+        .await
+        .unwrap();
+
+    // Reset
+    client
+        .reset_service_setting()
+        .setting_id("/ssm/parameter-store/high-throughput-enabled")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn ssm_get_default_patch_baseline() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let resp = client.get_default_patch_baseline().send().await.unwrap();
+    assert!(resp.baseline_id().is_some());
+}
+
+#[tokio::test]
+async fn ssm_describe_available_patches() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let resp = client.describe_available_patches().send().await.unwrap();
+    assert!(resp.patches().is_empty());
+}

--- a/crates/fakecloud-ssm/src/service.rs
+++ b/crates/fakecloud-ssm/src/service.rs
@@ -11,7 +11,9 @@ use fakecloud_core::validation::*;
 
 use crate::state::{
     MaintenanceWindow, MaintenanceWindowTarget, MaintenanceWindowTask, PatchBaseline, PatchGroup,
-    SharedSsmState, SsmCommand, SsmDocument, SsmDocumentVersion, SsmParameter, SsmParameterVersion,
+    SharedSsmState, SsmAssociation, SsmAssociationVersion, SsmCommand, SsmDocument,
+    SsmDocumentVersion, SsmOpsItem, SsmParameter, SsmParameterVersion, SsmResourcePolicy,
+    SsmServiceSetting,
 };
 
 use fakecloud_secretsmanager::state::SharedSecretsManagerState;
@@ -101,6 +103,45 @@ impl AwsService for SsmService {
             }
             "GetPatchBaselineForPatchGroup" => self.get_patch_baseline_for_patch_group(&req),
             "DescribePatchGroups" => self.describe_patch_groups(&req),
+            // Associations
+            "CreateAssociation" => self.create_association(&req),
+            "DescribeAssociation" => self.describe_association(&req),
+            "DeleteAssociation" => self.delete_association(&req),
+            "ListAssociations" => self.list_associations(&req),
+            "UpdateAssociation" => self.update_association(&req),
+            "ListAssociationVersions" => self.list_association_versions(&req),
+            "UpdateAssociationStatus" => self.update_association_status(&req),
+            "StartAssociationsOnce" => self.start_associations_once(&req),
+            "CreateAssociationBatch" => self.create_association_batch(&req),
+            "DescribeAssociationExecutions" => self.describe_association_executions(&req),
+            "DescribeAssociationExecutionTargets" => {
+                self.describe_association_execution_targets(&req)
+            }
+            // OpsItems
+            "CreateOpsItem" => self.create_ops_item(&req),
+            "GetOpsItem" => self.get_ops_item(&req),
+            "UpdateOpsItem" => self.update_ops_item(&req),
+            "DeleteOpsItem" => self.delete_ops_item(&req),
+            "DescribeOpsItems" => self.describe_ops_items(&req),
+            // Document extras
+            "ListDocumentVersions" => self.list_document_versions(&req),
+            "ListDocumentMetadataHistory" => self.list_document_metadata_history(&req),
+            "UpdateDocumentMetadata" => self.update_document_metadata(&req),
+            // Resource policies
+            "PutResourcePolicy" => self.put_resource_policy(&req),
+            "GetResourcePolicies" => self.get_resource_policies(&req),
+            "DeleteResourcePolicy" => self.delete_resource_policy(&req),
+            // Stubs
+            "GetConnectionStatus" => self.get_connection_status(&req),
+            "GetCalendarState" => self.get_calendar_state(&req),
+            "DescribePatchGroupState" => self.describe_patch_group_state(&req),
+            "DescribePatchProperties" => self.describe_patch_properties(&req),
+            "GetDefaultPatchBaseline" => self.get_default_patch_baseline(&req),
+            "RegisterDefaultPatchBaseline" => self.register_default_patch_baseline(&req),
+            "DescribeAvailablePatches" => self.describe_available_patches(&req),
+            "GetServiceSetting" => self.get_service_setting(&req),
+            "ResetServiceSetting" => self.reset_service_setting(&req),
+            "UpdateServiceSetting" => self.update_service_setting(&req),
             _ => Err(AwsServiceError::action_not_implemented("ssm", &req.action)),
         }
     }
@@ -153,6 +194,43 @@ impl AwsService for SsmService {
             "DeregisterPatchBaselineForPatchGroup",
             "GetPatchBaselineForPatchGroup",
             "DescribePatchGroups",
+            // Associations
+            "CreateAssociation",
+            "DescribeAssociation",
+            "DeleteAssociation",
+            "ListAssociations",
+            "UpdateAssociation",
+            "ListAssociationVersions",
+            "UpdateAssociationStatus",
+            "StartAssociationsOnce",
+            "CreateAssociationBatch",
+            "DescribeAssociationExecutions",
+            "DescribeAssociationExecutionTargets",
+            // OpsItems
+            "CreateOpsItem",
+            "GetOpsItem",
+            "UpdateOpsItem",
+            "DeleteOpsItem",
+            "DescribeOpsItems",
+            // Document extras
+            "ListDocumentVersions",
+            "ListDocumentMetadataHistory",
+            "UpdateDocumentMetadata",
+            // Resource policies
+            "PutResourcePolicy",
+            "GetResourcePolicies",
+            "DeleteResourcePolicy",
+            // Stubs
+            "GetConnectionStatus",
+            "GetCalendarState",
+            "DescribePatchGroupState",
+            "DescribePatchProperties",
+            "GetDefaultPatchBaseline",
+            "RegisterDefaultPatchBaseline",
+            "DescribeAvailablePatches",
+            "GetServiceSetting",
+            "ResetServiceSetting",
+            "UpdateServiceSetting",
         ]
     }
 }
@@ -3792,6 +3870,1203 @@ impl SsmService {
 
         Ok(json_resp(resp))
     }
+
+    // -----------------------------------------------------------------------
+    // Associations
+    // -----------------------------------------------------------------------
+
+    fn create_association_inner(&self, body: &Value) -> Result<Value, AwsServiceError> {
+        let name = body["Name"]
+            .as_str()
+            .ok_or_else(|| missing("Name"))?
+            .to_string();
+
+        let targets: Vec<serde_json::Value> =
+            body["Targets"].as_array().cloned().unwrap_or_default();
+        let instance_id = body["InstanceId"].as_str().map(|s| s.to_string());
+
+        // Must have either Targets or InstanceId
+        if targets.is_empty() && instance_id.is_none() {
+            // Accept it anyway like AWS does for document-only associations
+        }
+
+        let schedule_expression = body["ScheduleExpression"].as_str().map(|s| s.to_string());
+        let parameters: HashMap<String, Vec<String>> = body["Parameters"]
+            .as_object()
+            .map(|obj| {
+                obj.iter()
+                    .map(|(k, v)| {
+                        let vals = v
+                            .as_array()
+                            .map(|a| {
+                                a.iter()
+                                    .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        (k.clone(), vals)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let association_name = body["AssociationName"].as_str().map(|s| s.to_string());
+        let document_version = body["DocumentVersion"].as_str().map(|s| s.to_string());
+        let output_location = body.get("OutputLocation").filter(|v| !v.is_null()).cloned();
+        let automation_target_parameter_name = body["AutomationTargetParameterName"]
+            .as_str()
+            .map(|s| s.to_string());
+        let max_errors = body["MaxErrors"].as_str().map(|s| s.to_string());
+        let max_concurrency = body["MaxConcurrency"].as_str().map(|s| s.to_string());
+        let compliance_severity = body["ComplianceSeverity"].as_str().map(|s| s.to_string());
+        let sync_compliance = body["SyncCompliance"].as_str().map(|s| s.to_string());
+        let apply_only_at_cron_interval =
+            body["ApplyOnlyAtCronInterval"].as_bool().unwrap_or(false);
+        let calendar_names: Vec<String> = body["CalendarNames"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let target_locations: Vec<serde_json::Value> = body["TargetLocations"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let schedule_offset = body["ScheduleOffset"].as_i64();
+        let target_maps: Vec<serde_json::Value> =
+            body["TargetMaps"].as_array().cloned().unwrap_or_default();
+        let tags: HashMap<String, String> = body["Tags"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let k = t["Key"].as_str()?;
+                        let v = t["Value"].as_str()?;
+                        Some((k.to_string(), v.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let now = Utc::now();
+        let association_id = uuid::Uuid::new_v4().to_string();
+
+        let version = SsmAssociationVersion {
+            version: 1,
+            name: name.clone(),
+            targets: targets.clone(),
+            schedule_expression: schedule_expression.clone(),
+            parameters: parameters.clone(),
+            document_version: document_version.clone(),
+            created_date: now,
+            association_name: association_name.clone(),
+            max_errors: max_errors.clone(),
+            max_concurrency: max_concurrency.clone(),
+            compliance_severity: compliance_severity.clone(),
+        };
+
+        let assoc = SsmAssociation {
+            association_id: association_id.clone(),
+            name: name.clone(),
+            targets: targets.clone(),
+            schedule_expression,
+            parameters,
+            association_name: association_name.clone(),
+            document_version,
+            output_location,
+            automation_target_parameter_name,
+            max_errors,
+            max_concurrency,
+            compliance_severity,
+            sync_compliance,
+            apply_only_at_cron_interval,
+            calendar_names,
+            target_locations,
+            schedule_offset,
+            target_maps,
+            tags,
+            status: "Pending".to_string(),
+            status_date: now,
+            overview: json!({"Status": "Pending", "DetailedStatus": "Creating", "AssociationStatusAggregatedCount": {}}),
+            created_date: now,
+            last_update_association_date: now,
+            last_execution_date: None,
+            instance_id,
+            versions: vec![version],
+        };
+
+        let resp = association_to_json(&assoc);
+
+        let mut state = self.state.write();
+        state.associations.insert(association_id, assoc);
+
+        Ok(resp)
+    }
+
+    fn create_association(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let resp = self.create_association_inner(&body)?;
+        Ok(json_resp(json!({ "AssociationDescription": resp })))
+    }
+
+    fn describe_association(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let association_id = body["AssociationId"].as_str();
+        let name = body["Name"].as_str();
+        let instance_id = body["InstanceId"].as_str();
+
+        let state = self.state.read();
+
+        let assoc = if let Some(id) = association_id {
+            state.associations.get(id)
+        } else if let Some(n) = name {
+            state.associations.values().find(|a| {
+                a.name == n && (instance_id.is_none() || a.instance_id.as_deref() == instance_id)
+            })
+        } else {
+            return Err(missing("AssociationId"));
+        };
+
+        match assoc {
+            Some(a) => Ok(json_resp(
+                json!({ "AssociationDescription": association_to_json(a) }),
+            )),
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "AssociationDoesNotExist",
+                "The specified association does not exist.".to_string(),
+            )),
+        }
+    }
+
+    fn delete_association(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let association_id = body["AssociationId"].as_str();
+        let name = body["Name"].as_str();
+        let instance_id = body["InstanceId"].as_str();
+
+        let mut state = self.state.write();
+
+        let key = if let Some(id) = association_id {
+            if state.associations.contains_key(id) {
+                Some(id.to_string())
+            } else {
+                None
+            }
+        } else if let Some(n) = name {
+            state
+                .associations
+                .iter()
+                .find(|(_, a)| {
+                    a.name == n
+                        && (instance_id.is_none() || a.instance_id.as_deref() == instance_id)
+                })
+                .map(|(k, _)| k.clone())
+        } else {
+            return Err(missing("AssociationId"));
+        };
+
+        match key {
+            Some(k) => {
+                state.associations.remove(&k);
+                Ok(json_resp(json!({})))
+            }
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "AssociationDoesNotExist",
+                "The specified association does not exist.".to_string(),
+            )),
+        }
+    }
+
+    fn list_associations(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
+        let next_token_offset: usize = body["NextToken"]
+            .as_str()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        let state = self.state.read();
+        let all: Vec<Value> = state
+            .associations
+            .values()
+            .map(|a| {
+                let mut v = json!({
+                    "AssociationId": a.association_id,
+                    "Name": a.name,
+                    "LastExecutionDate": a.last_execution_date.map(|d| d.timestamp_millis() as f64 / 1000.0),
+                });
+                if let Some(ref an) = a.association_name {
+                    v["AssociationName"] = json!(an);
+                }
+                if let Some(ref s) = a.schedule_expression {
+                    v["ScheduleExpression"] = json!(s);
+                }
+                if !a.targets.is_empty() {
+                    v["Targets"] = json!(a.targets);
+                }
+                if let Some(ref iid) = a.instance_id {
+                    v["InstanceId"] = json!(iid);
+                }
+                v["Overview"] = a.overview.clone();
+                v
+            })
+            .collect();
+
+        let page = if next_token_offset < all.len() {
+            &all[next_token_offset..]
+        } else {
+            &[]
+        };
+        let has_more = page.len() > max_results;
+        let items: Vec<Value> = page.iter().take(max_results).cloned().collect();
+
+        let mut resp = json!({ "Associations": items });
+        if has_more {
+            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        }
+        Ok(json_resp(resp))
+    }
+
+    fn update_association(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let association_id = body["AssociationId"]
+            .as_str()
+            .ok_or_else(|| missing("AssociationId"))?;
+
+        let mut state = self.state.write();
+        let assoc = state.associations.get_mut(association_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "AssociationDoesNotExist",
+                "The specified association does not exist.".to_string(),
+            )
+        })?;
+
+        let now = Utc::now();
+
+        if let Some(n) = body["Name"].as_str() {
+            assoc.name = n.to_string();
+        }
+        if let Some(targets) = body["Targets"].as_array() {
+            assoc.targets = targets.clone();
+        }
+        if let Some(s) = body["ScheduleExpression"].as_str() {
+            assoc.schedule_expression = Some(s.to_string());
+        }
+        if let Some(obj) = body["Parameters"].as_object() {
+            assoc.parameters = obj
+                .iter()
+                .map(|(k, v)| {
+                    let vals = v
+                        .as_array()
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    (k.clone(), vals)
+                })
+                .collect();
+        }
+        if let Some(an) = body["AssociationName"].as_str() {
+            assoc.association_name = Some(an.to_string());
+        }
+        if let Some(dv) = body["DocumentVersion"].as_str() {
+            assoc.document_version = Some(dv.to_string());
+        }
+        if let Some(me) = body["MaxErrors"].as_str() {
+            assoc.max_errors = Some(me.to_string());
+        }
+        if let Some(mc) = body["MaxConcurrency"].as_str() {
+            assoc.max_concurrency = Some(mc.to_string());
+        }
+        if let Some(cs) = body["ComplianceSeverity"].as_str() {
+            assoc.compliance_severity = Some(cs.to_string());
+        }
+
+        assoc.last_update_association_date = now;
+
+        let next_version = assoc.versions.len() as i64 + 1;
+        assoc.versions.push(SsmAssociationVersion {
+            version: next_version,
+            name: assoc.name.clone(),
+            targets: assoc.targets.clone(),
+            schedule_expression: assoc.schedule_expression.clone(),
+            parameters: assoc.parameters.clone(),
+            document_version: assoc.document_version.clone(),
+            created_date: now,
+            association_name: assoc.association_name.clone(),
+            max_errors: assoc.max_errors.clone(),
+            max_concurrency: assoc.max_concurrency.clone(),
+            compliance_severity: assoc.compliance_severity.clone(),
+        });
+
+        let resp = association_to_json(assoc);
+        Ok(json_resp(json!({ "AssociationDescription": resp })))
+    }
+
+    fn list_association_versions(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let association_id = body["AssociationId"]
+            .as_str()
+            .ok_or_else(|| missing("AssociationId"))?;
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
+        let next_token_offset: usize = body["NextToken"]
+            .as_str()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        let state = self.state.read();
+        let assoc = state.associations.get(association_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "AssociationDoesNotExist",
+                "The specified association does not exist.".to_string(),
+            )
+        })?;
+
+        let all: Vec<Value> = assoc
+            .versions
+            .iter()
+            .map(|v| {
+                let mut j = json!({
+                    "AssociationId": association_id,
+                    "AssociationVersion": v.version.to_string(),
+                    "Name": v.name,
+                    "CreatedDate": v.created_date.timestamp_millis() as f64 / 1000.0,
+                });
+                if !v.targets.is_empty() {
+                    j["Targets"] = json!(v.targets);
+                }
+                if let Some(ref s) = v.schedule_expression {
+                    j["ScheduleExpression"] = json!(s);
+                }
+                if let Some(ref an) = v.association_name {
+                    j["AssociationName"] = json!(an);
+                }
+                if let Some(ref dv) = v.document_version {
+                    j["DocumentVersion"] = json!(dv);
+                }
+                if let Some(ref me) = v.max_errors {
+                    j["MaxErrors"] = json!(me);
+                }
+                if let Some(ref mc) = v.max_concurrency {
+                    j["MaxConcurrency"] = json!(mc);
+                }
+                if let Some(ref cs) = v.compliance_severity {
+                    j["ComplianceSeverity"] = json!(cs);
+                }
+                j
+            })
+            .collect();
+
+        let page = if next_token_offset < all.len() {
+            &all[next_token_offset..]
+        } else {
+            &[]
+        };
+        let has_more = page.len() > max_results;
+        let items: Vec<Value> = page.iter().take(max_results).cloned().collect();
+
+        let mut resp = json!({ "AssociationVersions": items });
+        if has_more {
+            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        }
+        Ok(json_resp(resp))
+    }
+
+    fn update_association_status(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let instance_id = body["InstanceId"]
+            .as_str()
+            .ok_or_else(|| missing("InstanceId"))?;
+        let association_status = &body["AssociationStatus"];
+        let new_status = association_status["Name"]
+            .as_str()
+            .unwrap_or("Pending")
+            .to_string();
+
+        let mut state = self.state.write();
+        let assoc = state
+            .associations
+            .values_mut()
+            .find(|a| a.name == name && a.instance_id.as_deref() == Some(instance_id))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "AssociationDoesNotExist",
+                    "The specified association does not exist.".to_string(),
+                )
+            })?;
+
+        assoc.status = new_status;
+        assoc.status_date = Utc::now();
+
+        let resp = association_to_json(assoc);
+        Ok(json_resp(json!({ "AssociationDescription": resp })))
+    }
+
+    fn start_associations_once(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let _association_ids = body["AssociationIds"]
+            .as_array()
+            .ok_or_else(|| missing("AssociationIds"))?;
+        // No-op: return success
+        Ok(json_resp(json!({})))
+    }
+
+    fn create_association_batch(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let entries = body["Entries"]
+            .as_array()
+            .ok_or_else(|| missing("Entries"))?;
+
+        let mut successful = Vec::new();
+        let mut failed = Vec::new();
+
+        for entry in entries {
+            match self.create_association_inner(entry) {
+                Ok(desc) => successful.push(desc),
+                Err(e) => {
+                    let entry_name = entry["Name"].as_str().unwrap_or("");
+                    failed.push(json!({
+                        "Entry": entry,
+                        "Message": e.to_string(),
+                        "Fault": "Client",
+                    }));
+                    let _ = entry_name; // suppress unused
+                }
+            }
+        }
+
+        Ok(json_resp(json!({
+            "Successful": successful,
+            "Failed": failed,
+        })))
+    }
+
+    fn describe_association_executions(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let _association_id = body["AssociationId"]
+            .as_str()
+            .ok_or_else(|| missing("AssociationId"))?;
+        // Return empty list — associations don't actually run
+        Ok(json_resp(json!({ "AssociationExecutions": [] })))
+    }
+
+    fn describe_association_execution_targets(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let _association_id = body["AssociationId"]
+            .as_str()
+            .ok_or_else(|| missing("AssociationId"))?;
+        let _execution_id = body["ExecutionId"]
+            .as_str()
+            .ok_or_else(|| missing("ExecutionId"))?;
+        Ok(json_resp(json!({ "AssociationExecutionTargets": [] })))
+    }
+
+    // -----------------------------------------------------------------------
+    // OpsItems
+    // -----------------------------------------------------------------------
+
+    fn create_ops_item(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let title = body["Title"]
+            .as_str()
+            .ok_or_else(|| missing("Title"))?
+            .to_string();
+        let source = body["Source"]
+            .as_str()
+            .ok_or_else(|| missing("Source"))?
+            .to_string();
+        let description = body["Description"].as_str().map(|s| s.to_string());
+        let priority = body["Priority"].as_i64();
+        let severity = body["Severity"].as_str().map(|s| s.to_string());
+        let category = body["Category"].as_str().map(|s| s.to_string());
+        let ops_item_type = body["OpsItemType"].as_str().map(|s| s.to_string());
+        let operational_data: HashMap<String, serde_json::Value> = body["OperationalData"]
+            .as_object()
+            .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default();
+        let notifications: Vec<serde_json::Value> = body["Notifications"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let related_ops_items: Vec<serde_json::Value> = body["RelatedOpsItems"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let tags: HashMap<String, String> = body["Tags"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let k = t["Key"].as_str()?;
+                        let v = t["Value"].as_str()?;
+                        Some((k.to_string(), v.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let now = Utc::now();
+        let mut state = self.state.write();
+        state.ops_item_counter += 1;
+        let ops_item_id = format!("oi-{:012x}", state.ops_item_counter);
+
+        let item = SsmOpsItem {
+            ops_item_id: ops_item_id.clone(),
+            title,
+            description,
+            source,
+            status: "Open".to_string(),
+            priority,
+            severity,
+            category,
+            operational_data,
+            notifications,
+            related_ops_items,
+            tags,
+            created_time: now,
+            last_modified_time: now,
+            created_by: format!("arn:aws:iam::{}:root", state.account_id),
+            last_modified_by: format!("arn:aws:iam::{}:root", state.account_id),
+            ops_item_type,
+            planned_start_time: None,
+            planned_end_time: None,
+            actual_start_time: None,
+            actual_end_time: None,
+        };
+
+        state.ops_items.insert(ops_item_id.clone(), item);
+
+        Ok(json_resp(json!({ "OpsItemId": ops_item_id })))
+    }
+
+    fn get_ops_item(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let ops_item_id = body["OpsItemId"]
+            .as_str()
+            .ok_or_else(|| missing("OpsItemId"))?;
+
+        let state = self.state.read();
+        let item = state.ops_items.get(ops_item_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "OpsItemNotFoundException",
+                format!("OpsItem ID {ops_item_id} not found"),
+            )
+        })?;
+
+        Ok(json_resp(json!({ "OpsItem": ops_item_to_json(item) })))
+    }
+
+    fn update_ops_item(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let ops_item_id = body["OpsItemId"]
+            .as_str()
+            .ok_or_else(|| missing("OpsItemId"))?;
+
+        let mut state = self.state.write();
+        let account_id = state.account_id.clone();
+        let item = state.ops_items.get_mut(ops_item_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "OpsItemNotFoundException",
+                format!("OpsItem ID {ops_item_id} not found"),
+            )
+        })?;
+
+        if let Some(t) = body["Title"].as_str() {
+            item.title = t.to_string();
+        }
+        if let Some(d) = body["Description"].as_str() {
+            item.description = Some(d.to_string());
+        }
+        if let Some(s) = body["Status"].as_str() {
+            item.status = s.to_string();
+        }
+        if let Some(p) = body["Priority"].as_i64() {
+            item.priority = Some(p);
+        }
+        if let Some(s) = body["Severity"].as_str() {
+            item.severity = Some(s.to_string());
+        }
+        if let Some(c) = body["Category"].as_str() {
+            item.category = Some(c.to_string());
+        }
+        if let Some(obj) = body["OperationalData"].as_object() {
+            for (k, v) in obj {
+                item.operational_data.insert(k.clone(), v.clone());
+            }
+        }
+        if let Some(arr) = body["Notifications"].as_array() {
+            item.notifications = arr.clone();
+        }
+        if let Some(arr) = body["RelatedOpsItems"].as_array() {
+            item.related_ops_items = arr.clone();
+        }
+
+        item.last_modified_time = Utc::now();
+        item.last_modified_by = format!("arn:aws:iam::{}:root", account_id);
+
+        Ok(json_resp(json!({})))
+    }
+
+    fn delete_ops_item(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let ops_item_id = body["OpsItemId"]
+            .as_str()
+            .ok_or_else(|| missing("OpsItemId"))?;
+
+        let mut state = self.state.write();
+        state.ops_items.remove(ops_item_id);
+        Ok(json_resp(json!({})))
+    }
+
+    fn describe_ops_items(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
+        let next_token_offset: usize = body["NextToken"]
+            .as_str()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        let state = self.state.read();
+        let all: Vec<Value> = state
+            .ops_items
+            .values()
+            .map(|item| {
+                json!({
+                    "OpsItemId": item.ops_item_id,
+                    "Title": item.title,
+                    "Status": item.status,
+                    "Source": item.source,
+                    "Priority": item.priority,
+                    "Severity": item.severity,
+                    "Category": item.category,
+                    "CreatedTime": item.created_time.timestamp_millis() as f64 / 1000.0,
+                    "LastModifiedTime": item.last_modified_time.timestamp_millis() as f64 / 1000.0,
+                    "CreatedBy": item.created_by,
+                    "LastModifiedBy": item.last_modified_by,
+                })
+            })
+            .collect();
+
+        let page = if next_token_offset < all.len() {
+            &all[next_token_offset..]
+        } else {
+            &[]
+        };
+        let has_more = page.len() > max_results;
+        let items: Vec<Value> = page.iter().take(max_results).cloned().collect();
+
+        let mut resp = json!({ "OpsItemSummaries": items });
+        if has_more {
+            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        }
+        Ok(json_resp(resp))
+    }
+
+    // -----------------------------------------------------------------------
+    // Document extras
+    // -----------------------------------------------------------------------
+
+    fn list_document_versions(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
+        let next_token_offset: usize = body["NextToken"]
+            .as_str()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        let state = self.state.read();
+        let doc = state
+            .documents
+            .get(name)
+            .ok_or_else(|| doc_not_found(name))?;
+
+        let all: Vec<Value> = doc
+            .versions
+            .iter()
+            .map(|v| {
+                json!({
+                    "Name": name,
+                    "DocumentVersion": v.document_version,
+                    "CreatedDate": v.created_date.timestamp_millis() as f64 / 1000.0,
+                    "IsDefaultVersion": v.is_default_version,
+                    "DocumentFormat": v.document_format,
+                    "Status": v.status,
+                    "VersionName": v.version_name,
+                })
+            })
+            .collect();
+
+        let page = if next_token_offset < all.len() {
+            &all[next_token_offset..]
+        } else {
+            &[]
+        };
+        let has_more = page.len() > max_results;
+        let items: Vec<Value> = page.iter().take(max_results).cloned().collect();
+
+        let mut resp = json!({ "DocumentVersions": items });
+        if has_more {
+            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        }
+        Ok(json_resp(resp))
+    }
+
+    fn list_document_metadata_history(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let _name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let _metadata = body["Metadata"]
+            .as_str()
+            .ok_or_else(|| missing("Metadata"))?;
+
+        // Stub: return empty metadata
+        Ok(json_resp(json!({
+            "Name": _name,
+            "Author": "",
+            "Metadata": {
+                "ReviewerResponse": []
+            }
+        })))
+    }
+
+    fn update_document_metadata(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+
+        let state = self.state.read();
+        if !state.documents.contains_key(name) {
+            return Err(doc_not_found(name));
+        }
+
+        // Stub: accept but do nothing
+        Ok(json_resp(json!({})))
+    }
+
+    // -----------------------------------------------------------------------
+    // Resource policies
+    // -----------------------------------------------------------------------
+
+    fn put_resource_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let resource_arn = body["ResourceArn"]
+            .as_str()
+            .ok_or_else(|| missing("ResourceArn"))?
+            .to_string();
+        let policy = body["Policy"]
+            .as_str()
+            .ok_or_else(|| missing("Policy"))?
+            .to_string();
+
+        let policy_id = body["PolicyId"].as_str().map(|s| s.to_string());
+        let policy_hash = body["PolicyHash"].as_str().map(|s| s.to_string());
+
+        let mut state = self.state.write();
+
+        // If PolicyId is provided, update existing
+        if let Some(ref pid) = policy_id {
+            if let Some(existing) = state
+                .resource_policies
+                .iter_mut()
+                .find(|p| p.policy_id == *pid && p.resource_arn == resource_arn)
+            {
+                // Verify hash matches if provided
+                if let Some(ref expected_hash) = policy_hash {
+                    if existing.policy_hash != *expected_hash {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "ResourcePolicyConflictException",
+                            "The policy hash does not match.".to_string(),
+                        ));
+                    }
+                }
+                existing.policy = policy;
+                let new_hash = format!("{:x}", md5::compute(existing.policy.as_bytes()));
+                existing.policy_hash = new_hash.clone();
+                return Ok(json_resp(json!({
+                    "PolicyId": pid,
+                    "PolicyHash": new_hash,
+                })));
+            }
+        }
+
+        // Create new
+        let new_id = uuid::Uuid::new_v4().to_string();
+        let new_hash = format!("{:x}", md5::compute(policy.as_bytes()));
+        state.resource_policies.push(SsmResourcePolicy {
+            policy_id: new_id.clone(),
+            policy_hash: new_hash.clone(),
+            policy,
+            resource_arn,
+        });
+
+        Ok(json_resp(json!({
+            "PolicyId": new_id,
+            "PolicyHash": new_hash,
+        })))
+    }
+
+    fn get_resource_policies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let resource_arn = body["ResourceArn"]
+            .as_str()
+            .ok_or_else(|| missing("ResourceArn"))?;
+
+        let state = self.state.read();
+        let policies: Vec<Value> = state
+            .resource_policies
+            .iter()
+            .filter(|p| p.resource_arn == resource_arn)
+            .map(|p| {
+                json!({
+                    "PolicyId": p.policy_id,
+                    "PolicyHash": p.policy_hash,
+                    "Policy": p.policy,
+                })
+            })
+            .collect();
+
+        Ok(json_resp(json!({ "Policies": policies })))
+    }
+
+    fn delete_resource_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let resource_arn = body["ResourceArn"]
+            .as_str()
+            .ok_or_else(|| missing("ResourceArn"))?;
+        let policy_id = body["PolicyId"]
+            .as_str()
+            .ok_or_else(|| missing("PolicyId"))?;
+        let policy_hash = body["PolicyHash"]
+            .as_str()
+            .ok_or_else(|| missing("PolicyHash"))?;
+
+        let mut state = self.state.write();
+        let idx = state
+            .resource_policies
+            .iter()
+            .position(|p| p.resource_arn == resource_arn && p.policy_id == policy_id);
+
+        match idx {
+            Some(i) => {
+                if state.resource_policies[i].policy_hash != policy_hash {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ResourcePolicyConflictException",
+                        "The policy hash does not match.".to_string(),
+                    ));
+                }
+                state.resource_policies.remove(i);
+                Ok(json_resp(json!({})))
+            }
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourcePolicyNotFoundException",
+                "The resource policy was not found.".to_string(),
+            )),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Stubs
+    // -----------------------------------------------------------------------
+
+    fn get_connection_status(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let target = body["Target"].as_str().ok_or_else(|| missing("Target"))?;
+        Ok(json_resp(json!({
+            "Target": target,
+            "Status": "connected",
+        })))
+    }
+
+    fn get_calendar_state(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let _calendar_names = body["CalendarNames"]
+            .as_array()
+            .ok_or_else(|| missing("CalendarNames"))?;
+        Ok(json_resp(json!({
+            "State": "OPEN",
+            "AtTime": Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            "NextTransitionTime": null,
+        })))
+    }
+
+    fn describe_patch_group_state(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let _patch_group = body["PatchGroup"]
+            .as_str()
+            .ok_or_else(|| missing("PatchGroup"))?;
+        Ok(json_resp(json!({
+            "Instances": 0,
+            "InstancesWithInstalledPatches": 0,
+            "InstancesWithInstalledOtherPatches": 0,
+            "InstancesWithInstalledRejectedPatches": 0,
+            "InstancesWithInstalledPendingRebootPatches": 0,
+            "InstancesWithMissingPatches": 0,
+            "InstancesWithFailedPatches": 0,
+            "InstancesWithNotApplicablePatches": 0,
+            "InstancesWithUnreportedNotApplicablePatches": 0,
+            "InstancesWithCriticalNonCompliantPatches": 0,
+            "InstancesWithSecurityNonCompliantPatches": 0,
+            "InstancesWithOtherNonCompliantPatches": 0,
+        })))
+    }
+
+    fn describe_patch_properties(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        Ok(json_resp(json!({ "Properties": [] })))
+    }
+
+    fn get_default_patch_baseline(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let operating_system = body["OperatingSystem"].as_str().unwrap_or("WINDOWS");
+
+        let state = self.state.read();
+
+        // Check if a custom default has been registered
+        if let Some(ref baseline_id) = state.default_patch_baseline_id {
+            return Ok(json_resp(json!({
+                "BaselineId": baseline_id,
+                "OperatingSystem": operating_system,
+            })));
+        }
+
+        // Otherwise look up from defaults
+        let baseline_id =
+            default_patch_baseline(&state.region, operating_system).unwrap_or_default();
+        Ok(json_resp(json!({
+            "BaselineId": baseline_id,
+            "OperatingSystem": operating_system,
+        })))
+    }
+
+    fn register_default_patch_baseline(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let baseline_id = body["BaselineId"]
+            .as_str()
+            .ok_or_else(|| missing("BaselineId"))?
+            .to_string();
+
+        let mut state = self.state.write();
+
+        // Verify baseline exists (custom or default)
+        if !state.patch_baselines.contains_key(&baseline_id)
+            && !is_default_patch_baseline(&baseline_id)
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "DoesNotExistException",
+                format!("Patch baseline {baseline_id} does not exist"),
+            ));
+        }
+
+        state.default_patch_baseline_id = Some(baseline_id.clone());
+        Ok(json_resp(json!({
+            "BaselineId": baseline_id,
+        })))
+    }
+
+    fn describe_available_patches(
+        &self,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        Ok(json_resp(json!({ "Patches": [] })))
+    }
+
+    fn get_service_setting(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let setting_id = body["SettingId"]
+            .as_str()
+            .ok_or_else(|| missing("SettingId"))?;
+
+        let state = self.state.read();
+        if let Some(setting) = state.service_settings.get(setting_id) {
+            Ok(json_resp(json!({
+                "ServiceSetting": {
+                    "SettingId": setting.setting_id,
+                    "SettingValue": setting.setting_value,
+                    "LastModifiedDate": setting.last_modified_date.timestamp_millis() as f64 / 1000.0,
+                    "LastModifiedUser": setting.last_modified_user,
+                    "ARN": format!("arn:aws:ssm:{}:{}:servicesetting/{}", state.region, state.account_id, setting.setting_id),
+                    "Status": setting.status,
+                }
+            })))
+        } else {
+            // Return sensible default for known settings
+            Ok(json_resp(json!({
+                "ServiceSetting": {
+                    "SettingId": setting_id,
+                    "SettingValue": get_default_service_setting(setting_id),
+                    "LastModifiedDate": Utc::now().timestamp_millis() as f64 / 1000.0,
+                    "LastModifiedUser": "System",
+                    "ARN": format!("arn:aws:ssm:{}:{}:servicesetting/{}", state.region, state.account_id, setting_id),
+                    "Status": "Default",
+                }
+            })))
+        }
+    }
+
+    fn reset_service_setting(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let setting_id = body["SettingId"]
+            .as_str()
+            .ok_or_else(|| missing("SettingId"))?;
+
+        let mut state = self.state.write();
+        state.service_settings.remove(setting_id);
+
+        let default_value = get_default_service_setting(setting_id);
+        Ok(json_resp(json!({
+            "ServiceSetting": {
+                "SettingId": setting_id,
+                "SettingValue": default_value,
+                "LastModifiedDate": Utc::now().timestamp_millis() as f64 / 1000.0,
+                "LastModifiedUser": "System",
+                "ARN": format!("arn:aws:ssm:{}:{}:servicesetting/{}", state.region, state.account_id, setting_id),
+                "Status": "Default",
+            }
+        })))
+    }
+
+    fn update_service_setting(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = parse_body(req);
+        let setting_id = body["SettingId"]
+            .as_str()
+            .ok_or_else(|| missing("SettingId"))?
+            .to_string();
+        let setting_value = body["SettingValue"]
+            .as_str()
+            .ok_or_else(|| missing("SettingValue"))?
+            .to_string();
+
+        let mut state = self.state.write();
+        let now = Utc::now();
+        let account_id = state.account_id.clone();
+        state.service_settings.insert(
+            setting_id.clone(),
+            SsmServiceSetting {
+                setting_id,
+                setting_value,
+                last_modified_date: now,
+                last_modified_user: format!("arn:aws:iam::{}:root", account_id),
+                status: "Customized".to_string(),
+            },
+        );
+
+        Ok(json_resp(json!({})))
+    }
+}
+
+fn association_to_json(a: &SsmAssociation) -> Value {
+    let mut v = json!({
+        "AssociationId": a.association_id,
+        "Name": a.name,
+        "AssociationVersion": a.versions.len().to_string(),
+        "Date": a.created_date.timestamp_millis() as f64 / 1000.0,
+        "LastUpdateAssociationDate": a.last_update_association_date.timestamp_millis() as f64 / 1000.0,
+        "Status": {
+            "Date": a.status_date.timestamp_millis() as f64 / 1000.0,
+            "Name": a.status,
+            "Message": "",
+            "AdditionalInfo": "",
+        },
+        "Overview": a.overview,
+        "ApplyOnlyAtCronInterval": a.apply_only_at_cron_interval,
+    });
+    if !a.targets.is_empty() {
+        v["Targets"] = json!(a.targets);
+    }
+    if let Some(ref s) = a.schedule_expression {
+        v["ScheduleExpression"] = json!(s);
+    }
+    if !a.parameters.is_empty() {
+        v["Parameters"] = json!(a.parameters);
+    }
+    if let Some(ref an) = a.association_name {
+        v["AssociationName"] = json!(an);
+    }
+    if let Some(ref dv) = a.document_version {
+        v["DocumentVersion"] = json!(dv);
+    }
+    if let Some(ref ol) = a.output_location {
+        v["OutputLocation"] = ol.clone();
+    }
+    if let Some(ref me) = a.max_errors {
+        v["MaxErrors"] = json!(me);
+    }
+    if let Some(ref mc) = a.max_concurrency {
+        v["MaxConcurrency"] = json!(mc);
+    }
+    if let Some(ref cs) = a.compliance_severity {
+        v["ComplianceSeverity"] = json!(cs);
+    }
+    if let Some(ref sc) = a.sync_compliance {
+        v["SyncCompliance"] = json!(sc);
+    }
+    if let Some(ref iid) = a.instance_id {
+        v["InstanceId"] = json!(iid);
+    }
+    if let Some(so) = a.schedule_offset {
+        v["ScheduleOffset"] = json!(so);
+    }
+    if let Some(ref led) = a.last_execution_date {
+        v["LastExecutionDate"] = json!(led.timestamp_millis() as f64 / 1000.0);
+    }
+    v
+}
+
+fn ops_item_to_json(item: &SsmOpsItem) -> Value {
+    json!({
+        "OpsItemId": item.ops_item_id,
+        "Title": item.title,
+        "Description": item.description,
+        "Source": item.source,
+        "Status": item.status,
+        "Priority": item.priority,
+        "Severity": item.severity,
+        "Category": item.category,
+        "OperationalData": item.operational_data,
+        "Notifications": item.notifications,
+        "RelatedOpsItems": item.related_ops_items,
+        "CreatedTime": item.created_time.timestamp_millis() as f64 / 1000.0,
+        "LastModifiedTime": item.last_modified_time.timestamp_millis() as f64 / 1000.0,
+        "CreatedBy": item.created_by,
+        "LastModifiedBy": item.last_modified_by,
+        "OpsItemType": item.ops_item_type,
+    })
+}
+
+fn get_default_service_setting(setting_id: &str) -> String {
+    match setting_id {
+        s if s.contains("parameter-store") && s.contains("throughput") => "standard".to_string(),
+        s if s.contains("parameter-store") && s.contains("high-throughput") => "false".to_string(),
+        s if s.contains("session-manager") => "".to_string(),
+        s if s.contains("managed-instance") => "".to_string(),
+        _ => "".to_string(),
+    }
 }
 
 /// Validate a path value for parameter path filters.
@@ -4642,5 +5917,379 @@ mod tests {
         let body: Value = serde_json::from_slice(&resp.body).unwrap();
         assert_eq!(body["WindowIdentities"].as_array().unwrap().len(), 1);
         assert!(body.get("NextToken").is_none() || body["NextToken"].is_null());
+    }
+
+    // -- Associations --
+
+    #[test]
+    fn association_crud() {
+        let svc = make_service();
+
+        // Create
+        let req = make_request(
+            "CreateAssociation",
+            json!({
+                "Name": "AWS-RunShellScript",
+                "Targets": [{"Key": "InstanceIds", "Values": ["i-1234567890abcdef0"]}],
+                "ScheduleExpression": "rate(1 hour)",
+                "AssociationName": "my-assoc",
+            }),
+        );
+        let resp = svc.create_association(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let assoc_id = body["AssociationDescription"]["AssociationId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            body["AssociationDescription"]["Name"].as_str().unwrap(),
+            "AWS-RunShellScript"
+        );
+
+        // Describe
+        let req = make_request("DescribeAssociation", json!({ "AssociationId": assoc_id }));
+        let resp = svc.describe_association(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(
+            body["AssociationDescription"]["AssociationName"]
+                .as_str()
+                .unwrap(),
+            "my-assoc"
+        );
+
+        // List
+        let req = make_request("ListAssociations", json!({}));
+        let resp = svc.list_associations(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["Associations"].as_array().unwrap().len(), 1);
+
+        // Update
+        let req = make_request(
+            "UpdateAssociation",
+            json!({
+                "AssociationId": assoc_id,
+                "AssociationName": "updated-assoc",
+            }),
+        );
+        let resp = svc.update_association(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(
+            body["AssociationDescription"]["AssociationName"]
+                .as_str()
+                .unwrap(),
+            "updated-assoc"
+        );
+
+        // ListAssociationVersions
+        let req = make_request(
+            "ListAssociationVersions",
+            json!({ "AssociationId": assoc_id }),
+        );
+        let resp = svc.list_association_versions(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["AssociationVersions"].as_array().unwrap().len(), 2);
+
+        // Delete
+        let req = make_request("DeleteAssociation", json!({ "AssociationId": assoc_id }));
+        svc.delete_association(&req).unwrap();
+
+        // Verify deleted
+        let req = make_request("DescribeAssociation", json!({ "AssociationId": assoc_id }));
+        assert!(svc.describe_association(&req).is_err());
+    }
+
+    #[test]
+    fn association_batch_create() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateAssociationBatch",
+            json!({
+                "Entries": [
+                    {"Name": "AWS-RunShellScript", "Targets": [{"Key": "InstanceIds", "Values": ["i-001"]}]},
+                    {"Name": "AWS-RunShellScript", "Targets": [{"Key": "InstanceIds", "Values": ["i-002"]}]},
+                ]
+            }),
+        );
+        let resp = svc.create_association_batch(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["Successful"].as_array().unwrap().len(), 2);
+        assert!(body["Failed"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn start_associations_once_noop() {
+        let svc = make_service();
+        let req = make_request(
+            "StartAssociationsOnce",
+            json!({ "AssociationIds": ["fake-id"] }),
+        );
+        svc.start_associations_once(&req).unwrap();
+    }
+
+    // -- OpsItems --
+
+    #[test]
+    fn ops_item_crud() {
+        let svc = make_service();
+
+        // Create
+        let req = make_request(
+            "CreateOpsItem",
+            json!({
+                "Title": "Test OpsItem",
+                "Source": "test",
+                "Description": "A test ops item",
+            }),
+        );
+        let resp = svc.create_ops_item(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let ops_item_id = body["OpsItemId"].as_str().unwrap().to_string();
+
+        // Get
+        let req = make_request("GetOpsItem", json!({ "OpsItemId": ops_item_id }));
+        let resp = svc.get_ops_item(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["OpsItem"]["Title"].as_str().unwrap(), "Test OpsItem");
+        assert_eq!(body["OpsItem"]["Status"].as_str().unwrap(), "Open");
+
+        // Update
+        let req = make_request(
+            "UpdateOpsItem",
+            json!({
+                "OpsItemId": ops_item_id,
+                "Title": "Updated OpsItem",
+                "Status": "Resolved",
+            }),
+        );
+        svc.update_ops_item(&req).unwrap();
+
+        // Verify update
+        let req = make_request("GetOpsItem", json!({ "OpsItemId": ops_item_id }));
+        let resp = svc.get_ops_item(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(
+            body["OpsItem"]["Title"].as_str().unwrap(),
+            "Updated OpsItem"
+        );
+        assert_eq!(body["OpsItem"]["Status"].as_str().unwrap(), "Resolved");
+
+        // Describe
+        let req = make_request("DescribeOpsItems", json!({}));
+        let resp = svc.describe_ops_items(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["OpsItemSummaries"].as_array().unwrap().len(), 1);
+
+        // Delete
+        let req = make_request("DeleteOpsItem", json!({ "OpsItemId": ops_item_id }));
+        svc.delete_ops_item(&req).unwrap();
+
+        // Verify deleted
+        let req = make_request("GetOpsItem", json!({ "OpsItemId": ops_item_id }));
+        assert!(svc.get_ops_item(&req).is_err());
+    }
+
+    // -- Resource policies --
+
+    #[test]
+    fn resource_policy_crud() {
+        let svc = make_service();
+        let resource_arn = "arn:aws:ssm:us-east-1:123456789012:parameter/test";
+
+        // Put
+        let req = make_request(
+            "PutResourcePolicy",
+            json!({
+                "ResourceArn": resource_arn,
+                "Policy": r#"{"Version":"2012-10-17","Statement":[]}"#,
+            }),
+        );
+        let resp = svc.put_resource_policy(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let policy_id = body["PolicyId"].as_str().unwrap().to_string();
+        let policy_hash = body["PolicyHash"].as_str().unwrap().to_string();
+
+        // Get
+        let req = make_request(
+            "GetResourcePolicies",
+            json!({ "ResourceArn": resource_arn }),
+        );
+        let resp = svc.get_resource_policies(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["Policies"].as_array().unwrap().len(), 1);
+
+        // Delete
+        let req = make_request(
+            "DeleteResourcePolicy",
+            json!({
+                "ResourceArn": resource_arn,
+                "PolicyId": policy_id,
+                "PolicyHash": policy_hash,
+            }),
+        );
+        svc.delete_resource_policy(&req).unwrap();
+
+        // Verify deleted
+        let req = make_request(
+            "GetResourcePolicies",
+            json!({ "ResourceArn": resource_arn }),
+        );
+        let resp = svc.get_resource_policies(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(body["Policies"].as_array().unwrap().is_empty());
+    }
+
+    // -- Stubs --
+
+    #[test]
+    fn get_connection_status_returns_connected() {
+        let svc = make_service();
+        let req = make_request(
+            "GetConnectionStatus",
+            json!({ "Target": "i-1234567890abcdef0" }),
+        );
+        let resp = svc.get_connection_status(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["Status"].as_str().unwrap(), "connected");
+    }
+
+    #[test]
+    fn get_calendar_state_returns_open() {
+        let svc = make_service();
+        let req = make_request(
+            "GetCalendarState",
+            json!({ "CalendarNames": ["arn:aws:ssm:us-east-1:123456789012:document/cal"] }),
+        );
+        let resp = svc.get_calendar_state(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["State"].as_str().unwrap(), "OPEN");
+    }
+
+    #[test]
+    fn service_setting_crud() {
+        let svc = make_service();
+
+        // Get default
+        let req = make_request(
+            "GetServiceSetting",
+            json!({ "SettingId": "/ssm/parameter-store/high-throughput-enabled" }),
+        );
+        let resp = svc.get_service_setting(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(
+            body["ServiceSetting"]["Status"].as_str().unwrap(),
+            "Default"
+        );
+
+        // Update
+        let req = make_request(
+            "UpdateServiceSetting",
+            json!({
+                "SettingId": "/ssm/parameter-store/high-throughput-enabled",
+                "SettingValue": "true",
+            }),
+        );
+        svc.update_service_setting(&req).unwrap();
+
+        // Verify
+        let req = make_request(
+            "GetServiceSetting",
+            json!({ "SettingId": "/ssm/parameter-store/high-throughput-enabled" }),
+        );
+        let resp = svc.get_service_setting(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(
+            body["ServiceSetting"]["Status"].as_str().unwrap(),
+            "Customized"
+        );
+        assert_eq!(
+            body["ServiceSetting"]["SettingValue"].as_str().unwrap(),
+            "true"
+        );
+
+        // Reset
+        let req = make_request(
+            "ResetServiceSetting",
+            json!({ "SettingId": "/ssm/parameter-store/high-throughput-enabled" }),
+        );
+        svc.reset_service_setting(&req).unwrap();
+
+        // Verify reset
+        let req = make_request(
+            "GetServiceSetting",
+            json!({ "SettingId": "/ssm/parameter-store/high-throughput-enabled" }),
+        );
+        let resp = svc.get_service_setting(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(
+            body["ServiceSetting"]["Status"].as_str().unwrap(),
+            "Default"
+        );
+    }
+
+    #[test]
+    fn list_document_versions_works() {
+        let svc = make_service();
+
+        // Create a document
+        let req = make_request(
+            "CreateDocument",
+            json!({
+                "Name": "TestDocVer",
+                "Content": r#"{"schemaVersion":"2.2","mainSteps":[]}"#,
+                "DocumentType": "Command",
+            }),
+        );
+        svc.create_document(&req).unwrap();
+
+        // List versions
+        let req = make_request("ListDocumentVersions", json!({ "Name": "TestDocVer" }));
+        let resp = svc.list_document_versions(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(!body["DocumentVersions"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn describe_patch_group_state_returns_zeros() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribePatchGroupState",
+            json!({ "PatchGroup": "test-group" }),
+        );
+        let resp = svc.describe_patch_group_state(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["Instances"].as_i64().unwrap(), 0);
+    }
+
+    #[test]
+    fn get_default_patch_baseline_works() {
+        let svc = make_service();
+        let req = make_request(
+            "GetDefaultPatchBaseline",
+            json!({ "OperatingSystem": "WINDOWS" }),
+        );
+        let resp = svc.get_default_patch_baseline(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(body["BaselineId"].is_string());
+    }
+
+    #[test]
+    fn describe_available_patches_returns_empty() {
+        let svc = make_service();
+        let req = make_request("DescribeAvailablePatches", json!({}));
+        let resp = svc.describe_available_patches(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(body["Patches"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn describe_patch_properties_returns_empty() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribePatchProperties",
+            json!({ "OperatingSystem": "WINDOWS", "Property": "PRODUCT" }),
+        );
+        let resp = svc.describe_patch_properties(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(body["Properties"].as_array().unwrap().is_empty());
     }
 }

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -153,6 +153,94 @@ pub struct PatchGroup {
     pub patch_group: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct SsmAssociation {
+    pub association_id: String,
+    pub name: String, // document name
+    pub targets: Vec<serde_json::Value>,
+    pub schedule_expression: Option<String>,
+    pub parameters: HashMap<String, Vec<String>>,
+    pub association_name: Option<String>,
+    pub document_version: Option<String>,
+    pub output_location: Option<serde_json::Value>,
+    pub automation_target_parameter_name: Option<String>,
+    pub max_errors: Option<String>,
+    pub max_concurrency: Option<String>,
+    pub compliance_severity: Option<String>,
+    pub sync_compliance: Option<String>,
+    pub apply_only_at_cron_interval: bool,
+    pub calendar_names: Vec<String>,
+    pub target_locations: Vec<serde_json::Value>,
+    pub schedule_offset: Option<i64>,
+    pub target_maps: Vec<serde_json::Value>,
+    pub tags: HashMap<String, String>,
+    pub status: String,
+    pub status_date: DateTime<Utc>,
+    pub overview: serde_json::Value,
+    pub created_date: DateTime<Utc>,
+    pub last_update_association_date: DateTime<Utc>,
+    pub last_execution_date: Option<DateTime<Utc>>,
+    pub instance_id: Option<String>,
+    pub versions: Vec<SsmAssociationVersion>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SsmAssociationVersion {
+    pub version: i64,
+    pub name: String,
+    pub targets: Vec<serde_json::Value>,
+    pub schedule_expression: Option<String>,
+    pub parameters: HashMap<String, Vec<String>>,
+    pub document_version: Option<String>,
+    pub created_date: DateTime<Utc>,
+    pub association_name: Option<String>,
+    pub max_errors: Option<String>,
+    pub max_concurrency: Option<String>,
+    pub compliance_severity: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SsmOpsItem {
+    pub ops_item_id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub source: String,
+    pub status: String,
+    pub priority: Option<i64>,
+    pub severity: Option<String>,
+    pub category: Option<String>,
+    pub operational_data: HashMap<String, serde_json::Value>,
+    pub notifications: Vec<serde_json::Value>,
+    pub related_ops_items: Vec<serde_json::Value>,
+    pub tags: HashMap<String, String>,
+    pub created_time: DateTime<Utc>,
+    pub last_modified_time: DateTime<Utc>,
+    pub created_by: String,
+    pub last_modified_by: String,
+    pub ops_item_type: Option<String>,
+    pub planned_start_time: Option<DateTime<Utc>>,
+    pub planned_end_time: Option<DateTime<Utc>>,
+    pub actual_start_time: Option<DateTime<Utc>>,
+    pub actual_end_time: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SsmResourcePolicy {
+    pub policy_id: String,
+    pub policy_hash: String,
+    pub policy: String,
+    pub resource_arn: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SsmServiceSetting {
+    pub setting_id: String,
+    pub setting_value: String,
+    pub last_modified_date: DateTime<Utc>,
+    pub last_modified_user: String,
+    pub status: String,
+}
+
 pub struct SsmState {
     pub account_id: String,
     pub region: String,
@@ -162,6 +250,12 @@ pub struct SsmState {
     pub maintenance_windows: HashMap<String, MaintenanceWindow>,
     pub patch_baselines: HashMap<String, PatchBaseline>,
     pub patch_groups: Vec<PatchGroup>,
+    pub associations: HashMap<String, SsmAssociation>,
+    pub ops_items: HashMap<String, SsmOpsItem>,
+    pub resource_policies: Vec<SsmResourcePolicy>,
+    pub service_settings: HashMap<String, SsmServiceSetting>,
+    pub default_patch_baseline_id: Option<String>,
+    pub ops_item_counter: u64,
 }
 
 impl SsmState {
@@ -175,6 +269,12 @@ impl SsmState {
             maintenance_windows: HashMap::new(),
             patch_baselines: HashMap::new(),
             patch_groups: Vec::new(),
+            associations: HashMap::new(),
+            ops_items: HashMap::new(),
+            resource_policies: Vec::new(),
+            service_settings: HashMap::new(),
+            default_patch_baseline_id: None,
+            ops_item_counter: 0,
         };
         state.seed_defaults();
         state
@@ -187,6 +287,12 @@ impl SsmState {
         self.maintenance_windows.clear();
         self.patch_baselines.clear();
         self.patch_groups.clear();
+        self.associations.clear();
+        self.ops_items.clear();
+        self.resource_policies.clear();
+        self.service_settings.clear();
+        self.default_patch_baseline_id = None;
+        self.ops_item_counter = 0;
         self.seed_defaults();
     }
 


### PR DESCRIPTION
## Summary
- Implement 11 association operations (CreateAssociation, DescribeAssociation, DeleteAssociation, ListAssociations, UpdateAssociation, ListAssociationVersions, UpdateAssociationStatus, StartAssociationsOnce, CreateAssociationBatch, DescribeAssociationExecutions, DescribeAssociationExecutionTargets)
- Implement 5 OpsItem operations (CreateOpsItem, GetOpsItem, UpdateOpsItem, DeleteOpsItem, DescribeOpsItems)
- Implement 3 document extras (ListDocumentVersions, ListDocumentMetadataHistory, UpdateDocumentMetadata)
- Implement 3 resource policy operations (PutResourcePolicy, GetResourcePolicies, DeleteResourcePolicy)
- Implement 10 stub operations (GetConnectionStatus, GetCalendarState, DescribePatchGroupState, DescribePatchProperties, GetDefaultPatchBaseline, RegisterDefaultPatchBaseline, DescribeAvailablePatches, GetServiceSetting, ResetServiceSetting, UpdateServiceSetting)
- SSM conformance: 1775 -> 2801 variants passing (+1026)

## Test plan
- [x] 16 unit tests (13 new) pass in fakecloud-ssm
- [x] 29 E2E tests (10 new) pass in fakecloud-e2e
- [x] 38 conformance tests (21 new) pass in fakecloud-conformance
- [x] `cargo clippy -p fakecloud-ssm -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 38 missing AWS SSM operations to `fakecloud-ssm` across associations, OpsItems, documents, resource policies, and service settings. Improves SSM conformance from 1775 to 2801 passing variants (+1026).

- **New Features**
  - Associations: 11 ops (CRUD, list/versions/status, batch create, execution describe).
  - OpsItems: Create/Get/Update/Delete/Describe (5 ops).
  - Documents: ListDocumentVersions, ListDocumentMetadataHistory, UpdateDocumentMetadata (3 ops).
  - Resource policies: Put/Get/Delete (3 ops).
  - Stubs: 10 ops for service settings and patch/calendar/connection helpers.

<sup>Written for commit 0144f5fb58bec27216c4a4087705a857a307ef98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

