### PR TITLE
feat(lambda): implement real Lambda function execution via Docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +98,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "async-trait"
@@ -924,6 +944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +963,25 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -969,6 +1014,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1031,6 +1086,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -1104,6 +1165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1203,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1225,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1421,6 +1505,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "tokio",
+ "zip",
 ]
 
 [[package]]
@@ -1491,12 +1576,16 @@ dependencies = [
  "fakecloud-core",
  "http 1.4.0",
  "parking_lot",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -1778,9 +1867,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2218,6 +2309,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2319,6 +2419,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2529,6 +2650,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -3988,6 +4119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4036,6 +4176,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -4071,7 +4225,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ sha1 = "0.10"
 sha2 = "0.10"
 crc32fast = "1"
 reqwest = { version = "0.12", features = ["json"] }
+zip = "2"
+tempfile = "3"
 
 # Internal crates
 fakecloud-core = { path = "crates/fakecloud-core", version = "0.3.0" }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ cargo run --release --bin fakecloud
 docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud
 ```
 
+To enable Lambda function execution, mount the Docker socket:
+
+```sh
+docker run --rm -p 4566:4566 -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/faiscadev/fakecloud
+```
+
 ### Docker Compose
 
 ```yaml
@@ -76,6 +82,8 @@ services:
     image: ghcr.io/faiscadev/fakecloud
     ports:
       - "4566:4566"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock  # required for Lambda Invoke
     environment:
       FAKECLOUD_LOG: info
 ```
@@ -295,7 +303,7 @@ lifecycle rules with background expiration and storage class transitions, object
 lock (retention and legal hold), encryption, replication, and website
 configuration.
 
-### Lambda (10 actions, stub)
+### Lambda (10 actions)
 
 **Functions:** CreateFunction, GetFunction, DeleteFunction, ListFunctions,
 Invoke, PublishVersion
@@ -304,10 +312,12 @@ Invoke, PublishVersion
 GetEventSourceMapping, DeleteEventSourceMapping
 
 Key features: function CRUD with config storage (runtime, handler, role,
-memory, timeout, environment variables, tags, architectures), canned Invoke
-response (does not execute code), event source mapping management. Uses
-REST-style routing (HTTP method + URL path) with SigV4 credential-scope
-routing.
+memory, timeout, environment variables, tags, architectures), **real code
+execution** via Docker containers using official AWS Lambda base images,
+warm container reuse for fast repeated invocations, event source mapping
+management. Supported runtimes: Python 3.11–3.13, Node.js 18–22, Ruby 3.3–3.4,
+Java 17/21, .NET 8, and custom runtimes (provided.al2, provided.al2023).
+Requires Docker or Podman for Invoke; all other operations work without it.
 
 ### Secrets Manager (11 actions)
 
@@ -392,6 +402,7 @@ fakecloud is configured via CLI flags or environment variables.
 | `--region` | `FAKECLOUD_REGION` | `us-east-1` | AWS region to advertise |
 | `--account-id` | `FAKECLOUD_ACCOUNT_ID` | `123456789012` | AWS account ID |
 | `--log-level` | `FAKECLOUD_LOG` | `info` | Log level (trace, debug, info, warn, error) |
+| | `FAKECLOUD_CONTAINER_CLI` | auto-detect | Container CLI to use (`docker` or `podman`) |
 
 ```sh
 # Examples
@@ -428,7 +439,7 @@ fakecloud is organized as a Cargo workspace:
 | `fakecloud-iam` | IAM and STS implementation |
 | `fakecloud-ssm` | SSM Parameter Store implementation |
 | `fakecloud-dynamodb` | DynamoDB implementation |
-| `fakecloud-lambda` | Lambda stub implementation |
+| `fakecloud-lambda` | Lambda implementation with Docker-based execution |
 | `fakecloud-secretsmanager` | Secrets Manager implementation |
 | `fakecloud-s3` | S3 implementation |
 | `fakecloud-logs` | CloudWatch Logs implementation |

--- a/crates/fakecloud-e2e/Cargo.toml
+++ b/crates/fakecloud-e2e/Cargo.toml
@@ -31,3 +31,4 @@ reqwest = { version = "0.12", features = ["json"] }
 chrono = { workspace = true }
 base64 = { workspace = true }
 flate2 = { workspace = true }
+zip = { workspace = true }

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -157,8 +157,25 @@ impl TestServer {
 impl Drop for TestServer {
     fn drop(&mut self) {
         if let Some(mut child) = self.child.take() {
+            let pid = child.id();
             let _ = child.kill();
             let _ = child.wait();
+
+            // Clean up any Lambda containers spawned by this server instance
+            let label = format!("fakecloud-instance=fakecloud-{}", pid);
+            let output = Command::new("docker")
+                .args(["ps", "-q", "--filter", &format!("label={}", label)])
+                .output();
+            if let Ok(output) = output {
+                let ids = String::from_utf8_lossy(&output.stdout);
+                for id in ids.split_whitespace() {
+                    let _ = Command::new("docker")
+                        .args(["rm", "-f", id])
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .status();
+                }
+            }
         }
     }
 }

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -164,7 +164,7 @@ impl Drop for TestServer {
             // Clean up any Lambda containers spawned by this server instance
             let label = format!("fakecloud-instance=fakecloud-{}", pid);
             let output = Command::new("docker")
-                .args(["ps", "-q", "--filter", &format!("label={}", label)])
+                .args(["ps", "-aq", "--filter", &format!("label={}", label)])
                 .output();
             if let Ok(output) = output {
                 let ids = String::from_utf8_lossy(&output.stdout);

--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -1,7 +1,22 @@
 mod helpers;
 
+use std::io::Write;
+
 use aws_sdk_lambda::primitives::Blob;
 use helpers::TestServer;
+
+fn make_python_zip() -> Vec<u8> {
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    let options = zip::write::SimpleFileOptions::default();
+    writer.start_file("index.py", options).unwrap();
+    writer
+        .write_all(b"def handler(event, context):\n    return {\"statusCode\": 200}\n")
+        .unwrap();
+    let cursor = writer.finish().unwrap();
+    cursor.into_inner()
+}
 
 #[tokio::test]
 async fn lambda_create_get_delete_function() {
@@ -17,7 +32,7 @@ async fn lambda_create_get_delete_function() {
         .handler("index.handler")
         .code(
             aws_sdk_lambda::types::FunctionCode::builder()
-                .zip_file(Blob::new(b"fake-code"))
+                .zip_file(Blob::new(make_python_zip()))
                 .build(),
         )
         .send()
@@ -66,7 +81,7 @@ async fn lambda_list_functions() {
             .handler("index.handler")
             .code(
                 aws_sdk_lambda::types::FunctionCode::builder()
-                    .zip_file(Blob::new(b"fake"))
+                    .zip_file(Blob::new(make_python_zip()))
                     .build(),
             )
             .send()
@@ -91,7 +106,7 @@ async fn lambda_invoke() {
         .handler("index.handler")
         .code(
             aws_sdk_lambda::types::FunctionCode::builder()
-                .zip_file(Blob::new(b"fake"))
+                .zip_file(Blob::new(make_python_zip()))
                 .build(),
         )
         .send()
@@ -107,6 +122,8 @@ async fn lambda_invoke() {
         .unwrap();
 
     assert_eq!(resp.status_code(), 200);
+    let body: serde_json::Value = serde_json::from_slice(resp.payload().unwrap().as_ref()).unwrap();
+    assert_eq!(body["statusCode"], 200);
 }
 
 #[tokio::test]
@@ -122,7 +139,7 @@ async fn lambda_create_function_conflict() {
         .handler("index.handler")
         .code(
             aws_sdk_lambda::types::FunctionCode::builder()
-                .zip_file(Blob::new(b"fake"))
+                .zip_file(Blob::new(make_python_zip()))
                 .build(),
         )
         .send()
@@ -138,7 +155,7 @@ async fn lambda_create_function_conflict() {
         .handler("index.handler")
         .code(
             aws_sdk_lambda::types::FunctionCode::builder()
-                .zip_file(Blob::new(b"fake"))
+                .zip_file(Blob::new(make_python_zip()))
                 .build(),
         )
         .send()

--- a/crates/fakecloud-e2e/tests/lambda_invoke.rs
+++ b/crates/fakecloud-e2e/tests/lambda_invoke.rs
@@ -515,16 +515,12 @@ async fn test_invoke_no_code() {
         .await
         .unwrap();
 
-    // Invoke should return stub {}
-    let resp = client
+    // Invoke should fail — function has no deployment package
+    let result = client
         .invoke()
         .function_name("no-code-func")
         .payload(Blob::new(b"{}".to_vec()))
         .send()
-        .await
-        .unwrap();
-
-    let body = resp.payload().unwrap().as_ref().to_vec();
-    let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(result, serde_json::json!({}));
+        .await;
+    assert!(result.is_err());
 }

--- a/crates/fakecloud-e2e/tests/lambda_invoke.rs
+++ b/crates/fakecloud-e2e/tests/lambda_invoke.rs
@@ -1,0 +1,529 @@
+mod helpers;
+
+use std::io::Write;
+
+use aws_sdk_lambda::primitives::Blob;
+use aws_sdk_lambda::types::{Environment, FunctionCode, Runtime};
+use helpers::TestServer;
+
+/// Create a ZIP file in memory containing a single file.
+fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    for (name, content) in entries {
+        let options = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+        writer.start_file(*name, options).unwrap();
+        writer.write_all(content).unwrap();
+    }
+    let cursor = writer.finish().unwrap();
+    cursor.into_inner()
+}
+
+async fn create_and_invoke(
+    client: &aws_sdk_lambda::Client,
+    function_name: &str,
+    runtime: Runtime,
+    handler: &str,
+    zip_bytes: Vec<u8>,
+    payload: Option<&str>,
+) -> String {
+    // Create function
+    client
+        .create_function()
+        .function_name(function_name)
+        .runtime(runtime)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler(handler)
+        .code(
+            FunctionCode::builder()
+                .zip_file(Blob::new(zip_bytes))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Invoke
+    let resp = client
+        .invoke()
+        .function_name(function_name)
+        .payload(Blob::new(payload.unwrap_or("{}").as_bytes().to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    let payload_bytes = resp
+        .payload()
+        .map(|p| p.as_ref().to_vec())
+        .unwrap_or_default();
+    String::from_utf8(payload_bytes).unwrap()
+}
+
+// ---- Python runtime tests ----
+
+const PYTHON_HANDLER: &str = r#"
+def handler(event, context):
+    return {"statusCode": 200, "body": "hello from python"}
+"#;
+
+#[tokio::test]
+async fn test_invoke_python3_13() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("index.py", PYTHON_HANDLER.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "py313-func",
+        Runtime::Python313,
+        "index.handler",
+        zip,
+        None,
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["statusCode"], 200);
+    assert_eq!(body["body"], "hello from python");
+}
+
+#[tokio::test]
+async fn test_invoke_python3_12() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("index.py", PYTHON_HANDLER.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "py312-func",
+        Runtime::Python312,
+        "index.handler",
+        zip,
+        None,
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["statusCode"], 200);
+}
+
+#[tokio::test]
+async fn test_invoke_python3_11() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("index.py", PYTHON_HANDLER.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "py311-func",
+        Runtime::Python311,
+        "index.handler",
+        zip,
+        None,
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["statusCode"], 200);
+}
+
+// ---- Node.js runtime tests ----
+
+const NODEJS_HANDLER: &str = r#"
+exports.handler = async (event) => {
+    return { statusCode: 200, body: "hello from nodejs" };
+};
+"#;
+
+#[tokio::test]
+async fn test_invoke_nodejs22() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("index.js", NODEJS_HANDLER.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "node22-func",
+        Runtime::Nodejs22x,
+        "index.handler",
+        zip,
+        None,
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["statusCode"], 200);
+    assert_eq!(body["body"], "hello from nodejs");
+}
+
+#[tokio::test]
+async fn test_invoke_nodejs20() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("index.js", NODEJS_HANDLER.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "node20-func",
+        Runtime::Nodejs20x,
+        "index.handler",
+        zip,
+        None,
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["statusCode"], 200);
+}
+
+#[tokio::test]
+async fn test_invoke_nodejs18() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("index.js", NODEJS_HANDLER.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "node18-func",
+        Runtime::Nodejs18x,
+        "index.handler",
+        zip,
+        None,
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["statusCode"], 200);
+}
+
+// ---- Ruby runtime tests ----
+
+const RUBY_HANDLER: &str = r#"
+def handler(event:, context:)
+  { statusCode: 200, body: "hello from ruby" }
+end
+"#;
+
+#[tokio::test]
+async fn test_invoke_ruby3_4() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("index.rb", RUBY_HANDLER.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "ruby34-func",
+        Runtime::Ruby34,
+        "index.handler",
+        zip,
+        None,
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["statusCode"], 200);
+    assert_eq!(body["body"], "hello from ruby");
+}
+
+#[tokio::test]
+async fn test_invoke_ruby3_3() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("index.rb", RUBY_HANDLER.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "ruby33-func",
+        Runtime::Ruby33,
+        "index.handler",
+        zip,
+        None,
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["statusCode"], 200);
+}
+
+// ---- Custom runtime (provided) tests ----
+
+const PROVIDED_BOOTSTRAP: &str = r#"#!/bin/sh
+set -euo pipefail
+
+while true; do
+  # Get next invocation
+  HEADERS=$(mktemp)
+  EVENT_DATA=$(curl -sS -LD "$HEADERS" "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/next")
+
+  # Extract request ID from headers
+  REQUEST_ID=$(grep -Fi Lambda-Runtime-Aws-Request-Id "$HEADERS" | tr -d '[:space:]' | cut -d: -f2)
+
+  # Send response
+  RESPONSE='{"statusCode":200,"body":"hello from custom runtime"}'
+  curl -sS -X POST "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/$REQUEST_ID/response" -d "$RESPONSE"
+done
+"#;
+
+#[tokio::test]
+async fn test_invoke_provided_al2023() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("bootstrap", PROVIDED_BOOTSTRAP.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "provided-al2023-func",
+        Runtime::Providedal2023,
+        "bootstrap",
+        zip,
+        None,
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["statusCode"], 200);
+    assert_eq!(body["body"], "hello from custom runtime");
+}
+
+#[tokio::test]
+async fn test_invoke_provided_al2() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("bootstrap", PROVIDED_BOOTSTRAP.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "provided-al2-func",
+        Runtime::Providedal2,
+        "bootstrap",
+        zip,
+        None,
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["statusCode"], 200);
+}
+
+// ---- Java runtime tests ----
+// Java requires precompiled JARs. We test that the runtime mapping works
+// but use a minimal approach: create the function and verify Invoke attempts execution.
+
+#[tokio::test]
+async fn test_invoke_java21() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    // Create a minimal ZIP (not a valid JAR, so invocation will fail at the runtime level)
+    // This tests that container startup and image selection work for java21
+    let zip = make_zip(&[("dummy.class", b"not-a-real-class")]);
+
+    client
+        .create_function()
+        .function_name("java21-func")
+        .runtime(Runtime::Java21)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("dummy")
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    // Invoke will start a container but the handler will fail (invalid class)
+    // We just verify the container machinery works (no panic, returns an error or result)
+    let result = client
+        .invoke()
+        .function_name("java21-func")
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await;
+    // Either success (with error in payload) or service error - both are acceptable
+    // The point is that Docker execution was attempted
+    assert!(result.is_ok() || result.is_err());
+}
+
+#[tokio::test]
+async fn test_invoke_java17() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("dummy.class", b"not-a-real-class")]);
+
+    client
+        .create_function()
+        .function_name("java17-func")
+        .runtime(Runtime::Java17)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("dummy")
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .invoke()
+        .function_name("java17-func")
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await;
+    assert!(result.is_ok() || result.is_err());
+}
+
+// ---- .NET runtime test ----
+
+#[tokio::test]
+async fn test_invoke_dotnet8() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("dummy.dll", b"not-a-real-dll")]);
+
+    client
+        .create_function()
+        .function_name("dotnet8-func")
+        .runtime(Runtime::Dotnet8)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("dummy")
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .invoke()
+        .function_name("dotnet8-func")
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await;
+    assert!(result.is_ok() || result.is_err());
+}
+
+// ---- Behavior tests ----
+
+#[tokio::test]
+async fn test_invoke_warm_start() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("index.py", PYTHON_HANDLER.as_bytes())]);
+
+    client
+        .create_function()
+        .function_name("warm-func")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    // First invoke (cold start)
+    let resp1 = client
+        .invoke()
+        .function_name("warm-func")
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    // Second invoke (warm start — should reuse container)
+    let resp2 = client
+        .invoke()
+        .function_name("warm-func")
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    let body1: serde_json::Value =
+        serde_json::from_slice(resp1.payload().unwrap().as_ref()).unwrap();
+    let body2: serde_json::Value =
+        serde_json::from_slice(resp2.payload().unwrap().as_ref()).unwrap();
+    assert_eq!(body1["statusCode"], 200);
+    assert_eq!(body2["statusCode"], 200);
+}
+
+#[tokio::test]
+async fn test_invoke_with_payload() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    let handler = r#"
+def handler(event, context):
+    name = event.get("name", "world")
+    return {"greeting": f"hello {name}"}
+"#;
+    let zip = make_zip(&[("index.py", handler.as_bytes())]);
+
+    let result = create_and_invoke(
+        &client,
+        "payload-func",
+        Runtime::Python312,
+        "index.handler",
+        zip,
+        Some(r#"{"name": "fakecloud"}"#),
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(body["greeting"], "hello fakecloud");
+}
+
+#[tokio::test]
+async fn test_invoke_with_environment() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    let handler = r#"
+import os
+def handler(event, context):
+    return {"env_value": os.environ.get("MY_VAR", "not set")}
+"#;
+    let zip = make_zip(&[("index.py", handler.as_bytes())]);
+
+    client
+        .create_function()
+        .function_name("env-func")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .environment(
+            Environment::builder()
+                .variables("MY_VAR", "hello-from-env")
+                .build(),
+        )
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .invoke()
+        .function_name("env-func")
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    let body: serde_json::Value = serde_json::from_slice(resp.payload().unwrap().as_ref()).unwrap();
+    assert_eq!(body["env_value"], "hello-from-env");
+}
+
+#[tokio::test]
+async fn test_invoke_no_code() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    // Create function without ZipFile (empty Code)
+    client
+        .create_function()
+        .function_name("no-code-func")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(FunctionCode::builder().build())
+        .send()
+        .await
+        .unwrap();
+
+    // Invoke should return stub {}
+    let resp = client
+        .invoke()
+        .function_name("no-code-func")
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    let body = resp.payload().unwrap().as_ref().to_vec();
+    let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(result, serde_json::json!({}));
+}

