### PR TITLE
feat(s3): access logging, inventory reports, and static website hosting

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -2,6 +2,7 @@ mod helpers;
 
 use aws_sdk_s3::primitives::ByteStream;
 use helpers::TestServer;
+use std::time::Duration;
 
 #[tokio::test]
 async fn s3_create_list_delete_bucket() {
@@ -2051,5 +2052,303 @@ async fn s3_list_parts_invalid_argument() {
     assert!(
         body.contains("InvalidArgument"),
         "Expected InvalidArgument error for non-numeric part-number-marker, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn s3_access_logging_generates_logs() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    // Create source and log buckets
+    client
+        .create_bucket()
+        .bucket("source-bucket")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_bucket()
+        .bucket("log-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // Enable logging on source-bucket -> log-bucket with prefix "logs/"
+    let logging_config = r#"{
+        "LoggingEnabled": {
+            "TargetBucket": "log-bucket",
+            "TargetPrefix": "logs/"
+        }
+    }"#;
+    let result = server
+        .aws_cli(&[
+            "s3api",
+            "put-bucket-logging",
+            "--bucket",
+            "source-bucket",
+            "--bucket-logging-status",
+            logging_config,
+        ])
+        .await;
+    assert!(
+        result.success(),
+        "put-bucket-logging failed: {}",
+        result.stderr_text()
+    );
+
+    // Put an object in source-bucket to trigger logging
+    client
+        .put_object()
+        .bucket("source-bucket")
+        .key("hello.txt")
+        .body(ByteStream::from_static(b"hello world"))
+        .send()
+        .await
+        .unwrap();
+
+    // GET the object to trigger another log entry
+    client
+        .get_object()
+        .bucket("source-bucket")
+        .key("hello.txt")
+        .send()
+        .await
+        .unwrap();
+
+    // Small delay to ensure logs are written
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Check that log objects exist in log-bucket with prefix "logs/"
+    let log_objects = client
+        .list_objects_v2()
+        .bucket("log-bucket")
+        .prefix("logs/")
+        .send()
+        .await
+        .unwrap();
+
+    let contents = log_objects.contents();
+    assert!(
+        !contents.is_empty(),
+        "Expected access log objects in log-bucket/logs/, found none"
+    );
+
+    // Verify the log content contains expected fields
+    let first_log_key = contents[0].key().unwrap();
+    let log_obj = client
+        .get_object()
+        .bucket("log-bucket")
+        .key(first_log_key)
+        .send()
+        .await
+        .unwrap();
+    let log_body =
+        String::from_utf8(log_obj.body.collect().await.unwrap().into_bytes().to_vec()).unwrap();
+
+    assert!(
+        log_body.contains("source-bucket"),
+        "Log entry should contain source bucket name, got: {log_body}"
+    );
+    assert!(
+        log_body.contains("REST."),
+        "Log entry should contain REST operation, got: {log_body}"
+    );
+}
+
+#[tokio::test]
+async fn s3_inventory_generates_report() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    // Create source and destination buckets
+    client
+        .create_bucket()
+        .bucket("inv-source")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_bucket()
+        .bucket("inv-dest")
+        .send()
+        .await
+        .unwrap();
+
+    // Put some objects in the source bucket
+    for i in 0..3 {
+        client
+            .put_object()
+            .bucket("inv-source")
+            .key(format!("file-{i}.txt"))
+            .body(ByteStream::from_static(b"data"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // Configure inventory
+    let inv_config = r#"<InventoryConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Id>my-inventory</Id>
+        <IsEnabled>true</IsEnabled>
+        <Destination>
+            <S3BucketDestination>
+                <Bucket>arn:aws:s3:::inv-dest</Bucket>
+                <Format>CSV</Format>
+                <Prefix>inventory/</Prefix>
+            </S3BucketDestination>
+        </Destination>
+        <Schedule><Frequency>Daily</Frequency></Schedule>
+        <IncludedObjectVersions>Current</IncludedObjectVersions>
+    </InventoryConfiguration>"#;
+
+    // Use raw HTTP to put inventory config (CLI escaping is complex)
+    let http = reqwest::Client::new();
+    let url = format!("{}/inv-source?inventory&id=my-inventory", server.endpoint());
+    let resp = http
+        .put(&url)
+        .header("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=fake")
+        .body(inv_config)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "put-bucket-inventory failed");
+
+    // Check that inventory report was generated in dest bucket
+    let report_objects = client
+        .list_objects_v2()
+        .bucket("inv-dest")
+        .prefix("inventory/")
+        .send()
+        .await
+        .unwrap();
+
+    let contents = report_objects.contents();
+    assert!(
+        !contents.is_empty(),
+        "Expected inventory report in inv-dest/inventory/, found none"
+    );
+
+    // Read the report and verify CSV content
+    let report_key = contents[0].key().unwrap();
+    let report_obj = client
+        .get_object()
+        .bucket("inv-dest")
+        .key(report_key)
+        .send()
+        .await
+        .unwrap();
+    let report_body = String::from_utf8(
+        report_obj
+            .body
+            .collect()
+            .await
+            .unwrap()
+            .into_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+
+    // Verify CSV header
+    assert!(
+        report_body
+            .contains("\"Bucket\",\"Key\",\"Size\",\"LastModifiedDate\",\"ETag\",\"StorageClass\""),
+        "Report should contain CSV header, got: {report_body}"
+    );
+    // Verify each file is listed
+    assert!(
+        report_body.contains("file-0.txt"),
+        "Report should list file-0.txt"
+    );
+    assert!(
+        report_body.contains("file-1.txt"),
+        "Report should list file-1.txt"
+    );
+    assert!(
+        report_body.contains("file-2.txt"),
+        "Report should list file-2.txt"
+    );
+}
+
+#[tokio::test]
+async fn s3_website_serves_index() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    // Create bucket
+    client
+        .create_bucket()
+        .bucket("website-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // Configure website hosting
+    let website_config = r#"<WebsiteConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <IndexDocument><Suffix>index.html</Suffix></IndexDocument>
+        <ErrorDocument><Key>error.html</Key></ErrorDocument>
+    </WebsiteConfiguration>"#;
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/website-bucket?website", server.endpoint());
+    let resp = http
+        .put(&url)
+        .header("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=fake")
+        .body(website_config)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "put-bucket-website failed");
+
+    // Put index.html
+    client
+        .put_object()
+        .bucket("website-bucket")
+        .key("index.html")
+        .content_type("text/html")
+        .body(ByteStream::from_static(b"<h1>Welcome</h1>"))
+        .send()
+        .await
+        .unwrap();
+
+    // Put error.html
+    client
+        .put_object()
+        .bucket("website-bucket")
+        .key("error.html")
+        .content_type("text/html")
+        .body(ByteStream::from_static(b"<h1>Not Found</h1>"))
+        .send()
+        .await
+        .unwrap();
+
+    // GET / should serve index.html
+    let url = format!("{}/website-bucket", server.endpoint());
+    let resp = http
+        .get(&url)
+        .header("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=fake")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "GET / should return 200");
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("<h1>Welcome</h1>"),
+        "GET / should serve index.html content, got: {body}"
+    );
+
+    // GET /nonexistent should serve error.html with 404
+    let url = format!("{}/website-bucket/nonexistent", server.endpoint());
+    let resp = http
+        .get(&url)
+        .header("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=fake")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404, "GET /nonexistent should return 404");
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("<h1>Not Found</h1>"),
+        "GET /nonexistent should serve error.html content, got: {body}"
     );
 }

