### PR TITLE
Add unit and e2e tests for IAM group/user policies, MFA, and account ops

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -914,6 +914,585 @@ async fn sts_assume_role_validates_external_id() {
     );
 }
 
+// ---- Group Managed Policy Tests ----
+
+#[tokio::test]
+async fn iam_attach_detach_group_policy() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    // Create group
+    client
+        .create_group()
+        .group_name("policy-group")
+        .send()
+        .await
+        .unwrap();
+
+    // Create managed policy
+    let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}"#;
+    let policy = client
+        .create_policy()
+        .policy_name("s3-full")
+        .policy_document(policy_doc)
+        .send()
+        .await
+        .unwrap();
+    let policy_arn = policy.policy().unwrap().arn().unwrap().to_string();
+
+    // Attach
+    client
+        .attach_group_policy()
+        .group_name("policy-group")
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // List attached
+    let attached = client
+        .list_attached_group_policies()
+        .group_name("policy-group")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(attached.attached_policies().len(), 1);
+    assert_eq!(
+        attached.attached_policies()[0].policy_name().unwrap(),
+        "s3-full"
+    );
+
+    // Detach
+    client
+        .detach_group_policy()
+        .group_name("policy-group")
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let attached = client
+        .list_attached_group_policies()
+        .group_name("policy-group")
+        .send()
+        .await
+        .unwrap();
+    assert!(attached.attached_policies().is_empty());
+}
+
+// ---- Group Inline Policy Tests ----
+
+#[tokio::test]
+async fn iam_group_inline_policy() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_group()
+        .group_name("inline-group")
+        .send()
+        .await
+        .unwrap();
+
+    let inline_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sqs:*","Resource":"*"}]}"#;
+    client
+        .put_group_policy()
+        .group_name("inline-group")
+        .policy_name("sqs-access")
+        .policy_document(inline_doc)
+        .send()
+        .await
+        .unwrap();
+
+    // List inline policies
+    let policies = client
+        .list_group_policies()
+        .group_name("inline-group")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(policies.policy_names().len(), 1);
+    assert_eq!(policies.policy_names()[0], "sqs-access");
+
+    // Get inline policy
+    let get = client
+        .get_group_policy()
+        .group_name("inline-group")
+        .policy_name("sqs-access")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.policy_name(), "sqs-access");
+    assert_eq!(get.group_name(), "inline-group");
+
+    // Delete inline policy
+    client
+        .delete_group_policy()
+        .group_name("inline-group")
+        .policy_name("sqs-access")
+        .send()
+        .await
+        .unwrap();
+
+    let policies = client
+        .list_group_policies()
+        .group_name("inline-group")
+        .send()
+        .await
+        .unwrap();
+    assert!(policies.policy_names().is_empty());
+}
+
+// ---- User Managed Policy Attachment Tests ----
+
+#[tokio::test]
+async fn iam_attach_detach_user_policy() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("policy-user")
+        .send()
+        .await
+        .unwrap();
+
+    let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"logs:*","Resource":"*"}]}"#;
+    let policy = client
+        .create_policy()
+        .policy_name("logs-full")
+        .policy_document(policy_doc)
+        .send()
+        .await
+        .unwrap();
+    let policy_arn = policy.policy().unwrap().arn().unwrap().to_string();
+
+    // Attach
+    client
+        .attach_user_policy()
+        .user_name("policy-user")
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // List attached
+    let attached = client
+        .list_attached_user_policies()
+        .user_name("policy-user")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(attached.attached_policies().len(), 1);
+    assert_eq!(
+        attached.attached_policies()[0].policy_name().unwrap(),
+        "logs-full"
+    );
+
+    // Detach
+    client
+        .detach_user_policy()
+        .user_name("policy-user")
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let attached = client
+        .list_attached_user_policies()
+        .user_name("policy-user")
+        .send()
+        .await
+        .unwrap();
+    assert!(attached.attached_policies().is_empty());
+}
+
+// ---- User Inline Policy Tests ----
+
+#[tokio::test]
+async fn iam_user_inline_policy() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("inline-user")
+        .send()
+        .await
+        .unwrap();
+
+    let inline_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"dynamodb:*","Resource":"*"}]}"#;
+    client
+        .put_user_policy()
+        .user_name("inline-user")
+        .policy_name("ddb-access")
+        .policy_document(inline_doc)
+        .send()
+        .await
+        .unwrap();
+
+    // List
+    let policies = client
+        .list_user_policies()
+        .user_name("inline-user")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(policies.policy_names().len(), 1);
+    assert_eq!(policies.policy_names()[0], "ddb-access");
+
+    // Get
+    let get = client
+        .get_user_policy()
+        .user_name("inline-user")
+        .policy_name("ddb-access")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.policy_name(), "ddb-access");
+    assert_eq!(get.user_name(), "inline-user");
+
+    // Delete
+    client
+        .delete_user_policy()
+        .user_name("inline-user")
+        .policy_name("ddb-access")
+        .send()
+        .await
+        .unwrap();
+
+    let policies = client
+        .list_user_policies()
+        .user_name("inline-user")
+        .send()
+        .await
+        .unwrap();
+    assert!(policies.policy_names().is_empty());
+}
+
+// ---- Login Profile Tests ----
+
+#[tokio::test]
+async fn iam_login_profile_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("login-user")
+        .send()
+        .await
+        .unwrap();
+
+    // Create login profile
+    let resp = client
+        .create_login_profile()
+        .user_name("login-user")
+        .password("S3cureP@ss!")
+        .password_reset_required(true)
+        .send()
+        .await
+        .unwrap();
+    let profile = resp.login_profile().unwrap();
+    assert_eq!(profile.user_name(), "login-user");
+    assert!(profile.password_reset_required());
+
+    // Get login profile
+    let get = client
+        .get_login_profile()
+        .user_name("login-user")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.login_profile().unwrap().user_name(), "login-user");
+    assert!(get.login_profile().unwrap().password_reset_required());
+
+    // Update login profile
+    client
+        .update_login_profile()
+        .user_name("login-user")
+        .password_reset_required(false)
+        .send()
+        .await
+        .unwrap();
+
+    let get = client
+        .get_login_profile()
+        .user_name("login-user")
+        .send()
+        .await
+        .unwrap();
+    assert!(!get.login_profile().unwrap().password_reset_required());
+
+    // Delete login profile
+    client
+        .delete_login_profile()
+        .user_name("login-user")
+        .send()
+        .await
+        .unwrap();
+
+    // Get should fail after delete
+    let result = client
+        .get_login_profile()
+        .user_name("login-user")
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn iam_login_profile_duplicate_fails() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("dup-login")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_login_profile()
+        .user_name("dup-login")
+        .password("pass1")
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .create_login_profile()
+        .user_name("dup-login")
+        .password("pass2")
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+
+// ---- MFA Tests ----
+
+#[tokio::test]
+async fn iam_virtual_mfa_lifecycle_cli() {
+    let server = TestServer::start().await;
+    let tmp_dir = std::env::temp_dir();
+    let outfile = tmp_dir.join("test-mfa-lifecycle.png");
+
+    // Create virtual MFA device
+    let output = server
+        .aws_cli(&[
+            "iam",
+            "create-virtual-mfa-device",
+            "--virtual-mfa-device-name",
+            "lifecycle-mfa",
+            "--outfile",
+            outfile.to_str().unwrap(),
+            "--bootstrap-method",
+            "QRCodePNG",
+        ])
+        .await;
+    let _ = std::fs::remove_file(&outfile);
+    assert!(
+        output.success(),
+        "create-virtual-mfa-device failed: {}",
+        output.stderr_text()
+    );
+    let json = output.stdout_json();
+    let serial = json["VirtualMFADevice"]["SerialNumber"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // List virtual MFA devices
+    let output = server.aws_cli(&["iam", "list-virtual-mfa-devices"]).await;
+    assert!(output.success());
+    let json = output.stdout_json();
+    let devices = json["VirtualMFADevices"].as_array().unwrap();
+    assert_eq!(devices.len(), 1);
+
+    // Delete virtual MFA device
+    let output = server
+        .aws_cli(&[
+            "iam",
+            "delete-virtual-mfa-device",
+            "--serial-number",
+            &serial,
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "delete-virtual-mfa-device failed: {}",
+        output.stderr_text()
+    );
+
+    // List should be empty
+    let output = server.aws_cli(&["iam", "list-virtual-mfa-devices"]).await;
+    assert!(output.success());
+    let json = output.stdout_json();
+    assert!(json["VirtualMFADevices"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn iam_enable_deactivate_list_mfa_cli() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let tmp_dir = std::env::temp_dir();
+    let outfile = tmp_dir.join("test-enable-mfa.png");
+
+    // Create user
+    iam.create_user()
+        .user_name("mfa-cli-user")
+        .send()
+        .await
+        .unwrap();
+
+    // Create virtual MFA device
+    let output = server
+        .aws_cli(&[
+            "iam",
+            "create-virtual-mfa-device",
+            "--virtual-mfa-device-name",
+            "cli-mfa",
+            "--outfile",
+            outfile.to_str().unwrap(),
+            "--bootstrap-method",
+            "QRCodePNG",
+        ])
+        .await;
+    let _ = std::fs::remove_file(&outfile);
+    assert!(output.success());
+    let serial = output.stdout_json()["VirtualMFADevice"]["SerialNumber"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Enable MFA device
+    let output = server
+        .aws_cli(&[
+            "iam",
+            "enable-mfa-device",
+            "--user-name",
+            "mfa-cli-user",
+            "--serial-number",
+            &serial,
+            "--authentication-code1",
+            "123456",
+            "--authentication-code2",
+            "654321",
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "enable-mfa-device failed: {}",
+        output.stderr_text()
+    );
+
+    // List MFA devices for user
+    let output = server
+        .aws_cli(&["iam", "list-mfa-devices", "--user-name", "mfa-cli-user"])
+        .await;
+    assert!(output.success());
+    let json = output.stdout_json();
+    let devices = json["MFADevices"].as_array().unwrap();
+    assert_eq!(devices.len(), 1);
+    assert_eq!(devices[0]["UserName"].as_str().unwrap(), "mfa-cli-user");
+
+    // Deactivate MFA device
+    let output = server
+        .aws_cli(&[
+            "iam",
+            "deactivate-mfa-device",
+            "--user-name",
+            "mfa-cli-user",
+            "--serial-number",
+            &serial,
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "deactivate-mfa-device failed: {}",
+        output.stderr_text()
+    );
+
+    // List MFA devices - should be empty for the user now
+    let output = server
+        .aws_cli(&["iam", "list-mfa-devices", "--user-name", "mfa-cli-user"])
+        .await;
+    assert!(output.success());
+    let json = output.stdout_json();
+    assert!(json["MFADevices"].as_array().unwrap().is_empty());
+}
+
+// ---- Account Tests ----
+
+#[tokio::test]
+async fn iam_get_account_summary_cli() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    // Create some resources
+    iam.create_user()
+        .user_name("summary-user")
+        .send()
+        .await
+        .unwrap();
+    iam.create_group()
+        .group_name("summary-group")
+        .send()
+        .await
+        .unwrap();
+
+    let output = server.aws_cli(&["iam", "get-account-summary"]).await;
+    assert!(
+        output.success(),
+        "get-account-summary failed: {}",
+        output.stderr_text()
+    );
+    let json = output.stdout_json();
+    let summary = &json["SummaryMap"];
+    assert_eq!(summary["Users"].as_i64().unwrap(), 1);
+    assert_eq!(summary["Groups"].as_i64().unwrap(), 1);
+    assert_eq!(summary["UsersQuota"].as_i64().unwrap(), 5000);
+}
+
+#[tokio::test]
+async fn iam_account_alias_lifecycle_cli() {
+    let server = TestServer::start().await;
+
+    // Create alias
+    let output = server
+        .aws_cli(&["iam", "create-account-alias", "--account-alias", "test-org"])
+        .await;
+    assert!(
+        output.success(),
+        "create-account-alias failed: {}",
+        output.stderr_text()
+    );
+
+    // List aliases
+    let output = server.aws_cli(&["iam", "list-account-aliases"]).await;
+    assert!(output.success());
+    let json = output.stdout_json();
+    let aliases = json["AccountAliases"].as_array().unwrap();
+    assert_eq!(aliases.len(), 1);
+    assert_eq!(aliases[0].as_str().unwrap(), "test-org");
+
+    // Delete alias
+    let output = server
+        .aws_cli(&["iam", "delete-account-alias", "--account-alias", "test-org"])
+        .await;
+    assert!(
+        output.success(),
+        "delete-account-alias failed: {}",
+        output.stderr_text()
+    );
+
+    // List should be empty
+    let output = server.aws_cli(&["iam", "list-account-aliases"]).await;
+    assert!(output.success());
+    let json = output.stdout_json();
+    assert!(json["AccountAliases"].as_array().unwrap().is_empty());
+}
+
 /// Regression: ListVirtualMFADevices should only return virtual MFA devices,
 /// excluding hardware MFA devices created via EnableMFADevice with a non-virtual serial.
 #[tokio::test]

--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -6482,4 +6482,610 @@ mod tests {
             "non-numeric MaxItems should return an error"
         );
     }
+
+    // ---- Group inline policy tests ----
+
+    #[test]
+    fn put_and_get_group_policy() {
+        let svc = make_service();
+        let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}"#;
+
+        // Create group
+        svc.handle_sync("CreateGroup", vec![("GroupName", "devs")]);
+
+        // Put inline policy
+        svc.handle_sync(
+            "PutGroupPolicy",
+            vec![
+                ("GroupName", "devs"),
+                ("PolicyName", "s3-access"),
+                ("PolicyDocument", policy_doc),
+            ],
+        );
+
+        // Get inline policy
+        let resp = svc.handle_sync(
+            "GetGroupPolicy",
+            vec![("GroupName", "devs"), ("PolicyName", "s3-access")],
+        );
+        assert!(resp.contains("s3-access"));
+        assert!(resp.contains("devs"));
+    }
+
+    #[test]
+    fn list_group_policies() {
+        let svc = make_service();
+        let doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+
+        svc.handle_sync("CreateGroup", vec![("GroupName", "ops")]);
+        svc.handle_sync(
+            "PutGroupPolicy",
+            vec![
+                ("GroupName", "ops"),
+                ("PolicyName", "pol-a"),
+                ("PolicyDocument", doc),
+            ],
+        );
+        svc.handle_sync(
+            "PutGroupPolicy",
+            vec![
+                ("GroupName", "ops"),
+                ("PolicyName", "pol-b"),
+                ("PolicyDocument", doc),
+            ],
+        );
+
+        let resp = svc.handle_sync("ListGroupPolicies", vec![("GroupName", "ops")]);
+        assert!(resp.contains("pol-a"));
+        assert!(resp.contains("pol-b"));
+    }
+
+    #[test]
+    fn delete_group_policy() {
+        let svc = make_service();
+        let doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+
+        svc.handle_sync("CreateGroup", vec![("GroupName", "team")]);
+        svc.handle_sync(
+            "PutGroupPolicy",
+            vec![
+                ("GroupName", "team"),
+                ("PolicyName", "temp"),
+                ("PolicyDocument", doc),
+            ],
+        );
+
+        // Delete
+        svc.handle_sync(
+            "DeleteGroupPolicy",
+            vec![("GroupName", "team"), ("PolicyName", "temp")],
+        );
+
+        // List should be empty
+        let resp = svc.handle_sync("ListGroupPolicies", vec![("GroupName", "team")]);
+        assert!(!resp.contains("temp"));
+    }
+
+    #[test]
+    fn get_group_policy_not_found() {
+        let svc = make_service();
+        svc.handle_sync("CreateGroup", vec![("GroupName", "g1")]);
+
+        let req = make_request(
+            "GetGroupPolicy",
+            vec![("GroupName", "g1"), ("PolicyName", "nope")],
+        );
+        let result = svc.get_group_policy(&req);
+        assert!(result.is_err());
+    }
+
+    // ---- Group managed policy attachment tests ----
+
+    #[test]
+    fn attach_and_list_group_policies_managed() {
+        let svc = make_service();
+        let doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+
+        svc.handle_sync("CreateGroup", vec![("GroupName", "eng")]);
+        svc.handle_sync(
+            "CreatePolicy",
+            vec![("PolicyName", "read-policy"), ("PolicyDocument", doc)],
+        );
+
+        let create_resp = svc.handle_sync(
+            "CreatePolicy",
+            vec![("PolicyName", "write-policy"), ("PolicyDocument", doc)],
+        );
+        // Extract the ARN from the second policy
+        let arn_start = create_resp.find("<Arn>").unwrap() + 5;
+        let arn_end = create_resp.find("</Arn>").unwrap();
+        let write_arn = &create_resp[arn_start..arn_end];
+
+        // Attach both policies - for the first one, extract its ARN too
+        // Just use the write_arn which we already have
+        svc.handle_sync(
+            "AttachGroupPolicy",
+            vec![("GroupName", "eng"), ("PolicyArn", write_arn)],
+        );
+
+        let list = svc.handle_sync("ListAttachedGroupPolicies", vec![("GroupName", "eng")]);
+        assert!(list.contains("write-policy"));
+    }
+
+    #[test]
+    fn detach_group_policy() {
+        let svc = make_service();
+        let doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+
+        svc.handle_sync("CreateGroup", vec![("GroupName", "detach-grp")]);
+        let resp = svc.handle_sync(
+            "CreatePolicy",
+            vec![("PolicyName", "detach-pol"), ("PolicyDocument", doc)],
+        );
+        let arn = extract_xml_value(&resp, "Arn");
+
+        svc.handle_sync(
+            "AttachGroupPolicy",
+            vec![("GroupName", "detach-grp"), ("PolicyArn", &arn)],
+        );
+
+        // Detach
+        svc.handle_sync(
+            "DetachGroupPolicy",
+            vec![("GroupName", "detach-grp"), ("PolicyArn", &arn)],
+        );
+
+        let list = svc.handle_sync(
+            "ListAttachedGroupPolicies",
+            vec![("GroupName", "detach-grp")],
+        );
+        assert!(!list.contains("detach-pol"));
+    }
+
+    #[test]
+    fn detach_group_policy_not_attached_fails() {
+        let svc = make_service();
+        svc.handle_sync("CreateGroup", vec![("GroupName", "grp-err")]);
+
+        let req = make_request(
+            "DetachGroupPolicy",
+            vec![
+                ("GroupName", "grp-err"),
+                ("PolicyArn", "arn:aws:iam::123456789012:policy/nope"),
+            ],
+        );
+        let result = svc.detach_group_policy(&req);
+        assert!(result.is_err());
+    }
+
+    // ---- User inline policy tests ----
+
+    #[test]
+    fn put_get_delete_user_inline_policy() {
+        let svc = make_service();
+        let doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sqs:*","Resource":"*"}]}"#;
+
+        svc.handle_sync("CreateUser", vec![("UserName", "alice")]);
+
+        // Put
+        svc.handle_sync(
+            "PutUserPolicy",
+            vec![
+                ("UserName", "alice"),
+                ("PolicyName", "sqs-access"),
+                ("PolicyDocument", doc),
+            ],
+        );
+
+        // Get
+        let resp = svc.handle_sync(
+            "GetUserPolicy",
+            vec![("UserName", "alice"), ("PolicyName", "sqs-access")],
+        );
+        assert!(resp.contains("sqs-access"));
+        assert!(resp.contains("alice"));
+
+        // List
+        let list = svc.handle_sync("ListUserPolicies", vec![("UserName", "alice")]);
+        assert!(list.contains("sqs-access"));
+
+        // Delete
+        svc.handle_sync(
+            "DeleteUserPolicy",
+            vec![("UserName", "alice"), ("PolicyName", "sqs-access")],
+        );
+
+        let list = svc.handle_sync("ListUserPolicies", vec![("UserName", "alice")]);
+        assert!(!list.contains("sqs-access"));
+    }
+
+    #[test]
+    fn get_user_policy_not_found() {
+        let svc = make_service();
+        svc.handle_sync("CreateUser", vec![("UserName", "bob")]);
+
+        let req = make_request(
+            "GetUserPolicy",
+            vec![("UserName", "bob"), ("PolicyName", "ghost")],
+        );
+        let result = svc.get_user_policy(&req);
+        assert!(result.is_err());
+    }
+
+    // ---- User managed policy attachment tests ----
+
+    #[test]
+    fn attach_detach_list_user_policies_managed() {
+        let svc = make_service();
+        let doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+
+        svc.handle_sync("CreateUser", vec![("UserName", "carol")]);
+        let resp = svc.handle_sync(
+            "CreatePolicy",
+            vec![("PolicyName", "user-pol"), ("PolicyDocument", doc)],
+        );
+        let arn = extract_xml_value(&resp, "Arn");
+
+        // Attach
+        svc.handle_sync(
+            "AttachUserPolicy",
+            vec![("UserName", "carol"), ("PolicyArn", &arn)],
+        );
+
+        // List attached
+        let list = svc.handle_sync("ListAttachedUserPolicies", vec![("UserName", "carol")]);
+        assert!(list.contains("user-pol"));
+
+        // Detach
+        svc.handle_sync(
+            "DetachUserPolicy",
+            vec![("UserName", "carol"), ("PolicyArn", &arn)],
+        );
+
+        let list = svc.handle_sync("ListAttachedUserPolicies", vec![("UserName", "carol")]);
+        assert!(!list.contains("user-pol"));
+    }
+
+    #[test]
+    fn attach_user_policy_nonexistent_user_fails() {
+        let svc = make_service();
+        let req = make_request(
+            "AttachUserPolicy",
+            vec![
+                ("UserName", "nobody"),
+                ("PolicyArn", "arn:aws:iam::123456789012:policy/x"),
+            ],
+        );
+        let result = svc.attach_user_policy(&req);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn detach_user_policy_not_attached_fails() {
+        let svc = make_service();
+        svc.handle_sync("CreateUser", vec![("UserName", "dave")]);
+
+        let req = make_request(
+            "DetachUserPolicy",
+            vec![
+                ("UserName", "dave"),
+                ("PolicyArn", "arn:aws:iam::123456789012:policy/nope"),
+            ],
+        );
+        let result = svc.detach_user_policy(&req);
+        assert!(result.is_err());
+    }
+
+    // ---- Login profile tests ----
+
+    #[test]
+    fn login_profile_lifecycle() {
+        let svc = make_service();
+        svc.handle_sync("CreateUser", vec![("UserName", "loginuser")]);
+
+        // Create login profile
+        let resp = svc.handle_sync(
+            "CreateLoginProfile",
+            vec![
+                ("UserName", "loginuser"),
+                ("Password", "S3cureP@ss!"),
+                ("PasswordResetRequired", "true"),
+            ],
+        );
+        assert!(resp.contains("loginuser"));
+        assert!(resp.contains("<PasswordResetRequired>true</PasswordResetRequired>"));
+
+        // Get login profile
+        let resp = svc.handle_sync("GetLoginProfile", vec![("UserName", "loginuser")]);
+        assert!(resp.contains("loginuser"));
+        assert!(resp.contains("<PasswordResetRequired>true</PasswordResetRequired>"));
+
+        // Update login profile
+        svc.handle_sync(
+            "UpdateLoginProfile",
+            vec![
+                ("UserName", "loginuser"),
+                ("PasswordResetRequired", "false"),
+            ],
+        );
+
+        let resp = svc.handle_sync("GetLoginProfile", vec![("UserName", "loginuser")]);
+        assert!(resp.contains("<PasswordResetRequired>false</PasswordResetRequired>"));
+
+        // Delete login profile
+        svc.handle_sync("DeleteLoginProfile", vec![("UserName", "loginuser")]);
+
+        // Should fail now
+        let req = make_request("GetLoginProfile", vec![("UserName", "loginuser")]);
+        assert!(svc.get_login_profile(&req).is_err());
+    }
+
+    #[test]
+    fn create_login_profile_duplicate_fails() {
+        let svc = make_service();
+        svc.handle_sync("CreateUser", vec![("UserName", "dupuser")]);
+        svc.handle_sync(
+            "CreateLoginProfile",
+            vec![("UserName", "dupuser"), ("Password", "pass1")],
+        );
+
+        let req = make_request(
+            "CreateLoginProfile",
+            vec![("UserName", "dupuser"), ("Password", "pass2")],
+        );
+        assert!(svc.create_login_profile(&req).is_err());
+    }
+
+    #[test]
+    fn delete_login_profile_nonexistent_fails() {
+        let svc = make_service();
+        svc.handle_sync("CreateUser", vec![("UserName", "nologin")]);
+
+        let req = make_request("DeleteLoginProfile", vec![("UserName", "nologin")]);
+        assert!(svc.delete_login_profile(&req).is_err());
+    }
+
+    // ---- MFA tests ----
+
+    #[test]
+    fn virtual_mfa_device_lifecycle() {
+        let svc = make_service();
+
+        // Create virtual MFA device
+        let resp = svc.handle_sync(
+            "CreateVirtualMFADevice",
+            vec![("VirtualMFADeviceName", "my-mfa")],
+        );
+        assert!(resp.contains("my-mfa"));
+        assert!(resp.contains("<Base32StringSeed>"));
+        assert!(resp.contains("<QRCodePNG>"));
+        let serial = extract_xml_value(&resp, "SerialNumber");
+
+        // List should include it
+        let list = svc.handle_sync("ListVirtualMFADevices", vec![]);
+        assert!(list.contains("my-mfa"));
+
+        // Delete
+        svc.handle_sync("DeleteVirtualMFADevice", vec![("SerialNumber", &serial)]);
+
+        // List should be empty
+        let list = svc.handle_sync("ListVirtualMFADevices", vec![]);
+        assert!(!list.contains("my-mfa"));
+    }
+
+    #[test]
+    fn delete_virtual_mfa_device_not_found() {
+        let svc = make_service();
+        let req = make_request(
+            "DeleteVirtualMFADevice",
+            vec![("SerialNumber", "arn:aws:iam::123456789012:mfa/ghost")],
+        );
+        assert!(svc.delete_virtual_mfa_device(&req).is_err());
+    }
+
+    #[test]
+    fn enable_and_list_mfa_devices() {
+        let svc = make_service();
+        svc.handle_sync("CreateUser", vec![("UserName", "mfauser")]);
+
+        // Create virtual MFA
+        let resp = svc.handle_sync(
+            "CreateVirtualMFADevice",
+            vec![("VirtualMFADeviceName", "dev-mfa")],
+        );
+        let serial = extract_xml_value(&resp, "SerialNumber");
+
+        // Enable MFA device for user
+        svc.handle_sync(
+            "EnableMFADevice",
+            vec![
+                ("UserName", "mfauser"),
+                ("SerialNumber", &serial),
+                ("AuthenticationCode1", "123456"),
+                ("AuthenticationCode2", "654321"),
+            ],
+        );
+
+        // List MFA devices for user
+        let list = svc.handle_sync("ListMFADevices", vec![("UserName", "mfauser")]);
+        assert!(list.contains(&serial));
+        assert!(list.contains("mfauser"));
+    }
+
+    #[test]
+    fn deactivate_mfa_device() {
+        let svc = make_service();
+        svc.handle_sync("CreateUser", vec![("UserName", "deactuser")]);
+
+        let resp = svc.handle_sync(
+            "CreateVirtualMFADevice",
+            vec![("VirtualMFADeviceName", "deact-mfa")],
+        );
+        let serial = extract_xml_value(&resp, "SerialNumber");
+
+        svc.handle_sync(
+            "EnableMFADevice",
+            vec![
+                ("UserName", "deactuser"),
+                ("SerialNumber", &serial),
+                ("AuthenticationCode1", "111111"),
+                ("AuthenticationCode2", "222222"),
+            ],
+        );
+
+        // Deactivate
+        svc.handle_sync(
+            "DeactivateMFADevice",
+            vec![("UserName", "deactuser"), ("SerialNumber", &serial)],
+        );
+
+        // Should no longer appear in user's MFA device list
+        let list = svc.handle_sync("ListMFADevices", vec![("UserName", "deactuser")]);
+        assert!(!list.contains(&serial));
+    }
+
+    #[test]
+    fn list_virtual_mfa_devices_assignment_filter() {
+        let svc = make_service();
+        svc.handle_sync("CreateUser", vec![("UserName", "filteruser")]);
+
+        // Create two MFA devices with distinct names
+        let resp1 = svc.handle_sync(
+            "CreateVirtualMFADevice",
+            vec![("VirtualMFADeviceName", "enabled-device")],
+        );
+        let serial1 = extract_xml_value(&resp1, "SerialNumber");
+        svc.handle_sync(
+            "CreateVirtualMFADevice",
+            vec![("VirtualMFADeviceName", "spare-device")],
+        );
+
+        // Enable only the first
+        svc.handle_sync(
+            "EnableMFADevice",
+            vec![
+                ("UserName", "filteruser"),
+                ("SerialNumber", &serial1),
+                ("AuthenticationCode1", "123456"),
+                ("AuthenticationCode2", "654321"),
+            ],
+        );
+
+        // Filter by Assigned
+        let assigned = svc.handle_sync(
+            "ListVirtualMFADevices",
+            vec![("AssignmentStatus", "Assigned")],
+        );
+        assert!(assigned.contains("enabled-device"));
+        assert!(!assigned.contains("spare-device"));
+
+        // Filter by Unassigned
+        let unassigned = svc.handle_sync(
+            "ListVirtualMFADevices",
+            vec![("AssignmentStatus", "Unassigned")],
+        );
+        assert!(!unassigned.contains("enabled-device"));
+        assert!(unassigned.contains("spare-device"));
+    }
+
+    // ---- Account tests ----
+
+    #[test]
+    fn get_account_summary() {
+        let svc = make_service();
+
+        // Create some resources to verify counts
+        svc.handle_sync("CreateUser", vec![("UserName", "u1")]);
+        svc.handle_sync("CreateUser", vec![("UserName", "u2")]);
+        svc.handle_sync("CreateGroup", vec![("GroupName", "g1")]);
+
+        let resp = svc.handle_sync("GetAccountSummary", vec![]);
+        assert!(resp.contains("<key>Users</key><value>2</value>"));
+        assert!(resp.contains("<key>Groups</key><value>1</value>"));
+        assert!(resp.contains("<key>UsersQuota</key><value>5000</value>"));
+    }
+
+    #[test]
+    fn account_alias_lifecycle() {
+        let svc = make_service();
+
+        // Create alias
+        svc.handle_sync("CreateAccountAlias", vec![("AccountAlias", "my-org")]);
+
+        // List aliases
+        let list = svc.handle_sync("ListAccountAliases", vec![]);
+        assert!(list.contains("my-org"));
+
+        // Delete alias
+        svc.handle_sync("DeleteAccountAlias", vec![("AccountAlias", "my-org")]);
+
+        let list = svc.handle_sync("ListAccountAliases", vec![]);
+        assert!(!list.contains("my-org"));
+    }
+
+    #[test]
+    fn create_account_alias_idempotent() {
+        let svc = make_service();
+        svc.handle_sync("CreateAccountAlias", vec![("AccountAlias", "test-alias")]);
+        svc.handle_sync("CreateAccountAlias", vec![("AccountAlias", "test-alias")]);
+
+        let list = svc.handle_sync("ListAccountAliases", vec![]);
+        // Should only appear once
+        let count = list.matches("test-alias").count();
+        assert_eq!(count, 1, "alias should appear exactly once");
+    }
+
+    // ---- Helper methods for tests ----
+
+    fn extract_xml_value(xml: &str, tag: &str) -> String {
+        let open = format!("<{tag}>");
+        let close = format!("</{tag}>");
+        let start = xml.find(&open).unwrap() + open.len();
+        let end = xml.find(&close).unwrap();
+        xml[start..end].to_string()
+    }
+
+    impl IamService {
+        /// Synchronous helper for unit tests: dispatches to the correct method
+        fn handle_sync(&self, action: &str, params: Vec<(&str, &str)>) -> String {
+            let req = make_request(action, params);
+            let resp = match action {
+                "CreateUser" => self.create_user(&req),
+                "CreateGroup" => self.create_group(&req),
+                "CreatePolicy" => self.create_policy(&req),
+                "ListPolicies" => self.list_policies(&req),
+                "PutGroupPolicy" => self.put_group_policy(&req),
+                "GetGroupPolicy" => self.get_group_policy(&req),
+                "DeleteGroupPolicy" => self.delete_group_policy(&req),
+                "ListGroupPolicies" => self.list_group_policies(&req),
+                "AttachGroupPolicy" => self.attach_group_policy(&req),
+                "DetachGroupPolicy" => self.detach_group_policy(&req),
+                "ListAttachedGroupPolicies" => self.list_attached_group_policies(&req),
+                "PutUserPolicy" => self.put_user_policy(&req),
+                "GetUserPolicy" => self.get_user_policy(&req),
+                "DeleteUserPolicy" => self.delete_user_policy(&req),
+                "ListUserPolicies" => self.list_user_policies(&req),
+                "AttachUserPolicy" => self.attach_user_policy(&req),
+                "DetachUserPolicy" => self.detach_user_policy(&req),
+                "ListAttachedUserPolicies" => self.list_attached_user_policies(&req),
+                "CreateLoginProfile" => self.create_login_profile(&req),
+                "GetLoginProfile" => self.get_login_profile(&req),
+                "UpdateLoginProfile" => self.update_login_profile(&req),
+                "DeleteLoginProfile" => self.delete_login_profile(&req),
+                "CreateVirtualMFADevice" => self.create_virtual_mfa_device(&req),
+                "DeleteVirtualMFADevice" => self.delete_virtual_mfa_device(&req),
+                "ListVirtualMFADevices" => self.list_virtual_mfa_devices(&req),
+                "EnableMFADevice" => self.enable_mfa_device(&req),
+                "DeactivateMFADevice" => self.deactivate_mfa_device(&req),
+                "ListMFADevices" => self.list_mfa_devices(&req),
+                "GetAccountSummary" => self.get_account_summary(&req),
+                "CreateAccountAlias" => self.create_account_alias(&req),
+                "DeleteAccountAlias" => self.delete_account_alias(&req),
+                "ListAccountAliases" => self.list_account_aliases(&req),
+                other => panic!("handle_sync: unhandled action {other}"),
+            }
+            .unwrap();
+            String::from_utf8(resp.body.to_vec()).unwrap()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add 22 unit tests covering group inline/managed policies, user inline/managed policies, login profiles, MFA device lifecycle, and account aliases/summary
- Add 10 E2E tests exercising the same operations end-to-end via SDK and CLI
- Total new test coverage: 32 tests across 5 previously untested feature areas

## Test plan
- [x] `cargo test -p fakecloud-iam` passes (49 tests, all green)
- [x] `cargo test -p fakecloud-e2e --test iam` passes (38 tests, all green)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 23 unit tests in `fakecloud-iam` and 10 end-to-end tests in `fakecloud-e2e` for IAM group/user policies, login profiles, virtual MFA, and account alias/summary. This expands coverage across five previously untested areas and validates both SDK and CLI flows.

- **Test Coverage**
  - Group policies: inline CRUD and managed attach/list/detach.
  - User policies: inline CRUD and managed attach/list/detach, with error cases.
  - Login profiles: create/get/update/delete, duplicate and missing profile errors.
  - MFA: virtual device create/list/delete; enable/deactivate/list for users; assignment filters.
  - Account: get account summary; account alias create/list/delete; alias idempotency.

<sup>Written for commit 71637e91ad79028450d2deeefcf063edf8d934ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

