### PR TITLE
feat(sns): implement real SNS->Lambda execution

### DIFF
--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -11,6 +11,8 @@ pub struct DeliveryBus {
     sqs_sender: Option<Arc<dyn SqsDelivery>>,
     /// Publish a message to an SNS topic by ARN.
     sns_sender: Option<Arc<dyn SnsDelivery>>,
+    /// Invoke a Lambda function by ARN.
+    lambda_invoker: Option<Arc<dyn LambdaDelivery>>,
 }
 
 /// Message attribute for SQS delivery from SNS.
@@ -50,11 +52,23 @@ pub trait SnsDelivery: Send + Sync {
     fn publish_to_topic(&self, topic_arn: &str, message: &str, subject: Option<&str>);
 }
 
+/// Trait for invoking Lambda functions from cross-service integrations.
+pub trait LambdaDelivery: Send + Sync {
+    /// Invoke a Lambda function with the given payload.
+    /// The function is identified by ARN. Returns the response bytes on success.
+    fn invoke_lambda(
+        &self,
+        function_arn: &str,
+        payload: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>, String>> + Send>>;
+}
+
 impl DeliveryBus {
     pub fn new() -> Self {
         Self {
             sqs_sender: None,
             sns_sender: None,
+            lambda_invoker: None,
         }
     }
 
@@ -65,6 +79,11 @@ impl DeliveryBus {
 
     pub fn with_sns(mut self, sender: Arc<dyn SnsDelivery>) -> Self {
         self.sns_sender = Some(sender);
+        self
+    }
+
+    pub fn with_lambda(mut self, invoker: Arc<dyn LambdaDelivery>) -> Self {
+        self.lambda_invoker = Some(invoker);
         self
     }
 
@@ -104,6 +123,19 @@ impl DeliveryBus {
     pub fn publish_to_sns(&self, topic_arn: &str, message: &str, subject: Option<&str>) {
         if let Some(ref sender) = self.sns_sender {
             sender.publish_to_topic(topic_arn, message, subject);
+        }
+    }
+
+    /// Invoke a Lambda function identified by ARN.
+    pub async fn invoke_lambda(
+        &self,
+        function_arn: &str,
+        payload: &str,
+    ) -> Option<Result<Vec<u8>, String>> {
+        if let Some(ref invoker) = self.lambda_invoker {
+            Some(invoker.invoke_lambda(function_arn, payload).await)
+        } else {
+            None
         }
     }
 }

--- a/crates/fakecloud-e2e/tests/cross_service.rs
+++ b/crates/fakecloud-e2e/tests/cross_service.rs
@@ -1,12 +1,30 @@
 mod helpers;
 
+use std::io::Write;
+
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
     ScalarAttributeType,
 };
 use aws_sdk_eventbridge::types::{PutEventsRequestEntry, Target};
+use aws_sdk_lambda::primitives::Blob;
+use aws_sdk_lambda::types::{Environment, FunctionCode, Runtime};
 use aws_sdk_s3::primitives::ByteStream;
 use helpers::TestServer;
+
+/// Create a ZIP file in memory containing a single file.
+fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    for (name, content) in entries {
+        let options = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+        writer.start_file(*name, options).unwrap();
+        writer.write_all(content).unwrap();
+    }
+    let cursor = writer.finish().unwrap();
+    cursor.into_inner()
+}
 
 /// Query recorded Lambda invocations via internal API.
 async fn get_lambda_invocations(endpoint: &str) -> serde_json::Value {
@@ -1050,4 +1068,142 @@ async fn dynamodb_export_import_roundtrip() {
             "Item should have 'count' attribute"
         );
     }
+}
+
+/// SNS -> Lambda real execution: publishing to an SNS topic with a Lambda subscriber
+/// actually invokes the Lambda function via a container. The Lambda function writes
+/// proof to an SQS queue to confirm it ran and received the SNS event.
+#[tokio::test]
+#[ignore] // Requires Docker with host.docker.internal networking — run locally, not in CI
+async fn sns_to_lambda_actually_executes() {
+    let server = TestServer::start().await;
+    let sqs = server.sqs_client().await;
+    let sns = server.sns_client().await;
+    let lambda = server.lambda_client().await;
+
+    // 1. Create an SQS queue where Lambda will write proof that it ran
+    let queue = sqs
+        .create_queue()
+        .queue_name("lambda-proof-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let _queue_arn = get_queue_arn(&sqs, &queue_url).await;
+
+    // 2. Create a Lambda function with Python code that sends a message to SQS
+    //    containing the SNS event it received.
+    // Inside Docker, host.docker.internal resolves to the host machine.
+    let docker_endpoint = format!("http://host.docker.internal:{}", server.port());
+    // The queue URL returned by SQS uses localhost:4566, but from inside Docker
+    // we need to use host.docker.internal:{port}. Construct it directly.
+    let docker_queue_url = format!(
+        "http://host.docker.internal:{}/123456789012/lambda-proof-queue",
+        server.port()
+    );
+    let python_code = format!(
+        r#"
+import json
+import urllib.request
+import urllib.parse
+
+def handler(event, context):
+    endpoint = "{docker_endpoint}"
+    queue_url = "{docker_queue_url}"
+    params = urllib.parse.urlencode({{
+        "Action": "SendMessage",
+        "QueueUrl": queue_url,
+        "MessageBody": json.dumps(event),
+        "Version": "2012-11-05",
+    }})
+    req = urllib.request.Request(
+        endpoint + "/",
+        data=params.encode("utf-8"),
+        headers={{
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Authorization": "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/sqs/aws4_request, SignedHeaders=host, Signature=fake",
+        }},
+    )
+    urllib.request.urlopen(req, timeout=5)
+    return {{"statusCode": 200, "body": "ok"}}
+"#
+    );
+
+    let zip = make_zip(&[("index.py", python_code.as_bytes())]);
+
+    lambda
+        .create_function()
+        .function_name("sns-proof-func")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("index.handler")
+        .environment(
+            Environment::builder()
+                .variables("FAKECLOUD_ENDPOINT", server.endpoint())
+                .build(),
+        )
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    // 3. Create an SNS topic
+    let topic = sns
+        .create_topic()
+        .name("lambda-trigger-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    // 4. Subscribe the Lambda function to the topic
+    let lambda_arn = "arn:aws:lambda:us-east-1:123456789012:function:sns-proof-func";
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("lambda")
+        .endpoint(lambda_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // 5. Publish a message to the topic
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("hello from SNS")
+        .subject("Test Subject")
+        .send()
+        .await
+        .unwrap();
+
+    // 6. Wait for Lambda to execute and write to SQS
+    let mut proof_message = None;
+    for _ in 0..30 {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        let msgs = sqs
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(1)
+            .send()
+            .await
+            .unwrap();
+        if !msgs.messages().is_empty() {
+            proof_message = Some(msgs.messages()[0].body().unwrap().to_string());
+            break;
+        }
+    }
+
+    // 7. Assert the queue has a message proving Lambda ran and received the SNS event
+    let proof = proof_message
+        .expect("Lambda did not write proof to SQS — SNS->Lambda execution did not happen");
+    let event: serde_json::Value = serde_json::from_str(&proof).unwrap();
+
+    // The Lambda receives an SNS event with Records array
+    assert!(
+        event["Records"].is_array(),
+        "Expected SNS event with Records array, got: {event}"
+    );
+    let record = &event["Records"][0];
+    assert_eq!(record["EventSource"], "aws:sns");
+    assert_eq!(record["Sns"]["Message"], "hello from SNS");
+    assert_eq!(record["Sns"]["Subject"], "Test Subject");
 }

--- a/crates/fakecloud-server/src/lambda_delivery.rs
+++ b/crates/fakecloud-server/src/lambda_delivery.rs
@@ -1,0 +1,62 @@
+//! Implements the `LambdaDelivery` trait for real Lambda execution via containers.
+
+use std::sync::Arc;
+
+use fakecloud_core::delivery::LambdaDelivery;
+use fakecloud_lambda::runtime::ContainerRuntime;
+use fakecloud_lambda::state::SharedLambdaState;
+
+/// Invokes Lambda functions using the container runtime.
+pub struct LambdaDeliveryImpl {
+    lambda_state: SharedLambdaState,
+    runtime: Arc<ContainerRuntime>,
+}
+
+impl LambdaDeliveryImpl {
+    pub fn new(lambda_state: SharedLambdaState, runtime: Arc<ContainerRuntime>) -> Self {
+        Self {
+            lambda_state,
+            runtime,
+        }
+    }
+}
+
+impl LambdaDelivery for LambdaDeliveryImpl {
+    fn invoke_lambda(
+        &self,
+        function_arn: &str,
+        payload: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>, String>> + Send>> {
+        // Extract function name from ARN: arn:aws:lambda:region:account:function:name[:qualifier]
+        let function_name = {
+            let parts: Vec<&str> = function_arn.split(':').collect();
+            if parts.len() >= 7 && parts[5] == "function" {
+                parts[6].to_string()
+            } else {
+                // Fallback: treat the whole thing as a function name
+                function_arn.to_string()
+            }
+        };
+
+        let func = {
+            let state = self.lambda_state.read();
+            state.functions.get(&function_name).cloned()
+        };
+
+        let runtime = self.runtime.clone();
+        let payload = payload.to_string();
+
+        Box::pin(async move {
+            let func = func.ok_or_else(|| format!("Function not found: {function_name}"))?;
+            if func.code_zip.is_none() {
+                return Err(format!(
+                    "Function {function_name} has no deployment package"
+                ));
+            }
+            runtime
+                .invoke(&func, payload.as_bytes())
+                .await
+                .map_err(|e| format!("Lambda invocation failed: {e}"))
+        })
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -10,6 +10,7 @@ use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::dispatch::{self, DispatchConfig};
 use fakecloud_core::registry::ServiceRegistry;
 
+mod lambda_delivery;
 mod sqs_lambda_poller;
 use sqs_lambda_poller::SqsLambdaPoller;
 
@@ -118,7 +119,23 @@ async fn main() {
     let sqs_delivery = Arc::new(fakecloud_sqs::delivery::SqsDeliveryImpl::new(
         sqs_state.clone(),
     ));
-    let delivery_for_sns = Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone()));
+
+    // Lambda delivery (SNS can invoke Lambda functions via container runtime)
+    let lambda_delivery: Option<Arc<dyn fakecloud_core::delivery::LambdaDelivery>> =
+        container_runtime.as_ref().map(|rt| {
+            Arc::new(lambda_delivery::LambdaDeliveryImpl::new(
+                lambda_state.clone(),
+                rt.clone(),
+            )) as Arc<dyn fakecloud_core::delivery::LambdaDelivery>
+        });
+
+    let delivery_for_sns = {
+        let mut bus = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+        if let Some(ref ld) = lambda_delivery {
+            bus = bus.with_lambda(ld.clone());
+        }
+        Arc::new(bus)
+    };
 
     // Step 2: SNS delivery (EventBridge can publish to SNS topics, which then fan out to SQS)
     let sns_delivery = Arc::new(fakecloud_sns::delivery::SnsDeliveryImpl::new(

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -74,14 +74,37 @@ impl SnsDelivery for SnsDeliveryImpl {
             .map(|s| s.endpoint.clone())
             .collect();
 
-        // Store Lambda invocations
+        // Build SNS Lambda event payload (matches real AWS format)
         let now = Utc::now();
-        for function_arn in &lambda_subscribers {
-            tracing::info!(
-                function_arn = %function_arn,
-                topic_arn = %topic_arn,
-                "SNS cross-service delivering to Lambda (stub)"
-            );
+        let lambda_payloads: Vec<(String, String)> = lambda_subscribers
+            .iter()
+            .map(|function_arn| {
+                let sns_event = serde_json::json!({
+                    "Records": [{
+                        "EventVersion": "1.0",
+                        "EventSubscriptionArn": format!("{}:lambda-sub", topic_arn),
+                        "EventSource": "aws:sns",
+                        "Sns": {
+                            "SignatureVersion": "1",
+                            "Timestamp": now.to_rfc3339(),
+                            "Signature": "FAKE_SIGNATURE",
+                            "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
+                            "MessageId": msg_id.clone(),
+                            "Message": message,
+                            "MessageAttributes": {},
+                            "Type": "Notification",
+                            "UnsubscribeUrl": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
+                            "TopicArn": topic_arn,
+                            "Subject": subject.unwrap_or(""),
+                        }
+                    }]
+                });
+                (function_arn.clone(), sns_event.to_string())
+            })
+            .collect();
+
+        // Record invocations in state
+        for (function_arn, _) in &lambda_payloads {
             state
                 .lambda_invocations
                 .push(crate::state::LambdaInvocation {
@@ -141,6 +164,40 @@ impl SnsDelivery for SnsDeliveryImpl {
         for queue_arn in sqs_subscribers {
             self.delivery
                 .send_to_sqs(&queue_arn, &envelope_str, &HashMap::new());
+        }
+
+        // Invoke Lambda subscribers via container runtime
+        if !lambda_payloads.is_empty() {
+            let delivery = self.delivery.clone();
+            tokio::spawn(async move {
+                for (function_arn, payload) in lambda_payloads {
+                    tracing::info!(
+                        function_arn = %function_arn,
+                        "SNS invoking Lambda function"
+                    );
+                    match delivery.invoke_lambda(&function_arn, &payload).await {
+                        Some(Ok(_)) => {
+                            tracing::info!(
+                                function_arn = %function_arn,
+                                "SNS->Lambda invocation succeeded"
+                            );
+                        }
+                        Some(Err(e)) => {
+                            tracing::error!(
+                                function_arn = %function_arn,
+                                error = %e,
+                                "SNS->Lambda invocation failed"
+                            );
+                        }
+                        None => {
+                            tracing::info!(
+                                function_arn = %function_arn,
+                                "SNS->Lambda: no container runtime available, skipping real execution"
+                            );
+                        }
+                    }
+                }
+            });
         }
     }
 }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -1044,26 +1044,84 @@ impl SnsService {
             });
         }
 
-        // Deliver to Lambda subscribers (stub — log and store)
+        // Deliver to Lambda subscribers
         if !lambda_subscribers.is_empty() {
             let now = Utc::now();
-            let mut state = self.state.write();
-            for function_arn in lambda_subscribers {
-                tracing::info!(
-                    function_arn = %function_arn,
-                    message = %default_message,
-                    topic_arn = %topic_arn,
-                    "SNS delivering to Lambda function (stub)"
-                );
-                state
-                    .lambda_invocations
-                    .push(crate::state::LambdaInvocation {
-                        function_arn,
-                        message: default_message.clone(),
-                        subject: subject.clone(),
-                        timestamp: now,
+
+            // Build SNS Lambda event payloads
+            let lambda_payloads: Vec<(String, String)> = lambda_subscribers
+                .iter()
+                .map(|function_arn| {
+                    let sns_event = serde_json::json!({
+                        "Records": [{
+                            "EventVersion": "1.0",
+                            "EventSubscriptionArn": format!("{}:lambda-sub", topic_arn),
+                            "EventSource": "aws:sns",
+                            "Sns": {
+                                "SignatureVersion": "1",
+                                "Timestamp": now.to_rfc3339(),
+                                "Signature": "FAKE_SIGNATURE",
+                                "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
+                                "MessageId": msg_id.clone(),
+                                "Message": &default_message,
+                                "MessageAttributes": &envelope_attrs,
+                                "Type": "Notification",
+                                "UnsubscribeUrl": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
+                                "TopicArn": &topic_arn,
+                                "Subject": subject.as_deref().unwrap_or(""),
+                            }
+                        }]
                     });
+                    (function_arn.clone(), sns_event.to_string())
+                })
+                .collect();
+
+            // Record invocations in state
+            {
+                let mut state = self.state.write();
+                for (function_arn, _) in &lambda_payloads {
+                    state
+                        .lambda_invocations
+                        .push(crate::state::LambdaInvocation {
+                            function_arn: function_arn.clone(),
+                            message: default_message.clone(),
+                            subject: subject.clone(),
+                            timestamp: now,
+                        });
+                }
             }
+
+            // Invoke Lambda functions asynchronously via container runtime
+            let delivery = self.delivery.clone();
+            tokio::spawn(async move {
+                for (function_arn, payload) in lambda_payloads {
+                    tracing::info!(
+                        function_arn = %function_arn,
+                        "SNS invoking Lambda function"
+                    );
+                    match delivery.invoke_lambda(&function_arn, &payload).await {
+                        Some(Ok(_)) => {
+                            tracing::info!(
+                                function_arn = %function_arn,
+                                "SNS->Lambda invocation succeeded"
+                            );
+                        }
+                        Some(Err(e)) => {
+                            tracing::error!(
+                                function_arn = %function_arn,
+                                error = %e,
+                                "SNS->Lambda invocation failed"
+                            );
+                        }
+                        None => {
+                            tracing::debug!(
+                                function_arn = %function_arn,
+                                "SNS->Lambda: no container runtime, skipping real execution"
+                            );
+                        }
+                    }
+                }
+            });
         }
 
         // Deliver to email subscribers (stub — log and store)


### PR DESCRIPTION
## Summary
- Add `LambdaDelivery` trait to `DeliveryBus` in fakecloud-core, enabling cross-service Lambda invocation via container runtime
- Replace SNS->Lambda stub with real execution: when a message is published to an SNS topic with Lambda subscribers, the Lambda function is invoked asynchronously in a Docker container with a proper SNS event payload
- Wire the Lambda delivery into the SNS delivery bus in the server entrypoint

## Test plan
- [x] New e2e test `sns_to_lambda_actually_executes` proves end-to-end: creates SQS queue, Lambda function (Python), SNS topic, subscribes Lambda, publishes message, then verifies Lambda ran by checking SQS for proof message containing the SNS event
- [x] All existing unit tests pass (`cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the SNS→Lambda stub with real Lambda execution via containers. Publishing to an SNS topic now invokes subscribed Lambda functions asynchronously with an AWS‑compatible SNS event.

- **New Features**
  - Added `LambdaDelivery` to `fakecloud-core` `DeliveryBus` with `with_lambda` and async `invoke_lambda`.
  - Implemented `LambdaDeliveryImpl` in `fakecloud-server` using the container runtime; wired into both SNS publish paths.
  - `fakecloud-sns` builds a real SNS event (Records, Subject, MessageAttributes) and invokes Lambda subscribers; invocations are recorded in state.
  - Added e2e test `sns_to_lambda_actually_executes` proving end-to-end execution with a Python Lambda writing to SQS.

- **Migration**
  - Requires a working container runtime (Docker). If unavailable, SNS logs and skips Lambda execution. No API changes.

<sup>Written for commit cce0e2dd9c8cc72ea52e36544c0b480bd2a3e114. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

