### PR TITLE
feat(logs): implement CloudWatch Logs transformer processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
  "flate2",
  "http 1.4.0",
  "parking_lot",
+ "regex",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ crc32fast = "1"
 reqwest = { version = "0.12", features = ["json"] }
 zip = "2"
 tempfile = "3"
+regex = "1"
 
 # Internal crates
 fakecloud-core = { path = "crates/fakecloud-core", version = "0.3.0" }

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -718,6 +718,189 @@ async fn logs_transformer_lifecycle() {
 }
 
 #[tokio::test]
+async fn logs_transformer_applies_processors() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    // Create log group and stream
+    client
+        .create_log_group()
+        .log_group_name("/tx/processors")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_log_stream()
+        .log_group_name("/tx/processors")
+        .log_stream_name("stream1")
+        .send()
+        .await
+        .unwrap();
+
+    // Put a transformer with addKeys + deleteKeys + renameKeys
+    client
+        .put_transformer()
+        .log_group_identifier("/tx/processors")
+        .transformer_config(
+            aws_sdk_cloudwatchlogs::types::Processor::builder()
+                .add_keys(
+                    aws_sdk_cloudwatchlogs::types::AddKeys::builder()
+                        .entries(
+                            aws_sdk_cloudwatchlogs::types::AddKeyEntry::builder()
+                                .key("env")
+                                .value("staging")
+                                .build()
+                                .unwrap(),
+                        )
+                        .entries(
+                            aws_sdk_cloudwatchlogs::types::AddKeyEntry::builder()
+                                .key("tmp")
+                                .value("remove_me")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .transformer_config(
+            aws_sdk_cloudwatchlogs::types::Processor::builder()
+                .delete_keys(
+                    aws_sdk_cloudwatchlogs::types::DeleteKeys::builder()
+                        .with_keys("tmp")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .transformer_config(
+            aws_sdk_cloudwatchlogs::types::Processor::builder()
+                .rename_keys(
+                    aws_sdk_cloudwatchlogs::types::RenameKeys::builder()
+                        .entries(
+                            aws_sdk_cloudwatchlogs::types::RenameKeyEntry::builder()
+                                .key("message")
+                                .rename_to("original_message")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Test transformer via TestTransformer
+    let test_resp = client
+        .test_transformer()
+        .transformer_config(
+            aws_sdk_cloudwatchlogs::types::Processor::builder()
+                .add_keys(
+                    aws_sdk_cloudwatchlogs::types::AddKeys::builder()
+                        .entries(
+                            aws_sdk_cloudwatchlogs::types::AddKeyEntry::builder()
+                                .key("env")
+                                .value("staging")
+                                .build()
+                                .unwrap(),
+                        )
+                        .entries(
+                            aws_sdk_cloudwatchlogs::types::AddKeyEntry::builder()
+                                .key("tmp")
+                                .value("remove_me")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .transformer_config(
+            aws_sdk_cloudwatchlogs::types::Processor::builder()
+                .delete_keys(
+                    aws_sdk_cloudwatchlogs::types::DeleteKeys::builder()
+                        .with_keys("tmp")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .transformer_config(
+            aws_sdk_cloudwatchlogs::types::Processor::builder()
+                .rename_keys(
+                    aws_sdk_cloudwatchlogs::types::RenameKeys::builder()
+                        .entries(
+                            aws_sdk_cloudwatchlogs::types::RenameKeyEntry::builder()
+                                .key("message")
+                                .rename_to("original_message")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .log_event_messages("hello world")
+        .send()
+        .await
+        .unwrap();
+
+    let transformed_logs = test_resp.transformed_logs();
+    assert_eq!(transformed_logs.len(), 1);
+
+    let record = &transformed_logs[0];
+    assert_eq!(record.event_message(), Some("hello world"));
+    let transformed_str = record.transformed_event_message().unwrap();
+    let transformed: Value = serde_json::from_str(transformed_str).unwrap();
+    assert_eq!(transformed["env"], "staging");
+    assert!(transformed.get("tmp").is_none());
+    assert!(transformed.get("message").is_none());
+    assert_eq!(transformed["original_message"], "hello world");
+
+    // Push events via PutLogEvents — transformer should be applied before storage
+    let now = chrono::Utc::now().timestamp_millis();
+    client
+        .put_log_events()
+        .log_group_name("/tx/processors")
+        .log_stream_name("stream1")
+        .log_events(
+            InputLogEvent::builder()
+                .message("test event")
+                .timestamp(now)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Retrieve events and verify transformation was applied
+    let events_resp = client
+        .get_log_events()
+        .log_group_name("/tx/processors")
+        .log_stream_name("stream1")
+        .send()
+        .await
+        .unwrap();
+
+    let events = events_resp.events();
+    assert_eq!(events.len(), 1);
+    let stored_message = events[0].message().unwrap();
+    let stored: Value = serde_json::from_str(stored_message).unwrap();
+    assert_eq!(stored["env"], "staging");
+    assert!(stored.get("tmp").is_none());
+    assert!(stored.get("message").is_none());
+    assert_eq!(stored["original_message"], "test event");
+}
+
+#[tokio::test]
 async fn logs_anomaly_detector_lifecycle() {
     let server = TestServer::start().await;
     let client = server.logs_client().await;

--- a/crates/fakecloud-logs/Cargo.toml
+++ b/crates/fakecloud-logs/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
 flate2 = { workspace = true }
+regex = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/fakecloud-logs/src/lib.rs
+++ b/crates/fakecloud-logs/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod query;
 pub mod service;
 pub mod state;
+pub mod transformer;

--- a/crates/fakecloud-logs/src/service.rs
+++ b/crates/fakecloud-logs/src/service.rs
@@ -21,6 +21,7 @@ use crate::state::{
     LogGroup, LogStream, LookupTable, MetricFilter, MetricTransformation, QueryDefinition,
     QueryInfo, ResourcePolicy, ScheduledQuery, SharedLogsState, SubscriptionFilter, Transformer,
 };
+use crate::transformer;
 
 pub struct LogsService {
     state: SharedLogsState,
@@ -871,6 +872,15 @@ impl LogsService {
                 format!("The specified log group does not exist: {group_name}"),
             )
         })?;
+
+        // Apply transformer if configured on the log group
+        if let Some(ref tx) = group.transformer {
+            for event in &mut new_events {
+                let transformed =
+                    transformer::apply_transformer(&tx.transformer_config, &event.message);
+                event.message = serde_json::to_string(&transformed).unwrap();
+            }
+        }
 
         let stream = group.log_streams.get_mut(stream_name).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -4465,7 +4475,7 @@ impl LogsService {
 
     fn test_transformer(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = body_json(req);
-        let _transformer_config = body.get("transformerConfig").ok_or_else(|| {
+        let transformer_config = body.get("transformerConfig").ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameterException",
@@ -4480,13 +4490,15 @@ impl LogsService {
             )
         })?;
 
-        // Stub: return the input events as transformed output unchanged
         let transformed: Vec<Value> = log_event_messages
             .iter()
             .map(|msg| {
+                let message = msg.as_str().unwrap_or("");
+                let transformed_event = transformer::apply_transformer(transformer_config, message);
+                let transformed_str = serde_json::to_string(&transformed_event).unwrap();
                 json!({
                     "eventMessage": msg,
-                    "transformedEventMessage": msg,
+                    "transformedEventMessage": transformed_str,
                 })
             })
             .collect();

--- a/crates/fakecloud-logs/src/transformer.rs
+++ b/crates/fakecloud-logs/src/transformer.rs
@@ -1,0 +1,668 @@
+use serde_json::{json, Map, Value};
+
+/// Apply a transformer config (JSON array of processor objects) to a log event message.
+/// The message is initially wrapped as `{"message": "<original>"}`, then each processor
+/// is applied in sequence.
+pub fn apply_transformer(config: &Value, message: &str) -> Value {
+    let mut event = json!({ "message": message });
+
+    let processors = match config.as_array() {
+        Some(arr) => arr,
+        None => return event,
+    };
+
+    for processor in processors {
+        let obj = match processor.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+        // Each processor object has exactly one key indicating the type
+        for (proc_type, proc_config) in obj {
+            apply_processor(proc_type, proc_config, &mut event);
+        }
+    }
+
+    event
+}
+
+fn apply_processor(proc_type: &str, config: &Value, event: &mut Value) {
+    match proc_type {
+        "parseJSON" => apply_parse_json(config, event),
+        "addKeys" => apply_add_keys(config, event),
+        "deleteKeys" => apply_delete_keys(config, event),
+        "renameKeys" => apply_rename_keys(config, event),
+        "moveKeys" => apply_move_keys(config, event),
+        "copyValue" => apply_copy_value(config, event),
+        "lowerCaseString" => apply_lower_case_string(config, event),
+        "upperCaseString" => apply_upper_case_string(config, event),
+        "trimString" => apply_trim_string(config, event),
+        "splitString" => apply_split_string(config, event),
+        "substituteString" => apply_substitute_string(config, event),
+        "typeConverter" => apply_type_converter(config, event),
+        "csv" => apply_csv(config, event),
+        "parseKeyValue" => apply_parse_key_value(config, event),
+        "dateTimeConverter" => apply_date_time_converter(config, event),
+        _ => {} // Unknown processor, skip
+    }
+}
+
+// --- Helpers for nested key access (dot-separated paths) ---
+
+fn get_nested<'a>(event: &'a Value, key: &str) -> Option<&'a Value> {
+    let parts: Vec<&str> = key.split('.').collect();
+    let mut current = event;
+    for part in parts {
+        current = current.get(part)?;
+    }
+    Some(current)
+}
+
+fn set_nested(event: &mut Value, key: &str, value: Value) {
+    let parts: Vec<&str> = key.split('.').collect();
+    if parts.is_empty() {
+        return;
+    }
+    let mut current = event;
+    for part in &parts[..parts.len() - 1] {
+        if !current.get(*part).is_some_and(|v| v.is_object()) {
+            current[*part] = json!({});
+        }
+        current = current.get_mut(*part).unwrap();
+    }
+    current[*parts.last().unwrap()] = value;
+}
+
+fn remove_nested(event: &mut Value, key: &str) -> Option<Value> {
+    let parts: Vec<&str> = key.split('.').collect();
+    if parts.is_empty() {
+        return None;
+    }
+    if parts.len() == 1 {
+        return event.as_object_mut().and_then(|m| m.remove(parts[0]));
+    }
+    let mut current = event;
+    for part in &parts[..parts.len() - 1] {
+        current = current.get_mut(*part)?;
+    }
+    current
+        .as_object_mut()
+        .and_then(|m| m.remove(*parts.last().unwrap()))
+}
+
+// --- Processor implementations ---
+
+fn apply_parse_json(config: &Value, event: &mut Value) {
+    let source = config["source"].as_str().unwrap_or("message");
+    let destination = config["destination"].as_str();
+
+    let raw = match get_nested(event, source).and_then(|v| v.as_str()) {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+
+    let parsed: Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    if let Some(dest) = destination {
+        set_nested(event, dest, parsed);
+    } else {
+        // Merge parsed fields into event root
+        if let Value::Object(map) = parsed {
+            if let Value::Object(ref mut ev) = event {
+                for (k, v) in map {
+                    ev.insert(k, v);
+                }
+            }
+        }
+    }
+}
+
+fn apply_add_keys(config: &Value, event: &mut Value) {
+    let entries = match config["entries"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for entry in entries {
+        if let (Some(key), Some(value)) = (entry["key"].as_str(), entry.get("value")) {
+            let val = match value {
+                Value::String(s) => Value::String(s.clone()),
+                other => other.clone(),
+            };
+            set_nested(event, key, val);
+        }
+    }
+}
+
+fn apply_delete_keys(config: &Value, event: &mut Value) {
+    let keys = match config["withKeys"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for key in keys {
+        if let Some(k) = key.as_str() {
+            remove_nested(event, k);
+        }
+    }
+}
+
+fn apply_rename_keys(config: &Value, event: &mut Value) {
+    let entries = match config["entries"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for entry in entries {
+        if let (Some(old_key), Some(new_key)) = (entry["key"].as_str(), entry["renameTo"].as_str())
+        {
+            if let Some(val) = remove_nested(event, old_key) {
+                set_nested(event, new_key, val);
+            }
+        }
+    }
+}
+
+fn apply_move_keys(config: &Value, event: &mut Value) {
+    let entries = match config["entries"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for entry in entries {
+        if let (Some(source), Some(target)) = (entry["source"].as_str(), entry["target"].as_str()) {
+            if let Some(val) = remove_nested(event, source) {
+                set_nested(event, target, val);
+            }
+        }
+    }
+}
+
+fn apply_copy_value(config: &Value, event: &mut Value) {
+    let entries = match config["entries"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for entry in entries {
+        if let (Some(source), Some(target)) = (entry["source"].as_str(), entry["target"].as_str()) {
+            if let Some(val) = get_nested(event, source).cloned() {
+                set_nested(event, target, val);
+            }
+        }
+    }
+}
+
+fn apply_lower_case_string(config: &Value, event: &mut Value) {
+    let keys = match config["withKeys"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for key in keys {
+        if let Some(k) = key.as_str() {
+            if let Some(val) = get_nested(event, k).and_then(|v| v.as_str()) {
+                set_nested(event, k, Value::String(val.to_lowercase()));
+            }
+        }
+    }
+}
+
+fn apply_upper_case_string(config: &Value, event: &mut Value) {
+    let keys = match config["withKeys"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for key in keys {
+        if let Some(k) = key.as_str() {
+            if let Some(val) = get_nested(event, k).and_then(|v| v.as_str()) {
+                set_nested(event, k, Value::String(val.to_uppercase()));
+            }
+        }
+    }
+}
+
+fn apply_trim_string(config: &Value, event: &mut Value) {
+    let keys = match config["withKeys"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for key in keys {
+        if let Some(k) = key.as_str() {
+            if let Some(val) = get_nested(event, k).and_then(|v| v.as_str()) {
+                set_nested(event, k, Value::String(val.trim().to_string()));
+            }
+        }
+    }
+}
+
+fn apply_split_string(config: &Value, event: &mut Value) {
+    let entries = match config["entries"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for entry in entries {
+        if let (Some(source), Some(delimiter)) =
+            (entry["source"].as_str(), entry["delimiter"].as_str())
+        {
+            if let Some(val) = get_nested(event, source).and_then(|v| v.as_str()) {
+                let parts: Vec<Value> = val
+                    .split(delimiter)
+                    .map(|s| Value::String(s.to_string()))
+                    .collect();
+                set_nested(event, source, Value::Array(parts));
+            }
+        }
+    }
+}
+
+fn apply_substitute_string(config: &Value, event: &mut Value) {
+    let entries = match config["entries"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for entry in entries {
+        if let (Some(source), Some(from), Some(to)) = (
+            entry["source"].as_str(),
+            entry["from"].as_str(),
+            entry["to"].as_str(),
+        ) {
+            if let Some(val) = get_nested(event, source).and_then(|v| v.as_str()) {
+                let replaced = match regex::Regex::new(from) {
+                    Ok(re) => re.replace_all(val, to).to_string(),
+                    Err(_) => val.replace(from, to),
+                };
+                set_nested(event, source, Value::String(replaced));
+            }
+        }
+    }
+}
+
+fn apply_type_converter(config: &Value, event: &mut Value) {
+    let entries = match config["entries"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+    for entry in entries {
+        if let (Some(key), Some(target_type)) = (entry["key"].as_str(), entry["type"].as_str()) {
+            if let Some(val) = get_nested(event, key).cloned() {
+                let converted = match target_type {
+                    "integer" => {
+                        if let Some(s) = val.as_str() {
+                            s.parse::<i64>().ok().map(|n| json!(n))
+                        } else {
+                            val.as_f64().map(|f| json!(f as i64))
+                        }
+                    }
+                    "double" | "float" => {
+                        if let Some(s) = val.as_str() {
+                            s.parse::<f64>().ok().map(|n| json!(n))
+                        } else {
+                            val.as_f64().map(|n| json!(n))
+                        }
+                    }
+                    "string" => match &val {
+                        Value::String(_) => Some(val),
+                        Value::Number(n) => Some(Value::String(n.to_string())),
+                        Value::Bool(b) => Some(Value::String(b.to_string())),
+                        _ => Some(Value::String(val.to_string())),
+                    },
+                    "boolean" => {
+                        if let Some(s) = val.as_str() {
+                            match s.to_lowercase().as_str() {
+                                "true" | "1" => Some(json!(true)),
+                                "false" | "0" => Some(json!(false)),
+                                _ => None,
+                            }
+                        } else if let Some(b) = val.as_bool() {
+                            Some(json!(b))
+                        } else {
+                            val.as_i64().map(|n| json!(n != 0))
+                        }
+                    }
+                    _ => None,
+                };
+                if let Some(c) = converted {
+                    set_nested(event, key, c);
+                }
+            }
+        }
+    }
+}
+
+fn apply_csv(config: &Value, event: &mut Value) {
+    let source = config["source"].as_str().unwrap_or("message");
+    let delimiter = config["delimiter"].as_str().unwrap_or(",");
+    let columns = match config["columns"].as_array() {
+        Some(arr) => arr,
+        None => return,
+    };
+
+    let raw = match get_nested(event, source).and_then(|v| v.as_str()) {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+
+    let delim_char = delimiter.chars().next().unwrap_or(',');
+    let values: Vec<&str> = raw.split(delim_char).collect();
+
+    for (i, col) in columns.iter().enumerate() {
+        if let Some(col_name) = col.as_str() {
+            if let Some(val) = values.get(i) {
+                set_nested(event, col_name, Value::String(val.trim().to_string()));
+            }
+        }
+    }
+}
+
+fn apply_parse_key_value(config: &Value, event: &mut Value) {
+    let source = config["source"].as_str().unwrap_or("message");
+    let destination = config["destination"].as_str();
+
+    let raw = match get_nested(event, source).and_then(|v| v.as_str()) {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+
+    let mut parsed = Map::new();
+    // Parse key=value or key="value" pairs
+    let re = regex::Regex::new(r#"(\w+)=(?:"([^"]*)"|(\S+))"#).unwrap();
+    for caps in re.captures_iter(&raw) {
+        let key = caps.get(1).unwrap().as_str();
+        let value = caps
+            .get(2)
+            .or_else(|| caps.get(3))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        parsed.insert(key.to_string(), Value::String(value.to_string()));
+    }
+
+    let parsed_value = Value::Object(parsed);
+    if let Some(dest) = destination {
+        set_nested(event, dest, parsed_value);
+    } else {
+        // Merge into root
+        if let Value::Object(map) = parsed_value {
+            if let Value::Object(ref mut ev) = event {
+                for (k, v) in map {
+                    ev.insert(k, v);
+                }
+            }
+        }
+    }
+}
+
+fn apply_date_time_converter(config: &Value, event: &mut Value) {
+    let source = config["source"].as_str().unwrap_or("timestamp");
+    let target = config["target"].as_str();
+    let match_patterns = config["matchPatterns"].as_array();
+
+    let raw = match get_nested(event, source) {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Number(n)) => n.to_string(),
+        _ => return,
+    };
+
+    let patterns = match match_patterns {
+        Some(arr) => arr,
+        None => return,
+    };
+
+    // Try each pattern, use the first that succeeds
+    let mut parsed_value: Option<String> = None;
+    for pattern in patterns {
+        if let Some(pat) = pattern.as_str() {
+            if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(&raw, pat) {
+                parsed_value = Some(dt.format("%Y-%m-%dT%H:%M:%S").to_string());
+                break;
+            }
+            // Also try NaiveDate for date-only patterns
+            if let Ok(d) = chrono::NaiveDate::parse_from_str(&raw, pat) {
+                parsed_value = Some(d.format("%Y-%m-%d").to_string());
+                break;
+            }
+        }
+    }
+
+    if let Some(val) = parsed_value {
+        let dest = target.unwrap_or(source);
+        set_nested(event, dest, Value::String(val));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_parse_json() {
+        let config = json!([{"parseJSON": {"source": "message"}}]);
+        let result = apply_transformer(&config, r#"{"level":"ERROR","msg":"fail"}"#);
+        assert_eq!(result["level"], "ERROR");
+        assert_eq!(result["msg"], "fail");
+    }
+
+    #[test]
+    fn test_parse_json_with_destination() {
+        let config = json!([{"parseJSON": {"source": "message", "destination": "parsed"}}]);
+        let result = apply_transformer(&config, r#"{"level":"INFO"}"#);
+        assert_eq!(result["parsed"]["level"], "INFO");
+        assert_eq!(result["message"], r#"{"level":"INFO"}"#);
+    }
+
+    #[test]
+    fn test_add_keys() {
+        let config = json!([{"addKeys": {"entries": [{"key": "env", "value": "prod"}, {"key": "version", "value": "1.0"}]}}]);
+        let result = apply_transformer(&config, "hello");
+        assert_eq!(result["env"], "prod");
+        assert_eq!(result["version"], "1.0");
+        assert_eq!(result["message"], "hello");
+    }
+
+    #[test]
+    fn test_delete_keys() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "tmp", "value": "x"}, {"key": "debug", "value": "y"}]}},
+            {"deleteKeys": {"withKeys": ["tmp", "debug"]}}
+        ]);
+        let result = apply_transformer(&config, "hello");
+        assert!(result.get("tmp").is_none());
+        assert!(result.get("debug").is_none());
+        assert_eq!(result["message"], "hello");
+    }
+
+    #[test]
+    fn test_rename_keys() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "oldName", "value": "val"}]}},
+            {"renameKeys": {"entries": [{"key": "oldName", "renameTo": "newName"}]}}
+        ]);
+        let result = apply_transformer(&config, "hello");
+        assert!(result.get("oldName").is_none());
+        assert_eq!(result["newName"], "val");
+    }
+
+    #[test]
+    fn test_move_keys() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "a.b", "value": "val"}]}},
+            {"moveKeys": {"entries": [{"source": "a.b", "target": "c.d"}]}}
+        ]);
+        let result = apply_transformer(&config, "hello");
+        assert_eq!(result["c"]["d"], "val");
+        assert!(result["a"].get("b").is_none());
+    }
+
+    #[test]
+    fn test_copy_value() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "src", "value": "data"}]}},
+            {"copyValue": {"entries": [{"source": "src", "target": "dst"}]}}
+        ]);
+        let result = apply_transformer(&config, "hello");
+        assert_eq!(result["src"], "data");
+        assert_eq!(result["dst"], "data");
+    }
+
+    #[test]
+    fn test_lower_case_string() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "name", "value": "HELLO World"}]}},
+            {"lowerCaseString": {"withKeys": ["name"]}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["name"], "hello world");
+    }
+
+    #[test]
+    fn test_upper_case_string() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "name", "value": "hello"}]}},
+            {"upperCaseString": {"withKeys": ["name"]}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["name"], "HELLO");
+    }
+
+    #[test]
+    fn test_trim_string() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "val", "value": "  hello  "}]}},
+            {"trimString": {"withKeys": ["val"]}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["val"], "hello");
+    }
+
+    #[test]
+    fn test_split_string() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "tags", "value": "a,b,c"}]}},
+            {"splitString": {"entries": [{"source": "tags", "delimiter": ","}]}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["tags"], json!(["a", "b", "c"]));
+    }
+
+    #[test]
+    fn test_substitute_string() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "msg", "value": "error: bad thing"}]}},
+            {"substituteString": {"entries": [{"source": "msg", "from": "error", "to": "warning"}]}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["msg"], "warning: bad thing");
+    }
+
+    #[test]
+    fn test_substitute_string_regex() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "msg", "value": "id=123 id=456"}]}},
+            {"substituteString": {"entries": [{"source": "msg", "from": "\\d+", "to": "***"}]}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["msg"], "id=*** id=***");
+    }
+
+    #[test]
+    fn test_type_converter_integer() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "count", "value": "42"}]}},
+            {"typeConverter": {"entries": [{"key": "count", "type": "integer"}]}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["count"], 42);
+    }
+
+    #[test]
+    fn test_type_converter_boolean() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "flag", "value": "true"}]}},
+            {"typeConverter": {"entries": [{"key": "flag", "type": "boolean"}]}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["flag"], true);
+    }
+
+    #[test]
+    fn test_type_converter_string() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "num", "value": "99"}]}},
+            {"typeConverter": {"entries": [{"key": "num", "type": "integer"}]}},
+            {"typeConverter": {"entries": [{"key": "num", "type": "string"}]}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["num"], "99");
+    }
+
+    #[test]
+    fn test_csv() {
+        let config = json!([{"csv": {"source": "message", "delimiter": ",", "columns": ["name", "age", "city"]}}]);
+        let result = apply_transformer(&config, "Alice,30,NYC");
+        assert_eq!(result["name"], "Alice");
+        assert_eq!(result["age"], "30");
+        assert_eq!(result["city"], "NYC");
+    }
+
+    #[test]
+    fn test_parse_key_value() {
+        let config = json!([{"parseKeyValue": {"source": "message", "destination": "parsed"}}]);
+        let result = apply_transformer(&config, r#"user=alice status=200 path="/api""#);
+        assert_eq!(result["parsed"]["user"], "alice");
+        assert_eq!(result["parsed"]["status"], "200");
+        assert_eq!(result["parsed"]["path"], "/api");
+    }
+
+    #[test]
+    fn test_parse_key_value_no_destination() {
+        let config = json!([{"parseKeyValue": {"source": "message"}}]);
+        let result = apply_transformer(&config, "host=localhost port=8080");
+        assert_eq!(result["host"], "localhost");
+        assert_eq!(result["port"], "8080");
+    }
+
+    #[test]
+    fn test_date_time_converter() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "ts", "value": "2024-01-15"}]}},
+            {"dateTimeConverter": {"source": "ts", "matchPatterns": ["%Y-%m-%d"], "target": "parsedTime"}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["parsedTime"], "2024-01-15");
+    }
+
+    #[test]
+    fn test_date_time_converter_datetime() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "ts", "value": "2024-01-15 10:30:00"}]}},
+            {"dateTimeConverter": {"source": "ts", "matchPatterns": ["%Y-%m-%d %H:%M:%S"], "target": "parsedTime"}}
+        ]);
+        let result = apply_transformer(&config, "test");
+        assert_eq!(result["parsedTime"], "2024-01-15T10:30:00");
+    }
+
+    #[test]
+    fn test_pipeline_add_delete_rename() {
+        let config = json!([
+            {"addKeys": {"entries": [{"key": "env", "value": "staging"}, {"key": "tmp", "value": "remove_me"}]}},
+            {"deleteKeys": {"withKeys": ["tmp"]}},
+            {"renameKeys": {"entries": [{"key": "message", "renameTo": "original_message"}]}}
+        ]);
+        let result = apply_transformer(&config, "hello world");
+        assert_eq!(result["env"], "staging");
+        assert!(result.get("tmp").is_none());
+        assert!(result.get("message").is_none());
+        assert_eq!(result["original_message"], "hello world");
+    }
+
+    #[test]
+    fn test_empty_config() {
+        let config = json!([]);
+        let result = apply_transformer(&config, "hello");
+        assert_eq!(result["message"], "hello");
+    }
+
+    #[test]
+    fn test_non_array_config() {
+        let config = json!("invalid");
+        let result = apply_transformer(&config, "hello");
+        assert_eq!(result["message"], "hello");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `transformer.rs` module with 15 processor types: parseJSON, addKeys, deleteKeys, renameKeys, moveKeys, copyValue, lowerCaseString, upperCaseString, trimString, splitString, substituteString, typeConverter, csv, parseKeyValue, dateTimeConverter
- Integrate transformer into `TestTransformer` action (applies pipeline to input events and returns transformed output)
- Integrate transformer into `PutLogEvents` (applies transformer before storing events when a log group has a transformer configured)
- Unit tests for every processor type plus pipeline combinations
- E2E test: `logs_transformer_applies_processors` verifying addKeys+deleteKeys+renameKeys via both TestTransformer and PutLogEvents storage path

## Test plan
- [x] `cargo test -p fakecloud-logs` — 98 unit tests pass (20 new transformer tests)
- [x] `cargo clippy -p fakecloud-logs -- -D warnings` — clean
- [ ] `cargo test -p fakecloud-e2e --test logs -- logs_transformer_applies_processors` — E2E test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a CloudWatch Logs transformer pipeline with 15 processors. Applies it in `TestTransformer` and `PutLogEvents` so events are transformed before testing and storage.

- New Features
  - New transformer module with processors: parseJSON, addKeys, deleteKeys, renameKeys, moveKeys, copyValue, lowerCaseString, upperCaseString, trimString, splitString, substituteString, typeConverter, csv, parseKeyValue, dateTimeConverter.
  - Tests: unit tests for each processor and pipeline combos, plus an E2E validating addKeys+deleteKeys+renameKeys via both `TestTransformer` and `PutLogEvents`.

- Dependencies
  - Add `regex`.

<sup>Written for commit 664bd41aac70276f2b2621b56a7497adb629ad24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

