### PR TITLE
feat(logs): implement 22 missing CloudWatch Logs operations

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,26 +1,30 @@
 {
-  "variants_passed": 29113,
+  "variants_passed": 29860,
   "total_variants": 34856,
   "per_service": {
-    "s3": {
-      "passed": 3620,
-      "total": 3620
-    },
     "kms": {
       "passed": 1905,
       "total": 2196
     },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
+    "ssm": {
+      "passed": 2801,
+      "total": 5303
     },
     "lambda": {
       "passed": 3347,
       "total": 3347
+    },
+    "s3": {
+      "passed": 3620,
+      "total": 3620
+    },
+    "logs": {
+      "passed": 2784,
+      "total": 3911
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
     },
     "cloudformation": {
       "passed": 3420,
@@ -30,29 +34,25 @@
       "passed": 1079,
       "total": 2123
     },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
+    "events": {
+      "passed": 2078,
+      "total": 2108
     },
-    "logs": {
-      "passed": 2037,
-      "total": 3911
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
     },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "ssm": {
-      "passed": 2801,
-      "total": 5303
+    "sqs": {
+      "passed": 549,
+      "total": 549
     },
     "sts": {
       "passed": 436,
       "total": 438
     },
-    "events": {
-      "passed": 2078,
-      "total": 2108
+    "iam": {
+      "passed": 5962,
+      "total": 5962
     }
   }
 }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -679,6 +679,10 @@ impl ResourceProvisioner {
             log_streams: HashMap::new(),
             tags: HashMap::new(),
             subscription_filters: Vec::new(),
+            data_protection_policy: None,
+            index_policies: Vec::new(),
+            transformer: None,
+            deletion_protection: false,
         };
 
         state

--- a/crates/fakecloud-conformance/tests/logs.rs
+++ b/crates/fakecloud-conformance/tests/logs.rs
@@ -1077,7 +1077,7 @@ async fn logs_stop_query() {
         .unwrap();
     let query_id = start.query_id().unwrap().to_string();
 
-    client.stop_query().query_id(&query_id).send().await;
+    client.stop_query().query_id(&query_id).send().await.unwrap();
 }
 
 #[test_action("logs", "PutLogGroupDeletionProtection", checksum = "9e6e0d1a")]

--- a/crates/fakecloud-conformance/tests/logs.rs
+++ b/crates/fakecloud-conformance/tests/logs.rs
@@ -1077,7 +1077,7 @@ async fn logs_stop_query() {
         .unwrap();
     let query_id = start.query_id().unwrap().to_string();
 
-    let _ = client.stop_query().query_id(&query_id).send().await;
+    client.stop_query().query_id(&query_id).send().await;
 }
 
 #[test_action("logs", "PutLogGroupDeletionProtection", checksum = "9e6e0d1a")]

--- a/crates/fakecloud-conformance/tests/logs.rs
+++ b/crates/fakecloud-conformance/tests/logs.rs
@@ -739,3 +739,398 @@ async fn logs_query_definitions() {
         .await
         .unwrap();
 }
+
+// -- Account policies --
+
+#[test_action("logs", "PutAccountPolicy", checksum = "c90a216e")]
+#[test_action("logs", "DescribeAccountPolicies", checksum = "7dfa3538")]
+#[test_action("logs", "DeleteAccountPolicy", checksum = "fc4e2766")]
+#[tokio::test]
+async fn logs_account_policies() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .put_account_policy()
+        .policy_name("conf-acct-policy")
+        .policy_type(aws_sdk_cloudwatchlogs::types::PolicyType::DataProtectionPolicy)
+        .policy_document("{\"Name\":\"conformance\"}")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_account_policies()
+        .policy_type(aws_sdk_cloudwatchlogs::types::PolicyType::DataProtectionPolicy)
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.account_policies().is_empty());
+
+    client
+        .delete_account_policy()
+        .policy_name("conf-acct-policy")
+        .policy_type(aws_sdk_cloudwatchlogs::types::PolicyType::DataProtectionPolicy)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Data protection policy --
+
+#[test_action("logs", "PutDataProtectionPolicy", checksum = "84bc14b9")]
+#[test_action("logs", "GetDataProtectionPolicy", checksum = "941a9768")]
+#[test_action("logs", "DeleteDataProtectionPolicy", checksum = "acd3e2c8")]
+#[tokio::test]
+async fn logs_data_protection_policy() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/dp")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_data_protection_policy()
+        .log_group_identifier("/conf/dp")
+        .policy_document("{\"Name\":\"dp\"}")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .get_data_protection_policy()
+        .log_group_identifier("/conf/dp")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_data_protection_policy()
+        .log_group_identifier("/conf/dp")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Index policies --
+
+#[test_action("logs", "PutIndexPolicy", checksum = "717ed27c")]
+#[test_action("logs", "DescribeIndexPolicies", checksum = "051994f3")]
+#[test_action("logs", "DeleteIndexPolicy", checksum = "5d81a42e")]
+#[test_action("logs", "DescribeFieldIndexes", checksum = "815cc664")]
+#[tokio::test]
+async fn logs_index_policies() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/idx")
+        .send()
+        .await
+        .unwrap();
+
+    let groups = client
+        .describe_log_groups()
+        .log_group_name_prefix("/conf/idx")
+        .send()
+        .await
+        .unwrap();
+    let arn = groups.log_groups()[0].arn().unwrap().to_string();
+
+    client
+        .put_index_policy()
+        .log_group_identifier(&arn)
+        .policy_document("{\"Fields\":[\"field1\"]}")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .describe_index_policies()
+        .log_group_identifiers(&arn)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .describe_field_indexes()
+        .log_group_identifiers(&arn)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_index_policy()
+        .log_group_identifier(&arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Transformers --
+
+#[test_action("logs", "PutTransformer", checksum = "3a40be72")]
+#[test_action("logs", "GetTransformer", checksum = "a519f091")]
+#[test_action("logs", "DeleteTransformer", checksum = "c8d3b01f")]
+#[test_action("logs", "TestTransformer", checksum = "8f7e1aa2")]
+#[tokio::test]
+async fn logs_transformers() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/tx")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_transformer()
+        .log_group_identifier("/conf/tx")
+        .transformer_config(
+            aws_sdk_cloudwatchlogs::types::Processor::builder()
+                .add_keys(
+                    aws_sdk_cloudwatchlogs::types::AddKeys::builder()
+                        .entries(
+                            aws_sdk_cloudwatchlogs::types::AddKeyEntry::builder()
+                                .key("testKey")
+                                .value("testValue")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .get_transformer()
+        .log_group_identifier("/conf/tx")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .test_transformer()
+        .transformer_config(
+            aws_sdk_cloudwatchlogs::types::Processor::builder()
+                .add_keys(
+                    aws_sdk_cloudwatchlogs::types::AddKeys::builder()
+                        .entries(
+                            aws_sdk_cloudwatchlogs::types::AddKeyEntry::builder()
+                                .key("k")
+                                .value("v")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .log_event_messages("hello")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_transformer()
+        .log_group_identifier("/conf/tx")
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Anomaly detectors --
+
+#[test_action("logs", "CreateLogAnomalyDetector", checksum = "dc124741")]
+#[test_action("logs", "GetLogAnomalyDetector", checksum = "290ad64c")]
+#[test_action("logs", "ListLogAnomalyDetectors", checksum = "be4ef5f5")]
+#[test_action("logs", "UpdateLogAnomalyDetector", checksum = "c91b4202")]
+#[test_action("logs", "DeleteLogAnomalyDetector", checksum = "4c49f211")]
+#[tokio::test]
+async fn logs_anomaly_detectors() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/anomaly")
+        .send()
+        .await
+        .unwrap();
+
+    let groups = client
+        .describe_log_groups()
+        .log_group_name_prefix("/conf/anomaly")
+        .send()
+        .await
+        .unwrap();
+    let group_arn = groups.log_groups()[0].arn().unwrap().to_string();
+
+    let create = client
+        .create_log_anomaly_detector()
+        .log_group_arn_list(&group_arn)
+        .detector_name("conf-detector")
+        .send()
+        .await
+        .unwrap();
+    let detector_arn = create.anomaly_detector_arn().unwrap().to_string();
+
+    client
+        .get_log_anomaly_detector()
+        .anomaly_detector_arn(&detector_arn)
+        .send()
+        .await
+        .unwrap();
+
+    client.list_log_anomaly_detectors().send().await.unwrap();
+
+    client
+        .update_log_anomaly_detector()
+        .anomaly_detector_arn(&detector_arn)
+        .enabled(false)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_log_anomaly_detector()
+        .anomaly_detector_arn(&detector_arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+// -- Misc operations --
+
+#[test_action("logs", "GetLogGroupFields", checksum = "239f32e1")]
+#[tokio::test]
+async fn logs_get_log_group_fields() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/fields")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_log_group_fields()
+        .log_group_name("/conf/fields")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.log_group_fields().is_empty());
+}
+
+#[test_action("logs", "TestMetricFilter", checksum = "0b46bd90")]
+#[tokio::test]
+async fn logs_test_metric_filter() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    let resp = client
+        .test_metric_filter()
+        .filter_pattern("ERROR")
+        .log_event_messages("ERROR: oops")
+        .log_event_messages("INFO: ok")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.matches().is_empty());
+}
+
+#[test_action("logs", "StopQuery", checksum = "efcdfd12")]
+#[tokio::test]
+async fn logs_stop_query() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/stopq")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_query()
+        .log_group_name("/conf/stopq")
+        .start_time(0)
+        .end_time(9999999999)
+        .query_string("fields @timestamp")
+        .send()
+        .await
+        .unwrap();
+    let query_id = start.query_id().unwrap().to_string();
+
+    let _ = client.stop_query().query_id(&query_id).send().await;
+}
+
+#[test_action("logs", "PutLogGroupDeletionProtection", checksum = "9e6e0d1a")]
+#[tokio::test]
+async fn logs_deletion_protection() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/conf/delprot")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_log_group_deletion_protection()
+        .log_group_identifier("/conf/delprot")
+        .deletion_protection_enabled(true)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("logs", "GetLogRecord", checksum = "f45a109e")]
+#[tokio::test]
+async fn logs_get_log_record() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    let resp = client
+        .get_log_record()
+        .log_record_pointer("some-pointer")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.log_record().is_some());
+}
+
+#[test_action("logs", "ListAnomalies", checksum = "1a886ba0")]
+#[test_action("logs", "UpdateAnomaly", checksum = "286a19fd")]
+#[tokio::test]
+async fn logs_anomalies_stub() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    let resp = client.list_anomalies().send().await.unwrap();
+    assert!(resp.anomalies().is_empty());
+
+    // UpdateAnomaly needs anomalyDetectorArn
+    let _ = client
+        .update_anomaly()
+        .anomaly_detector_arn("arn:aws:logs:us-east-1:123456789012:anomaly-detector:dummy")
+        .send()
+        .await;
+}

