### PR TITLE
feat(cloudformation): Custom Resource Lambda invocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -1,7 +1,9 @@
 use chrono::Utc;
 use std::collections::HashMap;
+use std::sync::Arc;
 use uuid::Uuid;
 
+use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_dynamodb::state::{
     AttributeDefinition, DynamoTable, KeySchemaElement, ProvisionedThroughput, SharedDynamoDbState,
 };
@@ -26,8 +28,10 @@ pub struct ResourceProvisioner {
     pub eventbridge_state: SharedEventBridgeState,
     pub dynamodb_state: SharedDynamoDbState,
     pub logs_state: SharedLogsState,
+    pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
+    pub stack_id: String,
 }
 
 impl ResourceProvisioner {
@@ -44,7 +48,22 @@ impl ResourceProvisioner {
             "AWS::Events::Rule" => self.create_eventbridge_rule(resource),
             "AWS::DynamoDB::Table" => self.create_dynamodb_table(resource),
             "AWS::Logs::LogGroup" => self.create_log_group(resource),
+            t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
+                self.create_custom_resource(resource)
+            }
             other => Err(format!("Unsupported resource type: {other}")),
+        };
+
+        let is_custom = resource.resource_type.starts_with("Custom::")
+            || resource.resource_type == "AWS::CloudFormation::CustomResource";
+        let service_token = if is_custom {
+            resource
+                .properties
+                .get("ServiceToken")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        } else {
+            None
         };
 
         result.map(|physical_id| StackResource {
@@ -52,6 +71,7 @@ impl ResourceProvisioner {
             physical_id,
             resource_type: resource.resource_type.clone(),
             status: "CREATE_COMPLETE".to_string(),
+            service_token,
         })
     }
 
@@ -68,6 +88,9 @@ impl ResourceProvisioner {
             "AWS::Events::Rule" => self.delete_eventbridge_rule(&resource.physical_id),
             "AWS::DynamoDB::Table" => self.delete_dynamodb_table(&resource.physical_id),
             "AWS::Logs::LogGroup" => self.delete_log_group(&resource.physical_id),
+            t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
+                self.delete_custom_resource(resource)
+            }
             other => Err(format!("Unsupported resource type: {other}")),
         }
     }
@@ -708,13 +731,118 @@ impl ResourceProvisioner {
         }
         Ok(())
     }
+
+    // --- Custom Resources ---
+
+    /// Invoke a Lambda function synchronously via the delivery bus.
+    fn invoke_lambda_sync(&self, function_arn: &str, payload: &str) -> Result<(), String> {
+        let delivery = self.delivery.clone();
+        let function_arn = function_arn.to_string();
+        let payload = payload.to_string();
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| format!("Failed to create runtime: {e}"))?;
+                rt.block_on(async {
+                    match delivery.invoke_lambda(&function_arn, &payload).await {
+                        Some(Ok(_)) => {
+                            tracing::info!(
+                                "Custom resource Lambda {} invoked successfully",
+                                function_arn
+                            );
+                            Ok(())
+                        }
+                        Some(Err(e)) => {
+                            tracing::warn!(
+                                "Custom resource Lambda {} invocation failed: {e}",
+                                function_arn
+                            );
+                            Err(format!("Lambda invocation failed: {e}"))
+                        }
+                        None => {
+                            tracing::warn!(
+                                "No Lambda delivery configured; skipping custom resource invocation for {}",
+                                function_arn
+                            );
+                            Ok(())
+                        }
+                    }
+                })
+            })
+            .join()
+            .map_err(|_| "Lambda invocation thread panicked".to_string())?
+        })
+    }
+
+    fn create_custom_resource(&self, resource: &ResourceDefinition) -> Result<String, String> {
+        let props = &resource.properties;
+        let service_token = props
+            .get("ServiceToken")
+            .and_then(|v| v.as_str())
+            .ok_or("Custom resource requires ServiceToken property")?;
+
+        let request_id = Uuid::new_v4().to_string();
+
+        // Build the CloudFormation custom resource event
+        let event = serde_json::json!({
+            "RequestType": "Create",
+            "ServiceToken": service_token,
+            "StackId": self.stack_id,
+            "RequestId": request_id,
+            "ResourceType": resource.resource_type,
+            "LogicalResourceId": resource.logical_id,
+            "ResourceProperties": props,
+        });
+
+        let payload = serde_json::to_string(&event).map_err(|e| e.to_string())?;
+        self.invoke_lambda_sync(service_token, &payload)?;
+
+        // Physical resource ID: use a generated ID (the Lambda could return one,
+        // but for simplicity we generate one here).
+        let physical_id = format!("{}-{}", resource.logical_id, &request_id[..8]);
+        Ok(physical_id)
+    }
+
+    fn delete_custom_resource(&self, resource: &StackResource) -> Result<(), String> {
+        let service_token = match &resource.service_token {
+            Some(token) => token.clone(),
+            None => {
+                // No ServiceToken stored — nothing to invoke
+                return Ok(());
+            }
+        };
+
+        let request_id = Uuid::new_v4().to_string();
+
+        let event = serde_json::json!({
+            "RequestType": "Delete",
+            "ServiceToken": service_token,
+            "StackId": self.stack_id,
+            "RequestId": request_id,
+            "ResourceType": resource.resource_type,
+            "LogicalResourceId": resource.logical_id,
+            "PhysicalResourceId": resource.physical_id,
+        });
+
+        let payload = serde_json::to_string(&event).map_err(|e| e.to_string())?;
+
+        // Best-effort: don't fail stack deletion if Lambda invocation fails
+        if let Err(e) = self.invoke_lambda_sync(&service_token, &payload) {
+            tracing::warn!(
+                "Custom resource delete Lambda invocation failed for {}: {e}",
+                resource.logical_id
+            );
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use parking_lot::RwLock;
-    use std::sync::Arc;
 
     fn make_provisioner() -> ResourceProvisioner {
         ResourceProvisioner {
@@ -749,8 +877,10 @@ mod tests {
                 "123456789012",
                 "us-east-1",
             ))),
+            delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),
+            stack_id: "arn:aws:cloudformation:us-east-1:123456789012:stack/test/00000000-0000-0000-0000-000000000000".to_string(),
         }
     }
 
