### PR TITLE
fix: replace hardcoded localhost with configured endpoint

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -105,7 +105,7 @@ impl ResourceProvisioner {
             .unwrap_or(&resource.logical_id);
 
         let mut state = self.sqs_state.write();
-        let queue_url = format!("http://localhost:4566/{}/{}", state.account_id, queue_name);
+        let queue_url = format!("{}/{}/{}", state.endpoint, state.account_id, queue_name);
         let arn = format!(
             "arn:aws:sqs:{}:{}:{}",
             state.region, state.account_id, queue_name
@@ -854,6 +854,7 @@ mod tests {
             sns_state: Arc::new(RwLock::new(fakecloud_sns::state::SnsState::new(
                 "123456789012",
                 "us-east-1",
+                "http://localhost:4566",
             ))),
             ssm_state: Arc::new(RwLock::new(fakecloud_ssm::state::SsmState::new(
                 "123456789012",

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -681,6 +681,7 @@ mod tests {
             Arc::new(RwLock::new(fakecloud_sns::state::SnsState::new(
                 "123456789012",
                 "us-east-1",
+                "http://localhost:4566",
             ))),
             Arc::new(RwLock::new(fakecloud_ssm::state::SsmState::new(
                 "123456789012",

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -61,12 +61,17 @@ async fn main() {
         )
         .init();
 
-    // Derive endpoint URL from the configured bind address
+    // Derive endpoint URL from the configured bind address.
+    // Use rsplit to handle IPv6 addresses (e.g., "[::1]:4566").
     let endpoint_url = {
         let addr = &cli.addr;
-        let host = addr.split(':').next().unwrap_or("0.0.0.0");
-        let host = if host == "0.0.0.0" { "localhost" } else { host };
-        let port = addr.split(':').nth(1).unwrap_or("4566");
+        let port = addr.rsplit(':').next().unwrap_or("4566");
+        let host = addr.rsplit_once(':').map(|(h, _)| h).unwrap_or("0.0.0.0");
+        let host = if host == "0.0.0.0" || host == "[::]" {
+            "localhost"
+        } else {
+            host
+        };
         format!("http://{host}:{port}")
     };
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -61,15 +61,25 @@ async fn main() {
         )
         .init();
 
+    // Derive endpoint URL from the configured bind address
+    let endpoint_url = {
+        let addr = &cli.addr;
+        let host = addr.split(':').next().unwrap_or("0.0.0.0");
+        let host = if host == "0.0.0.0" { "localhost" } else { host };
+        let port = addr.split(':').nth(1).unwrap_or("4566");
+        format!("http://{host}:{port}")
+    };
+
     // Shared state
     let iam_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_iam::state::IamState::new(&cli.account_id),
     ));
     let sqs_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_sqs::state::SqsState::new(&cli.account_id, &cli.region, "http://localhost:4566"),
+        fakecloud_sqs::state::SqsState::new(&cli.account_id, &cli.region, &endpoint_url),
     ));
     let sns_state = Arc::new(parking_lot::RwLock::new({
-        let mut s = fakecloud_sns::state::SnsState::new(&cli.account_id, &cli.region);
+        let mut s =
+            fakecloud_sns::state::SnsState::new(&cli.account_id, &cli.region, &endpoint_url);
         s.seed_default_opted_out();
         s
     }));

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -74,6 +74,8 @@ impl SnsDelivery for SnsDeliveryImpl {
             .map(|s| s.endpoint.clone())
             .collect();
 
+        let endpoint = state.endpoint.clone();
+
         // Build SNS Lambda event payload (matches real AWS format)
         let now = Utc::now();
         let empty_attrs = serde_json::Map::new();
@@ -88,6 +90,7 @@ impl SnsDelivery for SnsDeliveryImpl {
                     subject,
                     &empty_attrs,
                     &now,
+                    &endpoint,
                 );
                 (function_arn.clone(), payload)
             })
@@ -147,7 +150,7 @@ impl SnsDelivery for SnsDeliveryImpl {
             "SignatureVersion": "1",
             "Signature": "FAKE_SIGNATURE",
             "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
-            "UnsubscribeURL": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", topic_arn),
+            "UnsubscribeURL": format!("{}/?Action=Unsubscribe&SubscriptionArn={}", endpoint, topic_arn),
         });
         let envelope_str = sns_envelope.to_string();
 

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -938,6 +938,7 @@ impl SnsService {
             .map(|s| s.endpoint.clone())
             .collect();
 
+        let endpoint = state.endpoint.clone();
         drop(state);
 
         // Determine actual message content per protocol
@@ -1011,6 +1012,7 @@ impl SnsService {
                     &subject,
                     &sqs_message,
                     &envelope_attrs,
+                    &endpoint,
                 );
                 self.delivery
                     .send_to_sqs(queue_arn, &envelope_str, &HashMap::new());
@@ -1025,6 +1027,7 @@ impl SnsService {
                 &subject,
                 &default_message,
                 &envelope_attrs,
+                &endpoint,
             );
             let body = sns_envelope_str;
             let topic = topic_arn.clone();
@@ -1060,6 +1063,7 @@ impl SnsService {
                         subject.as_deref(),
                         &envelope_attrs,
                         &now,
+                        &endpoint,
                     );
                     (function_arn.clone(), payload)
                 })
@@ -1173,6 +1177,7 @@ impl SnsService {
             .get(&topic_arn)
             .ok_or_else(|| not_found("Topic"))?;
         let is_fifo = topic.is_fifo;
+        let endpoint = state.endpoint.clone();
         drop(state);
 
         // Parse batch entries: PublishBatchRequestEntries.member.N.*
@@ -1334,6 +1339,7 @@ impl SnsService {
                         subject,
                         &sqs_message,
                         &envelope_attrs,
+                        &endpoint,
                     );
                     self.delivery
                         .send_to_sqs(queue_arn, &envelope_str, &HashMap::new());
@@ -2510,6 +2516,7 @@ impl SnsService {
 
 /// Build an SNS Lambda event payload (matches real AWS format).
 /// Used by both direct Publish and cross-service delivery.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_sns_lambda_event(
     message_id: &str,
     topic_arn: &str,
@@ -2518,6 +2525,7 @@ pub(crate) fn build_sns_lambda_event(
     subject: Option<&str>,
     message_attributes: &serde_json::Map<String, Value>,
     timestamp: &chrono::DateTime<Utc>,
+    endpoint: &str,
 ) -> String {
     let sns_event = serde_json::json!({
         "Records": [{
@@ -2533,7 +2541,7 @@ pub(crate) fn build_sns_lambda_event(
                 "Message": message,
                 "MessageAttributes": message_attributes,
                 "Type": "Notification",
-                "UnsubscribeUrl": format!("http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}", subscription_arn),
+                "UnsubscribeUrl": format!("{}/?Action=Unsubscribe&SubscriptionArn={}", endpoint, subscription_arn),
                 "TopicArn": topic_arn,
                 "Subject": subject.unwrap_or(""),
             }
@@ -2550,6 +2558,7 @@ fn build_sns_envelope(
     subject: &Option<String>,
     message: &str,
     message_attributes: &serde_json::Map<String, Value>,
+    endpoint: &str,
 ) -> String {
     let mut map = serde_json::Map::new();
     map.insert(
@@ -2584,8 +2593,8 @@ fn build_sns_envelope(
     map.insert(
         "UnsubscribeURL".to_string(),
         Value::String(format!(
-            "http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={}",
-            topic_arn
+            "{}/?Action=Unsubscribe&SubscriptionArn={}",
+            endpoint, topic_arn
         )),
     );
     if !message_attributes.is_empty() {
@@ -3479,6 +3488,7 @@ mod tests {
             Some("test subject"),
             &attrs,
             &now,
+            "http://localhost:4566",
         );
 
         let parsed: Value = serde_json::from_str(&payload).unwrap();
@@ -3494,6 +3504,61 @@ mod tests {
         assert!(
             unsub_url.contains(sub_arn),
             "UnsubscribeUrl should contain subscription ARN"
+        );
+    }
+
+    #[test]
+    fn build_sns_envelope_uses_configured_endpoint() {
+        let endpoint = "http://myhost:5555";
+        let topic_arn = "arn:aws:sns:us-east-1:123456789012:my-topic";
+        let attrs = serde_json::Map::new();
+
+        let envelope = build_sns_envelope(
+            "msg-002",
+            topic_arn,
+            &None,
+            "test message",
+            &attrs,
+            endpoint,
+        );
+
+        let parsed: Value = serde_json::from_str(&envelope).unwrap();
+        let unsub_url = parsed["UnsubscribeURL"].as_str().unwrap();
+        assert!(
+            unsub_url.starts_with("http://myhost:5555/"),
+            "UnsubscribeURL should use the configured endpoint, got: {unsub_url}"
+        );
+        assert!(
+            unsub_url.contains(topic_arn),
+            "UnsubscribeURL should contain topic ARN"
+        );
+    }
+
+    #[test]
+    fn build_sns_lambda_event_uses_configured_endpoint() {
+        let now = Utc::now();
+        let sub_arn = "arn:aws:sns:us-east-1:123456789012:my-topic:abc-def-123";
+        let attrs = serde_json::Map::new();
+        let endpoint = "http://custom:9999";
+
+        let payload = build_sns_lambda_event(
+            "msg-003",
+            "arn:aws:sns:us-east-1:123456789012:my-topic",
+            sub_arn,
+            "hello",
+            None,
+            &attrs,
+            &now,
+            endpoint,
+        );
+
+        let parsed: Value = serde_json::from_str(&payload).unwrap();
+        let unsub_url = parsed["Records"][0]["Sns"]["UnsubscribeUrl"]
+            .as_str()
+            .unwrap();
+        assert!(
+            unsub_url.starts_with("http://custom:9999/"),
+            "UnsubscribeUrl should use configured endpoint, got: {unsub_url}"
         );
     }
 }

--- a/crates/fakecloud-sns/src/state.rs
+++ b/crates/fakecloud-sns/src/state.rs
@@ -84,6 +84,7 @@ pub struct SentEmail {
 pub struct SnsState {
     pub account_id: String,
     pub region: String,
+    pub endpoint: String,
     pub topics: BTreeMap<String, SnsTopic>, // arn -> topic (ordered for predictable iteration)
     pub subscriptions: BTreeMap<String, SnsSubscription>, // sub_arn -> subscription
     pub published: Vec<PublishedMessage>,
@@ -98,10 +99,11 @@ pub struct SnsState {
 }
 
 impl SnsState {
-    pub fn new(account_id: &str, region: &str) -> Self {
+    pub fn new(account_id: &str, region: &str, endpoint: &str) -> Self {
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
+            endpoint: endpoint.to_string(),
             topics: BTreeMap::new(),
             subscriptions: BTreeMap::new(),
             published: Vec::new(),


### PR DESCRIPTION
## Summary

- Derive the endpoint URL from the server's `--addr` CLI flag instead of hardcoding `http://localhost:4566`
- Add `endpoint` field to `SnsState` (matching the existing pattern in `SqsState`)
- Thread the configured endpoint through `build_sns_envelope` and `build_sns_lambda_event` so SNS unsubscribe URLs use the correct host/port
- Fix CloudFormation `ResourceProvisioner` to read the endpoint from SQS state instead of hardcoding it

## Test plan

- [x] New unit tests: `build_sns_envelope_uses_configured_endpoint` and `build_sns_lambda_event_uses_configured_endpoint`
- [x] All existing SNS and CloudFormation unit tests pass
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --check` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded `http://localhost:4566` with an endpoint derived from the server `--addr` flag (IPv6-safe). Queue URLs and SNS Unsubscribe URLs now use the actual bind host and port.

- **Bug Fixes**
  - Derive endpoint from `--addr` (IPv6-safe via `rsplit`; map `0.0.0.0`/`[::]` to `localhost`) and pass it to `SqsState` and `SnsState` in `fakecloud-server`.
  - Add `endpoint` to `SnsState` and thread it through `build_sns_envelope` and `build_sns_lambda_event` so Unsubscribe URLs are correct.
  - Update `fakecloud-cloudformation` `ResourceProvisioner` to build queue URLs using `SqsState.endpoint` instead of a hardcoded host.

<sup>Written for commit 89b52e56e3810995c83f28386f60275d77d6d347. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