--- a/crates/fakecloud-conformance/tests/logs.rs
+++ b/crates/fakecloud-conformance/tests/logs.rs
@@ -1077,7 +1077,12 @@ async fn logs_stop_query() {
         .unwrap();
     let query_id = start.query_id().unwrap().to_string();
 
-    client.stop_query().query_id(&query_id).send().await.unwrap();
+    client
+        .stop_query()
+        .query_id(&query_id)
+        .send()
+        .await
+        .unwrap();
 }
 
 #[test_action("logs", "PutLogGroupDeletionProtection", checksum = "9e6e0d1a")]

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -442,3 +442,225 @@ async fn logs_put_events_to_nonexistent_stream_fails() {
         .await;
     assert!(result.is_err());
 }
+
+#[tokio::test]
+async fn logs_account_policy_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    // Put account policy
+    client
+        .put_account_policy()
+        .policy_name("test-acct-policy")
+        .policy_type(aws_sdk_cloudwatchlogs::types::PolicyType::DataProtectionPolicy)
+        .policy_document("{\"Name\":\"test\"}")
+        .send()
+        .await
+        .unwrap();
+
+    // Describe
+    let resp = client
+        .describe_account_policies()
+        .policy_type(aws_sdk_cloudwatchlogs::types::PolicyType::DataProtectionPolicy)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.account_policies().len(), 1);
+    assert_eq!(
+        resp.account_policies()[0].policy_name().unwrap(),
+        "test-acct-policy"
+    );
+
+    // Delete
+    client
+        .delete_account_policy()
+        .policy_name("test-acct-policy")
+        .policy_type(aws_sdk_cloudwatchlogs::types::PolicyType::DataProtectionPolicy)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_account_policies()
+        .policy_type(aws_sdk_cloudwatchlogs::types::PolicyType::DataProtectionPolicy)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.account_policies().is_empty());
+}
+
+#[tokio::test]
+async fn logs_data_protection_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/dp/test")
+        .send()
+        .await
+        .unwrap();
+
+    // Put data protection policy
+    client
+        .put_data_protection_policy()
+        .log_group_identifier("/dp/test")
+        .policy_document("{\"Name\":\"dp\"}")
+        .send()
+        .await
+        .unwrap();
+
+    // Get
+    let resp = client
+        .get_data_protection_policy()
+        .log_group_identifier("/dp/test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.policy_document().unwrap(), "{\"Name\":\"dp\"}");
+
+    // Delete
+    client
+        .delete_data_protection_policy()
+        .log_group_identifier("/dp/test")
+        .send()
+        .await
+        .unwrap();
+
+    // Verify gone
+    let resp = client
+        .get_data_protection_policy()
+        .log_group_identifier("/dp/test")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.policy_document().is_none());
+}
+
+#[tokio::test]
+async fn logs_transformer_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/tx/test")
+        .send()
+        .await
+        .unwrap();
+
+    // Put transformer
+    client
+        .put_transformer()
+        .log_group_identifier("/tx/test")
+        .transformer_config(
+            aws_sdk_cloudwatchlogs::types::Processor::builder()
+                .add_keys(
+                    aws_sdk_cloudwatchlogs::types::AddKeys::builder()
+                        .entries(
+                            aws_sdk_cloudwatchlogs::types::AddKeyEntry::builder()
+                                .key("testKey")
+                                .value("testValue")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Get transformer
+    let resp = client
+        .get_transformer()
+        .log_group_identifier("/tx/test")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.transformer_config().is_empty());
+
+    // Delete transformer
+    client
+        .delete_transformer()
+        .log_group_identifier("/tx/test")
+        .send()
+        .await
+        .unwrap();
+
+    // Verify gone
+    let resp = client
+        .get_transformer()
+        .log_group_identifier("/tx/test")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.transformer_config().is_empty());
+}
+
+#[tokio::test]
+async fn logs_anomaly_detector_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/anomaly/test")
+        .send()
+        .await
+        .unwrap();
+
+    // Get log group ARN
+    let groups = client
+        .describe_log_groups()
+        .log_group_name_prefix("/anomaly/test")
+        .send()
+        .await
+        .unwrap();
+    let group_arn = groups.log_groups()[0].arn().unwrap().to_string();
+
+    // Create anomaly detector
+    let resp = client
+        .create_log_anomaly_detector()
+        .log_group_arn_list(&group_arn)
+        .detector_name("test-detector")
+        .send()
+        .await
+        .unwrap();
+    let detector_arn = resp.anomaly_detector_arn().unwrap().to_string();
+
+    // Get anomaly detector
+    let resp = client
+        .get_log_anomaly_detector()
+        .anomaly_detector_arn(&detector_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.detector_name().unwrap(), "test-detector");
+
+    // List anomaly detectors
+    let resp = client.list_log_anomaly_detectors().send().await.unwrap();
+    assert_eq!(resp.anomaly_detectors().len(), 1);
+
+    // Update
+    client
+        .update_log_anomaly_detector()
+        .anomaly_detector_arn(&detector_arn)
+        .enabled(false)
+        .send()
+        .await
+        .unwrap();
+
+    // Delete
+    client
+        .delete_log_anomaly_detector()
+        .anomaly_detector_arn(&detector_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client.list_log_anomaly_detectors().send().await.unwrap();
+    assert!(resp.anomaly_detectors().is_empty());
+}

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -3601,6 +3601,10 @@ pub fn deliver_to_logs(
             log_streams: HashMap::new(),
             stored_bytes: 0,
             subscription_filters: Vec::new(),
+            data_protection_policy: None,
+            index_policies: Vec::new(),
+            transformer: None,
+            deletion_protection: false,
         });
 
     let stream = group