@@ -882,5 +1012,61 @@ mod tests {
         let result = prov.create_resource(&resource);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("does not exist"));
+    }
+
+    #[test]
+    fn custom_resource_requires_service_token() {
+        let prov = make_provisioner();
+        let resource = make_resource(
+            "Custom::MyResource",
+            "MyCustom",
+            serde_json::json!({
+                "Foo": "bar"
+            }),
+        );
+        let result = prov.create_resource(&resource);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().contains("ServiceToken"),
+            "Should require ServiceToken property"
+        );
+    }
+
+    #[test]
+    fn custom_resource_succeeds_without_lambda_delivery() {
+        // When no Lambda delivery is configured, custom resource creation
+        // should still succeed (the invocation is silently skipped).
+        let prov = make_provisioner();
+        let resource = make_resource(
+            "Custom::MyResource",
+            "MyCustom",
+            serde_json::json!({
+                "ServiceToken": "arn:aws:lambda:us-east-1:123456789012:function:my-func",
+                "Foo": "bar"
+            }),
+        );
+        let result = prov.create_resource(&resource);
+        assert!(result.is_ok());
+        let sr = result.unwrap();
+        assert_eq!(sr.logical_id, "MyCustom");
+        assert_eq!(sr.resource_type, "Custom::MyResource");
+        assert!(sr.physical_id.starts_with("MyCustom-"));
+    }
+
+    #[test]
+    fn cloudformation_custom_resource_type_succeeds() {
+        let prov = make_provisioner();
+        let resource = make_resource(
+            "AWS::CloudFormation::CustomResource",
+            "MyCustom2",
+            serde_json::json!({
+                "ServiceToken": "arn:aws:lambda:us-east-1:123456789012:function:my-func",
+                "Key": "value"
+            }),
+        );
+        let result = prov.create_resource(&resource);
+        assert!(result.is_ok());
+        let sr = result.unwrap();
+        assert_eq!(sr.resource_type, "AWS::CloudFormation::CustomResource");
     }
 }

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -2,7 +2,9 @@ use async_trait::async_trait;
 use chrono::Utc;
 use http::StatusCode;
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_dynamodb::state::SharedDynamoDbState;
 use fakecloud_eventbridge::state::SharedEventBridgeState;
