### PR TITLE
fix(sns): reject invalid JSON when MessageStructure=json

### DIFF
--- a/crates/fakecloud-e2e/tests/sns.rs
+++ b/crates/fakecloud-e2e/tests/sns.rs
@@ -725,3 +725,61 @@ async fn sns_binary_message_attribute_delivery() {
     let attr = msg_attrs.get("binData").unwrap();
     assert_eq!(attr.data_type(), "Binary");
 }
+
+#[tokio::test]
+async fn sns_publish_message_structure_json_invalid_json() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("json-validate")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap();
+
+    let err = client
+        .publish()
+        .topic_arn(topic_arn)
+        .message("not valid json")
+        .message_structure("json")
+        .send()
+        .await
+        .unwrap_err();
+
+    let service_err = err.into_service_error();
+    assert!(
+        format!("{service_err:?}").contains("InvalidParameter"),
+        "expected InvalidParameter, got: {service_err:?}"
+    );
+}
+
+#[tokio::test]
+async fn sns_publish_message_structure_json_missing_default_key() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("json-validate-default")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap();
+
+    let err = client
+        .publish()
+        .topic_arn(topic_arn)
+        .message(r#"{"sqs": "hello"}"#)
+        .message_structure("json")
+        .send()
+        .await
+        .unwrap_err();
+
+    let service_err = err.into_service_error();
+    assert!(
+        format!("{service_err:?}").contains("InvalidParameter"),
+        "expected InvalidParameter, got: {service_err:?}"
+    );
+}

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -191,6 +191,24 @@ fn required(req: &AwsRequest, name: &str) -> Result<String, AwsServiceError> {
     })
 }
 
+fn validate_message_structure_json(message: &str) -> Result<(), AwsServiceError> {
+    let parsed: Value = serde_json::from_str(message).map_err(|_| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            "Invalid parameter: Message Structure - No JSON message body is parseable",
+        )
+    })?;
+    if parsed.get("default").is_none() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            "Invalid parameter: Message Structure - No default entry in JSON message body",
+        ));
+    }
+    Ok(())
+}
+
 fn not_found(entity: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::NOT_FOUND,
@@ -753,6 +771,11 @@ impl SnsService {
             ));
         }
 
+        // Validate MessageStructure=json
+        if message_structure.as_deref() == Some("json") {
+            validate_message_structure_json(&message)?;
+        }
+
         // Parse MessageAttributes from query params
         let message_attributes = parse_message_attributes(req);
 
@@ -876,8 +899,9 @@ impl SnsService {
         });
 
         // Resolve the actual message per protocol for MessageStructure=json
+        // Validation already happened above, so unwrap is safe here
         let parsed_structure: Option<Value> = if message_structure.as_deref() == Some("json") {
-            serde_json::from_str(&message).ok()
+            Some(serde_json::from_str(&message).expect("already validated"))
         } else {
             None
         };
@@ -1243,6 +1267,11 @@ impl SnsService {
             // Parse per-entry message attributes
             let batch_attrs = parse_batch_message_attributes(req, idx + 1);
 
+            // Validate MessageStructure=json
+            if structure.as_deref() == Some("json") {
+                validate_message_structure_json(message)?;
+            }
+
             let msg_id = uuid::Uuid::new_v4().to_string();
             let mut state = self.state.write();
             state.published.push(PublishedMessage {
@@ -1257,8 +1286,9 @@ impl SnsService {
             });
 
             // Resolve message for SQS via MessageStructure=json
+            // Validation already happened above, so unwrap is safe here
             let parsed_structure: Option<Value> = if structure.as_deref() == Some("json") {
-                serde_json::from_str(message).ok()
+                Some(serde_json::from_str(message).expect("already validated"))
             } else {
                 None
             };
@@ -3463,6 +3493,34 @@ fn validate_numeric_filter(arr: &[Value]) -> Result<(), AwsServiceError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validate_message_structure_json_rejects_invalid_json() {
+        let result = validate_message_structure_json("not valid json");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("No JSON message body is parseable"), "{msg}");
+    }
+
+    #[test]
+    fn validate_message_structure_json_rejects_missing_default_key() {
+        let result = validate_message_structure_json(r#"{"sqs": "hello"}"#);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("No default entry in JSON message body"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn validate_message_structure_json_accepts_valid() {
+        let result =
+            validate_message_structure_json(r#"{"default": "hello", "sqs": "hello from sqs"}"#);
+        assert!(result.is_ok());
+    }
 
     #[test]
     fn build_sns_lambda_event_uses_real_subscription_arn() {


### PR DESCRIPTION
## Summary
- When `MessageStructure=json` is set on SNS Publish/PublishBatch, the message body is now validated as proper JSON (previously silently ignored via `.ok()`)
- Returns `InvalidParameter` if the message is not valid JSON or if the parsed JSON lacks a required `"default"` key, matching real AWS behavior
- Adds unit tests for the validation function and E2E tests for both error cases

## Test plan
- [x] Unit tests: `validate_message_structure_json_rejects_invalid_json`, `validate_message_structure_json_rejects_missing_default_key`, `validate_message_structure_json_accepts_valid`
- [x] E2E tests: `sns_publish_message_structure_json_invalid_json`, `sns_publish_message_structure_json_missing_default_key`
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --check` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid JSON when `MessageStructure=json` in SNS `Publish` and `PublishBatch`, matching AWS behavior. Returns `InvalidParameter` for invalid JSON or missing `"default"` instead of silently accepting bad input.

- **Bug Fixes**
  - Validate JSON body and require a `"default"` key.
  - Apply validation to both `Publish` and `PublishBatch`.
  - Return `InvalidParameter` with AWS-style messages for invalid JSON or missing `"default"`.
  - Add unit and E2E tests for both error cases and a valid case.

<sup>Written for commit ec1b9406e1a59dcc7aaafa5007527a13b02efee3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