--- a/crates/fakecloud-s3/src/inventory.rs
+++ b/crates/fakecloud-s3/src/inventory.rs
@@ -1,0 +1,220 @@
+use bytes::Bytes;
+use chrono::Utc;
+use md5::{Digest, Md5};
+
+use crate::state::{S3Object, SharedS3State};
+
+/// Parsed inventory destination from the inventory configuration XML.
+struct InventoryDestination {
+    bucket_arn: String,
+    prefix: Option<String>,
+}
+
+/// Parse the destination from an `<InventoryConfiguration>` XML body.
+fn parse_inventory_destination(xml: &str) -> Option<InventoryDestination> {
+    let dest_start = xml.find("<Destination>")?;
+    let dest_end = xml.find("</Destination>")?;
+    let dest_body = &xml[dest_start + 13..dest_end];
+
+    // Look for <S3BucketDestination>
+    let s3_start = dest_body.find("<S3BucketDestination>")?;
+    let s3_end = dest_body.find("</S3BucketDestination>")?;
+    let s3_body = &dest_body[s3_start + 21..s3_end];
+
+    let bucket_arn = extract_tag(s3_body, "Bucket")?;
+    let prefix = extract_tag(s3_body, "Prefix");
+
+    Some(InventoryDestination { bucket_arn, prefix })
+}
+
+/// Extract the bucket name from an ARN like `arn:aws:s3:::my-bucket`.
+fn bucket_name_from_arn(arn: &str) -> Option<&str> {
+    arn.strip_prefix("arn:aws:s3:::")
+}
+
+/// Generate an inventory report for a bucket and store it in the destination.
+///
+/// The report is a CSV with columns: Bucket, Key, Size, LastModifiedDate, ETag, StorageClass.
+pub fn generate_inventory_report(state: &SharedS3State, source_bucket: &str, config_id: &str) {
+    // Read the inventory config
+    let config_xml = {
+        let st = state.read();
+        st.buckets
+            .get(source_bucket)
+            .and_then(|b| b.inventory_configs.get(config_id).cloned())
+    };
+
+    let config_xml = match config_xml {
+        Some(c) => c,
+        None => return,
+    };
+
+    let destination = match parse_inventory_destination(&config_xml) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let dest_bucket_name = match bucket_name_from_arn(&destination.bucket_arn) {
+        Some(name) => name.to_string(),
+        None => return,
+    };
+
+    // Collect object data from source bucket
+    let rows: Vec<String> = {
+        let st = state.read();
+        let bucket = match st.buckets.get(source_bucket) {
+            Some(b) => b,
+            None => return,
+        };
+
+        let mut csv_rows = vec![
+            "\"Bucket\",\"Key\",\"Size\",\"LastModifiedDate\",\"ETag\",\"StorageClass\""
+                .to_string(),
+        ];
+
+        for (key, obj) in &bucket.objects {
+            if obj.is_delete_marker {
+                continue;
+            }
+            csv_rows.push(format!(
+                "{},{},{},{},{},{}",
+                csv_escape(source_bucket),
+                csv_escape(key),
+                obj.size,
+                csv_escape(
+                    &obj.last_modified
+                        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+                        .to_string()
+                ),
+                csv_escape(&obj.etag),
+                csv_escape(&obj.storage_class),
+            ));
+        }
+
+        csv_rows
+    };
+
+    let csv_content = rows.join("\n") + "\n";
+    let data = Bytes::from(csv_content);
+    let size = data.len() as u64;
+    let etag = format!("{:x}", Md5::digest(&data));
+    let now = Utc::now();
+
+    let report_key = format!(
+        "{}{}/{}/data/{}.csv",
+        destination.prefix.as_deref().unwrap_or(""),
+        source_bucket,
+        config_id,
+        now.format("%Y-%m-%dT%H-%M-%SZ"),
+    );
+
+    let report_object = S3Object {
+        key: report_key.clone(),
+        data,
+        content_type: "text/csv".to_string(),
+        etag,
+        size,
+        last_modified: now,
+        metadata: Default::default(),
+        storage_class: "STANDARD".to_string(),
+        tags: Default::default(),
+        acl_grants: vec![],
+        acl_owner_id: None,
+        parts_count: None,
+        part_sizes: None,
+        sse_algorithm: None,
+        sse_kms_key_id: None,
+        bucket_key_enabled: None,
+        version_id: None,
+        is_delete_marker: false,
+        content_encoding: None,
+        website_redirect_location: None,
+        restore_ongoing: None,
+        restore_expiry: None,
+        checksum_algorithm: None,
+        checksum_value: None,
+        lock_mode: None,
+        lock_retain_until: None,
+        lock_legal_hold: None,
+    };
+
+    let mut st = state.write();
+    if let Some(target) = st.buckets.get_mut(&dest_bucket_name) {
+        target.objects.insert(report_key, report_object);
+    }
+}
+
+/// Escape a value for inclusion in a CSV field.  If the value contains a
+/// comma, double-quote, or newline it is wrapped in double quotes and any
+/// embedded double quotes are doubled.
+fn csv_escape(value: &str) -> String {
+    if value.contains(',') || value.contains('"') || value.contains('\n') {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        format!("\"{value}\"")
+    }
+}
+
+fn extract_tag(body: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = body.find(&open)?;
+    let content_start = start + open.len();
+    let end = body[content_start..].find(&close)?;
+    Some(body[content_start..content_start + end].trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_destination_from_inventory_config() {
+        let xml = r#"<InventoryConfiguration>
+            <Id>my-inv</Id>
+            <Destination>
+                <S3BucketDestination>
+                    <Bucket>arn:aws:s3:::dest-bucket</Bucket>
+                    <Format>CSV</Format>
+                    <Prefix>inventory/</Prefix>
+                </S3BucketDestination>
+            </Destination>
+            <IsEnabled>true</IsEnabled>
+            <Schedule><Frequency>Daily</Frequency></Schedule>
+            <IncludedObjectVersions>Current</IncludedObjectVersions>
+        </InventoryConfiguration>"#;
+
+        let dest = parse_inventory_destination(xml).unwrap();
+        assert_eq!(dest.bucket_arn, "arn:aws:s3:::dest-bucket");
+        assert_eq!(dest.prefix.as_deref(), Some("inventory/"));
+    }
+
+    #[test]
+    fn bucket_name_from_arn_works() {
+        assert_eq!(
+            bucket_name_from_arn("arn:aws:s3:::my-bucket"),
+            Some("my-bucket")
+        );
+        assert_eq!(bucket_name_from_arn("not-an-arn"), None);
+    }
+
+    #[test]
+    fn csv_escape_plain_value() {
+        assert_eq!(csv_escape("hello"), "\"hello\"");
+    }
+
+    #[test]
+    fn csv_escape_value_with_comma() {
+        assert_eq!(csv_escape("a,b"), "\"a,b\"");
+    }
+
+    #[test]
+    fn csv_escape_value_with_quotes() {
+        assert_eq!(csv_escape("say \"hi\""), "\"say \"\"hi\"\"\"");
+    }
+
+    #[test]
+    fn csv_escape_value_with_comma_and_quotes() {
+        assert_eq!(csv_escape("a,\"b\""), "\"a,\"\"b\"\"\"");
+    }
+}

--- a/crates/fakecloud-s3/src/lib.rs
+++ b/crates/fakecloud-s3/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod inventory;
 pub mod lifecycle;
+pub mod logging;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-s3/src/logging.rs
+++ b/crates/fakecloud-s3/src/logging.rs
@@ -1,0 +1,219 @@
+use bytes::Bytes;
+use chrono::Utc;
+use md5::{Digest, Md5};
+use uuid::Uuid;
+
+use crate::state::{S3Object, SharedS3State};
+
+/// Parsed logging configuration extracted from the XML stored on the bucket.
+pub struct LoggingConfig {
+    pub target_bucket: String,
+    pub target_prefix: String,
+}
+
+/// Parse a `<BucketLoggingStatus>` XML body into a `LoggingConfig`, if logging
+/// is enabled (i.e. the `<LoggingEnabled>` element is present).
+pub fn parse_logging_config(xml: &str) -> Option<LoggingConfig> {
+    let le_start = xml.find("<LoggingEnabled>")?;
+    let le_end = xml.find("</LoggingEnabled>")?;
+    let le_body = &xml[le_start + 16..le_end];
+
+    let target_bucket = extract_tag(le_body, "TargetBucket")?;
+    let target_prefix = extract_tag(le_body, "TargetPrefix").unwrap_or_default();
+
+    Some(LoggingConfig {
+        target_bucket,
+        target_prefix,
+    })
+}
+
+/// Generate an S3 access log line in a format similar to AWS.
+///
+/// See <https://docs.aws.amazon.com/AmazonS3/latest/userguide/LogFormat.html>
+#[allow(clippy::too_many_arguments)]
+pub fn format_access_log_entry(
+    bucket_owner: &str,
+    bucket: &str,
+    operation: &str,
+    key: Option<&str>,
+    status: u16,
+    request_id: &str,
+    method: &str,
+    path: &str,
+) -> String {
+    let now = Utc::now();
+    let time = now.format("[%d/%b/%Y:%H:%M:%S %z]");
+    let key_str = key.unwrap_or("-");
+    // Simplified log line matching the AWS format fields
+    format!(
+        "{bucket_owner} {bucket} {time} 127.0.0.1 arn:aws:iam::000000000000:user/testuser {request_id} REST.{operation} {key_str} \"{method} {path} HTTP/1.1\" {status} - - - - - \"-\" \"FakeCloud/1.0\" - - - - -\n"
+    )
+}
+
+/// After a request has been processed, check whether the source bucket has
+/// logging enabled and, if so, write a log entry to the target bucket.
+///
+/// This should be called at the end of the `handle` method so that every S3
+/// operation on a logging-enabled bucket produces a record.
+#[allow(clippy::too_many_arguments)]
+pub fn maybe_write_access_log(
+    state: &SharedS3State,
+    source_bucket: &str,
+    operation: &str,
+    key: Option<&str>,
+    status: u16,
+    request_id: &str,
+    method: &str,
+    path: &str,
+) {
+    // Read logging config from the source bucket
+    let logging_config_xml = {
+        let st = state.read();
+        st.buckets
+            .get(source_bucket)
+            .and_then(|b| b.logging_config.clone())
+    };
+
+    let config = match logging_config_xml.and_then(|xml| parse_logging_config(&xml)) {
+        Some(c) => c,
+        None => return,
+    };
+
+    let bucket_owner = {
+        let st = state.read();
+        st.buckets
+            .get(source_bucket)
+            .map(|b| b.acl_owner_id.clone())
+            .unwrap_or_else(|| "unknown".to_string())
+    };
+
+    let entry = format_access_log_entry(
+        &bucket_owner,
+        source_bucket,
+        operation,
+        key,
+        status,
+        request_id,
+        method,
+        path,
+    );
+
+    let now = Utc::now();
+    let log_key = format!(
+        "{}{}",
+        config.target_prefix,
+        now.format("%Y-%m-%d-%H-%M-%S-")
+    ) + &Uuid::new_v4().to_string()[..8];
+
+    let data = Bytes::from(entry);
+    let size = data.len() as u64;
+    let etag = format!("{:x}", Md5::digest(&data));
+
+    let log_object = S3Object {
+        key: log_key.clone(),
+        data,
+        content_type: "text/plain".to_string(),
+        etag,
+        size,
+        last_modified: now,
+        metadata: Default::default(),
+        storage_class: "STANDARD".to_string(),
+        tags: Default::default(),
+        acl_grants: vec![],
+        acl_owner_id: None,
+        parts_count: None,
+        part_sizes: None,
+        sse_algorithm: None,
+        sse_kms_key_id: None,
+        bucket_key_enabled: None,
+        version_id: None,
+        is_delete_marker: false,
+        content_encoding: None,
+        website_redirect_location: None,
+        restore_ongoing: None,
+        restore_expiry: None,
+        checksum_algorithm: None,
+        checksum_value: None,
+        lock_mode: None,
+        lock_retain_until: None,
+        lock_legal_hold: None,
+    };
+
+    let mut st = state.write();
+    if let Some(target) = st.buckets.get_mut(&config.target_bucket) {
+        target.objects.insert(log_key, log_object);
+    }
+}
+
+/// Determine the S3 operation name from the HTTP method and key presence.
+pub fn operation_name(method: &http::Method, key: Option<&str>) -> &'static str {
+    match (method.as_str(), key) {
+        ("GET", None) => "GET.BUCKET",
+        ("GET", Some(_)) => "GET.OBJECT",
+        ("PUT", None) => "PUT.BUCKET",
+        ("PUT", Some(_)) => "PUT.OBJECT",
+        ("DELETE", None) => "DELETE.BUCKET",
+        ("DELETE", Some(_)) => "DELETE.OBJECT",
+        ("HEAD", None) => "HEAD.BUCKET",
+        ("HEAD", Some(_)) => "HEAD.OBJECT",
+        ("POST", _) => "POST",
+        _ => "UNKNOWN",
+    }
+}
+
+fn extract_tag(body: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = body.find(&open)?;
+    let content_start = start + open.len();
+    let end = body[content_start..].find(&close)?;
+    Some(body[content_start..content_start + end].trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_logging_config_enabled() {
+        let xml = r#"<BucketLoggingStatus xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <LoggingEnabled>
+                <TargetBucket>log-bucket</TargetBucket>
+                <TargetPrefix>logs/</TargetPrefix>
+            </LoggingEnabled>
+        </BucketLoggingStatus>"#;
+
+        let config = parse_logging_config(xml).unwrap();
+        assert_eq!(config.target_bucket, "log-bucket");
+        assert_eq!(config.target_prefix, "logs/");
+    }
+
+    #[test]
+    fn parse_logging_config_disabled() {
+        let xml = r#"<BucketLoggingStatus xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        </BucketLoggingStatus>"#;
+
+        assert!(parse_logging_config(xml).is_none());
+    }
+
+    #[test]
+    fn format_log_entry_contains_fields() {
+        let entry = format_access_log_entry(
+            "owner123",
+            "my-bucket",
+            "GET.OBJECT",
+            Some("my-key.txt"),
+            200,
+            "req-abc",
+            "GET",
+            "/my-bucket/my-key.txt",
+        );
+        assert!(entry.contains("owner123"));
+        assert!(entry.contains("my-bucket"));
+        assert!(entry.contains("GET.OBJECT"));
+        assert!(entry.contains("my-key.txt"));
+        assert!(entry.contains("200"));
+        assert!(entry.contains("req-abc"));
+        assert!(entry.contains("\"GET /my-bucket/my-key.txt HTTP/1.1\""));
+    }
+}

--- a/crates/fakecloud-s3/src/service.rs
+++ b/crates/fakecloud-s3/src/service.rs
@@ -14,6 +14,8 @@ use fakecloud_kms::state::SharedKmsState;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
 
+use crate::inventory;
+use crate::logging;
 use crate::state::{AclGrant, MultipartUpload, S3Bucket, S3Object, SharedS3State, UploadPart};
 
 pub struct S3Service {
@@ -340,6 +342,32 @@ impl AwsService for S3Service {
                     }
                 } else if req.query_params.get("list-type").map(|s| s.as_str()) == Some("2") {
                     self.list_objects_v2(&req, b)
+                } else if req.query_params.is_empty() {
+                    // If bucket has website config and no query params, serve index document
+                    let website_config = {
+                        let state = self.state.read();
+                        state
+                            .buckets
+                            .get(b)
+                            .and_then(|bkt| bkt.website_config.clone())
+                    };
+                    if let Some(ref config) = website_config {
+                        if let Some(index_doc) = extract_xml_value(config, "Suffix").or_else(|| {
+                            extract_xml_value(config, "IndexDocument").and_then(|inner| {
+                                let open = "<Suffix>";
+                                let close = "</Suffix>";
+                                let s = inner.find(open)? + open.len();
+                                let e = inner.find(close)?;
+                                Some(inner[s..e].trim().to_string())
+                            })
+                        }) {
+                            self.serve_website_object(&req, b, &index_doc, config)
+                        } else {
+                            self.list_objects_v1(&req, b)
+                        }
+                    } else {
+                        self.list_objects_v1(&req, b)
+                    }
                 } else {
                     self.list_objects_v1(&req, b)
                 }
@@ -373,7 +401,36 @@ impl AwsService for S3Service {
                 } else if req.query_params.contains_key("attributes") {
                     self.get_object_attributes(&req, b, k)
                 } else {
-                    self.get_object(&req, b, k)
+                    let result = self.get_object(&req, b, k);
+                    // If object not found and bucket has website config, serve error document
+                    let is_not_found = matches!(
+                        &result,
+                        Err(e) if e.code() == "NoSuchKey"
+                    );
+                    if is_not_found {
+                        let website_config = {
+                            let state = self.state.read();
+                            state
+                                .buckets
+                                .get(b)
+                                .and_then(|bkt| bkt.website_config.clone())
+                        };
+                        if let Some(ref config) = website_config {
+                            if let Some(error_key) = extract_xml_value(config, "ErrorDocument")
+                                .and_then(|inner| {
+                                    let open = "<Key>";
+                                    let close = "</Key>";
+                                    let s = inner.find(open)? + open.len();
+                                    let e = inner.find(close)?;
+                                    Some(inner[s..e].trim().to_string())
+                                })
+                                .or_else(|| extract_xml_value(config, "Key"))
+                            {
+                                return self.serve_website_error(&req, b, &error_key);
+                            }
+                        }
+                    }
+                    result
                 }
             }
             (&Method::DELETE, Some(b), Some(k)) => {
@@ -428,6 +485,25 @@ impl AwsService for S3Service {
                     }
                 }
             }