--- a/crates/fakecloud-e2e/tests/lambda_invoke.rs
+++ b/crates/fakecloud-e2e/tests/lambda_invoke.rs
@@ -320,17 +320,16 @@ async fn test_invoke_java21() {
         .await
         .unwrap();
 
-    // Invoke will start a container but the handler will fail (invalid class)
-    // We just verify the container machinery works (no panic, returns an error or result)
-    let result = client
+    // Invoke will start a container but the handler will fail (invalid class).
+    // RIE returns 200 with the error in the payload body.
+    let resp = client
         .invoke()
         .function_name("java21-func")
         .payload(Blob::new(b"{}".to_vec()))
         .send()
-        .await;
-    // Either success (with error in payload) or service error - both are acceptable
-    // The point is that Docker execution was attempted
-    assert!(result.is_ok() || result.is_err());
+        .await
+        .unwrap();
+    assert_eq!(resp.status_code(), 200);
 }
 
 #[tokio::test]
@@ -350,13 +349,14 @@ async fn test_invoke_java17() {
         .await
         .unwrap();
 
-    let result = client
+    let resp = client
         .invoke()
         .function_name("java17-func")
         .payload(Blob::new(b"{}".to_vec()))
         .send()
-        .await;
-    assert!(result.is_ok() || result.is_err());
+        .await
+        .unwrap();
+    assert_eq!(resp.status_code(), 200);
 }
 
 // ---- .NET runtime test ----
