### PR TITLE
feat(dynamodb): global table replication and contributor insights

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -632,6 +632,7 @@ impl ResourceProvisioner {
             pitr_enabled: false,
             kinesis_destinations: Vec::new(),
             contributor_insights_status: "DISABLED".to_string(),
+            contributor_insights_counters: HashMap::new(),
         };
 
         state.tables.insert(table_name.to_string(), table);

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -139,6 +139,7 @@ impl DynamoDbService {
             pitr_enabled: false,
             kinesis_destinations: Vec::new(),
             contributor_insights_status: "DISABLED".to_string(),
+            contributor_insights_counters: HashMap::new(),
         };
 
         state.tables.insert(table_name, table);
@@ -332,11 +333,12 @@ impl DynamoDbService {
         };
 
         if let Some(idx) = existing_idx {
-            table.items[idx] = item;
+            table.items[idx] = item.clone();
         } else {
-            table.items.push(item);
+            table.items.push(item.clone());
         }
 
+        table.record_item_access(&item);
         table.recalculate_stats();
 
         let mut result = json!({});
@@ -352,8 +354,10 @@ impl DynamoDbService {
         let table_name = require_str(&body, "TableName")?;
         let key = require_object(&body, "Key")?;
 
-        let state = self.state.read();
-        let table = get_table(&state.tables, table_name)?;
+        let mut state = self.state.write();
+        let table = get_table_mut(&mut state.tables, table_name)?;
+
+        table.record_key_access(&key);
 
         let result = match table.find_item_index(&key) {
             Some(idx) => {
@@ -618,6 +622,18 @@ impl DynamoDbService {
             matched.truncate(lim);
         }
 
+        // Collect partition key values for contributor insights
+        let insights_enabled = table.contributor_insights_status == "ENABLED";
+        let pk_name = table.hash_key_name().to_string();
+        let accessed_keys: Vec<String> = if insights_enabled {
+            matched
+                .iter()
+                .filter_map(|item| item.get(&pk_name).map(|v| v.to_string()))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         let items: Vec<Value> = matched
             .iter()
             .map(|item| {
@@ -626,11 +642,27 @@ impl DynamoDbService {
             })
             .collect();
 
-        Self::ok_json(json!({
+        let result = json!({
             "Items": items,
             "Count": items.len(),
             "ScannedCount": scanned_count,
-        }))
+        });
+
+        drop(state);
+
+        if !accessed_keys.is_empty() {
+            let mut state = self.state.write();
+            if let Some(table) = state.tables.get_mut(table_name) {
+                for key_str in accessed_keys {
+                    *table
+                        .contributor_insights_counters
+                        .entry(key_str)
+                        .or_insert(0) += 1;
+                }
+            }
+        }
+
+        Self::ok_json(result)
     }
 
     fn scan(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -658,6 +690,18 @@ impl DynamoDbService {
             matched.truncate(lim);
         }
 
+        // Collect partition key values for contributor insights
+        let insights_enabled = table.contributor_insights_status == "ENABLED";
+        let pk_name = table.hash_key_name().to_string();
+        let accessed_keys: Vec<String> = if insights_enabled {
+            matched
+                .iter()
+                .filter_map(|item| item.get(&pk_name).map(|v| v.to_string()))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         let items: Vec<Value> = matched
             .iter()
             .map(|item| {
@@ -666,11 +710,27 @@ impl DynamoDbService {
             })
             .collect();
 
-        Self::ok_json(json!({
+        let result = json!({
             "Items": items,
             "Count": items.len(),
             "ScannedCount": scanned_count,
-        }))
+        });
+
+        drop(state);
+
+        if !accessed_keys.is_empty() {
+            let mut state = self.state.write();
+            if let Some(table) = state.tables.get_mut(table_name) {
+                for key_str in accessed_keys {
+                    *table
+                        .contributor_insights_counters
+                        .entry(key_str)
+                        .or_insert(0) += 1;
+                }
+            }
+        }
+
+        Self::ok_json(result)
     }
 
     // ── Batch Operations ────────────────────────────────────────────────
@@ -1629,6 +1689,7 @@ impl DynamoDbService {
             pitr_enabled: false,
             kinesis_destinations: Vec::new(),
             contributor_insights_status: "DISABLED".to_string(),
+            contributor_insights_counters: HashMap::new(),
         };
         table.recalculate_stats();
 
@@ -1699,6 +1760,7 @@ impl DynamoDbService {
             pitr_enabled: false,
             kinesis_destinations: Vec::new(),
             contributor_insights_status: "DISABLED".to_string(),
+            contributor_insights_counters: HashMap::new(),
         };
         table.recalculate_stats();
 
@@ -2202,10 +2264,22 @@ impl DynamoDbService {
         let state = self.state.read();
         let table = get_table(&state.tables, table_name)?;
 
+        let top = table.top_contributors(10);
+        let contributors: Vec<Value> = top
+            .iter()
+            .map(|(key, count)| {
+                json!({
+                    "Key": key,
+                    "Count": count
+                })
+            })
+            .collect();
+
         let mut result = json!({
             "TableName": table_name,
             "ContributorInsightsStatus": table.contributor_insights_status,
-            "ContributorInsightsRuleList": []
+            "ContributorInsightsRuleList": ["DynamoDBContributorInsights"],
+            "TopContributors": contributors
         });
         if let Some(idx) = index_name {
             result["IndexName"] = json!(idx);
@@ -2238,6 +2312,9 @@ impl DynamoDbService {
             }
         };
         table.contributor_insights_status = status.to_string();
+        if status == "DISABLED" {
+            table.contributor_insights_counters.clear();
+        }
 
         let mut result = json!({
             "TableName": table_name,
@@ -2476,6 +2553,7 @@ impl DynamoDbService {
             pitr_enabled: false,
             kinesis_destinations: Vec::new(),
             contributor_insights_status: "DISABLED".to_string(),
+            contributor_insights_counters: HashMap::new(),
         };
         state.tables.insert(table_name.to_string(), table);
 
@@ -5447,5 +5525,153 @@ mod tests {
         let body: Value = serde_json::from_slice(&resp.body).unwrap();
         assert_eq!(body["Count"], 3);
         assert_eq!(body["Items"].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn global_table_replicates_writes() {
+        let svc = make_service();
+        create_test_table(&svc);
+
+        // Create global table with replicas
+        let req = make_request(
+            "CreateGlobalTable",
+            json!({
+                "GlobalTableName": "test-table",
+                "ReplicationGroup": [
+                    { "RegionName": "us-east-1" },
+                    { "RegionName": "eu-west-1" }
+                ]
+            }),
+        );
+        let resp = svc.create_global_table(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(
+            body["GlobalTableDescription"]["GlobalTableStatus"],
+            "ACTIVE"
+        );
+
+        // Put an item
+        let req = make_request(
+            "PutItem",
+            json!({
+                "TableName": "test-table",
+                "Item": {
+                    "pk": { "S": "replicated-key" },
+                    "data": { "S": "replicated-value" }
+                }
+            }),
+        );
+        svc.put_item(&req).unwrap();
+
+        // Verify the item is readable (since all replicas share the same table)
+        let req = make_request(
+            "GetItem",
+            json!({
+                "TableName": "test-table",
+                "Key": { "pk": { "S": "replicated-key" } }
+            }),
+        );
+        let resp = svc.get_item(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["Item"]["pk"]["S"], "replicated-key");
+        assert_eq!(body["Item"]["data"]["S"], "replicated-value");
+    }
+
+    #[test]
+    fn contributor_insights_tracks_access() {
+        let svc = make_service();
+        create_test_table(&svc);
+
+        // Enable contributor insights
+        let req = make_request(
+            "UpdateContributorInsights",
+            json!({
+                "TableName": "test-table",
+                "ContributorInsightsAction": "ENABLE"
+            }),
+        );
+        svc.update_contributor_insights(&req).unwrap();
+
+        // Put items with different partition keys
+        for key in &["alpha", "beta", "alpha", "alpha", "beta"] {
+            let req = make_request(
+                "PutItem",
+                json!({
+                    "TableName": "test-table",
+                    "Item": {
+                        "pk": { "S": key },
+                        "data": { "S": "value" }
+                    }
+                }),
+            );
+            svc.put_item(&req).unwrap();
+        }
+
+        // Get items (to also track read access)
+        for _ in 0..3 {
+            let req = make_request(
+                "GetItem",
+                json!({
+                    "TableName": "test-table",
+                    "Key": { "pk": { "S": "alpha" } }
+                }),
+            );
+            svc.get_item(&req).unwrap();
+        }
+
+        // Describe contributor insights — should show top contributors
+        let req = make_request(
+            "DescribeContributorInsights",
+            json!({ "TableName": "test-table" }),
+        );
+        let resp = svc.describe_contributor_insights(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["ContributorInsightsStatus"], "ENABLED");
+
+        let contributors = body["TopContributors"].as_array().unwrap();
+        assert!(
+            !contributors.is_empty(),
+            "TopContributors should not be empty"
+        );
+
+        // alpha was accessed 3 (put) + 3 (get) = 6 times, beta 2 times
+        // alpha should be the top contributor
+        let top = &contributors[0];
+        assert!(top["Count"].as_u64().unwrap() > 0);
+
+        // Verify the rule list is populated
+        let rules = body["ContributorInsightsRuleList"].as_array().unwrap();
+        assert!(!rules.is_empty());
+    }
+
+    #[test]
+    fn contributor_insights_not_tracked_when_disabled() {
+        let svc = make_service();
+        create_test_table(&svc);
+
+        // Put items without enabling insights
+        let req = make_request(
+            "PutItem",
+            json!({
+                "TableName": "test-table",
+                "Item": {
+                    "pk": { "S": "key1" },
+                    "data": { "S": "value" }
+                }
+            }),
+        );
+        svc.put_item(&req).unwrap();
+
+        // Describe — should show empty contributors
+        let req = make_request(
+            "DescribeContributorInsights",
+            json!({ "TableName": "test-table" }),
+        );
+        let resp = svc.describe_contributor_insights(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["ContributorInsightsStatus"], "DISABLED");
+
+        let contributors = body["TopContributors"].as_array().unwrap();
+        assert!(contributors.is_empty());
     }
 }

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -83,6 +83,8 @@ pub struct DynamoTable {
     pub kinesis_destinations: Vec<KinesisDestination>,
     /// Contributor insights status
     pub contributor_insights_status: String,
+    /// Contributor insights: partition key access counters (key_value_string -> count)
+    pub contributor_insights_counters: HashMap<String, u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -242,6 +244,49 @@ impl DynamoTable {
             }
             _ => v.to_string().len() as i64,
         }
+    }
+
+    /// Record a partition key access for contributor insights.
+    /// Only records if contributor insights is enabled.
+    pub fn record_key_access(&mut self, key: &HashMap<String, AttributeValue>) {
+        if self.contributor_insights_status != "ENABLED" {
+            return;
+        }
+        let hash_key = self.hash_key_name().to_string();
+        if let Some(pk_value) = key.get(&hash_key) {
+            let key_str = pk_value.to_string();
+            *self
+                .contributor_insights_counters
+                .entry(key_str)
+                .or_insert(0) += 1;
+        }
+    }
+
+    /// Record a partition key access from a full item (extracts the key first).
+    pub fn record_item_access(&mut self, item: &HashMap<String, AttributeValue>) {
+        if self.contributor_insights_status != "ENABLED" {
+            return;
+        }
+        let hash_key = self.hash_key_name().to_string();
+        if let Some(pk_value) = item.get(&hash_key) {
+            let key_str = pk_value.to_string();
+            *self
+                .contributor_insights_counters
+                .entry(key_str)
+                .or_insert(0) += 1;
+        }
+    }
+
+    /// Get top N contributors sorted by access count (descending).
+    pub fn top_contributors(&self, n: usize) -> Vec<(&str, u64)> {
+        let mut entries: Vec<(&str, u64)> = self
+            .contributor_insights_counters
+            .iter()
+            .map(|(k, &v)| (k.as_str(), v))
+            .collect();
+        entries.sort_by(|a, b| b.1.cmp(&a.1));
+        entries.truncate(n);
+        entries
     }
 
     /// Recalculate item_count and size_bytes from the items vec.

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -3,8 +3,8 @@ mod helpers;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, BillingMode, ContributorInsightsAction, Delete,
     DeleteRequest, Get, KeySchemaElement, KeyType, PointInTimeRecoverySpecification,
-    ProvisionedThroughput, Put, PutRequest, ScalarAttributeType, Tag, TimeToLiveSpecification,
-    TransactGetItem, TransactWriteItem, WriteRequest,
+    ProvisionedThroughput, Put, PutRequest, Replica, ScalarAttributeType, Tag,
+    TimeToLiveSpecification, TransactGetItem, TransactWriteItem, WriteRequest,
 };
 use helpers::TestServer;
 use std::collections::HashMap;
@@ -1634,4 +1634,157 @@ async fn dynamodb_restore_to_point_in_time_preserves_data() {
         .unwrap();
     assert_eq!(scan.count(), 3);
     assert_eq!(scan.items().len(), 3);
+}
+
+#[tokio::test]
+async fn dynamodb_global_table_replicates_writes() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    // Create the table first
+    client
+        .create_table()
+        .table_name("GlobalTestTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Create global table with replicas
+    client
+        .create_global_table()
+        .global_table_name("GlobalTestTable")
+        .replication_group(Replica::builder().region_name("us-east-1").build())
+        .replication_group(Replica::builder().region_name("eu-west-1").build())
+        .send()
+        .await
+        .unwrap();
+
+    // Write an item
+    client
+        .put_item()
+        .table_name("GlobalTestTable")
+        .item("pk", AttributeValue::S("global-key".to_string()))
+        .item("data", AttributeValue::S("global-value".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    // Read it back (all replicas share the same table in fakecloud)
+    let resp = client
+        .get_item()
+        .table_name("GlobalTestTable")
+        .key("pk", AttributeValue::S("global-key".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    let item = resp.item().unwrap();
+    assert_eq!(item.get("pk").unwrap().as_s().unwrap(), "global-key");
+    assert_eq!(item.get("data").unwrap().as_s().unwrap(), "global-value");
+
+    // Verify the global table is described correctly
+    let gt = client
+        .describe_global_table()
+        .global_table_name("GlobalTestTable")
+        .send()
+        .await
+        .unwrap();
+    let desc = gt.global_table_description().unwrap();
+    assert_eq!(desc.replication_group().len(), 2);
+}
+
+#[tokio::test]
+async fn dynamodb_contributor_insights_tracks_access() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    // Create table
+    client
+        .create_table()
+        .table_name("InsightsTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Enable contributor insights
+    client
+        .update_contributor_insights()
+        .table_name("InsightsTable")
+        .contributor_insights_action(ContributorInsightsAction::Enable)
+        .send()
+        .await
+        .unwrap();
+
+    // Put items with different partition keys
+    for key in &["alpha", "beta", "alpha", "gamma", "alpha"] {
+        client
+            .put_item()
+            .table_name("InsightsTable")
+            .item("pk", AttributeValue::S(key.to_string()))
+            .item("data", AttributeValue::S("value".to_string()))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // Get items to also track read access
+    for _ in 0..2 {
+        client
+            .get_item()
+            .table_name("InsightsTable")
+            .key("pk", AttributeValue::S("beta".to_string()))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // Describe contributor insights
+    let resp = client
+        .describe_contributor_insights()
+        .table_name("InsightsTable")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.contributor_insights_status().unwrap().as_str(),
+        "ENABLED"
+    );
+
+    // Verify that rules list is non-empty
+    let rules = resp.contributor_insights_rule_list();
+    assert!(
+        !rules.is_empty(),
+        "ContributorInsightsRuleList should not be empty"
+    );
 }


### PR DESCRIPTION
## Summary
- **Global Tables**: All replicas share the same underlying table in fakecloud, so writes to a global table are automatically visible from any replica region
- **Contributor Insights**: Track partition key access counts on PutItem, GetItem, Query, and Scan. DescribeContributorInsights returns top contributors sorted by access count. Counters reset when insights are disabled.
- Added unit tests (global_table_replicates_writes, contributor_insights_tracks_access, contributor_insights_not_tracked_when_disabled) and E2E tests (dynamodb_global_table_replicates_writes, dynamodb_contributor_insights_tracks_access)

## Test plan
- [x] `cargo test -p fakecloud-dynamodb` — 32 unit tests pass
- [x] `cargo clippy -p fakecloud-dynamodb -- -D warnings` — no warnings
- [x] `cargo build -p fakecloud-e2e --tests` — E2E tests compile
- [ ] `cargo test -p fakecloud-e2e` — E2E tests against running server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DynamoDB Global Tables write replication and Contributor Insights tracking. Writes are visible from any replica region, and you can view top partition-key contributors.

- **New Features**
  - Global Tables: replicas share a single table; writes are readable from any region.
  - Contributor Insights: counts partition-key access on PutItem, GetItem, Query, and Scan; DescribeContributorInsights returns TopContributors (sorted by count) and includes the DynamoDBContributorInsights rule; counters clear when insights are disabled.

<sup>Written for commit 1217356819d44672954ece7c25d7a108066da62d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