+        }
+
+        // Write S3 access log entry if the source bucket has logging enabled
+        if let Some(b_name) = bucket {
+            let status_code = match &result {
+                Ok(resp) => resp.status.as_u16(),
+                Err(e) => e.status().as_u16(),
+            };
+            let op = logging::operation_name(&req.method, key.as_deref());
+            logging::maybe_write_access_log(
+                &self.state,
+                b_name,
+                op,
+                key.as_deref(),
+                status_code,
+                &req.request_id,
+                req.method.as_str(),
+                &req.raw_path,
+            );
         }
 
         result
@@ -2179,12 +2255,16 @@ impl S3Service {
         let inv_id = extract_xml_value(&body_str, "Id")
             .or_else(|| req.query_params.get("id").cloned())
             .unwrap_or_default();
-        let mut state = self.state.write();
-        let b = state
-            .buckets
-            .get_mut(bucket)
-            .ok_or_else(|| no_such_bucket(bucket))?;
-        b.inventory_configs.insert(inv_id, body_str);
+        {
+            let mut state = self.state.write();
+            let b = state
+                .buckets
+                .get_mut(bucket)
+                .ok_or_else(|| no_such_bucket(bucket))?;
+            b.inventory_configs.insert(inv_id.clone(), body_str);
+        }
+        // Generate the inventory report immediately so tests can verify it
+        inventory::generate_inventory_report(&self.state, bucket, &inv_id);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -2900,6 +2980,49 @@ impl S3Service {
             body: response_body,
             headers,
         })