@@ -378,13 +378,14 @@ async fn test_invoke_dotnet8() {
         .await
         .unwrap();
 
-    let result = client
+    let resp = client
         .invoke()
         .function_name("dotnet8-func")
         .payload(Blob::new(b"{}".to_vec()))
         .send()
-        .await;
-    assert!(result.is_ok() || result.is_err());
+        .await
+        .unwrap();
+    assert_eq!(resp.status_code(), 200);
 }
 
 // ---- Behavior tests ----

--- a/crates/fakecloud-lambda/Cargo.toml
+++ b/crates/fakecloud-lambda/Cargo.toml
@@ -20,7 +20,11 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+tracing = { workspace = true }
+zip = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
 bytes = { workspace = true }

--- a/crates/fakecloud-lambda/src/lib.rs
+++ b/crates/fakecloud-lambda/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod runtime;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-lambda/src/runtime.rs
+++ b/crates/fakecloud-lambda/src/runtime.rs
@@ -20,6 +20,8 @@ struct WarmContainer {
 pub struct ContainerRuntime {
     cli: String,
     containers: RwLock<HashMap<String, WarmContainer>>,
+    /// Serializes container startup per function to prevent duplicate containers.
+    starting: RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
     instance_id: String,
 }
 
@@ -48,7 +50,8 @@ impl ContainerRuntime {
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())
                 .status()
-                .is_ok()
+                .map(|s| s.success())
+                .unwrap_or(false)
             {
                 cli
             } else {
@@ -67,6 +70,7 @@ impl ContainerRuntime {
         Some(Self {
             cli,
             containers: RwLock::new(HashMap::new()),
+            starting: RwLock::new(HashMap::new()),
             instance_id,
         })
     }
@@ -104,14 +108,38 @@ impl ContainerRuntime {
         let port = match port {
             Some(p) => p,
             None => {
-                // Stop old container if code changed
-                self.stop_container(&func.function_name).await;
-                let container = self.start_container(func, zip_bytes).await?;
-                let p = container.host_port;
-                self.containers
-                    .write()
-                    .insert(func.function_name.clone(), container);
-                p
+                // Serialize container startup per function to prevent duplicates
+                let startup_lock = {
+                    let mut starting = self.starting.write();
+                    starting
+                        .entry(func.function_name.clone())
+                        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                        .clone()
+                };
+                let _guard = startup_lock.lock().await;
+
+                // Re-check after acquiring lock — another task may have started it
+                let existing_port = {
+                    let containers = self.containers.read();
+                    containers
+                        .get(&func.function_name)
+                        .filter(|c| c.code_sha256 == func.code_sha256)
+                        .map(|c| {
+                            *c.last_used.write() = Instant::now();
+                            c.host_port
+                        })
+                };
+                if let Some(p) = existing_port {
+                    p
+                } else {
+                    self.stop_container(&func.function_name).await;
+                    let container = self.start_container(func, zip_bytes).await?;
+                    let p = container.host_port;
+                    self.containers
+                        .write()
+                        .insert(func.function_name.clone(), container);
+                    p
+                }
             }
         };
 

--- a/crates/fakecloud-lambda/src/runtime.rs
+++ b/crates/fakecloud-lambda/src/runtime.rs
@@ -1,0 +1,495 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+use tempfile::TempDir;
+
+use crate::state::LambdaFunction;
+
+/// A running container kept warm for reuse.
+struct WarmContainer {
+    container_id: String,
+    host_port: u16,
+    last_used: RwLock<Instant>,
+    code_sha256: String,
+}
+
+/// Docker/Podman-based Lambda execution engine.
+pub struct ContainerRuntime {
+    cli: String,
+    containers: RwLock<HashMap<String, WarmContainer>>,
+    instance_id: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("no code ZIP provided for function {0}")]
+    NoCodeZip(String),
+    #[error("unsupported runtime: {0}")]
+    UnsupportedRuntime(String),
+    #[error("container failed to start: {0}")]
+    ContainerStartFailed(String),
+    #[error("invocation failed: {0}")]
+    InvocationFailed(String),
+    #[error("ZIP extraction failed: {0}")]
+    ZipExtractionFailed(String),
+}
+
+impl ContainerRuntime {
+    /// Auto-detect Docker or Podman. Returns `None` if neither is available.
+    /// Override with `FAKECLOUD_CONTAINER_CLI` env var.
+    pub fn new() -> Option<Self> {
+        let cli = if let Ok(cli) = std::env::var("FAKECLOUD_CONTAINER_CLI") {
+            // Verify the configured CLI works
+            if std::process::Command::new(&cli)
+                .arg("info")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .is_ok()
+            {
+                cli
+            } else {
+                return None;
+            }
+        } else if is_cli_available("docker") {
+            "docker".to_string()
+        } else if is_cli_available("podman") {
+            "podman".to_string()
+        } else {
+            return None;
+        };
+
+        let instance_id = format!("fakecloud-{}", std::process::id());
+
+        Some(Self {
+            cli,
+            containers: RwLock::new(HashMap::new()),
+            instance_id,
+        })
+    }
+
+    pub fn cli_name(&self) -> &str {
+        &self.cli
+    }
+
+    /// Invoke a Lambda function, starting a container if needed.
+    pub async fn invoke(
+        &self,
+        func: &LambdaFunction,
+        payload: &[u8],
+    ) -> Result<Vec<u8>, RuntimeError> {
+        let zip_bytes = func
+            .code_zip
+            .as_ref()
+            .ok_or_else(|| RuntimeError::NoCodeZip(func.function_name.clone()))?;
+
+        // Check for warm container with matching code
+        let port = {
+            let containers = self.containers.read();
+            if let Some(container) = containers.get(&func.function_name) {
+                if container.code_sha256 == func.code_sha256 {
+                    *container.last_used.write() = Instant::now();
+                    Some(container.host_port)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
+        let port = match port {
+            Some(p) => p,
+            None => {
+                // Stop old container if code changed
+                self.stop_container(&func.function_name).await;
+                let container = self.start_container(func, zip_bytes).await?;
+                let p = container.host_port;
+                self.containers
+                    .write()
+                    .insert(func.function_name.clone(), container);
+                p
+            }
+        };
+
+        // POST to the RIE endpoint
+        let url = format!(
+            "http://localhost:{}/2015-03-31/functions/function/invocations",
+            port
+        );
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(&url)
+            .body(payload.to_vec())
+            .timeout(Duration::from_secs(func.timeout as u64 + 5))
+            .send()
+            .await
+            .map_err(|e| RuntimeError::InvocationFailed(e.to_string()))?;
+
+        let body = resp
+            .bytes()
+            .await
+            .map_err(|e| RuntimeError::InvocationFailed(e.to_string()))?;
+
+        Ok(body.to_vec())
+    }
+
+    async fn start_container(
+        &self,
+        func: &LambdaFunction,
+        zip_bytes: &[u8],
+    ) -> Result<WarmContainer, RuntimeError> {
+        let image = runtime_to_image(&func.runtime)
+            .ok_or_else(|| RuntimeError::UnsupportedRuntime(func.runtime.clone()))?;
+
+        // Extract ZIP to a temp directory (only needed during container setup)
+        let code_dir =
+            TempDir::new().map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))?;
+        extract_zip(zip_bytes, code_dir.path())?;
+
+        // Step 1: docker create (no volume mounts — works in Docker-in-Docker)
+        let mut cmd = tokio::process::Command::new(&self.cli);
+        cmd.arg("create")
+            .arg("-p")
+            .arg("0:8080")
+            .arg("--label")
+            .arg(format!("fakecloud-lambda={}", func.function_name))
+            .arg("--label")
+            .arg(format!("fakecloud-instance={}", self.instance_id));
+
+        for (key, value) in &func.environment {
+            cmd.arg("-e").arg(format!("{}={}", key, value));
+        }
+
+        cmd.arg("-e")
+            .arg(format!("AWS_LAMBDA_FUNCTION_TIMEOUT={}", func.timeout));
+
+        cmd.arg(&image).arg(&func.handler);
+
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(RuntimeError::ContainerStartFailed(stderr.to_string()));
+        }
+
+        let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+        // Step 2: docker cp — copy code into the container
+        let cp_result = tokio::process::Command::new(&self.cli)
+            .arg("cp")
+            .arg(format!("{}/.", code_dir.path().display()))
+            .arg(format!("{}:/var/task", container_id))
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+
+        if !cp_result.status.success() {
+            let _ = self.remove_container(&container_id).await;
+            let stderr = String::from_utf8_lossy(&cp_result.stderr);
+            return Err(RuntimeError::ContainerStartFailed(format!(
+                "docker cp failed: {}",
+                stderr
+            )));
+        }
+
+        // For provided/custom runtimes, also copy to /var/runtime
+        if func.runtime.starts_with("provided") {
+            let cp_runtime = tokio::process::Command::new(&self.cli)
+                .arg("cp")
+                .arg(format!("{}/.", code_dir.path().display()))
+                .arg(format!("{}:/var/runtime", container_id))
+                .output()
+                .await
+                .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+
+            if !cp_runtime.status.success() {
+                let _ = self.remove_container(&container_id).await;
+                let stderr = String::from_utf8_lossy(&cp_runtime.stderr);
+                return Err(RuntimeError::ContainerStartFailed(format!(
+                    "docker cp to /var/runtime failed: {}",
+                    stderr
+                )));
+            }
+        }
+
+        // TempDir is dropped here — code now lives inside the container
+
+        // Step 3: docker start
+        let start_result = tokio::process::Command::new(&self.cli)
+            .args(["start", &container_id])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+
+        if !start_result.status.success() {
+            let _ = self.remove_container(&container_id).await;
+            let stderr = String::from_utf8_lossy(&start_result.stderr);
+            return Err(RuntimeError::ContainerStartFailed(format!(
+                "docker start failed: {}",
+                stderr
+            )));
+        }
+
+        // Query the actual assigned port
+        let port_output = tokio::process::Command::new(&self.cli)
+            .args(["port", &container_id, "8080"])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+
+        let port_str = String::from_utf8_lossy(&port_output.stdout);
+        let port: u16 = port_str
+            .trim()
+            .rsplit(':')
+            .next()
+            .and_then(|p| p.parse().ok())
+            .ok_or_else(|| {
+                RuntimeError::ContainerStartFailed(format!(
+                    "could not determine port from: {}",
+                    port_str.trim()
+                ))
+            })?;
+
+        // Wait for RIE to start accepting connections
+        let mut ready = false;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            if tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+                .await
+                .is_ok()
+            {
+                ready = true;
+                break;
+            }
+        }
+
+        if !ready {
+            let _ = self.remove_container(&container_id).await;
+            return Err(RuntimeError::ContainerStartFailed(
+                "container did not become ready within 10 seconds".to_string(),
+            ));
+        }
+
+        tracing::info!(
+            function = %func.function_name,
+            container_id = %container_id,
+            port = port,
+            runtime = %func.runtime,
+            "Lambda container started"
+        );
+
+        Ok(WarmContainer {
+            container_id,
+            host_port: port,
+            last_used: RwLock::new(Instant::now()),
+            code_sha256: func.code_sha256.clone(),
+        })
+    }
+
+    /// Remove a container (stop + rm, since we don't use --rm with docker create).
+    async fn remove_container(&self, container_id: &str) {
+        let _ = tokio::process::Command::new(&self.cli)
+            .args(["rm", "-f", container_id])
+            .output()
+            .await;
+    }
+
+    /// Stop and remove a container for a specific function.
+    pub async fn stop_container(&self, function_name: &str) {
+        let container = self.containers.write().remove(function_name);
+        if let Some(container) = container {
+            tracing::info!(
+                function = %function_name,
+                container_id = %container.container_id,
+                "stopping Lambda container"
+            );
+            self.remove_container(&container.container_id).await;
+        }
+    }
+
+    /// Stop and remove all containers (used on server shutdown or reset).
+    pub async fn stop_all(&self) {
+        let containers: Vec<(String, String)> = {
+            let mut map = self.containers.write();
+            map.drain()
+                .map(|(name, c)| (name, c.container_id))
+                .collect()
+        };
+        for (name, container_id) in containers {
+            tracing::info!(
+                function = %name,
+                container_id = %container_id,
+                "stopping Lambda container (cleanup)"
+            );
+            self.remove_container(&container_id).await;
+        }
+    }
+
+    /// Background loop that stops containers idle longer than `ttl`.
+    pub async fn run_cleanup_loop(self: Arc<Self>, ttl: Duration) {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        loop {
+            interval.tick().await;
+            self.cleanup_idle(ttl).await;
+        }
+    }
+
+    async fn cleanup_idle(&self, ttl: Duration) {
+        let expired: Vec<String> = {
+            let containers = self.containers.read();
+            containers
+                .iter()
+                .filter(|(_, c)| c.last_used.read().elapsed() > ttl)
+                .map(|(name, _)| name.clone())
+                .collect()
+        };
+        for name in expired {
+            tracing::info!(function = %name, "stopping idle Lambda container");
+            self.stop_container(&name).await;
+        }
+    }
+}
+
+/// Map AWS runtime identifier to a Docker image tag.
+pub fn runtime_to_image(runtime: &str) -> Option<String> {
+    let (base, tag) = match runtime {
+        "python3.13" => ("python", "3.13"),
+        "python3.12" => ("python", "3.12"),
+        "python3.11" => ("python", "3.11"),
+        "nodejs22.x" => ("nodejs", "22"),
+        "nodejs20.x" => ("nodejs", "20"),
+        "nodejs18.x" => ("nodejs", "18"),
+        "ruby3.4" => ("ruby", "3.4"),
+        "ruby3.3" => ("ruby", "3.3"),
+        "java21" => ("java", "21"),
+        "java17" => ("java", "17"),
+        "dotnet8" => ("dotnet", "8"),
+        "provided.al2023" => ("provided", "al2023"),
+        "provided.al2" => ("provided", "al2"),
+        _ => return None,
+    };
+    Some(format!("public.ecr.aws/lambda/{}:{}", base, tag))
+}
+
+/// Extract a ZIP archive to a destination directory.
+pub fn extract_zip(zip_bytes: &[u8], dest: &Path) -> Result<(), RuntimeError> {
+    let cursor = std::io::Cursor::new(zip_bytes);
+    let mut archive = zip::ZipArchive::new(cursor)
+        .map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))?;
+
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))?;
+
+        let out_path = dest.join(file.enclosed_name().ok_or_else(|| {
+            RuntimeError::ZipExtractionFailed("invalid file name in ZIP".to_string())
+        })?);
+
+        if file.is_dir() {
+            std::fs::create_dir_all(&out_path)
+                .map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))?;
+        } else {
+            if let Some(parent) = out_path.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))?;
+            }
+            let mut out_file = std::fs::File::create(&out_path)
+                .map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))?;
+            std::io::copy(&mut file, &mut out_file)
+                .map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))?;
+
+            // Preserve executable permissions
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Some(mode) = file.unix_mode() {
+                    std::fs::set_permissions(&out_path, std::fs::Permissions::from_mode(mode))
+                        .map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_cli_available(name: &str) -> bool {
+    std::process::Command::new(name)
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+
+    use super::*;
+
+    #[test]
+    fn test_runtime_to_image() {
+        assert_eq!(
+            runtime_to_image("python3.12"),
+            Some("public.ecr.aws/lambda/python:3.12".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("nodejs20.x"),
+            Some("public.ecr.aws/lambda/nodejs:20".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("provided.al2023"),
+            Some("public.ecr.aws/lambda/provided:al2023".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("ruby3.4"),
+            Some("public.ecr.aws/lambda/ruby:3.4".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("java21"),
+            Some("public.ecr.aws/lambda/java:21".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("dotnet8"),
+            Some("public.ecr.aws/lambda/dotnet:8".to_string())
+        );
+        assert_eq!(runtime_to_image("unknown"), None);
+    }
+
+    #[test]
+    fn test_extract_zip() {
+        // Create a minimal ZIP in memory
+        let buf = Vec::new();
+        let cursor = std::io::Cursor::new(buf);
+        let mut writer = zip::ZipWriter::new(cursor);
+        let options = zip::write::SimpleFileOptions::default();
+        writer.start_file("handler.py", options).unwrap();
+        writer
+            .write_all(b"def handler(event, context):\n    return {'statusCode': 200}\n")
+            .unwrap();
+        let cursor = writer.finish().unwrap();
+        let zip_bytes = cursor.into_inner();
+
+        let dir = TempDir::new().unwrap();
+        extract_zip(&zip_bytes, dir.path()).unwrap();
+
+        let handler_path = dir.path().join("handler.py");
+        assert!(handler_path.exists());
+
+        let mut content = String::new();
+        std::fs::File::open(&handler_path)
+            .unwrap()
+            .read_to_string(&mut content)
+            .unwrap();
+        assert!(content.contains("def handler"));
+    }
+}

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -296,44 +296,40 @@ impl LambdaService {
             })?
         };
 
-        // Try Docker execution if runtime is available and function has code
-        if let Some(ref runtime) = self.runtime {
-            if func.code_zip.is_some() {
-                match runtime.invoke(&func, payload).await {
-                    Ok(response_bytes) => {
-                        let mut resp = AwsResponse::json(StatusCode::OK, response_bytes);
-                        resp.headers.insert(
-                            http::header::HeaderName::from_static("x-amz-executed-version"),
-                            http::header::HeaderValue::from_static("$LATEST"),
-                        );
-                        return Ok(resp);
-                    }
-                    Err(e) => {
-                        tracing::error!(function = %function_name, error = %e, "Lambda invocation failed");
-                        return Err(AwsServiceError::aws_error(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "ServiceException",
-                            format!("Lambda execution failed: {e}"),
-                        ));
-                    }
-                }
-            }
-        } else if func.code_zip.is_some() {
-            // Function has code but no container runtime available
-            return Err(AwsServiceError::aws_error(
+        let runtime = self.runtime.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "ServiceException",
                 "Docker/Podman is required for Lambda execution but is not available",
+            )
+        })?;
+
+        if func.code_zip.is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValueException",
+                "Function has no deployment package",
             ));
         }
 
-        // No code ZIP — return empty response
-        let mut resp = AwsResponse::json(StatusCode::OK, "{}");
-        resp.headers.insert(
-            http::header::HeaderName::from_static("x-amz-executed-version"),
-            http::header::HeaderValue::from_static("$LATEST"),
-        );
-        Ok(resp)
+        match runtime.invoke(&func, payload).await {
+            Ok(response_bytes) => {
+                let mut resp = AwsResponse::json(StatusCode::OK, response_bytes);
+                resp.headers.insert(
+                    http::header::HeaderName::from_static("x-amz-executed-version"),
+                    http::header::HeaderValue::from_static("$LATEST"),
+                );
+                Ok(resp)
+            }
+            Err(e) => {
+                tracing::error!(function = %function_name, error = %e, "Lambda invocation failed");
+                Err(AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "ServiceException",
+                    format!("Lambda execution failed: {e}"),
+                ))
+            }
+        }
     }
 
     fn publish_version(&self, function_name: &str) -> Result<AwsResponse, AwsServiceError> {
@@ -673,7 +669,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_invoke() {
+    async fn test_invoke_without_runtime_returns_error() {
         let state = make_state();
         let svc = LambdaService::new(state);
 
@@ -697,8 +693,22 @@ mod tests {
             "/2015-03-31/functions/invoke-me/invocations",
             r#"{"key": "value"}"#,
         );
-        let resp = svc.handle(req).await.unwrap();
-        assert_eq!(resp.status, StatusCode::OK);
+        let resp = svc.handle(req).await;
+        assert!(resp.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_invoke_nonexistent_function() {
+        let state = make_state();
+        let svc = LambdaService::new(state);
+
+        let req = make_request(
+            Method::POST,
+            "/2015-03-31/functions/does-not-exist/invocations",
+            "{}",
+        );
+        let resp = svc.handle(req).await;
+        assert!(resp.is_err());
     }
 
     #[tokio::test]

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::Utc;
 use http::{Method, StatusCode};
@@ -6,15 +8,25 @@ use sha2::{Digest, Sha256};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
+use crate::runtime::ContainerRuntime;
 use crate::state::{EventSourceMapping, LambdaFunction, SharedLambdaState};
 
 pub struct LambdaService {
     state: SharedLambdaState,
+    runtime: Option<Arc<ContainerRuntime>>,
 }
 
 impl LambdaService {
     pub fn new(state: SharedLambdaState) -> Self {
-        Self { state }
+        Self {
+            state,
+            runtime: None,
+        }
+    }
+
+    pub fn with_runtime(mut self, runtime: Arc<ContainerRuntime>) -> Self {
+        self.runtime = Some(runtime);
+        self
     }
 
     /// Determine the action from the HTTP method and path segments.
@@ -139,13 +151,19 @@ impl LambdaService {
             })
             .unwrap_or_else(|| vec!["x86_64".to_string()]);
 
-        // Compute a code hash from the code body (or use a deterministic placeholder)
-        let code_body = serde_json::to_vec(&body["Code"]).unwrap_or_default();
+        // Decode Code.ZipFile if present (base64-encoded ZIP)
+        let code_zip: Option<Vec<u8>> = body["Code"]["ZipFile"].as_str().and_then(|b64| {
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, b64).ok()
+        });
+
+        // Compute a code hash from the actual ZIP bytes (or from the Code JSON as fallback)
+        let code_fallback = serde_json::to_vec(&body["Code"]).unwrap_or_default();
+        let code_bytes = code_zip.as_deref().unwrap_or(&code_fallback);
         let mut hasher = Sha256::new();
-        hasher.update(&code_body);
+        hasher.update(code_bytes);
         let hash = hasher.finalize();
         let code_sha256 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, hash);
-        let code_size = code_body.len() as i64;
+        let code_size = code_bytes.len() as i64;
 
         let function_arn = format!(
             "arn:aws:lambda:{}:{}:function:{}",
@@ -170,6 +188,7 @@ impl LambdaService {
             environment: environment.clone(),
             architectures: architectures.clone(),
             package_type: package_type.clone(),
+            code_zip,
         };
 
         let response = self.function_config_json(&func);
@@ -222,6 +241,13 @@ impl LambdaService {
             ));
         }
 
+        // Clean up any running container for this function
+        if let Some(ref runtime) = self.runtime {
+            let rt = runtime.clone();
+            let name = function_name.to_string();
+            tokio::spawn(async move { rt.stop_container(&name).await });
+        }
+
         Ok(AwsResponse::json(StatusCode::NO_CONTENT, ""))
     }
 
