### PR TITLE
fix(s3): validate parts in CompleteMultipartUpload

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -2268,3 +2268,232 @@ async fn s3_replication_prefix_filter() {
         "Non-matching object should not be replicated"
     );
 }
+
+/// CompleteMultipartUpload returns InvalidPart when a specified part was never uploaded.
+#[tokio::test]
+async fn s3_complete_multipart_invalid_part() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("mpu-invalid-part")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("mpu-invalid-part")
+        .key("test.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    // Upload only part 1
+    let part1 = client
+        .upload_part()
+        .bucket("mpu-invalid-part")
+        .key("test.bin")
+        .upload_id(&upload_id)
+        .part_number(1)
+        .body(ByteStream::from_static(b"data"))
+        .send()
+        .await
+        .unwrap();
+    let etag1 = part1.e_tag().unwrap().to_string();
+
+    // Complete referencing part 1 (exists) and part 2 (never uploaded)
+    use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+    let completed = CompletedMultipartUpload::builder()
+        .parts(
+            CompletedPart::builder()
+                .part_number(1)
+                .e_tag(&etag1)
+                .build(),
+        )
+        .parts(
+            CompletedPart::builder()
+                .part_number(2)
+                .e_tag("\"fake-etag\"")
+                .build(),
+        )
+        .build();
+
+    let result = client
+        .complete_multipart_upload()
+        .bucket("mpu-invalid-part")
+        .key("test.bin")
+        .upload_id(&upload_id)
+        .multipart_upload(completed)
+        .send()
+        .await;
+    assert!(result.is_err(), "Expected InvalidPart error");
+    let err_str = format!("{:?}", result.unwrap_err());
+    assert!(
+        err_str.contains("InvalidPart"),
+        "Error should mention InvalidPart, got: {err_str}"
+    );
+}
+
+/// CompleteMultipartUpload returns InvalidPartOrder when parts aren't in ascending order.
+#[tokio::test]
+async fn s3_complete_multipart_invalid_part_order() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("mpu-order")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("mpu-order")
+        .key("test.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    // Upload parts 1 and 2
+    let part1 = client
+        .upload_part()
+        .bucket("mpu-order")
+        .key("test.bin")
+        .upload_id(&upload_id)
+        .part_number(1)
+        .body(ByteStream::from_static(b"part1"))
+        .send()
+        .await
+        .unwrap();
+    let etag1 = part1.e_tag().unwrap().to_string();
+
+    let part2 = client
+        .upload_part()
+        .bucket("mpu-order")
+        .key("test.bin")
+        .upload_id(&upload_id)
+        .part_number(2)
+        .body(ByteStream::from_static(b"part2"))
+        .send()
+        .await
+        .unwrap();
+    let etag2 = part2.e_tag().unwrap().to_string();
+
+    // Complete with parts in descending order (2 then 1)
+    use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+    let completed = CompletedMultipartUpload::builder()
+        .parts(
+            CompletedPart::builder()
+                .part_number(2)
+                .e_tag(&etag2)
+                .build(),
+        )
+        .parts(
+            CompletedPart::builder()
+                .part_number(1)
+                .e_tag(&etag1)
+                .build(),
+        )
+        .build();
+
+    let result = client
+        .complete_multipart_upload()
+        .bucket("mpu-order")
+        .key("test.bin")
+        .upload_id(&upload_id)
+        .multipart_upload(completed)
+        .send()
+        .await;
+    assert!(result.is_err(), "Expected InvalidPartOrder error");
+    let err_str = format!("{:?}", result.unwrap_err());
+    assert!(
+        err_str.contains("InvalidPartOrder"),
+        "Error should mention InvalidPartOrder, got: {err_str}"
+    );
+}
+
+/// CompleteMultipartUpload returns EntityTooSmall when a non-last part is under 5MB.
+#[tokio::test]
+async fn s3_complete_multipart_entity_too_small() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("mpu-small")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("mpu-small")
+        .key("test.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    // Upload part 1 with only 100 bytes (under 5MB minimum)
+    let part1 = client
+        .upload_part()
+        .bucket("mpu-small")
+        .key("test.bin")
+        .upload_id(&upload_id)
+        .part_number(1)
+        .body(ByteStream::from(vec![b'X'; 100]))
+        .send()
+        .await
+        .unwrap();
+    let etag1 = part1.e_tag().unwrap().to_string();
+
+    // Upload part 2
+    let part2 = client
+        .upload_part()
+        .bucket("mpu-small")
+        .key("test.bin")
+        .upload_id(&upload_id)
+        .part_number(2)
+        .body(ByteStream::from_static(b"last-part"))
+        .send()
+        .await
+        .unwrap();
+    let etag2 = part2.e_tag().unwrap().to_string();
+
+    // Complete — should fail because part 1 is under 5MB
+    use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+    let completed = CompletedMultipartUpload::builder()
+        .parts(
+            CompletedPart::builder()
+                .part_number(1)
+                .e_tag(&etag1)
+                .build(),
+        )
+        .parts(
+            CompletedPart::builder()
+                .part_number(2)
+                .e_tag(&etag2)
+                .build(),
+        )
+        .build();
+
+    let result = client
+        .complete_multipart_upload()
+        .bucket("mpu-small")
+        .key("test.bin")
+        .upload_id(&upload_id)
+        .multipart_upload(completed)
+        .send()
+        .await;
+    assert!(result.is_err(), "Expected EntityTooSmall error");
+    let err_str = format!("{:?}", result.unwrap_err());
+    assert!(
+        err_str.contains("EntityTooSmall"),
+        "Error should mention EntityTooSmall, got: {err_str}"
+    );
+}

