### PR TITLE
fix(dynamodb): preserve item data in backup/restore

### DIFF
--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -1431,6 +1431,7 @@ impl DynamoDbService {
             billing_mode: table.billing_mode.clone(),
             item_count: table.item_count,
             size_bytes: table.size_bytes,
+            items: table.items.clone(),
         };
 
         state.backups.insert(backup_arn.clone(), backup);
@@ -1606,13 +1607,14 @@ impl DynamoDbService {
             state.region, state.account_id, target_table_name
         );
 
-        let table = DynamoTable {
+        let restored_items = backup.items.clone();
+        let mut table = DynamoTable {
             name: target_table_name.to_string(),
             arn: arn.clone(),
             key_schema: backup.key_schema.clone(),
             attribute_definitions: backup.attribute_definitions.clone(),
             provisioned_throughput: backup.provisioned_throughput.clone(),
-            items: Vec::new(),
+            items: restored_items,
             gsi: Vec::new(),
             lsi: Vec::new(),
             tags: HashMap::new(),
@@ -1628,6 +1630,7 @@ impl DynamoDbService {
             kinesis_destinations: Vec::new(),
             contributor_insights_status: "DISABLED".to_string(),
         };
+        table.recalculate_stats();
 
         let desc = build_table_description(&table);
         state.tables.insert(target_table_name.to_string(), table);
@@ -1675,13 +1678,13 @@ impl DynamoDbService {
             state.region, state.account_id, target_table_name
         );
 
-        let table = DynamoTable {
+        let mut table = DynamoTable {
             name: target_table_name.to_string(),
             arn: arn.clone(),
             key_schema: source.key_schema.clone(),
             attribute_definitions: source.attribute_definitions.clone(),
             provisioned_throughput: source.provisioned_throughput.clone(),
-            items: Vec::new(),
+            items: source.items.clone(),
             gsi: Vec::new(),
             lsi: Vec::new(),
             tags: HashMap::new(),
@@ -1697,6 +1700,7 @@ impl DynamoDbService {
             kinesis_destinations: Vec::new(),
             contributor_insights_status: "DISABLED".to_string(),
         };
+        table.recalculate_stats();
 
         let desc = build_table_description(&table);
         state.tables.insert(target_table_name.to_string(), table);
@@ -5372,5 +5376,76 @@ mod tests {
         let resp = svc.describe_table(&req).unwrap();
         let body: Value = serde_json::from_slice(&resp.body).unwrap();
         assert_eq!(body["Table"]["TableStatus"], "ACTIVE");
+    }
+
+    #[test]
+    fn backup_restore_preserves_items() {
+        let svc = make_service();
+        create_test_table(&svc);
+
+        // Put 3 items
+        for i in 1..=3 {
+            let req = make_request(
+                "PutItem",
+                json!({
+                    "TableName": "test-table",
+                    "Item": {
+                        "pk": { "S": format!("key{i}") },
+                        "data": { "S": format!("value{i}") }
+                    }
+                }),
+            );
+            svc.put_item(&req).unwrap();
+        }
+
+        // Create backup
+        let req = make_request(
+            "CreateBackup",
+            json!({
+                "TableName": "test-table",
+                "BackupName": "my-backup"
+            }),
+        );
+        let resp = svc.create_backup(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let backup_arn = body["BackupDetails"]["BackupArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Delete all items from the original table
+        for i in 1..=3 {
+            let req = make_request(
+                "DeleteItem",
+                json!({
+                    "TableName": "test-table",
+                    "Key": { "pk": { "S": format!("key{i}") } }
+                }),
+            );
+            svc.delete_item(&req).unwrap();
+        }
+
+        // Verify original table is empty
+        let req = make_request("Scan", json!({ "TableName": "test-table" }));
+        let resp = svc.scan(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["Count"], 0);
+
+        // Restore from backup
+        let req = make_request(
+            "RestoreTableFromBackup",
+            json!({
+                "BackupArn": backup_arn,
+                "TargetTableName": "restored-table"
+            }),
+        );
+        svc.restore_table_from_backup(&req).unwrap();
+
+        // Scan restored table — should have 3 items
+        let req = make_request("Scan", json!({ "TableName": "restored-table" }));
+        let resp = svc.scan(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["Count"], 3);
+        assert_eq!(body["Items"].as_array().unwrap().len(), 3);
     }
 }

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -107,6 +107,8 @@ pub struct BackupDescription {
     pub billing_mode: String,
     pub item_count: i64,
     pub size_bytes: i64,
+    /// Snapshot of the table items at backup creation time.
+    pub items: Vec<HashMap<String, AttributeValue>>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -1466,3 +1466,172 @@ async fn dynamodb_kinesis_streaming_destination() {
         .unwrap();
     assert_eq!(resp.destination_status().unwrap().as_str(), "DISABLED");
 }
+
+#[tokio::test]
+async fn dynamodb_backup_restore_preserves_data() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    // Create table
+    client
+        .create_table()
+        .table_name("BackupTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Put 3 items
+    for i in 1..=3 {
+        client
+            .put_item()
+            .table_name("BackupTable")
+            .item("pk", AttributeValue::S(format!("key{i}")))
+            .item("data", AttributeValue::S(format!("value{i}")))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // Create backup
+    let backup_resp = client
+        .create_backup()
+        .table_name("BackupTable")
+        .backup_name("my-backup")
+        .send()
+        .await
+        .unwrap();
+    let backup_arn = backup_resp
+        .backup_details()
+        .unwrap()
+        .backup_arn()
+        .to_string();
+
+    // Delete all items from original table
+    for i in 1..=3 {
+        client
+            .delete_item()
+            .table_name("BackupTable")
+            .key("pk", AttributeValue::S(format!("key{i}")))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // Verify original table is empty
+    let scan = client
+        .scan()
+        .table_name("BackupTable")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(scan.count(), 0);
+
+    // Restore from backup
+    client
+        .restore_table_from_backup()
+        .backup_arn(&backup_arn)
+        .target_table_name("RestoredTable")
+        .send()
+        .await
+        .unwrap();
+
+    // Scan restored table — should have 3 items
+    let scan = client
+        .scan()
+        .table_name("RestoredTable")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(scan.count(), 3);
+    assert_eq!(scan.items().len(), 3);
+}
+
+#[tokio::test]
+async fn dynamodb_restore_to_point_in_time_preserves_data() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    // Create table
+    client
+        .create_table()
+        .table_name("PitrTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Put 3 items
+    for i in 1..=3 {
+        client
+            .put_item()
+            .table_name("PitrTable")
+            .item("pk", AttributeValue::S(format!("key{i}")))
+            .item("data", AttributeValue::S(format!("value{i}")))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // Enable PITR
+    client
+        .update_continuous_backups()
+        .table_name("PitrTable")
+        .point_in_time_recovery_specification(
+            PointInTimeRecoverySpecification::builder()
+                .point_in_time_recovery_enabled(true)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Restore to point in time
+    client
+        .restore_table_to_point_in_time()
+        .source_table_name("PitrTable")
+        .target_table_name("PitrRestored")
+        .use_latest_restorable_time(true)
+        .send()
+        .await
+        .unwrap();
+
+    // Scan restored table — should have 3 items
+    let scan = client
+        .scan()
+        .table_name("PitrRestored")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(scan.count(), 3);
+    assert_eq!(scan.items().len(), 3);
+}


### PR DESCRIPTION
## Summary
- **CreateBackup** now snapshots table items into the `BackupDescription`, not just metadata
- **RestoreTableFromBackup** copies backed-up items into the restored table (was always empty)
- **RestoreTableToPointInTime** copies items from the source table into the restored table (was always empty)
- Added `items` field to `BackupDescription` in `state.rs`

## Test plan
- [x] Unit test: `backup_restore_preserves_items` — create table, put 3 items, backup, delete items, restore, scan verifies 3 items
- [x] E2E test: `dynamodb_backup_restore_preserves_data` — same flow via SDK
- [x] E2E test: `dynamodb_restore_to_point_in_time_preserves_data` — put items, PITR restore, verify items present
- [x] All existing dynamodb tests still pass
- [x] Clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB backup and restore to preserve table items. Restored tables now include data instead of being empty.

- **Bug Fixes**
  - `CreateBackup` snapshots items into `BackupDescription.items`.
  - `RestoreTableFromBackup` and `RestoreTableToPointInTime` copy items into the restored table and recalculate stats.
  - Added unit and e2e tests to verify item preservation for backup/restore and PITR.

<sup>Written for commit 6ee41af5ac7852d097fc23b76ee45ebe64bf8a24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