@@ -240,22 +266,60 @@ impl LambdaService {
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
     }
 
-    fn invoke(&self, function_name: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
-        if !state.functions.contains_key(function_name) {
-            let region = state.region.clone();
-            let account_id = state.account_id.clone();
+    async fn invoke(
+        &self,
+        function_name: &str,
+        payload: &[u8],
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let func = {
+            let state = self.state.read();
+            state.functions.get(function_name).cloned().ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFoundException",
+                    format!(
+                        "Function not found: arn:aws:lambda:{}:{}:function:{}",
+                        state.region, state.account_id, function_name
+                    ),
+                )
+            })?
+        };
+
+        // Try Docker execution if runtime is available and function has code
+        if let Some(ref runtime) = self.runtime {
+            if func.code_zip.is_some() {
+                match runtime.invoke(&func, payload).await {
+                    Ok(response_bytes) => {
+                        let mut resp = AwsResponse::json(
+                            StatusCode::OK,
+                            String::from_utf8_lossy(&response_bytes).to_string(),
+                        );
+                        resp.headers.insert(
+                            http::header::HeaderName::from_static("x-amz-executed-version"),
+                            http::header::HeaderValue::from_static("$LATEST"),
+                        );
+                        return Ok(resp);
+                    }
+                    Err(e) => {
+                        tracing::error!(function = %function_name, error = %e, "Lambda invocation failed");
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "ServiceException",
+                            format!("Lambda execution failed: {e}"),
+                        ));
+                    }
+                }
+            }
+        } else if func.code_zip.is_some() {
+            // Function has code but no container runtime available
             return Err(AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "ResourceNotFoundException",
-                format!(
-                    "Function not found: arn:aws:lambda:{}:{}:function:{}",
-                    region, account_id, function_name
-                ),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "ServiceException",
+                "Docker/Podman is required for Lambda execution but is not available",
             ));
         }
 
