### PR TITLE
feat(sqs): add ListQueues pagination

### DIFF
--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -1001,6 +1001,95 @@ async fn sqs_get_queue_attributes_via_query_protocol() {
     );
 }
 
+#[tokio::test]
+async fn sqs_list_queues_pagination() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+
+    // Create 5 queues
+    for i in 0..5 {
+        client
+            .create_queue()
+            .queue_name(format!("page-queue-{i}"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // List with MaxResults=2: should return 2 queues and a NextToken
+    let resp = client.list_queues().max_results(2).send().await.unwrap();
+    assert_eq!(resp.queue_urls().len(), 2);
+    let token = resp
+        .next_token()
+        .expect("expected NextToken when more results exist");
+
+    // Use NextToken to get next page
+    let resp2 = client
+        .list_queues()
+        .max_results(2)
+        .next_token(token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp2.queue_urls().len(), 2);
+    let token2 = resp2
+        .next_token()
+        .expect("expected NextToken for third page");
+
+    // Third page: 1 remaining queue, no NextToken
+    let resp3 = client
+        .list_queues()
+        .max_results(2)
+        .next_token(token2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp3.queue_urls().len(), 1);
+    assert!(
+        resp3.next_token().is_none(),
+        "expected no NextToken on last page"
+    );
+
+    // Collect all URLs across pages and verify all 5 queues are returned
+    let mut all_urls: Vec<String> = Vec::new();
+    all_urls.extend(resp.queue_urls().iter().cloned());
+    all_urls.extend(resp2.queue_urls().iter().cloned());
+    all_urls.extend(resp3.queue_urls().iter().cloned());
+    assert_eq!(all_urls.len(), 5);
+    for i in 0..5 {
+        assert!(
+            all_urls
+                .iter()
+                .any(|u| u.contains(&format!("page-queue-{i}"))),
+            "missing page-queue-{i} in paginated results"
+        );
+    }
+}
+
+#[tokio::test]
+async fn sqs_list_queues_pagination_all_fit_in_one_page() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+
+    // Create 2 queues
+    for i in 0..2 {
+        client
+            .create_queue()
+            .queue_name(format!("small-page-{i}"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // List with MaxResults=10: all fit, no NextToken
+    let resp = client.list_queues().max_results(10).send().await.unwrap();
+    assert_eq!(resp.queue_urls().len(), 2);
+    assert!(
+        resp.next_token().is_none(),
+        "expected no NextToken when all queues fit in one page"
+    );
+}
+
 /// Regression: CreateQueue with invalid DelaySeconds should return an error.
 #[tokio::test]
 async fn sqs_create_queue_invalid_delay_seconds() {

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -707,7 +707,7 @@ impl SqsService {
         let max_results = body["MaxResults"]
             .as_u64()
             .or_else(|| body["MaxResults"].as_str().and_then(|s| s.parse().ok()))
-            .map(|n| n.min(1000) as usize)
+            .map(|n| n.clamp(1, 1000) as usize)
             .unwrap_or(1000);
 
         let offset = body["NextToken"]

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -226,6 +226,9 @@ fn sqs_response(action: &str, body: Value, request_id: &str, is_query: bool) -> 
                     }
                 }
             }
+            if let Some(token) = body["NextToken"].as_str() {
+                inner.push_str(&format!("<NextToken>{}</NextToken>", xml_escape(token)));
+            }
             AwsResponse::xml(StatusCode::OK, xml_wrap(action, &inner, request_id))
         }
         "SendMessage" => {
@@ -701,16 +704,41 @@ impl SqsService {
         let prefix = body["QueueNamePrefix"].as_str();
         let state = self.state.read();
 
-        let urls: Vec<String> = state
+        let max_results = body["MaxResults"]
+            .as_u64()
+            .or_else(|| body["MaxResults"].as_str().and_then(|s| s.parse().ok()))
+            .map(|n| n.min(1000) as usize)
+            .unwrap_or(1000);
+
+        let offset = body["NextToken"]
+            .as_str()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(0);
+
+        let mut all_urls: Vec<String> = state
             .queues
             .values()
             .filter(|q| prefix.map(|p| q.queue_name.starts_with(p)).unwrap_or(true))
             .map(|q| q.queue_url.clone())
             .collect();
+        all_urls.sort();
+
+        let total = all_urls.len();
+        let page: Vec<String> = all_urls
+            .into_iter()
+            .skip(offset)
+            .take(max_results)
+            .collect();
+        let next_offset = offset + page.len();
+
+        let mut result = json!({ "QueueUrls": page });
+        if next_offset < total {
+            result["NextToken"] = json!(next_offset.to_string());
+        }
 
         Ok(sqs_response(
             "ListQueues",
-            json!({ "QueueUrls": urls }),
+            result,
             &req.request_id,
             req.is_query_protocol,
         ))


### PR DESCRIPTION
## Summary
- Add `MaxResults` and `NextToken` parameter support to SQS `ListQueues`
- `MaxResults` defaults to 1000 (AWS max), `NextToken` is a simple offset index
- Results are sorted for stable pagination ordering
- XML (query protocol) responses include `NextToken` element when applicable

## Test plan
- [x] E2E test: paginate through 5 queues with MaxResults=2, verify 3 pages with correct NextToken behavior
- [x] E2E test: verify no NextToken when all queues fit in one page
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --check` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pagination to SQS `ListQueues` so clients can page through queue URLs reliably. Results are stably sorted and XML responses include `NextToken` when more pages exist.

- **New Features**
  - Support `MaxResults` (clamped to 1-1000; accepts string or number) and `NextToken`.
  - `NextToken` is a string offset; results are sorted for stable ordering.
  - Query protocol XML includes `NextToken` when applicable.

<sup>Written for commit b955600319ccbe6b3267e216b4ffdf8011777b11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

