### PR TITLE
feat(sqs): real Lambda execution for SQS event source mappings

### DIFF
--- a/crates/fakecloud-e2e/tests/cross_service.rs
+++ b/crates/fakecloud-e2e/tests/cross_service.rs
@@ -1346,3 +1346,133 @@ def handler(event, context):
     assert_eq!(record["Sns"]["Message"], "hello from SNS");
     assert_eq!(record["Sns"]["Subject"], "Test Subject");
 }
+
+/// SQS -> Lambda ESM real execution: send a message to SQS, the event source mapping
+/// triggers a Lambda that processes the message and writes "processed:<body>" to a result queue.
+#[tokio::test]
+#[ignore] // Requires Docker with host.docker.internal networking — run locally, not in CI
+async fn sqs_to_lambda_esm_actually_executes() {
+    let server = TestServer::start().await;
+    let sqs = server.sqs_client().await;
+    let lambda = server.lambda_client().await;
+
+    // 1. Create source queue and result queue
+    let source_queue = sqs
+        .create_queue()
+        .queue_name("esm-source-queue")
+        .send()
+        .await
+        .unwrap();
+    let source_url = source_queue.queue_url().unwrap().to_string();
+    let source_arn = get_queue_arn(&sqs, &source_url).await;
+
+    let result_queue = sqs
+        .create_queue()
+        .queue_name("esm-result-queue")
+        .send()
+        .await
+        .unwrap();
+    let result_url = result_queue.queue_url().unwrap().to_string();
+
+    // 2. Create Lambda (Python) that reads SQS event, extracts message body,
+    //    and sends "processed:<body>" to the result queue
+    let docker_endpoint = format!("http://host.docker.internal:{}", server.port());
+    let docker_result_url = format!(
+        "http://host.docker.internal:{}/123456789012/esm-result-queue",
+        server.port()
+    );
+    let python_code = format!(
+        r#"
+import json
+import urllib.request
+import urllib.parse
+
+def handler(event, context):
+    for record in event.get("Records", []):
+        body = record.get("body", "")
+        result = "processed:" + body
+        params = urllib.parse.urlencode({{
+            "Action": "SendMessage",
+            "QueueUrl": "{docker_result_url}",
+            "MessageBody": result,
+            "Version": "2012-11-05",
+        }})
+        req = urllib.request.Request(
+            "{docker_endpoint}/",
+            data=params.encode("utf-8"),
+            headers={{
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Authorization": "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/sqs/aws4_request, SignedHeaders=host, Signature=fake",
+            }},
+        )
+        urllib.request.urlopen(req, timeout=5)
+    return {{"statusCode": 200, "body": "ok"}}
+"#
+    );
+
+    let zip = make_zip(&[("index.py", python_code.as_bytes())]);
+
+    lambda
+        .create_function()
+        .function_name("esm-processor")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("index.handler")
+        .timeout(10)
+        .environment(
+            Environment::builder()
+                .variables("AWS_ACCESS_KEY_ID", "test")
+                .variables("AWS_SECRET_ACCESS_KEY", "test")
+                .build(),
+        )
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    // 3. Create event source mapping from source queue to Lambda
+    lambda
+        .create_event_source_mapping()
+        .event_source_arn(&source_arn)
+        .function_name("esm-processor")
+        .batch_size(10)
+        .enabled(true)
+        .send()
+        .await
+        .unwrap();
+
+    // 4. Send a message to the source queue
+    let original_body = "hello-esm-test";
+    sqs.send_message()
+        .queue_url(&source_url)
+        .message_body(original_body)
+        .send()
+        .await
+        .unwrap();
+
+    // 5. Wait and receive from result queue
+    let mut proof_message = None;
+    for _ in 0..30 {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        let msgs = sqs
+            .receive_message()
+            .queue_url(&result_url)
+            .max_number_of_messages(1)
+            .send()
+            .await
+            .unwrap();
+        if !msgs.messages().is_empty() {
+            proof_message = Some(msgs.messages()[0].body().unwrap().to_string());
+            break;
+        }
+    }
+
+    // 6. Assert the result contains "processed:" + original message
+    let msg = proof_message
+        .expect("Lambda was not actually invoked by SQS ESM -- no message in result queue");
+    assert_eq!(
+        msg,
+        format!("processed:{original_body}"),
+        "Lambda should have processed the SQS message and sent 'processed:<body>' to result queue"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -233,7 +233,10 @@ async fn main() {
     let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state);
     tokio::spawn(lifecycle_processor.run());
 
-    let sqs_lambda_poller = SqsLambdaPoller::new(sqs_state, lambda_state);
+    let mut sqs_lambda_poller = SqsLambdaPoller::new(sqs_state, lambda_state);
+    if let Some(ref ld) = lambda_delivery {
+        sqs_lambda_poller = sqs_lambda_poller.with_lambda_delivery(ld.clone());
+    }
     tokio::spawn(sqs_lambda_poller.run());
 
     if let Some(ref rt) = container_runtime {

--- a/crates/fakecloud-server/src/sqs_lambda_poller.rs
+++ b/crates/fakecloud-server/src/sqs_lambda_poller.rs
@@ -1,14 +1,17 @@
 //! Background poller that bridges SQS -> Lambda event source mappings.
 //!
 //! Periodically checks Lambda state for enabled event source mappings
-//! pointing to SQS queues, polls those queues for messages, and records
-//! Lambda invocations in Lambda state.
+//! pointing to SQS queues, polls those queues for messages, and either
+//! invokes the Lambda function via the container runtime (when available)
+//! or records the invocation in Lambda state.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
 use serde_json::json;
 
+use fakecloud_core::delivery::LambdaDelivery;
 use fakecloud_lambda::state::{LambdaInvocation, SharedLambdaState};
 use fakecloud_sqs::state::SharedSqsState;
 
@@ -16,6 +19,7 @@ use fakecloud_sqs::state::SharedSqsState;
 pub struct SqsLambdaPoller {
     sqs_state: SharedSqsState,
     lambda_state: SharedLambdaState,
+    lambda_delivery: Option<Arc<dyn LambdaDelivery>>,
 }
 
 impl SqsLambdaPoller {
@@ -23,18 +27,24 @@ impl SqsLambdaPoller {
         Self {
             sqs_state,
             lambda_state,
+            lambda_delivery: None,
         }
+    }
+
+    pub fn with_lambda_delivery(mut self, delivery: Arc<dyn LambdaDelivery>) -> Self {
+        self.lambda_delivery = Some(delivery);
+        self
     }
 
     pub async fn run(self) {
         let mut interval = tokio::time::interval(Duration::from_millis(500));
         loop {
             interval.tick().await;
-            self.poll();
+            self.poll().await;
         }
     }
 
-    fn poll(&self) {
+    async fn poll(&self) {
         // Collect enabled mappings that point to SQS sources
         let mappings: Vec<(String, String, i64)> = {
             let lambda = self.lambda_state.read();
@@ -125,7 +135,26 @@ impl SqsLambdaPoller {
                 "SQS->Lambda: delivering messages to function"
             );
 
-            // Record the invocation in Lambda state
+            // If we have a real Lambda delivery mechanism, invoke the function
+            if let Some(ref delivery) = self.lambda_delivery {
+                match delivery.invoke_lambda(&function_arn, &payload).await {
+                    Ok(_) => {
+                        tracing::debug!(
+                            function_arn = %function_arn,
+                            "SQS->Lambda: function invoked successfully"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            function_arn = %function_arn,
+                            error = %e,
+                            "SQS->Lambda: function invocation failed"
+                        );
+                    }
+                }
+            }
+
+            // Record the invocation in Lambda state (for observability / testing)
             let mut lambda = self.lambda_state.write();
             lambda.invocations.push(LambdaInvocation {
                 function_arn,


### PR DESCRIPTION
## Summary
- Wire `SqsLambdaPoller` to the `LambdaDelivery` trait so SQS→Lambda event source mappings actually invoke functions via the container runtime (Docker/Podman) instead of only recording invocations
- Add `with_lambda_delivery()` builder method to `SqsLambdaPoller` and make `poll()` async
- Pass the existing `lambda_delivery` from `main.rs` into the poller at startup
- Add E2E test `sqs_to_lambda_esm_actually_executes` (ignored, requires Docker) that creates a source queue, result queue, Python Lambda, and ESM, then verifies the Lambda processes the SQS message and writes "processed:<body>" to the result queue

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance` passes
- [ ] `cargo test -p fakecloud-e2e -- --ignored sqs_to_lambda_esm_actually_executes` (requires Docker)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable real Lambda execution for SQS event source mappings by wiring the SQS→Lambda poller to the container runtime via `LambdaDelivery`. When a runtime is available, SQS messages now trigger actual function runs; otherwise, invocations are still recorded.

- **New Features**
  - `SqsLambdaPoller` accepts optional `LambdaDelivery` via `with_lambda_delivery()` and invokes functions before recording.
  - `poll()` is now async; `run()` awaits it.
  - `main.rs` passes the existing `lambda_delivery` into the poller at startup.
  - Added an ignored E2E test that verifies SQS→Lambda execution with a Python handler writing to a result queue (requires Docker).

<sup>Written for commit 145206062ebdc3c73dc98d2a76cdfa71835cf15b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