-        // Canned success response - Lambda stub doesn't execute code
+        // No code ZIP — return stub response
         let mut resp = AwsResponse::json(StatusCode::OK, "{}");
         resp.headers.insert(
             http::header::HeaderName::from_static("x-amz-executed-version"),
@@ -467,7 +531,10 @@ impl AwsService for LambdaService {
             "ListFunctions" => self.list_functions(),
             "GetFunction" => self.get_function(resource_name.as_deref().unwrap_or("")),
             "DeleteFunction" => self.delete_function(resource_name.as_deref().unwrap_or("")),
-            "Invoke" => self.invoke(resource_name.as_deref().unwrap_or("")),
+            "Invoke" => {
+                self.invoke(resource_name.as_deref().unwrap_or(""), &req.body)
+                    .await
+            }
             "PublishVersion" => self.publish_version(resource_name.as_deref().unwrap_or("")),
             "CreateEventSourceMapping" => self.create_event_source_mapping(&req),
             "ListEventSourceMappings" => self.list_event_source_mappings(),

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -327,7 +327,7 @@ impl LambdaService {
             ));
         }
 
-        // No code ZIP — return stub response
+        // No code ZIP — return empty response
         let mut resp = AwsResponse::json(StatusCode::OK, "{}");
         resp.headers.insert(
             http::header::HeaderName::from_static("x-amz-executed-version"),

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -152,9 +152,20 @@ impl LambdaService {
             .unwrap_or_else(|| vec!["x86_64".to_string()]);
 
         // Decode Code.ZipFile if present (base64-encoded ZIP)
-        let code_zip: Option<Vec<u8>> = body["Code"]["ZipFile"].as_str().and_then(|b64| {
-            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, b64).ok()
-        });
+        let code_zip: Option<Vec<u8>> = match body["Code"]["ZipFile"].as_str() {
+            Some(b64) => Some(
+                base64::Engine::decode(&base64::engine::general_purpose::STANDARD, b64).map_err(
+                    |_| {
+                        AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidParameterValueException",
+                            "Could not decode Code.ZipFile: invalid base64",
+                        )
+                    },
+                )?,
+            ),
+            None => None,
+        };
 
         // Compute a code hash from the actual ZIP bytes (or from the Code JSON as fallback)
         let code_fallback = serde_json::to_vec(&body["Code"]).unwrap_or_default();
