### PR TITLE
fix(ci): pin Docker base image and add release tag verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,8 +114,8 @@ jobs:
         run: |
           COMMIT_SHA="${GITHUB_SHA}"
           STATUS=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/status" --jq '.state')
-          if [ "$STATUS" = "failure" ]; then
-            echo "::error::CI checks failed on commit ${COMMIT_SHA}"
+          if [ "$STATUS" != "success" ]; then
+            echo "::error::CI checks not successful on commit ${COMMIT_SHA} (status: ${STATUS})"
             exit 1
           fi
           echo "CI status on ${COMMIT_SHA}: ${STATUS}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,28 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      - name: Verify tag matches Cargo.toml version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "::error::Tag v${TAG} does not match Cargo.toml version ${VERSION}"
+            exit 1
+          fi
+          echo "Tag v${TAG} matches Cargo.toml version ${VERSION}"
+
+      - name: Verify CI checks passed on tagged commit
+        run: |
+          COMMIT_SHA="${GITHUB_SHA}"
+          STATUS=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/status" --jq '.state')
+          if [ "$STATUS" = "failure" ]; then
+            echo "::error::CI checks failed on commit ${COMMIT_SHA}"
+            exit 1
+          fi
+          echo "CI status on ${COMMIT_SHA}: ${STATUS}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Publish all crates
         run: |
           publish() {

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --bin fakecloud
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /build/target/release/fakecloud /usr/local/bin/
 EXPOSE 4566


### PR DESCRIPTION
## Summary

- Pin `debian:bookworm-slim` Docker base image to a specific SHA256 digest for reproducible builds
- Add release tag verification before crate publishing: checks that the git tag matches the `version` in `Cargo.toml` and that CI status checks passed on the tagged commit

## Test plan

- [ ] Verify Dockerfile builds correctly with the pinned digest
- [ ] Test release workflow with a matching tag (e.g., `v0.3.0` with `version = "0.3.0"`)
- [ ] Test release workflow rejects a mismatched tag

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `debian:bookworm-slim` to a digest for reproducible Docker builds and adds stricter release gates: tag/version must match and CI must be green before publishing.

- **New Features**
  - Pre-publish step in `release.yml` fails if the git tag (vX.Y.Z) does not match the `Cargo.toml` version.
  - Require explicit "success" CI status on the tagged commit via the GitHub Status API; pending/neutral/error states block publishing.

- **Dependencies**
  - Pin `debian:bookworm-slim` base image to a specific SHA256 digest to avoid upstream changes.

<sup>Written for commit 5e307c1233901b88dd0ede71afbb7680ec455f42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

