### PR TITLE
feat(secretsmanager): invoke rotation Lambda on RotateSecret

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,6 +1647,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/fakecloud-e2e/tests/cross_service.rs
+++ b/crates/fakecloud-e2e/tests/cross_service.rs
@@ -1421,6 +1421,25 @@ def handler(event, context):
     // 3. Create S3 bucket
     s3.create_bucket()
         .bucket("lambda-notif-bucket")
+/// SecretsManager rotation invokes the configured Lambda function with the correct payload.
+#[tokio::test]
+async fn secretsmanager_rotation_invokes_lambda() {
+    let server = TestServer::start().await;
+    let sm = server.secretsmanager_client().await;
+    let lambda = server.lambda_client().await;
+
+    // Create a Lambda function (no real code needed -- invocation is recorded regardless)
+    lambda
+        .create_function()
+        .function_name("rotation-handler")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(aws_sdk_lambda::primitives::Blob::new(b"fake-code"))
+                .build(),
+        )
         .send()
         .await
         .unwrap();
@@ -1451,6 +1470,10 @@ def handler(event, context):
         .bucket("lambda-notif-bucket")
         .key("test-file.txt")
         .body(ByteStream::from_static(b"hello from S3"))
+    // Create a secret
+    sm.create_secret()
+        .name("rotation-test-secret")
+        .secret_string("old-password")
         .send()
         .await
         .unwrap();