--- a/crates/fakecloud-logs/src/service.rs
+++ b/crates/fakecloud-logs/src/service.rs
@@ -321,7 +321,7 @@ impl LogsService {
         let mut state = self.state.write();
         // Check deletion protection
         if let Some(group) = state.log_groups.get(name) {
-            if group.deletion_protected {
+            if group.deletion_protection {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "OperationAbortedException",

--- a/crates/fakecloud-logs/src/service.rs
+++ b/crates/fakecloud-logs/src/service.rs
@@ -7,9 +7,10 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 use fakecloud_core::validation::*;
 
 use crate::state::{
-    Delivery, DeliveryDestination, DeliverySource, Destination, ExportTask, LogEvent, LogGroup,
-    LogStream, MetricFilter, MetricTransformation, QueryDefinition, QueryInfo, ResourcePolicy,
-    SharedLogsState, SubscriptionFilter,
+    AccountPolicy, AnomalyDetector, DataProtectionPolicy, Delivery, DeliveryDestination,
+    DeliverySource, Destination, ExportTask, IndexPolicy, LogEvent, LogGroup, LogStream,
+    MetricFilter, MetricTransformation, QueryDefinition, QueryInfo, ResourcePolicy,
+    SharedLogsState, SubscriptionFilter, Transformer,
 };
 
 pub struct LogsService {
@@ -86,6 +87,32 @@ impl AwsService for LogsService {
             "PutQueryDefinition" => self.put_query_definition(&req),
             "DescribeQueryDefinitions" => self.describe_query_definitions(&req),
             "DeleteQueryDefinition" => self.delete_query_definition(&req),
+            "PutAccountPolicy" => self.put_account_policy(&req),
+            "DescribeAccountPolicies" => self.describe_account_policies(&req),
+            "DeleteAccountPolicy" => self.delete_account_policy(&req),
+            "PutDataProtectionPolicy" => self.put_data_protection_policy(&req),
+            "GetDataProtectionPolicy" => self.get_data_protection_policy(&req),
+            "DeleteDataProtectionPolicy" => self.delete_data_protection_policy(&req),
+            "PutIndexPolicy" => self.put_index_policy(&req),
+            "DescribeIndexPolicies" => self.describe_index_policies(&req),
+            "DeleteIndexPolicy" => self.delete_index_policy(&req),
+            "DescribeFieldIndexes" => self.describe_field_indexes(&req),
+            "PutTransformer" => self.put_transformer(&req),
+            "GetTransformer" => self.get_transformer(&req),
+            "DeleteTransformer" => self.delete_transformer(&req),
+            "TestTransformer" => self.test_transformer(&req),
+            "CreateLogAnomalyDetector" => self.create_log_anomaly_detector(&req),
+            "GetLogAnomalyDetector" => self.get_log_anomaly_detector(&req),
+            "DeleteLogAnomalyDetector" => self.delete_log_anomaly_detector(&req),
+            "ListLogAnomalyDetectors" => self.list_log_anomaly_detectors(&req),
+            "UpdateLogAnomalyDetector" => self.update_log_anomaly_detector(&req),
+            "GetLogGroupFields" => self.get_log_group_fields(&req),
+            "TestMetricFilter" => self.test_metric_filter(&req),
+            "StopQuery" => self.stop_query(&req),
+            "PutLogGroupDeletionProtection" => self.put_log_group_deletion_protection(&req),
+            "GetLogRecord" => self.get_log_record(&req),
+            "ListAnomalies" => self.list_anomalies(&req),
+            "UpdateAnomaly" => self.update_anomaly(&req),
             _ => Err(AwsServiceError::action_not_implemented("logs", &req.action)),
         }
     }
@@ -148,6 +175,32 @@ impl AwsService for LogsService {
             "PutQueryDefinition",
             "DescribeQueryDefinitions",
             "DeleteQueryDefinition",
+            "PutAccountPolicy",
+            "DescribeAccountPolicies",
+            "DeleteAccountPolicy",
+            "PutDataProtectionPolicy",
+            "GetDataProtectionPolicy",
+            "DeleteDataProtectionPolicy",
+            "PutIndexPolicy",
+            "DescribeIndexPolicies",
+            "DeleteIndexPolicy",
+            "DescribeFieldIndexes",
+            "PutTransformer",
+            "GetTransformer",
+            "DeleteTransformer",
+            "TestTransformer",
+            "CreateLogAnomalyDetector",
+            "GetLogAnomalyDetector",
+            "DeleteLogAnomalyDetector",
+            "ListLogAnomalyDetectors",
+            "UpdateLogAnomalyDetector",
+            "GetLogGroupFields",
+            "TestMetricFilter",
+            "StopQuery",
+            "PutLogGroupDeletionProtection",
+            "GetLogRecord",
+            "ListAnomalies",
+            "UpdateAnomaly",
         ]
     }
 }
@@ -243,6 +296,10 @@ impl LogsService {
                 log_streams: std::collections::HashMap::new(),
                 stored_bytes: 0,
                 subscription_filters: Vec::new(),
+                data_protection_policy: None,
+                index_policies: Vec::new(),
+                transformer: None,
+                deletion_protection: false,
             },
         );
 
@@ -3490,6 +3547,1056 @@ impl LogsService {
             serde_json::to_string(&json!({ "success": success })).unwrap(),
         ))
     }