@@ -28,6 +30,7 @@ pub struct CloudFormationService {
     eventbridge_state: SharedEventBridgeState,
     dynamodb_state: SharedDynamoDbState,
     logs_state: SharedLogsState,
+    delivery: Arc<DeliveryBus>,
 }
 
 impl CloudFormationService {
@@ -42,6 +45,7 @@ impl CloudFormationService {
         eventbridge_state: SharedEventBridgeState,
         dynamodb_state: SharedDynamoDbState,
         logs_state: SharedLogsState,
+        delivery: Arc<DeliveryBus>,
     ) -> Self {
         Self {
             state,
@@ -53,10 +57,11 @@ impl CloudFormationService {
             eventbridge_state,
             dynamodb_state,
             logs_state,
+            delivery,
         }
     }
 
-    fn provisioner(&self) -> ResourceProvisioner {
+    fn provisioner(&self, stack_id: &str) -> ResourceProvisioner {
         let cf_state = self.state.read();
         ResourceProvisioner {
             sqs_state: self.sqs_state.clone(),
@@ -67,8 +72,10 @@ impl CloudFormationService {
             eventbridge_state: self.eventbridge_state.clone(),
             dynamodb_state: self.dynamodb_state.clone(),
             logs_state: self.logs_state.clone(),
+            delivery: self.delivery.clone(),
             account_id: cf_state.account_id.clone(),
             region: cf_state.region.clone(),
+            stack_id: stack_id.to_string(),
         }
     }
 
@@ -162,7 +169,18 @@ impl CloudFormationService {
             AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
         })?;
 
-        let provisioner = self.provisioner();
+        let stack_id = {
+            let state = self.state.read();
+            format!(
+                "arn:aws:cloudformation:{}:{}:stack/{}/{}",
+                state.region,
+                state.account_id,
+                stack_name,
+                uuid::Uuid::new_v4()
+            )
+        };
+
+        let provisioner = self.provisioner(&stack_id);
         let mut resources = Vec::new();
         let mut physical_ids: HashMap<String, String> = HashMap::new();
 
@@ -231,17 +249,6 @@ impl CloudFormationService {
             }
         }
 
-        let stack_id = {
-            let state = self.state.read();
-            format!(
-                "arn:aws:cloudformation:{}:{}:stack/{}/{}",
-                state.region,
-                state.account_id,
-                stack_name,
-                uuid::Uuid::new_v4()
-            )
-        };
-
         let stack = Stack {
             name: stack_name.clone(),
             stack_id: stack_id.clone(),
@@ -275,8 +282,6 @@ impl CloudFormationService {
             )
         })?;
 
-        let provisioner = self.provisioner();
-
         let mut state = self.state.write();
 
         // Find stack by name or stack ID
@@ -285,13 +290,25 @@ impl CloudFormationService {
         });
 
         if let Some(stack) = stack {
-            // Delete resources in reverse order
+            let stack_id = stack.stack_id.clone();
             let resources: Vec<_> = stack.resources.clone();
+
+            // Build the provisioner while we still have the stack_id
+            // Drop the write lock temporarily so the provisioner can read state
+            drop(state);
+            let provisioner = self.provisioner(&stack_id);
+
+            // Delete resources in reverse order
             for resource in resources.iter().rev() {
                 let _ = provisioner.delete_resource(resource);
             }
-            stack.status = "DELETE_COMPLETE".to_string();
-            stack.resources.clear();
+
+            // Re-acquire the write lock to update stack status
+            let mut state = self.state.write();
+            if let Some(stack) = state.stacks.values_mut().find(|s| s.stack_id == stack_id) {
+                stack.status = "DELETE_COMPLETE".to_string();
+                stack.resources.clear();
+            }
         }
 
         Ok(AwsResponse::xml(
@@ -438,7 +455,21 @@ impl CloudFormationService {
             AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
         })?;
 
-        let provisioner = self.provisioner();
+        // Get stack_id before write lock for the provisioner
+        let found_stack_id = {
+            let state = self.state.read();
+            state
+                .stacks
+                .values()
+                .find(|s| {
+                    (s.name == *stack_name || s.stack_id == *stack_name)
+                        && s.status != "DELETE_COMPLETE"
+                })
+                .map(|s| s.stack_id.clone())
+                .unwrap_or_default()
+        };
+
+        let provisioner = self.provisioner(&found_stack_id);
 
         let mut state = self.state.write();
         let stack = state
@@ -673,6 +704,7 @@ mod tests {
                 "123456789012",
                 "us-east-1",
             ))),