+    }
+
+    /// Serve a website object (index or error document) from the bucket.
+    fn serve_website_object(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+        key: &str,
+        website_config: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let result = self.get_object(req, bucket, key);
+        if result.is_err() {
+            // If index doc doesn't exist either, try error document
+            if let Some(error_key) = extract_xml_value(website_config, "ErrorDocument")
+                .and_then(|inner| {
+                    let open = "<Key>";
+                    let close = "</Key>";
+                    let s = inner.find(open)? + open.len();
+                    let e = inner.find(close)?;
+                    Some(inner[s..e].trim().to_string())
+                })
+                .or_else(|| extract_xml_value(website_config, "Key"))
+            {
+                return self.serve_website_error(req, bucket, &error_key);
+            }
+        }
+        result
+    }
+
+    /// Serve the website error document with a 404 status.
+    fn serve_website_error(
+        &self,
+        req: &AwsRequest,
+        bucket: &str,
+        error_key: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        match self.get_object(req, bucket, error_key) {
+            Ok(mut resp) => {
+                resp.status = StatusCode::NOT_FOUND;
+                Ok(resp)
+            }
+            Err(e) => Err(e),
+        }
     }
 
     fn delete_object(


### PR DESCRIPTION
## Summary
- **Access logging**: when a bucket has logging enabled via `PutBucketLogging`, every subsequent S3 operation generates an access log entry stored in the target bucket with the configured prefix
- **Inventory reports**: when `PutBucketInventoryConfiguration` is called, a CSV inventory report is immediately generated in the destination bucket listing all objects with Bucket, Key, Size, LastModifiedDate, ETag, and StorageClass
- **Static website hosting**: GET requests to a bucket with website configuration serve the `IndexDocument` for root path and the `ErrorDocument` (with 404 status) when an object is not found

## Test plan
- [x] `s3_access_logging_generates_logs` — enables logging, makes requests, verifies log objects exist in target bucket with correct content
- [x] `s3_inventory_generates_report` — creates inventory config, verifies CSV report is generated with correct object listings
- [x] `s3_website_serves_index` — configures website hosting, verifies index.html is served for root and error.html is served with 404 for missing objects
- [x] All 22 unit tests pass (including new tests for logging config parsing, inventory destination parsing, log entry formatting)
- [x] `cargo clippy -p fakecloud-s3 --no-deps -- -D warnings` passes clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds S3 access logging, inventory reports, and static website hosting to `fakecloud-s3`. Improves AWS parity and makes it easier to test logging, inventory, and website flows.

- **New Features**
  - Access logging: After each S3 operation, if enabled via `PutBucketLogging`, an AWS-format access log is written to the target bucket/prefix.
  - Inventory reports: On `PutBucketInventoryConfiguration`, a CSV is generated immediately in the destination ARN/prefix with Bucket, Key, Size, LastModifiedDate, ETag, and StorageClass.
  - Static website hosting: Buckets with website config serve the `IndexDocument` at root, and return the `ErrorDocument` with 404 when an object is missing.

<sup>Written for commit 1335ac2f3dfd8b9a484838de09d18faf90db63d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