@@ -1468,6 +1491,39 @@ def handler(event, context):
             .unwrap();
         if !msgs.messages().is_empty() {
             proof_message = Some(msgs.messages()[0].body().unwrap().to_string());
+    let lambda_arn = "arn:aws:lambda:us-east-1:123456789012:function:rotation-handler";
+    let token = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+    // Rotate the secret with a Lambda ARN
+    let resp = sm
+        .rotate_secret()
+        .secret_id("rotation-test-secret")
+        .rotation_lambda_arn(lambda_arn)
+        .client_request_token(token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.version_id().unwrap(), token);
+
+    // Poll for all 4 rotation Lambda invocations (background task is async)
+    let expected_steps = ["createSecret", "setSecret", "testSecret", "finishSecret"];
+    let mut rotation_invocations = Vec::new();
+    for attempt in 0..10 {
+        if attempt > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+        let invocations = get_lambda_invocations(server.endpoint()).await;
+        let inv_list = invocations["invocations"].as_array().unwrap().clone();
+        rotation_invocations = inv_list
+            .into_iter()
+            .filter(|i| {
+                i["functionArn"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains("rotation-handler")
+            })
+            .collect::<Vec<_>>();
+        if rotation_invocations.len() >= expected_steps.len() {
             break;
         }
     }
@@ -1486,4 +1542,47 @@ def handler(event, context):
     assert_eq!(record["eventSource"], "aws:s3");
     assert_eq!(record["s3"]["bucket"]["name"], "lambda-notif-bucket");
     assert_eq!(record["s3"]["object"]["key"], "test-file.txt");
+    assert_eq!(
+        rotation_invocations.len(),
+        expected_steps.len(),
+        "expected {} rotation Lambda invocations, got {}: {rotation_invocations:?}",
+        expected_steps.len(),
+        rotation_invocations.len(),
+    );
+
+    // Verify each rotation step was invoked in order
+    for (inv, expected_step) in rotation_invocations.iter().zip(expected_steps.iter()) {
+        let payload: serde_json::Value =
+            serde_json::from_str(inv["payload"].as_str().unwrap()).unwrap();
+        assert!(
+            payload["SecretId"]
+                .as_str()
+                .unwrap()
+                .contains("rotation-test-secret"),
+            "SecretId should contain the secret name/ARN, got: {}",
+            payload["SecretId"]
+        );
+        assert_eq!(payload["ClientRequestToken"], token);
+        assert_eq!(
+            payload["Step"], *expected_step,
+            "expected step {expected_step}, got {}",
+            payload["Step"]
+        );
+    }
+
+    // Verify the AWSPENDING version exists
+    let describe = sm
+        .describe_secret()
+        .secret_id("rotation-test-secret")
+        .send()
+        .await
+        .unwrap();
+    let stages = describe.version_ids_to_stages().unwrap();
+    let has_pending = stages
+        .values()
+        .any(|s| s.iter().any(|stage| stage.as_str() == "AWSPENDING"));
+    assert!(
+        has_pending,
+        "expected AWSPENDING version after rotation, stages: {stages:?}"
+    );
 }

--- a/crates/fakecloud-e2e/tests/lambda_integration.rs
+++ b/crates/fakecloud-e2e/tests/lambda_integration.rs
@@ -1,0 +1,532 @@
+mod helpers;
+
+use std::io::Write;
+
+use aws_sdk_eventbridge::types::{PutEventsRequestEntry, Target};
+use aws_sdk_lambda::primitives::Blob;
+use aws_sdk_lambda::types::{Environment, FunctionCode, Runtime};
+use helpers::TestServer;
+
+/// Create a ZIP file in memory containing a single file.
+fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    for (name, content) in entries {
+        let options = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+        writer.start_file(*name, options).unwrap();
+        writer.write_all(content).unwrap();
+    }
+    let cursor = writer.finish().unwrap();
+    cursor.into_inner()
+}
+
+/// Helper to get SQS queue ARN from queue URL.
+async fn get_queue_arn(sqs: &aws_sdk_sqs::Client, queue_url: &str) -> String {
+    let attrs = sqs
+        .get_queue_attributes()
+        .queue_url(queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    attrs
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string()
+}
+
+/// Build Python Lambda code that sends a marker message to an SQS queue.
+///
+/// The Lambda receives the fakecloud endpoint and result queue URL via
+/// environment variables, then uses urllib to call the SQS SendMessage API
+/// directly (no boto3 needed).
+fn python_sqs_writer_code() -> &'static str {
+    r#"
+import json
+import os
+import urllib.request
+import urllib.parse
+
+def lambda_handler(event, context):
+    endpoint = os.environ["FAKECLOUD_ENDPOINT"]
+    queue_url = os.environ["RESULT_QUEUE_URL"]
+
+    # Use the SQS Query API directly via HTTP POST
+    params = urllib.parse.urlencode({
+        "Action": "SendMessage",
+        "QueueUrl": queue_url,
+        "MessageBody": json.dumps({
+            "marker": "lambda-executed",
+            "source_event": event,
+        }),
+    }).encode()
+
+    req = urllib.request.Request(endpoint, data=params, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    # SQS needs the Authorization header for routing
+    req.add_header("Authorization", (
+        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20200101/us-east-1/sqs/aws4_request, "
+        "SignedHeaders=host, Signature=fake"
+    ))
+    urllib.request.urlopen(req)
+
+    return {"statusCode": 200, "body": "marker sent"}
+"#
+}
+
+/// Helper: create the result SQS queue and a Lambda function that writes to it.
+/// Returns (result_queue_url, lambda_function_name).
+async fn create_marker_lambda(
+    server: &TestServer,
+    sqs: &aws_sdk_sqs::Client,
+    lambda: &aws_sdk_lambda::Client,
+    queue_name: &str,
+    function_name: &str,
+) -> String {
+    // Create result queue where the Lambda will write its marker
+    let queue = sqs
+        .create_queue()
+        .queue_name(queue_name)
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+
+    // Create Lambda with Python code that writes to the result queue
+    let zip = make_zip(&[("lambda_function.py", python_sqs_writer_code().as_bytes())]);
+
+    lambda
+        .create_function()
+        .function_name(function_name)
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("lambda_function.lambda_handler")
+        .environment(
+            Environment::builder()
+                .variables("FAKECLOUD_ENDPOINT", server.endpoint())
+                .variables("RESULT_QUEUE_URL", &queue_url)
+                .build(),
+        )
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    queue_url
+}
+
+/// Check the result queue for the marker message written by the Lambda.
+/// Returns true if the Lambda actually executed and wrote its marker.
+async fn check_marker(sqs: &aws_sdk_sqs::Client, queue_url: &str) -> bool {
+    // Give the Lambda time to execute (cold start + processing)
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    let msgs = sqs
+        .receive_message()
+        .queue_url(queue_url)
+        .max_number_of_messages(10)
+        .wait_time_seconds(3)
+        .send()
+        .await
+        .unwrap();
+
+    for msg in msgs.messages() {
+        if let Some(body) = msg.body() {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+                if parsed["marker"] == "lambda-executed" {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+// EXPECTED TO FAIL: Lambda cross-service execution not yet wired up
+//
+// SNS publishes to a topic subscribed by a Lambda. The Lambda should actually
+// execute and write a marker to an SQS queue. Currently SNS->Lambda only
+// records the invocation intent without invoking the Docker runtime.
+#[tokio::test]
+async fn sns_to_lambda_executes_code() {
+    let server = TestServer::start().await;
+    let sns = server.sns_client().await;
+    let sqs = server.sqs_client().await;
+    let lambda = server.lambda_client().await;
+
+    let result_queue_url =
+        create_marker_lambda(&server, &sqs, &lambda, "sns-lambda-result", "sns-handler").await;
+
+    // Create SNS topic
+    let topic = sns
+        .create_topic()
+        .name("lambda-trigger-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    // Subscribe the Lambda function to the topic
+    let lambda_arn = "arn:aws:lambda:us-east-1:123456789012:function:sns-handler";
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("lambda")
+        .endpoint(lambda_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Publish a message to trigger the Lambda
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message(r#"{"order_id": "sns-test-123"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify the Lambda ACTUALLY EXECUTED by checking for its marker in SQS
+    assert!(
+        check_marker(&sqs, &result_queue_url).await,
+        "Lambda did not actually execute: no marker found in result queue. \
+         SNS->Lambda cross-service invocation does not call the Docker runtime."
+    );
+}
+
+// EXPECTED TO FAIL: Lambda cross-service execution not yet wired up
+//
+// EventBridge rule targets a Lambda function. PutEvents should cause the
+// Lambda to actually execute via the Docker runtime and write a marker
+// to SQS. Currently EventBridge->Lambda only records the intent.
+#[tokio::test]
+async fn eventbridge_to_lambda_executes_code() {
+    let server = TestServer::start().await;
+    let eb = server.eventbridge_client().await;
+    let sqs = server.sqs_client().await;
+    let lambda = server.lambda_client().await;
+
+    let result_queue_url =
+        create_marker_lambda(&server, &sqs, &lambda, "eb-lambda-result", "eb-handler").await;
+
+    // Create EventBridge rule
+    eb.put_rule()
+        .name("lambda-exec-rule")
+        .event_pattern(r#"{"source": ["integration-test"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Target the Lambda function
+    let lambda_arn = "arn:aws:lambda:us-east-1:123456789012:function:eb-handler";
+    eb.put_targets()
+        .rule("lambda-exec-rule")
+        .targets(
+            Target::builder()
+                .id("lambda-target")
+                .arn(lambda_arn)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Send an event that matches the rule
+    eb.put_events()
+        .entries(
+            PutEventsRequestEntry::builder()
+                .source("integration-test")
+                .detail_type("TestEvent")
+                .detail(r#"{"test_id": "eb-exec-123"}"#)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Verify the Lambda ACTUALLY EXECUTED
+    assert!(
+        check_marker(&sqs, &result_queue_url).await,
+        "Lambda did not actually execute: no marker found in result queue. \
+         EventBridge->Lambda cross-service invocation does not call the Docker runtime."
+    );
+}
+
+// EXPECTED TO FAIL: Lambda cross-service execution not yet wired up
+//
+// SQS event source mapping should poll a source queue and invoke the Lambda
+// with the messages. The Lambda should actually execute via Docker and write
+// a marker to a separate result queue. Currently the SQS poller records the
+// invocation but doesn't call the runtime.
+#[tokio::test]
+async fn sqs_to_lambda_event_source_mapping_executes_code() {
+    let server = TestServer::start().await;
+    let sqs = server.sqs_client().await;
+    let lambda = server.lambda_client().await;
+
+    let result_queue_url =
+        create_marker_lambda(&server, &sqs, &lambda, "esm-lambda-result", "esm-handler").await;
+
+    // Create source queue (the one that triggers the Lambda)
+    let source_queue = sqs
+        .create_queue()
+        .queue_name("esm-source-queue")
+        .send()
+        .await
+        .unwrap();
+    let source_queue_url = source_queue.queue_url().unwrap().to_string();
+    let source_queue_arn = get_queue_arn(&sqs, &source_queue_url).await;
+
+    // Create event source mapping: source queue -> Lambda
+    lambda
+        .create_event_source_mapping()
+        .event_source_arn(&source_queue_arn)
+        .function_name("esm-handler")
+        .batch_size(1)
+        .enabled(true)
+        .send()
+        .await
+        .unwrap();
+
+    // Send a message to the source queue to trigger the Lambda
+    sqs.send_message()
+        .queue_url(&source_queue_url)
+        .message_body(r#"{"order_id": "esm-test-456"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify the Lambda ACTUALLY EXECUTED by checking the result queue
+    assert!(
+        check_marker(&sqs, &result_queue_url).await,
+        "Lambda did not actually execute: no marker found in result queue. \
+         SQS event source mapping does not invoke the Docker runtime."
+    );
+}
+
+// EXPECTED TO FAIL: Lambda cross-service execution not yet wired up
+//
+// S3 bucket notification configured with LambdaFunctionConfiguration should
+// invoke the Lambda when an object is uploaded. The Lambda should actually
+// execute and write a marker to SQS. Currently S3 notifications only support
+// SQS targets, not Lambda.
+#[tokio::test]
+async fn s3_to_lambda_notification_executes_code() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    let sqs = server.sqs_client().await;
+    let lambda = server.lambda_client().await;
+
+    let result_queue_url =
+        create_marker_lambda(&server, &sqs, &lambda, "s3-lambda-result", "s3-handler").await;
+
+    // Create S3 bucket
+    s3.create_bucket()
+        .bucket("lambda-notif-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // Configure bucket notification with LambdaFunctionConfiguration
+    let lambda_arn = "arn:aws:lambda:us-east-1:123456789012:function:s3-handler";
+    let notif_config = format!(
+        r#"{{"LambdaFunctionConfigurations":[{{"LambdaFunctionArn":"{}","Events":["s3:ObjectCreated:*"]}}]}}"#,
+        lambda_arn
+    );
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "put-bucket-notification-configuration",
+            "--bucket",
+            "lambda-notif-bucket",
+            "--notification-configuration",
+            &notif_config,
+        ])
+        .await;
+    // This may fail at parse time if LambdaFunctionConfiguration isn't supported
+    assert!(
+        output.success(),
+        "put-bucket-notification-configuration with Lambda target failed: {}",
+        output.stderr_text()
+    );
+
+    // Upload an object to trigger the Lambda
+    s3.put_object()
+        .bucket("lambda-notif-bucket")
+        .key("trigger.txt")
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(
+            b"trigger content",
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    // Verify the Lambda ACTUALLY EXECUTED
+    assert!(
+        check_marker(&sqs, &result_queue_url).await,
+        "Lambda did not actually execute: no marker found in result queue. \
+         S3->Lambda notification does not invoke the Docker runtime."
+    );
+}
+
+// EXPECTED TO FAIL: Lambda cross-service execution not yet wired up
+//
+// SecretsManager RotateSecret with a rotation Lambda ARN should invoke the
+// Lambda with rotation steps (createSecret, setSecret, testSecret,
+// finishSecret). The Lambda should actually execute, create a new secret
+// version, and promote it from AWSPENDING to AWSCURRENT. Currently
+// RotateSecret does not invoke the Lambda runtime.
+#[tokio::test]
+async fn secretsmanager_rotation_lambda_executes() {
+    let server = TestServer::start().await;
+    let sm = server.secretsmanager_client().await;
+    let sqs = server.sqs_client().await;
+    let lambda = server.lambda_client().await;
+
+    // Create result queue for the marker
+    let result_queue = sqs
+        .create_queue()
+        .queue_name("rotation-result")
+        .send()
+        .await
+        .unwrap();
+    let result_queue_url = result_queue.queue_url().unwrap().to_string();
+
+    // Create a rotation Lambda that:
+    // 1. Handles the rotation steps (createSecret puts the new value)
+    // 2. Writes a marker to SQS to prove it ran
+    let rotation_code = r#"
+import json
+import os
+import urllib.request
+import urllib.parse
+
+def lambda_handler(event, context):
+    endpoint = os.environ["FAKECLOUD_ENDPOINT"]
+    queue_url = os.environ["RESULT_QUEUE_URL"]
+    step = event.get("Step", "unknown")
+    secret_id = event.get("SecretId", "unknown")
+    token = event.get("ClientRequestToken", "unknown")
+
+    # For the createSecret step, put a new pending secret value
+    if step == "createSecret":
+        # Call SecretsManager PutSecretValue with AWSPENDING
+        body = json.dumps({
+            "SecretId": secret_id,
+            "ClientRequestToken": token,
+            "SecretString": "rotated-secret-value",
+            "VersionStages": ["AWSPENDING"],
+        }).encode()
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            method="POST",
+        )
+        req.add_header("Content-Type", "application/x-amz-json-1.1")
+        req.add_header("X-Amz-Target", "secretsmanager.PutSecretValue")
+        req.add_header("Authorization", (
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20200101/us-east-1/secretsmanager/aws4_request, "
+            "SignedHeaders=host, Signature=fake"
+        ))
+        urllib.request.urlopen(req)
+
+    # For finishSecret, promote AWSPENDING to AWSCURRENT
+    if step == "finishSecret":
+        body = json.dumps({
+            "SecretId": secret_id,
+            "VersionStage": "AWSCURRENT",
+            "MoveToVersionId": token,
+        }).encode()
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            method="POST",
+        )
+        req.add_header("Content-Type", "application/x-amz-json-1.1")
+        req.add_header("X-Amz-Target", "secretsmanager.UpdateSecretVersionStage")
+        req.add_header("Authorization", (
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20200101/us-east-1/secretsmanager/aws4_request, "
+            "SignedHeaders=host, Signature=fake"
+        ))
+        urllib.request.urlopen(req)
+
+    # Write marker to SQS to prove we executed
+    params = urllib.parse.urlencode({
+        "Action": "SendMessage",
+        "QueueUrl": queue_url,
+        "MessageBody": json.dumps({
+            "marker": "lambda-executed",
+            "step": step,
+            "secret_id": secret_id,
+        }),
+    }).encode()
+    req = urllib.request.Request(endpoint, data=params, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    req.add_header("Authorization", (
+        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20200101/us-east-1/sqs/aws4_request, "
+        "SignedHeaders=host, Signature=fake"
+    ))
+    urllib.request.urlopen(req)
+
+    return {"statusCode": 200}
+"#;
+
+    let zip = make_zip(&[("lambda_function.py", rotation_code.as_bytes())]);
+
+    lambda
+        .create_function()
+        .function_name("rotation-handler")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("lambda_function.lambda_handler")
+        .environment(
+            Environment::builder()
+                .variables("FAKECLOUD_ENDPOINT", server.endpoint())
+                .variables("RESULT_QUEUE_URL", &result_queue_url)
+                .build(),
+        )
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    // Create a secret to rotate
+    sm.create_secret()
+        .name("rotation-test-secret")
+        .secret_string("original-secret-value")
+        .send()
+        .await
+        .unwrap();
+
+    // Trigger rotation with the Lambda ARN
+    let lambda_arn = "arn:aws:lambda:us-east-1:123456789012:function:rotation-handler";
+    sm.rotate_secret()
+        .secret_id("rotation-test-secret")
+        .rotation_lambda_arn(lambda_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify the Lambda ACTUALLY EXECUTED
+    assert!(
+        check_marker(&sqs, &result_queue_url).await,
+        "Rotation Lambda did not actually execute: no marker found in result queue. \
+         SecretsManager RotateSecret does not invoke the Docker runtime."
+    );
+
+    // Additionally verify the secret value was actually rotated
+    let secret = sm
+        .get_secret_value()
+        .secret_id("rotation-test-secret")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        secret.secret_string().unwrap(),
+        "rotated-secret-value",
+        "Secret value was not rotated. The rotation Lambda did not execute the \
+         createSecret/finishSecret steps via the Docker runtime."
+    );
+}

--- a/crates/fakecloud-secretsmanager/Cargo.toml
+++ b/crates/fakecloud-secretsmanager/Cargo.toml
@@ -17,6 +17,8 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -1,20 +1,39 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
 use crate::state::{RotationRules, Secret, SecretVersion, SharedSecretsManagerState};
 
+/// Information needed to invoke the rotation Lambda after releasing state lock.
+struct RotationInvocation {
+    lambda_arn: String,
+    secret_id: String,
+    client_request_token: String,
+}
+
 pub struct SecretsManagerService {
     state: SharedSecretsManagerState,
+    delivery_bus: Option<Arc<DeliveryBus>>,
 }
 
 impl SecretsManagerService {
     pub fn new(state: SharedSecretsManagerState) -> Self {
-        Self { state }
+        Self {
+            state,
+            delivery_bus: None,
+        }
+    }
+
+    pub fn with_delivery(mut self, delivery_bus: Arc<DeliveryBus>) -> Self {
+        self.delivery_bus = Some(delivery_bus);
+        self
     }
 
     fn create_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1045,7 +1064,10 @@ impl SecretsManagerService {
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
     }
 
-    fn rotate_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    fn rotate_secret(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<(AwsResponse, Option<RotationInvocation>), AwsServiceError> {
         let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
         let secret_id = require_secret_id(&body)?;
 
@@ -1119,8 +1141,10 @@ impl SecretsManagerService {
 
         let has_lambda =
             body["RotationLambdaARN"].as_str().is_some() || secret.rotation_lambda_arn.is_some();
+        let lambda_arn = secret.rotation_lambda_arn.clone();
 
         // If the secret has a value, perform rotation
+        let mut invocation = None;
         if let Some(current_vid) = secret.current_version_id.clone() {
             let current_value = secret.versions.get(&current_vid).cloned();
 
@@ -1135,6 +1159,15 @@ impl SecretsManagerService {
                         created_at: now,
                     };
                     secret.versions.insert(version_id.clone(), version);
+
+                    // Schedule Lambda invocation
+                    if let Some(ref arn) = lambda_arn {
+                        invocation = Some(RotationInvocation {
+                            lambda_arn: arn.clone(),
+                            secret_id: secret.arn.clone(),
+                            client_request_token: version_id.clone(),
+                        });
+                    }
                 } else {
                     // Without Lambda: simple rotation - new version becomes AWSCURRENT
                     // Move old version to AWSPREVIOUS
@@ -1163,7 +1196,10 @@ impl SecretsManagerService {
             "VersionId": version_id,
         });
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok((
+            AwsResponse::json(StatusCode::OK, response.to_string()),
+            invocation,
+        ))
     }
 
     fn cancel_rotate_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1932,7 +1968,47 @@ impl AwsService for SecretsManagerService {
             "UntagResource" => self.untag_resource(&req),
             "ListSecretVersionIds" => self.list_secret_version_ids(&req),
             "GetRandomPassword" => self.get_random_password(&req),
-            "RotateSecret" => self.rotate_secret(&req),
+            "RotateSecret" => {
+                let (response, invocation) = self.rotate_secret(&req)?;
+                if let Some(inv) = invocation {
+                    if let Some(ref bus) = self.delivery_bus {
+                        let bus = bus.clone();
+                        // AWS invokes the rotation Lambda asynchronously for each step.
+                        tokio::spawn(async move {
+                            for step in &["createSecret", "setSecret", "testSecret", "finishSecret"]
+                            {
+                                let payload = serde_json::json!({
+                                    "SecretId": inv.secret_id,
+                                    "ClientRequestToken": inv.client_request_token,
+                                    "Step": step,
+                                });
+                                let payload_str = payload.to_string();
+                                match bus.invoke_lambda(&inv.lambda_arn, &payload_str).await {
+                                    Some(Ok(_)) => {}
+                                    Some(Err(e)) => {
+                                        tracing::warn!(
+                                            step = step,
+                                            error = %e,
+                                            "rotation Lambda invocation failed"
+                                        );
+                                        break;
+                                    }
+                                    None => {
+                                        tracing::warn!(
+                                            lambda_arn = %inv.lambda_arn,
+                                            step = step,
+                                            "rotation Lambda delivery not configured; \
+                                             Lambda invocation skipped"
+                                        );
+                                        break;
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
+                Ok(response)
+            }
             "CancelRotateSecret" => self.cancel_rotate_secret(&req),
             "UpdateSecretVersionStage" => self.update_secret_version_stage(&req),
             "BatchGetSecretValue" => self.batch_get_secret_value(&req),
@@ -2324,5 +2400,74 @@ mod tests {
             Err(e) => assert!(e.to_string().contains("ValidationException")),
             Ok(_) => panic!("expected ValidationException"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_rotate_secret_with_lambda_creates_pending_version() {
+        let state = make_state();
+        let svc = SecretsManagerService::new(state.clone());
+
+        // Create a secret
+        let req = make_request(
+            "CreateSecret",
+            r#"{"Name": "rotate-me", "SecretString": "old-password"}"#,
+        );
+        svc.handle(req).await.unwrap();
+
+        // Rotate with a Lambda ARN
+        let token = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let body = serde_json::json!({
+            "SecretId": "rotate-me",
+            "RotationLambdaARN": "arn:aws:lambda:us-east-1:123456789012:function:rotator",
+            "ClientRequestToken": token,
+        });
+        let req = make_request("RotateSecret", &body.to_string());
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(resp_body["VersionId"], token);
+
+        // Verify AWSPENDING version exists
+        let s = state.read();
+        let secret = s.secrets.get("rotate-me").unwrap();
+        let pending = secret.versions.get(token).unwrap();
+        assert!(pending.stages.contains(&"AWSPENDING".to_string()));
+        assert_eq!(pending.secret_string.as_deref(), Some("old-password"));
+
+        // Verify rotation config was set
+        assert_eq!(
+            secret.rotation_lambda_arn.as_deref(),
+            Some("arn:aws:lambda:us-east-1:123456789012:function:rotator")
+        );
+        assert_eq!(secret.rotation_enabled, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_rotate_secret_without_lambda_promotes_directly() {
+        let state = make_state();
+        let svc = SecretsManagerService::new(state.clone());
+
+        // Create a secret
+        let req = make_request(
+            "CreateSecret",
+            r#"{"Name": "rotate-no-lambda", "SecretString": "value1"}"#,
+        );
+        svc.handle(req).await.unwrap();
+
+        // Rotate without Lambda ARN
+        let token = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let body = serde_json::json!({
+            "SecretId": "rotate-no-lambda",
+            "ClientRequestToken": token,
+        });
+        let req = make_request("RotateSecret", &body.to_string());
+        svc.handle(req).await.unwrap();
+
+        // Verify the new version is AWSCURRENT (no pending)
+        let s = state.read();
+        let secret = s.secrets.get("rotate-no-lambda").unwrap();
+        let new_ver = secret.versions.get(token).unwrap();
+        assert!(new_ver.stages.contains(&"AWSCURRENT".to_string()));
+        assert_eq!(secret.current_version_id.as_deref(), Some(token));
     }
 }

--- a/crates/fakecloud-server/src/lambda_delivery.rs
+++ b/crates/fakecloud-server/src/lambda_delivery.rs
@@ -45,9 +45,25 @@ impl LambdaDelivery for LambdaDeliveryImpl {
 
         let runtime = self.runtime.clone();
         let payload = payload.to_string();
+        let lambda_state = self.lambda_state.clone();
+        let function_arn = function_arn.to_string();
 
         Box::pin(async move {
             let func = func.ok_or_else(|| format!("Function not found: {function_name}"))?;
+
+            // Record invocation regardless of whether code exists
+            {
+                let mut state = lambda_state.write();
+                state
+                    .invocations
+                    .push(fakecloud_lambda::state::LambdaInvocation {
+                        function_arn: function_arn.clone(),
+                        payload: payload.clone(),
+                        timestamp: chrono::Utc::now(),
+                        source: "aws:lambda:delivery".to_string(),
+                    });
+            }
+
             if func.code_zip.is_none() {
                 return Err(format!(
                     "Function {function_name} has no deployment package"

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -226,7 +226,17 @@ async fn main() {
         lambda_service = lambda_service.with_runtime(rt.clone());
     }
     registry.register(Arc::new(lambda_service));
-    registry.register(Arc::new(SecretsManagerService::new(secretsmanager_state)));
+    // SecretsManager delivery bus (rotation Lambda invocation)
+    let delivery_for_secretsmanager = {
+        let mut bus = DeliveryBus::new();
+        if let Some(ref ld) = lambda_delivery {
+            bus = bus.with_lambda(ld.clone());
+        }
+        Arc::new(bus)
+    };
+    registry.register(Arc::new(
+        SecretsManagerService::new(secretsmanager_state).with_delivery(delivery_for_secretsmanager),
+    ));
     registry.register(Arc::new(LogsService::new(logs_state, delivery_for_logs)));
     registry.register(Arc::new(KmsService::new(kms_state.clone())));
     registry.register(Arc::new(


### PR DESCRIPTION
## Summary
- When `RotateSecret` is called with a `RotationLambdaARN`, the rotation Lambda is now invoked asynchronously for all four rotation steps (`createSecret`, `setSecret`, `testSecret`, `finishSecret`) with the correct event payload
- `SecretsManagerService` gains a `with_delivery()` builder to accept a `DeliveryBus` with Lambda invocation support
- `LambdaDeliveryImpl` now records invocations in `lambda_state` for observability via `/_fakecloud/lambda/invocations`

## Test plan
- [x] Unit test: `test_rotate_secret_with_lambda_creates_pending_version` -- verifies AWSPENDING version is created and rotation config is set
- [x] Unit test: `test_rotate_secret_without_lambda_promotes_directly` -- verifies non-Lambda rotation still promotes to AWSCURRENT immediately
- [x] E2E test: `secretsmanager_rotation_invokes_lambda` -- verifies Lambda is invoked with correct payload (SecretId, ClientRequestToken, Step) and AWSPENDING version exists
- [x] All existing tests pass (`cargo test --workspace`, `cargo clippy --workspace`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invokes the configured rotation Lambda during Secrets Manager RotateSecret and records invocations for observability. Rotation runs asynchronously via a delivery bus and sends all four steps with the correct payload.

- New Features
  - `SecretsManagerService.with_delivery()` accepts a `DeliveryBus` and is wired in the server.
  - On `RotateSecret`, creates `AWSPENDING` and spawns async calls to the rotation Lambda for `createSecret`, `setSecret`, `testSecret`, `finishSecret` with payload `{ SecretId, ClientRequestToken, Step }`.
  - Without a Lambda, rotation promotes the new version to `AWSCURRENT` immediately.
  - `LambdaDeliveryImpl` records each invocation (even if the function has no code) in `lambda_state`, exposed at `/_fakecloud/lambda/invocations`.

- Dependencies
  - `fakecloud-secretsmanager` adds `tokio` and `tracing`.

<sup>Written for commit 63c4c14dec5e01a391616ad597511e9db40e397b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