+
+    // ---- Account Policies ----
+
+    fn put_account_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let policy_name = body["policyName"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "policyName is required",
+            )
+        })?;
+        let policy_type = body["policyType"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "policyType is required",
+            )
+        })?;
+        let policy_document = body["policyDocument"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "policyDocument is required",
+            )
+        })?;
+
+        let now = Utc::now().timestamp_millis();
+        let mut state = self.state.write();
+        let account_id = state.account_id.clone();
+        let scope = body["scope"].as_str().map(|s| s.to_string());
+        let selection_criteria = body["selectionCriteria"].as_str().map(|s| s.to_string());
+
+        let policy = AccountPolicy {
+            policy_name: policy_name.to_string(),
+            policy_type: policy_type.to_string(),
+            policy_document: policy_document.to_string(),
+            scope: scope.clone(),
+            selection_criteria: selection_criteria.clone(),
+            account_id: account_id.clone(),
+            last_updated_time: now,
+        };
+
+        let key = (policy_name.to_string(), policy_type.to_string());
+        state.account_policies.insert(key, policy);
+
+        let mut result = json!({
+            "accountPolicy": {
+                "policyName": policy_name,
+                "policyType": policy_type,
+                "policyDocument": policy_document,
+                "accountId": account_id,
+                "lastUpdatedTime": now,
+            }
+        });
+        if let Some(s) = scope {
+            result["accountPolicy"]["scope"] = json!(s);
+        }
+        if let Some(s) = selection_criteria {
+            result["accountPolicy"]["selectionCriteria"] = json!(s);
+        }
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&result).unwrap(),
+        ))
+    }
+
+    fn describe_account_policies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let policy_type = body["policyType"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "policyType is required",
+            )
+        })?;
+        let policy_name = body["policyName"].as_str();
+
+        let state = self.state.read();
+        let policies: Vec<Value> = state
+            .account_policies
+            .values()
+            .filter(|p| {
+                p.policy_type == policy_type && policy_name.is_none_or(|n| p.policy_name == n)
+            })
+            .map(|p| {
+                let mut obj = json!({
+                    "policyName": p.policy_name,
+                    "policyType": p.policy_type,
+                    "policyDocument": p.policy_document,
+                    "accountId": p.account_id,
+                    "lastUpdatedTime": p.last_updated_time,
+                });
+                if let Some(ref s) = p.scope {
+                    obj["scope"] = json!(s);
+                }
+                if let Some(ref s) = p.selection_criteria {
+                    obj["selectionCriteria"] = json!(s);
+                }
+                obj
+            })
+            .collect();
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({ "accountPolicies": policies })).unwrap(),
+        ))
+    }
+
+    fn delete_account_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let policy_name = body["policyName"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "policyName is required",
+            )
+        })?;
+        let policy_type = body["policyType"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "policyType is required",
+            )
+        })?;
+
+        let key = (policy_name.to_string(), policy_type.to_string());
+        let mut state = self.state.write();
+        if state.account_policies.remove(&key).is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Account policy {policy_name} of type {policy_type} not found"),
+            ));
+        }
+
+        Ok(AwsResponse::json(StatusCode::OK, "{}"))
+    }
+
+    // ---- Data Protection Policies ----
+
+    fn put_data_protection_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_id = body["logGroupIdentifier"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupIdentifier is required",
+                )
+            })?
+            .to_string();
+        let policy_document = body["policyDocument"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "policyDocument is required",
+                )
+            })?
+            .to_string();
+
+        let group_name = if log_group_id.starts_with("arn:") {
+            extract_log_group_from_arn(&log_group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Invalid ARN: {log_group_id}"),
+                )
+            })?
+        } else {
+            log_group_id.clone()
+        };
+
+        let now = Utc::now().timestamp_millis();
+        let mut state = self.state.write();
+        let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("The specified log group does not exist: {group_name}"),
+            )
+        })?;
+        let log_group_id_resp = group.arn.clone();
+
+        group.data_protection_policy = Some(DataProtectionPolicy {
+            policy_document: policy_document.clone(),
+            last_updated_time: now,
+        });
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({
+                "logGroupIdentifier": log_group_id_resp,
+                "policyDocument": policy_document,
+                "lastUpdatedTime": now,
+            }))
+            .unwrap(),
+        ))
+    }
+
+    fn get_data_protection_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_id = body["logGroupIdentifier"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupIdentifier is required",
+                )
+            })?
+            .to_string();
+
+        let group_name = if log_group_id.starts_with("arn:") {
+            extract_log_group_from_arn(&log_group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Invalid ARN: {log_group_id}"),
+                )
+            })?
+        } else {
+            log_group_id.clone()
+        };
+
+        let state = self.state.read();
+        let group = state.log_groups.get(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("The specified log group does not exist: {group_name}"),
+            )
+        })?;
+
+        let mut result = json!({
+            "logGroupIdentifier": group.arn,
+        });
+        if let Some(ref dp) = group.data_protection_policy {
+            result["policyDocument"] = json!(dp.policy_document);
+            result["lastUpdatedTime"] = json!(dp.last_updated_time);
+        }
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&result).unwrap(),
+        ))
+    }
+
+    fn delete_data_protection_policy(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_id = body["logGroupIdentifier"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupIdentifier is required",
+                )
+            })?
+            .to_string();
+
+        let group_name = if log_group_id.starts_with("arn:") {
+            extract_log_group_from_arn(&log_group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Invalid ARN: {log_group_id}"),
+                )
+            })?
+        } else {
+            log_group_id
+        };
+
+        let mut state = self.state.write();
+        let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("The specified log group does not exist: {group_name}"),
+            )
+        })?;
+
+        if group.data_protection_policy.is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "No data protection policy found for this log group",
+            ));
+        }
+
+        group.data_protection_policy = None;
+        Ok(AwsResponse::json(StatusCode::OK, "{}"))
+    }
+
+    // ---- Index Policies ----
+
+    fn put_index_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_id = body["logGroupIdentifier"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupIdentifier is required",
+                )
+            })?
+            .to_string();
+        let policy_document = body["policyDocument"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "policyDocument is required",
+                )
+            })?
+            .to_string();
+
+        let group_name = if log_group_id.starts_with("arn:") {
+            extract_log_group_from_arn(&log_group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Invalid ARN: {log_group_id}"),
+                )
+            })?
+        } else {
+            log_group_id.clone()
+        };
+
+        let policy_name = body["policyName"].as_str().unwrap_or("default").to_string();
+
+        let now = Utc::now().timestamp_millis();
+        let mut state = self.state.write();
+        let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("The specified log group does not exist: {group_name}"),
+            )
+        })?;
+
+        // Replace existing policy with same name, or add new one
+        if let Some(existing) = group
+            .index_policies
+            .iter_mut()
+            .find(|p| p.policy_name == policy_name)
+        {
+            existing.policy_document = policy_document.clone();
+            existing.last_updated_time = now;
+        } else {
+            group.index_policies.push(IndexPolicy {
+                policy_name: policy_name.clone(),
+                policy_document: policy_document.clone(),
+                last_updated_time: now,
+            });
+        }
+
+        let result = json!({
+            "indexPolicy": {
+                "policyName": policy_name,
+                "policyDocument": policy_document,
+                "logGroupIdentifier": group.arn,
+                "lastUpdateTime": now,
+            }
+        });
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&result).unwrap(),
+        ))
+    }
+
+    fn describe_index_policies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_ids = body["logGroupIdentifiers"].as_array().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "logGroupIdentifiers is required",
+            )
+        })?;
+
+        let state = self.state.read();
+        let mut policies = Vec::new();
+
+        for id_val in log_group_ids {
+            let id = id_val.as_str().unwrap_or("");
+            let group_name = if id.starts_with("arn:") {
+                extract_log_group_from_arn(id).unwrap_or_default()
+            } else {
+                id.to_string()
+            };
+            if let Some(group) = state.log_groups.get(&group_name) {
+                for p in &group.index_policies {
+                    policies.push(json!({
+                        "policyName": p.policy_name,
+                        "policyDocument": p.policy_document,
+                        "logGroupIdentifier": group.arn,
+                        "lastUpdateTime": p.last_updated_time,
+                    }));
+                }
+            }
+        }
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({ "indexPolicies": policies })).unwrap(),
+        ))
+    }
+
+    fn delete_index_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_id = body["logGroupIdentifier"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupIdentifier is required",
+                )
+            })?
+            .to_string();
+
+        let group_name = if log_group_id.starts_with("arn:") {
+            extract_log_group_from_arn(&log_group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Invalid ARN: {log_group_id}"),
+                )
+            })?
+        } else {
+            log_group_id
+        };
+
+        let mut state = self.state.write();
+        let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("The specified log group does not exist: {group_name}"),
+            )
+        })?;
+
+        if group.index_policies.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "No index policy found for this log group",
+            ));
+        }
+
+        group.index_policies.clear();
+        Ok(AwsResponse::json(StatusCode::OK, "{}"))
+    }
+
+    fn describe_field_indexes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        // Validate that logGroupIdentifiers is provided
+        let _log_group_ids = body["logGroupIdentifiers"].as_array().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "logGroupIdentifiers is required",
+            )
+        })?;
+
+        // Stub: return empty list
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({ "fieldIndexes": [] })).unwrap(),
+        ))
+    }
+
+    // ---- Transformers ----
+
+    fn put_transformer(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_id = body["logGroupIdentifier"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupIdentifier is required",
+                )
+            })?
+            .to_string();
+        let transformer_config = body.get("transformerConfig").cloned().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "transformerConfig is required",
+            )
+        })?;
+
+        let group_name = if log_group_id.starts_with("arn:") {
+            extract_log_group_from_arn(&log_group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Invalid ARN: {log_group_id}"),
+                )
+            })?
+        } else {
+            log_group_id.clone()
+        };
+
+        let now = Utc::now().timestamp_millis();
+        let mut state = self.state.write();
+        let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("The specified log group does not exist: {group_name}"),
+            )
+        })?;
+
+        group.transformer = Some(Transformer {
+            transformer_config,
+            creation_time: now,
+            last_modified_time: now,
+        });
+
+        Ok(AwsResponse::json(StatusCode::OK, "{}"))
+    }
+
+    fn get_transformer(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_id = body["logGroupIdentifier"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupIdentifier is required",
+                )
+            })?
+            .to_string();
+
+        let group_name = if log_group_id.starts_with("arn:") {
+            extract_log_group_from_arn(&log_group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Invalid ARN: {log_group_id}"),
+                )
+            })?
+        } else {
+            log_group_id.clone()
+        };
+
+        let state = self.state.read();
+        let group = state.log_groups.get(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("The specified log group does not exist: {group_name}"),
+            )
+        })?;
+
+        let mut result = json!({
+            "logGroupIdentifier": group.arn,
+        });
+        if let Some(ref t) = group.transformer {
+            result["transformerConfig"] = t.transformer_config.clone();
+            result["creationTime"] = json!(t.creation_time);
+            result["lastModifiedTime"] = json!(t.last_modified_time);
+        }
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&result).unwrap(),
+        ))
+    }
+
+    fn delete_transformer(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_id = body["logGroupIdentifier"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupIdentifier is required",
+                )
+            })?
+            .to_string();
+
+        let group_name = if log_group_id.starts_with("arn:") {
+            extract_log_group_from_arn(&log_group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Invalid ARN: {log_group_id}"),
+                )
+            })?
+        } else {
+            log_group_id
+        };
+
+        let mut state = self.state.write();
+        let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("The specified log group does not exist: {group_name}"),
+            )
+        })?;
+
+        group.transformer = None;
+        Ok(AwsResponse::json(StatusCode::OK, "{}"))
+    }
+
+    fn test_transformer(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let _transformer_config = body.get("transformerConfig").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "transformerConfig is required",
+            )
+        })?;
+        let log_event_messages = body["logEventMessages"].as_array().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "logEventMessages is required",
+            )
+        })?;
+
+        // Stub: return the input events as transformed output unchanged
+        let transformed: Vec<Value> = log_event_messages
+            .iter()
+            .map(|msg| {
+                json!({
+                    "eventMessage": msg,
+                    "transformedEventMessage": msg,
+                })
+            })
+            .collect();
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({
+                "transformedLogs": transformed,
+            }))
+            .unwrap(),
+        ))
+    }
+
+    // ---- Anomaly Detectors ----
+
+    fn create_log_anomaly_detector(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_arn_list = body["logGroupArnList"]
+            .as_array()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupArnList is required",
+                )
+            })?
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect::<Vec<_>>();
+
+        let detector_name = body["detectorName"].as_str().unwrap_or("").to_string();
+        let evaluation_frequency = body["evaluationFrequency"].as_str().map(|s| s.to_string());
+        let filter_pattern = body["filterPattern"].as_str().map(|s| s.to_string());
+        let anomaly_visibility_time = body["anomalyVisibilityTime"].as_i64();
+
+        let now = Utc::now().timestamp_millis();
+        let mut state = self.state.write();
+        let detector_id = uuid::Uuid::new_v4().to_string();
+        let arn = format!(
+            "arn:aws:logs:{}:{}:anomaly-detector:{}",
+            state.region, state.account_id, detector_id
+        );
+
+        let detector = AnomalyDetector {
+            detector_name: detector_name.clone(),
+            arn: arn.clone(),
+            log_group_arn_list,
+            evaluation_frequency,
+            filter_pattern,
+            anomaly_visibility_time,
+            creation_time: now,
+            last_modified_time: now,
+            enabled: true,
+        };
+
+        state.anomaly_detectors.insert(arn.clone(), detector);
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({ "anomalyDetectorArn": arn })).unwrap(),
+        ))
+    }
+
+    fn get_log_anomaly_detector(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let arn = body["anomalyDetectorArn"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "anomalyDetectorArn is required",
+            )
+        })?;
+
+        let state = self.state.read();
+        let detector = state.anomaly_detectors.get(arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Anomaly detector not found: {arn}"),
+            )
+        })?;
+
+        let mut result = json!({
+            "anomalyDetectorArn": detector.arn,
+            "detectorName": detector.detector_name,
+            "logGroupArnList": detector.log_group_arn_list,
+            "creationTimeStamp": detector.creation_time,
+            "lastModifiedTimeStamp": detector.last_modified_time,
+            "anomalyDetectorStatus": if detector.enabled { "TRAINING" } else { "PAUSED" },
+        });
+        if let Some(ref f) = detector.evaluation_frequency {
+            result["evaluationFrequency"] = json!(f);
+        }
+        if let Some(ref f) = detector.filter_pattern {
+            result["filterPattern"] = json!(f);
+        }
+        if let Some(t) = detector.anomaly_visibility_time {
+            result["anomalyVisibilityTime"] = json!(t);
+        }
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&result).unwrap(),
+        ))
+    }
+
+    fn delete_log_anomaly_detector(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let arn = body["anomalyDetectorArn"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "anomalyDetectorArn is required",
+            )
+        })?;
+
+        let mut state = self.state.write();
+        if state.anomaly_detectors.remove(arn).is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Anomaly detector not found: {arn}"),
+            ));
+        }
+
+        Ok(AwsResponse::json(StatusCode::OK, "{}"))
+    }
+
+    fn list_log_anomaly_detectors(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let filter_log_group_arn = body["filterLogGroupArn"].as_str();
+        let _limit = body["limit"].as_i64().unwrap_or(50);
+
+        let state = self.state.read();
+        let detectors: Vec<Value> = state
+            .anomaly_detectors
+            .values()
+            .filter(|d| {
+                filter_log_group_arn.is_none_or(|arn| d.log_group_arn_list.iter().any(|a| a == arn))
+            })
+            .map(|d| {
+                let mut obj = json!({
+                    "anomalyDetectorArn": d.arn,
+                    "detectorName": d.detector_name,
+                    "logGroupArnList": d.log_group_arn_list,
+                    "creationTimeStamp": d.creation_time,
+                    "lastModifiedTimeStamp": d.last_modified_time,
+                    "anomalyDetectorStatus": if d.enabled { "TRAINING" } else { "PAUSED" },
+                });
+                if let Some(ref f) = d.evaluation_frequency {
+                    obj["evaluationFrequency"] = json!(f);
+                }
+                if let Some(ref f) = d.filter_pattern {
+                    obj["filterPattern"] = json!(f);
+                }
+                if let Some(t) = d.anomaly_visibility_time {
+                    obj["anomalyVisibilityTime"] = json!(t);
+                }
+                obj
+            })
+            .collect();
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({ "anomalyDetectors": detectors })).unwrap(),
+        ))
+    }
+
+    fn update_log_anomaly_detector(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let arn = body["anomalyDetectorArn"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "anomalyDetectorArn is required",
+            )
+        })?;
+        let enabled = body["enabled"].as_bool().unwrap_or(true);
+
+        let mut state = self.state.write();
+        let detector = state.anomaly_detectors.get_mut(arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Anomaly detector not found: {arn}"),
+            )
+        })?;
+
+        detector.enabled = enabled;
+        if let Some(f) = body["evaluationFrequency"].as_str() {
+            detector.evaluation_frequency = Some(f.to_string());
+        }
+        if let Some(f) = body["filterPattern"].as_str() {
+            detector.filter_pattern = Some(f.to_string());
+        }
+        if let Some(t) = body["anomalyVisibilityTime"].as_i64() {
+            detector.anomaly_visibility_time = Some(t);
+        }
+        detector.last_modified_time = Utc::now().timestamp_millis();
+
+        Ok(AwsResponse::json(StatusCode::OK, "{}"))
+    }
+
+    // ---- Misc Operations ----
+
+    fn get_log_group_fields(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_id = body["logGroupName"]
+            .as_str()
+            .or_else(|| body["logGroupIdentifier"].as_str())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupName or logGroupIdentifier is required",
+                )
+            })?;
+
+        let group_name = if log_group_id.starts_with("arn:") {
+            extract_log_group_from_arn(log_group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Invalid ARN: {log_group_id}"),
+                )
+            })?
+        } else {
+            log_group_id.to_string()
+        };
+
+        let state = self.state.read();
+        if !state.log_groups.contains_key(&group_name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("The specified log group does not exist: {group_name}"),
+            ));
+        }
+
+        // Stub response with common fields
+        let fields = json!([
+            { "fieldName": "@timestamp", "percent": 100 },
+            { "fieldName": "@message", "percent": 100 },
+        ]);
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({ "logGroupFields": fields })).unwrap(),
+        ))
+    }
+
+    fn test_metric_filter(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let filter_pattern = body["filterPattern"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "filterPattern is required",
+            )
+        })?;
+        let log_event_messages = body["logEventMessages"].as_array().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "logEventMessages is required",
+            )
+        })?;
+
+        let matches: Vec<Value> = log_event_messages
+            .iter()
+            .enumerate()
+            .filter(|(_, msg)| {
+                let msg_str = msg.as_str().unwrap_or("");
+                matches_filter_pattern(filter_pattern, msg_str)
+            })
+            .map(|(i, msg)| {
+                json!({
+                    "eventNumber": i + 1,
+                    "eventMessage": msg,
+                    "extractedValues": {},
+                })
+            })
+            .collect();
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(
+                &json!({ "matches": matches, "testResults": !matches.is_empty() }),
+            )
+            .unwrap(),
+        ))
+    }
+
+    fn stop_query(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let query_id = body["queryId"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "queryId is required",
+            )
+        })?;
+
+        let mut state = self.state.write();
+        let query = state.queries.get_mut(query_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                format!("Query {query_id} is not in a cancellable state"),
+            )
+        })?;
+
+        let was_running = query.status == "Running" || query.status == "Scheduled";
+        if was_running {
+            query.status = "Cancelled".to_string();
+        }
+
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({ "success": was_running })).unwrap(),
+        ))
+    }
+
+    fn put_log_group_deletion_protection(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let log_group_id = body["logGroupIdentifier"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupIdentifier is required",
+                )
+            })?
+            .to_string();
+        let deletion_protection = body["deletionProtectionEnabled"].as_bool().unwrap_or(true);
+
+        let group_name = if log_group_id.starts_with("arn:") {
+            extract_log_group_from_arn(&log_group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Invalid ARN: {log_group_id}"),
+                )
+            })?
+        } else {
+            log_group_id
+        };
+
+        let mut state = self.state.write();
+        let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("The specified log group does not exist: {group_name}"),
+            )
+        })?;
+
+        group.deletion_protection = deletion_protection;
+        Ok(AwsResponse::json(StatusCode::OK, "{}"))
+    }
+
+    fn get_log_record(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = body_json(req);
+        let _log_record_pointer = body["logRecordPointer"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "logRecordPointer is required",
+            )
+        })?;
+
+        // Stub: return empty log record
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({ "logRecord": {} })).unwrap(),
+        ))
+    }
+
+    fn list_anomalies(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        // Stub: return empty anomalies list
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({ "anomalies": [] })).unwrap(),
+        ))
+    }
+
+    fn update_anomaly(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        // No-op stub
+        Ok(AwsResponse::json(StatusCode::OK, "{}"))
+    }
 }
 
 /// Resolve log group name from either logGroupName or resourceIdentifier.
