### PR TITLE
feat(eventbridge): real Lambda execution for EventBridge targets

### DIFF
--- a/crates/fakecloud-e2e/tests/cross_service.rs
+++ b/crates/fakecloud-e2e/tests/cross_service.rs
@@ -925,6 +925,145 @@ async fn logs_subscription_filter_delivers_to_sqs() {
     assert_eq!(log_events[1]["message"], "second event");
 }
 
+/// EventBridge -> Lambda real execution: put_events triggers a Lambda function
+/// that sends a message to an SQS proof queue, verifying end-to-end execution.
+#[tokio::test]
+#[ignore] // Requires Docker for Lambda execution
+async fn eventbridge_to_lambda_actually_executes() {
+    use aws_sdk_lambda::primitives::Blob;
+    use aws_sdk_lambda::types::{Environment, FunctionCode, Runtime};
+
+    let server = TestServer::start().await;
+    let sqs = server.sqs_client().await;
+    let lambda = server.lambda_client().await;
+    let eb = server.eventbridge_client().await;
+
+    // 1. Create SQS proof queue
+    let queue = sqs
+        .create_queue()
+        .queue_name("eb-lambda-proof")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let _queue_arn = get_queue_arn(&sqs, &queue_url).await;
+
+    // 2. Create Lambda function (Python) that sends a message to the proof queue
+    let handler_code = format!(
+        r#"
+import json
+import urllib.request
+
+def handler(event, context):
+    # Send proof message to SQS via fakecloud endpoint
+    endpoint = "http://host.docker.internal:{port}"
+    queue_url = "{queue_url}"
+    body = (
+        "Action=SendMessage"
+        "&QueueUrl=" + queue_url
+        + "&MessageBody=" + json.dumps(event)
+    )
+    req = urllib.request.Request(
+        endpoint,
+        data=body.encode("utf-8"),
+        headers={{"Content-Type": "application/x-www-form-urlencoded"}},
+    )
+    urllib.request.urlopen(req, timeout=5)
+    return {{"statusCode": 200}}
+"#,
+        port = server.port(),
+        queue_url = queue_url.replace("127.0.0.1", "host.docker.internal"),
+    );
+
+    let zip_bytes = make_zip(&[("index.py", handler_code.as_bytes())]);
+    lambda
+        .create_function()
+        .function_name("eb-proof-fn")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .timeout(10)
+        .environment(
+            Environment::builder()
+                .variables("AWS_ACCESS_KEY_ID", "test")
+                .variables("AWS_SECRET_ACCESS_KEY", "test")
+                .build(),
+        )
+        .code(
+            FunctionCode::builder()
+                .zip_file(Blob::new(zip_bytes))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // 3. Create EventBridge rule matching source "test.app"
+    eb.put_rule()
+        .name("eb-lambda-test-rule")
+        .event_pattern(r#"{"source": ["test.app"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // 4. Add Lambda as target
+    let lambda_arn = "arn:aws:lambda:us-east-1:123456789012:function:eb-proof-fn";
+    eb.put_targets()
+        .rule("eb-lambda-test-rule")
+        .targets(
+            Target::builder()
+                .id("lambda-target")
+                .arn(lambda_arn)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // 5. PutEvents with source "test.app"
+    eb.put_events()
+        .entries(
+            PutEventsRequestEntry::builder()
+                .source("test.app")
+                .detail_type("TestEvent")
+                .detail(r#"{"key": "value"}"#)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // 6. Wait and receive from proof queue
+    let mut found = false;
+    for _ in 0..15 {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        let msgs = sqs
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(1)
+            .send()
+            .await
+            .unwrap();
+        if !msgs.messages().is_empty() {
+            // 7. Assert Lambda ran -- the message body should contain the event
+            let body = msgs.messages()[0].body().unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+            assert_eq!(parsed["source"], "test.app");
+            assert_eq!(parsed["detail-type"], "TestEvent");
+            found = true;
+            break;
+        }
+    }
+    assert!(
+        found,
+        "Lambda was not actually invoked by EventBridge -- no message in proof queue"
+    );
+}
+
+// make_zip is defined at the top of this file
+
 /// DynamoDB export to S3 and import from S3 roundtrip test.
 #[tokio::test]
 async fn dynamodb_export_import_roundtrip() {

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -6,6 +6,7 @@ use chrono::{Datelike, Timelike, Utc};
 use serde_json::json;
 
 use fakecloud_core::delivery::DeliveryBus;
+use fakecloud_lambda::runtime::ContainerRuntime;
 use fakecloud_lambda::state::{LambdaInvocation, SharedLambdaState};
 use fakecloud_logs::state::SharedLogsState;
 
@@ -109,6 +110,7 @@ pub struct Scheduler {
     delivery: Arc<DeliveryBus>,
     lambda_state: Option<SharedLambdaState>,
     logs_state: Option<SharedLogsState>,
+    container_runtime: Option<Arc<ContainerRuntime>>,
 }
 
 impl Scheduler {
@@ -118,6 +120,7 @@ impl Scheduler {
             delivery,
             lambda_state: None,
             logs_state: None,
+            container_runtime: None,
         }
     }
 
@@ -128,6 +131,11 @@ impl Scheduler {
 
     pub fn with_logs(mut self, logs_state: SharedLogsState) -> Self {
         self.logs_state = Some(logs_state);
+        self
+    }
+
+    pub fn with_runtime(mut self, runtime: Arc<ContainerRuntime>) -> Self {
+        self.container_runtime = Some(runtime);
         self
     }
 
@@ -261,6 +269,12 @@ impl Scheduler {
                             source: "aws:events".to_string(),
                         });
                     }
+                    crate::service::invoke_lambda_async(
+                        &self.container_runtime,
+                        &self.lambda_state,
+                        arn,
+                        &event_str,
+                    );
                 } else if arn.contains(":logs:") {
                     tracing::info!(
                         log_group_arn = %arn,

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -10,6 +10,7 @@ use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
+use fakecloud_lambda::runtime::ContainerRuntime;
 use fakecloud_lambda::state::{LambdaInvocation, SharedLambdaState};
 use fakecloud_logs::state::SharedLogsState;
 
@@ -23,6 +24,7 @@ pub struct EventBridgeService {
     delivery: Arc<DeliveryBus>,
     lambda_state: Option<SharedLambdaState>,
     logs_state: Option<SharedLogsState>,
+    container_runtime: Option<Arc<ContainerRuntime>>,
 }
 
 impl EventBridgeService {
@@ -32,6 +34,7 @@ impl EventBridgeService {
             delivery,
             lambda_state: None,
             logs_state: None,
+            container_runtime: None,
         }
     }
 
@@ -42,6 +45,11 @@ impl EventBridgeService {
 
     pub fn with_logs(mut self, logs_state: SharedLogsState) -> Self {
         self.logs_state = Some(logs_state);
+        self
+    }
+
+    pub fn with_runtime(mut self, runtime: Arc<ContainerRuntime>) -> Self {
+        self.container_runtime = Some(runtime);
         self
     }
 }
@@ -1973,6 +1981,13 @@ impl EventBridgeService {
                             source: "aws:events".to_string(),
                         });
                     }
+                    // Actually invoke the Lambda function if a container runtime is available
+                    invoke_lambda_async(
+                        &self.container_runtime,
+                        &self.lambda_state,
+                        arn,
+                        &body_str,
+                    );
                 } else if arn.contains(":logs:") {
                     tracing::info!(
                         log_group_arn = %arn,
@@ -3193,6 +3208,12 @@ impl EventBridgeService {
                             source: "aws:events".to_string(),
                         });
                     }
+                    invoke_lambda_async(
+                        &self.container_runtime,
+                        &self.lambda_state,
+                        target_arn,
+                        &body_str,
+                    );
                 } else if target_arn.contains(":logs:") {
                     let mut state = self.state.write();
                     state.log_deliveries.push(crate::state::LogDelivery {
@@ -3765,6 +3786,68 @@ fn missing(name: &str) -> AwsServiceError {
         "ValidationException",
         format!("The request must contain the parameter {name}"),
     )
+}
+
+/// Extract a Lambda function name from its ARN.
+///
+/// Handles both unqualified (`arn:aws:lambda:region:account:function:NAME`)
+/// and qualified (`arn:aws:lambda:region:account:function:NAME:alias`) ARNs.
+fn function_name_from_arn(arn: &str) -> &str {
+    let parts: Vec<&str> = arn.split(':').collect();
+    if parts.len() >= 7 && parts[5] == "function" {
+        parts[6]
+    } else {
+        arn
+    }
+}
+
+/// Spawn a background task to invoke a Lambda function via ContainerRuntime.
+/// This is fire-and-forget: EventBridge delivery is asynchronous.
+pub fn invoke_lambda_async(
+    container_runtime: &Option<Arc<ContainerRuntime>>,
+    lambda_state: &Option<SharedLambdaState>,
+    function_arn: &str,
+    payload: &str,
+) {
+    let runtime = match container_runtime {
+        Some(rt) => rt.clone(),
+        None => return,
+    };
+    let lambda_state = match lambda_state {
+        Some(ls) => ls.clone(),
+        None => return,
+    };
+    let func_name = function_name_from_arn(function_arn).to_string();
+    let payload = payload.as_bytes().to_vec();
+
+    tokio::spawn(async move {
+        let func = {
+            let state = lambda_state.read();
+            state.functions.get(&func_name).cloned()
+        };
+        let func = match func {
+            Some(f) => f,
+            None => {
+                tracing::warn!(
+                    function = %func_name,
+                    "EventBridge Lambda target not found, skipping invocation"
+                );
+                return;
+            }
+        };
+        match runtime.invoke(&func, &payload).await {
+            Ok(_) => {
+                tracing::info!(function = %func_name, "EventBridge Lambda invocation succeeded");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    function = %func_name,
+                    error = %e,
+                    "EventBridge Lambda invocation failed"
+                );
+            }
+        }
+    });
 }
 
 /// Deliver an EventBridge event to CloudWatch Logs by writing a log event
@@ -5349,5 +5432,30 @@ mod tests {
         assert_eq!(body["FailedEntryCount"], 0);
         assert_eq!(body["Entries"].as_array().unwrap().len(), 1);
         assert!(body["Entries"][0]["EventId"].as_str().is_some());
+    }
+
+    #[test]
+    fn test_function_name_from_arn() {
+        // Unqualified ARN
+        assert_eq!(
+            super::function_name_from_arn("arn:aws:lambda:us-east-1:123456789012:function:my-func"),
+            "my-func"
+        );
+        // Qualified ARN with alias
+        assert_eq!(
+            super::function_name_from_arn(
+                "arn:aws:lambda:us-east-1:123456789012:function:my-func:prod"
+            ),
+            "my-func"
+        );
+        // Qualified ARN with version
+        assert_eq!(
+            super::function_name_from_arn(
+                "arn:aws:lambda:us-east-1:123456789012:function:my-func:42"
+            ),
+            "my-func"
+        );
+        // Plain function name (not an ARN)
+        assert_eq!(super::function_name_from_arn("my-func"), "my-func");
     }
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -193,16 +193,21 @@ async fn main() {
     )));
     registry.register(Arc::new(SqsService::new(sqs_state.clone())));
     registry.register(Arc::new(SnsService::new(sns_state, delivery_for_sns)));
-    registry.register(Arc::new(
-        EventBridgeService::new(eb_state.clone(), delivery_for_eb.clone())
-            .with_lambda(lambda_state.clone())
-            .with_logs(logs_state.clone()),
-    ));
-
-    // Spawn the EventBridge scheduler as a background task
-    let scheduler = fakecloud_eventbridge::scheduler::Scheduler::new(eb_state, delivery_for_eb)
+    let mut eb_service = EventBridgeService::new(eb_state.clone(), delivery_for_eb.clone())
         .with_lambda(lambda_state.clone())
         .with_logs(logs_state.clone());
+    if let Some(ref rt) = container_runtime {
+        eb_service = eb_service.with_runtime(rt.clone());
+    }
+    registry.register(Arc::new(eb_service));
+
+    // Spawn the EventBridge scheduler as a background task
+    let mut scheduler = fakecloud_eventbridge::scheduler::Scheduler::new(eb_state, delivery_for_eb)
+        .with_lambda(lambda_state.clone())
+        .with_logs(logs_state.clone());
+    if let Some(ref rt) = container_runtime {
+        scheduler = scheduler.with_runtime(rt.clone());
+    }
     tokio::spawn(scheduler.run());
     registry.register(Arc::new(IamService::new(iam_state.clone())));
     registry.register(Arc::new(StsService::new(iam_state)));


### PR DESCRIPTION
## Summary
- EventBridge Lambda targets now actually invoke functions via Docker/Podman `ContainerRuntime`, instead of only recording stubs in state
- All three Lambda delivery paths updated: `put_events`, archive replay delivery, and the background scheduler
- Added `invoke_lambda_async` helper that spawns fire-and-forget invocations (matching EventBridge's async delivery model)
- Wired `ContainerRuntime` into both `EventBridgeService` and `Scheduler` in the server entrypoint

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance` passes
- [ ] `eventbridge_to_lambda_actually_executes` E2E test (marked `#[ignore]`, requires Docker): creates SQS proof queue, deploys Python Lambda that posts back to SQS, fires EventBridge event, asserts message arrives in proof queue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
EventBridge Lambda targets now invoke real Lambda functions via Docker/Podman `ContainerRuntime` for `put_events`, archive replay, and scheduled rules. If no runtime is available, delivery remains record-only.

- **New Features**
  - Added `invoke_lambda_async` for fire-and-forget delivery, supporting qualified Lambda ARNs (aliases/versions).
  - Wired `ContainerRuntime` into `EventBridgeService` and `Scheduler`; background tasks invoke and log success/failure.
  - Ignored E2E test demonstrates EventBridge→Lambda→SQS roundtrip; falls back to record-only without a runtime.

- **Migration**
  - No breaking changes; enable execution by running the server with Docker/Podman so a `ContainerRuntime` is available.

<sup>Written for commit a41553de31ea25125ea0671dd5ae7e7ab401d383. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

