### PR TITLE
fix: address deferred Cubic review follow-ups

### DIFF
--- a/crates/fakecloud-core/src/validation.rs
+++ b/crates/fakecloud-core/src/validation.rs
@@ -104,6 +104,62 @@ pub fn validate_optional_range_i64(
     Ok(())
 }
 
+/// Validate an optional numeric JSON value is within [min, max].
+///
+/// Unlike `validate_optional_range_i64`, this takes a raw `serde_json::Value` reference
+/// so it can detect non-null, non-integer values (e.g. strings, large unsigned numbers)
+/// that would silently become `None` via `as_i64()`.
+pub fn validate_optional_json_range(
+    field: &str,
+    value: &serde_json::Value,
+    min: i64,
+    max: i64,
+) -> Result<(), AwsServiceError> {
+    if value.is_null() {
+        return Ok(());
+    }
+    let n = value.as_i64().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            format!(
+                "Value at '{}' failed to satisfy constraint: \
+                 Member must have value between {} and {}",
+                field, min, max,
+            ),
+        )
+    })?;
+    validate_range_i64(field, n, min, max)
+}
+
+/// Parse a string as an i64 for range validation, returning a `ValidationException`
+/// when the value is present but not a valid integer.
+///
+/// Use this instead of `.parse::<i64>().ok()` + `validate_optional_range_i64` to
+/// catch non-numeric strings that would silently fall through to defaults.
+pub fn parse_optional_i64_param(
+    field: &str,
+    value: Option<&str>,
+) -> Result<Option<i64>, AwsServiceError> {
+    match value {
+        None => Ok(None),
+        Some(s) => {
+            let n = s.parse::<i64>().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!(
+                        "Value '{}' at '{}' failed to satisfy constraint: \
+                         Member must be a number",
+                        s, field,
+                    ),
+                )
+            })?;
+            Ok(Some(n))
+        }
+    }
+}
+
 /// Validate an optional enum value if present.
 pub fn validate_optional_enum(
     field: &str,
@@ -136,4 +192,61 @@ pub fn validate_optional_enum_value(
         )
     })?;
     validate_enum(field, s, allowed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_optional_json_range_rejects_non_integer() {
+        let val = serde_json::json!("abc");
+        let result = validate_optional_json_range("limit", &val, 1, 100);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_optional_json_range_rejects_large_unsigned() {
+        let val = serde_json::json!(u64::MAX);
+        let result = validate_optional_json_range("limit", &val, 1, 1000);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_optional_json_range_allows_null() {
+        let val = serde_json::Value::Null;
+        let result = validate_optional_json_range("limit", &val, 1, 100);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_optional_json_range_validates_range() {
+        let val = serde_json::json!(0);
+        let result = validate_optional_json_range("limit", &val, 1, 100);
+        assert!(result.is_err());
+
+        let val = serde_json::json!(50);
+        let result = validate_optional_json_range("limit", &val, 1, 100);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parse_optional_i64_param_rejects_non_numeric() {
+        let result = parse_optional_i64_param("maxItems", Some("abc"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_optional_i64_param_allows_none() {
+        let result = parse_optional_i64_param("maxItems", None);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn parse_optional_i64_param_parses_valid_number() {
+        let result = parse_optional_i64_param("maxItems", Some("42"));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some(42));
+    }
 }

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -664,11 +664,15 @@ impl DynamoDbService {
         if !accessed_keys.is_empty() {
             let mut state = self.state.write();
             if let Some(table) = state.tables.get_mut(table_name) {
-                for key_str in accessed_keys {
-                    *table
-                        .contributor_insights_counters
-                        .entry(key_str)
-                        .or_insert(0) += 1;
+                // Re-check insights status after acquiring write lock in case it
+                // was disabled between the read and write lock acquisitions.
+                if table.contributor_insights_status == "ENABLED" {
+                    for key_str in accessed_keys {
+                        *table
+                            .contributor_insights_counters
+                            .entry(key_str)
+                            .or_insert(0) += 1;
+                    }
                 }
             }
         }
@@ -732,11 +736,15 @@ impl DynamoDbService {
         if !accessed_keys.is_empty() {
             let mut state = self.state.write();
             if let Some(table) = state.tables.get_mut(table_name) {
-                for key_str in accessed_keys {
-                    *table
-                        .contributor_insights_counters
-                        .entry(key_str)
-                        .or_insert(0) += 1;
+                // Re-check insights status after acquiring write lock in case it
+                // was disabled between the read and write lock acquisitions.
+                if table.contributor_insights_status == "ENABLED" {
+                    for key_str in accessed_keys {
+                        *table
+                            .contributor_insights_counters
+                            .entry(key_str)
+                            .or_insert(0) += 1;
+                    }
                 }
             }
         }
@@ -5813,5 +5821,77 @@ mod tests {
 
         let contributors = body["TopContributors"].as_array().unwrap();
         assert!(contributors.is_empty());
+    }
+
+    #[test]
+    fn contributor_insights_disabled_table_no_counters_after_scan() {
+        let svc = make_service();
+        create_test_table(&svc);
+
+        // Put items
+        for key in &["alpha", "beta"] {
+            let req = make_request(
+                "PutItem",
+                json!({
+                    "TableName": "test-table",
+                    "Item": { "pk": { "S": key } }
+                }),
+            );
+            svc.put_item(&req).unwrap();
+        }
+
+        // Enable insights, then scan, then disable, then check counters are cleared
+        let req = make_request(
+            "UpdateContributorInsights",
+            json!({
+                "TableName": "test-table",
+                "ContributorInsightsAction": "ENABLE"
+            }),
+        );
+        svc.update_contributor_insights(&req).unwrap();
+
+        // Scan to trigger counter collection
+        let req = make_request("Scan", json!({ "TableName": "test-table" }));
+        svc.scan(&req).unwrap();
+
+        // Verify counters were collected
+        let req = make_request(
+            "DescribeContributorInsights",
+            json!({ "TableName": "test-table" }),
+        );
+        let resp = svc.describe_contributor_insights(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let contributors = body["TopContributors"].as_array().unwrap();
+        assert!(
+            !contributors.is_empty(),
+            "counters should be non-empty while enabled"
+        );
+
+        // Disable insights (this clears counters)
+        let req = make_request(
+            "UpdateContributorInsights",
+            json!({
+                "TableName": "test-table",
+                "ContributorInsightsAction": "DISABLE"
+            }),
+        );
+        svc.update_contributor_insights(&req).unwrap();
+
+        // Scan again -- should NOT accumulate counters since insights is disabled
+        let req = make_request("Scan", json!({ "TableName": "test-table" }));
+        svc.scan(&req).unwrap();
+
+        // Verify counters are still empty
+        let req = make_request(
+            "DescribeContributorInsights",
+            json!({ "TableName": "test-table" }),
+        );
+        let resp = svc.describe_contributor_insights(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let contributors = body["TopContributors"].as_array().unwrap();
+        assert!(
+            contributors.is_empty(),
+            "counters should be empty after disabling insights"
+        );
     }
 }

--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -535,12 +535,16 @@ fn tags_xml(tags: &[Tag]) -> String {
         .join("\n")
 }
 
-fn paginated_tags_response(action: &str, tags: &[Tag], req: &AwsRequest) -> String {
-    let max_items: usize = req
-        .query_params
-        .get("MaxItems")
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(100);
+fn paginated_tags_response(
+    action: &str,
+    tags: &[Tag],
+    req: &AwsRequest,
+) -> Result<String, AwsServiceError> {
+    let max_items: usize = parse_optional_i64_param(
+        "maxItems",
+        req.query_params.get("MaxItems").map(|s| s.as_str()),
+    )?
+    .unwrap_or(100) as usize;
     let offset: usize = req
         .query_params
         .get("Marker")
@@ -557,7 +561,7 @@ fn paginated_tags_response(action: &str, tags: &[Tag], req: &AwsRequest) -> Stri
         String::new()
     };
 
-    format!(
+    Ok(format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <{action}Response xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <{action}Result>
@@ -572,7 +576,7 @@ fn paginated_tags_response(action: &str, tags: &[Tag], req: &AwsRequest) -> Stri
   </ResponseMetadata>
 </{action}Response>"#,
         req.request_id
-    )
+    ))
 }
 
 fn validate_tags(tags: &[Tag], existing_count: usize) -> Result<(), AwsServiceError> {
@@ -893,9 +897,10 @@ impl IamService {
         )?;
         validate_optional_range_i64(
             "maxItems",
-            req.query_params
-                .get("MaxItems")
-                .and_then(|v| v.parse::<i64>().ok()),
+            parse_optional_i64_param(
+                "maxItems",
+                req.query_params.get("MaxItems").map(|s| s.as_str()),
+            )?,
             1,
             1000,
         )?;
@@ -1198,9 +1203,10 @@ impl IamService {
         let marker = req.query_params.get("Marker").cloned();
         validate_optional_range_i64(
             "maxItems",
-            req.query_params
-                .get("MaxItems")
-                .and_then(|v| v.parse::<i64>().ok()),
+            parse_optional_i64_param(
+                "maxItems",
+                req.query_params.get("MaxItems").map(|s| s.as_str()),
+            )?,
             1,
             1000,
         )?;
@@ -1454,9 +1460,10 @@ impl IamService {
         )?;
         validate_optional_range_i64(
             "maxItems",
-            req.query_params
-                .get("MaxItems")
-                .and_then(|v| v.parse::<i64>().ok()),
+            parse_optional_i64_param(
+                "maxItems",
+                req.query_params.get("MaxItems").map(|s| s.as_str()),
+            )?,
             1,
             1000,
         )?;
@@ -1700,7 +1707,7 @@ impl IamService {
             )
         })?;
 
-        let xml = paginated_tags_response("ListRoleTags", &role.tags, req);
+        let xml = paginated_tags_response("ListRoleTags", &role.tags, req)?;
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 
@@ -1891,9 +1898,10 @@ impl IamService {
         )?;
         validate_optional_range_i64(
             "maxItems",
-            req.query_params
-                .get("MaxItems")
-                .and_then(|v| v.parse::<i64>().ok()),
+            parse_optional_i64_param(
+                "maxItems",
+                req.query_params.get("MaxItems").map(|s| s.as_str()),
+            )?,
             1,
             1000,
         )?;
@@ -1987,7 +1995,7 @@ impl IamService {
             )
         })?;
 
-        let xml = paginated_tags_response("ListPolicyTags", &policy.tags, req);
+        let xml = paginated_tags_response("ListPolicyTags", &policy.tags, req)?;
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 }
@@ -4445,7 +4453,7 @@ impl IamService {
             )
         })?;
 
-        let xml = paginated_tags_response("ListOpenIDConnectProviderTags", &provider.tags, req);
+        let xml = paginated_tags_response("ListOpenIDConnectProviderTags", &provider.tags, req)?;
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 }
@@ -6042,10 +6050,11 @@ impl IamService {
     fn list_virtual_mfa_devices(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let state = self.state.read();
         let assignment_status = req.query_params.get("AssignmentStatus").cloned();
-        let max_items: Option<usize> = req
-            .query_params
-            .get("MaxItems")
-            .and_then(|v| v.parse().ok());
+        let max_items: Option<usize> = parse_optional_i64_param(
+            "maxItems",
+            req.query_params.get("MaxItems").map(|s| s.as_str()),
+        )?
+        .map(|v| v as usize);
         let marker: Option<usize> = req
             .query_params
             .get("Marker")
@@ -6437,5 +6446,38 @@ mod tests {
         );
         let result = svc.list_access_keys(&req);
         assert!(result.is_err(), "MaxItems=0 should return an error");
+    }
+
+    #[test]
+    fn list_users_rejects_non_numeric_max_items() {
+        let svc = make_service();
+        let req = make_request("ListUsers", vec![("MaxItems", "abc")]);
+        let result = svc.list_users(&req);
+        assert!(
+            result.is_err(),
+            "non-numeric MaxItems should return an error"
+        );
+    }
+
+    #[test]
+    fn list_roles_rejects_non_numeric_max_items() {
+        let svc = make_service();
+        let req = make_request("ListRoles", vec![("MaxItems", "xyz")]);
+        let result = svc.list_roles(&req);
+        assert!(
+            result.is_err(),
+            "non-numeric MaxItems should return an error"
+        );
+    }
+
+    #[test]
+    fn list_policies_rejects_non_numeric_max_items() {
+        let svc = make_service();
+        let req = make_request("ListPolicies", vec![("MaxItems", "notanumber")]);
+        let result = svc.list_policies(&req);
+        assert!(
+            result.is_err(),
+            "non-numeric MaxItems should return an error"
+        );
     }
 }

--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -540,11 +540,12 @@ fn paginated_tags_response(
     tags: &[Tag],
     req: &AwsRequest,
 ) -> Result<String, AwsServiceError> {
-    let max_items: usize = parse_optional_i64_param(
+    let max_items_i64 = parse_optional_i64_param(
         "maxItems",
         req.query_params.get("MaxItems").map(|s| s.as_str()),
-    )?
-    .unwrap_or(100) as usize;
+    )?;
+    validate_optional_range_i64("maxItems", max_items_i64, 1, 1000)?;
+    let max_items: usize = max_items_i64.unwrap_or(100) as usize;
     let offset: usize = req
         .query_params
         .get("Marker")
@@ -6050,11 +6051,12 @@ impl IamService {
     fn list_virtual_mfa_devices(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let state = self.state.read();
         let assignment_status = req.query_params.get("AssignmentStatus").cloned();
-        let max_items: Option<usize> = parse_optional_i64_param(
+        let max_items_i64 = parse_optional_i64_param(
             "maxItems",
             req.query_params.get("MaxItems").map(|s| s.as_str()),
-        )?
-        .map(|v| v as usize);
+        )?;
+        validate_optional_range_i64("maxItems", max_items_i64, 1, 1000)?;
+        let max_items: Option<usize> = max_items_i64.map(|v| v as usize);
         let marker: Option<usize> = req
             .query_params
             .get("Marker")

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -496,10 +496,10 @@ impl KmsService {
     fn list_keys(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = body_json(req);
 
-        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 1000)?;
+        validate_optional_json_range("limit", &body["Limit"], 1, 1000)?;
         validate_optional_string_length("marker", body["Marker"].as_str(), 1, 320)?;
 
-        let limit = body["Limit"].as_u64().unwrap_or(1000) as usize;
+        let limit = body["Limit"].as_i64().unwrap_or(1000) as usize;
         let marker = body["Marker"].as_str();
 
         let state = self.state.read();
@@ -1261,7 +1261,7 @@ impl KmsService {
     fn list_aliases(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = body_json(req);
 
-        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
+        validate_optional_json_range("limit", &body["Limit"], 1, 100)?;
         validate_optional_string_length("marker", body["Marker"].as_str(), 1, 320)?;
 
         if !body["KeyId"].is_null() && !body["KeyId"].is_string() {
@@ -1600,7 +1600,8 @@ impl KmsService {
     fn list_key_rotations(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = body_json(req);
         let resolved = self.resolve_required_key(&body)?;
-        let limit = body["Limit"].as_u64().unwrap_or(1000) as usize;
+        validate_optional_json_range("limit", &body["Limit"], 1, 1000)?;
+        let limit = body["Limit"].as_i64().unwrap_or(1000) as usize;
         let marker = body["Marker"].as_str();
 
         let state = self.state.read();
@@ -1968,10 +1969,10 @@ impl KmsService {
             )
         })?;
         validate_string_length("retiringPrincipal", retiring_principal, 1, 256)?;
-        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 1000)?;
+        validate_optional_json_range("limit", &body["Limit"], 1, 1000)?;
         validate_optional_string_length("marker", body["Marker"].as_str(), 1, 320)?;
 
-        let limit = body["Limit"].as_u64().unwrap_or(1000) as usize;
+        let limit = body["Limit"].as_i64().unwrap_or(1000) as usize;
         let marker = body["Marker"].as_str();
 
         let state = self.state.read();
@@ -2796,12 +2797,12 @@ impl KmsService {
             1,
             256,
         )?;
-        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 1000)?;
+        validate_optional_json_range("limit", &body["Limit"], 1, 1000)?;
         validate_optional_string_length("marker", body["Marker"].as_str(), 1, 1024)?;
 
         let filter_id = body["CustomKeyStoreId"].as_str();
         let filter_name = body["CustomKeyStoreName"].as_str();
-        let limit = body["Limit"].as_u64().unwrap_or(1000) as usize;
+        let limit = body["Limit"].as_i64().unwrap_or(1000) as usize;
         let marker = body["Marker"].as_str();
 
         let state = self.state.read();
@@ -4029,5 +4030,35 @@ mod tests {
             result.is_err(),
             "Decrypt should fail after key material deletion"
         );
+    }
+
+    #[test]
+    fn list_keys_rejects_non_integer_limit() {
+        let svc = make_service();
+        // String value should fail validation
+        let req = make_request("ListKeys", json!({ "Limit": "abc" }));
+        let result = svc.list_keys(&req);
+        assert!(result.is_err(), "non-integer Limit should be rejected");
+    }
+
+    #[test]
+    fn list_keys_rejects_large_unsigned_limit() {
+        let svc = make_service();
+        // Value larger than i64::MAX should fail validation
+        let req = make_request("ListKeys", json!({ "Limit": u64::MAX }));
+        let result = svc.list_keys(&req);
+        assert!(result.is_err(), "large unsigned Limit should be rejected");
+    }
+
+    #[test]
+    fn list_keys_rejects_out_of_range_limit() {
+        let svc = make_service();
+        let req = make_request("ListKeys", json!({ "Limit": 0 }));
+        let result = svc.list_keys(&req);
+        assert!(result.is_err(), "Limit=0 should be rejected");
+
+        let req = make_request("ListKeys", json!({ "Limit": 1001 }));
+        let result = svc.list_keys(&req);
+        assert!(result.is_err(), "Limit=1001 should be rejected");
     }
 }

--- a/crates/fakecloud-logs/src/transformer.rs
+++ b/crates/fakecloud-logs/src/transformer.rs
@@ -399,6 +399,16 @@ fn parse_csv_fields(input: &str, delimiter: char) -> Vec<String> {
         }
     }
 
+    // Handle trailing delimiter producing an empty final field
+    if !input.is_empty() && input.ends_with(delimiter) {
+        fields.push(String::new());
+    }
+
+    // Handle empty input producing a single empty field
+    if fields.is_empty() {
+        fields.push(String::new());
+    }
+
     fields
 }
 
@@ -756,5 +766,23 @@ mod tests {
         let config = json!("invalid");
         let result = apply_transformer(&config, "hello");
         assert_eq!(result["message"], "hello");
+    }
+
+    #[test]
+    fn test_csv_trailing_empty_column() {
+        let fields = parse_csv_fields("a,b,", ',');
+        assert_eq!(fields, vec!["a", "b", ""]);
+    }
+
+    #[test]
+    fn test_csv_empty_input() {
+        let fields = parse_csv_fields("", ',');
+        assert_eq!(fields, vec![""]);
+    }
+
+    #[test]
+    fn test_csv_quoted_with_embedded_delimiter() {
+        let fields = parse_csv_fields(r#""hello, world",bar"#, ',');
+        assert_eq!(fields, vec!["hello, world", "bar"]);
     }
 }

--- a/crates/fakecloud-logs/src/transformer.rs
+++ b/crates/fakecloud-logs/src/transformer.rs
@@ -340,7 +340,7 @@ fn apply_csv(config: &Value, event: &mut Value) {
     };
 
     let delim_char = delimiter.chars().next().unwrap_or(',');
-    let values: Vec<&str> = raw.split(delim_char).collect();
+    let values = parse_csv_fields(&raw, delim_char);
 
     for (i, col) in columns.iter().enumerate() {
         if let Some(col_name) = col.as_str() {
@@ -349,6 +349,57 @@ fn apply_csv(config: &Value, event: &mut Value) {
             }
         }
     }
+}
+
+/// Parse CSV fields with RFC 4180 quoted field support.
+/// Fields wrapped in double quotes may contain the delimiter and escaped quotes ("").
+fn parse_csv_fields(input: &str, delimiter: char) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut chars = input.chars().peekable();
+    let mut field = String::new();
+
+    while chars.peek().is_some() {
+        if chars.peek() == Some(&'"') {
+            // Quoted field
+            chars.next(); // consume opening quote
+            loop {
+                match chars.next() {
+                    Some('"') => {
+                        if chars.peek() == Some(&'"') {
+                            // Escaped quote
+                            field.push('"');
+                            chars.next();
+                        } else {
+                            // End of quoted field
+                            break;
+                        }
+                    }
+                    Some(c) => field.push(c),
+                    None => break, // Unterminated quote, end of input
+                }
+            }
+            // Consume delimiter after quoted field if present
+            if chars.peek() == Some(&delimiter) {
+                chars.next();
+            }
+            fields.push(std::mem::take(&mut field));
+        } else {
+            // Unquoted field
+            loop {
+                match chars.peek() {
+                    Some(&c) if c == delimiter => {
+                        chars.next();
+                        break;
+                    }
+                    Some(_) => field.push(chars.next().unwrap()),
+                    None => break,
+                }
+            }
+            fields.push(std::mem::take(&mut field));
+        }
+    }
+
+    fields
 }
 
 fn apply_parse_key_value(config: &Value, event: &mut Value) {
@@ -599,6 +650,47 @@ mod tests {
         assert_eq!(result["name"], "Alice");
         assert_eq!(result["age"], "30");
         assert_eq!(result["city"], "NYC");
+    }
+
+    #[test]
+    fn test_csv_quoted_fields() {
+        let config = json!([{"csv": {"source": "message", "delimiter": ",", "columns": ["name", "desc", "city"]}}]);
+        let result = apply_transformer(&config, r#"Alice,"hello, world",NYC"#);
+        assert_eq!(result["name"], "Alice");
+        assert_eq!(result["desc"], "hello, world");
+        assert_eq!(result["city"], "NYC");
+    }
+
+    #[test]
+    fn test_csv_escaped_quotes() {
+        let config =
+            json!([{"csv": {"source": "message", "delimiter": ",", "columns": ["name", "quote"]}}]);
+        let result = apply_transformer(&config, r#"Alice,"She said ""hi"""#);
+        assert_eq!(result["name"], "Alice");
+        assert_eq!(result["quote"], r#"She said "hi""#);
+    }
+
+    #[test]
+    fn test_csv_quoted_field_with_custom_delimiter() {
+        let config =
+            json!([{"csv": {"source": "message", "delimiter": "|", "columns": ["a", "b", "c"]}}]);
+        let result = apply_transformer(&config, r#"one|"two|three"|four"#);
+        assert_eq!(result["a"], "one");
+        assert_eq!(result["b"], "two|three");
+        assert_eq!(result["c"], "four");
+    }
+
+    #[test]
+    fn test_parse_csv_fields_unit() {
+        let fields = parse_csv_fields(r#"a,"b,c",d"#, ',');
+        assert_eq!(fields, vec!["a", "b,c", "d"]);
+
+        let fields = parse_csv_fields(r#""escaped ""quotes""",normal"#, ',');
+        assert_eq!(fields, vec![r#"escaped "quotes""#, "normal"]);
+
+        // Simple unquoted
+        let fields = parse_csv_fields("a,b,c", ',');
+        assert_eq!(fields, vec!["a", "b", "c"]);
     }
 
     #[test]

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -49,11 +49,11 @@ impl SnsDelivery for SnsDeliveryImpl {
             .collect();
 
         // Collect Lambda, email, and SMS subscribers
-        let lambda_subscribers: Vec<String> = state
+        let lambda_subscribers: Vec<(String, String)> = state
             .subscriptions
             .values()
             .filter(|s| s.topic_arn == topic_arn && s.protocol == "lambda" && s.confirmed)
-            .map(|s| s.endpoint.clone())
+            .map(|s| (s.endpoint.clone(), s.subscription_arn.clone()))
             .collect();
 
         let email_subscribers: Vec<String> = state
@@ -76,30 +76,20 @@ impl SnsDelivery for SnsDeliveryImpl {
 
         // Build SNS Lambda event payload (matches real AWS format)
         let now = Utc::now();
+        let empty_attrs = serde_json::Map::new();
         let lambda_payloads: Vec<(String, String)> = lambda_subscribers
             .iter()
-            .map(|function_arn| {
-                let sns_event = serde_json::json!({
-                    "Records": [{
-                        "EventVersion": "1.0",
-                        "EventSubscriptionArn": format!("{}:lambda-sub", topic_arn),
-                        "EventSource": "aws:sns",
-                        "Sns": {
-                            "SignatureVersion": "1",
-                            "Timestamp": now.to_rfc3339(),
-                            "Signature": "FAKE_SIGNATURE",
-                            "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
-                            "MessageId": msg_id.clone(),
-                            "Message": message,
-                            "MessageAttributes": {},
-                            "Type": "Notification",
-                            "UnsubscribeUrl": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
-                            "TopicArn": topic_arn,
-                            "Subject": subject.unwrap_or(""),
-                        }
-                    }]
-                });
-                (function_arn.clone(), sns_event.to_string())
+            .map(|(function_arn, subscription_arn)| {
+                let payload = crate::service::build_sns_lambda_event(
+                    &msg_id,
+                    topic_arn,
+                    subscription_arn,
+                    message,
+                    subject,
+                    &empty_attrs,
+                    &now,
+                );
+                (function_arn.clone(), payload)
             })
             .collect();
 

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -910,12 +910,12 @@ impl SnsService {
             .map(|s| s.endpoint.clone())
             .collect();
 
-        let lambda_subscribers: Vec<String> = state
+        let lambda_subscribers: Vec<(String, String)> = state
             .subscriptions
             .values()
             .filter(|s| s.topic_arn == topic_arn && s.protocol == "lambda" && s.confirmed)
             .filter(|s| matches_filter_policy(s, &message_attributes, &message))
-            .map(|s| s.endpoint.clone())
+            .map(|s| (s.endpoint.clone(), s.subscription_arn.clone()))
             .collect();
 
         let email_subscribers: Vec<String> = state
@@ -1051,28 +1051,17 @@ impl SnsService {
             // Build SNS Lambda event payloads
             let lambda_payloads: Vec<(String, String)> = lambda_subscribers
                 .iter()
-                .map(|function_arn| {
-                    let sns_event = serde_json::json!({
-                        "Records": [{
-                            "EventVersion": "1.0",
-                            "EventSubscriptionArn": format!("{}:lambda-sub", topic_arn),
-                            "EventSource": "aws:sns",
-                            "Sns": {
-                                "SignatureVersion": "1",
-                                "Timestamp": now.to_rfc3339(),
-                                "Signature": "FAKE_SIGNATURE",
-                                "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
-                                "MessageId": msg_id.clone(),
-                                "Message": &default_message,
-                                "MessageAttributes": &envelope_attrs,
-                                "Type": "Notification",
-                                "UnsubscribeUrl": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
-                                "TopicArn": &topic_arn,
-                                "Subject": subject.as_deref().unwrap_or(""),
-                            }
-                        }]
-                    });
-                    (function_arn.clone(), sns_event.to_string())
+                .map(|(function_arn, subscription_arn)| {
+                    let payload = build_sns_lambda_event(
+                        &msg_id,
+                        &topic_arn,
+                        subscription_arn,
+                        &default_message,
+                        subject.as_deref(),
+                        &envelope_attrs,
+                        &now,
+                    );
+                    (function_arn.clone(), payload)
                 })
                 .collect();
 
@@ -2519,6 +2508,40 @@ impl SnsService {
     }
 }
 
+/// Build an SNS Lambda event payload (matches real AWS format).
+/// Used by both direct Publish and cross-service delivery.
+pub(crate) fn build_sns_lambda_event(
+    message_id: &str,
+    topic_arn: &str,
+    subscription_arn: &str,
+    message: &str,
+    subject: Option<&str>,
+    message_attributes: &serde_json::Map<String, Value>,
+    timestamp: &chrono::DateTime<Utc>,
+) -> String {
+    let sns_event = serde_json::json!({
+        "Records": [{
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": subscription_arn,
+            "EventSource": "aws:sns",
+            "Sns": {
+                "SignatureVersion": "1",
+                "Timestamp": timestamp.to_rfc3339(),
+                "Signature": "FAKE_SIGNATURE",
+                "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
+                "MessageId": message_id,
+                "Message": message,
+                "MessageAttributes": message_attributes,
+                "Type": "Notification",
+                "UnsubscribeUrl": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", subscription_arn),
+                "TopicArn": topic_arn,
+                "Subject": subject.unwrap_or(""),
+            }
+        }]
+    });
+    sns_event.to_string()
+}
+
 /// Build an SNS notification envelope as JSON string.
 /// Subject and MessageAttributes are only included when present.
 fn build_sns_envelope(
@@ -3435,4 +3458,42 @@ fn validate_numeric_filter(arr: &[Value]) -> Result<(), AwsServiceError> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_sns_lambda_event_uses_real_subscription_arn() {
+        let now = Utc::now();
+        let sub_arn = "arn:aws:sns:us-east-1:123456789012:my-topic:abc-def-123";
+        let topic_arn = "arn:aws:sns:us-east-1:123456789012:my-topic";
+        let attrs = serde_json::Map::new();
+
+        let payload = build_sns_lambda_event(
+            "msg-001",
+            topic_arn,
+            sub_arn,
+            "hello",
+            Some("test subject"),
+            &attrs,
+            &now,
+        );
+
+        let parsed: Value = serde_json::from_str(&payload).unwrap();
+        let record = &parsed["Records"][0];
+        assert_eq!(record["EventSubscriptionArn"], sub_arn);
+        assert_eq!(record["EventSource"], "aws:sns");
+        assert_eq!(record["Sns"]["TopicArn"], topic_arn);
+        assert_eq!(record["Sns"]["Message"], "hello");
+        assert_eq!(record["Sns"]["Subject"], "test subject");
+        assert_eq!(record["Sns"]["MessageId"], "msg-001");
+        // UnsubscribeUrl should use subscription ARN, not topic ARN
+        let unsub_url = record["Sns"]["UnsubscribeUrl"].as_str().unwrap();
+        assert!(
+            unsub_url.contains(sub_arn),
+            "UnsubscribeUrl should contain subscription ARN"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- **SNS subscription ARN in Lambda event**: Lambda event payloads now use the real subscription ARN from subscriber state instead of a derived `{topic_arn}:lambda-sub` placeholder
- **SNS deduplicate Lambda payload code**: Extracted `build_sns_lambda_event()` shared helper used by both `service.rs` (direct Publish) and `delivery.rs` (cross-service delivery)
- **Logs CSV quoted field parsing**: `apply_csv` now uses RFC 4180 compliant `parse_csv_fields()` supporting quoted fields with embedded delimiters and escaped double-quotes
- **KMS Limit validation bypass**: Replaced `as_i64()` validation + `as_u64()` consumption with `validate_optional_json_range()` that rejects non-integer and out-of-range values from the raw JSON
- **DynamoDB contributor insights race condition**: Re-check `contributor_insights_status` after acquiring the write lock before incrementing counters in both query and scan paths
- **IAM/all services MaxItems parse bypass**: Added `parse_optional_i64_param()` to `fakecloud-core` validation that returns `ValidationException` for non-numeric strings; applied across all IAM list operations

## Test plan

- [x] Unit test: `build_sns_lambda_event_uses_real_subscription_arn` verifies subscription ARN propagation
- [x] Unit tests: `test_csv_quoted_fields`, `test_csv_escaped_quotes`, `test_csv_quoted_field_with_custom_delimiter`, `test_parse_csv_fields_unit`
- [x] Unit tests: `list_keys_rejects_non_integer_limit`, `list_keys_rejects_large_unsigned_limit`, `list_keys_rejects_out_of_range_limit`
- [x] Unit test: `contributor_insights_disabled_table_no_counters_after_scan`
- [x] Unit tests: `list_users_rejects_non_numeric_max_items`, `list_roles_rejects_non_numeric_max_items`, `list_policies_rejects_non_numeric_max_items`
- [x] Unit tests: `validate_optional_json_range_*` and `parse_optional_i64_param_*` in fakecloud-core
- [x] All existing tests continue to pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several correctness gaps across services: accurate SNS Lambda events, stricter KMS/IAM parameter validation, RFC 4180 CSV parsing (including edge cases), and a DynamoDB contributor insights race fix.

- **Bug Fixes**
  - `fakecloud-sns`: Use the real subscription ARN in Lambda event payloads and UnsubscribeUrl.
  - `fakecloud-logs`: CSV parsing now supports quoted fields, escaped quotes (RFC 4180), preserves trailing empty columns, and handles empty input.
  - `fakecloud-kms`: Validate `Limit` from raw JSON; reject non-integer, out-of-range, and large unsigned values.
  - `fakecloud-dynamodb`: Re-check contributor insights status under write lock to avoid counter increments after disable.
  - `fakecloud-iam`: Return ValidationException for non-numeric `MaxItems` across list APIs; enforce 1–1000 range in tag list responses and virtual MFA devices to prevent negative-to-usize wrapping.

- **Refactors**
  - `fakecloud-sns`: Extract `build_sns_lambda_event()` helper; remove duplicate payload code in `service.rs` and `delivery.rs`.
  - `fakecloud-core`: Add `validate_optional_json_range()` and `parse_optional_i64_param()` for consistent validation; adopted in `fakecloud-iam` and `fakecloud-kms`.

<sup>Written for commit 619cea7a404c087133b94b0a8d1284cc0dba26a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