@@ -3945,5 +5052,324 @@ mod tests {
     #[test]
     fn extract_log_group_from_arn_invalid() {
         assert_eq!(extract_log_group_from_arn("not-an-arn"), None);
+    }
+
+    // ---- Account policies ----
+
+    #[test]
+    fn account_policy_lifecycle() {
+        let svc = make_service();
+
+        let req = make_request(
+            "PutAccountPolicy",
+            json!({
+                "policyName": "test-policy",
+                "policyType": "DATA_PROTECTION_POLICY",
+                "policyDocument": "{\"Name\":\"test\"}",
+            }),
+        );
+        let resp = svc.put_account_policy(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["accountPolicy"]["policyName"], "test-policy");
+
+        let req = make_request(
+            "DescribeAccountPolicies",
+            json!({ "policyType": "DATA_PROTECTION_POLICY" }),
+        );
+        let resp = svc.describe_account_policies(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["accountPolicies"].as_array().unwrap().len(), 1);
+
+        let req = make_request(
+            "DeleteAccountPolicy",
+            json!({
+                "policyName": "test-policy",
+                "policyType": "DATA_PROTECTION_POLICY",
+            }),
+        );
+        svc.delete_account_policy(&req).unwrap();
+
+        let req = make_request(
+            "DescribeAccountPolicies",
+            json!({ "policyType": "DATA_PROTECTION_POLICY" }),
+        );
+        let resp = svc.describe_account_policies(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(body["accountPolicies"].as_array().unwrap().is_empty());
+    }
+
+    // ---- Data protection policy ----
+
+    #[test]
+    fn data_protection_policy_lifecycle() {
+        let svc = make_service();
+        create_group(&svc, "dp-group");
+
+        let req = make_request(
+            "PutDataProtectionPolicy",
+            json!({
+                "logGroupIdentifier": "dp-group",
+                "policyDocument": "{\"Name\":\"dp\"}",
+            }),
+        );
+        svc.put_data_protection_policy(&req).unwrap();
+
+        let req = make_request(
+            "GetDataProtectionPolicy",
+            json!({ "logGroupIdentifier": "dp-group" }),
+        );
+        let resp = svc.get_data_protection_policy(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["policyDocument"], "{\"Name\":\"dp\"}");
+
+        let req = make_request(
+            "DeleteDataProtectionPolicy",
+            json!({ "logGroupIdentifier": "dp-group" }),
+        );
+        svc.delete_data_protection_policy(&req).unwrap();
+
+        let req = make_request(
+            "GetDataProtectionPolicy",
+            json!({ "logGroupIdentifier": "dp-group" }),
+        );
+        let resp = svc.get_data_protection_policy(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(body.get("policyDocument").is_none());
+    }
+
+    // ---- Index policies ----
+
+    #[test]
+    fn index_policy_lifecycle() {
+        let svc = make_service();
+        create_group(&svc, "idx-group");
+
+        let req = make_request(
+            "PutIndexPolicy",
+            json!({
+                "logGroupIdentifier": "idx-group",
+                "policyDocument": "{\"Fields\":[\"field1\"]}",
+            }),
+        );
+        svc.put_index_policy(&req).unwrap();
+
+        let req = make_request(
+            "DescribeIndexPolicies",
+            json!({ "logGroupIdentifiers": ["idx-group"] }),
+        );
+        let resp = svc.describe_index_policies(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["indexPolicies"].as_array().unwrap().len(), 1);
+
+        let req = make_request(
+            "DeleteIndexPolicy",
+            json!({
+                "logGroupIdentifier": "idx-group",
+            }),
+        );
+        svc.delete_index_policy(&req).unwrap();
+    }
+
+    // ---- Transformers ----
+
+    #[test]
+    fn transformer_lifecycle() {
+        let svc = make_service();
+        create_group(&svc, "tx-group");
+
+        let req = make_request(
+            "PutTransformer",
+            json!({
+                "logGroupIdentifier": "tx-group",
+                "transformerConfig": [{"addKeys":{"entries":[{"key":"new","value":"val"}]}}],
+            }),
+        );
+        svc.put_transformer(&req).unwrap();
+
+        let req = make_request(
+            "GetTransformer",
+            json!({ "logGroupIdentifier": "tx-group" }),
+        );
+        let resp = svc.get_transformer(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(body["transformerConfig"].is_array());
+
+        let req = make_request(
+            "DeleteTransformer",
+            json!({ "logGroupIdentifier": "tx-group" }),
+        );
+        svc.delete_transformer(&req).unwrap();
+    }
+
+    #[test]
+    fn test_transformer_returns_transformed_events() {
+        let svc = make_service();
+
+        let req = make_request(
+            "TestTransformer",
+            json!({
+                "transformerConfig": [{"addKeys":{"entries":[]}}],
+                "logEventMessages": ["hello", "world"],
+            }),
+        );
+        let resp = svc.test_transformer(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["transformedLogs"].as_array().unwrap().len(), 2);
+    }
+
+    // ---- Anomaly detectors ----
+
+    #[test]
+    fn anomaly_detector_lifecycle() {
+        let svc = make_service();
+
+        let req = make_request(
+            "CreateLogAnomalyDetector",
+            json!({
+                "logGroupArnList": ["arn:aws:logs:us-east-1:123456789012:log-group:test:*"],
+                "detectorName": "my-detector",
+            }),
+        );
+        let resp = svc.create_log_anomaly_detector(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let arn = body["anomalyDetectorArn"].as_str().unwrap().to_string();
+
+        let req = make_request(
+            "GetLogAnomalyDetector",
+            json!({ "anomalyDetectorArn": &arn }),
+        );
+        let resp = svc.get_log_anomaly_detector(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["detectorName"], "my-detector");
+
+        let req = make_request("ListLogAnomalyDetectors", json!({}));
+        let resp = svc.list_log_anomaly_detectors(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["anomalyDetectors"].as_array().unwrap().len(), 1);
+
+        let req = make_request(
+            "UpdateLogAnomalyDetector",
+            json!({ "anomalyDetectorArn": &arn, "enabled": false }),
+        );
+        svc.update_log_anomaly_detector(&req).unwrap();
+
+        let req = make_request(
+            "DeleteLogAnomalyDetector",
+            json!({ "anomalyDetectorArn": &arn }),
+        );
+        svc.delete_log_anomaly_detector(&req).unwrap();
+    }
+
+    // ---- Misc operations ----
+
+    #[test]
+    fn get_log_group_fields_returns_stub() {
+        let svc = make_service();
+        create_group(&svc, "fields-group");
+
+        let req = make_request(
+            "GetLogGroupFields",
+            json!({ "logGroupName": "fields-group" }),
+        );
+        let resp = svc.get_log_group_fields(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["logGroupFields"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_metric_filter_matches() {
+        let svc = make_service();
+
+        let req = make_request(
+            "TestMetricFilter",
+            json!({
+                "filterPattern": "ERROR",
+                "logEventMessages": ["ERROR: oops", "INFO: ok", "ERROR: again"],
+            }),
+        );
+        let resp = svc.test_metric_filter(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["matches"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn stop_query_marks_as_cancelled() {
+        let svc = make_service();
+        create_group(&svc, "sq-group");
+
+        let req = make_request(
+            "StartQuery",
+            json!({
+                "logGroupName": "sq-group",
+                "startTime": 0,
+                "endTime": 9999999999i64,
+                "queryString": "fields @timestamp",
+            }),
+        );
+        let resp = svc.start_query(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let qid = body["queryId"].as_str().unwrap().to_string();
+
+        // Manually set query status to Running so we can test cancellation
+        {
+            let mut state = svc.state.write();
+            state.queries.get_mut(&qid).unwrap().status = "Running".to_string();
+        }
+
+        let req = make_request("StopQuery", json!({ "queryId": &qid }));
+        let resp = svc.stop_query(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["success"], true);
+
+        let state = svc.state.read();
+        assert_eq!(state.queries[&qid].status, "Cancelled");
+    }
+
+    #[test]
+    fn put_log_group_deletion_protection() {
+        let svc = make_service();
+        create_group(&svc, "prot-group");
+
+        let req = make_request(
+            "PutLogGroupDeletionProtection",
+            json!({
+                "logGroupIdentifier": "prot-group",
+                "deletionProtectionEnabled": true,
+            }),
+        );
+        svc.put_log_group_deletion_protection(&req).unwrap();
+
+        let state = svc.state.read();
+        assert!(state.log_groups["prot-group"].deletion_protection);
+    }
+
+    #[test]
+    fn get_log_record_returns_empty_stub() {
+        let svc = make_service();
+
+        let req = make_request(
+            "GetLogRecord",
+            json!({ "logRecordPointer": "some-pointer" }),
+        );
+        let resp = svc.get_log_record(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(body["logRecord"].is_object());
+    }
+
+    #[test]
+    fn list_anomalies_returns_empty() {
+        let svc = make_service();
+
+        let req = make_request("ListAnomalies", json!({}));
+        let resp = svc.list_anomalies(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(body["anomalies"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn update_anomaly_noop() {
+        let svc = make_service();
+        let req = make_request("UpdateAnomaly", json!({}));
+        svc.update_anomaly(&req).unwrap();
     }
 }

--- a/crates/fakecloud-logs/src/service.rs
+++ b/crates/fakecloud-logs/src/service.rs
@@ -319,6 +319,16 @@ impl LogsService {
         validate_string_length("logGroupName", name, 1, 512)?;
 
         let mut state = self.state.write();
+        // Check deletion protection
+        if let Some(group) = state.log_groups.get(name) {
+            if group.deletion_protected {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "OperationAbortedException",
+                    format!("Log group {name} has deletion protection enabled"),
+                ));
+            }
+        }
         if state.log_groups.remove(name).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -18,6 +18,10 @@ pub struct LogsState {
     pub delivery_sources: HashMap<String, DeliverySource>,
     pub deliveries: HashMap<String, Delivery>,
     pub query_definitions: HashMap<String, QueryDefinition>,
+    /// Account policies keyed by (policy_name, policy_type)
+    pub account_policies: HashMap<(String, String), AccountPolicy>,
+    /// Anomaly detectors keyed by detector ARN
+    pub anomaly_detectors: HashMap<String, AnomalyDetector>,
 }
 
 impl LogsState {
@@ -35,6 +39,8 @@ impl LogsState {
             delivery_sources: HashMap::new(),
             deliveries: HashMap::new(),
             query_definitions: HashMap::new(),
+            account_policies: HashMap::new(),
+            anomaly_detectors: HashMap::new(),
         }
     }
 
@@ -49,6 +55,8 @@ impl LogsState {
         self.delivery_sources.clear();
         self.deliveries.clear();
         self.query_definitions.clear();
+        self.account_policies.clear();
+        self.anomaly_detectors.clear();
     }
 }
 
@@ -62,6 +70,10 @@ pub struct LogGroup {
     pub log_streams: HashMap<String, LogStream>,
     pub stored_bytes: i64,
     pub subscription_filters: Vec<SubscriptionFilter>,
+    pub data_protection_policy: Option<DataProtectionPolicy>,
+    pub index_policies: Vec<IndexPolicy>,
+    pub transformer: Option<Transformer>,
+    pub deletion_protection: bool,
 }
 
 pub struct LogStream {
@@ -179,4 +191,43 @@ pub struct QueryDefinition {
     pub query_string: String,
     pub log_group_names: Vec<String>,
     pub last_modified: i64,
+}
+
+pub struct AccountPolicy {
+    pub policy_name: String,
+    pub policy_type: String,
+    pub policy_document: String,
+    pub scope: Option<String>,
+    pub selection_criteria: Option<String>,
+    pub account_id: String,
+    pub last_updated_time: i64,
+}
+
+pub struct DataProtectionPolicy {
+    pub policy_document: String,
+    pub last_updated_time: i64,
+}
+
+pub struct IndexPolicy {
+    pub policy_name: String,
+    pub policy_document: String,
+    pub last_updated_time: i64,
+}
+
+pub struct Transformer {
+    pub transformer_config: serde_json::Value,
+    pub creation_time: i64,
+    pub last_modified_time: i64,
+}
+
+pub struct AnomalyDetector {
+    pub detector_name: String,
+    pub arn: String,
+    pub log_group_arn_list: Vec<String>,
+    pub evaluation_frequency: Option<String>,
+    pub filter_pattern: Option<String>,
+    pub anomaly_visibility_time: Option<i64>,
+    pub creation_time: i64,
+    pub last_modified_time: i64,
+    pub enabled: bool,
 }


### PR DESCRIPTION
## Summary
- Implement 22 new CloudWatch Logs operations: account policies (Put/Describe/Delete), data protection policies (Put/Get/Delete), index policies (Put/Describe/Delete/DescribeFieldIndexes), transformers (Put/Get/Delete/Test), anomaly detectors (Create/Get/Delete/List/Update), and misc ops (GetLogGroupFields, TestMetricFilter, StopQuery, PutLogGroupDeletionProtection, GetLogRecord, ListAnomalies, UpdateAnomaly)
- Add new state structs: AccountPolicy, DataProtectionPolicy, IndexPolicy, Transformer, AnomalyDetector
- Add unit tests, E2E tests, and conformance tests with correct checksums for all new operations

## Test plan
- [x] `cargo test -p fakecloud-logs` -- 30 unit tests pass
- [x] `cargo clippy -p fakecloud-logs -- -D warnings` -- clean
- [x] `cargo run -p fakecloud-conformance -- audit` -- 0 failures
- [x] E2E and conformance tests compile successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 22 missing CloudWatch Logs APIs and fully enforces deletion protection on log groups, including a fix to the `deletion_protection` field name. Also fixes StopQuery to return the correct success status when canceling a running query.

- **New Features**
  - Policies: account (Put/Describe/Delete), data protection (Put/Get/Delete), index (Put/Describe/Delete/DescribeFieldIndexes).
  - Processing: transformers (Put/Get/Delete/Test).
  - Anomaly detection: detectors (Create/Get/Delete/List/Update); anomalies stubs (ListAnomalies, UpdateAnomaly).
  - Misc: GetLogGroupFields, TestMetricFilter, StopQuery, PutLogGroupDeletionProtection, GetLogRecord; DeleteLogGroup respects deletion protection.
  - State updates in `fakecloud-logs`: adds AccountPolicy, DataProtectionPolicy, IndexPolicy, Transformer, AnomalyDetector; extends LogGroup with data protection, index policies, transformer, and deletion protection. Initializers updated in `fakecloud-cloudformation` and `fakecloud-eventbridge`.

- **Tests & Coverage**
  - Adds unit tests in `fakecloud-logs`, E2E tests in `fakecloud-e2e`, and conformance tests in `fakecloud-conformance` for all new operations.
  - Conformance baseline improved: Logs passed 2037 → 2784; total variants passed 29113 → 29860.

<sup>Written for commit 720c8a67960447a2d1030c49af9916f84f295596. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