--- a/crates/fakecloud-s3/src/service.rs
+++ b/crates/fakecloud-s3/src/service.rs
@@ -4645,14 +4645,33 @@ impl S3Service {
             }
         }
 
-        // Use parts in submitted order (AWS requires ascending, but we don't enforce)
+        // Validate parts are in ascending order
+        for window in submitted_parts.windows(2) {
+            if window[0].0 >= window[1].0 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidPartOrder",
+                    "The list of parts was not in ascending order. The parts list must be specified in order by part number.",
+                ));
+            }
+        }
+
         let sorted_parts = submitted_parts;
 
+        // Validate all specified parts exist in the upload
+        for (part_num, _) in &sorted_parts {
+            if !upload.parts.contains_key(part_num) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidPart",
+                    "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not have matched the part's entity tag.",
+                ));
+            }
+        }
+
         // Validate minimum part size: all non-last parts must be >= 5MB
-        // Use a relaxed threshold for testing compatibility (the decorator
-        // `reduced_min_part_size` in test suites lowers this to 256 bytes).
+        const MIN_PART_SIZE: usize = 5 * 1024 * 1024; // 5MB
         if sorted_parts.len() > 1 {
-            const MIN_PART_SIZE: usize = 256;
             for (i, (part_num, _)) in sorted_parts.iter().enumerate() {
                 if i >= sorted_parts.len() - 1 {
                     break; // skip last part


### PR DESCRIPTION
## Summary
- Add `InvalidPartOrder` error when parts aren't in ascending order
- Add `InvalidPart` error when a specified part number doesn't exist in the upload
- Add `EntityTooSmall` error when any non-last part is under 5MB (AWS minimum)
- Add E2E tests for all three validation cases

## Test plan
- [x] `s3_complete_multipart_invalid_part` — verifies InvalidPart for non-existent parts
- [x] `s3_complete_multipart_invalid_part_order` — verifies InvalidPartOrder for descending order
- [x] `s3_complete_multipart_entity_too_small` — verifies EntityTooSmall for undersized non-last parts
- [x] Existing S3 unit tests pass
- [x] clippy and fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces AWS-compliant validation for S3 CompleteMultipartUpload, returning correct errors and blocking invalid requests. Adds E2E tests for each validation.

- **Bug Fixes**
  - Enforce ascending part order; returns InvalidPartOrder.
  - Verify all referenced parts exist; returns InvalidPart.
  - Require 5MB minimum for non-last parts; returns EntityTooSmall.

<sup>Written for commit d95a3665cb7c2964e0dac031cb66f072ba8d4cd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

