### PR TITLE
feat(logs): deliver subscription filter matches to SQS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,7 +1413,9 @@ dependencies = [
  "aws-sdk-ssm",
  "aws-sdk-sts",
  "aws-types",
+ "base64",
  "chrono",
+ "flate2",
  "reqwest",
  "serde_json",
  "tokio",
@@ -1493,9 +1501,11 @@ name = "fakecloud-logs"
 version = "0.3.0"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "fakecloud-core",
+ "flate2",
  "http 1.4.0",
  "parking_lot",
  "serde",
@@ -1629,6 +1639,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2342,6 +2362,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,6 +3062,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 toml = "0.8"
 percent-encoding = "2"
 base64 = "0.22"
+flate2 = "1"
 http = "1"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["trace"] }

--- a/crates/fakecloud-e2e/Cargo.toml
+++ b/crates/fakecloud-e2e/Cargo.toml
@@ -29,3 +29,5 @@ aws-credential-types = "1"
 aws-types = "1"
 reqwest = { version = "0.12", features = ["json"] }
 chrono = { workspace = true }
+base64 = { workspace = true }
+flate2 = { workspace = true }

--- a/crates/fakecloud-e2e/tests/cross_service.rs
+++ b/crates/fakecloud-e2e/tests/cross_service.rs
@@ -796,3 +796,109 @@ async fn s3_kms_encryption() {
         "expected KMS key ID on auto-encrypted object"
     );
 }
+
+/// CloudWatch Logs subscription filter -> SQS: verify that log events
+/// matching a subscription filter are delivered to the SQS queue.
+#[tokio::test]
+async fn logs_subscription_filter_delivers_to_sqs() {
+    use aws_sdk_cloudwatchlogs::types::InputLogEvent;
+    use base64::Engine;
+    use std::io::Read;
+
+    let server = TestServer::start().await;
+    let logs = server.logs_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create SQS queue
+    let queue = sqs
+        .create_queue()
+        .queue_name("logs-sub-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let queue_arn = get_queue_arn(&sqs, &queue_url).await;
+
+    // Create log group and stream
+    let group_name = "/test/subscription";
+    let stream_name = "app-stream";
+
+    logs.create_log_group()
+        .log_group_name(group_name)
+        .send()
+        .await
+        .unwrap();
+
+    logs.create_log_stream()
+        .log_group_name(group_name)
+        .log_stream_name(stream_name)
+        .send()
+        .await
+        .unwrap();
+
+    // Put subscription filter targeting the SQS queue
+    logs.put_subscription_filter()
+        .log_group_name(group_name)
+        .filter_name("all-events")
+        .filter_pattern("")
+        .destination_arn(&queue_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Put log events
+    let now = chrono::Utc::now().timestamp_millis();
+    logs.put_log_events()
+        .log_group_name(group_name)
+        .log_stream_name(stream_name)
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now)
+                .message("hello from subscription test")
+                .build()
+                .unwrap(),
+        )
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now + 1)
+                .message("second event")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Receive message from SQS
+    let recv = sqs
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .wait_time_seconds(1)
+        .send()
+        .await
+        .unwrap();
+
+    let messages = recv.messages().to_vec();
+    assert_eq!(messages.len(), 1, "expected exactly one SQS message");
+
+    // Decode the payload: base64 -> gzip -> JSON
+    let body = messages[0].body().unwrap();
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(body)
+        .unwrap();
+    let mut decoder = flate2::read::GzDecoder::new(&decoded[..]);
+    let mut json_str = String::new();
+    decoder.read_to_string(&mut json_str).unwrap();
+    let payload: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(payload["messageType"], "DATA_MESSAGE");
+    assert_eq!(payload["logGroup"], group_name);
+    assert_eq!(payload["logStream"], stream_name);
+    assert_eq!(payload["subscriptionFilters"][0], "all-events");
+
+    let log_events = payload["logEvents"].as_array().unwrap();
+    assert_eq!(log_events.len(), 2);
+    assert_eq!(log_events[0]["message"], "hello from subscription test");
+    assert_eq!(log_events[1]["message"], "second event");
+}

