### PR TITLE
Fix 104 conformance failures across DynamoDB, EventBridge, KMS, and STS

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,58 +1,58 @@
 {
-  "variants_passed": 34175,
+  "variants_passed": 34279,
   "total_variants": 34856,
   "per_service": {
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
     "events": {
-      "passed": 2078,
+      "passed": 2108,
       "total": 2108
     },
     "sqs": {
       "passed": 549,
       "total": 549
     },
-    "ssm": {
-      "passed": 4974,
-      "total": 5303
-    },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "dynamodb": {
-      "passed": 2057,
-      "total": 2123
-    },
-    "kms": {
-      "passed": 2190,
-      "total": 2196
-    },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
-    },
     "secretsmanager": {
       "passed": 852,
       "total": 852
+    },
+    "ssm": {
+      "passed": 4974,
+      "total": 5303
     },
     "logs": {
       "passed": 3663,
       "total": 3911
     },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "sts": {
+      "passed": 438,
+      "total": 438
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
     "s3": {
       "passed": 3620,
       "total": 3620
     },
-    "sts": {
-      "passed": 436,
-      "total": 438
+    "kms": {
+      "passed": 2196,
+      "total": 2196
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
     }
   }
 }

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -15,6 +15,9 @@ use crate::state::{
     ReplicaDescription, SharedDynamoDbState,
 };
 
+const RETURN_CONSUMED_CAPACITY_VALUES: &[&str] = &["INDEXES", "TOTAL", "NONE"];
+const RETURN_ITEM_COLLECTION_METRICS_VALUES: &[&str] = &["SIZE", "NONE"];
+
 pub struct DynamoDbService {
     state: SharedDynamoDbState,
 }
@@ -908,6 +911,11 @@ impl DynamoDbService {
 
     fn transact_get_items(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_enum_value(
+            "returnConsumedCapacity",
+            &body["ReturnConsumedCapacity"],
+            RETURN_CONSUMED_CAPACITY_VALUES,
+        )?;
         let transact_items = body["TransactItems"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -947,6 +955,22 @@ impl DynamoDbService {
 
     fn transact_write_items(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length(
+            "clientRequestToken",
+            body["ClientRequestToken"].as_str(),
+            1,
+            36,
+        )?;
+        validate_optional_enum_value(
+            "returnConsumedCapacity",
+            &body["ReturnConsumedCapacity"],
+            RETURN_CONSUMED_CAPACITY_VALUES,
+        )?;
+        validate_optional_enum_value(
+            "returnItemCollectionMetrics",
+            &body["ReturnItemCollectionMetrics"],
+            RETURN_ITEM_COLLECTION_METRICS_VALUES,
+        )?;
         let transact_items = body["TransactItems"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1139,6 +1163,11 @@ impl DynamoDbService {
 
     fn batch_execute_statement(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_enum_value(
+            "returnConsumedCapacity",
+            &body["ReturnConsumedCapacity"],
+            RETURN_CONSUMED_CAPACITY_VALUES,
+        )?;
         let statements = body["Statements"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1176,6 +1205,17 @@ impl DynamoDbService {
 
     fn execute_transaction(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length(
+            "clientRequestToken",
+            body["ClientRequestToken"].as_str(),
+            1,
+            36,
+        )?;
+        validate_optional_enum_value(
+            "returnConsumedCapacity",
+            &body["ReturnConsumedCapacity"],
+            RETURN_CONSUMED_CAPACITY_VALUES,
+        )?;
         let transact_statements = body["TransactStatements"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1502,6 +1542,19 @@ impl DynamoDbService {
 
     fn list_backups(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length("tableName", body["TableName"].as_str(), 3, 255)?;
+        validate_optional_string_length(
+            "exclusiveStartBackupArn",
+            body["ExclusiveStartBackupArn"].as_str(),
+            37,
+            1024,
+        )?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
+        validate_optional_enum_value(
+            "backupType",
+            &body["BackupType"],
+            &["USER", "SYSTEM", "AWS_BACKUP", "ALL"],
+        )?;
         let table_name = body["TableName"].as_str();
 
         let state = self.state.read();
@@ -1723,6 +1776,7 @@ impl DynamoDbService {
     fn create_global_table(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let global_table_name = require_str(&body, "GlobalTableName")?;
+        validate_string_length("globalTableName", global_table_name, 3, 255)?;
 
         let replication_group = body["ReplicationGroup"]
             .as_array()
@@ -1787,6 +1841,7 @@ impl DynamoDbService {
     fn describe_global_table(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let global_table_name = require_str(&body, "GlobalTableName")?;
+        validate_string_length("globalTableName", global_table_name, 3, 255)?;
 
         let state = self.state.read();
         let gt = state.global_tables.get(global_table_name).ok_or_else(|| {
@@ -1817,6 +1872,7 @@ impl DynamoDbService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let global_table_name = require_str(&body, "GlobalTableName")?;
+        validate_string_length("globalTableName", global_table_name, 3, 255)?;
 
         let state = self.state.read();
         let gt = state.global_tables.get(global_table_name).ok_or_else(|| {
@@ -1848,6 +1904,13 @@ impl DynamoDbService {
 
     fn list_global_tables(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length(
+            "exclusiveStartGlobalTableName",
+            body["ExclusiveStartGlobalTableName"].as_str(),
+            3,
+            255,
+        )?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, i64::MAX)?;
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
 
         let state = self.state.read();
@@ -1873,6 +1936,8 @@ impl DynamoDbService {
     fn update_global_table(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let global_table_name = require_str(&body, "GlobalTableName")?;
+        validate_string_length("globalTableName", global_table_name, 3, 255)?;
+        validate_required("ReplicaUpdates", &body["ReplicaUpdates"])?;
 
         let mut state = self.state.write();
         let gt = state
@@ -1924,6 +1989,18 @@ impl DynamoDbService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let global_table_name = require_str(&body, "GlobalTableName")?;
+        validate_string_length("globalTableName", global_table_name, 3, 255)?;
+        validate_optional_enum_value(
+            "globalTableBillingMode",
+            &body["GlobalTableBillingMode"],
+            &["PROVISIONED", "PAY_PER_REQUEST"],
+        )?;
+        validate_optional_range_i64(
+            "globalTableProvisionedWriteCapacityUnits",
+            body["GlobalTableProvisionedWriteCapacityUnits"].as_i64(),
+            1,
+            i64::MAX,
+        )?;
 
         let state = self.state.read();
         let gt = state.global_tables.get(global_table_name).ok_or_else(|| {
@@ -2174,6 +2251,8 @@ impl DynamoDbService {
 
     fn list_contributor_insights(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length("tableName", body["TableName"].as_str(), 3, 255)?;
+        validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 0, 100)?;
         let table_name = body["TableName"].as_str();
 
         let state = self.state.read();
@@ -2286,6 +2365,8 @@ impl DynamoDbService {
 
     fn list_exports(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length("tableArn", body["TableArn"].as_str(), 1, 1024)?;
+        validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 1, 25)?;
         let table_arn = body["TableArn"].as_str();
 
         let state = self.state.read();
@@ -2411,6 +2492,18 @@ impl DynamoDbService {
         };
         state.imports.insert(import_arn.clone(), import_desc);
 
+        let table = state.tables.get(table_name).unwrap();
+        let ks: Vec<Value> = table
+            .key_schema
+            .iter()
+            .map(|k| json!({"AttributeName": k.attribute_name, "KeyType": k.key_type}))
+            .collect();
+        let ad: Vec<Value> = table
+            .attribute_definitions
+            .iter()
+            .map(|a| json!({"AttributeName": a.attribute_name, "AttributeType": a.attribute_type}))
+            .collect();
+
         Self::ok_json(json!({
             "ImportTableDescription": {
                 "ImportArn": import_arn,
@@ -2422,7 +2515,9 @@ impl DynamoDbService {
                 },
                 "InputFormat": input_format,
                 "TableCreationParameters": {
-                    "TableName": table_name
+                    "TableName": table_name,
+                    "KeySchema": ks,
+                    "AttributeDefinitions": ad
                 },
                 "StartTime": now.timestamp() as f64,
                 "EndTime": now.timestamp() as f64,
@@ -2464,6 +2559,9 @@ impl DynamoDbService {
 
     fn list_imports(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length("tableArn", body["TableArn"].as_str(), 1, 1024)?;
+        validate_optional_string_length("nextToken", body["NextToken"].as_str(), 112, 1024)?;
+        validate_optional_range_i64("pageSize", body["PageSize"].as_i64(), 1, 25)?;
         let table_arn = body["TableArn"].as_str();
 
         let state = self.state.read();

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -1163,7 +1163,13 @@ impl EventBridgeService {
 
     fn list_partner_event_sources(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
-        let name_prefix = body["NamePrefix"].as_str();
+        validate_required("NamePrefix", &body["NamePrefix"])?;
+        let name_prefix_str = body["NamePrefix"]
+            .as_str()
+            .ok_or_else(|| missing("NamePrefix"))?;
+        validate_string_length("namePrefix", name_prefix_str, 1, 256)?;
+        validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
         let offset: usize = body["NextToken"]
             .as_str()
@@ -1174,17 +1180,13 @@ impl EventBridgeService {
         let filtered: Vec<Value> = state
             .partner_event_sources
             .values()
-            .filter(|ps| match name_prefix {
-                Some(prefix) => ps.name.starts_with(prefix),
-                None => true,
-            })
+            .filter(|ps| ps.name.starts_with(name_prefix_str))
             .skip(offset)
             .take(limit + 1)
             .map(|ps| {
                 json!({
                     "Arn": ps.arn,
                     "Name": ps.name,
-                    "CreationTime": ps.creation_time.timestamp() as f64,
                 })
             })
             .collect();
@@ -1208,6 +1210,9 @@ impl EventBridgeService {
         let event_source_name = body["EventSourceName"]
             .as_str()
             .ok_or_else(|| missing("EventSourceName"))?;
+        validate_string_length("eventSourceName", event_source_name, 1, 256)?;
+        validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
 
         let state = self.state.read();
         let accounts: Vec<Value> = state
@@ -1292,6 +1297,9 @@ impl EventBridgeService {
 
     fn list_event_sources(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
+        validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 256)?;
+        validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
         let offset: usize = body["NextToken"]
@@ -1412,6 +1420,13 @@ impl EventBridgeService {
 
     fn update_event_bus(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
+        validate_optional_string_length("description", body["Description"].as_str(), 0, 512)?;
+        validate_optional_string_length(
+            "kmsKeyIdentifier",
+            body["KmsKeyIdentifier"].as_str(),
+            0,
+            2048,
+        )?;
         let name = body["Name"].as_str().unwrap_or("default");
 
         let mut state = self.state.write();
@@ -1574,6 +1589,10 @@ impl EventBridgeService {
 
     fn list_endpoints(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
+        validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 64)?;
+        validate_optional_string_length("homeRegion", body["HomeRegion"].as_str(), 9, 20)?;
+        validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 1, 100)?;
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["MaxResults"].as_i64().unwrap_or(100) as usize;
         let offset: usize = body["NextToken"]
@@ -4643,7 +4662,10 @@ mod tests {
         assert_eq!(body["Name"], "partner/test");
 
         // List
-        let req = make_request("ListPartnerEventSources", json!({}));
+        let req = make_request(
+            "ListPartnerEventSources",
+            json!({ "NamePrefix": "partner/" }),
+        );
         let resp = svc.list_partner_event_sources(&req).unwrap();
         let body: Value = serde_json::from_slice(&resp.body).unwrap();
         assert_eq!(body["PartnerEventSources"].as_array().unwrap().len(), 1);

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -592,6 +592,7 @@ impl StsService {
                 "The request must contain the parameter EncodedMessage",
             )
         })?;
+        validate_string_length("encodedMessage", _encoded_message, 1, 10240)?;
 
         let decoded_message =
             r#"{"allowed":true,"explicitDeny":false,"matchedStatements":{"items":[]}}"#;

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -2631,6 +2631,14 @@ impl KmsService {
 
     fn describe_custom_key_stores(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = body_json(req);
+        validate_optional_string_length(
+            "customKeyStoreName",
+            body["CustomKeyStoreName"].as_str(),
+            1,
+            256,
+        )?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 1000)?;
+        validate_optional_string_length("marker", body["Marker"].as_str(), 1, 1024)?;
 
         let filter_id = body["CustomKeyStoreId"].as_str();
         let filter_name = body["CustomKeyStoreName"].as_str();


### PR DESCRIPTION
## Summary
- Add input validation (string length, numeric range, enum, required field checks) to 15+ operations across DynamoDB, EventBridge, KMS, and STS that were missing Smithy model constraint enforcement
- Fix ImportTable response to include required KeySchema and AttributeDefinitions in TableCreationParameters (21 shape_mismatch failures)
- Remove non-model CreationTime field from ListPartnerEventSources response (1 shape_mismatch failure)

## Failure breakdown
- DynamoDB: 66 failures (string_length: 28, shape_mismatch: 21, numeric_range: 9, enum: 7, required: 1)
- EventBridge: 30 failures (string_length: 20, numeric_range: 8, shape_mismatch: 1, required: 1)
- KMS: 6 failures (string_length: 4, numeric_range: 2)
- STS: 2 failures (string_length: 2)

## Test plan
- [x] `cargo fmt --all && cargo build --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p fakecloud-dynamodb -p fakecloud-eventbridge -p fakecloud-kms -p fakecloud-iam` (all pass)
- [x] Conformance: 0 remaining failures for dynamodb, events, kms, sts
- [x] Baseline updated (98.3% overall pass rate)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 104 conformance failures by adding missing input validation and correcting response shapes across DynamoDB, EventBridge, KMS, and STS. All conformance tests for these services now pass; baseline updated to 34,279/34,856 (~98.3%).

- **Bug Fixes**
  - DynamoDB: add Smithy constraint checks to transactions, backups, global tables, exports/imports, and contributor insights (enum, length, range, required, paging tokens); fix ImportTable to include KeySchema and AttributeDefinitions in TableCreationParameters.
  - EventBridge: require NamePrefix and validate Limit/NextToken in ListPartnerEventSources; remove non-model CreationTime; add length/range checks for ListEventSources, ListEndpoints, and ListPartnerEventSourceAccounts; validate UpdateEventBus fields.
  - KMS: validate CustomKeyStoreName, Limit, and Marker in DescribeCustomKeyStores.
  - STS: validate EncodedMessage length in DecodeAuthorizationMessage.
  - Conformance: 0 remaining failures for DynamoDB/EventBridge/KMS/STS; variants_passed +104.

<sup>Written for commit 5ba2f0d842309db38e4d862049504e1476f0abe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

