### PR TITLE
fix(ci): add security audit, MSRV check, and fix publish error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.94"
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --workspace
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,17 @@ jobs:
         run: |
           publish() {
             echo "Publishing $1..."
-            cargo publish -p "$1" 2>&1 || true
+            OUTPUT=$(cargo publish -p "$1" 2>&1) && {
+              echo "Successfully published $1"
+            } || {
+              if echo "$OUTPUT" | grep -q "already uploaded"; then
+                echo "Skipping $1: already published"
+              else
+                echo "ERROR publishing $1:"
+                echo "$OUTPUT"
+                exit 1
+              fi
+            }
             echo "Waiting for crates.io index..."
             sleep 60
           }

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,20 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install cargo-audit
+      - run: cargo audit


### PR DESCRIPTION
## Summary

- **Security audit workflow**: New `.github/workflows/security.yml` runs `cargo audit` on push to main and PRs, with Swatinem/rust-cache@v2 for caching
- **MSRV check**: New job in `ci.yml` runs `cargo check --workspace` with Rust 1.94 (the `rust-version` from Cargo.toml) to catch accidental MSRV bumps
- **Publish error handling**: Replaced `|| true` in `release.yml` publish script with proper error handling that skips already-published crates but fails on real errors

## Test plan

- [ ] Verify security.yml workflow triggers on PR creation
- [ ] Verify MSRV job runs with Rust 1.94 and passes
- [ ] Verify release publish script correctly distinguishes "already uploaded" from real errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI security audit with `cargo audit`, enforces MSRV 1.94 in CI, and fixes release publishing to fail on real errors while skipping already-published crates.

- **New Features**
  - Adds `.github/workflows/security.yml` to run `cargo audit` on pushes and PRs (pins `dtolnay/rust-toolchain@stable`, uses `Swatinem/rust-cache@v2`).
  - Adds an MSRV job in `ci.yml` that runs `cargo check --workspace` on Rust 1.94 (via `dtolnay/rust-toolchain@stable`).

- **Bug Fixes**
  - Replaces `|| true` in `release.yml` with error handling that skips “already uploaded” but exits on other errors.

<sup>Written for commit 49713986c88ed29c6258c07b2af7fd768d6d0113. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