--- a/crates/fakecloud-logs/Cargo.toml
+++ b/crates/fakecloud-logs/Cargo.toml
@@ -17,6 +17,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
+base64 = { workspace = true }
+flate2 = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/fakecloud-logs/src/service.rs
+++ b/crates/fakecloud-logs/src/service.rs
@@ -1,8 +1,15 @@
+use std::io::Write;
+use std::sync::Arc;
+
 use async_trait::async_trait;
+use base64::Engine;
 use chrono::Utc;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -15,11 +22,12 @@ use crate::state::{
 
 pub struct LogsService {
     state: SharedLogsState,
+    delivery: Arc<DeliveryBus>,
 }
 
 impl LogsService {
-    pub fn new(state: SharedLogsState) -> Self {
-        Self { state }
+    pub fn new(state: SharedLogsState, delivery: Arc<DeliveryBus>) -> Self {
+        Self { state, delivery }
     }
 }
 
@@ -884,11 +892,53 @@ impl LogsService {
         // Generate new sequence token
         stream.upload_sequence_token = generate_sequence_token();
 
+        let accepted_events: Vec<LogEvent> = new_events.clone();
         stream.events.append(&mut new_events);
         stream.events.sort_by_key(|e| e.timestamp);
 
+        // Collect subscription filter info and sequence token while we still hold the lock
+        let subscription_filters: Vec<(String, String, String)> = group
+            .subscription_filters
+            .iter()
+            .map(|f| {
+                (
+                    f.filter_name.clone(),
+                    f.filter_pattern.clone(),
+                    f.destination_arn.clone(),
+                )
+            })
+            .collect();
+        let log_group_name = group.name.clone();
+        let next_sequence_token = stream.upload_sequence_token.clone();
+
+        // Drop the write lock before doing cross-service delivery
+        drop(state);
+
+        // Deliver matching events to subscription filter destinations
+        for (filter_name, filter_pattern, destination_arn) in &subscription_filters {
+            let matching: Vec<&LogEvent> = accepted_events
+                .iter()
+                .filter(|e| matches_filter_pattern(filter_pattern, &e.message))
+                .collect();
+
+            if matching.is_empty() {
+                continue;
+            }
+
+            let payload =
+                build_subscription_payload(&log_group_name, stream_name, filter_name, &matching);
+
+            if destination_arn.contains(":sqs:") {
+                self.delivery.send_to_sqs(
+                    destination_arn,
+                    &payload,
+                    &std::collections::HashMap::new(),
+                );
+            }
+        }
+
         let mut response = json!({
-            "nextSequenceToken": stream.upload_sequence_token,
+            "nextSequenceToken": next_sequence_token,
         });
         if has_rejected {
             response["rejectedLogEventsInfo"] = rejected_info;
@@ -5613,6 +5663,35 @@ fn matches_filter_pattern(pattern: &str, message: &str) -> bool {
     words.iter().all(|word| message.contains(word))
 }
 
+/// Build the CloudWatch Logs subscription payload: a base64-encoded gzip JSON blob.
+///
+/// This matches the format that real AWS sends to subscription filter destinations.
+fn build_subscription_payload(
+    log_group: &str,
+    log_stream: &str,
+    filter_name: &str,
+    events: &[&LogEvent],
+) -> String {
+    let payload = json!({
+        "messageType": "DATA_MESSAGE",
+        "owner": "123456789012",
+        "logGroup": log_group,
+        "logStream": log_stream,
+        "subscriptionFilters": [filter_name],
+        "logEvents": events.iter().map(|e| json!({
+            "id": format!("{}", e.ingestion_time),
+            "timestamp": e.timestamp,
+            "message": e.message,
+        })).collect::<Vec<_>>(),
+    });
+
+    let json_bytes = serde_json::to_vec(&payload).unwrap();
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&json_bytes).unwrap();
+    let compressed = encoder.finish().unwrap();
+    base64::engine::general_purpose::STANDARD.encode(&compressed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5627,7 +5706,8 @@ mod tests {
             "123456789012",
             "us-east-1",
         )));
-        LogsService::new(state)
+        let delivery = Arc::new(fakecloud_core::delivery::DeliveryBus::new());
+        LogsService::new(state, delivery)
     }
 
     fn make_request(action: &str, body: Value) -> AwsRequest {
@@ -6671,5 +6751,170 @@ mod tests {
             .as_array()
             .unwrap()
             .is_empty());
+    }
+
+    /// Mock SQS delivery that captures messages for testing.
+    struct MockSqsDelivery {
+        messages: parking_lot::Mutex<Vec<(String, String)>>,
+    }
+
+    impl MockSqsDelivery {
+        fn new() -> Self {
+            Self {
+                messages: parking_lot::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn take_messages(&self) -> Vec<(String, String)> {
+            std::mem::take(&mut *self.messages.lock())
+        }
+    }
+
+    impl fakecloud_core::delivery::SqsDelivery for MockSqsDelivery {
+        fn deliver_to_queue(
+            &self,
+            queue_arn: &str,
+            message_body: &str,
+            _attributes: &HashMap<String, String>,
+        ) {
+            self.messages
+                .lock()
+                .push((queue_arn.to_string(), message_body.to_string()));
+        }
+    }
+
+    fn make_service_with_mock_sqs() -> (LogsService, Arc<MockSqsDelivery>) {
+        let state = Arc::new(parking_lot::RwLock::new(LogsState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        let mock = Arc::new(MockSqsDelivery::new());
+        let delivery =
+            Arc::new(fakecloud_core::delivery::DeliveryBus::new().with_sqs(mock.clone()));
+        (LogsService::new(state, delivery), mock)
+    }
+
+    #[test]
+    fn subscription_filter_delivers_matching_events_to_sqs() {
+        let (svc, mock) = make_service_with_mock_sqs();
+        let group = "/test/sub";
+        let stream = "stream-1";
+        let queue_arn = "arn:aws:sqs:us-east-1:123456789012:my-queue";
+
+        // Create log group and stream
+        create_group(&svc, group);
+        create_stream(&svc, group, stream);
+
+        // Put subscription filter targeting SQS
+        let req = make_request(
+            "PutSubscriptionFilter",
+            json!({
+                "logGroupName": group,
+                "filterName": "my-filter",
+                "filterPattern": "",
+                "destinationArn": queue_arn,
+            }),
+        );
+        svc.put_subscription_filter(&req).unwrap();
+
+        // Put log events
+        put_events(&svc, group, stream, &["hello world", "test message"]);
+
+        // Verify delivery
+        let messages = mock.take_messages();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].0, queue_arn);
+
+        // Decode the payload: base64 -> gzip -> JSON
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&messages[0].1)
+            .unwrap();
+        let mut decoder = flate2::read::GzDecoder::new(&decoded[..]);
+        let mut json_str = String::new();
+        std::io::Read::read_to_string(&mut decoder, &mut json_str).unwrap();
+        let payload: Value = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(payload["messageType"], "DATA_MESSAGE");
+        assert_eq!(payload["logGroup"], group);
+        assert_eq!(payload["logStream"], stream);
+        assert_eq!(payload["subscriptionFilters"][0], "my-filter");
+        let events = payload["logEvents"].as_array().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0]["message"], "hello world");
+        assert_eq!(events[1]["message"], "test message");
+    }
+
+    #[test]
+    fn subscription_filter_respects_pattern() {
+        let (svc, mock) = make_service_with_mock_sqs();
+        let group = "/test/pattern";
+        let stream = "stream-1";
+        let queue_arn = "arn:aws:sqs:us-east-1:123456789012:pattern-queue";
+
+        create_group(&svc, group);
+        create_stream(&svc, group, stream);
+
+        // Filter only matches "ERROR"
+        let req = make_request(
+            "PutSubscriptionFilter",
+            json!({
+                "logGroupName": group,
+                "filterName": "error-filter",
+                "filterPattern": "ERROR",
+                "destinationArn": queue_arn,
+            }),
+        );
+        svc.put_subscription_filter(&req).unwrap();
+
+        // Put events, only one matches
+        put_events(
+            &svc,
+            group,
+            stream,
+            &["INFO all good", "ERROR something broke"],
+        );
+
+        let messages = mock.take_messages();
+        assert_eq!(messages.len(), 1);
+
+        // Decode and verify only the matching event was sent
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&messages[0].1)
+            .unwrap();
+        let mut decoder = flate2::read::GzDecoder::new(&decoded[..]);
+        let mut json_str = String::new();
+        std::io::Read::read_to_string(&mut decoder, &mut json_str).unwrap();
+        let payload: Value = serde_json::from_str(&json_str).unwrap();
+
+        let events = payload["logEvents"].as_array().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["message"], "ERROR something broke");
+    }
+
+    #[test]
+    fn subscription_filter_no_delivery_when_no_match() {
+        let (svc, mock) = make_service_with_mock_sqs();
+        let group = "/test/nomatch";
+        let stream = "stream-1";
+        let queue_arn = "arn:aws:sqs:us-east-1:123456789012:nomatch-queue";
+
+        create_group(&svc, group);
+        create_stream(&svc, group, stream);
+
+        let req = make_request(
+            "PutSubscriptionFilter",
+            json!({
+                "logGroupName": group,
+                "filterName": "strict-filter",
+                "filterPattern": "CRITICAL",
+                "destinationArn": queue_arn,
+            }),
+        );
+        svc.put_subscription_filter(&req).unwrap();
+
+        put_events(&svc, group, stream, &["INFO all good", "WARN something"]);
+
+        let messages = mock.take_messages();
+        assert!(messages.is_empty());
     }
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -122,9 +122,12 @@ async fn main() {
     // Step 3: S3 delivery (S3 notifications can push to SQS and SNS)
     let delivery_for_s3 = Arc::new(
         DeliveryBus::new()
-            .with_sqs(sqs_delivery)
+            .with_sqs(sqs_delivery.clone())
             .with_sns(sns_delivery),
     );
+
+    // Step 4: Logs delivery (subscription filters can push to SQS)
+    let delivery_for_logs = Arc::new(DeliveryBus::new().with_sqs(sqs_delivery));
 
     // Clone state refs for internal endpoints
     let lambda_invocations_state = lambda_state.clone();
@@ -179,7 +182,7 @@ async fn main() {
     registry.register(Arc::new(DynamoDbService::new(dynamodb_state)));
     registry.register(Arc::new(LambdaService::new(lambda_state.clone())));
     registry.register(Arc::new(SecretsManagerService::new(secretsmanager_state)));
-    registry.register(Arc::new(LogsService::new(logs_state)));
+    registry.register(Arc::new(LogsService::new(logs_state, delivery_for_logs)));
     registry.register(Arc::new(KmsService::new(kms_state.clone())));
     registry.register(Arc::new(
         S3Service::new(s3_state.clone(), delivery_for_s3).with_kms(kms_state),


### PR DESCRIPTION
## Summary
- When `PutLogEvents` is called, subscription filters on the log group are evaluated against incoming events
- Matching events are packaged in the CloudWatch Logs subscription format (base64-encoded gzip JSON with `logGroup`, `logStream`, `subscriptionFilters`, `logEvents` fields) and delivered to SQS via the cross-service `DeliveryBus`
- Empty filter patterns match all events; non-empty patterns use the existing `matches_filter_pattern` logic (substring, quoted exact, multi-word)

## Test plan
- [x] Unit test: subscription filter delivers matching events to SQS (mock delivery)
- [x] Unit test: subscription filter respects pattern (only matching events forwarded)
- [x] Unit test: no delivery when no events match the filter pattern
- [x] E2E test: `logs_subscription_filter_delivers_to_sqs` — full flow from log group creation through SQS message receipt and payload verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delivers matching CloudWatch Logs subscription events to SQS on PutLogEvents. Ensures consumers receive AWS-like payloads.

- **New Features**
  - Evaluate subscription filters when PutLogEvents runs; empty patterns match all; non-empty use existing pattern logic.
  - Package matches in the CloudWatch Logs subscription format (gzip JSON + base64) with logGroup, logStream, subscriptionFilters, and logEvents; deliver to SQS via the cross-service bus.
  - Added unit tests for match/no-match and an E2E test covering log group → SQS receipt.

- **Refactors**
  - LogsService now takes a DeliveryBus; the server wires SQS delivery for logs.

<sup>Written for commit 8885221c21344d1c68b6f0214ed49b0b89c55700. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

