### PR TITLE
fix: resolve 104 conformance failures across DynamoDB, EventBridge, KMS, STS

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,14 +1,26 @@
 {
-  "variants_passed": 34504,
+  "variants_passed": 34608,
   "total_variants": 34856,
   "per_service": {
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
+    "iam": {
+      "passed": 5962,
+      "total": 5962
     },
-    "logs": {
-      "passed": 3663,
-      "total": 3911
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "s3": {
+      "passed": 3620,
+      "total": 3620
+    },
+    "events": {
+      "passed": 2108,
+      "total": 2108
     },
     "secretsmanager": {
       "passed": 852,
@@ -19,40 +31,28 @@
       "total": 3420
     },
     "kms": {
-      "passed": 2190,
+      "passed": 2196,
       "total": 2196
-    },
-    "dynamodb": {
-      "passed": 2057,
-      "total": 2123
-    },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
     },
     "sns": {
       "passed": 1027,
       "total": 1027
     },
-    "sts": {
-      "passed": 436,
-      "total": 438
-    },
-    "events": {
-      "passed": 2078,
-      "total": 2108
-    },
     "sqs": {
       "passed": 549,
       "total": 549
     },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
+    },
+    "sts": {
+      "passed": 438,
+      "total": 438
+    },
+    "logs": {
+      "passed": 3663,
+      "total": 3911
     }
   }
 }

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -908,6 +908,11 @@ impl DynamoDbService {
 
     fn transact_get_items(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_enum_value(
+            "returnConsumedCapacity",
+            &body["ReturnConsumedCapacity"],
+            &["INDEXES", "TOTAL", "NONE"],
+        )?;
         let transact_items = body["TransactItems"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -947,6 +952,22 @@ impl DynamoDbService {
 
     fn transact_write_items(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length(
+            "clientRequestToken",
+            body["ClientRequestToken"].as_str(),
+            1,
+            36,
+        )?;
+        validate_optional_enum_value(
+            "returnConsumedCapacity",
+            &body["ReturnConsumedCapacity"],
+            &["INDEXES", "TOTAL", "NONE"],
+        )?;
+        validate_optional_enum_value(
+            "returnItemCollectionMetrics",
+            &body["ReturnItemCollectionMetrics"],
+            &["SIZE", "NONE"],
+        )?;
         let transact_items = body["TransactItems"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1139,6 +1160,11 @@ impl DynamoDbService {
 
     fn batch_execute_statement(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_enum_value(
+            "returnConsumedCapacity",
+            &body["ReturnConsumedCapacity"],
+            &["INDEXES", "TOTAL", "NONE"],
+        )?;
         let statements = body["Statements"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1176,6 +1202,17 @@ impl DynamoDbService {
 
     fn execute_transaction(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length(
+            "clientRequestToken",
+            body["ClientRequestToken"].as_str(),
+            1,
+            36,
+        )?;
+        validate_optional_enum_value(
+            "returnConsumedCapacity",
+            &body["ReturnConsumedCapacity"],
+            &["INDEXES", "TOTAL", "NONE"],
+        )?;
         let transact_statements = body["TransactStatements"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1502,6 +1539,19 @@ impl DynamoDbService {
 
     fn list_backups(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length("tableName", body["TableName"].as_str(), 1, 1024)?;
+        validate_optional_string_length(
+            "exclusiveStartBackupArn",
+            body["ExclusiveStartBackupArn"].as_str(),
+            37,
+            1024,
+        )?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
+        validate_optional_enum_value(
+            "backupType",
+            &body["BackupType"],
+            &["USER", "SYSTEM", "AWS_BACKUP", "ALL"],
+        )?;
         let table_name = body["TableName"].as_str();
 
         let state = self.state.read();
@@ -1723,6 +1773,7 @@ impl DynamoDbService {
     fn create_global_table(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let global_table_name = require_str(&body, "GlobalTableName")?;
+        validate_string_length("globalTableName", global_table_name, 3, 255)?;
 
         let replication_group = body["ReplicationGroup"]
             .as_array()
@@ -1787,6 +1838,7 @@ impl DynamoDbService {
     fn describe_global_table(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let global_table_name = require_str(&body, "GlobalTableName")?;
+        validate_string_length("globalTableName", global_table_name, 3, 255)?;
 
         let state = self.state.read();
         let gt = state.global_tables.get(global_table_name).ok_or_else(|| {
@@ -1817,6 +1869,7 @@ impl DynamoDbService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let global_table_name = require_str(&body, "GlobalTableName")?;
+        validate_string_length("globalTableName", global_table_name, 3, 255)?;
 
         let state = self.state.read();
         let gt = state.global_tables.get(global_table_name).ok_or_else(|| {
@@ -1848,6 +1901,13 @@ impl DynamoDbService {
 
     fn list_global_tables(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length(
+            "exclusiveStartGlobalTableName",
+            body["ExclusiveStartGlobalTableName"].as_str(),
+            3,
+            255,
+        )?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, i64::MAX)?;
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
 
         let state = self.state.read();
@@ -1873,6 +1933,8 @@ impl DynamoDbService {
     fn update_global_table(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let global_table_name = require_str(&body, "GlobalTableName")?;
+        validate_string_length("globalTableName", global_table_name, 3, 255)?;
+        validate_required("replicaUpdates", &body["ReplicaUpdates"])?;
 
         let mut state = self.state.write();
         let gt = state
@@ -1924,6 +1986,18 @@ impl DynamoDbService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let global_table_name = require_str(&body, "GlobalTableName")?;
+        validate_string_length("globalTableName", global_table_name, 3, 255)?;
+        validate_optional_enum_value(
+            "globalTableBillingMode",
+            &body["GlobalTableBillingMode"],
+            &["PROVISIONED", "PAY_PER_REQUEST"],
+        )?;
+        validate_optional_range_i64(
+            "globalTableProvisionedWriteCapacityUnits",
+            body["GlobalTableProvisionedWriteCapacityUnits"].as_i64(),
+            1,
+            i64::MAX,
+        )?;
 
         let state = self.state.read();
         let gt = state.global_tables.get(global_table_name).ok_or_else(|| {
@@ -2174,6 +2248,8 @@ impl DynamoDbService {
 
     fn list_contributor_insights(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length("tableName", body["TableName"].as_str(), 1, 1024)?;
+        validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 0, 100)?;
         let table_name = body["TableName"].as_str();
 
         let state = self.state.read();
@@ -2286,6 +2362,8 @@ impl DynamoDbService {
 
     fn list_exports(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length("tableArn", body["TableArn"].as_str(), 1, 1024)?;
+        validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 1, 25)?;
         let table_arn = body["TableArn"].as_str();
 
         let state = self.state.read();
@@ -2411,6 +2489,18 @@ impl DynamoDbService {
         };
         state.imports.insert(import_arn.clone(), import_desc);
 
+        let table_ref = state.tables.get(table_name).unwrap();
+        let ks: Vec<Value> = table_ref
+            .key_schema
+            .iter()
+            .map(|k| json!({"AttributeName": k.attribute_name, "KeyType": k.key_type}))
+            .collect();
+        let ad: Vec<Value> = table_ref
+            .attribute_definitions
+            .iter()
+            .map(|a| json!({"AttributeName": a.attribute_name, "AttributeType": a.attribute_type}))
+            .collect();
+
         Self::ok_json(json!({
             "ImportTableDescription": {
                 "ImportArn": import_arn,
@@ -2422,7 +2512,9 @@ impl DynamoDbService {
                 },
                 "InputFormat": input_format,
                 "TableCreationParameters": {
-                    "TableName": table_name
+                    "TableName": table_name,
+                    "KeySchema": ks,
+                    "AttributeDefinitions": ad
                 },
                 "StartTime": now.timestamp() as f64,
                 "EndTime": now.timestamp() as f64,
@@ -2464,6 +2556,9 @@ impl DynamoDbService {
 
     fn list_imports(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
+        validate_optional_string_length("tableArn", body["TableArn"].as_str(), 1, 1024)?;
+        validate_optional_string_length("nextToken", body["NextToken"].as_str(), 112, 1024)?;
+        validate_optional_range_i64("pageSize", body["PageSize"].as_i64(), 1, 25)?;
         let table_arn = body["TableArn"].as_str();
 
         let state = self.state.read();

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -1163,7 +1163,13 @@ impl EventBridgeService {
 
     fn list_partner_event_sources(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
-        let name_prefix = body["NamePrefix"].as_str();
+        validate_required("namePrefix", &body["NamePrefix"])?;
+        let name_prefix = body["NamePrefix"]
+            .as_str()
+            .ok_or_else(|| missing("NamePrefix"))?;
+        validate_string_length("namePrefix", name_prefix, 1, 256)?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
+        validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
         let offset: usize = body["NextToken"]
             .as_str()
@@ -1174,17 +1180,13 @@ impl EventBridgeService {
         let filtered: Vec<Value> = state
             .partner_event_sources
             .values()
-            .filter(|ps| match name_prefix {
-                Some(prefix) => ps.name.starts_with(prefix),
-                None => true,
-            })
+            .filter(|ps| ps.name.starts_with(name_prefix))
             .skip(offset)
             .take(limit + 1)
             .map(|ps| {
                 json!({
                     "Arn": ps.arn,
                     "Name": ps.name,
-                    "CreationTime": ps.creation_time.timestamp() as f64,
                 })
             })
             .collect();
@@ -1208,6 +1210,9 @@ impl EventBridgeService {
         let event_source_name = body["EventSourceName"]
             .as_str()
             .ok_or_else(|| missing("EventSourceName"))?;
+        validate_string_length("eventSourceName", event_source_name, 1, 256)?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
+        validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
 
         let state = self.state.read();
         let accounts: Vec<Value> = state
@@ -1292,6 +1297,9 @@ impl EventBridgeService {
 
     fn list_event_sources(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
+        validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 256)?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
+        validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
         let offset: usize = body["NextToken"]
@@ -1412,6 +1420,13 @@ impl EventBridgeService {
 
     fn update_event_bus(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
+        validate_optional_string_length("description", body["Description"].as_str(), 0, 512)?;
+        validate_optional_string_length(
+            "kmsKeyIdentifier",
+            body["KmsKeyIdentifier"].as_str(),
+            0,
+            2048,
+        )?;
         let name = body["Name"].as_str().unwrap_or("default");
 
         let mut state = self.state.write();
@@ -1574,6 +1589,10 @@ impl EventBridgeService {
 
     fn list_endpoints(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
+        validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 64)?;
+        validate_optional_string_length("homeRegion", body["HomeRegion"].as_str(), 9, 20)?;
+        validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 1, 100)?;
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["MaxResults"].as_i64().unwrap_or(100) as usize;
         let offset: usize = body["NextToken"]
@@ -4643,7 +4662,7 @@ mod tests {
         assert_eq!(body["Name"], "partner/test");
 
         // List
-        let req = make_request("ListPartnerEventSources", json!({}));
+        let req = make_request("ListPartnerEventSources", json!({"NamePrefix": "partner/"}));
         let resp = svc.list_partner_event_sources(&req).unwrap();
         let body: Value = serde_json::from_slice(&resp.body).unwrap();
         assert_eq!(body["PartnerEventSources"].as_array().unwrap().len(), 1);

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -585,13 +585,14 @@ impl StsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let _encoded_message = req.query_params.get("EncodedMessage").ok_or_else(|| {
+        let encoded_message = req.query_params.get("EncodedMessage").ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "MissingParameter",
                 "The request must contain the parameter EncodedMessage",
             )
         })?;
+        validate_string_length("encodedMessage", encoded_message, 1, 10240)?;
 
         let decoded_message =
             r#"{"allowed":true,"explicitDeny":false,"matchedStatements":{"items":[]}}"#;

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -2631,6 +2631,14 @@ impl KmsService {
 
     fn describe_custom_key_stores(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = body_json(req);
+        validate_optional_string_length(
+            "customKeyStoreName",
+            body["CustomKeyStoreName"].as_str(),
+            1,
+            256,
+        )?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 1000)?;
+        validate_optional_string_length("marker", body["Marker"].as_str(), 1, 1024)?;
 
         let filter_id = body["CustomKeyStoreId"].as_str();
         let filter_name = body["CustomKeyStoreName"].as_str();


### PR DESCRIPTION
## Summary

- **DynamoDB (66 fixes):** Add input validation (GlobalTableName length, ClientRequestToken length, enum validation for ReturnConsumedCapacity/ReturnItemCollectionMetrics/BackupType/BillingMode, range checks for Limit/MaxResults/PageSize, string length checks for TableArn/BackupArn/NextToken, required ReplicaUpdates on UpdateGlobalTable). Fix ImportTable response to include AttributeDefinitions and KeySchema in TableCreationParameters.
- **EventBridge (30 fixes):** Remove extra CreationTime from ListPartnerEventSources response shape. Add validation for NamePrefix (required + length), HomeRegion length, NextToken length, Limit/MaxResults ranges, Description/KmsKeyIdentifier length on UpdateEventBus.
- **KMS (6 fixes):** Add validation for CustomKeyStoreName length, Limit range, Marker length on DescribeCustomKeyStores.
- **STS (2 fixes):** Add EncodedMessage length validation on DecodeAuthorizationMessage.

Conformance: 34,608/34,856 (99.3%, up from 99.0%)

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all`
- [x] Conformance tests pass with 0 new failures
- [x] Pre-existing test failures (eb_cancel_replay, eb_describe_replay, eb_start_replay) unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 104 conformance failures by adding missing input validation and correcting a DynamoDB ImportTable response. Conformance now 34,608/34,856 (99.3%).

- **Bug Fixes**
  - DynamoDB: Add enum/length/range checks across Transact*, List*, and GlobalTable APIs; require ReplicaUpdates on UpdateGlobalTable; include KeySchema and AttributeDefinitions in ImportTable response.
  - EventBridge: Require NamePrefix and validate lengths/limits for list APIs (including endpoints); remove extra CreationTime from ListPartnerEventSources; add length checks for UpdateEventBus fields.
  - KMS: Validate CustomKeyStoreName, Limit, and Marker in DescribeCustomKeyStores.
  - STS: Validate EncodedMessage length in DecodeAuthorizationMessage.

<sup>Written for commit 5570180652353ce9b1c7f9262ef89c1b3400ba8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