@@ -290,10 +301,7 @@ impl LambdaService {
             if func.code_zip.is_some() {
                 match runtime.invoke(&func, payload).await {
                     Ok(response_bytes) => {
-                        let mut resp = AwsResponse::json(
-                            StatusCode::OK,
-                            String::from_utf8_lossy(&response_bytes).to_string(),
-                        );
+                        let mut resp = AwsResponse::json(StatusCode::OK, response_bytes);
                         resp.headers.insert(
                             http::header::HeaderName::from_static("x-amz-executed-version"),
                             http::header::HeaderValue::from_static("$LATEST"),

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -21,6 +21,7 @@ pub struct LambdaFunction {
     pub environment: HashMap<String, String>,
     pub architectures: Vec<String>,
     pub package_type: String,
+    pub code_zip: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -84,6 +84,18 @@ async fn main() {
     let lambda_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_lambda::state::LambdaState::new(&cli.account_id, &cli.region),
     ));
+
+    // Auto-detect Docker/Podman for Lambda execution
+    let container_runtime = fakecloud_lambda::runtime::ContainerRuntime::new().map(Arc::new);
+    if let Some(ref rt) = container_runtime {
+        tracing::info!(
+            cli = rt.cli_name(),
+            "Lambda execution enabled via container runtime"
+        );
+    } else {
+        tracing::info!("Docker/Podman not available — Lambda Invoke will return errors for functions with code");
+    }
+
     let secretsmanager_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_secretsmanager::state::SecretsManagerState::new(&cli.account_id, &cli.region),
     ));
@@ -146,6 +158,7 @@ async fn main() {
         logs: logs_state.clone(),
         kms: kms_state.clone(),
         cloudformation: cloudformation_state.clone(),
+        container_runtime: container_runtime.clone(),
     };
 
     // Register services
@@ -182,7 +195,11 @@ async fn main() {
     registry.register(Arc::new(
         DynamoDbService::new(dynamodb_state).with_s3(s3_state.clone()),
     ));
-    registry.register(Arc::new(LambdaService::new(lambda_state.clone())));
+    let mut lambda_service = LambdaService::new(lambda_state.clone());
+    if let Some(ref rt) = container_runtime {
+        lambda_service = lambda_service.with_runtime(rt.clone());
+    }
+    registry.register(Arc::new(lambda_service));
     registry.register(Arc::new(SecretsManagerService::new(secretsmanager_state)));
     registry.register(Arc::new(LogsService::new(logs_state, delivery_for_logs)));
     registry.register(Arc::new(KmsService::new(kms_state.clone())));
@@ -196,6 +213,11 @@ async fn main() {
 
     let sqs_lambda_poller = SqsLambdaPoller::new(sqs_state, lambda_state);
     tokio::spawn(sqs_lambda_poller.run());
+
+    if let Some(ref rt) = container_runtime {
+        let rt = rt.clone();
+        tokio::spawn(rt.run_cleanup_loop(std::time::Duration::from_secs(300)));
+    }
 
     let services: Vec<&str> = registry.service_names();
     tracing::info!(services = ?services, "registered services");
@@ -266,6 +288,11 @@ async fn main() {
         .with_graceful_shutdown(shutdown_signal())
         .await
         .unwrap();
+
+    // Clean up Lambda containers on shutdown
+    if let Some(rt) = container_runtime {
+        rt.stop_all().await;
+    }
 }
 
 #[derive(Clone)]
@@ -282,6 +309,7 @@ struct ResetState {
     logs: fakecloud_logs::state::SharedLogsState,
     kms: fakecloud_kms::state::SharedKmsState,
     cloudformation: fakecloud_cloudformation::state::SharedCloudFormationState,
+    container_runtime: Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
 }
 
 impl ResetState {
@@ -310,6 +338,11 @@ impl ResetState {
         self.ssm.write().reset();
         self.dynamodb.write().reset();
         self.lambda.write().reset();
+        // Stop all Lambda containers on reset
+        if let Some(ref rt) = self.container_runtime {
+            let rt = rt.clone();
+            tokio::spawn(async move { rt.stop_all().await });
+        }
         self.secretsmanager.write().reset();
         self.s3.write().reset();
         self.logs.write().reset();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "4566:4566"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       FAKECLOUD_ADDR: "0.0.0.0:4566"
       FAKECLOUD_REGION: "us-east-1"

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     image: faiscadev/fakecloud
     ports:
       - "4566:4566"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock  # enables Lambda Invoke
     environment:
       FAKECLOUD_LOG: info
     healthcheck:


### PR DESCRIPTION
## Summary
- Lambda Invoke now executes real function code via Docker containers using official AWS Lambda base images with RIE
- Supports 13 runtimes: Python 3.11–3.13, Node.js 18–22, Ruby 3.3–3.4, Java 17/21, .NET 8, provided.al2/al2023
- Docker-in-Docker compatible — uses `docker create` + `docker cp` instead of bind mounts, zero configuration needed
- Docker/Podman auto-detected at startup; all other Lambda operations work without it (Invoke returns 500)
- Warm container reuse for fast repeated invocations, per-instance labels for safe parallel test execution
- 17 new E2E tests covering every runtime + warm start, payload, env vars, no-code, and cleanup behavior

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` (unit tests) passes
- [x] `cargo test -p fakecloud-e2e --test lambda_invoke` — 17/17 passing
- [x] Zero leftover containers after test runs
- [x] Existing E2E and conformance tests unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lambda Invoke now runs real function code in containers using AWS Lambda base images with the Runtime Interface Emulator. It requires Docker/Podman and a deployment package; no more stub responses.

- **New Features**
  - Real code execution for Invoke via Docker/Podman; returns raw bytes from the handler.
  - Supported runtimes: Python 3.11–3.13, Node.js 18–22, Ruby 3.3–3.4, Java 17/21, .NET 8, provided.al2/al2023.
  - Docker-in-Docker friendly (uses create + cp; no bind mounts).
  - Warm container reuse keyed by code hash; per-function serialized startup; idle/delete/reset/shutdown cleanup with per-instance labels.
  - Auto-detects and verifies Docker/Podman (optional `FAKECLOUD_CONTAINER_CLI`).
  - Stores `Code.ZipFile` bytes and computes `CodeSha256` from real bytes; rejects invalid base64 with `InvalidParameterValueException`.

- **Migration**
  - Mount the Docker socket to enable Invoke:
    - docker run: `-v /var/run/docker.sock:/var/run/docker.sock`
    - compose: add `- /var/run/docker.sock:/var/run/docker.sock`
  - Optional: set `FAKECLOUD_CONTAINER_CLI=docker` or `podman`.
  - Error behavior:
    - Without Docker/Podman, Invoke returns 500 `ServiceException`.
    - Invoking a function without code returns 400 `InvalidParameterValueException`.

<sup>Written for commit 03e0eda0777c7430d16aa4dd9b513ef96e2443a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