+            Arc::new(DeliveryBus::new()),
         )
     }
 

--- a/crates/fakecloud-cloudformation/src/state.rs
+++ b/crates/fakecloud-cloudformation/src/state.rs
@@ -9,6 +9,8 @@ pub struct StackResource {
     pub physical_id: String,
     pub resource_type: String,
     pub status: String,
+    /// For custom resources, the Lambda ARN (ServiceToken) used for invocation.
+    pub service_token: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/fakecloud-e2e/tests/cloudformation.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation.rs
@@ -1,5 +1,7 @@
 mod helpers;
 
+use std::io::Write;
+
 use helpers::TestServer;
 
 #[tokio::test]
@@ -449,5 +451,162 @@ async fn cloudformation_update_stack() {
     assert_eq!(
         desc.stacks()[0].stack_status().map(|s| s.as_str()),
         Some("UPDATE_COMPLETE")
+    );
+}
+
+/// Create a ZIP file in memory containing a single file.
+fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    for (name, content) in entries {
+        let options = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+        writer.start_file(*name, options).unwrap();
+        writer.write_all(content).unwrap();
+    }
+    let cursor = writer.finish().unwrap();
+    cursor.into_inner()
+}
+
+/// CloudFormation Custom Resource invokes a Lambda function via ServiceToken.
+///
+/// 1. Create an SQS result queue
+/// 2. Create a Lambda that receives the CF custom resource event and sends
+///    ResourceProperties to the SQS queue as proof of execution
+/// 3. Create a CF stack with a Custom::MyResource pointing ServiceToken at the Lambda
+/// 4. Receive from SQS and assert the Lambda was invoked with the right event
+#[tokio::test]
+#[ignore] // requires Docker for Lambda execution
+async fn cloudformation_custom_resource_invokes_lambda() {
+    use aws_sdk_lambda::primitives::Blob;
+    use aws_sdk_lambda::types::{Environment, FunctionCode, Runtime};
+
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+    let sqs_client = server.sqs_client().await;
+    let lambda_client = server.lambda_client().await;
+
+    // 1. Create result queue
+    let queue = sqs_client
+        .create_queue()
+        .queue_name("cf-custom-result")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+
+    // 2. Create Lambda that forwards the CF event's ResourceProperties to SQS
+    let python_code = r#"
+import json
+import os
+import urllib.request
+import urllib.parse
+
+def lambda_handler(event, context):
+    endpoint = os.environ["FAKECLOUD_ENDPOINT"]
+    queue_url = os.environ["RESULT_QUEUE_URL"]
+
+    params = urllib.parse.urlencode({
+        "Action": "SendMessage",
+        "QueueUrl": queue_url,
+        "MessageBody": json.dumps({
+            "marker": "custom-resource-invoked",
+            "request_type": event.get("RequestType", ""),
+            "resource_type": event.get("ResourceType", ""),
+            "logical_resource_id": event.get("LogicalResourceId", ""),
+            "resource_properties": event.get("ResourceProperties", {}),
+        }),
+    }).encode()
+
+    req = urllib.request.Request(endpoint, data=params, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    req.add_header("Authorization", (
+        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20200101/us-east-1/sqs/aws4_request, "
+        "SignedHeaders=host, Signature=fake"
+    ))
+    urllib.request.urlopen(req)
+
+    return {"statusCode": 200, "body": "ok"}
+"#;
+
+    let zip = make_zip(&[("lambda_function.py", python_code.as_bytes())]);
+
+    let function_name = "cf-custom-handler";
+    lambda_client
+        .create_function()
+        .function_name(function_name)
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("lambda_function.lambda_handler")
+        .environment(
+            Environment::builder()
+                .variables("FAKECLOUD_ENDPOINT", server.endpoint())
+                .variables("RESULT_QUEUE_URL", &queue_url)
+                .build(),
+        )
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    let lambda_arn = format!(
+        "arn:aws:lambda:us-east-1:123456789012:function:{}",
+        function_name
+    );
+
+    // 3. Create a CF stack with a Custom::MyResource
+    let template = serde_json::json!({
+        "Resources": {
+            "MyCustom": {
+                "Type": "Custom::MyResource",
+                "Properties": {
+                    "ServiceToken": lambda_arn,
+                    "Foo": "bar",
+                    "Count": 42
+                }
+            }
+        }
+    });
+
+    let result = cf_client
+        .create_stack()
+        .stack_name("custom-resource-stack")
+        .template_body(template.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert!(result.stack_id().is_some());
+
+    // 4. Wait and receive from SQS
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    let msgs = sqs_client
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .wait_time_seconds(5)
+        .send()
+        .await
+        .unwrap();
+
+    let mut found = false;
+    for msg in msgs.messages() {
+        if let Some(body) = msg.body() {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+                if parsed["marker"] == "custom-resource-invoked" {
+                    assert_eq!(parsed["request_type"], "Create");
+                    assert_eq!(parsed["resource_type"], "Custom::MyResource");
+                    assert_eq!(parsed["logical_resource_id"], "MyCustom");
+                    assert_eq!(parsed["resource_properties"]["Foo"], "bar");
+                    assert_eq!(parsed["resource_properties"]["Count"], 42);
+                    found = true;
+                    break;
+                }
+            }
+        }
+    }
+    assert!(
+        found,
+        "Lambda should have been invoked with the custom resource event"
     );
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -182,6 +182,15 @@ async fn main() {
         container_runtime: container_runtime.clone(),
     };
 
+    // Step 5: CloudFormation delivery (custom resources can invoke Lambda)
+    let delivery_for_cf = {
+        let mut bus = DeliveryBus::new();
+        if let Some(ref ld) = lambda_delivery {
+            bus = bus.with_lambda(ld.clone());
+        }
+        Arc::new(bus)
+    };
+
     // Register services
     let mut registry = ServiceRegistry::new();
     registry.register(Arc::new(CloudFormationService::new(
@@ -194,6 +203,7 @@ async fn main() {
         eb_state.clone(),
         dynamodb_state.clone(),
         logs_state.clone(),
+        delivery_for_cf,
     )));
     registry.register(Arc::new(SqsService::new(sqs_state.clone())));
     registry.register(Arc::new(SnsService::new(sns_state, delivery_for_sns)));


### PR DESCRIPTION
## Summary

- Custom resources (`Custom::*` and `AWS::CloudFormation::CustomResource`) now invoke the Lambda function specified in `ServiceToken` during stack creation
- The Lambda receives the standard CloudFormation custom resource event: `RequestType`, `StackId`, `RequestId`, `ResourceType`, `LogicalResourceId`, and `ResourceProperties`
- CloudFormation service now receives a `DeliveryBus` for cross-service Lambda invocation, wired up in the server

## Test plan

- [x] Unit test: `custom_resource_requires_service_token` -- verifies error when ServiceToken is missing
- [x] Unit test: `custom_resource_succeeds_without_lambda_delivery` -- verifies graceful no-op when no Lambda runtime is configured
- [x] Unit test: `cloudformation_custom_resource_type_succeeds` -- verifies `AWS::CloudFormation::CustomResource` type is handled
- [ ] E2E test: `cloudformation_custom_resource_invokes_lambda` (marked `#[ignore]`, requires Docker) -- creates a Lambda + SQS queue, deploys a stack with a Custom::MyResource, and verifies the Lambda receives the correct event

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Custom resources now invoke the `ServiceToken` Lambda on Create and best‑effort on Delete, sending standard CloudFormation custom resource events. Stack IDs are generated before provisioning and passed through so events include the correct `StackId`; Lambda delivery is wired via `DeliveryBus`.

- **New Features**
  - Support for `Custom::*` and `AWS::CloudFormation::CustomResource`: invokes the `ServiceToken` Lambda on Create and best‑effort on Delete; sends standard fields; generates a physical resource ID and includes it on Delete.
  - `CloudFormationService` generates `StackId` before provisioning and passes it to the provisioner; `StackResource` stores `ServiceToken` for Delete and uses the same `StackId`.
  - Invokes Lambda via `DeliveryBus` (wired in the server); no‑op if no Lambda runtime is configured.

- **Bug Fixes**
  - Secrets Manager rotation now invokes all four steps (`CreateSecret`, `SetSecret`, `TestSecret`, `FinishSecret`) even if a step fails, matching AWS behavior.

<sup>Written for commit a8ac1cd1674f02f8b2248275f5b01c57d63c9de0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

