### PR TITLE
test(ses): add conformance infrastructure and RestJson protocol fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,6 +1442,7 @@ dependencies = [
  "aws-sdk-lambda",
  "aws-sdk-s3",
  "aws-sdk-secretsmanager",
+ "aws-sdk-sesv2",
  "aws-sdk-sns",
  "aws-sdk-sqs",
  "aws-sdk-ssm",

--- a/aws-models/service-map.json
+++ b/aws-models/service-map.json
@@ -50,5 +50,9 @@
   "cloudformation": {
     "repo_dir": "cloudformation",
     "service_name": "cloudformation"
+  },
+  "sesv2": {
+    "repo_dir": "sesv2",
+    "service_name": "ses"
   }
 }

--- a/aws-models/sesv2.json
+++ b/aws-models/sesv2.json
@@ -1,0 +1,15758 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.sesv2#AccountDetails": {
+      "type": "structure",
+      "members": {
+        "MailType": {
+          "target": "com.amazonaws.sesv2#MailType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of email your account is sending. The mail type can be one of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>MARKETING</code> \u2013 Most of your sending traffic is to keep your\n                    customers informed of your latest offering.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TRANSACTIONAL</code> \u2013 Most of your sending traffic is to\n                    communicate during a transaction with a customer.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "WebsiteURL": {
+          "target": "com.amazonaws.sesv2#WebsiteURL",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL of your website. This information helps us better understand the type of\n            content that you plan to send.</p>"
+          }
+        },
+        "ContactLanguage": {
+          "target": "com.amazonaws.sesv2#ContactLanguage",
+          "traits": {
+            "smithy.api#documentation": "<p>The language you would prefer for the case. The contact language can be one of\n                <code>ENGLISH</code> or <code>JAPANESE</code>.</p>"
+          }
+        },
+        "UseCaseDescription": {
+          "target": "com.amazonaws.sesv2#UseCaseDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the types of email that you plan to send.</p>"
+          }
+        },
+        "AdditionalContactEmailAddresses": {
+          "target": "com.amazonaws.sesv2#AdditionalContactEmailAddresses",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional email addresses where updates are sent about your account review\n            process.</p>"
+          }
+        },
+        "ReviewDetails": {
+          "target": "com.amazonaws.sesv2#ReviewDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about the review of the latest details you submitted.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about your account details.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#AccountSuspendedException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The message can't be sent because the account's ability to send email has been\n            permanently restricted.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.sesv2#AdditionalContactEmailAddress": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 6,
+          "max": 254
+        },
+        "smithy.api#pattern": "^(.+)@(.+)$",
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.sesv2#AdditionalContactEmailAddresses": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#AdditionalContactEmailAddress"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 4
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.sesv2#AdminEmail": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#AlreadyExistsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The resource specified in your request already exists.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.sesv2#AmazonResourceName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ArchiveArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 20,
+          "max": 1011
+        },
+        "smithy.api#pattern": "^arn:(aws|aws-[a-z-]+):ses:[a-z]{2,4}-[a-z-]+-[0-9]:[0-9]{1,20}:mailmanager-archive/a-[a-z0-9]{24,62}$"
+      }
+    },
+    "com.amazonaws.sesv2#ArchivingOptions": {
+      "type": "structure",
+      "members": {
+        "ArchiveArn": {
+          "target": "com.amazonaws.sesv2#ArchiveArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the MailManager archive where the Amazon SES API v2 will archive sent\n        emails.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Used to associate a configuration set with a MailManager archive.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Attachment": {
+      "type": "structure",
+      "members": {
+        "RawContent": {
+          "target": "com.amazonaws.sesv2#RawAttachmentData",
+          "traits": {
+            "smithy.api#documentation": "<p> The raw data of the attachment. It needs to be base64-encoded if you are accessing Amazon SES\n            directly through the HTTPS interface. If you are accessing Amazon SES using an Amazon Web Services\n            SDK, the SDK takes care of the base 64-encoding for you.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ContentDisposition": {
+          "target": "com.amazonaws.sesv2#AttachmentContentDisposition",
+          "traits": {
+            "smithy.api#documentation": "<p> A standard descriptor indicating how the attachment should be rendered in the email.\n            Supported values: <code>ATTACHMENT</code> or <code>INLINE</code>.</p>"
+          }
+        },
+        "FileName": {
+          "target": "com.amazonaws.sesv2#AttachmentFileName",
+          "traits": {
+            "smithy.api#documentation": "<p>The file name for the attachment as it will appear in the email.\n            Amazon SES restricts certain file extensions. To ensure attachments are accepted,\n            check the <a href=\"https://docs.aws.amazon.com/ses/latest/dg/mime-types.html\">Unsupported attachment types</a>\n            in the Amazon SES Developer Guide.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ContentDescription": {
+          "target": "com.amazonaws.sesv2#AttachmentContentDescription",
+          "traits": {
+            "smithy.api#documentation": "<p> A brief description of the attachment content.</p>"
+          }
+        },
+        "ContentId": {
+          "target": "com.amazonaws.sesv2#AttachmentContentId",
+          "traits": {
+            "smithy.api#documentation": "<p> Unique identifier for the attachment, used for referencing attachments with INLINE disposition in HTML content.</p>"
+          }
+        },
+        "ContentTransferEncoding": {
+          "target": "com.amazonaws.sesv2#AttachmentContentTransferEncoding",
+          "traits": {
+            "smithy.api#documentation": "<p> Specifies how the attachment is encoded.\n            Supported values: <code>BASE64</code>, <code>QUOTED_PRINTABLE</code>, <code>SEVEN_BIT</code>.</p>"
+          }
+        },
+        "ContentType": {
+          "target": "com.amazonaws.sesv2#AttachmentContentType",
+          "traits": {
+            "smithy.api#documentation": "<p> The MIME type of the attachment.</p>\n         <note>\n            <p>Example: <code>application/pdf</code>, <code>image/jpeg</code>\n            </p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Contains metadata and attachment raw content.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#AttachmentContentDescription": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.sesv2#AttachmentContentDisposition": {
+      "type": "enum",
+      "members": {
+        "ATTACHMENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ATTACHMENT"
+          }
+        },
+        "INLINE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INLINE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#AttachmentContentId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 78
+        }
+      }
+    },
+    "com.amazonaws.sesv2#AttachmentContentTransferEncoding": {
+      "type": "enum",
+      "members": {
+        "BASE64": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BASE64"
+          }
+        },
+        "QUOTED_PRINTABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "QUOTED_PRINTABLE"
+          }
+        },
+        "SEVEN_BIT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SEVEN_BIT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#AttachmentContentType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 78
+        }
+      }
+    },
+    "com.amazonaws.sesv2#AttachmentFileName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 255
+        }
+      }
+    },
+    "com.amazonaws.sesv2#AttachmentList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Attachment"
+      }
+    },
+    "com.amazonaws.sesv2#AttributesData": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#BadRequestException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input you provided is invalid.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.sesv2#BatchGetMetricData": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#BatchGetMetricDataRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#BatchGetMetricDataResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#InternalServiceErrorException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieves batches of metric data collected based on your sending activity.</p>\n         <p>You can execute this operation no more than 16 times per second,\n            and with at most 160 queries from the batches per second (cumulative).</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/metrics/batch",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#BatchGetMetricDataQueries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#BatchGetMetricDataQuery"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.sesv2#BatchGetMetricDataQuery": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.sesv2#QueryIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The query identifier.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Namespace": {
+          "target": "com.amazonaws.sesv2#MetricNamespace",
+          "traits": {
+            "smithy.api#documentation": "<p>The query namespace - e.g. <code>VDM</code>\n         </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Metric": {
+          "target": "com.amazonaws.sesv2#Metric",
+          "traits": {
+            "smithy.api#documentation": "<p>The queried metric. This can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SEND</code> \u2013 Emails sent eligible for tracking\n                    in the VDM dashboard. This excludes emails sent to the mailbox simulator and emails\n                    addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>COMPLAINT</code> \u2013 Complaints received for your\n                    account. This excludes complaints from the mailbox simulator, those originating from\n                    your account-level suppression list (if enabled), and those for emails addressed to more\n                    than one recipient</p>\n            </li>\n            <li>\n               <p>\n                  <code>PERMANENT_BOUNCE</code> \u2013 Permanent bounces - i.e. feedback received for\n                    emails sent to non-existent mailboxes. Excludes bounces from the mailbox simulator, those\n                    originating from your account-level suppression list (if enabled), and those for emails\n                    addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TRANSIENT_BOUNCE</code> \u2013 Transient bounces - i.e. feedback received for\n                    delivery failures excluding issues with non-existent mailboxes. Excludes bounces from the\n                    mailbox simulator, and those for emails addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OPEN</code> \u2013 Unique open events for emails including open trackers.\n                    Excludes opens for emails addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CLICK</code> \u2013 Unique click events for emails including wrapped links.\n                    Excludes clicks for emails addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY</code> \u2013 Successful deliveries for email sending attempts.\n                    Excludes deliveries to the mailbox simulator and for emails addressed to more\n                    than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY_OPEN</code> \u2013 Successful deliveries for email sending attempts.\n                    Excludes deliveries to the mailbox simulator, for emails addressed to more than one recipient,\n                    and emails without open trackers.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY_CLICK</code> \u2013 Successful deliveries for email sending attempts.\n                    Excludes deliveries to the mailbox simulator, for emails addressed to more than one recipient,\n                    and emails without click trackers.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY_COMPLAINT</code> \u2013 Successful deliveries for email sending attempts.\n                    Excludes deliveries to the mailbox simulator, for emails addressed to more than one recipient,\n                    and emails addressed to recipients hosted by ISPs with which Amazon SES does not have a\n                    feedback loop agreement.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "Dimensions": {
+          "target": "com.amazonaws.sesv2#Dimensions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains mapping between <code>MetricDimensionName</code>\n            and <code>MetricDimensionValue</code> to filter metrics by.</p>"
+          }
+        },
+        "StartDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the start date for the query interval.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EndDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the end date for the query interval.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a single metric data query to include in a batch.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#BatchGetMetricDataRequest": {
+      "type": "structure",
+      "members": {
+        "Queries": {
+          "target": "com.amazonaws.sesv2#BatchGetMetricDataQueries",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of queries for metrics to be retrieved.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to retrieve a batch of metric data.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#BatchGetMetricDataResponse": {
+      "type": "structure",
+      "members": {
+        "Results": {
+          "target": "com.amazonaws.sesv2#MetricDataResultList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of successfully retrieved <code>MetricDataResult</code>.</p>"
+          }
+        },
+        "Errors": {
+          "target": "com.amazonaws.sesv2#MetricDataErrorList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>MetricDataError</code> encountered while processing your metric data batch request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents the result of processing your metric data batch request</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#BehaviorOnMxFailure": {
+      "type": "enum",
+      "members": {
+        "USE_DEFAULT_VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "USE_DEFAULT_VALUE"
+          }
+        },
+        "REJECT_MESSAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REJECT_MESSAGE"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The action to take if the required MX record can't be found when you send an email.\n            When you set this value to <code>UseDefaultValue</code>, the mail is sent using\n                <i>amazonses.com</i> as the MAIL FROM domain. When you set this value\n            to <code>RejectMessage</code>, the Amazon SES API v2 returns a\n                <code>MailFromDomainNotVerified</code> error, and doesn't attempt to deliver the\n            email.</p>\n         <p>These behaviors are taken when the custom MAIL FROM domain configuration is in the\n                <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code>\n            states.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#BlacklistEntries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#BlacklistEntry"
+      }
+    },
+    "com.amazonaws.sesv2#BlacklistEntry": {
+      "type": "structure",
+      "members": {
+        "RblName": {
+          "target": "com.amazonaws.sesv2#RblName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the blacklist that the IP address appears on.</p>"
+          }
+        },
+        "ListingTime": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the blacklisting event occurred.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.sesv2#BlacklistingDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the blacklisting event, as provided by the blacklist\n            maintainer.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about a blacklisting event that impacts one of the\n            dedicated IP addresses that is associated with your account.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#BlacklistItemName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>An IP address that you want to obtain blacklist information for.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#BlacklistItemNames": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#BlacklistItemName"
+      }
+    },
+    "com.amazonaws.sesv2#BlacklistReport": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.sesv2#BlacklistItemName"
+      },
+      "value": {
+        "target": "com.amazonaws.sesv2#BlacklistEntries"
+      }
+    },
+    "com.amazonaws.sesv2#BlacklistingDescription": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A description of the blacklisting event.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Body": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.sesv2#Content",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that represents the version of the message that is displayed in email\n            clients that don't support HTML, or clients where the recipient has disabled HTML\n            rendering.</p>"
+          }
+        },
+        "Html": {
+          "target": "com.amazonaws.sesv2#Content",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that represents the version of the message that is displayed in email\n            clients that support HTML. HTML messages can include formatted text, hyperlinks, images,\n            and more. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents the body of the email message.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Bounce": {
+      "type": "structure",
+      "members": {
+        "BounceType": {
+          "target": "com.amazonaws.sesv2#BounceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the bounce, as determined by SES.\n            Can be one of <code>UNDETERMINED</code>, <code>TRANSIENT</code>, or <code>PERMANENT</code>\n         </p>"
+          }
+        },
+        "BounceSubType": {
+          "target": "com.amazonaws.sesv2#BounceSubType",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtype of the bounce, as determined by SES.</p>"
+          }
+        },
+        "DiagnosticCode": {
+          "target": "com.amazonaws.sesv2#DiagnosticCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The status code issued by the reporting Message Transfer Authority (MTA).\n            This field only appears if a delivery status notification (DSN) was attached to the bounce\n            and the <code>Diagnostic-Code</code> was provided in the DSN.\n        </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about a <code>Bounce</code> event.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#BounceSubType": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#BounceType": {
+      "type": "enum",
+      "members": {
+        "UNDETERMINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNDETERMINED"
+          }
+        },
+        "TRANSIENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRANSIENT"
+          }
+        },
+        "PERMANENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERMANENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#BulkEmailContent": {
+      "type": "structure",
+      "members": {
+        "Template": {
+          "target": "com.amazonaws.sesv2#Template",
+          "traits": {
+            "smithy.api#documentation": "<p>The template to use for the bulk email message.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains the body of the message. You can specify a template\n            message.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#BulkEmailEntry": {
+      "type": "structure",
+      "members": {
+        "Destination": {
+          "target": "com.amazonaws.sesv2#Destination",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the destination of the message, consisting of To:, CC:, and BCC:\n            fields.</p>\n         <note>\n            <p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href=\"https://tools.ietf.org/html/rfc6531\">RFC6531</a>. For this reason, the\n                local part of a destination email address (the part of the email address that\n                precedes the @ sign) may only contain <a href=\"https://en.wikipedia.org/wiki/Email_address#Local-part\">7-bit ASCII\n                    characters</a>. If the domain part of an address (the part after the @ sign)\n                contains non-ASCII characters, they must be encoded using Punycode, as described in\n                    <a href=\"https://tools.ietf.org/html/rfc3492.html\">RFC3492</a>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "ReplacementTags": {
+          "target": "com.amazonaws.sesv2#MessageTagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags, in the form of name/value pairs, to apply to an email that you send\n            using the <code>SendBulkTemplatedEmail</code> operation. Tags correspond to\n            characteristics of the email that you define, so that you can publish email sending\n            events.</p>"
+          }
+        },
+        "ReplacementEmailContent": {
+          "target": "com.amazonaws.sesv2#ReplacementEmailContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>ReplacementEmailContent</code> associated with a\n            <code>BulkEmailEntry</code>.</p>"
+          }
+        },
+        "ReplacementHeaders": {
+          "target": "com.amazonaws.sesv2#MessageHeaderList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of message headers associated with the <code>BulkEmailEntry</code> data type.</p>\n         <ul>\n            <li>\n               <p>Headers Not Present in <code>BulkEmailEntry</code>: If a header is specified in\n                    <a href=\"https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_Template.html\">\n                     <code>Template</code>\n                  </a> but not in <code>BulkEmailEntry</code>, the header\n                    from <code>Template</code> will be added to the outgoing email.</p>\n            </li>\n            <li>\n               <p>Headers Present in <code>BulkEmailEntry</code>: If a header is specified in\n                    <code>BulkEmailEntry</code>, it takes precedence over any header of the same name specified\n                    in <a href=\"https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_Template.html\">\n                     <code>Template</code>\n                  </a>:</p>\n               <ul>\n                  <li>\n                     <p>If the header is also defined within <code>Template</code>,\n                            the value from <code>BulkEmailEntry</code> will replace the header's\n                            value in the email.</p>\n                  </li>\n                  <li>\n                     <p>If the header is not defined within <code>Template</code>,\n                            it will simply be added to the email as specified in\n                            <code>BulkEmailEntry</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#BulkEmailEntryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#BulkEmailEntry"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of <code>BulkEmailEntry</code> objects.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#BulkEmailEntryResult": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.sesv2#BulkEmailStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of a message sent using the <code>SendBulkTemplatedEmail</code>\n            operation.</p>\n         <p>Possible values for this parameter include:</p>\n         <ul>\n            <li>\n               <p>SUCCESS: Amazon SES accepted the message, and will attempt to deliver it to\n                    the recipients.</p>\n            </li>\n            <li>\n               <p>MESSAGE_REJECTED: The message was rejected because it contained a\n                    virus.</p>\n            </li>\n            <li>\n               <p>MAIL_FROM_DOMAIN_NOT_VERIFIED: The sender's email address or domain was not\n                    verified.</p>\n            </li>\n            <li>\n               <p>CONFIGURATION_SET_DOES_NOT_EXIST: The configuration set you specified does not\n                    exist.</p>\n            </li>\n            <li>\n               <p>TEMPLATE_DOES_NOT_EXIST: The template you specified does not exist.</p>\n            </li>\n            <li>\n               <p>ACCOUNT_SUSPENDED: Your account has been shut down because of issues related\n                    to your email sending practices.</p>\n            </li>\n            <li>\n               <p>ACCOUNT_THROTTLED: The number of emails you can send has been reduced because\n                    your account has exceeded its allocated sending limit.</p>\n            </li>\n            <li>\n               <p>ACCOUNT_DAILY_QUOTA_EXCEEDED: You have reached or exceeded the maximum number\n                    of emails you can send from your account in a 24-hour period.</p>\n            </li>\n            <li>\n               <p>INVALID_SENDING_POOL_NAME: The configuration set you specified refers to an IP\n                    pool that does not exist.</p>\n            </li>\n            <li>\n               <p>ACCOUNT_SENDING_PAUSED: Email sending for the Amazon SES account was disabled\n                    using the <a href=\"https://docs.aws.amazon.com/ses/latest/APIReference/API_UpdateAccountSendingEnabled.html\">UpdateAccountSendingEnabled</a> operation.</p>\n            </li>\n            <li>\n               <p>CONFIGURATION_SET_SENDING_PAUSED: Email sending for this configuration set was\n                    disabled using the <a href=\"https://docs.aws.amazon.com/ses/latest/APIReference/API_UpdateConfigurationSetSendingEnabled.html\">UpdateConfigurationSetSendingEnabled</a> operation.</p>\n            </li>\n            <li>\n               <p>INVALID_PARAMETER_VALUE: One or more of the parameters you specified when\n                    calling this operation was invalid. See the error message for additional\n                    information.</p>\n            </li>\n            <li>\n               <p>TRANSIENT_FAILURE: Amazon SES was unable to process your request because of a\n                    temporary issue.</p>\n            </li>\n            <li>\n               <p>FAILED: Amazon SES was unable to process your request. See the error message\n                    for additional information.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Error": {
+          "target": "com.amazonaws.sesv2#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of an error that prevented a message being sent using the\n                <code>SendBulkTemplatedEmail</code> operation.</p>"
+          }
+        },
+        "MessageId": {
+          "target": "com.amazonaws.sesv2#OutboundMessageId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique message identifier returned from the <code>SendBulkTemplatedEmail</code>\n            operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The result of the <code>SendBulkEmail</code> operation of each specified\n                <code>BulkEmailEntry</code>.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#BulkEmailEntryResultList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#BulkEmailEntryResult"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of <code>BulkMailEntry</code> objects.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#BulkEmailStatus": {
+      "type": "enum",
+      "members": {
+        "SUCCESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCESS"
+          }
+        },
+        "MESSAGE_REJECTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MESSAGE_REJECTED"
+          }
+        },
+        "MAIL_FROM_DOMAIN_NOT_VERIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MAIL_FROM_DOMAIN_NOT_VERIFIED"
+          }
+        },
+        "CONFIGURATION_SET_NOT_FOUND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONFIGURATION_SET_NOT_FOUND"
+          }
+        },
+        "TEMPLATE_NOT_FOUND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEMPLATE_NOT_FOUND"
+          }
+        },
+        "ACCOUNT_SUSPENDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACCOUNT_SUSPENDED"
+          }
+        },
+        "ACCOUNT_THROTTLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACCOUNT_THROTTLED"
+          }
+        },
+        "ACCOUNT_DAILY_QUOTA_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACCOUNT_DAILY_QUOTA_EXCEEDED"
+          }
+        },
+        "INVALID_SENDING_POOL_NAME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INVALID_SENDING_POOL_NAME"
+          }
+        },
+        "ACCOUNT_SENDING_PAUSED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACCOUNT_SENDING_PAUSED"
+          }
+        },
+        "CONFIGURATION_SET_SENDING_PAUSED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONFIGURATION_SET_SENDING_PAUSED"
+          }
+        },
+        "INVALID_PARAMETER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INVALID_PARAMETER"
+          }
+        },
+        "TRANSIENT_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRANSIENT_FAILURE"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CampaignId": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#CancelExportJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CancelExportJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CancelExportJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Cancels an export job.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "Cancel export job",
+            "documentation": "Cancels the export job with ID ef28cf62-9d8e-4b60-9283-b09816c99a99",
+            "input": {
+              "JobId": "ef28cf62-9d8e-4b60-9283-b09816c99a99"
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/export-jobs/{JobId}/cancel",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CancelExportJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.sesv2#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The export job ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to cancel an export job using the export job ID.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CancelExportJobResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CaseId": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#Charset": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#CloudWatchDestination": {
+      "type": "structure",
+      "members": {
+        "DimensionConfigurations": {
+          "target": "com.amazonaws.sesv2#CloudWatchDimensionConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the dimensions to use when you send email events to\n            Amazon CloudWatch.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines an Amazon CloudWatch destination for email events. You can use Amazon CloudWatch to\n            monitor and gain insights on your email sending metrics.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#CloudWatchDimensionConfiguration": {
+      "type": "structure",
+      "members": {
+        "DimensionName": {
+          "target": "com.amazonaws.sesv2#DimensionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of an Amazon CloudWatch dimension associated with an email sending metric. The name has to\n            meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>It can only contain ASCII letters (a\u2013z, A\u2013Z), numbers (0\u20139),\n                    underscores (_), or dashes (-).</p>\n            </li>\n            <li>\n               <p>It can contain no more than 256 characters.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "DimensionValueSource": {
+          "target": "com.amazonaws.sesv2#DimensionValueSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The location where the Amazon SES API v2 finds the value of a dimension to publish to Amazon CloudWatch. To\n            use the message tags that you specify using an <code>X-SES-MESSAGE-TAGS</code> header or\n            a parameter to the <code>SendEmail</code> or <code>SendRawEmail</code> API, choose\n                <code>messageTag</code>. To use your own email headers, choose\n                <code>emailHeader</code>. To use link tags, choose <code>linkTags</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DefaultDimensionValue": {
+          "target": "com.amazonaws.sesv2#DefaultDimensionValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The default value of the dimension that is published to Amazon CloudWatch if you don't provide the\n            value of the dimension when you send an email. This value has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>Can only contain ASCII letters (a\u2013z, A\u2013Z), numbers (0\u20139),\n                    underscores (_), or dashes (-), at signs (@), and periods (.).</p>\n            </li>\n            <li>\n               <p>It can contain no more than 256 characters.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines the dimension configuration to use when you send email events\n            to Amazon CloudWatch.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#CloudWatchDimensionConfigurations": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#CloudWatchDimensionConfiguration"
+      }
+    },
+    "com.amazonaws.sesv2#Complaint": {
+      "type": "structure",
+      "members": {
+        "ComplaintSubType": {
+          "target": "com.amazonaws.sesv2#ComplaintSubType",
+          "traits": {
+            "smithy.api#documentation": "<p>\n            Can either be <code>null</code> or <code>OnAccountSuppressionList</code>.\n            If the value is <code>OnAccountSuppressionList</code>, SES accepted the message,\n            but didn't attempt to send it because it was on the account-level suppression list.\n        </p>"
+          }
+        },
+        "ComplaintFeedbackType": {
+          "target": "com.amazonaws.sesv2#ComplaintFeedbackType",
+          "traits": {
+            "smithy.api#documentation": "<p>\n            The value of the <code>Feedback-Type</code> field from the feedback report received from the ISP.\n        </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about a <code>Complaint</code> event.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ComplaintFeedbackType": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#ComplaintSubType": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#ConcurrentModificationException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The resource is being modified by another operation or thread.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.sesv2#ConfigurationSetName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of a configuration set.</p>\n         <p>\n            <i>Configuration sets</i> are groups of rules that you can apply to the\n            emails you send. You apply a configuration set to an email by including a reference to\n            the configuration set in the headers of the email. When you apply a configuration set to\n            an email, all of the rules in that configuration set are applied to the email.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ConfigurationSetNameList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#ConfigurationSetName"
+      }
+    },
+    "com.amazonaws.sesv2#ConflictException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>If there is already an ongoing account details update under review.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
+      }
+    },
+    "com.amazonaws.sesv2#Contact": {
+      "type": "structure",
+      "members": {
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's email address.</p>"
+          }
+        },
+        "TopicPreferences": {
+          "target": "com.amazonaws.sesv2#TopicPreferenceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's preference for being opted-in to or opted-out of a topic.</p>"
+          }
+        },
+        "TopicDefaultPreferences": {
+          "target": "com.amazonaws.sesv2#TopicPreferenceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The default topic preferences applied to the contact.</p>"
+          }
+        },
+        "UnsubscribeAll": {
+          "target": "com.amazonaws.sesv2#UnsubscribeAll",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>A boolean value status noting if the contact is unsubscribed from all contact list\n            topics.</p>"
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>A timestamp noting the last time the contact's information was updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A contact is the end-user who is receiving the email.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ContactLanguage": {
+      "type": "enum",
+      "members": {
+        "EN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EN"
+          }
+        },
+        "JA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "JA"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ContactList": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list.</p>"
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>A timestamp noting the last time the contact list was updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list that contains contacts that have subscribed to a particular topic or\n            topics.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ContactListDestination": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ContactListImportAction": {
+          "target": "com.amazonaws.sesv2#ContactListImportAction",
+          "traits": {
+            "smithy.api#documentation": "<p>>The type of action to perform on the addresses. The following are the possible\n            values:</p>\n         <ul>\n            <li>\n               <p>PUT: add the addresses to the contact list. If the record already exists, it\n                    will override it with the new value.</p>\n            </li>\n            <li>\n               <p>DELETE: remove the addresses from the contact list.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains details about the action of a contact list.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ContactListImportAction": {
+      "type": "enum",
+      "members": {
+        "DELETE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE"
+          }
+        },
+        "PUT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PUT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ContactListName": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#Content": {
+      "type": "structure",
+      "members": {
+        "Data": {
+          "target": "com.amazonaws.sesv2#MessageData",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the message itself.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Charset": {
+          "target": "com.amazonaws.sesv2#Charset",
+          "traits": {
+            "smithy.api#documentation": "<p>The character set for the content. Because of the constraints of the SMTP protocol,\n            Amazon SES uses 7-bit ASCII by default. If the text includes characters outside of the ASCII\n            range, you have to specify a character set. For example, you could specify\n                <code>UTF-8</code>, <code>ISO-8859-1</code>, or <code>Shift_JIS</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the content of the email, and optionally a character set\n            specification.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Counter": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.sesv2#CreateConfigurationSet": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateConfigurationSetRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateConfigurationSetResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Create a configuration set. <i>Configuration sets</i> are groups of\n            rules that you can apply to the emails that you send. You apply a configuration set to\n            an email by specifying the name of the configuration set when you call the Amazon SES API v2. When\n            you apply a configuration set to an email, all of the rules in that configuration set\n            are applied to the email. </p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/configuration-sets",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateConfigurationSetEventDestination": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateConfigurationSetEventDestinationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateConfigurationSetEventDestinationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Create an event destination. <i>Events</i> include message sends,\n            deliveries, opens, clicks, bounces, and complaints. <i>Event\n                destinations</i> are places that you can send information about these events\n            to. For example, you can send event data to Amazon EventBridge and associate a rule to send the event\n            to the specified target.</p>\n         <p>A single configuration set can include more than one event destination.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateConfigurationSetEventDestinationRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set .</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "EventDestinationName": {
+          "target": "com.amazonaws.sesv2#EventDestinationName",
+          "traits": {
+            "smithy.api#documentation": "<p>A name that identifies the event destination within the configuration set.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EventDestination": {
+          "target": "com.amazonaws.sesv2#EventDestinationDefinition",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the event destination.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to add an event destination to a configuration set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateConfigurationSetEventDestinationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateConfigurationSetRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set. The name can contain up to 64 alphanumeric\n            characters, including letters, numbers, hyphens (-) and underscores (_) only.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TrackingOptions": {
+          "target": "com.amazonaws.sesv2#TrackingOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the open and click tracking options for emails that you send\n            using the configuration set.</p>"
+          }
+        },
+        "DeliveryOptions": {
+          "target": "com.amazonaws.sesv2#DeliveryOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the dedicated IP pool that is used to send emails that you send\n            using the configuration set.</p>"
+          }
+        },
+        "ReputationOptions": {
+          "target": "com.amazonaws.sesv2#ReputationOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines whether or not Amazon SES collects reputation metrics for the emails\n            that you send that use the configuration set.</p>"
+          }
+        },
+        "SendingOptions": {
+          "target": "com.amazonaws.sesv2#SendingOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines whether or not Amazon SES can send email that you send using the\n            configuration set.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) to associate with the\n            configuration set.</p>"
+          }
+        },
+        "SuppressionOptions": {
+          "target": "com.amazonaws.sesv2#SuppressionOptions"
+        },
+        "VdmOptions": {
+          "target": "com.amazonaws.sesv2#VdmOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the VDM options for emails that you send using the\n            configuration set.</p>"
+          }
+        },
+        "ArchivingOptions": {
+          "target": "com.amazonaws.sesv2#ArchivingOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the MailManager archiving options for emails that you send\n            using the configuration set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to create a configuration set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateConfigurationSetResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateContact": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateContactRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateContactResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a contact, which is an end-user who is receiving the email, and adds them to a\n            contact list.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/contact-lists/{ContactListName}/contacts",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateContactList": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateContactListRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateContactListResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a contact list.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/contact-lists",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateContactListRequest": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Topics": {
+          "target": "com.amazonaws.sesv2#Topics",
+          "traits": {
+            "smithy.api#documentation": "<p>An interest group, theme, or label within a list. A contact list can have multiple\n            topics.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.sesv2#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of what the contact list is about.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags associated with a contact list.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateContactListResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateContactRequest": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list to which the contact should be added.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's email address.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TopicPreferences": {
+          "target": "com.amazonaws.sesv2#TopicPreferenceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's preferences for being opted-in to or opted-out of topics.</p>"
+          }
+        },
+        "UnsubscribeAll": {
+          "target": "com.amazonaws.sesv2#UnsubscribeAll",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>A boolean value status noting if the contact is unsubscribed from all contact list\n            topics.</p>"
+          }
+        },
+        "AttributesData": {
+          "target": "com.amazonaws.sesv2#AttributesData",
+          "traits": {
+            "smithy.api#documentation": "<p>The attribute data attached to a contact.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateContactResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateCustomVerificationEmailTemplate": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateCustomVerificationEmailTemplateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateCustomVerificationEmailTemplateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new custom verification email template.</p>\n         <p>For more information about custom verification email templates, see <a href=\"https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#send-email-verify-address-custom\">Using\n                custom verification email templates</a> in the <i>Amazon SES Developer\n                Guide</i>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/custom-verification-email-templates",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateCustomVerificationEmailTemplateRequest": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom verification email template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FromEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address that the custom verification email is sent from.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateSubject": {
+          "target": "com.amazonaws.sesv2#EmailTemplateSubject",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line of the custom verification email.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateContent": {
+          "target": "com.amazonaws.sesv2#TemplateContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the custom verification email. The total size of the email must be less\n            than 10 MB. The message body may contain HTML, with some limitations. For more\n            information, see <a href=\"https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#send-email-verify-address-custom-faq\">Custom verification email frequently asked questions</a> in the <i>Amazon SES\n                Developer Guide</i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) to associate with the\n            custom verification email template.</p>"
+          }
+        },
+        "SuccessRedirectionURL": {
+          "target": "com.amazonaws.sesv2#SuccessRedirectionURL",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL that the recipient of the verification email is sent to if his or her address\n            is successfully verified.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FailureRedirectionURL": {
+          "target": "com.amazonaws.sesv2#FailureRedirectionURL",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL that the recipient of the verification email is sent to if his or her address\n            is not successfully verified.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to create a custom verification email template.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateCustomVerificationEmailTemplateResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty\n            HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateDedicatedIpPool": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateDedicatedIpPoolRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateDedicatedIpPoolResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Create a new pool of dedicated IP addresses. A pool can include one or more dedicated\n            IP addresses that are associated with your Amazon Web Services account. You can associate a pool with\n            a configuration set. When you send an email that uses that configuration set, the\n            message is sent from one of the addresses in the associated pool.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/dedicated-ip-pools",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateDedicatedIpPoolRequest": {
+      "type": "structure",
+      "members": {
+        "PoolName": {
+          "target": "com.amazonaws.sesv2#PoolName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the dedicated IP pool.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the tags (keys and values) that you want to associate with the\n            pool.</p>"
+          }
+        },
+        "ScalingMode": {
+          "target": "com.amazonaws.sesv2#ScalingMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of scaling mode.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to create a new dedicated IP pool.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateDedicatedIpPoolResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateDeliverabilityTestReport": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateDeliverabilityTestReportRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateDeliverabilityTestReportResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AccountSuspendedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#MailFromDomainNotVerifiedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#MessageRejected"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#SendingPausedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Create a new predictive inbox placement test. Predictive inbox placement tests can help you predict how your messages will be handled\n            by various email providers around the world. When you perform a predictive inbox placement test, you provide a\n            sample message that contains the content that you plan to send to your customers. Amazon SES\n            then sends that message to special email addresses spread across several major email\n            providers. After about 24 hours, the test is complete, and you can use the\n                <code>GetDeliverabilityTestReport</code> operation to view the results of the\n            test.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/deliverability-dashboard/test",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateDeliverabilityTestReportRequest": {
+      "type": "structure",
+      "members": {
+        "ReportName": {
+          "target": "com.amazonaws.sesv2#ReportName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name that helps you to identify the predictive inbox placement test when you retrieve the\n            results.</p>"
+          }
+        },
+        "FromEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address that the predictive inbox placement test email was sent from.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Content": {
+          "target": "com.amazonaws.sesv2#EmailContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The HTML body of the message that you sent when you performed the predictive inbox placement test.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) that you want to associate\n            with the predictive inbox placement test.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to perform a predictive inbox placement test. Predictive inbox placement tests can help you predict how your messages will\n            be handled by various email providers around the world. When you perform a predictive inbox placement test, you\n            provide a sample message that contains the content that you plan to send to your\n            customers. We send that message to special email addresses spread across several major\n            email providers around the world. The test takes about 24 hours to complete. When the\n            test is complete, you can use the <code>GetDeliverabilityTestReport</code> operation to\n            view the results of the test.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateDeliverabilityTestReportResponse": {
+      "type": "structure",
+      "members": {
+        "ReportId": {
+          "target": "com.amazonaws.sesv2#ReportId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique string that identifies the predictive inbox placement test.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DeliverabilityTestStatus": {
+          "target": "com.amazonaws.sesv2#DeliverabilityTestStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the predictive inbox placement test. If the status is <code>IN_PROGRESS</code>, then the predictive inbox placement test\n            is currently running. Predictive inbox placement tests are usually complete within 24 hours of creating the\n            test. If the status is <code>COMPLETE</code>, then the test is finished, and you can use\n            the <code>GetDeliverabilityTestReport</code> to view the results of the test.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the predictive inbox placement test that you created.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateEmailIdentity": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateEmailIdentityRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateEmailIdentityResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts the process of verifying an email identity. An <i>identity</i> is\n            an email address or domain that you use when you send email. Before you can use an\n            identity to send email, you first have to verify it. By verifying an identity, you\n            demonstrate that you're the owner of the identity, and that you've given Amazon SES API v2\n            permission to send email from the identity.</p>\n         <p>When you verify an email address, Amazon SES sends an email to the address. Your email\n            address is verified as soon as you follow the link in the verification email.\n            \n        </p>\n         <p>When you verify a domain without specifying the <code>DkimSigningAttributes</code>\n            object, this operation provides a set of DKIM tokens. You can convert these tokens into\n            CNAME records, which you then add to the DNS configuration for your domain. Your domain\n            is verified when Amazon SES detects these records in the DNS configuration for your domain.\n            This verification method is known as <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Easy DKIM</a>.</p>\n         <p>Alternatively, you can perform the verification process by providing your own\n            public-private key pair. This verification method is known as Bring Your Own DKIM\n            (BYODKIM). To use BYODKIM, your call to the <code>CreateEmailIdentity</code> operation\n            has to include the <code>DkimSigningAttributes</code> object. When you specify this\n            object, you provide a selector (a component of the DNS record name that identifies the\n            public key to use for DKIM authentication) and a private key.</p>\n         <p>When you verify a domain, this operation provides a set of DKIM tokens, which you can\n            convert into CNAME tokens. You add these CNAME tokens to the DNS configuration for your\n            domain. Your domain is verified when Amazon SES detects these records in the DNS\n            configuration for your domain. For some DNS providers, it can take 72 hours or more to\n            complete the domain verification process.</p>\n         <p>Additionally, you can associate an existing configuration set with the email identity that you're verifying.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/identities",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateEmailIdentityPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateEmailIdentityPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateEmailIdentityPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates the specified sending authorization policy for the given identity (an email\n        address or a domain).</p>\n         <note>\n            <p>This API is for the identity owner only. If you have not verified the identity,\n                this API will return an error.</p>\n         </note>\n         <p>Sending authorization is a feature that enables an identity owner to authorize other\n            senders to use its identities. For information about using sending authorization, see\n            the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer\n                Guide</a>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/identities/{EmailIdentity}/policies/{PolicyName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateEmailIdentityPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "PolicyName": {
+          "target": "com.amazonaws.sesv2#PolicyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the policy.</p>\n         <p>The policy name cannot exceed 64 characters and can only include alphanumeric\n            characters, dashes, and underscores.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Policy": {
+          "target": "com.amazonaws.sesv2#Policy",
+          "traits": {
+            "smithy.api#documentation": "<p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p>\n         <p>For information about the syntax of sending authorization policies, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html\">Amazon SES Developer\n                Guide</a>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to create a sending authorization policy for an identity. Sending\n            authorization is an Amazon SES feature that enables you to authorize other senders to use\n            your identities. For information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-identity-owner-tasks-management.html\">Amazon SES Developer Guide</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateEmailIdentityPolicyResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateEmailIdentityRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address or domain to verify.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) to associate with the email\n            identity.</p>"
+          }
+        },
+        "DkimSigningAttributes": {
+          "target": "com.amazonaws.sesv2#DkimSigningAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If your request includes this object, Amazon SES configures the identity to use Bring Your\n            Own DKIM (BYODKIM) for DKIM authentication purposes, or, configures the key length to be\n            used for <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Easy\n                DKIM</a>.</p>\n         <p>You can only specify this object if the email identity is a domain, as opposed to an\n            address.</p>"
+          }
+        },
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration set to use by default when sending from this identity. Note that any\n            configuration set defined in the email sending request takes precedence. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to begin the verification process for an email identity (an email address or\n            domain).</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateEmailIdentityResponse": {
+      "type": "structure",
+      "members": {
+        "IdentityType": {
+          "target": "com.amazonaws.sesv2#IdentityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity type. Note: the <code>MANAGED_DOMAIN</code> identity type is not\n            supported.</p>"
+          }
+        },
+        "VerifiedForSendingStatus": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether or not the identity is verified. You can only send email from\n            verified email addresses or domains. For more information about verifying identities,\n            see the <a href=\"https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-email-manage-verify.html\">Amazon Pinpoint User Guide</a>.</p>"
+          }
+        },
+        "DkimAttributes": {
+          "target": "com.amazonaws.sesv2#DkimAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the DKIM attributes for the identity.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>If the email identity is a domain, this object contains information about the DKIM\n            verification status for the domain.</p>\n         <p>If the email identity is an email address, this object is empty. </p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateEmailTemplate": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateEmailTemplateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateEmailTemplateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an email template. Email templates enable you to send personalized email to\n            one or more destinations in a single API operation. For more information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\">Amazon SES Developer\n                Guide</a>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/templates",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateEmailTemplateRequest": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateContent": {
+          "target": "com.amazonaws.sesv2#EmailTemplateContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the email template, composed of a subject line, an HTML part, and a\n            text-only part.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) to associate with the email template.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to create an email template. For more information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\">Amazon SES\n                Developer Guide</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateEmailTemplateResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty\n            HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateExportJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateExportJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateExportJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an export job for a data source and destination.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/export-jobs",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateExportJobRequest": {
+      "type": "structure",
+      "members": {
+        "ExportDataSource": {
+          "target": "com.amazonaws.sesv2#ExportDataSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The data source for the export job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ExportDestination": {
+          "target": "com.amazonaws.sesv2#ExportDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>The destination for the export job.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to create an export job from a data source to a data\n            destination.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateExportJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.sesv2#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that represents the export job ID.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateImportJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateImportJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateImportJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an import job for a data destination.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/import-jobs",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateImportJobRequest": {
+      "type": "structure",
+      "members": {
+        "ImportDestination": {
+          "target": "com.amazonaws.sesv2#ImportDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>The destination for the import job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ImportDataSource": {
+          "target": "com.amazonaws.sesv2#ImportDataSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The data source for the import job.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to create an import job from a data source for a data\n            destination.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateImportJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.sesv2#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that represents the import job ID.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateMultiRegionEndpoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateMultiRegionEndpointRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateMultiRegionEndpointResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a multi-region endpoint (global-endpoint).</p>\n         <p>The primary region is going to be the AWS-Region where the operation is executed.\n            The secondary region has to be provided in request's parameters.\n            From the data flow standpoint there is no difference between primary\n            and secondary regions - sending traffic will be split equally between the two.\n            The primary region is the region where the resource has been created and where it can be managed.\n        </p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/multi-region-endpoints",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateMultiRegionEndpointRequest": {
+      "type": "structure",
+      "members": {
+        "EndpointName": {
+          "target": "com.amazonaws.sesv2#EndpointName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the multi-region endpoint (global-endpoint).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Details": {
+          "target": "com.amazonaws.sesv2#Details",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains details of a multi-region endpoint (global-endpoint) being created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) to associate with the multi-region endpoint (global-endpoint).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to create a multi-region endpoint (global-endpoint).</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateMultiRegionEndpointResponse": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.sesv2#Status",
+          "traits": {
+            "smithy.api#documentation": "<p>A status of the multi-region endpoint (global-endpoint) right after the create request.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> \u2013 The resource is being provisioned.</p>\n            </li>\n            <li>\n               <p>\n                  <code>READY</code> \u2013 The resource is ready to use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 The resource failed to be provisioned.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> \u2013 The resource is being deleted as requested.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "EndpointId": {
+          "target": "com.amazonaws.sesv2#EndpointId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the multi-region endpoint (global-endpoint).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateTenant": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateTenantRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateTenantResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Create a tenant.</p>\n         <p>\n            <i>Tenants</i> are logical containers that group related SES resources together.\n            Each tenant can have its own set of resources like email identities, configuration sets,\n            and templates, along with reputation metrics and sending status. This helps isolate and manage\n            email sending for different customers or business units within your Amazon SES API v2 account.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/tenants",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateTenantRequest": {
+      "type": "structure",
+      "members": {
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant to create. The name can contain up to 64 alphanumeric\n            characters, including letters, numbers, hyphens (-) and underscores (_) only.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) to associate with the tenant</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to create a tenant.</p>\n         <p>\n            <i>Tenants</i> are logical containers that group related SES resources together.\n            Each tenant can have its own set of resources like email identities, configuration sets, and templates,\n            along with reputation metrics and sending status. This helps isolate and manage email sending\n            for different customers or business units within your Amazon SES API v2 account.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateTenantResourceAssociation": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#CreateTenantResourceAssociationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#CreateTenantResourceAssociationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Associate a resource with a tenant.</p>\n         <p>\n            <i>Resources</i> can be email identities, configuration sets, or email templates.\n            When you associate a resource with a tenant, you can use that resource when sending emails\n            on behalf of that tenant.</p>\n         <p>A single resource can be associated with multiple tenants, allowing for resource sharing\n            across different tenants while maintaining isolation in email sending operations.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/tenants/resources",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#CreateTenantResourceAssociationRequest": {
+      "type": "structure",
+      "members": {
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant to associate the resource with.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource to associate with the tenant.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to associate a resource with a tenant.</p>\n         <p>Resources can be email identities, configuration sets, or email templates.\n            When you associate a resource with a tenant, you can use that resource when sending\n            emails on behalf of that tenant.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateTenantResourceAssociationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty\n            HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CreateTenantResponse": {
+      "type": "structure",
+      "members": {
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant.</p>"
+          }
+        },
+        "TenantId": {
+          "target": "com.amazonaws.sesv2#TenantId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the tenant.</p>"
+          }
+        },
+        "TenantArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the tenant.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the tenant was created.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) associated with the tenant.</p>"
+          }
+        },
+        "SendingStatus": {
+          "target": "com.amazonaws.sesv2#SendingStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of email sending capability for the tenant.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about a newly created tenant.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#CustomRedirectDomain": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The domain to use for tracking open and click events.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#CustomVerificationEmailTemplateMetadata": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom verification email template.</p>"
+          }
+        },
+        "FromEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address that the custom verification email is sent from.</p>"
+          }
+        },
+        "TemplateSubject": {
+          "target": "com.amazonaws.sesv2#EmailTemplateSubject",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line of the custom verification email.</p>"
+          }
+        },
+        "SuccessRedirectionURL": {
+          "target": "com.amazonaws.sesv2#SuccessRedirectionURL",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL that the recipient of the verification email is sent to if his or her address\n            is successfully verified.</p>"
+          }
+        },
+        "FailureRedirectionURL": {
+          "target": "com.amazonaws.sesv2#FailureRedirectionURL",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL that the recipient of the verification email is sent to if his or her address\n            is not successfully verified.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about a custom verification email template.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#CustomVerificationEmailTemplatesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#CustomVerificationEmailTemplateMetadata"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of the custom verification email templates that exist in your account.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DailyVolume": {
+      "type": "structure",
+      "members": {
+        "StartDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date that the DailyVolume metrics apply to, in Unix time.</p>"
+          }
+        },
+        "VolumeStatistics": {
+          "target": "com.amazonaws.sesv2#VolumeStatistics",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains inbox placement metrics for a specific day in the analysis\n            period.</p>"
+          }
+        },
+        "DomainIspPlacements": {
+          "target": "com.amazonaws.sesv2#DomainIspPlacements",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains inbox placement metrics for a specified day in the analysis\n            period, broken out by the recipient's email provider.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about the volume of email sent on each day of the\n            analysis period.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DailyVolumes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#DailyVolume"
+      }
+    },
+    "com.amazonaws.sesv2#DashboardAttributes": {
+      "type": "structure",
+      "members": {
+        "EngagementMetrics": {
+          "target": "com.amazonaws.sesv2#FeatureStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the status of your VDM engagement metrics collection. Can be one of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> \u2013 Amazon SES enables engagement metrics for your\n                    account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> \u2013 Amazon SES disables engagement metrics for your\n                    account.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object containing additional settings for your VDM configuration as applicable to\n            the Dashboard.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DashboardOptions": {
+      "type": "structure",
+      "members": {
+        "EngagementMetrics": {
+          "target": "com.amazonaws.sesv2#FeatureStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the status of your VDM engagement metrics collection. Can be one of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> \u2013 Amazon SES enables engagement metrics for the\n                    configuration set.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> \u2013 Amazon SES disables engagement metrics for the\n                    configuration set.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object containing additional settings for your VDM configuration as applicable to\n            the Dashboard.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DataFormat": {
+      "type": "enum",
+      "members": {
+        "CSV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CSV"
+          }
+        },
+        "JSON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "JSON"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The data format of a file, can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CSV</code> \u2013 A comma-separated values file.</p>\n            </li>\n            <li>\n               <p>\n                  <code>JSON</code> \u2013 A JSON file.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#DedicatedIp": {
+      "type": "structure",
+      "members": {
+        "Ip": {
+          "target": "com.amazonaws.sesv2#Ip",
+          "traits": {
+            "smithy.api#documentation": "<p>An IPv4 address.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "WarmupStatus": {
+          "target": "com.amazonaws.sesv2#WarmupStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The warm-up status of a dedicated IP address. The status can have one of the following\n            values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IN_PROGRESS</code> \u2013 The IP address isn't ready to use because the\n                    dedicated IP warm-up process is ongoing.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DONE</code> \u2013 The dedicated IP warm-up process is complete, and\n                    the IP address is ready to use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NOT_APPLICABLE</code> \u2013 The warm-up status doesn't apply to this IP address.\n                    This status is used for IP addresses in managed dedicated IP pools, where Amazon SES automatically\n                    handles the warm-up process.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "WarmupPercentage": {
+          "target": "com.amazonaws.sesv2#Percentage100Wrapper",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the progress of your dedicated IP warm-up:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>0-100</code> \u2013 For standard dedicated IP addresses, this shows the warm-up completion percentage. A value of 100 means the IP address is fully warmed up and ready for use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>-1</code> \u2013 Appears for IP addresses in managed dedicated pools where Amazon SES automatically handles the warm-up process, making the percentage not applicable.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "PoolName": {
+          "target": "com.amazonaws.sesv2#PoolName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the dedicated IP pool that the IP address is associated with.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about a dedicated IP address that is associated with your Amazon SES\n            account.</p>\n         <p>To learn more about requesting dedicated IP addresses, see <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/dedicated-ip-case.html\">Requesting and Relinquishing\n                Dedicated IP Addresses</a> in the <i>Amazon SES Developer\n            Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DedicatedIpList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#DedicatedIp"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of dedicated IP addresses that are associated with your Amazon Web Services account.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DedicatedIpPool": {
+      "type": "structure",
+      "members": {
+        "PoolName": {
+          "target": "com.amazonaws.sesv2#PoolName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the dedicated IP pool.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ScalingMode": {
+          "target": "com.amazonaws.sesv2#ScalingMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the dedicated IP pool.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>STANDARD</code> \u2013 A dedicated IP pool where you can\n                    control which IPs are part of the pool.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MANAGED</code> \u2013 A dedicated IP pool where the reputation and\n                    number of IPs are automatically managed by Amazon SES.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about a dedicated IP pool.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DefaultDimensionValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The default value of the dimension that is published to Amazon CloudWatch if you don't provide the\n            value of the dimension when you send an email. This value has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>It can only contain ASCII letters (a\u2013z, A\u2013Z), numbers (0\u20139),\n                    underscores (_), or dashes (-).</p>\n            </li>\n            <li>\n               <p>It can contain no more than 256 characters.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#DeleteConfigurationSet": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteConfigurationSetRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteConfigurationSetResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Delete an existing configuration set.</p>\n         <p>\n            <i>Configuration sets</i> are groups of rules that you can apply to the\n            emails you send. You apply a configuration set to an email by including a reference to\n            the configuration set in the headers of the email. When you apply a configuration set to\n            an email, all of the rules in that configuration set are applied to the email.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteConfigurationSetEventDestination": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteConfigurationSetEventDestinationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteConfigurationSetEventDestinationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Delete an event destination.</p>\n         <p>\n            <i>Events</i> include message sends, deliveries, opens, clicks, bounces,\n            and complaints. <i>Event destinations</i> are places that you can send\n            information about these events to. For example, you can send event data to Amazon EventBridge and\n            associate a rule to send the event to the specified target.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations/{EventDestinationName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteConfigurationSetEventDestinationRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set that contains the event destination to\n            delete.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "EventDestinationName": {
+          "target": "com.amazonaws.sesv2#EventDestinationName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event destination to delete.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to delete an event destination from a configuration set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteConfigurationSetEventDestinationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteConfigurationSetRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to delete a configuration set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteConfigurationSetResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteContact": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteContactRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteContactResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes a contact from a contact list.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/contact-lists/{ContactListName}/contacts/{EmailAddress}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteContactList": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteContactListRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteContactListResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a contact list and all of the contacts on that list.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/contact-lists/{ContactListName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteContactListRequest": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteContactListResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteContactRequest": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list from which the contact should be removed.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's email address.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteContactResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteCustomVerificationEmailTemplate": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteCustomVerificationEmailTemplateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteCustomVerificationEmailTemplateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an existing custom verification email template.</p>\n         <p>For more information about custom verification email templates, see <a href=\"https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#send-email-verify-address-custom\">Using\n                custom verification email templates</a> in the <i>Amazon SES Developer\n                Guide</i>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/custom-verification-email-templates/{TemplateName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteCustomVerificationEmailTemplateRequest": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom verification email template that you want to delete.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to delete an existing custom verification email template.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteCustomVerificationEmailTemplateResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty\n            HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteDedicatedIpPool": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteDedicatedIpPoolRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteDedicatedIpPoolResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Delete a dedicated IP pool.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/dedicated-ip-pools/{PoolName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteDedicatedIpPoolRequest": {
+      "type": "structure",
+      "members": {
+        "PoolName": {
+          "target": "com.amazonaws.sesv2#PoolName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the dedicated IP pool that you want to delete.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to delete a dedicated IP pool.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteDedicatedIpPoolResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteEmailIdentity": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteEmailIdentityRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteEmailIdentityResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an email identity. An identity can be either an email address or a domain\n            name.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/identities/{EmailIdentity}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteEmailIdentityPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteEmailIdentityPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteEmailIdentityPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified sending authorization policy for the given identity (an email\n            address or a domain). This API returns successfully even if a policy with the specified\n            name does not exist.</p>\n         <note>\n            <p>This API is for the identity owner only. If you have not verified the identity,\n                this API will return an error.</p>\n         </note>\n         <p>Sending authorization is a feature that enables an identity owner to authorize other\n            senders to use its identities. For information about using sending authorization, see\n            the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer\n                Guide</a>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/identities/{EmailIdentity}/policies/{PolicyName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteEmailIdentityPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "PolicyName": {
+          "target": "com.amazonaws.sesv2#PolicyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the policy.</p>\n         <p>The policy name cannot exceed 64 characters and can only include alphanumeric\n            characters, dashes, and underscores.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to delete a sending authorization policy for an identity. Sending\n            authorization is an Amazon SES feature that enables you to authorize other senders to\n            use your identities. For information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-identity-owner-tasks-management.html\">Amazon SES Developer Guide</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteEmailIdentityPolicyResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteEmailIdentityRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The identity (that is, the email address or domain) to delete.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to delete an existing email identity. When you delete an identity, you lose\n            the ability to send email from that identity. You can restore your ability to send email\n            by completing the verification process for the identity again.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteEmailIdentityResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteEmailTemplate": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteEmailTemplateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteEmailTemplateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an email template.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/templates/{TemplateName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteEmailTemplateRequest": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the template to be deleted.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to delete an email template. For more information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\">Amazon SES Developer\n                Guide</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteEmailTemplateResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty\n            HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteMultiRegionEndpoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteMultiRegionEndpointRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteMultiRegionEndpointResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a multi-region endpoint (global-endpoint).</p>\n         <p>Only multi-region endpoints (global-endpoints) whose primary region is the AWS-Region\n            where operation is executed can be deleted.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/multi-region-endpoints/{EndpointName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteMultiRegionEndpointRequest": {
+      "type": "structure",
+      "members": {
+        "EndpointName": {
+          "target": "com.amazonaws.sesv2#EndpointName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the multi-region endpoint (global-endpoint) to be deleted.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to delete a multi-region endpoint (global-endpoint).</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteMultiRegionEndpointResponse": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.sesv2#Status",
+          "traits": {
+            "smithy.api#documentation": "<p>A status of the multi-region endpoint (global-endpoint) right after the delete request.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> \u2013 The resource is being provisioned.</p>\n            </li>\n            <li>\n               <p>\n                  <code>READY</code> \u2013 The resource is ready to use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 The resource failed to be provisioned.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> \u2013 The resource is being deleted as requested.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteSuppressedDestination": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteSuppressedDestinationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteSuppressedDestinationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes an email address from the suppression list for your account.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/suppression/addresses/{EmailAddress}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteSuppressedDestinationRequest": {
+      "type": "structure",
+      "members": {
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The suppressed email destination to remove from the account suppression list.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to remove an email address from the suppression list for your\n            account.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteSuppressedDestinationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteTenant": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteTenantRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteTenantResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Delete an existing tenant.</p>\n         <p>When you delete a tenant, its associations with resources\n            are removed, but the resources themselves are not deleted.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/tenants/delete",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteTenantRequest": {
+      "type": "structure",
+      "members": {
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to delete a tenant.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteTenantResourceAssociation": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#DeleteTenantResourceAssociationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#DeleteTenantResourceAssociationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Delete an association between a tenant and a resource.</p>\n         <p>When you delete a tenant-resource association, the resource itself is not deleted,\n            only its association with the specific tenant is removed. After removal, the resource\n            will no longer be available for use with that tenant's email sending operations.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/tenants/resources/delete",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DeleteTenantResourceAssociationRequest": {
+      "type": "structure",
+      "members": {
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant to remove the resource association from.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource to remove from the tenant association.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to delete an association between a tenant and a resource.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteTenantResourceAssociationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty\n            HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeleteTenantResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty\n            HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#DeliverabilityDashboardAccountStatus": {
+      "type": "enum",
+      "members": {
+        "ACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVE"
+          }
+        },
+        "PENDING_EXPIRATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING_EXPIRATION"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The current status of your Deliverability dashboard subscription. If this value is\n                <code>PENDING_EXPIRATION</code>, your subscription is scheduled to expire at the end\n            of the current calendar month.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DeliverabilityTestReport": {
+      "type": "structure",
+      "members": {
+        "ReportId": {
+          "target": "com.amazonaws.sesv2#ReportId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique string that identifies the predictive inbox placement test.</p>"
+          }
+        },
+        "ReportName": {
+          "target": "com.amazonaws.sesv2#ReportName",
+          "traits": {
+            "smithy.api#documentation": "<p>A name that helps you identify a predictive inbox placement test report.</p>"
+          }
+        },
+        "Subject": {
+          "target": "com.amazonaws.sesv2#DeliverabilityTestSubject",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line for an email that you submitted in a predictive inbox placement test.</p>"
+          }
+        },
+        "FromEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The sender address that you specified for the predictive inbox placement test.</p>"
+          }
+        },
+        "CreateDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the predictive inbox placement test was created.</p>"
+          }
+        },
+        "DeliverabilityTestStatus": {
+          "target": "com.amazonaws.sesv2#DeliverabilityTestStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the predictive inbox placement test. If the status is <code>IN_PROGRESS</code>, then the predictive inbox placement test\n            is currently running. Predictive inbox placement tests are usually complete within 24 hours of creating the\n            test. If the status is <code>COMPLETE</code>, then the test is finished, and you can use\n            the <code>GetDeliverabilityTestReport</code> to view the results of the test.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains metadata related to a predictive inbox placement test.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DeliverabilityTestReports": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#DeliverabilityTestReport"
+      }
+    },
+    "com.amazonaws.sesv2#DeliverabilityTestStatus": {
+      "type": "enum",
+      "members": {
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status of a predictive inbox placement test. If the status is <code>IN_PROGRESS</code>, then the predictive inbox placement test is\n            currently running. Predictive inbox placement tests are usually complete within 24 hours of creating the test.\n            If the status is <code>COMPLETE</code>, then the test is finished, and you can use the\n                <code>GetDeliverabilityTestReport</code> operation to view the results of the\n            test.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DeliverabilityTestSubject": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The subject line for an email that you submitted in a predictive inbox placement test.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DeliveryEventType": {
+      "type": "enum",
+      "members": {
+        "SEND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SEND"
+          }
+        },
+        "DELIVERY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELIVERY"
+          }
+        },
+        "TRANSIENT_BOUNCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRANSIENT_BOUNCE"
+          }
+        },
+        "PERMANENT_BOUNCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERMANENT_BOUNCE"
+          }
+        },
+        "UNDETERMINED_BOUNCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNDETERMINED_BOUNCE"
+          }
+        },
+        "COMPLAINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLAINT"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type of delivery events:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SEND</code> - The send request was successful and SES will\n                    attempt to deliver the message to the recipient\u2019s mail server. (If account-level\n                    or global suppression is being used, SES will still count it as a send,\n                    but delivery is suppressed.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY</code> - SES successfully delivered the email to the\n                    recipient's mail server. Excludes deliveries to the mailbox simulator and\n                    emails addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TRANSIENT_BOUNCE</code> - Feedback received for\n                    delivery failures excluding issues with non-existent mailboxes. Excludes bounces from the\n                    mailbox simulator, and those from emails addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PERMANENT_BOUNCE</code> - Feedback received for\n                    emails sent to non-existent mailboxes. Excludes bounces from the mailbox simulator, those\n                    originating from your account-level suppression list (if enabled), and those from emails\n                    addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UNDETERMINED_BOUNCE</code> - SES was unable to determine the bounce reason.</p>\n            </li>\n            <li>\n               <p>\n                  <code>COMPLAINT</code> - Complaint received for the email.\n                    This excludes complaints from the mailbox simulator, those originating from\n                    your account-level suppression list (if enabled), and those from emails addressed to more\n                    than one recipient.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#DeliveryOptions": {
+      "type": "structure",
+      "members": {
+        "TlsPolicy": {
+          "target": "com.amazonaws.sesv2#TlsPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether messages that use the configuration set are required to use\n            Transport Layer Security (TLS). If the value is <code>Require</code>, messages are only\n            delivered if a TLS connection can be established. If the value is <code>Optional</code>,\n            messages can be delivered in plain text if a TLS connection can't be established.</p>"
+          }
+        },
+        "SendingPoolName": {
+          "target": "com.amazonaws.sesv2#PoolName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the dedicated IP pool to associate with the configuration set.</p>"
+          }
+        },
+        "MaxDeliverySeconds": {
+          "target": "com.amazonaws.sesv2#MaxDeliverySeconds",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum amount of time, in seconds, that Amazon SES API v2 will attempt delivery of email.\n            If specified, the value must greater than or equal to 300 seconds (5 minutes)\n            and less than or equal to 50400 seconds (840 minutes).\n        </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Used to associate a configuration set with a dedicated IP pool.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Description": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#Destination": {
+      "type": "structure",
+      "members": {
+        "ToAddresses": {
+          "target": "com.amazonaws.sesv2#EmailAddressList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that contains the email addresses of the \"To\" recipients for the\n            email.</p>"
+          }
+        },
+        "CcAddresses": {
+          "target": "com.amazonaws.sesv2#EmailAddressList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that contains the email addresses of the \"CC\" (carbon copy) recipients for\n            the email.</p>"
+          }
+        },
+        "BccAddresses": {
+          "target": "com.amazonaws.sesv2#EmailAddressList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that contains the email addresses of the \"BCC\" (blind carbon copy) recipients\n            for the email.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that describes the recipients for an email.</p>\n         <note>\n            <p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href=\"https://tools.ietf.org/html/rfc6531\">RFC6531</a>. For this reason, the\n                    <i>local part</i> of a destination email address (the part of the\n                email address that precedes the @ sign) may only contain <a href=\"https://en.wikipedia.org/wiki/Email_address#Local-part\">7-bit ASCII\n                    characters</a>. If the <i>domain part</i> of an address (the\n                part after the @ sign) contains non-ASCII characters, they must be encoded using\n                Punycode, as described in <a href=\"https://tools.ietf.org/html/rfc3492.html\">RFC3492</a>.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.sesv2#Details": {
+      "type": "structure",
+      "members": {
+        "RoutesDetails": {
+          "target": "com.amazonaws.sesv2#RoutesDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of route configuration details. Must contain exactly one route configuration.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains configuration details of multi-region endpoint (global-endpoint).</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DiagnosticCode": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#DimensionName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of an Amazon CloudWatch dimension associated with an email sending metric. The name has to\n            meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>It can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_),\n                    or dashes (-).</p>\n            </li>\n            <li>\n               <p>It can contain no more than 256 characters.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#DimensionValueSource": {
+      "type": "enum",
+      "members": {
+        "MESSAGE_TAG": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MESSAGE_TAG"
+          }
+        },
+        "EMAIL_HEADER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMAIL_HEADER"
+          }
+        },
+        "LINK_TAG": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LINK_TAG"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The location where the Amazon SES API v2 finds the value of a dimension to publish to Amazon CloudWatch. To\n            use the message tags that you specify using an <code>X-SES-MESSAGE-TAGS</code> header or\n            a parameter to the <code>SendEmail</code> or <code>SendRawEmail</code> API, choose\n                <code>messageTag</code>. To use your own email headers, choose\n                <code>emailHeader</code>. To use link tags, choose <code>linkTags</code>.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Dimensions": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.sesv2#MetricDimensionName"
+      },
+      "value": {
+        "target": "com.amazonaws.sesv2#MetricDimensionValue"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 3
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DisplayName": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#DkimAttributes": {
+      "type": "structure",
+      "members": {
+        "SigningEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If the value is <code>true</code>, then the messages that you send from the identity\n            are signed using DKIM. If the value is <code>false</code>, then the messages that you\n            send from the identity aren't DKIM-signed.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.sesv2#DkimStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes whether or not Amazon SES has successfully located the DKIM records in the DNS\n            records for the domain. The status can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PENDING</code> \u2013 The verification process was initiated, but Amazon SES\n                    hasn't yet detected the DKIM records in the DNS configuration for the\n                    domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUCCESS</code> \u2013 The verification process completed\n                    successfully.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 The verification process failed. This typically\n                    occurs when Amazon SES fails to find the DKIM records in the DNS configuration of the\n                    domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TEMPORARY_FAILURE</code> \u2013 A temporary issue is preventing Amazon SES\n                    from determining the DKIM authentication status of the domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NOT_STARTED</code> \u2013 The DKIM verification process hasn't been\n                    initiated for the domain.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Tokens": {
+          "target": "com.amazonaws.sesv2#DnsTokenList",
+          "traits": {
+            "smithy.api#documentation": "<p>If you used <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Easy DKIM</a> to configure DKIM authentication for the domain, then this object\n            contains a set of unique strings that you use to create a set of CNAME records that you\n            add to the DNS configuration for your domain. When Amazon SES detects these records in the\n            DNS configuration for your domain, the DKIM authentication process is complete.</p>\n         <p>If you configured DKIM authentication for the domain by providing your own\n            public-private key pair, then this object contains the selector for the public\n            key.</p>\n         <p>Regardless of the DKIM authentication method you use, Amazon SES searches for the\n            appropriate records in the DNS configuration of the domain for up to 72 hours.</p>"
+          }
+        },
+        "SigningHostedZone": {
+          "target": "com.amazonaws.sesv2#HostedZone",
+          "traits": {
+            "smithy.api#documentation": "<p>The hosted zone where Amazon SES publishes the DKIM public key TXT records for this email identity. \n        This value indicates the DNS zone that customers must reference when configuring their CNAME records for DKIM authentication.</p>\n         <p>When configuring DKIM for your domain, create CNAME records in your DNS that point to the selectors in this hosted zone. \n        For example:</p>\n         <p>\n            <code>\n            selector1._domainkey.yourdomain.com CNAME selector1.<SigningHostedZone>\n        </code>\n         </p>\n         <p>\n            <code>\n            selector2._domainkey.yourdomain.com CNAME selector2.<SigningHostedZone>\n        </code>\n         </p>\n         <p>\n            <code>\n            selector3._domainkey.yourdomain.com CNAME selector3.<SigningHostedZone>\n        </code>\n         </p>"
+          }
+        },
+        "SigningAttributesOrigin": {
+          "target": "com.amazonaws.sesv2#DkimSigningAttributesOrigin",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that indicates how DKIM was configured for the identity. These are the\n            possible values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AWS_SES</code> \u2013 Indicates that DKIM was configured for the\n                    identity by using <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Easy DKIM</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>EXTERNAL</code> \u2013 Indicates that DKIM was configured for the\n                    identity by using Bring Your Own DKIM (BYODKIM).</p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AF_SOUTH_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Africa (Cape Town) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_NORTH_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Europe (Stockholm) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTH_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Asia Pacific (Mumbai) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTH_2</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Asia Pacific (Hyderabad) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_WEST_3</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Europe (Paris) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_WEST_2</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Europe (London) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_SOUTH_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Europe (Milan) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_WEST_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Europe (Ireland) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_NORTHEAST_3</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Asia Pacific (Osaka) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_NORTHEAST_2</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Asia Pacific (Seoul) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_ME_CENTRAL_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Middle East (UAE) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_ME_SOUTH_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Middle East (Bahrain) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_NORTHEAST_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Asia Pacific (Tokyo) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_IL_CENTRAL_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Israel (Tel Aviv) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_SA_EAST_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in South America (S\u00e3o Paulo) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_CA_CENTRAL_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Canada (Central) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_CA_WEST_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Canada (Calgary) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTHEAST_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Asia Pacific (Singapore) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTHEAST_2</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Asia Pacific (Sydney) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTHEAST_3</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Asia Pacific (Jakarta) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTHEAST_5</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Asia Pacific (Malaysia) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_CENTRAL_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Europe (Frankfurt) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_CENTRAL_2</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in Europe (Zurich) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_US_EAST_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in US East (N. Virginia) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_US_EAST_2</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in US East (Ohio) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_US_WEST_1</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in US West (N. California) region using Deterministic Easy-DKIM\n                    (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_US_WEST_2</code> \u2013 Indicates that DKIM was configured for the identity by\n                    replicating signing attributes from a parent identity in US West (Oregon) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n         </ul>"
+          }
+        },
+        "NextSigningKeyLength": {
+          "target": "com.amazonaws.sesv2#DkimSigningKeyLength",
+          "traits": {
+            "smithy.api#documentation": "<p>[Easy DKIM] The key length of the future DKIM key pair to be generated. This can be\n            changed at most once per day.</p>"
+          }
+        },
+        "CurrentSigningKeyLength": {
+          "target": "com.amazonaws.sesv2#DkimSigningKeyLength",
+          "traits": {
+            "smithy.api#documentation": "<p>[Easy DKIM] The key length of the DKIM key pair in use.</p>"
+          }
+        },
+        "LastKeyGenerationTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>[Easy DKIM] The last time a key pair was generated for this identity.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about the DKIM authentication status for an email\n            identity.</p>\n         <p>Amazon SES determines the authentication status by searching for specific records in the\n            DNS configuration for the domain. If you used <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Easy DKIM</a> to set up DKIM\n            authentication, Amazon SES tries to find three unique CNAME records in the DNS configuration\n            for your domain. If you provided a public key to perform DKIM authentication, Amazon SES\n            tries to find a TXT record that uses the selector that you specified. The value of the\n            TXT record must be a public key that's paired with the private key that you specified in\n            the process of creating the identity</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DkimSigningAttributes": {
+      "type": "structure",
+      "members": {
+        "DomainSigningSelector": {
+          "target": "com.amazonaws.sesv2#Selector",
+          "traits": {
+            "smithy.api#documentation": "<p>[Bring Your Own DKIM] A string that's used to identify a public key in the DNS\n            configuration for a domain.</p>"
+          }
+        },
+        "DomainSigningPrivateKey": {
+          "target": "com.amazonaws.sesv2#PrivateKey",
+          "traits": {
+            "smithy.api#documentation": "<p>[Bring Your Own DKIM] A private key that's used to generate a DKIM signature.</p>\n         <p>The private key must use 1024 or 2048-bit RSA encryption, and must be encoded using\n            base64 encoding.</p>"
+          }
+        },
+        "NextSigningKeyLength": {
+          "target": "com.amazonaws.sesv2#DkimSigningKeyLength",
+          "traits": {
+            "smithy.api#documentation": "<p>[Easy DKIM] The key length of the future DKIM key pair to be generated. This can be\n            changed at most once per day.</p>"
+          }
+        },
+        "DomainSigningAttributesOrigin": {
+          "target": "com.amazonaws.sesv2#DkimSigningAttributesOrigin",
+          "traits": {
+            "smithy.api#documentation": "<p>The attribute to use for configuring DKIM for the identity depends on the\n            operation:\n        </p>\n         <ol>\n            <li>\n               <p>For <code>PutEmailIdentityDkimSigningAttributes</code>:\n                </p>\n               <ul>\n                  <li>\n                     <p>None of the values are allowed - use the\n                            <a href=\"https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_PutEmailIdentityDkimSigningAttributes.html#SES-PutEmailIdentityDkimSigningAttributes-request-SigningAttributesOrigin\">\n                           <code>SigningAttributesOrigin</code>\n                        </a>\n                            parameter instead\n                        </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>For <code>CreateEmailIdentity</code> when replicating a parent identity's DKIM\n                    configuration:\n                </p>\n               <ul>\n                  <li>\n                     <p>Allowed values: All values except <code>AWS_SES</code> and\n                            <code>EXTERNAL</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n         </ol>\n         <ul>\n            <li>\n               <p>\n                  <code>AWS_SES</code> \u2013 Configure DKIM for the identity by using Easy DKIM.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>EXTERNAL</code> \u2013 Configure DKIM for the identity by using Bring Your Own DKIM\n                    (BYODKIM).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AF_SOUTH_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Africa (Cape Town) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_NORTH_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Europe (Stockholm) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTH_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Asia Pacific (Mumbai) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTH_2</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Asia Pacific (Hyderabad) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_WEST_3</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Europe (Paris) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_WEST_2</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Europe (London) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_SOUTH_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Europe (Milan) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_WEST_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Europe (Ireland) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_NORTHEAST_3</code> \u2013 Configure DKIM for the identity by replicating from a\n                    parent identity in Asia Pacific (Osaka) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_NORTHEAST_2</code> \u2013 Configure DKIM for the identity by replicating from a\n                    parent identity in Asia Pacific (Seoul) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_ME_CENTRAL_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Middle East (UAE) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_ME_SOUTH_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Middle East (Bahrain) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_NORTHEAST_1</code> \u2013 Configure DKIM for the identity by replicating from a\n                    parent identity in Asia Pacific (Tokyo) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_IL_CENTRAL_1</code> \u2013 Configure DKIM for the identity by replicating from a\n                    parent identity in Israel (Tel Aviv) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_SA_EAST_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in South America (S\u00e3o Paulo) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_CA_CENTRAL_1</code> \u2013 Configure DKIM for the identity by replicating from a\n                    parent identity in Canada (Central) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_CA_WEST_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Canada (Calgary) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTHEAST_1</code> \u2013 Configure DKIM for the identity by replicating from a\n                    parent identity in Asia Pacific (Singapore) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTHEAST_2</code> \u2013 Configure DKIM for the identity by replicating from a\n                    parent identity in Asia Pacific (Sydney) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTHEAST_3</code> \u2013 Configure DKIM for the identity by replicating from a\n                    parent identity in Asia Pacific (Jakarta) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_AP_SOUTHEAST_5</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Asia Pacific (Malaysia) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_CENTRAL_1</code> \u2013 Configure DKIM for the identity by replicating from a\n                    parent identity in Europe (Frankfurt) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_EU_CENTRAL_2</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in Europe (Zurich) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_US_EAST_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in US East (N. Virginia) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_US_EAST_2</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in US East (Ohio) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_US_WEST_1</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in US West (N. California) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_SES_US_WEST_2</code> \u2013 Configure DKIM for the identity by replicating from a parent\n                    identity in US West (Oregon) region using Deterministic Easy-DKIM (DEED).\n                </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains configuration for Bring Your Own DKIM (BYODKIM), or, for Easy\n            DKIM</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DkimSigningAttributesOrigin": {
+      "type": "enum",
+      "members": {
+        "AWS_SES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES"
+          }
+        },
+        "EXTERNAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXTERNAL"
+          }
+        },
+        "AWS_SES_AF_SOUTH_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_AF_SOUTH_1"
+          }
+        },
+        "AWS_SES_EU_NORTH_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_EU_NORTH_1"
+          }
+        },
+        "AWS_SES_AP_SOUTH_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_AP_SOUTH_1"
+          }
+        },
+        "AWS_SES_EU_WEST_3": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_EU_WEST_3"
+          }
+        },
+        "AWS_SES_EU_WEST_2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_EU_WEST_2"
+          }
+        },
+        "AWS_SES_EU_SOUTH_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_EU_SOUTH_1"
+          }
+        },
+        "AWS_SES_EU_WEST_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_EU_WEST_1"
+          }
+        },
+        "AWS_SES_AP_NORTHEAST_3": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_AP_NORTHEAST_3"
+          }
+        },
+        "AWS_SES_AP_NORTHEAST_2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_AP_NORTHEAST_2"
+          }
+        },
+        "AWS_SES_ME_SOUTH_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_ME_SOUTH_1"
+          }
+        },
+        "AWS_SES_AP_NORTHEAST_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_AP_NORTHEAST_1"
+          }
+        },
+        "AWS_SES_IL_CENTRAL_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_IL_CENTRAL_1"
+          }
+        },
+        "AWS_SES_SA_EAST_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_SA_EAST_1"
+          }
+        },
+        "AWS_SES_CA_CENTRAL_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_CA_CENTRAL_1"
+          }
+        },
+        "AWS_SES_AP_SOUTHEAST_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_AP_SOUTHEAST_1"
+          }
+        },
+        "AWS_SES_AP_SOUTHEAST_2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_AP_SOUTHEAST_2"
+          }
+        },
+        "AWS_SES_AP_SOUTHEAST_3": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_AP_SOUTHEAST_3"
+          }
+        },
+        "AWS_SES_EU_CENTRAL_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_EU_CENTRAL_1"
+          }
+        },
+        "AWS_SES_US_EAST_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_US_EAST_1"
+          }
+        },
+        "AWS_SES_US_EAST_2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_US_EAST_2"
+          }
+        },
+        "AWS_SES_US_WEST_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_US_WEST_1"
+          }
+        },
+        "AWS_SES_US_WEST_2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_US_WEST_2"
+          }
+        },
+        "AWS_SES_ME_CENTRAL_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_ME_CENTRAL_1"
+          }
+        },
+        "AWS_SES_AP_SOUTH_2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_AP_SOUTH_2"
+          }
+        },
+        "AWS_SES_EU_CENTRAL_2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_EU_CENTRAL_2"
+          }
+        },
+        "AWS_SES_AP_SOUTHEAST_5": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_AP_SOUTHEAST_5"
+          }
+        },
+        "AWS_SES_CA_WEST_1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SES_CA_WEST_1"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DkimSigningKeyLength": {
+      "type": "enum",
+      "members": {
+        "RSA_1024_BIT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RSA_1024_BIT"
+          }
+        },
+        "RSA_2048_BIT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RSA_2048_BIT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#DkimStatus": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "SUCCESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCESS"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "TEMPORARY_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEMPORARY_FAILURE"
+          }
+        },
+        "NOT_STARTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NOT_STARTED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The DKIM authentication status of the identity. The status can be one of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PENDING</code> \u2013 The verification process was initiated, but Amazon SES\n                    hasn't yet detected the DKIM records in the DNS configuration for the\n                    domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUCCESS</code> \u2013 The verification process completed\n                    successfully.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 The verification process failed. This typically\n                    occurs when Amazon SES fails to find the DKIM records in the DNS configuration of the\n                    domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TEMPORARY_FAILURE</code> \u2013 A temporary issue is preventing Amazon SES\n                    from determining the DKIM authentication status of the domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NOT_STARTED</code> \u2013 The DKIM verification process hasn't been\n                    initiated for the domain.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#DnsToken": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#DnsTokenList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#DnsToken"
+      }
+    },
+    "com.amazonaws.sesv2#Domain": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#DomainDeliverabilityCampaign": {
+      "type": "structure",
+      "members": {
+        "CampaignId": {
+          "target": "com.amazonaws.sesv2#CampaignId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the campaign. The Deliverability dashboard automatically generates\n            and assigns this identifier to a campaign.</p>"
+          }
+        },
+        "ImageUrl": {
+          "target": "com.amazonaws.sesv2#ImageUrl",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL of an image that contains a snapshot of the email message that was\n            sent.</p>"
+          }
+        },
+        "Subject": {
+          "target": "com.amazonaws.sesv2#Subject",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line, or title, of the email message.</p>"
+          }
+        },
+        "FromAddress": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The verified email address that the email message was sent from.</p>"
+          }
+        },
+        "SendingIps": {
+          "target": "com.amazonaws.sesv2#IpList",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP addresses that were used to send the email message.</p>"
+          }
+        },
+        "FirstSeenDateTime": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The first time when the email message was delivered to any\n            recipient's inbox. This value can help you determine how long it took for a campaign to\n            deliver an email message.</p>"
+          }
+        },
+        "LastSeenDateTime": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The last time when the email message was delivered to any\n            recipient's inbox. This value can help you determine how long it took for a campaign to\n            deliver an email message.</p>"
+          }
+        },
+        "InboxCount": {
+          "target": "com.amazonaws.sesv2#Volume",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of email messages that were delivered to recipients\u2019 inboxes.</p>"
+          }
+        },
+        "SpamCount": {
+          "target": "com.amazonaws.sesv2#Volume",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of email messages that were delivered to recipients' spam or junk mail\n            folders.</p>"
+          }
+        },
+        "ReadRate": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of email messages that were opened by recipients. Due to technical\n            limitations, this value only includes recipients who opened the message by using an\n            email client that supports images.</p>"
+          }
+        },
+        "DeleteRate": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of email messages that were deleted by recipients, without being opened\n            first. Due to technical limitations, this value only includes recipients who opened the\n            message by using an email client that supports images.</p>"
+          }
+        },
+        "ReadDeleteRate": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of email messages that were opened and then deleted by recipients. Due\n            to technical limitations, this value only includes recipients who opened the message by\n            using an email client that supports images.</p>"
+          }
+        },
+        "ProjectedVolume": {
+          "target": "com.amazonaws.sesv2#Volume",
+          "traits": {
+            "smithy.api#documentation": "<p>The projected number of recipients that the email message was sent to.</p>"
+          }
+        },
+        "Esps": {
+          "target": "com.amazonaws.sesv2#Esps",
+          "traits": {
+            "smithy.api#documentation": "<p>The major email providers who handled the email message.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains the deliverability data for a specific campaign. This data is\n            available for a campaign only if the campaign sent email by using a domain that the\n            Deliverability dashboard is enabled for (<code>PutDeliverabilityDashboardOption</code>\n            operation).</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DomainDeliverabilityCampaignList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#DomainDeliverabilityCampaign"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>"
+      }
+    },
+    "com.amazonaws.sesv2#DomainDeliverabilityTrackingOption": {
+      "type": "structure",
+      "members": {
+        "Domain": {
+          "target": "com.amazonaws.sesv2#Domain",
+          "traits": {
+            "smithy.api#documentation": "<p>A verified domain that\u2019s associated with your Amazon Web Services account and currently has an\n            active Deliverability dashboard subscription.</p>"
+          }
+        },
+        "SubscriptionStartDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date when you enabled the Deliverability dashboard for the\n            domain.</p>"
+          }
+        },
+        "InboxPlacementTrackingOption": {
+          "target": "com.amazonaws.sesv2#InboxPlacementTrackingOption",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the inbox placement data settings for the\n            domain.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about the Deliverability dashboard subscription for a\n            verified domain that you use to send email and currently has an active Deliverability dashboard\n            subscription. If a Deliverability dashboard subscription is active for a domain, you gain access\n            to reputation, inbox placement, and other metrics for the domain.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DomainDeliverabilityTrackingOptions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#DomainDeliverabilityTrackingOption"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about the Deliverability dashboard subscription for a\n            verified domain that you use to send email and currently has an active Deliverability dashboard\n            subscription. If a Deliverability dashboard subscription is active for a domain, you gain access\n            to reputation, inbox placement, and other metrics for the domain.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DomainIspPlacement": {
+      "type": "structure",
+      "members": {
+        "IspName": {
+          "target": "com.amazonaws.sesv2#IspName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the email provider that the inbox placement data applies to.</p>"
+          }
+        },
+        "InboxRawCount": {
+          "target": "com.amazonaws.sesv2#Volume",
+          "traits": {
+            "smithy.api#documentation": "<p>The total number of messages that were sent from the selected domain to the specified\n            email provider that arrived in recipients' inboxes.</p>"
+          }
+        },
+        "SpamRawCount": {
+          "target": "com.amazonaws.sesv2#Volume",
+          "traits": {
+            "smithy.api#documentation": "<p>The total number of messages that were sent from the selected domain to the specified\n            email provider that arrived in recipients' spam or junk mail folders.</p>"
+          }
+        },
+        "InboxPercentage": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of messages that were sent from the selected domain to the specified\n            email provider that arrived in recipients' inboxes.</p>"
+          }
+        },
+        "SpamPercentage": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of messages that were sent from the selected domain to the specified\n            email provider that arrived in recipients' spam or junk mail folders.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains inbox placement data for email sent from one of your email\n            domains to a specific email provider.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#DomainIspPlacements": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#DomainIspPlacement"
+      }
+    },
+    "com.amazonaws.sesv2#EmailAddress": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#EmailAddressFilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#InsightsEmailAddress"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.sesv2#EmailAddressInsightsConfidenceVerdict": {
+      "type": "enum",
+      "members": {
+        "LOW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LOW"
+          }
+        },
+        "MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEDIUM"
+          }
+        },
+        "HIGH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HIGH"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The confidence level of SES that the email address meets the validation criteria:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>LOW</code> - Weak or no indication of the speci\ufb01c check (e.g., LOW for IsRoleAddress means the email is less likely to be a role-based address).</p>\n            </li>\n            <li>\n               <p>\n                  <code>MEDIUM</code> - Moderate indication of the speci\ufb01c check (e.g., MEDIUM for IsDisposable means the email might be a disposable address).</p>\n            </li>\n            <li>\n               <p>\n                  <code>HIGH</code> - Strong indication of the speci\ufb01c check (e.g., HIGH for IsRandomInput means the email is very likely randomly generated).</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#EmailAddressInsightsMailboxEvaluations": {
+      "type": "structure",
+      "members": {
+        "HasValidSyntax": {
+          "target": "com.amazonaws.sesv2#EmailAddressInsightsVerdict",
+          "traits": {
+            "smithy.api#documentation": "<p>Checks that the email address follows proper RFC standards and contains valid characters in the correct format.</p>"
+          }
+        },
+        "HasValidDnsRecords": {
+          "target": "com.amazonaws.sesv2#EmailAddressInsightsVerdict",
+          "traits": {
+            "smithy.api#documentation": "<p>Checks that the domain exists, has valid DNS records, and is con\ufb01gured to receive email.</p>"
+          }
+        },
+        "MailboxExists": {
+          "target": "com.amazonaws.sesv2#EmailAddressInsightsVerdict",
+          "traits": {
+            "smithy.api#documentation": "<p>Checks that the mailbox exists and can receive messages without actually sending an email.</p>"
+          }
+        },
+        "IsRoleAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddressInsightsVerdict",
+          "traits": {
+            "smithy.api#documentation": "<p>Identi\ufb01es role-based addresses (such as admin@, support@, or info@) that may have lower engagement rates.</p>"
+          }
+        },
+        "IsDisposable": {
+          "target": "com.amazonaws.sesv2#EmailAddressInsightsVerdict",
+          "traits": {
+            "smithy.api#documentation": "<p>Checks disposable or temporary email addresses that could negatively impact your sender reputation.</p>"
+          }
+        },
+        "IsRandomInput": {
+          "target": "com.amazonaws.sesv2#EmailAddressInsightsVerdict",
+          "traits": {
+            "smithy.api#documentation": "<p>Checks if the input appears to be random text.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains individual validation checks performed on an email address.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EmailAddressInsightsVerdict": {
+      "type": "structure",
+      "members": {
+        "ConfidenceVerdict": {
+          "target": "com.amazonaws.sesv2#EmailAddressInsightsConfidenceVerdict",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence level of the validation verdict.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the overall validation verdict for an email address.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EmailAddressList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#EmailAddress"
+      }
+    },
+    "com.amazonaws.sesv2#EmailContent": {
+      "type": "structure",
+      "members": {
+        "Simple": {
+          "target": "com.amazonaws.sesv2#Message",
+          "traits": {
+            "smithy.api#documentation": "<p>The simple email message. The message consists of a subject, message body and attachments list.</p>"
+          }
+        },
+        "Raw": {
+          "target": "com.amazonaws.sesv2#RawMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The raw email message. The message has to meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>The message has to contain a header and a body, separated by one blank\n                    line.</p>\n            </li>\n            <li>\n               <p>All of the required header fields must be present in the message.</p>\n            </li>\n            <li>\n               <p>Each part of a multipart MIME message must be formatted properly.</p>\n            </li>\n            <li>\n               <p>If you include attachments, they must be in a file format that the Amazon SES API v2\n                    supports.\n                    </p>\n            </li>\n            <li>\n               <p>The raw data of the message needs to base64-encoded if you are accessing Amazon SES\n                    directly through the HTTPS interface. If you are accessing Amazon SES using an Amazon Web Services\n                    SDK, the SDK takes care of the base 64-encoding for you.</p>\n            </li>\n            <li>\n               <p>If any of the MIME parts in your message contain content that is outside of\n                    the 7-bit ASCII character range, you should encode that content to ensure that\n                    recipients' email clients render the message properly.</p>\n            </li>\n            <li>\n               <p>The length of any single line of text in the message can't exceed 1,000\n                    characters. This restriction is defined in <a href=\"https://tools.ietf.org/html/rfc5321\">RFC 5321</a>.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Template": {
+          "target": "com.amazonaws.sesv2#Template",
+          "traits": {
+            "smithy.api#documentation": "<p>The template to use for the email message.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines the entire content of the email, including the message headers, body content,\n            and attachments. For a simple email message, you specify the subject and provide both text\n            and HTML versions of the message body. You can also add attachments to simple and templated\n            messages. For a raw message, you provide a complete MIME-formatted message, which can\n            include custom headers and attachments.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EmailInsights": {
+      "type": "structure",
+      "members": {
+        "Destination": {
+          "target": "com.amazonaws.sesv2#InsightsEmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The recipient of the email.</p>"
+          }
+        },
+        "Isp": {
+          "target": "com.amazonaws.sesv2#Isp",
+          "traits": {
+            "smithy.api#documentation": "<p>The recipient's ISP (e.g., <code>Gmail</code>, <code>Yahoo</code>,\n        etc.).</p>"
+          }
+        },
+        "Events": {
+          "target": "com.amazonaws.sesv2#InsightsEvents",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of events associated with the sent email.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An email's insights contain metadata and delivery information about a specific email.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EmailInsightsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#EmailInsights"
+      }
+    },
+    "com.amazonaws.sesv2#EmailSubject": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 998
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.sesv2#EmailSubjectFilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#EmailSubject"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.sesv2#EmailTemplateContent": {
+      "type": "structure",
+      "members": {
+        "Subject": {
+          "target": "com.amazonaws.sesv2#EmailTemplateSubject",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line of the email.</p>"
+          }
+        },
+        "Text": {
+          "target": "com.amazonaws.sesv2#EmailTemplateText",
+          "traits": {
+            "smithy.api#documentation": "<p>The email body that will be visible to recipients whose email clients do not display\n            HTML.</p>"
+          }
+        },
+        "Html": {
+          "target": "com.amazonaws.sesv2#EmailTemplateHtml",
+          "traits": {
+            "smithy.api#documentation": "<p>The HTML body of the email.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The content of the email, composed of a subject line, an HTML part, and a text-only\n            part.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EmailTemplateData": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines the values to use for message variables in the template. This\n            object is a set of key-value pairs. Each key defines a message variable in the template.\n            The corresponding value defines the value to use for that variable.</p>",
+        "smithy.api#length": {
+          "min": 0,
+          "max": 262144
+        }
+      }
+    },
+    "com.amazonaws.sesv2#EmailTemplateHtml": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The HTML body of the email.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EmailTemplateMetadata": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the template.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time and date the template was created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about an email template.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EmailTemplateMetadataList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#EmailTemplateMetadata"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of the EmailTemplateMetadata object.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EmailTemplateName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of the template. You will refer to this name when you send email using the\n                <code>SendEmail</code> or <code>SendBulkEmail</code>\n            operations.</p>",
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.sesv2#EmailTemplateSubject": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The subject line of the email.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EmailTemplateText": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The email body that will be visible to recipients whose email clients do not display\n            HTML.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Enabled": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.sesv2#EnabledWrapper": {
+      "type": "boolean"
+    },
+    "com.amazonaws.sesv2#EndpointId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The ID of the multi-region endpoint (global-endpoint).</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EndpointName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of the multi-region endpoint (global-endpoint).</p>",
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[\\w\\-_]+$"
+      }
+    },
+    "com.amazonaws.sesv2#EngagementEventType": {
+      "type": "enum",
+      "members": {
+        "OPEN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPEN"
+          }
+        },
+        "CLICK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLICK"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type of delivery events:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>OPEN</code> - Open event for emails including open trackers.\n                    Excludes opens for emails addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CLICK</code> - Click event for emails including wrapped links.\n                    Excludes clicks for emails addressed to more than one recipient.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#ErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#Esp": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#Esps": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Esp"
+      }
+    },
+    "com.amazonaws.sesv2#EventBridgeDestination": {
+      "type": "structure",
+      "members": {
+        "EventBusArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon EventBridge bus to publish email events to. Only the default bus is supported. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines an Amazon EventBridge destination for email events. You can use Amazon EventBridge to\n            send notifications when certain email events occur.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EventDestination": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.sesv2#EventDestinationName",
+          "traits": {
+            "smithy.api#documentation": "<p>A name that identifies the event destination.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Enabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If <code>true</code>, the event destination is enabled. When the event destination is\n            enabled, the specified event types are sent to the destinations in this\n                <code>EventDestinationDefinition</code>.</p>\n         <p>If <code>false</code>, the event destination is disabled. When the event destination\n            is disabled, events aren't sent to the specified destinations.</p>"
+          }
+        },
+        "MatchingEventTypes": {
+          "target": "com.amazonaws.sesv2#EventTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The types of events that Amazon SES sends to the specified event destinations.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SEND</code> - The send request was successful and SES will\n                    attempt to deliver the message to the recipient\u2019s mail server. (If account-level\n                    or global suppression is being used, SES will still count it as a send,\n                    but delivery is suppressed.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>REJECT</code> - SES accepted the email, but determined that it\n                    contained a virus and didn\u2019t attempt to deliver it to the recipient\u2019s mail\n                    server.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BOUNCE</code> - (<i>Hard bounce</i>) The recipient's\n                    mail server permanently rejected the email. (<i>Soft bounces</i>\n                    are only included when SES fails to deliver the email after retrying for\n                    a period of time.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>COMPLAINT</code> - The email was successfully delivered to the\n                    recipient\u2019s mail server, but the recipient marked it as spam.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY</code> - SES successfully delivered the email to the\n                    recipient's mail server.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OPEN</code> - The recipient received the message and opened it in their\n                    email client.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CLICK</code> - The recipient clicked one or more links in the\n                    email.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RENDERING_FAILURE</code> - The email wasn't sent because of a\n                    template rendering issue. This event type can occur when template data is\n                    missing, or when there is a mismatch between template parameters and data. (This\n                    event type only occurs when you send email using the <a href=\"https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html\">\n                     <code>SendEmail</code>\n                  </a> or <a href=\"https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendBulkEmail.html\">\n                     <code>SendBulkEmail</code>\n                  </a> API operations.) </p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY_DELAY</code> - The email couldn't be delivered to the\n                    recipient\u2019s mail server because a temporary issue occurred. Delivery delays can\n                    occur, for example, when the recipient's inbox is full, or when the\n                    receiving email server experiences a transient issue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUBSCRIPTION</code> - The email was successfully delivered, but the\n                    recipient updated their subscription preferences by clicking on an\n                        <i>unsubscribe</i> link as part of your <a href=\"https://docs.aws.amazon.com/ses/latest/dg/sending-email-subscription-management.html\">subscription\n                        management</a>.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "KinesisFirehoseDestination": {
+          "target": "com.amazonaws.sesv2#KinesisFirehoseDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines an Amazon Kinesis Data Firehose destination for email events. You can use Amazon Kinesis Data Firehose to\n            stream data to other services, such as Amazon S3 and Amazon Redshift.</p>"
+          }
+        },
+        "CloudWatchDestination": {
+          "target": "com.amazonaws.sesv2#CloudWatchDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines an Amazon CloudWatch destination for email events. You can use Amazon CloudWatch to\n            monitor and gain insights on your email sending metrics.</p>"
+          }
+        },
+        "SnsDestination": {
+          "target": "com.amazonaws.sesv2#SnsDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines an Amazon SNS destination for email events. You can use Amazon SNS to\n            send notifications when certain email events occur.</p>"
+          }
+        },
+        "EventBridgeDestination": {
+          "target": "com.amazonaws.sesv2#EventBridgeDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines an Amazon EventBridge destination for email events. You can use Amazon EventBridge to\n            send notifications when certain email events occur.</p>"
+          }
+        },
+        "PinpointDestination": {
+          "target": "com.amazonaws.sesv2#PinpointDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines an Amazon Pinpoint project destination for email events. You can send\n            email event data to a Amazon Pinpoint project to view metrics using the Transactional Messaging\n            dashboards that are built in to Amazon Pinpoint. For more information, see <a href=\"https://docs.aws.amazon.com/pinpoint/latest/userguide/analytics-transactional-messages.html\">Transactional\n                Messaging Charts</a> in the <i>Amazon Pinpoint User Guide</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>In the Amazon SES API v2, <i>events</i> include message sends, deliveries, opens,\n            clicks, bounces, complaints and delivery delays. <i>Event destinations</i>\n            are places that you can send information about these events to. For example, you can\n            send event data to Amazon SNS to receive notifications when you receive bounces or\n            complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EventDestinationDefinition": {
+      "type": "structure",
+      "members": {
+        "Enabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If <code>true</code>, the event destination is enabled. When the event destination is\n            enabled, the specified event types are sent to the destinations in this\n                <code>EventDestinationDefinition</code>.</p>\n         <p>If <code>false</code>, the event destination is disabled. When the event destination\n            is disabled, events aren't sent to the specified destinations.</p>"
+          }
+        },
+        "MatchingEventTypes": {
+          "target": "com.amazonaws.sesv2#EventTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that specifies which events the Amazon SES API v2 should send to the destinations in\n            this <code>EventDestinationDefinition</code>.</p>"
+          }
+        },
+        "KinesisFirehoseDestination": {
+          "target": "com.amazonaws.sesv2#KinesisFirehoseDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines an Amazon Kinesis Data Firehose destination for email events. You can use Amazon Kinesis Data Firehose to\n            stream data to other services, such as Amazon S3 and Amazon Redshift.</p>"
+          }
+        },
+        "CloudWatchDestination": {
+          "target": "com.amazonaws.sesv2#CloudWatchDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines an Amazon CloudWatch destination for email events. You can use Amazon CloudWatch to\n            monitor and gain insights on your email sending metrics.</p>"
+          }
+        },
+        "SnsDestination": {
+          "target": "com.amazonaws.sesv2#SnsDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines an Amazon SNS destination for email events. You can use Amazon SNS to\n            send notifications when certain email events occur.</p>"
+          }
+        },
+        "EventBridgeDestination": {
+          "target": "com.amazonaws.sesv2#EventBridgeDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines an Amazon EventBridge destination for email events. You can use Amazon EventBridge to\n            send notifications when certain email events occur.</p>"
+          }
+        },
+        "PinpointDestination": {
+          "target": "com.amazonaws.sesv2#PinpointDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines an Amazon Pinpoint project destination for email events. You can send\n            email event data to a Amazon Pinpoint project to view metrics using the Transactional Messaging\n            dashboards that are built in to Amazon Pinpoint. For more information, see <a href=\"https://docs.aws.amazon.com/pinpoint/latest/userguide/analytics-transactional-messages.html\">Transactional\n                Messaging Charts</a> in the <i>Amazon Pinpoint User Guide</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines the event destination. Specifically, it defines which services\n            receive events from emails sent using the configuration set that the event destination\n            is associated with. Also defines the types of events that are sent to the event\n            destination.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EventDestinationName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of an event destination.</p>\n         <p>\n            <i>Events</i> include message sends, deliveries, opens, clicks, bounces,\n            and complaints. <i>Event destinations</i> are places that you can send\n            information about these events to. For example, you can send event data to Amazon SNS to\n            receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to\n            stream data to Amazon S3 for long-term storage.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EventDestinations": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#EventDestination"
+      }
+    },
+    "com.amazonaws.sesv2#EventDetails": {
+      "type": "structure",
+      "members": {
+        "Bounce": {
+          "target": "com.amazonaws.sesv2#Bounce",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about a <code>Bounce</code> event.</p>"
+          }
+        },
+        "Complaint": {
+          "target": "com.amazonaws.sesv2#Complaint",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about a <code>Complaint</code> event.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>\n            Contains a <code>Bounce</code> object if the event type is <code>BOUNCE</code>.\n            Contains a <code>Complaint</code> object if the event type is <code>COMPLAINT</code>.\n        </p>"
+      }
+    },
+    "com.amazonaws.sesv2#EventType": {
+      "type": "enum",
+      "members": {
+        "SEND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SEND"
+          }
+        },
+        "REJECT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REJECT"
+          }
+        },
+        "BOUNCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOUNCE"
+          }
+        },
+        "COMPLAINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLAINT"
+          }
+        },
+        "DELIVERY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELIVERY"
+          }
+        },
+        "OPEN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPEN"
+          }
+        },
+        "CLICK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLICK"
+          }
+        },
+        "RENDERING_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RENDERING_FAILURE"
+          }
+        },
+        "DELIVERY_DELAY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELIVERY_DELAY"
+          }
+        },
+        "SUBSCRIPTION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUBSCRIPTION"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An email sending event type. For example, email sends, opens, and bounces are all\n            email events.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#EventTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#EventType"
+      }
+    },
+    "com.amazonaws.sesv2#ExportDataSource": {
+      "type": "structure",
+      "members": {
+        "MetricsDataSource": {
+          "target": "com.amazonaws.sesv2#MetricsDataSource"
+        },
+        "MessageInsightsDataSource": {
+          "target": "com.amazonaws.sesv2#MessageInsightsDataSource"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains details about the data source of the export job. It can only\n            contain one of <code>MetricsDataSource</code> or <code>MessageInsightsDataSource</code> object.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ExportDestination": {
+      "type": "structure",
+      "members": {
+        "DataFormat": {
+          "target": "com.amazonaws.sesv2#DataFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The data format of the final export job file, can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CSV</code> - A comma-separated values file.</p>\n            </li>\n            <li>\n               <p>\n                  <code>JSON</code> - A Json file.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "S3Url": {
+          "target": "com.amazonaws.sesv2#S3Url",
+          "traits": {
+            "smithy.api#documentation": "<p>An Amazon S3 pre-signed URL that points to the generated export file.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains details about the destination of the export job.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ExportDimensionValue": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#MetricDimensionValue"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ExportDimensions": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.sesv2#MetricDimensionName"
+      },
+      "value": {
+        "target": "com.amazonaws.sesv2#ExportDimensionValue"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 3
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ExportJobSummary": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.sesv2#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The export job ID.</p>"
+          }
+        },
+        "ExportSourceType": {
+          "target": "com.amazonaws.sesv2#ExportSourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The source type of the export job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.sesv2#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the export job.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp of when the export job was created.</p>"
+          }
+        },
+        "CompletedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp of when the export job was completed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A summary of the export job.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ExportJobSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#ExportJobSummary"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of the export job summaries.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ExportMetric": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.sesv2#Metric"
+        },
+        "Aggregation": {
+          "target": "com.amazonaws.sesv2#MetricAggregation"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains a mapping between a <code>Metric</code> and\n            <code>MetricAggregation</code>.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ExportMetrics": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#ExportMetric"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ExportSourceType": {
+      "type": "enum",
+      "members": {
+        "METRICS_DATA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "METRICS_DATA"
+          }
+        },
+        "MESSAGE_INSIGHTS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MESSAGE_INSIGHTS"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type of data source of an export, can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>METRICS_DATA</code> - The metrics export.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MESSAGE_INSIGHTS</code> - The Message Insights export.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#ExportStatistics": {
+      "type": "structure",
+      "members": {
+        "ProcessedRecordsCount": {
+          "target": "com.amazonaws.sesv2#ProcessedRecordsCount",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of records that were processed to generate the final export file.</p>"
+          }
+        },
+        "ExportedRecordsCount": {
+          "target": "com.amazonaws.sesv2#ExportedRecordsCount",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of records that were exported to the final export file.</p>\n         <p>This value might not be available for all export source types</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Statistics about the execution of an export job.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ExportedRecordsCount": {
+      "type": "integer"
+    },
+    "com.amazonaws.sesv2#FailedRecordsCount": {
+      "type": "integer"
+    },
+    "com.amazonaws.sesv2#FailedRecordsS3Url": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#FailureInfo": {
+      "type": "structure",
+      "members": {
+        "FailedRecordsS3Url": {
+          "target": "com.amazonaws.sesv2#FailedRecordsS3Url",
+          "traits": {
+            "smithy.api#documentation": "<p>An Amazon S3 pre-signed URL that contains all the failed records and related information.</p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.sesv2#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A message about why the job failed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains the failure details about a job.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#FailureRedirectionURL": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The URL that the recipient of the verification email is sent to if his or her address\n            is not successfully verified.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#FeatureStatus": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#FeedbackId": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#GeneralEnforcementStatus": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#GetAccount": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetAccountRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetAccountResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Obtain information about the email-sending status and capabilities of your Amazon SES\n            account in the current Amazon Web Services Region.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/account",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetAccountRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>A request to obtain information about the email-sending capabilities of your Amazon SES\n            account.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetAccountResponse": {
+      "type": "structure",
+      "members": {
+        "DedicatedIpAutoWarmupEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Indicates whether or not the automatic warm-up feature is enabled for dedicated IP\n            addresses that are associated with your account.</p>"
+          }
+        },
+        "EnforcementStatus": {
+          "target": "com.amazonaws.sesv2#GeneralEnforcementStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The reputation status of your Amazon SES account. The status can be one of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HEALTHY</code> \u2013 There are no reputation-related issues that\n                    currently impact your account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PROBATION</code> \u2013 We've identified potential issues with your\n                    Amazon SES account. We're placing your account under review while you work on\n                    correcting these issues.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SHUTDOWN</code> \u2013 Your account's ability to send email is\n                    currently paused because of an issue with the email sent from your account. When\n                    you correct the issue, you can contact us and request that your account's\n                    ability to send email is resumed.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "ProductionAccessEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Indicates whether or not your account has production access in the current Amazon Web Services\n            Region.</p>\n         <p>If the value is <code>false</code>, then your account is in the\n                <i>sandbox</i>. When your account is in the sandbox, you can only send\n            email to verified identities.\n            </p>\n         <p>If the value is <code>true</code>, then your account has production access. When your\n            account has production access, you can send email to any address. The sending quota and\n            maximum sending rate for your account vary based on your specific use case.</p>"
+          }
+        },
+        "SendQuota": {
+          "target": "com.amazonaws.sesv2#SendQuota",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the per-day and per-second sending limits\n            for your Amazon SES account in the current Amazon Web Services Region.</p>"
+          }
+        },
+        "SendingEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Indicates whether or not email sending is enabled for your Amazon SES account in the\n            current Amazon Web Services Region.</p>"
+          }
+        },
+        "SuppressionAttributes": {
+          "target": "com.amazonaws.sesv2#SuppressionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the email address suppression preferences\n            for your account in the current Amazon Web Services Region.</p>"
+          }
+        },
+        "Details": {
+          "target": "com.amazonaws.sesv2#AccountDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines your account details.</p>"
+          }
+        },
+        "VdmAttributes": {
+          "target": "com.amazonaws.sesv2#VdmAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>The VDM attributes that apply to your Amazon SES account.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of details about the email-sending capabilities of your Amazon SES account in the\n            current Amazon Web Services Region.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetBlacklistReports": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetBlacklistReportsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetBlacklistReportsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve a list of the blacklists that your dedicated IP addresses appear on.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/deliverability-dashboard/blacklist-report",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetBlacklistReportsRequest": {
+      "type": "structure",
+      "members": {
+        "BlacklistItemNames": {
+          "target": "com.amazonaws.sesv2#BlacklistItemNames",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of IP addresses that you want to retrieve blacklist information about. You can\n            only specify the dedicated IP addresses that you use to send email using Amazon SES or\n            Amazon Pinpoint.</p>",
+            "smithy.api#httpQuery": "BlacklistItemNames",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to retrieve a list of the blacklists that your dedicated IP addresses appear\n            on.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetBlacklistReportsResponse": {
+      "type": "structure",
+      "members": {
+        "BlacklistReport": {
+          "target": "com.amazonaws.sesv2#BlacklistReport",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about a blacklist that one of your dedicated IP\n            addresses appears on.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about blacklist events.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetConfigurationSet": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetConfigurationSetRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetConfigurationSetResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Get information about an existing configuration set, including the dedicated IP pool\n            that it's associated with, whether or not it's enabled for sending email, and\n            more.</p>\n         <p>\n            <i>Configuration sets</i> are groups of rules that you can apply to the\n            emails you send. You apply a configuration set to an email by including a reference to\n            the configuration set in the headers of the email. When you apply a configuration set to\n            an email, all of the rules in that configuration set are applied to the email.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetConfigurationSetEventDestinations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetConfigurationSetEventDestinationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetConfigurationSetEventDestinationsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve a list of event destinations that are associated with a configuration\n            set.</p>\n         <p>\n            <i>Events</i> include message sends, deliveries, opens, clicks, bounces,\n            and complaints. <i>Event destinations</i> are places that you can send\n            information about these events to. For example, you can send event data to Amazon EventBridge and\n            associate a rule to send the event to the specified target.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetConfigurationSetEventDestinationsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set that contains the event destination.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to obtain information about the event destinations for a configuration\n            set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetConfigurationSetEventDestinationsResponse": {
+      "type": "structure",
+      "members": {
+        "EventDestinations": {
+          "target": "com.amazonaws.sesv2#EventDestinations",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that includes all of the events destinations that have been configured for\n            the configuration set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about an event destination for a configuration set.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetConfigurationSetRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to obtain information about a configuration set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetConfigurationSetResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set.</p>"
+          }
+        },
+        "TrackingOptions": {
+          "target": "com.amazonaws.sesv2#TrackingOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the open and click tracking options for emails that you send\n            using the configuration set.</p>"
+          }
+        },
+        "DeliveryOptions": {
+          "target": "com.amazonaws.sesv2#DeliveryOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the dedicated IP pool that is used to send emails that you send\n            using the configuration set.</p>"
+          }
+        },
+        "ReputationOptions": {
+          "target": "com.amazonaws.sesv2#ReputationOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines whether or not Amazon SES collects reputation metrics for the emails\n            that you send that use the configuration set.</p>"
+          }
+        },
+        "SendingOptions": {
+          "target": "com.amazonaws.sesv2#SendingOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines whether or not Amazon SES can send email that you send using the\n            configuration set.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) that are associated with\n            the configuration set.</p>"
+          }
+        },
+        "SuppressionOptions": {
+          "target": "com.amazonaws.sesv2#SuppressionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the suppression list preferences for your\n            account.</p>"
+          }
+        },
+        "VdmOptions": {
+          "target": "com.amazonaws.sesv2#VdmOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the VDM preferences for your configuration\n            set.</p>"
+          }
+        },
+        "ArchivingOptions": {
+          "target": "com.amazonaws.sesv2#ArchivingOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the MailManager archive where sent emails are archived that you send\n            using the configuration set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about a configuration set.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetContact": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetContactRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetContactResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a contact from a contact list.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/contact-lists/{ContactListName}/contacts/{EmailAddress}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetContactList": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetContactListRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetContactListResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns contact list metadata. It does not return any information about the contacts\n            present in the list.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/contact-lists/{ContactListName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetContactListRequest": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetContactListResponse": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list.</p>"
+          }
+        },
+        "Topics": {
+          "target": "com.amazonaws.sesv2#Topics",
+          "traits": {
+            "smithy.api#documentation": "<p>An interest group, theme, or label within a list. A contact list can have multiple\n            topics.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.sesv2#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of what the contact list is about.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>A timestamp noting when the contact list was created.</p>"
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>A timestamp noting the last time the contact list was updated.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags associated with a contact list.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetContactRequest": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list to which the contact belongs.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's email address.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetContactResponse": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list to which the contact belongs.</p>"
+          }
+        },
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's email address.</p>"
+          }
+        },
+        "TopicPreferences": {
+          "target": "com.amazonaws.sesv2#TopicPreferenceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's preference for being opted-in to or opted-out of a topic.></p>"
+          }
+        },
+        "TopicDefaultPreferences": {
+          "target": "com.amazonaws.sesv2#TopicPreferenceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The default topic preferences applied to the contact.</p>"
+          }
+        },
+        "UnsubscribeAll": {
+          "target": "com.amazonaws.sesv2#UnsubscribeAll",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>A boolean value status noting if the contact is unsubscribed from all contact list\n            topics.</p>"
+          }
+        },
+        "AttributesData": {
+          "target": "com.amazonaws.sesv2#AttributesData",
+          "traits": {
+            "smithy.api#documentation": "<p>The attribute data attached to a contact.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>A timestamp noting when the contact was created.</p>"
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>A timestamp noting the last time the contact's information was updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetCustomVerificationEmailTemplate": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetCustomVerificationEmailTemplateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetCustomVerificationEmailTemplateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the custom email verification template for the template name you\n            specify.</p>\n         <p>For more information about custom verification email templates, see <a href=\"https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#send-email-verify-address-custom\">Using\n                custom verification email templates</a> in the <i>Amazon SES Developer\n                Guide</i>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/custom-verification-email-templates/{TemplateName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetCustomVerificationEmailTemplateRequest": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom verification email template that you want to retrieve.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to retrieve an existing custom verification email\n            template.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetCustomVerificationEmailTemplateResponse": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom verification email template.</p>"
+          }
+        },
+        "FromEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address that the custom verification email is sent from.</p>"
+          }
+        },
+        "TemplateSubject": {
+          "target": "com.amazonaws.sesv2#EmailTemplateSubject",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line of the custom verification email.</p>"
+          }
+        },
+        "TemplateContent": {
+          "target": "com.amazonaws.sesv2#TemplateContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the custom verification email.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) that are associated with\n            the custom verification email template.</p>"
+          }
+        },
+        "SuccessRedirectionURL": {
+          "target": "com.amazonaws.sesv2#SuccessRedirectionURL",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL that the recipient of the verification email is sent to if his or her address\n            is successfully verified.</p>"
+          }
+        },
+        "FailureRedirectionURL": {
+          "target": "com.amazonaws.sesv2#FailureRedirectionURL",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL that the recipient of the verification email is sent to if his or her address\n            is not successfully verified.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The following elements are returned by the service.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDedicatedIp": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetDedicatedIpRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetDedicatedIpResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Get information about a dedicated IP address, including the name of the dedicated IP\n            pool that it's associated with, as well information about the automatic warm-up process\n            for the address.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/dedicated-ips/{Ip}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetDedicatedIpPool": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetDedicatedIpPoolRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetDedicatedIpPoolResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve information about the dedicated pool.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/dedicated-ip-pools/{PoolName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetDedicatedIpPoolRequest": {
+      "type": "structure",
+      "members": {
+        "PoolName": {
+          "target": "com.amazonaws.sesv2#PoolName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the dedicated IP pool to retrieve.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to obtain more information about a dedicated IP pool.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDedicatedIpPoolResponse": {
+      "type": "structure",
+      "members": {
+        "DedicatedIpPool": {
+          "target": "com.amazonaws.sesv2#DedicatedIpPool",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about a dedicated IP pool.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The following element is returned by the service.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDedicatedIpRequest": {
+      "type": "structure",
+      "members": {
+        "Ip": {
+          "target": "com.amazonaws.sesv2#Ip",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address that you want to obtain more information about. The value you specify\n            has to be a dedicated IP address that's assocaited with your Amazon Web Services account.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to obtain more information about a dedicated IP address.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDedicatedIpResponse": {
+      "type": "structure",
+      "members": {
+        "DedicatedIp": {
+          "target": "com.amazonaws.sesv2#DedicatedIp",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about a dedicated IP address.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about a dedicated IP address.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDedicatedIps": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetDedicatedIpsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetDedicatedIpsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List the dedicated IP addresses that are associated with your Amazon Web Services\n            account.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/dedicated-ips",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetDedicatedIpsRequest": {
+      "type": "structure",
+      "members": {
+        "PoolName": {
+          "target": "com.amazonaws.sesv2#PoolName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the IP pool that the dedicated IP address is associated with.</p>",
+            "smithy.api#httpQuery": "PoolName"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>GetDedicatedIps</code> to indicate the\n            position of the dedicated IP pool in the list of IP pools.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to <code>GetDedicatedIpsRequest</code>.\n            If the number of results is larger than the number you specified in this parameter, then\n            the response includes a <code>NextToken</code> element, which you can use to obtain\n            additional results.</p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to obtain more information about dedicated IP pools.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDedicatedIpsResponse": {
+      "type": "structure",
+      "members": {
+        "DedicatedIps": {
+          "target": "com.amazonaws.sesv2#DedicatedIpList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of dedicated IP addresses that are associated with your Amazon Web Services account.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that indicates that there are additional dedicated IP addresses to list. To\n            view additional addresses, issue another request to <code>GetDedicatedIps</code>,\n            passing this token in the <code>NextToken</code> parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the dedicated IP addresses that are associated with your Amazon Web Services\n            account.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDeliverabilityDashboardOptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetDeliverabilityDashboardOptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetDeliverabilityDashboardOptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve information about the status of the Deliverability dashboard for your account. When\n            the Deliverability dashboard is enabled, you gain access to reputation, deliverability, and other\n            metrics for the domains that you use to send email. You also gain the ability to perform\n            predictive inbox placement tests.</p>\n         <p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition\n            to any other fees that you accrue by using Amazon SES and other Amazon Web Services services. For more\n            information about the features and cost of a Deliverability dashboard subscription, see <a href=\"http://aws.amazon.com/ses/pricing/\">Amazon SES Pricing</a>.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/deliverability-dashboard",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetDeliverabilityDashboardOptionsRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve information about the status of the Deliverability dashboard for your Amazon Web Services account.\n            When the Deliverability dashboard is enabled, you gain access to reputation, deliverability, and\n            other metrics for your domains. You also gain the ability to perform predictive inbox placement tests.</p>\n         <p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition\n            to any other fees that you accrue by using Amazon SES and other Amazon Web Services services. For more\n            information about the features and cost of a Deliverability dashboard subscription, see <a href=\"http://aws.amazon.com/pinpoint/pricing/\">Amazon Pinpoint Pricing</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDeliverabilityDashboardOptionsResponse": {
+      "type": "structure",
+      "members": {
+        "DashboardEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether the Deliverability dashboard is enabled. If this value is <code>true</code>,\n            the dashboard is enabled.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SubscriptionExpiryDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date  when your current subscription to the Deliverability dashboard\n            is scheduled to expire, if your subscription is scheduled to expire at the end of the\n            current calendar month. This value is null if you have an active subscription that isn\u2019t\n            due to expire at the end of the month.</p>"
+          }
+        },
+        "AccountStatus": {
+          "target": "com.amazonaws.sesv2#DeliverabilityDashboardAccountStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of your Deliverability dashboard subscription. If this value is\n                <code>PENDING_EXPIRATION</code>, your subscription is scheduled to expire at the end\n            of the current calendar month.</p>"
+          }
+        },
+        "ActiveSubscribedDomains": {
+          "target": "com.amazonaws.sesv2#DomainDeliverabilityTrackingOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects, one for each verified domain that you use to send email and\n            currently has an active Deliverability dashboard subscription that isn\u2019t scheduled to expire at\n            the end of the current calendar month.</p>"
+          }
+        },
+        "PendingExpirationSubscribedDomains": {
+          "target": "com.amazonaws.sesv2#DomainDeliverabilityTrackingOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects, one for each verified domain that you use to send email and\n            currently has an active Deliverability dashboard subscription that's scheduled to expire at the\n            end of the current calendar month.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that shows the status of the Deliverability dashboard.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDeliverabilityTestReport": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetDeliverabilityTestReportRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetDeliverabilityTestReportResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve the results of a predictive inbox placement test.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/deliverability-dashboard/test-reports/{ReportId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetDeliverabilityTestReportRequest": {
+      "type": "structure",
+      "members": {
+        "ReportId": {
+          "target": "com.amazonaws.sesv2#ReportId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique string that identifies the predictive inbox placement test.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to retrieve the results of a predictive inbox placement test.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDeliverabilityTestReportResponse": {
+      "type": "structure",
+      "members": {
+        "DeliverabilityTestReport": {
+          "target": "com.amazonaws.sesv2#DeliverabilityTestReport",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the results of the predictive inbox placement test.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OverallPlacement": {
+          "target": "com.amazonaws.sesv2#PlacementStatistics",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that specifies how many test messages that were sent during the predictive inbox placement test were\n            delivered to recipients' inboxes, how many were sent to recipients' spam folders, and\n            how many weren't delivered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IspPlacements": {
+          "target": "com.amazonaws.sesv2#IspPlacements",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that describes how the test email was handled by several email providers,\n            including Gmail, Hotmail, Yahoo, AOL, and others.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.sesv2#MessageContent",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the message that you sent when you performed this\n            predictive inbox placement test.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) that are associated with\n            the predictive inbox placement test.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The results of the predictive inbox placement test.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDomainDeliverabilityCampaign": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetDomainDeliverabilityCampaignRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetDomainDeliverabilityCampaignResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve all the deliverability data for a specific campaign. This data is available\n            for a campaign only if the campaign sent email by using a domain that the\n            Deliverability dashboard is enabled for.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/deliverability-dashboard/campaigns/{CampaignId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetDomainDeliverabilityCampaignRequest": {
+      "type": "structure",
+      "members": {
+        "CampaignId": {
+          "target": "com.amazonaws.sesv2#CampaignId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the campaign. The Deliverability dashboard automatically generates\n            and assigns this identifier to a campaign.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve all the deliverability data for a specific campaign. This data is available\n            for a campaign only if the campaign sent email by using a domain that the\n            Deliverability dashboard is enabled for (<code>PutDeliverabilityDashboardOption</code>\n            operation).</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDomainDeliverabilityCampaignResponse": {
+      "type": "structure",
+      "members": {
+        "DomainDeliverabilityCampaign": {
+          "target": "com.amazonaws.sesv2#DomainDeliverabilityCampaign",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the deliverability data for the campaign.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains all the deliverability data for a specific campaign. This data\n            is available for a campaign only if the campaign sent email by using a domain that the\n            Deliverability dashboard is enabled for.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDomainStatisticsReport": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetDomainStatisticsReportRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetDomainStatisticsReportResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve inbox placement and engagement rates for the domains that you use to send\n            email.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/deliverability-dashboard/statistics-report/{Domain}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetDomainStatisticsReportRequest": {
+      "type": "structure",
+      "members": {
+        "Domain": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain that you want to obtain deliverability metrics for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "StartDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The first day (in Unix time) that you want to obtain domain deliverability metrics\n            for.</p>",
+            "smithy.api#httpQuery": "StartDate",
+            "smithy.api#required": {}
+          }
+        },
+        "EndDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The last day (in Unix time) that you want to obtain domain deliverability metrics for.\n            The <code>EndDate</code> that you specify has to be less than or equal to 30 days after\n            the <code>StartDate</code>.</p>",
+            "smithy.api#httpQuery": "EndDate",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to obtain deliverability metrics for a domain.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetDomainStatisticsReportResponse": {
+      "type": "structure",
+      "members": {
+        "OverallVolume": {
+          "target": "com.amazonaws.sesv2#OverallVolume",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains deliverability metrics for the domain that you specified. The\n            data in this object is a summary of all of the data that was collected from the\n                <code>StartDate</code> to the <code>EndDate</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DailyVolumes": {
+          "target": "com.amazonaws.sesv2#DailyVolumes",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains deliverability metrics for the domain that you specified. This\n            object contains data for each day, starting on the <code>StartDate</code> and ending on\n            the <code>EndDate</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that includes statistics that are related to the domain that you\n            specified.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailAddressInsights": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetEmailAddressInsightsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetEmailAddressInsightsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides validation insights about a specific email address, including syntax validation, DNS record checks, mailbox existence, and other deliverability factors.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "Get Email Address Insights",
+            "documentation": "Performs email validation against an email address.",
+            "input": {
+              "EmailAddress": "hello@example.com"
+            },
+            "output": {
+              "MailboxValidation": {
+                "IsValid": {
+                  "ConfidenceVerdict": "HIGH"
+                },
+                "Evaluations": {
+                  "HasValidSyntax": {
+                    "ConfidenceVerdict": "HIGH"
+                  },
+                  "HasValidDnsRecords": {
+                    "ConfidenceVerdict": "MEDIUM"
+                  },
+                  "MailboxExists": {
+                    "ConfidenceVerdict": "MEDIUM"
+                  },
+                  "IsRoleAddress": {
+                    "ConfidenceVerdict": "LOW"
+                  },
+                  "IsDisposable": {
+                    "ConfidenceVerdict": "LOW"
+                  },
+                  "IsRandomInput": {
+                    "ConfidenceVerdict": "LOW"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/email-address-insights",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailAddressInsightsRequest": {
+      "type": "structure",
+      "members": {
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address to analyze for validation insights.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to return validation insights about an email address.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailAddressInsightsResponse": {
+      "type": "structure",
+      "members": {
+        "MailboxValidation": {
+          "target": "com.amazonaws.sesv2#MailboxValidation",
+          "traits": {
+            "smithy.api#documentation": "<p>Detailed validation results for the email address.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Validation insights about an email address.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailIdentity": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetEmailIdentityRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetEmailIdentityResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a specific identity, including the identity's verification\n            status, sending authorization policies, its DKIM authentication status, and its custom\n            Mail-From settings.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/identities/{EmailIdentity}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailIdentityPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetEmailIdentityPoliciesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetEmailIdentityPoliciesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the requested sending authorization policies for the given identity (an email\n            address or a domain). The policies are returned as a map of policy names to policy\n            contents. You can retrieve a maximum of 20 policies at a time.</p>\n         <note>\n            <p>This API is for the identity owner only. If you have not verified the identity,\n                this API will return an error.</p>\n         </note>\n         <p>Sending authorization is a feature that enables an identity owner to authorize other\n            senders to use its identities. For information about using sending authorization, see\n            the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer\n                Guide</a>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/identities/{EmailIdentity}/policies",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailIdentityPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to return the policies of an email identity.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailIdentityPoliciesResponse": {
+      "type": "structure",
+      "members": {
+        "Policies": {
+          "target": "com.amazonaws.sesv2#PolicyMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map of policy names to policies.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Identity policies associated with email identity.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailIdentityRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to return details about an email identity.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailIdentityResponse": {
+      "type": "structure",
+      "members": {
+        "IdentityType": {
+          "target": "com.amazonaws.sesv2#IdentityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity type. Note: the <code>MANAGED_DOMAIN</code> identity type is not\n            supported.</p>"
+          }
+        },
+        "FeedbackForwardingStatus": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>The feedback forwarding configuration for the identity.</p>\n         <p>If the value is <code>true</code>, you receive email notifications when bounce or\n            complaint events occur. These notifications are sent to the address that you specified\n            in the <code>Return-Path</code> header of the original email.</p>\n         <p>You're required to have a method of tracking bounces and complaints. If you haven't\n            set up another mechanism for receiving bounce or complaint notifications (for example,\n            by setting up an event destination), you receive an email notification when these events\n            occur (even if this setting is disabled).</p>"
+          }
+        },
+        "VerifiedForSendingStatus": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether or not the identity is verified. You can only send email from\n            verified email addresses or domains. For more information about verifying identities,\n            see the <a href=\"https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-email-manage-verify.html\">Amazon Pinpoint User Guide</a>.</p>"
+          }
+        },
+        "DkimAttributes": {
+          "target": "com.amazonaws.sesv2#DkimAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the DKIM attributes for the identity.</p>"
+          }
+        },
+        "MailFromAttributes": {
+          "target": "com.amazonaws.sesv2#MailFromAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the Mail-From attributes for the email\n            identity.</p>"
+          }
+        },
+        "Policies": {
+          "target": "com.amazonaws.sesv2#PolicyMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map of policy names to policies.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) that are associated with\n            the email identity.</p>"
+          }
+        },
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration set used by default when sending from this identity.</p>"
+          }
+        },
+        "VerificationStatus": {
+          "target": "com.amazonaws.sesv2#VerificationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The verification status of the identity. The status can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PENDING</code> \u2013 The verification process was initiated, but Amazon SES\n                    hasn't yet been able to verify the identity.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUCCESS</code> \u2013 The verification process completed\n                    successfully.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 The verification process failed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TEMPORARY_FAILURE</code> \u2013 A temporary issue is preventing Amazon SES\n                    from determining the verification status of the identity.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NOT_STARTED</code> \u2013 The verification process hasn't been\n                    initiated for the identity.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "VerificationInfo": {
+          "target": "com.amazonaws.sesv2#VerificationInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains additional information about the verification status for the\n            identity.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details about an email identity.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailTemplate": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetEmailTemplateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetEmailTemplateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Displays the template object (which includes the subject line, HTML part and text\n            part) for the template you specify.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/templates/{TemplateName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailTemplateRequest": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the template.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to display the template object (which includes the subject line,\n            HTML part and text part) for the template you specify.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetEmailTemplateResponse": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateContent": {
+          "target": "com.amazonaws.sesv2#EmailTemplateContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the email template, composed of a subject line, an HTML part, and a\n            text-only part.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) that are associated with\n            the email template.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The following element is returned by the service.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetExportJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetExportJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetExportJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about an export job.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/export-jobs/{JobId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetExportJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.sesv2#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The export job ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to retrieve information about an export job using the export job\n            ID.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetExportJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.sesv2#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The export job ID.</p>"
+          }
+        },
+        "ExportSourceType": {
+          "target": "com.amazonaws.sesv2#ExportSourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of source of the export job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.sesv2#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the export job.</p>"
+          }
+        },
+        "ExportDestination": {
+          "target": "com.amazonaws.sesv2#ExportDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>The destination of the export job.</p>"
+          }
+        },
+        "ExportDataSource": {
+          "target": "com.amazonaws.sesv2#ExportDataSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The data source of the export job.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp of when the export job was created.</p>"
+          }
+        },
+        "CompletedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp of when the export job was completed.</p>"
+          }
+        },
+        "FailureInfo": {
+          "target": "com.amazonaws.sesv2#FailureInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>The failure details about an export job.</p>"
+          }
+        },
+        "Statistics": {
+          "target": "com.amazonaws.sesv2#ExportStatistics",
+          "traits": {
+            "smithy.api#documentation": "<p>The statistics about the export job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetImportJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetImportJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetImportJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about an import job.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/import-jobs/{JobId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetImportJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.sesv2#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the import job.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request for information about an import job using the import job\n            ID.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetImportJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.sesv2#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that represents the import job ID.</p>"
+          }
+        },
+        "ImportDestination": {
+          "target": "com.amazonaws.sesv2#ImportDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>The destination of the import job.</p>"
+          }
+        },
+        "ImportDataSource": {
+          "target": "com.amazonaws.sesv2#ImportDataSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The data source of the import job.</p>"
+          }
+        },
+        "FailureInfo": {
+          "target": "com.amazonaws.sesv2#FailureInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>The failure details about an import job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.sesv2#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the import job.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp of when the import job was created.</p>"
+          }
+        },
+        "CompletedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp of when the import job was completed.</p>"
+          }
+        },
+        "ProcessedRecordsCount": {
+          "target": "com.amazonaws.sesv2#ProcessedRecordsCount",
+          "traits": {
+            "smithy.api#documentation": "<p>The current number of records processed.</p>"
+          }
+        },
+        "FailedRecordsCount": {
+          "target": "com.amazonaws.sesv2#FailedRecordsCount",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of records that failed processing because of invalid input or other\n            reasons.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetMessageInsights": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetMessageInsightsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetMessageInsightsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a specific message, including the from address, the\n            subject, the recipient address, email tags, as well as events associated with the message.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/insights/{MessageId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetMessageInsightsRequest": {
+      "type": "structure",
+      "members": {
+        "MessageId": {
+          "target": "com.amazonaws.sesv2#OutboundMessageId",
+          "traits": {
+            "smithy.api#documentation": "<p>\n            A <code>MessageId</code> is a unique identifier for a message, and is\n            returned when sending emails through Amazon SES.\n        </p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to return information about a message.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetMessageInsightsResponse": {
+      "type": "structure",
+      "members": {
+        "MessageId": {
+          "target": "com.amazonaws.sesv2#OutboundMessageId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the message.</p>"
+          }
+        },
+        "FromEmailAddress": {
+          "target": "com.amazonaws.sesv2#InsightsEmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The from address used to send the message.</p>"
+          }
+        },
+        "Subject": {
+          "target": "com.amazonaws.sesv2#EmailSubject",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line of the message.</p>"
+          }
+        },
+        "EmailTags": {
+          "target": "com.amazonaws.sesv2#MessageTagList",
+          "traits": {
+            "smithy.api#documentation": "<p>\n            A list of tags, in the form of name/value pairs, that were applied to the email you sent, along with Amazon SES\n            <a href=\"https://docs.aws.amazon.com/ses/latest/dg/monitor-using-event-publishing.html\">Auto-Tags</a>.\n        </p>"
+          }
+        },
+        "Insights": {
+          "target": "com.amazonaws.sesv2#EmailInsightsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A set of insights associated with the message.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about a message.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetMultiRegionEndpoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetMultiRegionEndpointRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetMultiRegionEndpointResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Displays the multi-region endpoint (global-endpoint) configuration.</p>\n         <p>Only multi-region endpoints (global-endpoints) whose primary region is the AWS-Region\n            where operation is executed can be displayed.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/multi-region-endpoints/{EndpointName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetMultiRegionEndpointRequest": {
+      "type": "structure",
+      "members": {
+        "EndpointName": {
+          "target": "com.amazonaws.sesv2#EndpointName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the multi-region endpoint (global-endpoint).</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to display the multi-region endpoint (global-endpoint).</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetMultiRegionEndpointResponse": {
+      "type": "structure",
+      "members": {
+        "EndpointName": {
+          "target": "com.amazonaws.sesv2#EndpointName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the multi-region endpoint (global-endpoint).</p>"
+          }
+        },
+        "EndpointId": {
+          "target": "com.amazonaws.sesv2#EndpointId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the multi-region endpoint (global-endpoint).</p>"
+          }
+        },
+        "Routes": {
+          "target": "com.amazonaws.sesv2#Routes",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains routes information for the multi-region endpoint (global-endpoint).</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.sesv2#Status",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the multi-region endpoint (global-endpoint).</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> \u2013 The resource is being provisioned.</p>\n            </li>\n            <li>\n               <p>\n                  <code>READY</code> \u2013 The resource is ready to use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 The resource failed to be provisioned.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> \u2013 The resource is being deleted as requested.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp of when the multi-region endpoint (global-endpoint) was created.</p>"
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp of when the multi-region endpoint (global-endpoint) was last updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetReputationEntity": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetReputationEntityRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetReputationEntityResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve information about a specific reputation entity, including its reputation \n            management policy, customer-managed status, Amazon Web Services Amazon SES-managed status, and aggregate \n            sending status.</p>\n         <p>\n            <i>Reputation entities</i> represent resources in your Amazon SES account that have reputation \n            tracking and management capabilities. The reputation impact reflects the highest \n            impact reputation finding for the entity. Reputation findings can be retrieved \n            using the <code>ListRecommendations</code> operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/reputation/entities/{ReputationEntityType}/{ReputationEntityReference}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetReputationEntityRequest": {
+      "type": "structure",
+      "members": {
+        "ReputationEntityReference": {
+          "target": "com.amazonaws.sesv2#ReputationEntityReference",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the reputation entity. For resource-type entities, \n            this is the Amazon Resource Name (ARN) of the resource.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ReputationEntityType": {
+          "target": "com.amazonaws.sesv2#ReputationEntityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of reputation entity. Currently, only <code>RESOURCE</code> type entities are supported.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to retrieve information about a specific reputation entity.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetReputationEntityResponse": {
+      "type": "structure",
+      "members": {
+        "ReputationEntity": {
+          "target": "com.amazonaws.sesv2#ReputationEntity",
+          "traits": {
+            "smithy.api#documentation": "<p>The reputation entity information, including status records, policy configuration, \n            and reputation impact.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the requested reputation entity.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetSuppressedDestination": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetSuppressedDestinationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetSuppressedDestinationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieves information about a specific email address that's on the suppression list\n            for your account.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/suppression/addresses/{EmailAddress}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetSuppressedDestinationRequest": {
+      "type": "structure",
+      "members": {
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address that's on the account suppression list.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to retrieve information about an email address that's on the suppression\n            list for your account.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetSuppressedDestinationResponse": {
+      "type": "structure",
+      "members": {
+        "SuppressedDestination": {
+          "target": "com.amazonaws.sesv2#SuppressedDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object containing information about the suppressed email address.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the suppressed email address.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetTenant": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#GetTenantRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#GetTenantResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Get information about a specific tenant, including the tenant's name, ID, ARN,\n            creation timestamp, tags, and sending status.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/tenants/get",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#GetTenantRequest": {
+      "type": "structure",
+      "members": {
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant to retrieve information about.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to get information about a specific tenant.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#GetTenantResponse": {
+      "type": "structure",
+      "members": {
+        "Tenant": {
+          "target": "com.amazonaws.sesv2#Tenant",
+          "traits": {
+            "smithy.api#documentation": "<p>A structure that contains details about the tenant.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about a specific tenant.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#GuardianAttributes": {
+      "type": "structure",
+      "members": {
+        "OptimizedSharedDelivery": {
+          "target": "com.amazonaws.sesv2#FeatureStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the status of your VDM optimized shared delivery. Can be one of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> \u2013 Amazon SES enables optimized shared delivery for your\n                    account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> \u2013 Amazon SES disables optimized shared delivery for\n                    your account.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object containing additional settings for your VDM configuration as applicable to\n            the Guardian.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#GuardianOptions": {
+      "type": "structure",
+      "members": {
+        "OptimizedSharedDelivery": {
+          "target": "com.amazonaws.sesv2#FeatureStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the status of your VDM optimized shared delivery. Can be one of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> \u2013 Amazon SES enables optimized shared delivery for the\n                    configuration set.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> \u2013 Amazon SES disables optimized shared delivery for the\n                    configuration set.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object containing additional settings for your VDM configuration as applicable to\n            the Guardian.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#HostedZone": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#HttpsPolicy": {
+      "type": "enum",
+      "members": {
+        "REQUIRE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REQUIRE"
+          }
+        },
+        "REQUIRE_OPEN_ONLY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REQUIRE_OPEN_ONLY"
+          }
+        },
+        "OPTIONAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPTIONAL"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The https policy to use for tracking open and click events. If the value is OPTIONAL or HttpsPolicy is not\n        specified, the open trackers use HTTP and click tracker use the original protocol of the link.\n        If the value is REQUIRE, both open and click tracker uses HTTPS and if the value is REQUIRE_OPEN_ONLY\n            open tracker uses HTTPS and link tracker is same as original protocol of the link.\n        </p>"
+      }
+    },
+    "com.amazonaws.sesv2#Identity": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.sesv2#IdentityInfo": {
+      "type": "structure",
+      "members": {
+        "IdentityType": {
+          "target": "com.amazonaws.sesv2#IdentityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity type. Note: the <code>MANAGED_DOMAIN</code> type is not supported\n            for email identity types.</p>"
+          }
+        },
+        "IdentityName": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The address or domain of the identity.</p>"
+          }
+        },
+        "SendingEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Indicates whether or not you can send email from the identity.</p>\n         <p>An <i>identity</i> is an email address or domain that you send email\n            from. Before you can send email from an identity, you have to demostrate that you own\n            the identity, and that you authorize Amazon SES to send email from that identity.</p>"
+          }
+        },
+        "VerificationStatus": {
+          "target": "com.amazonaws.sesv2#VerificationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The verification status of the identity. The status can be one of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PENDING</code> \u2013 The verification process was initiated, but Amazon SES\n                    hasn't yet been able to verify the identity.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUCCESS</code> \u2013 The verification process completed\n                    successfully.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 The verification process failed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TEMPORARY_FAILURE</code> \u2013 A temporary issue is preventing Amazon SES\n                    from determining the verification status of the identity.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NOT_STARTED</code> \u2013 The verification process hasn't been\n                    initiated for the identity.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about an email identity.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#IdentityInfoList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#IdentityInfo"
+      }
+    },
+    "com.amazonaws.sesv2#IdentityType": {
+      "type": "enum",
+      "members": {
+        "EMAIL_ADDRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMAIL_ADDRESS"
+          }
+        },
+        "DOMAIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOMAIN"
+          }
+        },
+        "MANAGED_DOMAIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANAGED_DOMAIN"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ImageUrl": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#ImportDataSource": {
+      "type": "structure",
+      "members": {
+        "S3Url": {
+          "target": "com.amazonaws.sesv2#S3Url",
+          "traits": {
+            "smithy.api#documentation": "<p>An Amazon S3 URL in the format\n                s3://<i><bucket_name></i>/<i><object></i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataFormat": {
+          "target": "com.amazonaws.sesv2#DataFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The data format of the import job's data source.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains details about the data source of the import job.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ImportDestination": {
+      "type": "structure",
+      "members": {
+        "SuppressionListDestination": {
+          "target": "com.amazonaws.sesv2#SuppressionListDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the action of the import job towards suppression list.</p>"
+          }
+        },
+        "ContactListDestination": {
+          "target": "com.amazonaws.sesv2#ContactListDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the action of the import job towards a contact list.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains details about the resource destination the import job is going\n            to target.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ImportDestinationType": {
+      "type": "enum",
+      "members": {
+        "SUPPRESSION_LIST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUPPRESSION_LIST"
+          }
+        },
+        "CONTACT_LIST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONTACT_LIST"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The destination of the import job, which can be used to list import jobs that have a\n            certain <code>ImportDestinationType</code>.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ImportJobSummary": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.sesv2#JobId"
+        },
+        "ImportDestination": {
+          "target": "com.amazonaws.sesv2#ImportDestination"
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.sesv2#JobStatus"
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the import job was created.</p>"
+          }
+        },
+        "ProcessedRecordsCount": {
+          "target": "com.amazonaws.sesv2#ProcessedRecordsCount",
+          "traits": {
+            "smithy.api#documentation": "<p>The current number of records processed.</p>"
+          }
+        },
+        "FailedRecordsCount": {
+          "target": "com.amazonaws.sesv2#FailedRecordsCount",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of records that failed processing because of invalid input or other\n            reasons.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A summary of the import job.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ImportJobSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#ImportJobSummary"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of the import job summaries.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#InboxPlacementTrackingOption": {
+      "type": "structure",
+      "members": {
+        "Global": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether inbox placement data is being tracked for the domain.</p>"
+          }
+        },
+        "TrackedIsps": {
+          "target": "com.amazonaws.sesv2#IspNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of strings, one for each major email provider that the inbox placement data\n            applies to.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about the inbox placement data settings for a\n            verified domain that\u2019s associated with your Amazon Web Services account. This data is available only\n            if you enabled the Deliverability dashboard for the domain.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#InsightsEmailAddress": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 320
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.sesv2#InsightsEvent": {
+      "type": "structure",
+      "members": {
+        "Timestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp of the event.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.sesv2#EventType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of event:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SEND</code> - The send request was successful and SES will\n                    attempt to deliver the message to the recipient\u2019s mail server. (If account-level\n                    or global suppression is being used, SES will still count it as a send,\n                    but delivery is suppressed.)\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY</code> - SES successfully delivered the email to the\n                    recipient's mail server. Excludes deliveries to the mailbox simulator,\n                    and those from emails addressed to more than one recipient.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>BOUNCE</code> - Feedback received for delivery failures. Additional details about the bounce are provided in the <code>Details</code> object.\n                    Excludes bounces from the mailbox simulator, and those from emails addressed to more than one recipient.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>COMPLAINT</code> - Complaint received for the email. Additional details about the complaint are provided in the <code>Details</code> object.\n                    This excludes complaints from the mailbox simulator, those originating from\n                    your account-level suppression list (if enabled), and those from emails addressed\n                    to more than one recipient.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>OPEN</code> - Open event for emails including open trackers.\n                    Excludes opens for emails addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CLICK</code> - Click event for emails including wrapped links.\n                    Excludes clicks for emails addressed to more than one recipient.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Details": {
+          "target": "com.amazonaws.sesv2#EventDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>Details about bounce or complaint events.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object containing details about a specific event.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#InsightsEvents": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#InsightsEvent"
+      }
+    },
+    "com.amazonaws.sesv2#InternalServiceErrorException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request couldn't be processed because an error occurred with the Amazon SES API v2.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.sesv2#InvalidNextTokenException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified request includes an invalid or expired token.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.sesv2#Ip": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>An IPv4 address.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#IpList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Ip"
+      }
+    },
+    "com.amazonaws.sesv2#Isp": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#IspFilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Isp"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.sesv2#IspName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of an email provider.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#IspNameList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#IspName"
+      }
+    },
+    "com.amazonaws.sesv2#IspPlacement": {
+      "type": "structure",
+      "members": {
+        "IspName": {
+          "target": "com.amazonaws.sesv2#IspName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the email provider that the inbox placement data applies to.</p>"
+          }
+        },
+        "PlacementStatistics": {
+          "target": "com.amazonaws.sesv2#PlacementStatistics",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains inbox placement metrics for a specific email provider.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that describes how email sent during the predictive inbox placement test was handled by a certain\n            email provider.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#IspPlacements": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#IspPlacement"
+      }
+    },
+    "com.amazonaws.sesv2#JobId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string that represents a job ID.</p>",
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.sesv2#JobStatus": {
+      "type": "enum",
+      "members": {
+        "CREATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATED"
+          }
+        },
+        "PROCESSING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PROCESSING"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "CANCELLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CANCELLED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status of a job.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATED</code> \u2013 Job has just been created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PROCESSING</code> \u2013 Job is processing.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ERROR</code> \u2013 An error occurred during processing.</p>\n            </li>\n            <li>\n               <p>\n                  <code>COMPLETED</code> \u2013 Job has completed processing successfully.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#KinesisFirehoseDestination": {
+      "type": "structure",
+      "members": {
+        "IamRoleArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that the Amazon SES API v2 uses to send email\n            events to the Amazon Kinesis Data Firehose stream.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DeliveryStreamArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Kinesis Data Firehose stream that the Amazon SES API v2 sends email\n            events to.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines an Amazon Kinesis Data Firehose destination for email events. You can use Amazon Kinesis Data Firehose to\n            stream data to other services, such as Amazon S3 and Amazon Redshift.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#LastDeliveryEventList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#DeliveryEventType"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.sesv2#LastEngagementEventList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#EngagementEventType"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.sesv2#LastFreshStart": {
+      "type": "timestamp",
+      "traits": {
+        "smithy.api#documentation": "<p>The date and time (in Unix time) when the reputation metrics were last given a fresh\n            start. When your account is given a fresh start, your reputation metrics are calculated\n            starting from the date of the fresh start.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#LimitExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>There are too many instances of the specified resource type.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.sesv2#ListConfigurationSets": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListConfigurationSetsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListConfigurationSetsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List all of the configuration sets associated with your account in the current\n            region.</p>\n         <p>\n            <i>Configuration sets</i> are groups of rules that you can apply to the\n            emails you send. You apply a configuration set to an email by including a reference to\n            the configuration set in the headers of the email. When you apply a configuration set to\n            an email, all of the rules in that configuration set are applied to the email.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/configuration-sets",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListConfigurationSetsRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListConfigurationSets</code> to\n            indicate the position in the list of configuration sets.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to <code>ListConfigurationSets</code>.\n            If the number of results is larger than the number you specified in this parameter, then\n            the response includes a <code>NextToken</code> element, which you can use to obtain\n            additional results.</p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to obtain a list of configuration sets for your Amazon SES account in the current\n            Amazon Web Services Region.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListConfigurationSetsResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSets": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that contains all of the configuration sets in your Amazon SES account in the\n            current Amazon Web Services Region.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that indicates that there are additional configuration sets to list. To view\n            additional configuration sets, issue another request to\n                <code>ListConfigurationSets</code>, and pass this token in the\n                <code>NextToken</code> parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of configuration sets in your Amazon SES account in the current Amazon Web Services Region.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListContactLists": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListContactListsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListContactListsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all of the contact lists available.</p>\n         <p>If your output includes a \"NextToken\" field with a string value, this indicates there may be additional\n            contacts on the filtered list - regardless of the number of contacts returned.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/contact-lists",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListContactListsRequest": {
+      "type": "structure",
+      "members": {
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>Maximum number of contact lists to return at once. Use this parameter to paginate\n            results. If additional contact lists exist beyond the specified limit, the\n                <code>NextToken</code> element is sent in the response. Use the\n                <code>NextToken</code> value in subsequent requests to retrieve additional\n            lists.</p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A string token indicating that there might be additional contact lists available to be\n            listed. Use the token provided in the Response to use in the subsequent call to\n            ListContactLists with the same parameters to retrieve the next page of contact\n            lists.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListContactListsResponse": {
+      "type": "structure",
+      "members": {
+        "ContactLists": {
+          "target": "com.amazonaws.sesv2#ListOfContactLists",
+          "traits": {
+            "smithy.api#documentation": "<p>The available contact lists.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A string token indicating that there might be additional contact lists available to be\n            listed. Copy this token to a subsequent call to <code>ListContactLists</code> with the\n            same parameters to retrieve the next page of contact lists.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListContacts": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListContactsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListContactsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the contacts present in a specific contact list.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/contact-lists/{ContactListName}/contacts/list",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListContactsFilter": {
+      "type": "structure",
+      "members": {
+        "FilteredStatus": {
+          "target": "com.amazonaws.sesv2#SubscriptionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status by which you are filtering: <code>OPT_IN</code> or\n            <code>OPT_OUT</code>.</p>"
+          }
+        },
+        "TopicFilter": {
+          "target": "com.amazonaws.sesv2#TopicFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Used for filtering by a specific topic preference.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A filter that can be applied to a list of contacts.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ListContactsRequest": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Filter": {
+          "target": "com.amazonaws.sesv2#ListContactsFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A filter that can be applied to a list of contacts.</p>"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of contacts that may be returned at once, which is dependent on if there\n            are more or less contacts than the value of the PageSize. Use this parameter to paginate\n            results. If additional contacts exist beyond the specified limit, the\n                <code>NextToken</code> element is sent in the response. Use the\n                <code>NextToken</code> value in subsequent requests to retrieve additional\n            contacts.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A string token indicating that there might be additional contacts available to be\n            listed. Use the token provided in the Response to use in the subsequent call to\n            ListContacts with the same parameters to retrieve the next page of contacts.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListContactsResponse": {
+      "type": "structure",
+      "members": {
+        "Contacts": {
+          "target": "com.amazonaws.sesv2#ListOfContacts",
+          "traits": {
+            "smithy.api#documentation": "<p>The contacts present in a specific contact list.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A string token indicating that there might be additional contacts available to be\n            listed. Copy this token to a subsequent call to <code>ListContacts</code> with the same\n            parameters to retrieve the next page of contacts.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListCustomVerificationEmailTemplates": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListCustomVerificationEmailTemplatesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListCustomVerificationEmailTemplatesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the existing custom verification email templates for your account in the current\n                Amazon Web Services Region.</p>\n         <p>For more information about custom verification email templates, see <a href=\"https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#send-email-verify-address-custom\">Using\n                custom verification email templates</a> in the <i>Amazon SES Developer\n                Guide</i>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/custom-verification-email-templates",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListCustomVerificationEmailTemplatesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to\n                <code>ListCustomVerificationEmailTemplates</code> to indicate the position in the\n            list of custom verification email templates.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to\n                <code>ListCustomVerificationEmailTemplates</code>. If the number of results is\n            larger than the number you specified in this parameter, then the response includes a\n                <code>NextToken</code> element, which you can use to obtain additional\n            results.</p>\n         <p>The value you specify has to be at least 1, and can be no more than 50.</p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to list the existing custom verification email templates for your\n            account.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListCustomVerificationEmailTemplatesResponse": {
+      "type": "structure",
+      "members": {
+        "CustomVerificationEmailTemplates": {
+          "target": "com.amazonaws.sesv2#CustomVerificationEmailTemplatesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the custom verification email templates that exist in your account.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token indicating that there are additional custom verification email templates\n            available to be listed. Pass this token to a subsequent call to\n                <code>ListCustomVerificationEmailTemplates</code> to retrieve the next 50 custom\n            verification email templates.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The following elements are returned by the service.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListDedicatedIpPools": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListDedicatedIpPoolsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListDedicatedIpPoolsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List all of the dedicated IP pools that exist in your Amazon Web Services account in the current\n            Region.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/dedicated-ip-pools",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListDedicatedIpPoolsRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListDedicatedIpPools</code> to indicate\n            the position in the list of dedicated IP pools.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to <code>ListDedicatedIpPools</code>.\n            If the number of results is larger than the number you specified in this parameter, then\n            the response includes a <code>NextToken</code> element, which you can use to obtain\n            additional results.</p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to obtain a list of dedicated IP pools.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListDedicatedIpPoolsResponse": {
+      "type": "structure",
+      "members": {
+        "DedicatedIpPools": {
+          "target": "com.amazonaws.sesv2#ListOfDedicatedIpPools",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of all of the dedicated IP pools that are associated with your Amazon Web Services account in\n            the current Region.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that indicates that there are additional IP pools to list. To view additional\n            IP pools, issue another request to <code>ListDedicatedIpPools</code>, passing this token\n            in the <code>NextToken</code> parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of dedicated IP pools.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListDeliverabilityTestReports": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListDeliverabilityTestReportsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListDeliverabilityTestReportsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Show a list of the predictive inbox placement tests that you've performed, regardless of their statuses. For\n            predictive inbox placement tests that are complete, you can use the <code>GetDeliverabilityTestReport</code>\n            operation to view the results.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/deliverability-dashboard/test-reports",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListDeliverabilityTestReportsRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListDeliverabilityTestReports</code> to\n            indicate the position in the list of predictive inbox placement tests.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to\n                <code>ListDeliverabilityTestReports</code>. If the number of results is larger than\n            the number you specified in this parameter, then the response includes a\n                <code>NextToken</code> element, which you can use to obtain additional\n            results.</p>\n         <p>The value you specify has to be at least 0, and can be no more than 1000.</p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to list all of the predictive inbox placement tests that you've performed.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListDeliverabilityTestReportsResponse": {
+      "type": "structure",
+      "members": {
+        "DeliverabilityTestReports": {
+          "target": "com.amazonaws.sesv2#DeliverabilityTestReports",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains a lists of predictive inbox placement tests that you've performed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that indicates that there are additional predictive inbox placement tests to list. To view additional\n            predictive inbox placement tests, issue another request to <code>ListDeliverabilityTestReports</code>, and pass\n            this token in the <code>NextToken</code> parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of the predictive inbox placement test reports that are available for your account, regardless of\n            whether or not those tests are complete.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListDomainDeliverabilityCampaigns": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListDomainDeliverabilityCampaignsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListDomainDeliverabilityCampaignsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve deliverability data for all the campaigns that used a specific domain to send\n            email during a specified time range. This data is available for a domain only if you\n            enabled the Deliverability dashboard for the domain.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/deliverability-dashboard/domains/{SubscribedDomain}/campaigns",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListDomainDeliverabilityCampaignsRequest": {
+      "type": "structure",
+      "members": {
+        "StartDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The first day that you want to obtain deliverability data\n            for.</p>",
+            "smithy.api#httpQuery": "StartDate",
+            "smithy.api#required": {}
+          }
+        },
+        "EndDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The last day that you want to obtain deliverability data for.\n            This value has to be less than or equal to 30 days after the value of the\n                <code>StartDate</code> parameter.</p>",
+            "smithy.api#httpQuery": "EndDate",
+            "smithy.api#required": {}
+          }
+        },
+        "SubscribedDomain": {
+          "target": "com.amazonaws.sesv2#Domain",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain to obtain deliverability data for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that\u2019s returned from a previous call to the\n                <code>ListDomainDeliverabilityCampaigns</code> operation. This token indicates the\n            position of a campaign in the list of campaigns.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to include in response to a single call to the\n                <code>ListDomainDeliverabilityCampaigns</code> operation. If the number of results\n            is larger than the number that you specify in this parameter, the response includes a\n                <code>NextToken</code> element, which you can use to obtain additional\n            results.</p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve deliverability data for all the campaigns that used a specific domain to send\n            email during a specified time range. This data is available for a domain only if you\n            enabled the Deliverability dashboard.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListDomainDeliverabilityCampaignsResponse": {
+      "type": "structure",
+      "members": {
+        "DomainDeliverabilityCampaigns": {
+          "target": "com.amazonaws.sesv2#DomainDeliverabilityCampaignList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of responses, one for each campaign that used the domain to send email during\n            the specified time range.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that\u2019s returned from a previous call to the\n                <code>ListDomainDeliverabilityCampaigns</code> operation. This token indicates the\n            position of the campaign in the list of campaigns.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An array of objects that provide deliverability data for all the campaigns that used a\n            specific domain to send email during a specified time range. This data is available for\n            a domain only if you enabled the Deliverability dashboard for the domain.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListEmailIdentities": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListEmailIdentitiesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListEmailIdentitiesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of all of the email identities that are associated with your Amazon Web Services\n            account. An identity can be either an email address or a domain. This operation returns\n            identities that are verified as well as those that aren't. This operation returns\n            identities that are associated with Amazon SES and Amazon Pinpoint.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/identities",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListEmailIdentitiesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListEmailIdentities</code> to indicate\n            the position in the list of identities.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to <code>ListEmailIdentities</code>. If\n            the number of results is larger than the number you specified in this parameter, then\n            the response includes a <code>NextToken</code> element, which you can use to obtain\n            additional results.</p>\n         <p>The value you specify has to be at least 0, and can be no more than 1000.</p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to list all of the email identities associated with your Amazon Web Services account. This\n            list includes identities that you've already verified, identities that are unverified,\n            and identities that were verified in the past, but are no longer verified.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListEmailIdentitiesResponse": {
+      "type": "structure",
+      "members": {
+        "EmailIdentities": {
+          "target": "com.amazonaws.sesv2#IdentityInfoList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that includes all of the email identities associated with your Amazon Web Services\n            account.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that indicates that there are additional configuration sets to list. To view\n            additional configuration sets, issue another request to\n            <code>ListEmailIdentities</code>, and pass this token in the <code>NextToken</code>\n            parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of all of the identities that you've attempted to verify, regardless of whether\n            or not those identities were successfully verified.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListEmailTemplates": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListEmailTemplatesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListEmailTemplatesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the email templates present in your Amazon SES account in the current Amazon Web Services\n            Region.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/templates",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListEmailTemplatesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListEmailTemplates</code> to indicate\n            the position in the list of email templates.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to <code>ListEmailTemplates</code>. If the number of\n            results is larger than the number you specified in this parameter, then the response\n            includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>\n         <p>The value you specify has to be at least 1, and can be no more than 100.</p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to list the email templates present in your Amazon SES account in the\n            current Amazon Web Services Region. For more information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\">Amazon SES Developer\n                Guide</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListEmailTemplatesResponse": {
+      "type": "structure",
+      "members": {
+        "TemplatesMetadata": {
+          "target": "com.amazonaws.sesv2#EmailTemplateMetadataList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array the contains the name and creation time stamp for each template in your Amazon SES\n            account.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token indicating that there are additional email templates available to be listed.\n            Pass this token to a subsequent <code>ListEmailTemplates</code> call to retrieve the\n            next 10 email templates.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The following elements are returned by the service.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListExportJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListExportJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListExportJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all of the export jobs.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/list-export-jobs",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListExportJobsRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token returned from a previous call to <code>ListExportJobs</code> to\n            indicate the position in the list of export jobs.</p>"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>Maximum number of export jobs to return at once. Use this parameter to paginate\n            results. If additional export jobs exist beyond the specified limit, the\n            <code>NextToken</code> element is sent in the response. Use the\n            <code>NextToken</code> value in subsequent calls to <code>ListExportJobs</code> to\n            retrieve additional export jobs.</p>"
+          }
+        },
+        "ExportSourceType": {
+          "target": "com.amazonaws.sesv2#ExportSourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>A value used to list export jobs that have a certain\n            <code>ExportSourceType</code>.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.sesv2#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>A value used to list export jobs that have a certain <code>JobStatus</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to list all export jobs with filters.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListExportJobsResponse": {
+      "type": "structure",
+      "members": {
+        "ExportJobs": {
+          "target": "com.amazonaws.sesv2#ExportJobSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the export job summaries.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A string token indicating that there might be additional export jobs available to be\n            listed. Use this token to a subsequent call to <code>ListExportJobs</code> with the same\n            parameters to retrieve the next page of export jobs.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListImportJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListImportJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListImportJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all of the import jobs.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/import-jobs/list",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListImportJobsRequest": {
+      "type": "structure",
+      "members": {
+        "ImportDestinationType": {
+          "target": "com.amazonaws.sesv2#ImportDestinationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The destination of the import job, which can be used to list import jobs that have a\n            certain <code>ImportDestinationType</code>.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A string token indicating that there might be additional import jobs available to be\n            listed. Copy this token to a subsequent call to <code>ListImportJobs</code> with the\n            same parameters to retrieve the next page of import jobs.</p>"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>Maximum number of import jobs to return at once. Use this parameter to paginate\n            results. If additional import jobs exist beyond the specified limit, the\n                <code>NextToken</code> element is sent in the response. Use the\n                <code>NextToken</code> value in subsequent requests to retrieve additional\n            addresses.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to list all of the import jobs for a data destination within the\n            specified maximum number of import jobs.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListImportJobsResponse": {
+      "type": "structure",
+      "members": {
+        "ImportJobs": {
+          "target": "com.amazonaws.sesv2#ImportJobSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the import job summaries.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A string token indicating that there might be additional import jobs available to be\n            listed. Copy this token to a subsequent call to <code>ListImportJobs</code> with the\n            same parameters to retrieve the next page of import jobs.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListManagementOptions": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TopicName": {
+          "target": "com.amazonaws.sesv2#TopicName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the topic.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object used to specify a list or topic to which an email belongs, which will be\n            used when a contact chooses to unsubscribe.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ListMultiRegionEndpoints": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListMultiRegionEndpointsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListMultiRegionEndpointsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List the multi-region endpoints (global-endpoints).</p>\n         <p>Only multi-region endpoints (global-endpoints) whose primary region is the AWS-Region\n            where operation is executed will be listed.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/multi-region-endpoints",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "MultiRegionEndpoints",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListMultiRegionEndpointsRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextTokenV2",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListMultiRegionEndpoints</code> to indicate\n            the position in the list of multi-region endpoints (global-endpoints).</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#PageSizeV2",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to <code>ListMultiRegionEndpoints</code>.\n            If the number of results is larger than the number you specified in this parameter,\n            the response includes a <code>NextToken</code> element\n            that you can use to retrieve the next page of results.\n        </p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to list all the multi-region endpoints (global-endpoints)\n            whose primary region is the AWS-Region where operation is executed.\n        </p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListMultiRegionEndpointsResponse": {
+      "type": "structure",
+      "members": {
+        "MultiRegionEndpoints": {
+          "target": "com.amazonaws.sesv2#MultiRegionEndpoints",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that contains key multi-region endpoint (global-endpoint) properties.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextTokenV2",
+          "traits": {
+            "smithy.api#documentation": "<p>A token indicating that there are additional multi-region endpoints (global-endpoints) available to be listed.\n            Pass this token to a subsequent <code>ListMultiRegionEndpoints</code> call to retrieve the\n            next page.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The following elements are returned by the service.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListOfContactLists": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#ContactList"
+      }
+    },
+    "com.amazonaws.sesv2#ListOfContacts": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Contact"
+      }
+    },
+    "com.amazonaws.sesv2#ListOfDedicatedIpPools": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#PoolName"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of dedicated IP pools that are associated with your Amazon Web Services account.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ListRecommendationFilterValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListRecommendations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListRecommendationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListRecommendationsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the recommendations present in your Amazon SES account in the current Amazon Web Services Region.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/vdm/recommendations",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListRecommendationsFilter": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.sesv2#ListRecommendationsFilterKey"
+      },
+      "value": {
+        "target": "com.amazonaws.sesv2#ListRecommendationFilterValue"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains mapping between <code>ListRecommendationsFilterKey</code>\n            and <code>ListRecommendationFilterValue</code> to filter by.</p>",
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListRecommendationsFilterKey": {
+      "type": "enum",
+      "members": {
+        "TYPE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TYPE"
+          }
+        },
+        "IMPACT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IMPACT"
+          }
+        },
+        "STATUS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STATUS"
+          }
+        },
+        "RESOURCE_ARN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RESOURCE_ARN"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The <code>ListRecommendations</code> filter type. This can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TYPE</code> \u2013 The recommendation type, with values like <code>DKIM</code>,\n                    <code>SPF</code>, <code>DMARC</code>, <code>BIMI</code>, or <code>COMPLAINT</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>IMPACT</code> \u2013 The recommendation impact, with values like\n                    <code>HIGH</code> or <code>LOW</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STATUS</code> \u2013 The recommendation status, with values like\n                    <code>OPEN</code> or <code>FIXED</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RESOURCE_ARN</code> \u2013 The resource affected by the recommendation,\n                    with values like <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#ListRecommendationsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.sesv2#ListRecommendationsFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters applied when retrieving recommendations. Can eiter be an individual filter, or\n              combinations of <code>STATUS</code> and <code>IMPACT</code> or\n              <code>STATUS</code> and <code>TYPE</code>\n         </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListRecommendations</code> to\n            indicate the position in the list of recommendations.</p>"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to\n            <code>ListRecommendations</code>. If the number of results is larger than\n            the number you specified in this parameter, then the response includes a\n            <code>NextToken</code> element, which you can use to obtain additional\n            results.</p>\n         <p>The value you specify has to be at least 1, and can be no more than 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to list the existing recommendations for your account.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListRecommendationsResponse": {
+      "type": "structure",
+      "members": {
+        "Recommendations": {
+          "target": "com.amazonaws.sesv2#RecommendationsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The recommendations applicable to your account.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A string token indicating that there might be additional recommendations available to be\n            listed. Use the token provided in the <code>ListRecommendationsResponse</code> to use in the\n            subsequent call to <code>ListRecommendations</code> with the same parameters to retrieve the\n            next page of recommendations.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the response to your request to retrieve the list of recommendations for your account.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListReputationEntities": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListReputationEntitiesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListReputationEntitiesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List reputation entities in your Amazon SES account in the current Amazon Web Services Region. \n            You can filter the results by entity type, reputation impact, sending status, \n            or entity reference prefix.</p>\n         <p>\n            <i>Reputation entities</i> represent resources in your account that have reputation \n            tracking and management capabilities. Use this operation to get an overview of \n            all entities and their current reputation status.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/reputation/entities",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ReputationEntities",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListReputationEntitiesRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.sesv2#ReputationEntityFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains filters to apply when listing reputation entities. \n            You can filter by entity type, reputation impact, sending status, or entity \n            reference prefix.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListReputationEntities</code> to indicate \n            the position in the list of reputation entities.</p>"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to <code>ListReputationEntities</code>. \n            If the number of results is larger than the number you specified in this parameter, \n            then the response includes a <code>NextToken</code> element, which you can use to obtain \n            additional results.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to list reputation entities with optional filtering.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListReputationEntitiesResponse": {
+      "type": "structure",
+      "members": {
+        "ReputationEntities": {
+          "target": "com.amazonaws.sesv2#ReputationEntitiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that contains information about the reputation entities in your account.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that indicates that there are additional reputation entities to list. \n            To view additional reputation entities, issue another request to <code>ListReputationEntities</code>, \n            and pass this token in the <code>NextToken</code> parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of reputation entities in your account.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListResourceTenants": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListResourceTenantsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListResourceTenantsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List all tenants associated with a specific resource.</p>\n         <p>This operation returns a list of tenants that are associated with the specified\n            resource. This is useful for understanding which tenants are currently using a particular\n            resource such as an email identity, configuration set, or email template.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/resources/tenants/list",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ResourceTenants",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListResourceTenantsRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource to list associated tenants for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to <code>ListResourceTenants</code>.\n            If the number of results is larger than the number you specified in this parameter,\n            then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListResourceTenants</code> to indicate the position in the list of resource tenants.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to list tenants associated with a specific resource.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListResourceTenantsResponse": {
+      "type": "structure",
+      "members": {
+        "ResourceTenants": {
+          "target": "com.amazonaws.sesv2#ResourceTenantMetadataList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that contains information about each tenant associated with the resource.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that indicates that there are additional tenants to list. To view additional tenants,\n            issue another request to <code>ListResourceTenants</code>, and pass this token in the <code>NextToken</code> parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about tenants associated with a specific resource.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListSuppressedDestinations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListSuppressedDestinationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListSuppressedDestinationsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieves a list of email addresses that are on the suppression list for your\n            account.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/suppression/addresses",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListSuppressedDestinationsRequest": {
+      "type": "structure",
+      "members": {
+        "Reasons": {
+          "target": "com.amazonaws.sesv2#SuppressionListReasons",
+          "traits": {
+            "smithy.api#documentation": "<p>The factors that caused the email address to be added to .</p>",
+            "smithy.api#httpQuery": "Reason"
+          }
+        },
+        "StartDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Used to filter the list of suppressed email destinations so that it only includes\n            addresses that were added to the list after a specific date.</p>",
+            "smithy.api#httpQuery": "StartDate"
+          }
+        },
+        "EndDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Used to filter the list of suppressed email destinations so that it only includes\n            addresses that were added to the list before a specific date.</p>",
+            "smithy.api#httpQuery": "EndDate"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListSuppressedDestinations</code> to\n            indicate the position in the list of suppressed email addresses.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to\n                <code>ListSuppressedDestinations</code>. If the number of results is larger than the\n            number you specified in this parameter, then the response includes a\n                <code>NextToken</code> element, which you can use to obtain additional\n            results.</p>",
+            "smithy.api#httpQuery": "PageSize"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to obtain a list of email destinations that are on the suppression list for\n            your account.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListSuppressedDestinationsResponse": {
+      "type": "structure",
+      "members": {
+        "SuppressedDestinationSummaries": {
+          "target": "com.amazonaws.sesv2#SuppressedDestinationSummaries",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of summaries, each containing a summary for a suppressed email\n            destination.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that indicates that there are additional email addresses on the suppression\n            list for your account. To view additional suppressed addresses, issue another request to\n                <code>ListSuppressedDestinations</code>, and pass this token in the\n                <code>NextToken</code> parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of suppressed email addresses.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve a list of the tags (keys and values) that are associated with a specified\n            resource. A\u00a0<i>tag</i>\u00a0is a label that you optionally define and associate\n            with a resource. Each tag consists of a required\u00a0<i>tag key</i>\u00a0and an\n            optional associated\u00a0<i>tag value</i>. A tag key is a general label that\n            acts as a category for more specific tag values. A tag value acts as a descriptor within\n            a tag key.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/email/tags",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource that you want to retrieve tag\n            information for.</p>",
+            "smithy.api#httpQuery": "ResourceArn",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that lists all the tags that are associated with the resource. Each tag\n            consists of a required tag key (<code>Key</code>) and an associated tag value\n                (<code>Value</code>)</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListTenantResources": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListTenantResourcesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListTenantResourcesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List all resources associated with a specific tenant.</p>\n         <p>This operation returns a list of resources (email identities, configuration sets,\n            or email templates) that are associated with the specified tenant. You can optionally\n            filter the results by resource type.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/tenants/resources/list",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "TenantResources",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListTenantResourcesFilter": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.sesv2#ListTenantResourcesFilterKey"
+      },
+      "value": {
+        "target": "com.amazonaws.sesv2#ListTenantResourcesFilterValue"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains mapping between <code>ListTenantResourcesFilterKey</code>\n            and <code>ListTenantResourcesFilterValue</code> to filter by.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ListTenantResourcesFilterKey": {
+      "type": "enum",
+      "members": {
+        "RESOURCE_TYPE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RESOURCE_TYPE"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The key used to filter tenant resources. Currently, the only supported filter key is <code>RESOURCE_TYPE</code>.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ListTenantResourcesFilterValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The value used to filter tenant resources. When filtering by <code>RESOURCE_TYPE</code>,\n            valid values are <code>EMAIL_IDENTITY</code>, <code>CONFIGURATION_SET</code>, or <code>EMAIL_TEMPLATE</code>.</p>",
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListTenantResourcesRequest": {
+      "type": "structure",
+      "members": {
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant to list resources for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filter": {
+          "target": "com.amazonaws.sesv2#ListTenantResourcesFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A map of filter keys and values for filtering the list of tenant resources. Currently,\n            the only supported filter key is <code>RESOURCE_TYPE</code>.</p>"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to <code>ListTenantResources</code>.\n            If the number of results is larger than the number you specified in this parameter,\n            then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListTenantResources</code> to indicate the position in the list of tenant resources.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to list resources associated with a specific tenant.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListTenantResourcesResponse": {
+      "type": "structure",
+      "members": {
+        "TenantResources": {
+          "target": "com.amazonaws.sesv2#TenantResourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that contains information about each resource associated with the tenant.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that indicates that there are additional resources to list. To view additional resources,\n            issue another request to <code>ListTenantResources</code>, and pass this token in the <code>NextToken</code> parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about resources associated with a specific tenant.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListTenants": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#ListTenantsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#ListTenantsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List all tenants associated with your account in the current Amazon Web Services Region.</p>\n         <p>This operation returns basic information about each tenant,\n            such as tenant name, ID, ARN, and creation timestamp.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/tenants/list",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "Tenants",
+          "pageSize": "PageSize"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ListTenantsRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token returned from a previous call to <code>ListTenants</code> to indicate the position in the list of tenants.</p>"
+          }
+        },
+        "PageSize": {
+          "target": "com.amazonaws.sesv2#MaxItems",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of results to show in a single call to <code>ListTenants</code>.\n            If the number of results is larger than the number you specified in this parameter,\n            then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to list all tenants associated with your account in the current Amazon Web Services Region.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#ListTenantsResponse": {
+      "type": "structure",
+      "members": {
+        "Tenants": {
+          "target": "com.amazonaws.sesv2#TenantInfoList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that contains basic information about each tenant.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.sesv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token that indicates that there are additional tenants to list. To view additional tenants,\n            issue another request to <code>ListTenants</code>, and pass this token in the <code>NextToken</code> parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about tenants associated with your account.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#MailFromAttributes": {
+      "type": "structure",
+      "members": {
+        "MailFromDomain": {
+          "target": "com.amazonaws.sesv2#MailFromDomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a domain that an email identity uses as a custom MAIL FROM domain.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MailFromDomainStatus": {
+          "target": "com.amazonaws.sesv2#MailFromDomainStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the MAIL FROM domain. This status can have the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PENDING</code> \u2013 Amazon SES hasn't started searching for the MX record\n                    yet.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUCCESS</code> \u2013 Amazon SES detected the required MX record for the\n                    MAIL FROM domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 Amazon SES can't find the required MX record, or the\n                    record no longer exists.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TEMPORARY_FAILURE</code> \u2013 A temporary issue occurred, which\n                    prevented Amazon SES from determining the status of the MAIL FROM domain.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "BehaviorOnMxFailure": {
+          "target": "com.amazonaws.sesv2#BehaviorOnMxFailure",
+          "traits": {
+            "smithy.api#documentation": "<p>The action to take if the required MX record can't be found when you send an email.\n            When you set this value to <code>USE_DEFAULT_VALUE</code>, the mail is sent using\n                <i>amazonses.com</i> as the MAIL FROM domain. When you set this value\n            to <code>REJECT_MESSAGE</code>, the Amazon SES API v2 returns a\n                <code>MailFromDomainNotVerified</code> error, and doesn't attempt to deliver the\n            email.</p>\n         <p>These behaviors are taken when the custom MAIL FROM domain configuration is in the\n                <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code>\n            states.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of attributes that are associated with a MAIL FROM domain.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MailFromDomainName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The domain to use as a MAIL FROM domain.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MailFromDomainNotVerifiedException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The message can't be sent because the sending domain isn't verified.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.sesv2#MailFromDomainStatus": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "SUCCESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCESS"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "TEMPORARY_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEMPORARY_FAILURE"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status of the MAIL FROM domain. This status can have the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PENDING</code> \u2013 Amazon SES hasn't started searching for the MX record\n                    yet.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUCCESS</code> \u2013 Amazon SES detected the required MX record for the\n                    MAIL FROM domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 Amazon SES can't find the required MX record, or the\n                    record no longer exists.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TEMPORARY_FAILURE</code> \u2013 A temporary issue occurred, which\n                    prevented Amazon SES from determining the status of the MAIL FROM domain.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#MailType": {
+      "type": "enum",
+      "members": {
+        "MARKETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MARKETING"
+          }
+        },
+        "TRANSACTIONAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRANSACTIONAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#MailboxValidation": {
+      "type": "structure",
+      "members": {
+        "IsValid": {
+          "target": "com.amazonaws.sesv2#EmailAddressInsightsVerdict",
+          "traits": {
+            "smithy.api#documentation": "<p>Overall validity assessment with a con\ufb01dence verdict.</p>"
+          }
+        },
+        "Evaluations": {
+          "target": "com.amazonaws.sesv2#EmailAddressInsightsMailboxEvaluations",
+          "traits": {
+            "smithy.api#documentation": "<p>Specific validation checks performed on the email address.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains detailed validation information about an email address.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Max24HourSend": {
+      "type": "double",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.sesv2#MaxDeliverySeconds": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 300,
+          "max": 50400
+        }
+      }
+    },
+    "com.amazonaws.sesv2#MaxItems": {
+      "type": "integer"
+    },
+    "com.amazonaws.sesv2#MaxSendRate": {
+      "type": "double",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.sesv2#Message": {
+      "type": "structure",
+      "members": {
+        "Subject": {
+          "target": "com.amazonaws.sesv2#Content",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line of the email. The subject line can only contain 7-bit ASCII\n            characters. However, you can specify non-ASCII characters in the subject line by using\n            encoded-word syntax, as described in <a href=\"https://tools.ietf.org/html/rfc2047\">RFC 2047</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Body": {
+          "target": "com.amazonaws.sesv2#Body",
+          "traits": {
+            "smithy.api#documentation": "<p>The body of the message. You can specify an HTML version of the message, a text-only\n            version of the message, or both.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Headers": {
+          "target": "com.amazonaws.sesv2#MessageHeaderList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of message headers that will be added to the email message.</p>"
+          }
+        },
+        "Attachments": {
+          "target": "com.amazonaws.sesv2#AttachmentList",
+          "traits": {
+            "smithy.api#documentation": "<p> The List of attachments to include in your email. All recipients will receive the same attachments.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents the email message that you're sending. The <code>Message</code> object\n            consists of a subject line and a message body.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MessageContent": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The body of an email message.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MessageData": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#MessageHeader": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.sesv2#MessageHeaderName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the message header. The message header name has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>Can contain any printable ASCII character (33 - 126) except for colon (:).</p>\n            </li>\n            <li>\n               <p>Can contain no more than 126 characters.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.sesv2#MessageHeaderValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the message header. The message header value has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>Can contain any printable ASCII character.</p>\n            </li>\n            <li>\n               <p>Can contain no more than 995 characters.</p>\n            </li>\n            <li>\n               <p>The combined length of the header name and value must not exceed 996 characters.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the name and value of a message header that you add to an email.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MessageHeaderList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#MessageHeader"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of message headers. The list of message headers has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>Can contain no more than 15 headers in one message.</p>\n            </li>\n         </ul>",
+        "smithy.api#length": {
+          "min": 0,
+          "max": 15
+        }
+      }
+    },
+    "com.amazonaws.sesv2#MessageHeaderName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of the message header. The message header name has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>Can contain any printable ASCII character (33 - 126) except for colon (:).</p>\n            </li>\n            <li>\n               <p>Can contain no more than 126 characters.</p>\n            </li>\n         </ul>",
+        "smithy.api#length": {
+          "min": 1,
+          "max": 126
+        },
+        "smithy.api#pattern": "^[!-9;-@A-~]+$"
+      }
+    },
+    "com.amazonaws.sesv2#MessageHeaderValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The value of the message header. The message header value has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>Can contain any printable ASCII character.</p>\n            </li>\n         </ul>",
+        "smithy.api#length": {
+          "min": 1,
+          "max": 995
+        },
+        "smithy.api#pattern": "^[ -~]*$"
+      }
+    },
+    "com.amazonaws.sesv2#MessageInsightsDataSource": {
+      "type": "structure",
+      "members": {
+        "StartDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the start date for the export interval as a timestamp. The start date is inclusive.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EndDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the end date for the export interval as a timestamp. The end date is inclusive.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Include": {
+          "target": "com.amazonaws.sesv2#MessageInsightsFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters for results to be included in the export file.</p>"
+          }
+        },
+        "Exclude": {
+          "target": "com.amazonaws.sesv2#MessageInsightsFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters for results to be excluded from the export file.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.sesv2#MessageInsightsExportMaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains filters applied when performing the Message Insights export.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MessageInsightsExportMaxResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 10000
+        }
+      }
+    },
+    "com.amazonaws.sesv2#MessageInsightsFilters": {
+      "type": "structure",
+      "members": {
+        "FromEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddressFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The from address used to send the message.</p>"
+          }
+        },
+        "Destination": {
+          "target": "com.amazonaws.sesv2#EmailAddressFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The recipient's email address.</p>"
+          }
+        },
+        "Subject": {
+          "target": "com.amazonaws.sesv2#EmailSubjectFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line of the message.</p>"
+          }
+        },
+        "Isp": {
+          "target": "com.amazonaws.sesv2#IspFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The recipient's ISP (e.g., <code>Gmail</code>, <code>Yahoo</code>,\n            etc.).</p>"
+          }
+        },
+        "LastDeliveryEvent": {
+          "target": "com.amazonaws.sesv2#LastDeliveryEventList",
+          "traits": {
+            "smithy.api#documentation": "<p>\n            The last delivery-related event for the email, where the ordering is as follows:\n            <code>SEND</code> < <code>BOUNCE</code> < <code>DELIVERY</code> < <code>COMPLAINT</code>.\n        </p>"
+          }
+        },
+        "LastEngagementEvent": {
+          "target": "com.amazonaws.sesv2#LastEngagementEventList",
+          "traits": {
+            "smithy.api#documentation": "<p>\n            The last engagement-related event for the email, where the ordering is as follows:\n            <code>OPEN</code> < <code>CLICK</code>.\n        </p>\n         <p>\n            Engagement events are only available if <a href=\"https://docs.aws.amazon.com/ses/latest/dg/vdm-settings.html\">Engagement tracking</a>\n            is enabled.\n        </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object containing Message Insights filters.</p>\n         <p>If you specify multiple filters, the filters are joined by AND.</p>\n         <p>If you specify multiple values for a filter, the values are joined by OR. Filter values are case-sensitive.</p>\n         <p>\n            <code>FromEmailAddress</code>, <code>Destination</code>, and <code>Subject</code> filters support partial match.\n            A partial match is performed by using the <code>*</code> wildcard character placed at the beginning (suffix match), the end (prefix match)\n            or both ends of the string (contains match).\n            In order to match the literal characters <code>*</code> or <code>\\</code>, they must be escaped using the <code>\\</code> character.\n            If no wildcard character is present, an exact match is performed.\n        </p>"
+      }
+    },
+    "com.amazonaws.sesv2#MessageRejected": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The message can't be sent because it contains invalid content.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.sesv2#MessageTag": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.sesv2#MessageTagName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the message tag. The message tag name has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>It can only contain ASCII letters (a\u2013z, A\u2013Z), numbers (0\u20139),\n                    underscores (_), or dashes (-).</p>\n            </li>\n            <li>\n               <p>It can contain no more than 256 characters.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.sesv2#MessageTagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the message tag. The message tag value has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>It can only contain ASCII letters (a\u2013z, A\u2013Z), numbers (0\u20139),\n                    underscores (_), or dashes (-).</p>\n            </li>\n            <li>\n               <p>It can contain no more than 256 characters.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the name and value of a tag that you apply to an email. You can use message\n            tags when you publish email sending events.\n            </p>"
+      }
+    },
+    "com.amazonaws.sesv2#MessageTagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#MessageTag"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of message tags.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MessageTagName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of the message tag. The message tag name has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>It can only contain ASCII letters (a\u2013z, A\u2013Z), numbers (0\u20139),\n                    underscores (_), or dashes (-).</p>\n            </li>\n            <li>\n               <p>It can contain no more than 256 characters.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#MessageTagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The value of the message tag. The message tag value has to meet the following\n            criteria:</p>\n         <ul>\n            <li>\n               <p>It can only contain ASCII letters (a\u2013z, A\u2013Z), numbers (0\u20139),\n                    underscores (_), or dashes (-).</p>\n            </li>\n            <li>\n               <p>It can contain no more than 256 characters.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#Metric": {
+      "type": "enum",
+      "members": {
+        "SEND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SEND"
+          }
+        },
+        "COMPLAINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLAINT"
+          }
+        },
+        "PERMANENT_BOUNCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERMANENT_BOUNCE"
+          }
+        },
+        "TRANSIENT_BOUNCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRANSIENT_BOUNCE"
+          }
+        },
+        "OPEN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPEN"
+          }
+        },
+        "CLICK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLICK"
+          }
+        },
+        "DELIVERY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELIVERY"
+          }
+        },
+        "DELIVERY_OPEN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELIVERY_OPEN"
+          }
+        },
+        "DELIVERY_CLICK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELIVERY_CLICK"
+          }
+        },
+        "DELIVERY_COMPLAINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELIVERY_COMPLAINT"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The metric to export, can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SEND</code> - Emails sent eligible for tracking in the VDM\n                    dashboard. This excludes emails sent to the mailbox simulator and emails\n                    addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>COMPLAINT</code> - Complaints received for your account. This\n                    excludes complaints from the mailbox simulator, those originating from your\n                    account-level suppression list (if enabled), and those for emails addressed to\n                    more than one recipient</p>\n            </li>\n            <li>\n               <p>\n                  <code>PERMANENT_BOUNCE</code> - Permanent bounces - i.e., feedback\n                    received for emails sent to non-existent mailboxes. Excludes bounces from the\n                    mailbox simulator, those originating from your account-level suppression list\n                    (if enabled), and those for emails addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TRANSIENT_BOUNCE</code> - Transient bounces - i.e., feedback\n                    received for delivery failures excluding issues with non-existent mailboxes.\n                    Excludes bounces from the mailbox simulator, and those for emails addressed to\n                    more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OPEN</code> - Unique open events for emails including open\n                    trackers. Excludes opens for emails addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CLICK</code> - Unique click events for emails including wrapped\n                    links. Excludes clicks for emails addressed to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY</code> - Successful deliveries for email sending\n                    attempts. Excludes deliveries to the mailbox simulator and for emails addressed\n                    to more than one recipient.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY_OPEN</code> - Successful deliveries for email sending\n                    attempts. Excludes deliveries to the mailbox simulator, for emails addressed to\n                    more than one recipient, and emails without open trackers.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY_CLICK</code> - Successful deliveries for email sending\n                    attempts. Excludes deliveries to the mailbox simulator, for emails addressed to\n                    more than one recipient, and emails without click trackers.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELIVERY_COMPLAINT</code> - Successful deliveries for email\n                    sending attempts. Excludes deliveries to the mailbox simulator, for emails\n                    addressed to more than one recipient, and emails addressed to recipients hosted\n                    by ISPs with which Amazon SES does not have a feedback loop agreement.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#MetricAggregation": {
+      "type": "enum",
+      "members": {
+        "RATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RATE"
+          }
+        },
+        "VOLUME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VOLUME"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregation to apply to a metric, can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>VOLUME</code> - The volume of events for this metric.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RATE</code> - The rate for this metric relative to the\n                    <code>SEND</code> metric volume.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#MetricDataError": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.sesv2#QueryIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The query identifier.</p>"
+          }
+        },
+        "Code": {
+          "target": "com.amazonaws.sesv2#QueryErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The query error code. Can be one of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>INTERNAL_FAILURE</code> \u2013 Amazon SES has failed to process one of the queries.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACCESS_DENIED</code> \u2013 You have insufficient access to retrieve metrics\n                    based on the given query.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.sesv2#QueryErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The error message associated with the current query error.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An error corresponding to the unsuccessful processing of a single metric data query.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MetricDataErrorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#MetricDataError"
+      }
+    },
+    "com.amazonaws.sesv2#MetricDataResult": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.sesv2#QueryIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The query identifier.</p>"
+          }
+        },
+        "Timestamps": {
+          "target": "com.amazonaws.sesv2#TimestampList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of timestamps for the metric data results.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.sesv2#MetricValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of values (cumulative / sum) for the metric data results.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The result of a single metric data query.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MetricDataResultList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#MetricDataResult"
+      }
+    },
+    "com.amazonaws.sesv2#MetricDimensionName": {
+      "type": "enum",
+      "members": {
+        "EMAIL_IDENTITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMAIL_IDENTITY"
+          }
+        },
+        "CONFIGURATION_SET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONFIGURATION_SET"
+          }
+        },
+        "ISP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ISP"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The <code>BatchGetMetricDataQuery</code> dimension name. This can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>EMAIL_IDENTITY</code> \u2013 The email identity used when sending messages.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CONFIGURATION_SET</code> \u2013 The configuration set used when sending messages\n                    (if one was used).</p>\n            </li>\n            <li>\n               <p>\n                  <code>ISP</code> \u2013 The recipient ISP (e.g. <code>Gmail</code>, <code>Yahoo</code>,\n                    etc.).</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#MetricDimensionValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A list of values associated with the <code>MetricDimensionName</code> to filter\n            metrics by. Can either be <code>*</code> as a wildcard for all values or a list of up to\n            10 specific values. If one <code>Dimension</code> has the <code>*</code> value, other\n            dimensions can only contain one value. </p>"
+      }
+    },
+    "com.amazonaws.sesv2#MetricNamespace": {
+      "type": "enum",
+      "members": {
+        "VDM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VDM"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#MetricValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Counter"
+      }
+    },
+    "com.amazonaws.sesv2#MetricsDataSource": {
+      "type": "structure",
+      "members": {
+        "Dimensions": {
+          "target": "com.amazonaws.sesv2#ExportDimensions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains a mapping between a <code>MetricDimensionName</code> and\n            <code>MetricDimensionValue</code> to filter metrics by. Must contain a least 1\n            dimension but no more than 3 unique ones.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Namespace": {
+          "target": "com.amazonaws.sesv2#MetricNamespace",
+          "traits": {
+            "smithy.api#documentation": "<p>The metrics namespace - e.g., <code>VDM</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Metrics": {
+          "target": "com.amazonaws.sesv2#ExportMetrics",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ExportMetric</code> objects to export.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StartDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the start date for the export interval as a timestamp.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EndDate": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the end date for the export interval as a timestamp.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains details about the data source for the metrics export.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MultiRegionEndpoint": {
+      "type": "structure",
+      "members": {
+        "EndpointName": {
+          "target": "com.amazonaws.sesv2#EndpointName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the multi-region endpoint (global-endpoint).</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.sesv2#Status",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the multi-region endpoint (global-endpoint).</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> \u2013 The resource is being provisioned.</p>\n            </li>\n            <li>\n               <p>\n                  <code>READY</code> \u2013 The resource is ready to use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 The resource failed to be provisioned.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> \u2013 The resource is being deleted as requested.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "EndpointId": {
+          "target": "com.amazonaws.sesv2#EndpointId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the multi-region endpoint (global-endpoint).</p>"
+          }
+        },
+        "Regions": {
+          "target": "com.amazonaws.sesv2#Regions",
+          "traits": {
+            "smithy.api#documentation": "<p>Primary and secondary regions between which multi-region endpoint splits sending traffic.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp of when the multi-region endpoint (global-endpoint) was created.</p>"
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp of when the multi-region endpoint (global-endpoint) was last updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains multi-region endpoint (global-endpoint) properties.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#MultiRegionEndpoints": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#MultiRegionEndpoint"
+      }
+    },
+    "com.amazonaws.sesv2#NextToken": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#NextTokenV2": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 5000
+        },
+        "smithy.api#pattern": "^^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+      }
+    },
+    "com.amazonaws.sesv2#NotFoundException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The resource you attempted to access doesn't exist.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.sesv2#OutboundMessageId": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#OverallVolume": {
+      "type": "structure",
+      "members": {
+        "VolumeStatistics": {
+          "target": "com.amazonaws.sesv2#VolumeStatistics",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the numbers of messages that arrived in\n            recipients' inboxes and junk mail folders.</p>"
+          }
+        },
+        "ReadRatePercent": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of emails that were sent from the domain that were read by their\n            recipients.</p>"
+          }
+        },
+        "DomainIspPlacements": {
+          "target": "com.amazonaws.sesv2#DomainIspPlacements",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains inbox and junk mail placement metrics for individual email\n            providers.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about email that was sent from the selected\n            domain.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#PageSizeV2": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.sesv2#Percentage": {
+      "type": "double",
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about inbox placement percentages.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Percentage100Wrapper": {
+      "type": "integer"
+    },
+    "com.amazonaws.sesv2#PinpointDestination": {
+      "type": "structure",
+      "members": {
+        "ApplicationArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Pinpoint project to send email events to.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines an Amazon Pinpoint project destination for email events. You can send\n            email event data to a Amazon Pinpoint project to view metrics using the Transactional Messaging\n            dashboards that are built in to Amazon Pinpoint. For more information, see <a href=\"https://docs.aws.amazon.com/pinpoint/latest/userguide/analytics-transactional-messages.html\">Transactional\n                Messaging Charts</a> in the <i>Amazon Pinpoint User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#PlacementStatistics": {
+      "type": "structure",
+      "members": {
+        "InboxPercentage": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of emails that arrived in recipients' inboxes during the predictive inbox placement test.</p>"
+          }
+        },
+        "SpamPercentage": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of emails that arrived in recipients' spam or junk mail folders during\n            the predictive inbox placement test.</p>"
+          }
+        },
+        "MissingPercentage": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of emails that didn't arrive in recipients' inboxes at all during the\n            predictive inbox placement test.</p>"
+          }
+        },
+        "SpfPercentage": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of emails that were authenticated by using Sender Policy Framework\n            (SPF) during the predictive inbox placement test.</p>"
+          }
+        },
+        "DkimPercentage": {
+          "target": "com.amazonaws.sesv2#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of emails that were authenticated by using DomainKeys Identified Mail\n            (DKIM) during the predictive inbox placement test.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains inbox placement data for an email provider.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Policy": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p>\n         <p>For information about the syntax of sending authorization policies, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer Guide</a>.</p>",
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PolicyMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.sesv2#PolicyName"
+      },
+      "value": {
+        "target": "com.amazonaws.sesv2#Policy"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains mapping between <code>PolicyName</code> and\n                <code>Policy</code> text.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#PolicyName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of the policy.</p>\n         <p>The policy name cannot exceed 64 characters and can only include alphanumeric\n            characters, dashes, and underscores.</p>",
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PoolName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of a dedicated IP pool.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#PrimaryNameServer": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#PrivateKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 20480
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9+\\/]+={0,2}$",
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.sesv2#ProcessedRecordsCount": {
+      "type": "integer"
+    },
+    "com.amazonaws.sesv2#PutAccountDedicatedIpWarmupAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutAccountDedicatedIpWarmupAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutAccountDedicatedIpWarmupAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Enable or disable the automatic warm-up feature for dedicated IP addresses.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/account/dedicated-ips/warmup",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountDedicatedIpWarmupAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "AutoWarmupEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Enables or disables the automatic warm-up feature for dedicated IP addresses that are\n            associated with your Amazon SES account in the current Amazon Web Services Region. Set to <code>true</code>\n            to enable the automatic warm-up feature, or set to <code>false</code> to disable\n            it.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to enable or disable the automatic IP address warm-up feature.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountDedicatedIpWarmupAttributesResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountDetails": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutAccountDetailsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutAccountDetailsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Update your Amazon SES account details.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/account/details",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountDetailsRequest": {
+      "type": "structure",
+      "members": {
+        "MailType": {
+          "target": "com.amazonaws.sesv2#MailType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of email your account will send.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "WebsiteURL": {
+          "target": "com.amazonaws.sesv2#WebsiteURL",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL of your website. This information helps us better understand the type of\n            content that you plan to send.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ContactLanguage": {
+          "target": "com.amazonaws.sesv2#ContactLanguage",
+          "traits": {
+            "smithy.api#documentation": "<p>The language you would prefer to be contacted with.</p>"
+          }
+        },
+        "UseCaseDescription": {
+          "target": "com.amazonaws.sesv2#UseCaseDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the types of email that you plan to send.</p>"
+          }
+        },
+        "AdditionalContactEmailAddresses": {
+          "target": "com.amazonaws.sesv2#AdditionalContactEmailAddresses",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional email addresses that you would like to be notified regarding Amazon SES\n            matters.</p>"
+          }
+        },
+        "ProductionAccessEnabled": {
+          "target": "com.amazonaws.sesv2#EnabledWrapper",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether or not your account should have production access in the current\n            Amazon Web Services Region.</p>\n         <p>If the value is <code>false</code>, then your account is in the\n                <i>sandbox</i>. When your account is in the sandbox, you can only send\n            email to verified identities.\n            </p>\n         <p>If the value is <code>true</code>, then your account has production access. When your\n            account has production access, you can send email to any address. The sending quota and\n            maximum sending rate for your account vary based on your specific use case.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to submit new account details.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountDetailsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountSendingAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutAccountSendingAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutAccountSendingAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Enable or disable the ability of your account to send email.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/account/sending",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountSendingAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "SendingEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Enables or disables your account's ability to send email. Set to <code>true</code> to\n            enable email sending, or set to <code>false</code> to disable email sending.</p>\n         <note>\n            <p>If Amazon Web Services paused your account's ability to send email, you can't use this operation\n                to resume your account's ability to send email.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to change the ability of your account to send email.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountSendingAttributesResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountSuppressionAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutAccountSuppressionAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutAccountSuppressionAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Change the settings for the account-level suppression list.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/account/suppression",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountSuppressionAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "SuppressedReasons": {
+          "target": "com.amazonaws.sesv2#SuppressionListReasons",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains the reasons that email addresses will be automatically added to\n            the suppression list for your account. This list can contain any or all of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COMPLAINT</code> \u2013 Amazon SES adds an email address to the suppression\n                    list for your account when a message sent to that address results in a\n                    complaint.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BOUNCE</code> \u2013 Amazon SES adds an email address to the suppression\n                    list for your account when a message sent to that address results in a hard\n                    bounce.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "ValidationAttributes": {
+          "target": "com.amazonaws.sesv2#SuppressionValidationAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains additional suppression attributes for your account.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to change your account's suppression preferences.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountSuppressionAttributesResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n        fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountVdmAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutAccountVdmAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutAccountVdmAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Update your Amazon SES account VDM attributes.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/account/vdm",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountVdmAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "VdmAttributes": {
+          "target": "com.amazonaws.sesv2#VdmAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>The VDM attributes that you wish to apply to your Amazon SES account.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to submit new account VDM attributes.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutAccountVdmAttributesResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetArchivingOptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetArchivingOptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetArchivingOptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Associate the configuration set with a MailManager archive. When you send email using the\n        <code>SendEmail</code> or <code>SendBulkEmail</code> operations the message as it will be given\n        to the receiving SMTP server will be archived, along with the recipient information.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "Used to associate an MailManager archive with a ConfigurationSet.",
+            "documentation": "This example associates an archive arn with a configuration set.",
+            "input": {
+              "ConfigurationSetName": "sample-configuration-name",
+              "ArchiveArn": "arn:aws:ses:us-west-2:123456789012:mailmanager-archive/a-abcdefghijklmnopqrstuvwxyz"
+            },
+            "output": {}
+          }
+        ],
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/archiving-options",
+          "code": 200
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetArchivingOptionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set to associate with a MailManager archive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ArchiveArn": {
+          "target": "com.amazonaws.sesv2#ArchiveArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the MailManager archive that the Amazon SES API v2 sends email\n            to.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to associate a configuration set with a MailManager archive.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetArchivingOptionsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetDeliveryOptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetDeliveryOptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetDeliveryOptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Associate a configuration set with a dedicated IP pool. You can use dedicated IP pools\n            to create groups of dedicated IP addresses for sending specific types of email.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/delivery-options",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetDeliveryOptionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set to associate with a dedicated IP pool.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "TlsPolicy": {
+          "target": "com.amazonaws.sesv2#TlsPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether messages that use the configuration set are required to use\n            Transport Layer Security (TLS). If the value is <code>Require</code>, messages are only\n            delivered if a TLS connection can be established. If the value is <code>Optional</code>,\n            messages can be delivered in plain text if a TLS connection can't be established.</p>"
+          }
+        },
+        "SendingPoolName": {
+          "target": "com.amazonaws.sesv2#SendingPoolName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the dedicated IP pool to associate with the configuration set.</p>"
+          }
+        },
+        "MaxDeliverySeconds": {
+          "target": "com.amazonaws.sesv2#MaxDeliverySeconds",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum amount of time, in seconds, that Amazon SES API v2 will attempt delivery of email.\n            If specified, the value must greater than or equal to 300 seconds (5 minutes)\n            and less than or equal to 50400 seconds (840 minutes).\n        </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to associate a configuration set with a dedicated IP pool.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetDeliveryOptionsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetReputationOptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetReputationOptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetReputationOptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Enable or disable collection of reputation metrics for emails that you send using a\n            particular configuration set in a specific Amazon Web Services Region.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/reputation-options",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetReputationOptionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ReputationMetricsEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If <code>true</code>, tracking of reputation metrics is enabled for the configuration\n            set. If <code>false</code>, tracking of reputation metrics is disabled for the\n            configuration set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to enable or disable tracking of reputation metrics for a configuration\n            set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetReputationOptionsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetSendingOptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetSendingOptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetSendingOptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Enable or disable email sending for messages that use a particular configuration set\n            in a specific Amazon Web Services Region.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/sending",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetSendingOptionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set to enable or disable email sending for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "SendingEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If <code>true</code>, email sending is enabled for the configuration set. If\n                <code>false</code>, email sending is disabled for the configuration set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to enable or disable the ability of Amazon SES to send emails that use a specific\n            configuration set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetSendingOptionsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetSuppressionOptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetSuppressionOptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetSuppressionOptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Specify the account suppression list preferences for a configuration set.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/suppression-options",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetSuppressionOptionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set to change the suppression list preferences\n            for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "SuppressedReasons": {
+          "target": "com.amazonaws.sesv2#SuppressionListReasons",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains the reasons that email addresses are automatically added to the\n            suppression list for your account. This list can contain any or all of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COMPLAINT</code> \u2013 Amazon SES adds an email address to the suppression\n                    list for your account when a message sent to that address results in a\n                    complaint.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BOUNCE</code> \u2013 Amazon SES adds an email address to the suppression\n                    list for your account when a message sent to that address results in a hard\n                    bounce.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "ValidationOptions": {
+          "target": "com.amazonaws.sesv2#SuppressionValidationOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the email address suppression preferences for the configuration set in the current Amazon Web Services Region.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to change the account suppression list preferences for a specific\n            configuration set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetSuppressionOptionsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetTrackingOptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetTrackingOptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetTrackingOptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Specify a custom domain to use for open and click tracking elements in email that you\n            send.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/tracking-options",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetTrackingOptionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "CustomRedirectDomain": {
+          "target": "com.amazonaws.sesv2#CustomRedirectDomain",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain to use to track open and click events.</p>"
+          }
+        },
+        "HttpsPolicy": {
+          "target": "com.amazonaws.sesv2#HttpsPolicy"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to add a custom domain for tracking open and click events to a configuration\n            set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetTrackingOptionsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetVdmOptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetVdmOptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutConfigurationSetVdmOptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Specify VDM preferences for email that you send using the configuration set.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/vdm-options",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetVdmOptionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "VdmOptions": {
+          "target": "com.amazonaws.sesv2#VdmOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The VDM options to apply to the configuration set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to add specific VDM settings to a configuration set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutConfigurationSetVdmOptionsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutDedicatedIpInPool": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutDedicatedIpInPoolRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutDedicatedIpInPoolResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Move a dedicated IP address to an existing dedicated IP pool.</p>\n         <note>\n            <p>The dedicated IP address that you specify must already exist, and must be\n                associated with your Amazon Web Services account.\n                \n            </p>\n            <p>The dedicated IP pool you specify must already exist. You can create a new pool by\n                using the <code>CreateDedicatedIpPool</code> operation.</p>\n         </note>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/dedicated-ips/{Ip}/pool",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutDedicatedIpInPoolRequest": {
+      "type": "structure",
+      "members": {
+        "Ip": {
+          "target": "com.amazonaws.sesv2#Ip",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address that you want to move to the dedicated IP pool. The value you specify\n            has to be a dedicated IP address that's associated with your Amazon Web Services account.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DestinationPoolName": {
+          "target": "com.amazonaws.sesv2#PoolName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the IP pool that you want to add the dedicated IP address to. You have to\n            specify an IP pool that already exists.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to move a dedicated IP address to a dedicated IP pool.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutDedicatedIpInPoolResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutDedicatedIpPoolScalingAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutDedicatedIpPoolScalingAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutDedicatedIpPoolScalingAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used to convert a dedicated IP pool to a different scaling mode.</p>\n         <note>\n            <p>\n               <code>MANAGED</code> pools cannot be converted to <code>STANDARD</code> scaling mode.</p>\n         </note>",
+        "smithy.api#examples": [
+          {
+            "title": "Used to convert a dedicated IP pool to a different scaling mode.",
+            "documentation": "This example converts a dedicated IP pool from STANDARD to MANAGED.",
+            "input": {
+              "PoolName": "sample-ses-pool",
+              "ScalingMode": "MANAGED"
+            },
+            "output": {}
+          }
+        ],
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/dedicated-ip-pools/{PoolName}/scaling",
+          "code": 200
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutDedicatedIpPoolScalingAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "PoolName": {
+          "target": "com.amazonaws.sesv2#PoolName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the dedicated IP pool.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ScalingMode": {
+          "target": "com.amazonaws.sesv2#ScalingMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The scaling mode to apply to the dedicated IP pool.</p>\n         <note>\n            <p>Changing the scaling mode from <code>MANAGED</code> to <code>STANDARD</code> is not supported.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to convert a dedicated IP pool to a different scaling mode.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutDedicatedIpPoolScalingAttributesResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutDedicatedIpWarmupAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutDedicatedIpWarmupAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutDedicatedIpWarmupAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/dedicated-ips/{Ip}/warmup",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutDedicatedIpWarmupAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "Ip": {
+          "target": "com.amazonaws.sesv2#Ip",
+          "traits": {
+            "smithy.api#documentation": "<p>The dedicated IP address that you want to update the warm-up attributes for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "WarmupPercentage": {
+          "target": "com.amazonaws.sesv2#Percentage100Wrapper",
+          "traits": {
+            "smithy.api#documentation": "<p>The warm-up percentage that you want to associate with the dedicated IP\n            address.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to change the warm-up attributes for a dedicated IP address. This operation\n            is useful when you want to resume the warm-up process for an existing IP address.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutDedicatedIpWarmupAttributesResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutDeliverabilityDashboardOption": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutDeliverabilityDashboardOptionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutDeliverabilityDashboardOptionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Enable or disable the Deliverability dashboard. When you enable the Deliverability dashboard, you gain\n            access to reputation, deliverability, and other metrics for the domains that you use to\n            send email. You also gain the ability to perform predictive inbox placement tests.</p>\n         <p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition\n            to any other fees that you accrue by using Amazon SES and other Amazon Web Services services. For more\n            information about the features and cost of a Deliverability dashboard subscription, see <a href=\"http://aws.amazon.com/ses/pricing/\">Amazon SES Pricing</a>.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/deliverability-dashboard",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutDeliverabilityDashboardOptionRequest": {
+      "type": "structure",
+      "members": {
+        "DashboardEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether to enable the Deliverability dashboard. To enable the dashboard, set this\n            value to <code>true</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SubscribedDomains": {
+          "target": "com.amazonaws.sesv2#DomainDeliverabilityTrackingOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects, one for each verified domain that you use to send email and\n            enabled the Deliverability dashboard for.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Enable or disable the Deliverability dashboard. When you enable the Deliverability dashboard, you gain\n            access to reputation, deliverability, and other metrics for the domains that you use to\n            send email using Amazon SES API v2. You also gain the ability to perform predictive inbox placement tests.</p>\n         <p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition\n            to any other fees that you accrue by using Amazon SES and other Amazon Web Services services. For more\n            information about the features and cost of a Deliverability dashboard subscription, see <a href=\"http://aws.amazon.com/pinpoint/pricing/\">Amazon Pinpoint Pricing</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutDeliverabilityDashboardOptionResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>A response that indicates whether the Deliverability dashboard is enabled.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityConfigurationSetAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutEmailIdentityConfigurationSetAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutEmailIdentityConfigurationSetAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used to associate a configuration set with an email identity.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/identities/{EmailIdentity}/configuration-set",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityConfigurationSetAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address or domain to associate with a configuration set.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration set to associate with an email identity.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to associate a configuration set with an email identity.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityConfigurationSetAttributesResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty\n            HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityDkimAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutEmailIdentityDkimAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutEmailIdentityDkimAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used to enable or disable DKIM authentication for an email identity.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/identities/{EmailIdentity}/dkim",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityDkimAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "SigningEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Sets the DKIM signing configuration for the identity.</p>\n         <p>When you set this value <code>true</code>, then the messages that are sent from the\n            identity are signed using DKIM. If you set this value to <code>false</code>, your\n            messages are sent without DKIM signing.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to enable or disable DKIM signing of email that you send from an email\n            identity.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityDkimAttributesResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityDkimSigningAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutEmailIdentityDkimSigningAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutEmailIdentityDkimSigningAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used to configure or change the DKIM authentication settings for an email domain\n            identity. You can use this operation to do any of the following:</p>\n         <ul>\n            <li>\n               <p>Update the signing attributes for an identity that uses Bring Your Own DKIM\n                    (BYODKIM).</p>\n            </li>\n            <li>\n               <p>Update the key length that should be used for Easy DKIM.</p>\n            </li>\n            <li>\n               <p>Change from using no DKIM authentication to using Easy DKIM.</p>\n            </li>\n            <li>\n               <p>Change from using no DKIM authentication to using BYODKIM.</p>\n            </li>\n            <li>\n               <p>Change from using Easy DKIM to using BYODKIM.</p>\n            </li>\n            <li>\n               <p>Change from using BYODKIM to using Easy DKIM.</p>\n            </li>\n         </ul>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/identities/{EmailIdentity}/dkim/signing",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityDkimSigningAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "SigningAttributesOrigin": {
+          "target": "com.amazonaws.sesv2#DkimSigningAttributesOrigin",
+          "traits": {
+            "smithy.api#documentation": "<p>The method to use to configure DKIM for the identity. There are the following possible\n            values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AWS_SES</code> \u2013 Configure DKIM for the identity by using <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Easy\n                        DKIM</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>EXTERNAL</code> \u2013 Configure DKIM for the identity by using Bring\n                    Your Own DKIM (BYODKIM).</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "SigningAttributes": {
+          "target": "com.amazonaws.sesv2#DkimSigningAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the private key and selector that you want\n            to use to configure DKIM for the identity for Bring Your Own DKIM (BYODKIM) for the\n            identity, or, configures the key length to be used for <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Easy DKIM</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to change the DKIM attributes for an email identity.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityDkimSigningAttributesResponse": {
+      "type": "structure",
+      "members": {
+        "DkimStatus": {
+          "target": "com.amazonaws.sesv2#DkimStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The DKIM authentication status of the identity. Amazon SES determines the authentication\n            status by searching for specific records in the DNS configuration for your domain. If\n            you used <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Easy\n                DKIM</a> to set up DKIM authentication, Amazon SES tries to find three unique CNAME\n            records in the DNS configuration for your domain.</p>\n         <p>If you provided a public key to perform DKIM authentication, Amazon SES tries to find a TXT\n            record that uses the selector that you specified. The value of the TXT record must be a\n            public key that's paired with the private key that you specified in the process of\n            creating the identity.</p>\n         <p>The status can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PENDING</code> \u2013 The verification process was initiated, but Amazon SES\n                    hasn't yet detected the DKIM records in the DNS configuration for the\n                    domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUCCESS</code> \u2013 The verification process completed\n                    successfully.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 The verification process failed. This typically\n                    occurs when Amazon SES fails to find the DKIM records in the DNS configuration of the\n                    domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TEMPORARY_FAILURE</code> \u2013 A temporary issue is preventing Amazon SES\n                    from determining the DKIM authentication status of the domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NOT_STARTED</code> \u2013 The DKIM verification process hasn't been\n                    initiated for the domain.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "DkimTokens": {
+          "target": "com.amazonaws.sesv2#DnsTokenList",
+          "traits": {
+            "smithy.api#documentation": "<p>If you used <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Easy DKIM</a> to configure DKIM authentication for the domain, then this object\n            contains a set of unique strings that you use to create a set of CNAME records that you\n            add to the DNS configuration for your domain. When Amazon SES detects these records in the\n            DNS configuration for your domain, the DKIM authentication process is complete.</p>\n         <p>If you configured DKIM authentication for the domain by providing your own\n            public-private key pair, then this object contains the selector that's associated with\n            your public key.</p>\n         <p>Regardless of the DKIM authentication method you use, Amazon SES searches for the\n            appropriate records in the DNS configuration of the domain for up to 72 hours.</p>"
+          }
+        },
+        "SigningHostedZone": {
+          "target": "com.amazonaws.sesv2#HostedZone",
+          "traits": {
+            "smithy.api#documentation": "<p>The hosted zone where Amazon SES publishes the DKIM public key TXT records for this email identity. \n        This value indicates the DNS zone that customers must reference when configuring their CNAME records for DKIM authentication.</p>\n         <p>When configuring DKIM for your domain, create CNAME records in your DNS that point to the selectors in this hosted zone. \n        For example:</p>\n         <p>\n            <code>\n            selector1._domainkey.yourdomain.com CNAME selector1.<SigningHostedZone>\n        </code>\n         </p>\n         <p>\n            <code>\n            selector2._domainkey.yourdomain.com CNAME selector2.<SigningHostedZone>\n        </code>\n         </p>\n         <p>\n            <code>\n            selector3._domainkey.yourdomain.com CNAME selector3.<SigningHostedZone>\n        </code>\n         </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response.</p>\n         <p>The following data is returned in JSON format by the service.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityFeedbackAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutEmailIdentityFeedbackAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutEmailIdentityFeedbackAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used to enable or disable feedback forwarding for an identity. This setting determines\n            what happens when an identity is used to send an email that results in a bounce or\n            complaint event.</p>\n         <p>If the value is <code>true</code>, you receive email notifications when bounce or\n            complaint events occur. These notifications are sent to the address that you specified\n            in the <code>Return-Path</code> header of the original email.</p>\n         <p>You're required to have a method of tracking bounces and complaints. If you haven't\n            set up another mechanism for receiving bounce or complaint notifications (for example,\n            by setting up an event destination), you receive an email notification when these events\n            occur (even if this setting is disabled).</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/identities/{EmailIdentity}/feedback",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityFeedbackAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "EmailForwardingEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Sets the feedback forwarding configuration for the identity.</p>\n         <p>If the value is <code>true</code>, you receive email notifications when bounce or\n            complaint events occur. These notifications are sent to the address that you specified\n            in the <code>Return-Path</code> header of the original email.</p>\n         <p>You're required to have a method of tracking bounces and complaints. If you haven't\n            set up another mechanism for receiving bounce or complaint notifications (for example,\n            by setting up an event destination), you receive an email notification when these events\n            occur (even if this setting is disabled).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to set the attributes that control how bounce and complaint events are\n            processed.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityFeedbackAttributesResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityMailFromAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutEmailIdentityMailFromAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutEmailIdentityMailFromAttributesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used to enable or disable the custom Mail-From domain configuration for an email\n            identity.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/identities/{EmailIdentity}/mail-from",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityMailFromAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The verified email identity.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "MailFromDomain": {
+          "target": "com.amazonaws.sesv2#MailFromDomainName",
+          "traits": {
+            "smithy.api#documentation": "<p> The custom MAIL FROM domain that you want the verified identity to use. The MAIL FROM\n            domain must meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>It has to be a subdomain of the verified identity.</p>\n            </li>\n            <li>\n               <p>It can't be used to receive email.</p>\n            </li>\n            <li>\n               <p>It can't be used in a \"From\" address if the MAIL FROM domain is a destination\n                    for feedback forwarding emails.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "BehaviorOnMxFailure": {
+          "target": "com.amazonaws.sesv2#BehaviorOnMxFailure",
+          "traits": {
+            "smithy.api#documentation": "<p>The action to take if the required MX record isn't found when you send an email. When\n            you set this value to <code>UseDefaultValue</code>, the mail is sent using\n                <i>amazonses.com</i> as the MAIL FROM domain. When you set this value\n            to <code>RejectMessage</code>, the Amazon SES API v2 returns a\n                <code>MailFromDomainNotVerified</code> error, and doesn't attempt to deliver the\n            email.</p>\n         <p>These behaviors are taken when the custom MAIL FROM domain configuration is in the\n                <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code>\n            states.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to configure the custom MAIL FROM domain for a verified identity.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutEmailIdentityMailFromAttributesResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutSuppressedDestination": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#PutSuppressedDestinationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#PutSuppressedDestinationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds an email address to the suppression list for your account.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/suppression/addresses",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#PutSuppressedDestinationRequest": {
+      "type": "structure",
+      "members": {
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address that should be added to the suppression list for your\n            account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Reason": {
+          "target": "com.amazonaws.sesv2#SuppressionListReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The factors that should cause the email address to be added to the suppression list\n            for your account.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to add an email destination to the suppression list for your account.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#PutSuppressedDestinationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#QueryErrorCode": {
+      "type": "enum",
+      "members": {
+        "INTERNAL_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNAL_FAILURE"
+          }
+        },
+        "ACCESS_DENIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACCESS_DENIED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#QueryErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#QueryIdentifier": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 255
+        }
+      }
+    },
+    "com.amazonaws.sesv2#RawAttachmentData": {
+      "type": "blob"
+    },
+    "com.amazonaws.sesv2#RawMessage": {
+      "type": "structure",
+      "members": {
+        "Data": {
+          "target": "com.amazonaws.sesv2#RawMessageData",
+          "traits": {
+            "smithy.api#documentation": "<p>The raw email message. The message has to meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>The message has to contain a header and a body, separated by one blank\n                    line.</p>\n            </li>\n            <li>\n               <p>All of the required header fields must be present in the message.</p>\n            </li>\n            <li>\n               <p>Each part of a multipart MIME message must be formatted properly.</p>\n            </li>\n            <li>\n               <p>Attachments must be in a file format that the Amazon SES supports.</p>\n            </li>\n            <li>\n               <p>The raw data of the message needs to base64-encoded if you are accessing Amazon SES\n                    directly through the HTTPS interface. If you are accessing Amazon SES using an Amazon Web Services\n                    SDK, the SDK takes care of the base 64-encoding for you.</p>\n            </li>\n            <li>\n               <p>If any of the MIME parts in your message contain content that is outside of\n                    the 7-bit ASCII character range, you should encode that content to ensure that\n                    recipients' email clients render the message properly.</p>\n            </li>\n            <li>\n               <p>The length of any single line of text in the message can't exceed 1,000\n                    characters. This restriction is defined in <a href=\"https://tools.ietf.org/html/rfc5321\">RFC 5321</a>.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents the raw content of an email message.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#RawMessageData": {
+      "type": "blob",
+      "traits": {
+        "smithy.api#documentation": "<p>The raw email message. The message has to meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>The message has to contain a header and a body, separated by one blank\n                    line.</p>\n            </li>\n            <li>\n               <p>All of the required header fields must be present in the message.</p>\n            </li>\n            <li>\n               <p>Each part of a multipart MIME message must be formatted properly.</p>\n            </li>\n            <li>\n               <p>Attachments must be in a file format that the Amazon SES API v2 supports.\n                    </p>\n            </li>\n            <li>\n               <p>The entire message must be Base64 encoded.</p>\n            </li>\n            <li>\n               <p>If any of the MIME parts in your message contain content that is outside of\n                    the 7-bit ASCII character range, you should encode that content to ensure that\n                    recipients' email clients render the message properly.</p>\n            </li>\n            <li>\n               <p>The length of any single line of text in the message can't exceed 1,000\n                    characters. This restriction is defined in <a href=\"https://tools.ietf.org/html/rfc5321\">RFC 5321</a>.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#RblName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of a blacklist that an IP address was found on.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Recommendation": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource affected by the recommendation,\n            with values like <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.sesv2#RecommendationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The recommendation type, with values like <code>DKIM</code>,\n            <code>SPF</code>, <code>DMARC</code>, <code>BIMI</code>, or <code>COMPLAINT</code>.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.sesv2#RecommendationDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>The recommendation description / disambiguator - e.g. <code>DKIM1</code> and <code>DKIM2</code>\n              are different recommendations about your DKIM setup.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.sesv2#RecommendationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The recommendation status, with values like\n            <code>OPEN</code> or <code>FIXED</code>.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The first time this issue was encountered and the recommendation was generated.</p>"
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The last time the recommendation was updated.</p>"
+          }
+        },
+        "Impact": {
+          "target": "com.amazonaws.sesv2#RecommendationImpact",
+          "traits": {
+            "smithy.api#documentation": "<p>The recommendation impact, with values like\n            <code>HIGH</code> or <code>LOW</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A recommendation generated for your account.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#RecommendationDescription": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#RecommendationImpact": {
+      "type": "enum",
+      "members": {
+        "LOW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LOW"
+          }
+        },
+        "HIGH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HIGH"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#RecommendationStatus": {
+      "type": "enum",
+      "members": {
+        "OPEN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPEN"
+          }
+        },
+        "FIXED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FIXED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#RecommendationType": {
+      "type": "enum",
+      "members": {
+        "DKIM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DKIM"
+          }
+        },
+        "DMARC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DMARC"
+          }
+        },
+        "SPF": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPF"
+          }
+        },
+        "BIMI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BIMI"
+          }
+        },
+        "COMPLAINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLAINT"
+          }
+        },
+        "BOUNCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOUNCE"
+          }
+        },
+        "FEEDBACK_3P": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FEEDBACK_3P"
+          }
+        },
+        "IP_LISTING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IP_LISTING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#RecommendationsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Recommendation"
+      }
+    },
+    "com.amazonaws.sesv2#Region": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of an AWS-Region.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Regions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Region"
+      }
+    },
+    "com.amazonaws.sesv2#RenderedEmailTemplate": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The complete MIME message rendered by applying the data in the TemplateData parameter\n            to the template specified in the TemplateName parameter.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ReplacementEmailContent": {
+      "type": "structure",
+      "members": {
+        "ReplacementTemplate": {
+          "target": "com.amazonaws.sesv2#ReplacementTemplate",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>ReplacementTemplate</code> associated with\n                <code>ReplacementEmailContent</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The <code>ReplaceEmailContent</code> object to be used for a specific\n                <code>BulkEmailEntry</code>. The <code>ReplacementTemplate</code> can be specified\n            within this object.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ReplacementTemplate": {
+      "type": "structure",
+      "members": {
+        "ReplacementTemplateData": {
+          "target": "com.amazonaws.sesv2#EmailTemplateData",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of replacement values to apply to the template. This parameter is a JSON\n            object, typically consisting of key-value pairs in which the keys correspond to\n            replacement tags in the email template.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object which contains <code>ReplacementTemplateData</code> to be used for a\n            specific <code>BulkEmailEntry</code>.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ReportId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A unique string that identifies a Deliverability dashboard report.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ReportName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A name that helps you identify a report generated by the Deliverability dashboard.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ReputationEntitiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#ReputationEntity"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of reputation entities.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ReputationEntity": {
+      "type": "structure",
+      "members": {
+        "ReputationEntityReference": {
+          "target": "com.amazonaws.sesv2#ReputationEntityReference",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the reputation entity. For resource-type entities, \n            this is the Amazon Resource Name (ARN) of the resource.</p>"
+          }
+        },
+        "ReputationEntityType": {
+          "target": "com.amazonaws.sesv2#ReputationEntityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of reputation entity. Currently, only <code>RESOURCE</code> type entities are supported.</p>"
+          }
+        },
+        "ReputationManagementPolicy": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the reputation management policy applied to \n            this entity. This is an Amazon Web Services Amazon SES-managed policy.</p>"
+          }
+        },
+        "CustomerManagedStatus": {
+          "target": "com.amazonaws.sesv2#StatusRecord",
+          "traits": {
+            "smithy.api#documentation": "<p>The customer-managed status record for this reputation entity, including the \n            current status, cause description, and last updated timestamp.</p>"
+          }
+        },
+        "AwsSesManagedStatus": {
+          "target": "com.amazonaws.sesv2#StatusRecord",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services Amazon SES-managed status record for this reputation entity, including the \n            current status, cause description, and last updated timestamp.</p>"
+          }
+        },
+        "SendingStatusAggregate": {
+          "target": "com.amazonaws.sesv2#SendingStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregate sending status that determines whether the entity is allowed to\n            send emails. This status is derived from both the customer-managed and Amazon Web Services Amazon SES-managed\n            statuses. If either the customer-managed status or the Amazon Web Services Amazon SES-managed status is\n            <code>DISABLED</code>, the aggregate status will be <code>DISABLED</code> and the entity\n            will not be allowed to send emails. When the customer-managed status is set to\n            <code>REINSTATED</code>, the entity can continue sending even if there are active\n            reputation findings, provided the Amazon Web Services Amazon SES-managed status also permits sending.\n            The entity can only send emails when both statuses permit sending.</p>"
+          }
+        },
+        "ReputationImpact": {
+          "target": "com.amazonaws.sesv2#RecommendationImpact",
+          "traits": {
+            "smithy.api#documentation": "<p>The reputation impact level for this entity, representing the highest impact \n            reputation finding currently active. Reputation findings can be retrieved using \n            the <code>ListRecommendations</code> operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about a reputation entity, including its \n            reference, type, policy, status records, and reputation impact.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ReputationEntityFilter": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.sesv2#ReputationEntityFilterKey"
+      },
+      "value": {
+        "target": "com.amazonaws.sesv2#ReputationEntityFilterValue"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains filters to apply when listing reputation entities.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ReputationEntityFilterKey": {
+      "type": "enum",
+      "members": {
+        "ENTITY_TYPE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENTITY_TYPE"
+          }
+        },
+        "REPUTATION_IMPACT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REPUTATION_IMPACT"
+          }
+        },
+        "STATUS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SENDING_STATUS"
+          }
+        },
+        "ENTITY_REFERENCE_PREFIX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENTITY_REFERENCE_PREFIX"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The filter key to use when listing reputation entities. This can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENTITY_TYPE</code> \u2013 Filter by entity type.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REPUTATION_IMPACT</code> \u2013 Filter by reputation impact level.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SENDING_STATUS</code> \u2013 Filter by aggregate sending status.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ENTITY_REFERENCE_PREFIX</code> \u2013 Filter by entity reference prefix.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#ReputationEntityFilterValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The filter value to match against the specified filter key.</p>",
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ReputationEntityReference": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The unique identifier for a reputation entity. For resource-type entities, \n            this is the Amazon Resource Name (ARN) of the resource.</p>",
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.sesv2#ReputationEntityType": {
+      "type": "enum",
+      "members": {
+        "RESOURCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RESOURCE"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type of reputation entity. Currently, only <code>RESOURCE</code> type entities are supported, \n            which represent resources in your Amazon SES account that have reputation tracking capabilities.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ReputationOptions": {
+      "type": "structure",
+      "members": {
+        "ReputationMetricsEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If <code>true</code>, tracking of reputation metrics is enabled for the configuration\n            set. If <code>false</code>, tracking of reputation metrics is disabled for the\n            configuration set.</p>"
+          }
+        },
+        "LastFreshStart": {
+          "target": "com.amazonaws.sesv2#LastFreshStart",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time (in Unix time) when the reputation metrics were last given a fresh\n            start. When your account is given a fresh start, your reputation metrics are calculated\n            starting from the date of the fresh start.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Enable or disable collection of reputation metrics for emails that you send using this\n            configuration set in the current Amazon Web Services Region. </p>"
+      }
+    },
+    "com.amazonaws.sesv2#ResourceTenantMetadata": {
+      "type": "structure",
+      "members": {
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant associated with the resource.</p>"
+          }
+        },
+        "TenantId": {
+          "target": "com.amazonaws.sesv2#TenantId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the tenant associated with the resource.</p>"
+          }
+        },
+        "ResourceArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource.</p>"
+          }
+        },
+        "AssociatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the resource was associated with the tenant.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A structure that contains information about a tenant associated with a resource.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ResourceTenantMetadataList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#ResourceTenantMetadata"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of tenant metadata objects associated with a resource.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ResourceType": {
+      "type": "enum",
+      "members": {
+        "EMAIL_IDENTITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMAIL_IDENTITY"
+          }
+        },
+        "CONFIGURATION_SET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONFIGURATION_SET"
+          }
+        },
+        "EMAIL_TEMPLATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMAIL_TEMPLATE"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type of resource that can be associated with a tenant. Can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>EMAIL_IDENTITY</code> - An email address or domain that you use to send email.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CONFIGURATION_SET</code> - A set of rules that you can apply to emails you send.</p>\n            </li>\n            <li>\n               <p>\n                  <code>EMAIL_TEMPLATE</code> - A template that defines the content of an email message.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#ReviewDetails": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.sesv2#ReviewStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the latest review of your account. The status can be one of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PENDING</code> \u2013 We have received your appeal and are in the\n                    process of reviewing it.</p>\n            </li>\n            <li>\n               <p>\n                  <code>GRANTED</code> \u2013 Your appeal has been reviewed and your production\n                    access has been granted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DENIED</code> \u2013 Your appeal has been reviewed and your production\n                    access has been denied.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 An internal error occurred and we didn't receive\n                    your appeal. You can submit your appeal again.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CaseId": {
+          "target": "com.amazonaws.sesv2#CaseId",
+          "traits": {
+            "smithy.api#documentation": "<p>The associated support center case ID (if any).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about your account details review.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ReviewStatus": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "GRANTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GRANTED"
+          }
+        },
+        "DENIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DENIED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#Route": {
+      "type": "structure",
+      "members": {
+        "Region": {
+          "target": "com.amazonaws.sesv2#Region",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of an AWS-Region.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object which contains an AWS-Region and routing status.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#RouteDetails": {
+      "type": "structure",
+      "members": {
+        "Region": {
+          "target": "com.amazonaws.sesv2#Region",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of an AWS-Region to be a secondary region for the multi-region endpoint (global-endpoint).</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains route configuration. Includes secondary region name.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Routes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Route"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of routes between which the traffic will be split when sending through the multi-region endpoint (global-endpoint).</p>"
+      }
+    },
+    "com.amazonaws.sesv2#RoutesDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#RouteDetails"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of route configuration details. Must contain exactly one route configuration.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#S3Url": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>An Amazon S3 URL in the format s3://<i><bucket_name></i>/<i><object></i> or\n            a pre-signed URL.</p>",
+        "smithy.api#pattern": "^s3:\\/\\/([^\\/]+)\\/(.*?([^\\/]+)\\/?)$"
+      }
+    },
+    "com.amazonaws.sesv2#SOARecord": {
+      "type": "structure",
+      "members": {
+        "PrimaryNameServer": {
+          "target": "com.amazonaws.sesv2#PrimaryNameServer",
+          "traits": {
+            "smithy.api#documentation": "<p>Primary name server specified in the SOA record.</p>"
+          }
+        },
+        "AdminEmail": {
+          "target": "com.amazonaws.sesv2#AdminEmail",
+          "traits": {
+            "smithy.api#documentation": "<p>Administrative contact email from the SOA record.</p>"
+          }
+        },
+        "SerialNumber": {
+          "target": "com.amazonaws.sesv2#SerialNumber",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Serial number from the SOA record.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about the start of authority (SOA) record\n            associated with the identity.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#ScalingMode": {
+      "type": "enum",
+      "members": {
+        "STANDARD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STANDARD"
+          }
+        },
+        "MANAGED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANAGED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#Selector": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 63
+        },
+        "smithy.api#pattern": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9]))$"
+      }
+    },
+    "com.amazonaws.sesv2#SendBulkEmail": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#SendBulkEmailRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#SendBulkEmailResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AccountSuspendedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#MailFromDomainNotVerifiedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#MessageRejected"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#SendingPausedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Composes an email message to multiple destinations.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/outbound-bulk-emails",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#SendBulkEmailRequest": {
+      "type": "structure",
+      "members": {
+        "FromEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address to use as the \"From\" address for the email. The address that you\n            specify has to be verified.</p>"
+          }
+        },
+        "FromEmailAddressIdentityArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>This parameter is used only for sending authorization. It is the ARN of the identity\n            that is associated with the sending authorization policy that permits you to use the\n            email address specified in the <code>FromEmailAddress</code> parameter.</p>\n         <p>For example, if the owner of example.com (which has ARN\n            arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that\n            authorizes you to use sender@example.com, then you would specify the\n                <code>FromEmailAddressIdentityArn</code> to be\n            arn:aws:ses:us-east-1:123456789012:identity/example.com, and the\n                <code>FromEmailAddress</code> to be sender@example.com.</p>\n         <p>For more information about sending authorization, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer\n                Guide</a>.</p>"
+          }
+        },
+        "ReplyToAddresses": {
+          "target": "com.amazonaws.sesv2#EmailAddressList",
+          "traits": {
+            "smithy.api#documentation": "<p>The \"Reply-to\" email addresses for the message. When the recipient replies to the\n            message, each Reply-to address receives the reply.</p>"
+          }
+        },
+        "FeedbackForwardingEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The address that you want bounce and complaint notifications to be sent to.</p>"
+          }
+        },
+        "FeedbackForwardingEmailAddressIdentityArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>This parameter is used only for sending authorization. It is the ARN of the identity\n            that is associated with the sending authorization policy that permits you to use the\n            email address specified in the <code>FeedbackForwardingEmailAddress</code>\n            parameter.</p>\n         <p>For example, if the owner of example.com (which has ARN\n            arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that\n            authorizes you to use feedback@example.com, then you would specify the\n                <code>FeedbackForwardingEmailAddressIdentityArn</code> to be\n            arn:aws:ses:us-east-1:123456789012:identity/example.com, and the\n                <code>FeedbackForwardingEmailAddress</code> to be feedback@example.com.</p>\n         <p>For more information about sending authorization, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer\n                Guide</a>.</p>"
+          }
+        },
+        "DefaultEmailTags": {
+          "target": "com.amazonaws.sesv2#MessageTagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags, in the form of name/value pairs, to apply to an email that you send\n            using the <code>SendEmail</code> operation. Tags correspond to characteristics of the\n            email that you define, so that you can publish email sending events.</p>"
+          }
+        },
+        "DefaultContent": {
+          "target": "com.amazonaws.sesv2#BulkEmailContent",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the body of the message. You can specify a template\n            message.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "BulkEmailEntries": {
+          "target": "com.amazonaws.sesv2#BulkEmailEntryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of bulk email entry objects.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set to use when sending the email.</p>"
+          }
+        },
+        "EndpointId": {
+          "target": "com.amazonaws.sesv2#EndpointId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the multi-region endpoint (global-endpoint).</p>",
+            "smithy.rules#contextParam": {
+              "name": "EndpointId"
+            }
+          }
+        },
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant through which this bulk email will be sent.</p>\n         <note>\n            <p>\n                The email sending operation will only succeed if all referenced resources\n                (identities, configuration sets, and templates) are associated with this tenant.\n            </p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to send email messages to multiple destinations using Amazon SES. For\n            more information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\">Amazon SES Developer\n                Guide</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#SendBulkEmailResponse": {
+      "type": "structure",
+      "members": {
+        "BulkEmailEntryResults": {
+          "target": "com.amazonaws.sesv2#BulkEmailEntryResultList",
+          "traits": {
+            "smithy.api#documentation": "<p>One object per intended recipient. Check each response object and retry any messages\n            with a failure status.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The following data is returned in JSON format by the service.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#SendCustomVerificationEmail": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#SendCustomVerificationEmailRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#SendCustomVerificationEmailResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#MailFromDomainNotVerifiedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#MessageRejected"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#SendingPausedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds an email address to the list of identities for your Amazon SES account in the current\n                Amazon Web Services Region and attempts to verify it. As a result of executing this\n            operation, a customized verification email is sent to the specified address.</p>\n         <p>To use this operation, you must first create a custom verification email template. For\n            more information about creating and using custom verification email templates, see\n                <a href=\"https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#send-email-verify-address-custom\">Using\n                custom verification email templates</a> in the <i>Amazon SES Developer\n                Guide</i>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/outbound-custom-verification-emails",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#SendCustomVerificationEmailRequest": {
+      "type": "structure",
+      "members": {
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address to verify.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom verification email template to use when sending the\n            verification email.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of a configuration set to use when sending the verification email.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to send a custom verification email to a specified\n            recipient.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#SendCustomVerificationEmailResponse": {
+      "type": "structure",
+      "members": {
+        "MessageId": {
+          "target": "com.amazonaws.sesv2#OutboundMessageId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique message identifier returned from the\n                <code>SendCustomVerificationEmail</code> operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The following element is returned by the service.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#SendEmail": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#SendEmailRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#SendEmailResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#AccountSuspendedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#MailFromDomainNotVerifiedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#MessageRejected"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#SendingPausedException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Sends an email message. You can use the Amazon SES API v2 to send the following types of\n            messages:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Simple</b> \u2013 A standard email message. When\n                    you create this type of message, you specify the sender, the recipient, and the\n                    message body, and Amazon SES assembles the message for you.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Raw</b> \u2013 A raw, MIME-formatted email\n                    message. When you send this type of email, you have to specify all of the\n                    message headers, as well as the message body. You can use this message type to\n                    send messages that contain attachments. The message that you specify has to be a\n                    valid MIME message.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Templated</b> \u2013 A message that contains\n                    personalization tags. When you send this type of email, Amazon SES API v2 automatically\n                    replaces the tags with values that you specify.</p>\n            </li>\n         </ul>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/outbound-emails",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#SendEmailRequest": {
+      "type": "structure",
+      "members": {
+        "FromEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address to use as the \"From\" address for the email. The address that you\n            specify has to be verified.\n            </p>"
+          }
+        },
+        "FromEmailAddressIdentityArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>This parameter is used only for sending authorization. It is the ARN of the identity\n            that is associated with the sending authorization policy that permits you to use the\n            email address specified in the <code>FromEmailAddress</code> parameter.</p>\n         <p>For example, if the owner of example.com (which has ARN\n            arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that\n            authorizes you to use sender@example.com, then you would specify the\n                <code>FromEmailAddressIdentityArn</code> to be\n            arn:aws:ses:us-east-1:123456789012:identity/example.com, and the\n                <code>FromEmailAddress</code> to be sender@example.com.</p>\n         <p>For more information about sending authorization, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer\n                Guide</a>.</p>\n         <p>For Raw emails, the <code>FromEmailAddressIdentityArn</code> value overrides the\n            X-SES-SOURCE-ARN and X-SES-FROM-ARN headers specified in raw email message\n            content.</p>"
+          }
+        },
+        "Destination": {
+          "target": "com.amazonaws.sesv2#Destination",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the recipients of the email message.</p>"
+          }
+        },
+        "ReplyToAddresses": {
+          "target": "com.amazonaws.sesv2#EmailAddressList",
+          "traits": {
+            "smithy.api#documentation": "<p>The \"Reply-to\" email addresses for the message. When the recipient replies to the\n            message, each Reply-to address receives the reply.</p>"
+          }
+        },
+        "FeedbackForwardingEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The address that you want bounce and complaint notifications to be sent to.</p>"
+          }
+        },
+        "FeedbackForwardingEmailAddressIdentityArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>This parameter is used only for sending authorization. It is the ARN of the identity\n            that is associated with the sending authorization policy that permits you to use the\n            email address specified in the <code>FeedbackForwardingEmailAddress</code>\n            parameter.</p>\n         <p>For example, if the owner of example.com (which has ARN\n            arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that\n            authorizes you to use feedback@example.com, then you would specify the\n                <code>FeedbackForwardingEmailAddressIdentityArn</code> to be\n            arn:aws:ses:us-east-1:123456789012:identity/example.com, and the\n                <code>FeedbackForwardingEmailAddress</code> to be feedback@example.com.</p>\n         <p>For more information about sending authorization, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer\n                Guide</a>.</p>"
+          }
+        },
+        "Content": {
+          "target": "com.amazonaws.sesv2#EmailContent",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the body of the message. You can send either a Simple message,\n            Raw message, or a Templated message.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EmailTags": {
+          "target": "com.amazonaws.sesv2#MessageTagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags, in the form of name/value pairs, to apply to an email that you send\n            using the <code>SendEmail</code> operation. Tags correspond to characteristics of the\n            email that you define, so that you can publish email sending events. </p>"
+          }
+        },
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set to use when sending the email.</p>"
+          }
+        },
+        "EndpointId": {
+          "target": "com.amazonaws.sesv2#EndpointId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the multi-region endpoint (global-endpoint).</p>",
+            "smithy.rules#contextParam": {
+              "name": "EndpointId"
+            }
+          }
+        },
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant through which this email will be sent.</p>\n         <note>\n            <p>The email sending operation will only succeed if all referenced resources\n                (identities, configuration sets, and templates) are associated with this tenant.\n            </p>\n         </note>"
+          }
+        },
+        "ListManagementOptions": {
+          "target": "com.amazonaws.sesv2#ListManagementOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An object used to specify a list or topic to which an email belongs, which will be\n            used when a contact chooses to unsubscribe.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to send a single formatted email using Amazon SES. For more\n            information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-formatted.html\">Amazon SES Developer\n                Guide</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#SendEmailResponse": {
+      "type": "structure",
+      "members": {
+        "MessageId": {
+          "target": "com.amazonaws.sesv2#OutboundMessageId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the message that is generated when the message is\n            accepted.</p>\n         <note>\n            <p>It's possible for Amazon SES to accept a message without sending it. For example, this\n                can happen when the message that you're trying to send has an attachment that\n                contains a virus, or when you send a templated email that contains invalid\n                personalization content.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A unique message ID that you receive when an email is accepted for sending.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#SendQuota": {
+      "type": "structure",
+      "members": {
+        "Max24HourSend": {
+          "target": "com.amazonaws.sesv2#Max24HourSend",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of emails that you can send in the current Amazon Web Services Region over a\n            24-hour period. A value of -1 signifies an unlimited quota. (This value is also referred\n            to as your <i>sending quota</i>.)</p>"
+          }
+        },
+        "MaxSendRate": {
+          "target": "com.amazonaws.sesv2#MaxSendRate",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of emails that you can send per second in the current Amazon Web Services Region.\n            This value is also called your <i>maximum sending rate</i> or your\n                <i>maximum TPS (transactions per second) rate</i>.</p>"
+          }
+        },
+        "SentLast24Hours": {
+          "target": "com.amazonaws.sesv2#SentLast24Hours",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of emails sent from your Amazon SES account in the current Amazon Web Services Region over the\n            past 24 hours.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about the per-day and per-second sending limits\n            for your Amazon SES account in the current Amazon Web Services Region.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SendingOptions": {
+      "type": "structure",
+      "members": {
+        "SendingEnabled": {
+          "target": "com.amazonaws.sesv2#Enabled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If <code>true</code>, email sending is enabled for the configuration set. If\n                <code>false</code>, email sending is disabled for the configuration set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Used to enable or disable email sending for messages that use this configuration set\n            in the current Amazon Web Services Region.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SendingPausedException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The message can't be sent because the account's ability to send email is currently\n            paused.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.sesv2#SendingPoolName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of the dedicated IP pool to associate with the configuration set.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SendingStatus": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "REINSTATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REINSTATED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sending status for a reputation entity. This can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> \u2013 Sending is allowed for this entity.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> \u2013 Sending is prevented for this entity.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REINSTATED</code> \u2013 Sending is allowed even if there are active reputation findings.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#SentLast24Hours": {
+      "type": "double",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.sesv2#SerialNumber": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.sesv2#SimpleEmailService_v2": {
+      "type": "service",
+      "version": "2019-09-27",
+      "operations": [
+        {
+          "target": "com.amazonaws.sesv2#BatchGetMetricData"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CancelExportJob"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateConfigurationSet"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateConfigurationSetEventDestination"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateContact"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateContactList"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateCustomVerificationEmailTemplate"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateDedicatedIpPool"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateDeliverabilityTestReport"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateEmailIdentity"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateEmailIdentityPolicy"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateEmailTemplate"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateExportJob"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateImportJob"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateMultiRegionEndpoint"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateTenant"
+        },
+        {
+          "target": "com.amazonaws.sesv2#CreateTenantResourceAssociation"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteConfigurationSet"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteConfigurationSetEventDestination"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteContact"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteContactList"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteCustomVerificationEmailTemplate"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteDedicatedIpPool"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteEmailIdentity"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteEmailIdentityPolicy"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteEmailTemplate"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteMultiRegionEndpoint"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteSuppressedDestination"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteTenant"
+        },
+        {
+          "target": "com.amazonaws.sesv2#DeleteTenantResourceAssociation"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetAccount"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetBlacklistReports"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetConfigurationSet"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetConfigurationSetEventDestinations"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetContact"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetContactList"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetCustomVerificationEmailTemplate"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetDedicatedIp"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetDedicatedIpPool"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetDedicatedIps"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetDeliverabilityDashboardOptions"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetDeliverabilityTestReport"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetDomainDeliverabilityCampaign"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetDomainStatisticsReport"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetEmailAddressInsights"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetEmailIdentity"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetEmailIdentityPolicies"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetEmailTemplate"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetExportJob"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetImportJob"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetMessageInsights"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetMultiRegionEndpoint"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetReputationEntity"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetSuppressedDestination"
+        },
+        {
+          "target": "com.amazonaws.sesv2#GetTenant"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListConfigurationSets"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListContactLists"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListContacts"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListCustomVerificationEmailTemplates"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListDedicatedIpPools"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListDeliverabilityTestReports"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListDomainDeliverabilityCampaigns"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListEmailIdentities"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListEmailTemplates"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListExportJobs"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListImportJobs"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListMultiRegionEndpoints"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListRecommendations"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListReputationEntities"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListResourceTenants"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListSuppressedDestinations"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListTenantResources"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ListTenants"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutAccountDedicatedIpWarmupAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutAccountDetails"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutAccountSendingAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutAccountSuppressionAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutAccountVdmAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutConfigurationSetArchivingOptions"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutConfigurationSetDeliveryOptions"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutConfigurationSetReputationOptions"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutConfigurationSetSendingOptions"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutConfigurationSetSuppressionOptions"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutConfigurationSetTrackingOptions"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutConfigurationSetVdmOptions"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutDedicatedIpInPool"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutDedicatedIpPoolScalingAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutDedicatedIpWarmupAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutDeliverabilityDashboardOption"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutEmailIdentityConfigurationSetAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutEmailIdentityDkimAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutEmailIdentityDkimSigningAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutEmailIdentityFeedbackAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutEmailIdentityMailFromAttributes"
+        },
+        {
+          "target": "com.amazonaws.sesv2#PutSuppressedDestination"
+        },
+        {
+          "target": "com.amazonaws.sesv2#SendBulkEmail"
+        },
+        {
+          "target": "com.amazonaws.sesv2#SendCustomVerificationEmail"
+        },
+        {
+          "target": "com.amazonaws.sesv2#SendEmail"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TagResource"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TestRenderEmailTemplate"
+        },
+        {
+          "target": "com.amazonaws.sesv2#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.sesv2#UpdateConfigurationSetEventDestination"
+        },
+        {
+          "target": "com.amazonaws.sesv2#UpdateContact"
+        },
+        {
+          "target": "com.amazonaws.sesv2#UpdateContactList"
+        },
+        {
+          "target": "com.amazonaws.sesv2#UpdateCustomVerificationEmailTemplate"
+        },
+        {
+          "target": "com.amazonaws.sesv2#UpdateEmailIdentityPolicy"
+        },
+        {
+          "target": "com.amazonaws.sesv2#UpdateEmailTemplate"
+        },
+        {
+          "target": "com.amazonaws.sesv2#UpdateReputationEntityCustomerManagedStatus"
+        },
+        {
+          "target": "com.amazonaws.sesv2#UpdateReputationEntityPolicy"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "SESv2",
+          "arnNamespace": "ses",
+          "cloudFormationName": "SESv2",
+          "cloudTrailEventSource": "sesv2.amazonaws.com",
+          "endpointPrefix": "email"
+        },
+        "aws.auth#sigv4": {
+          "name": "ses"
+        },
+        "aws.protocols#restJson1": {},
+        "smithy.api#documentation": "<fullname>Amazon SES API v2</fullname>\n         <p>\n            <a href=\"http://aws.amazon.com/ses\">Amazon SES</a> is an Amazon Web Services service that\n            you can use to send email messages to your customers.</p>\n         <p>If you're new to Amazon SES API v2, you might find it helpful to review the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/\">Amazon Simple Email Service Developer\n                Guide</a>. The <i>Amazon SES Developer Guide</i> provides information\n            and code samples that demonstrate how to use Amazon SES API v2 features programmatically.</p>",
+        "smithy.api#title": "Amazon Simple Email Service",
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            },
+            "EndpointId": {
+              "required": false,
+              "documentation": "Operation parameter for EndpointId",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "EndpointId"
+                    }
+                  ]
+                },
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                },
+                {
+                  "fn": "aws.partition",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ],
+                  "assign": "PartitionResult"
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "isValidHostLabel",
+                      "argv": [
+                        {
+                          "ref": "EndpointId"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            false
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "isSet",
+                              "argv": [
+                                {
+                                  "ref": "Endpoint"
+                                }
+                              ]
+                            }
+                          ],
+                          "endpoint": {
+                            "url": {
+                              "ref": "Endpoint"
+                            },
+                            "properties": {
+                              "authSchemes": [
+                                {
+                                  "name": "sigv4a",
+                                  "signingName": "ses",
+                                  "signingRegionSet": [
+                                    "*"
+                                  ]
+                                }
+                              ]
+                            },
+                            "headers": {}
+                          },
+                          "type": "endpoint"
+                        },
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseDualStack"
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "booleanEquals",
+                                  "argv": [
+                                    true,
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "rules": [
+                                {
+                                  "conditions": [],
+                                  "endpoint": {
+                                    "url": "https://{EndpointId}.endpoints.email.global.{PartitionResult#dualStackDnsSuffix}",
+                                    "properties": {
+                                      "authSchemes": [
+                                        {
+                                          "name": "sigv4a",
+                                          "signingName": "ses",
+                                          "signingRegionSet": [
+                                            "*"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "headers": {}
+                                  },
+                                  "type": "endpoint"
+                                }
+                              ],
+                              "type": "tree"
+                            },
+                            {
+                              "conditions": [],
+                              "error": "DualStack is enabled but this partition does not support DualStack",
+                              "type": "error"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "endpoint": {
+                            "url": "https://{EndpointId}.endpoints.email.{PartitionResult#dnsSuffix}",
+                            "properties": {
+                              "authSchemes": [
+                                {
+                                  "name": "sigv4a",
+                                  "signingName": "ses",
+                                  "signingRegionSet": [
+                                    "*"
+                                  ]
+                                }
+                              ]
+                            },
+                            "headers": {}
+                          },
+                          "type": "endpoint"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "error": "Invalid Configuration: FIPS is not supported with multi-region endpoints",
+                      "type": "error"
+                    }
+                  ],
+                  "type": "tree"
+                },
+                {
+                  "conditions": [],
+                  "error": "EndpointId must be a valid host label",
+                  "type": "error"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://email-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://email-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://email.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://email.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.af-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "af-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.ap-northeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.ap-northeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.ap-northeast-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.ap-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.ap-southeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.ap-southeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.eu-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.eu-north-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.eu-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.eu-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.eu-west-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.me-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "me-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.sa-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "sa-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email-fips.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email-fips.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email-fips.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            },
+            {
+              "documentation": "Valid EndpointId with dualstack and FIPS disabled. i.e, IPv4 Only stack with no FIPS",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "signingName": "ses",
+                        "name": "sigv4a",
+                        "signingRegionSet": [
+                          "*"
+                        ]
+                      }
+                    ]
+                  },
+                  "url": "https://abc123.456def.endpoints.email.amazonaws.com"
+                }
+              },
+              "params": {
+                "EndpointId": "abc123.456def",
+                "UseDualStack": false,
+                "UseFIPS": false,
+                "Region": "us-east-1"
+              }
+            },
+            {
+              "documentation": "Valid EndpointId with dualstack enabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "signingName": "ses",
+                        "name": "sigv4a",
+                        "signingRegionSet": [
+                          "*"
+                        ]
+                      }
+                    ]
+                  },
+                  "url": "https://abc123.456def.endpoints.email.global.api.aws"
+                }
+              },
+              "params": {
+                "EndpointId": "abc123.456def",
+                "UseDualStack": true,
+                "UseFIPS": false,
+                "Region": "us-west-2"
+              }
+            },
+            {
+              "documentation": "Valid EndpointId with FIPS set, dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS is not supported with multi-region endpoints"
+              },
+              "params": {
+                "EndpointId": "abc123.456def",
+                "UseDualStack": false,
+                "UseFIPS": true,
+                "Region": "ap-northeast-1"
+              }
+            },
+            {
+              "documentation": "Valid EndpointId with both dualstack and FIPS enabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS is not supported with multi-region endpoints"
+              },
+              "params": {
+                "EndpointId": "abc123.456def",
+                "UseDualStack": true,
+                "UseFIPS": true,
+                "Region": "ap-northeast-2"
+              }
+            },
+            {
+              "documentation": "Regular regional request, without EndpointId",
+              "expect": {
+                "endpoint": {
+                  "url": "https://email.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "UseDualStack": false,
+                "Region": "eu-west-1"
+              }
+            },
+            {
+              "documentation": "Invalid EndpointId (Invalid chars / format)",
+              "expect": {
+                "error": "EndpointId must be a valid host label"
+              },
+              "params": {
+                "EndpointId": "badactor.com?foo=bar",
+                "UseDualStack": false,
+                "Region": "eu-west-2"
+              }
+            },
+            {
+              "documentation": "Invalid EndpointId (Empty)",
+              "expect": {
+                "error": "EndpointId must be a valid host label"
+              },
+              "params": {
+                "EndpointId": "",
+                "UseDualStack": false,
+                "Region": "ap-south-1"
+              }
+            },
+            {
+              "documentation": "Valid EndpointId with custom sdk endpoint",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "signingName": "ses",
+                        "name": "sigv4a",
+                        "signingRegionSet": [
+                          "*"
+                        ]
+                      }
+                    ]
+                  },
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "EndpointId": "abc123.456def",
+                "UseDualStack": false,
+                "Region": "us-east-1",
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Valid EndpointId with custom sdk endpoint with FIPS enabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS is not supported with multi-region endpoints"
+              },
+              "params": {
+                "EndpointId": "abc123.456def",
+                "UseDualStack": false,
+                "UseFIPS": true,
+                "Region": "us-east-1",
+                "Endpoint": "https://example.com"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.sesv2#SnsDestination": {
+      "type": "structure",
+      "members": {
+        "TopicArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to publish email events to. For\n            more information about Amazon SNS topics, see the <a href=\"https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\">Amazon SNS Developer Guide</a>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines an Amazon SNS destination for email events. You can use Amazon SNS to\n            send notifications when certain email events occur.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Status": {
+      "type": "enum",
+      "members": {
+        "CREATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATING"
+          }
+        },
+        "READY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "READY"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status of the multi-region endpoint (global-endpoint).</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> \u2013 The resource is being provisioned.</p>\n            </li>\n            <li>\n               <p>\n                  <code>READY</code> \u2013 The resource is ready to use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 The resource failed to be provisioned.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> \u2013 The resource is being deleted as requested.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#StatusCause": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A description of the reason for a status change, such as automated actions \n            taken due to reputation findings or manual status updates.</p>",
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.sesv2#StatusRecord": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.sesv2#SendingStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current sending status. This can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> \u2013 Sending is allowed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> \u2013 Sending is prevented.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REINSTATED</code> \u2013 Sending is allowed even with active reputation findings.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Cause": {
+          "target": "com.amazonaws.sesv2#StatusCause",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the reason for the current status, or null if no specific \n            cause is available.</p>"
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when this status was last updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains status information for a reputation entity, including \n            the current status, cause description, and timestamp.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Subject": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#SubscriptionStatus": {
+      "type": "enum",
+      "members": {
+        "OPT_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPT_IN"
+          }
+        },
+        "OPT_OUT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPT_OUT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#SuccessRedirectionURL": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The URL that the recipient of the verification email is sent to if his or her address\n            is successfully verified.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressedDestination": {
+      "type": "structure",
+      "members": {
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address that is on the suppression list for your account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Reason": {
+          "target": "com.amazonaws.sesv2#SuppressionListReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason that the address was added to the suppression list for your account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LastUpdateTime": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the suppressed destination was last updated, shown in Unix time\n            format.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Attributes": {
+          "target": "com.amazonaws.sesv2#SuppressedDestinationAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>An optional value that can contain additional information about the reasons that the\n            address was added to the suppression list for your account.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about an email address that is on the suppression\n            list for your account.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressedDestinationAttributes": {
+      "type": "structure",
+      "members": {
+        "MessageId": {
+          "target": "com.amazonaws.sesv2#OutboundMessageId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the email message that caused the email address to be added\n            to the suppression list for your account.</p>"
+          }
+        },
+        "FeedbackId": {
+          "target": "com.amazonaws.sesv2#FeedbackId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier that's generated when an email address is added to the suppression\n            list for your account.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains additional attributes that are related an email address that\n            is on the suppression list for your account.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressedDestinationSummaries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#SuppressedDestinationSummary"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressedDestinationSummary": {
+      "type": "structure",
+      "members": {
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address that's on the suppression list for your account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Reason": {
+          "target": "com.amazonaws.sesv2#SuppressionListReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason that the address was added to the suppression list for your account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LastUpdateTime": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the suppressed destination was last updated, shown in Unix time\n            format.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A summary that describes the suppressed email address.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionAttributes": {
+      "type": "structure",
+      "members": {
+        "SuppressedReasons": {
+          "target": "com.amazonaws.sesv2#SuppressionListReasons",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains the reasons that email addresses will be automatically added to\n            the suppression list for your account. This list can contain any or all of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COMPLAINT</code> \u2013 Amazon SES adds an email address to the suppression\n                    list for your account when a message sent to that address results in a\n                    complaint.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BOUNCE</code> \u2013 Amazon SES adds an email address to the suppression\n                    list for your account when a message sent to that address results in a hard\n                    bounce.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "ValidationAttributes": {
+          "target": "com.amazonaws.sesv2#SuppressionValidationAttributes"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about the email address suppression preferences\n            for your account in the current Amazon Web Services Region.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionConditionThreshold": {
+      "type": "structure",
+      "members": {
+        "ConditionThresholdEnabled": {
+          "target": "com.amazonaws.sesv2#FeatureStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether Auto Validation is enabled for suppression. Set to <code>ENABLED</code>\n            to enable the Auto Validation feature, or set to <code>DISABLED</code> to disable\n            it.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OverallConfidenceThreshold": {
+          "target": "com.amazonaws.sesv2#SuppressionConfidenceThreshold",
+          "traits": {
+            "smithy.api#documentation": "<p>The overall confidence threshold used to determine suppression decisions.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains Auto Validation settings, allowing you to suppress sending to specific destination(s)\n            if they do not meet required threshold. For details on Auto Validation, see <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/email-validation.html\">Auto Validation</a>.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionConfidenceThreshold": {
+      "type": "structure",
+      "members": {
+        "ConfidenceVerdictThreshold": {
+          "target": "com.amazonaws.sesv2#SuppressionConfidenceVerdictThreshold",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence level threshold for suppression decisions.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the confidence threshold settings for Auto Validation.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionConfidenceVerdictThreshold": {
+      "type": "enum",
+      "members": {
+        "MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEDIUM"
+          }
+        },
+        "HIGH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HIGH"
+          }
+        },
+        "MANAGED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANAGED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The confidence level threshold for suppression validation:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>MEDIUM</code> \u2013 Allows emails to be sent to addresses with medium or high delivery likelihood.</p>\n            </li>\n            <li>\n               <p>\n                  <code>HIGH</code> \u2013 Allows emails to be sent only to addresses with high delivery likelihood.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MANAGED</code> \u2013 Managed confidence threshold where Amazon SES automatically determines the appropriate level.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionListDestination": {
+      "type": "structure",
+      "members": {
+        "SuppressionListImportAction": {
+          "target": "com.amazonaws.sesv2#SuppressionListImportAction",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of action to perform on the address. The following are possible values:</p>\n         <ul>\n            <li>\n               <p>PUT: add the addresses to the suppression list. If the record already exists,\n                    it will override it with the new value.</p>\n            </li>\n            <li>\n               <p>DELETE: remove the addresses from the suppression list.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains details about the action of suppression list.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionListImportAction": {
+      "type": "enum",
+      "members": {
+        "DELETE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE"
+          }
+        },
+        "PUT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PUT"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type of action to perform on the address. The following are possible values:</p>\n         <ul>\n            <li>\n               <p>PUT: add the addresses to the suppression list.</p>\n            </li>\n            <li>\n               <p>DELETE: remove the address from the suppression list.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionListReason": {
+      "type": "enum",
+      "members": {
+        "BOUNCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOUNCE"
+          }
+        },
+        "COMPLAINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLAINT"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The reason that the address was added to the suppression list for your account. The\n            value can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COMPLAINT</code> \u2013 Amazon SES added an email address to the suppression\n                    list for your account because a message sent to that address results in a\n                    complaint.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BOUNCE</code> \u2013 Amazon SES added an email address to the suppression\n                    list for your account because a message sent to that address results in a hard\n                    bounce.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionListReasons": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#SuppressionListReason"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionOptions": {
+      "type": "structure",
+      "members": {
+        "SuppressedReasons": {
+          "target": "com.amazonaws.sesv2#SuppressionListReasons",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains the reasons that email addresses are automatically added to the\n            suppression list for your account. This list can contain any or all of the\n            following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COMPLAINT</code> \u2013 Amazon SES adds an email address to the suppression\n                    list for your account when a message sent to that address results in a\n                    complaint.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BOUNCE</code> \u2013 Amazon SES adds an email address to the suppression\n                    list for your account when a message sent to that address results in a hard\n                    bounce.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "ValidationOptions": {
+          "target": "com.amazonaws.sesv2#SuppressionValidationOptions"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about the suppression list preferences for your\n            account.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionValidationAttributes": {
+      "type": "structure",
+      "members": {
+        "ConditionThreshold": {
+          "target": "com.amazonaws.sesv2#SuppressionConditionThreshold",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the condition threshold settings for account-level suppression.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Structure containing validation attributes used for suppressing sending to specific destination on account level.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#SuppressionValidationOptions": {
+      "type": "structure",
+      "members": {
+        "ConditionThreshold": {
+          "target": "com.amazonaws.sesv2#SuppressionConditionThreshold",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the condition threshold settings for suppression validation.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains validation options for email address suppression.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Tag": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.sesv2#TagKey",
+          "traits": {
+            "smithy.api#documentation": "<p>One part of a key-value pair that defines a tag. The maximum length of a tag key is\n            128 characters. The minimum length is 1 character.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.sesv2#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The optional part of a key-value pair that defines a tag. The maximum length of a tag\n            value is 256 characters. The minimum length is 0 characters. If you don't want a\n            resource to have a specific tag value, don't specify a value for this\u00a0parameter. If you\n            don't specify a value, Amazon SES sets the value to an empty string.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines the tags that are associated with a resource.\n                A\u00a0<i>tag</i>\u00a0is a label that you optionally define and associate with\n            a resource. Tags can help you categorize and manage resources in different ways, such as\n            by purpose, owner, environment, or other criteria. A resource can have as many as 50\n            tags.</p>\n         <p>Each tag consists of a required\u00a0<i>tag key</i>\u00a0and an\n                associated\u00a0<i>tag value</i>, both of which you define. A tag key is a\n            general label that acts as a category for a more specific tag value. A tag value acts as\n            a descriptor within a tag key. A tag key can contain as many as 128 characters. A tag\n            value can contain as many as 256 characters. The characters can be Unicode letters,\n            digits, white space, or one of the following symbols: _ . : / = + -. The following\n            additional restrictions apply to tags:</p>\n         <ul>\n            <li>\n               <p>Tag keys and values are case sensitive.</p>\n            </li>\n            <li>\n               <p>For each associated resource, each tag key must be unique and it can have only\n                    one value.</p>\n            </li>\n            <li>\n               <p>The\u00a0<code>aws:</code>\u00a0prefix is reserved for use by Amazon Web Services; you can\u2019t use it in\n                    any tag keys or values that you define. In addition, you can't edit or remove\n                    tag keys or values that use this prefix. Tags that use this prefix don\u2019t count\n                    against the limit of 50 tags per resource.</p>\n            </li>\n            <li>\n               <p>You can associate tags with public or shared resources, but the tags are\n                    available only for your Amazon Web Services account, not any other accounts that share the\n                    resource. In addition, the tags are available only for resources that are\n                    located in the specified Amazon Web Services Region for your Amazon Web Services account.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.sesv2#TagKey": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#TagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#TagKey"
+      }
+    },
+    "com.amazonaws.sesv2#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Tag"
+      }
+    },
+    "com.amazonaws.sesv2#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Add one or more tags (keys and values) to a specified resource. A\n                <i>tag</i>\u00a0is a label that you optionally define and associate with a\n            resource. Tags can help you categorize and manage resources in different ways, such as\n            by purpose, owner, environment, or other criteria. A resource can have as many as 50\n            tags.</p>\n         <p>Each tag consists of a required\u00a0<i>tag key</i>\u00a0and an\n                associated\u00a0<i>tag value</i>, both of which you define. A tag key is a\n            general label that acts as a category for more specific tag values. A tag value acts as\n            a descriptor within a tag key.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/tags",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource that you want to add one or more tags\n            to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the tags that you want to add to the resource. A tag consists of a required\n            tag key (<code>Key</code>) and an associated tag value (<code>Value</code>). The maximum\n            length of a tag key is 128 characters. The maximum length of a tag value is 256\n            characters.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#TagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#TagValue": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#Template": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the template. You will refer to this name when you send email using the\n                <code>SendEmail</code> or <code>SendBulkEmail</code> operations.\n        </p>"
+          }
+        },
+        "TemplateArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the template.</p>"
+          }
+        },
+        "TemplateContent": {
+          "target": "com.amazonaws.sesv2#EmailTemplateContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the template.</p>\n         <note>\n            <p>Amazon SES supports only simple substitions when you send email using the  \n                <code>SendEmail</code> or <code>SendBulkEmail</code> operations and \n                you provide the full template content in the request.</p>\n         </note>"
+          }
+        },
+        "TemplateData": {
+          "target": "com.amazonaws.sesv2#EmailTemplateData",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the values to use for message variables in the template. This\n            object is a set of key-value pairs. Each key defines a message variable in the template.\n            The corresponding value defines the value to use for that variable.</p>"
+          }
+        },
+        "Headers": {
+          "target": "com.amazonaws.sesv2#MessageHeaderList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of message headers that will be added to the email message.</p>"
+          }
+        },
+        "Attachments": {
+          "target": "com.amazonaws.sesv2#AttachmentList",
+          "traits": {
+            "smithy.api#documentation": "<p> The List of attachments to include in your email. All recipients will receive the same attachments.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines the email template to use for an email message, and the values\n            to use for any message variables in that template. An <i>email\n                template</i> is a type of message template that contains content that you\n            want to reuse in email messages that you send. You can specifiy the email template by providing \n            the name or ARN of an <i>email template</i> \n            previously saved in your Amazon SES account or by providing the full template content.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#TemplateContent": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The content of the custom verification email template.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#Tenant": {
+      "type": "structure",
+      "members": {
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant.</p>"
+          }
+        },
+        "TenantId": {
+          "target": "com.amazonaws.sesv2#TenantId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the tenant.</p>"
+          }
+        },
+        "TenantArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the tenant.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the tenant was created.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.sesv2#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of objects that define the tags (keys and values) associated with the tenant.</p>"
+          }
+        },
+        "SendingStatus": {
+          "target": "com.amazonaws.sesv2#SendingStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of sending capability for the tenant.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A structure that contains details about a tenant.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#TenantId": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#TenantInfo": {
+      "type": "structure",
+      "members": {
+        "TenantName": {
+          "target": "com.amazonaws.sesv2#TenantName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the tenant.</p>"
+          }
+        },
+        "TenantId": {
+          "target": "com.amazonaws.sesv2#TenantId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the tenant.</p>"
+          }
+        },
+        "TenantArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the tenant.</p>"
+          }
+        },
+        "CreatedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the tenant was created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A structure that contains basic information about a tenant.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#TenantInfoList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#TenantInfo"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of tenant information objects.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#TenantName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The name of a tenant. The name can contain up to 64 alphanumeric characters, including\n            letters, numbers, hyphens (-) and underscores (_) only.</p>",
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.sesv2#TenantResource": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.sesv2#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of resource associated with the tenant. Valid values are <code>EMAIL_IDENTITY</code>,\n            <code>CONFIGURATION_SET</code>, or <code>EMAIL_TEMPLATE</code>.</p>"
+          }
+        },
+        "ResourceArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource associated with the tenant.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A structure that contains information about a resource associated with a tenant.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#TenantResourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#TenantResource"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of resources associated with a tenant.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#TestRenderEmailTemplate": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#TestRenderEmailTemplateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#TestRenderEmailTemplateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a preview of the MIME content of an email when provided with a template and a\n            set of replacement data.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/email/templates/{TemplateName}/render",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#TestRenderEmailTemplateRequest": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the template.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateData": {
+          "target": "com.amazonaws.sesv2#EmailTemplateData",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of replacement values to apply to the template. This parameter is a JSON\n            object, typically consisting of key-value pairs in which the keys correspond to\n            replacement tags in the email template.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>>Represents a request to create a preview of the MIME content of an email when\n            provided with a template and a set of replacement data.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#TestRenderEmailTemplateResponse": {
+      "type": "structure",
+      "members": {
+        "RenderedTemplate": {
+          "target": "com.amazonaws.sesv2#RenderedEmailTemplate",
+          "traits": {
+            "smithy.api#documentation": "<p>The complete MIME message rendered by applying the data in the\n                <code>TemplateData</code> parameter to the template specified in the TemplateName\n            parameter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The following element is returned by the service.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#Timestamp": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.sesv2#TimestampList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Timestamp"
+      }
+    },
+    "com.amazonaws.sesv2#TlsPolicy": {
+      "type": "enum",
+      "members": {
+        "REQUIRE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REQUIRE"
+          }
+        },
+        "OPTIONAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPTIONAL"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies whether messages that use the configuration set are required to use\n            Transport Layer Security (TLS). If the value is <code>Require</code>, messages are only\n            delivered if a TLS connection can be established. If the value is <code>Optional</code>,\n            messages can be delivered in plain text if a TLS connection can't be established.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#TooManyRequestsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.sesv2#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Too many requests have been made to the operation.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
+      }
+    },
+    "com.amazonaws.sesv2#Topic": {
+      "type": "structure",
+      "members": {
+        "TopicName": {
+          "target": "com.amazonaws.sesv2#TopicName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the topic.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayName": {
+          "target": "com.amazonaws.sesv2#DisplayName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the topic the contact will see.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.sesv2#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of what the topic is about, which the contact will see.</p>"
+          }
+        },
+        "DefaultSubscriptionStatus": {
+          "target": "com.amazonaws.sesv2#SubscriptionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The default subscription status to be applied to a contact if the contact has not\n            noted their preference for subscribing to a topic.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An interest group, theme, or label within a list. Lists can have multiple\n            topics.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#TopicFilter": {
+      "type": "structure",
+      "members": {
+        "TopicName": {
+          "target": "com.amazonaws.sesv2#TopicName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a topic on which you wish to apply the filter.</p>"
+          }
+        },
+        "UseDefaultIfPreferenceUnavailable": {
+          "target": "com.amazonaws.sesv2#UseDefaultIfPreferenceUnavailable",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Notes that the default subscription status should be applied to a contact because the\n            contact has not noted their preference for subscribing to a topic.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Used for filtering by a specific topic preference.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#TopicName": {
+      "type": "string"
+    },
+    "com.amazonaws.sesv2#TopicPreference": {
+      "type": "structure",
+      "members": {
+        "TopicName": {
+          "target": "com.amazonaws.sesv2#TopicName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the topic.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SubscriptionStatus": {
+          "target": "com.amazonaws.sesv2#SubscriptionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's subscription status to a topic which is either <code>OPT_IN</code> or\n                <code>OPT_OUT</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The contact's preference for being opted-in to or opted-out of a topic.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#TopicPreferenceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#TopicPreference"
+      }
+    },
+    "com.amazonaws.sesv2#Topics": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sesv2#Topic"
+      }
+    },
+    "com.amazonaws.sesv2#TrackingOptions": {
+      "type": "structure",
+      "members": {
+        "CustomRedirectDomain": {
+          "target": "com.amazonaws.sesv2#CustomRedirectDomain",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain to use for tracking open and click events.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "HttpsPolicy": {
+          "target": "com.amazonaws.sesv2#HttpsPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The https policy to use for tracking open and click events.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines the tracking options for a configuration set. When you use the\n            Amazon SES API v2 to send an email, it contains an invisible image that's used to track when\n            recipients open your email. If your email contains links, those links are changed\n            slightly in order to track when recipients click them.</p>\n         <p>These images and links include references to a domain operated by Amazon Web Services. You can\n            optionally configure the Amazon SES to use a domain that you operate for these images and\n            links.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#UnsubscribeAll": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.sesv2#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#UntagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Remove one or more tags (keys and values) from a specified resource.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/email/tags",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource that you want to remove one or more\n            tags from.</p>",
+            "smithy.api#httpQuery": "ResourceArn",
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.sesv2#TagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags (tag keys) that you want to remove from the resource. When you specify a tag\n            key, the action removes both that key and its associated tag value.</p>\n         <p>To remove more than one tag from the resource, append the <code>TagKeys</code>\n            parameter and argument for each additional tag to remove, separated by an ampersand. For\n            example:\n                <code>/v2/email/tags?ResourceArn=ResourceArn&TagKeys=Key1&TagKeys=Key2</code>\n         </p>",
+            "smithy.api#httpQuery": "TagKeys",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#UntagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateConfigurationSetEventDestination": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#UpdateConfigurationSetEventDestinationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#UpdateConfigurationSetEventDestinationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Update the configuration of an event destination for a configuration set.</p>\n         <p>\n            <i>Events</i> include message sends, deliveries, opens, clicks, bounces,\n            and complaints. <i>Event destinations</i> are places that you can send\n            information about these events to. For example, you can send event data to Amazon EventBridge and\n            associate a rule to send the event to the specified target.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations/{EventDestinationName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#UpdateConfigurationSetEventDestinationRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationSetName": {
+          "target": "com.amazonaws.sesv2#ConfigurationSetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration set that contains the event destination to\n            modify.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "EventDestinationName": {
+          "target": "com.amazonaws.sesv2#EventDestinationName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event destination.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "EventDestination": {
+          "target": "com.amazonaws.sesv2#EventDestinationDefinition",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that defines the event destination.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to change the settings for an event destination for a configuration\n            set.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateConfigurationSetEventDestinationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateContact": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#UpdateContactRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#UpdateContactResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a contact's preferences for a list.</p>\n         <note>\n            <p>You must specify all existing topic preferences in the\n                    <code>TopicPreferences</code> object, not just the ones that need updating;\n                otherwise, all your existing preferences will be removed.</p>\n         </note>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/contact-lists/{ContactListName}/contacts/{EmailAddress}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#UpdateContactList": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#UpdateContactListRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#UpdateContactListResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates contact list metadata. This operation does a complete replacement.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/contact-lists/{ContactListName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#UpdateContactListRequest": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Topics": {
+          "target": "com.amazonaws.sesv2#Topics",
+          "traits": {
+            "smithy.api#documentation": "<p>An interest group, theme, or label within a list. A contact list can have multiple\n            topics.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.sesv2#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of what the contact list is about.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateContactListResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateContactRequest": {
+      "type": "structure",
+      "members": {
+        "ContactListName": {
+          "target": "com.amazonaws.sesv2#ContactListName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contact list.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "EmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's email address.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "TopicPreferences": {
+          "target": "com.amazonaws.sesv2#TopicPreferenceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The contact's preference for being opted-in to or opted-out of a topic.</p>"
+          }
+        },
+        "UnsubscribeAll": {
+          "target": "com.amazonaws.sesv2#UnsubscribeAll",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>A boolean value status noting if the contact is unsubscribed from all contact list\n            topics.</p>"
+          }
+        },
+        "AttributesData": {
+          "target": "com.amazonaws.sesv2#AttributesData",
+          "traits": {
+            "smithy.api#documentation": "<p>The attribute data attached to a contact.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateContactResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateCustomVerificationEmailTemplate": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#UpdateCustomVerificationEmailTemplateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#UpdateCustomVerificationEmailTemplateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an existing custom verification email template.</p>\n         <p>For more information about custom verification email templates, see <a href=\"https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#send-email-verify-address-custom\">Using\n                custom verification email templates</a> in the <i>Amazon SES Developer\n                Guide</i>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/custom-verification-email-templates/{TemplateName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#UpdateCustomVerificationEmailTemplateRequest": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom verification email template that you want to update.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "FromEmailAddress": {
+          "target": "com.amazonaws.sesv2#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address that the custom verification email is sent from.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateSubject": {
+          "target": "com.amazonaws.sesv2#EmailTemplateSubject",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line of the custom verification email.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateContent": {
+          "target": "com.amazonaws.sesv2#TemplateContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the custom verification email. The total size of the email must be less\n            than 10 MB. The message body may contain HTML, with some limitations. For more\n            information, see <a href=\"https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#send-email-verify-address-custom-faq\">Custom verification email frequently asked questions</a> in the <i>Amazon SES\n                Developer Guide</i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SuccessRedirectionURL": {
+          "target": "com.amazonaws.sesv2#SuccessRedirectionURL",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL that the recipient of the verification email is sent to if his or her address\n            is successfully verified.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FailureRedirectionURL": {
+          "target": "com.amazonaws.sesv2#FailureRedirectionURL",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL that the recipient of the verification email is sent to if his or her address\n            is not successfully verified.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to update an existing custom verification email template.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateCustomVerificationEmailTemplateResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty\n            HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateEmailIdentityPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#UpdateEmailIdentityPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#UpdateEmailIdentityPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates the specified sending authorization policy for the given identity (an email\n            address or a domain). This API returns successfully even if a policy with the specified\n            name does not exist.</p>\n         <note>\n            <p>This API is for the identity owner only. If you have not verified the identity,\n                this API will return an error.</p>\n         </note>\n         <p>Sending authorization is a feature that enables an identity owner to authorize other\n            senders to use its identities. For information about using sending authorization, see\n            the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer\n                Guide</a>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/identities/{EmailIdentity}/policies/{PolicyName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#UpdateEmailIdentityPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "EmailIdentity": {
+          "target": "com.amazonaws.sesv2#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>The email identity.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "PolicyName": {
+          "target": "com.amazonaws.sesv2#PolicyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the policy.</p>\n         <p>The policy name cannot exceed 64 characters and can only include alphanumeric\n            characters, dashes, and underscores.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Policy": {
+          "target": "com.amazonaws.sesv2#Policy",
+          "traits": {
+            "smithy.api#documentation": "<p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p>\n         <p> For information about the syntax of sending authorization policies, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html\">Amazon SES Developer\n                Guide</a>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to update a sending authorization policy for an identity. Sending\n            authorization is an Amazon SES feature that enables you to authorize other senders to use\n            your identities. For information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-identity-owner-tasks-management.html\">Amazon SES Developer Guide</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateEmailIdentityPolicyResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An HTTP 200 response if the request succeeds, or an error message if the request\n            fails.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateEmailTemplate": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#UpdateEmailTemplateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#UpdateEmailTemplateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an email template. Email templates enable you to send personalized email to\n            one or more destinations in a single API operation. For more information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\">Amazon SES Developer\n                Guide</a>.</p>\n         <p>You can execute this operation no more than once per second.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/templates/{TemplateName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#UpdateEmailTemplateRequest": {
+      "type": "structure",
+      "members": {
+        "TemplateName": {
+          "target": "com.amazonaws.sesv2#EmailTemplateName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the template.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateContent": {
+          "target": "com.amazonaws.sesv2#EmailTemplateContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the email template, composed of a subject line, an HTML part, and a\n            text-only part.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to update an email template. For more information, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\">Amazon SES\n                Developer Guide</a>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateEmailTemplateResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty\n            HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateReputationEntityCustomerManagedStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#UpdateReputationEntityCustomerManagedStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#UpdateReputationEntityCustomerManagedStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Update the customer-managed sending status for a reputation entity. This allows \n            you to enable, disable, or reinstate sending for the entity.</p>\n         <p>The customer-managed status works in conjunction with the Amazon Web Services Amazon SES-managed status\n        to determine the overall sending capability. When you update the customer-managed status,\n        the Amazon Web Services Amazon SES-managed status remains unchanged. If Amazon Web Services Amazon SES has disabled the entity,\n        it will not be allowed to send regardless of the customer-managed status setting. When you\n        reinstate an entity through the customer-managed status, it can continue sending only if\n        the Amazon Web Services Amazon SES-managed status also permits sending, even if there are active reputation\n        findings, until the findings are resolved or new violations occur.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/reputation/entities/{ReputationEntityType}/{ReputationEntityReference}/customer-managed-status",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#UpdateReputationEntityCustomerManagedStatusRequest": {
+      "type": "structure",
+      "members": {
+        "ReputationEntityType": {
+          "target": "com.amazonaws.sesv2#ReputationEntityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of reputation entity. Currently, only <code>RESOURCE</code> type entities are supported.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ReputationEntityReference": {
+          "target": "com.amazonaws.sesv2#ReputationEntityReference",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the reputation entity. For resource-type entities, \n            this is the Amazon Resource Name (ARN) of the resource.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "SendingStatus": {
+          "target": "com.amazonaws.sesv2#SendingStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The new customer-managed sending status for the reputation entity. This can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> \u2013 Allow sending for this entity.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> \u2013 Prevent sending for this entity.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REINSTATED</code> \u2013 Allow sending even if there are active reputation findings.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to update the customer-managed sending status for a reputation entity.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateReputationEntityCustomerManagedStatusResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateReputationEntityPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.sesv2#UpdateReputationEntityPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.sesv2#UpdateReputationEntityPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.sesv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.sesv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Update the reputation management policy for a reputation entity. The policy \n            determines how the entity responds to reputation findings, such as automatically \n            pausing sending when certain thresholds are exceeded.</p>\n         <p>Reputation management policies are Amazon Web Services Amazon SES-managed (predefined policies).\n        You can select from none, standard, and strict policies.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/email/reputation/entities/{ReputationEntityType}/{ReputationEntityReference}/policy",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.sesv2#UpdateReputationEntityPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "ReputationEntityType": {
+          "target": "com.amazonaws.sesv2#ReputationEntityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of reputation entity. Currently, only <code>RESOURCE</code> type entities are supported.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ReputationEntityReference": {
+          "target": "com.amazonaws.sesv2#ReputationEntityReference",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the reputation entity. For resource-type entities, \n            this is the Amazon Resource Name (ARN) of the resource.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ReputationEntityPolicy": {
+          "target": "com.amazonaws.sesv2#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the reputation management policy to apply \n            to this entity. This is an Amazon Web Services Amazon SES-managed policy.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a request to update the reputation management policy for a reputation entity.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.sesv2#UpdateReputationEntityPolicyResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.sesv2#UseCaseDescription": {
+      "type": "string",
+      "traits": {
+        "smithy.api#deprecated": {
+          "message": "Use case description is optional and deprecated"
+        },
+        "smithy.api#length": {
+          "min": 0,
+          "max": 5000
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.sesv2#UseDefaultIfPreferenceUnavailable": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.sesv2#VdmAttributes": {
+      "type": "structure",
+      "members": {
+        "VdmEnabled": {
+          "target": "com.amazonaws.sesv2#FeatureStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the status of your VDM configuration. Can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> \u2013 Amazon SES enables VDM for your account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> \u2013 Amazon SES disables VDM for your account.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "DashboardAttributes": {
+          "target": "com.amazonaws.sesv2#DashboardAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies additional settings for your VDM configuration as applicable to the\n            Dashboard.</p>"
+          }
+        },
+        "GuardianAttributes": {
+          "target": "com.amazonaws.sesv2#GuardianAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies additional settings for your VDM configuration as applicable to the\n            Guardian.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The VDM attributes that apply to your Amazon SES account.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#VdmOptions": {
+      "type": "structure",
+      "members": {
+        "DashboardOptions": {
+          "target": "com.amazonaws.sesv2#DashboardOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies additional settings for your VDM configuration as applicable to the\n            Dashboard.</p>"
+          }
+        },
+        "GuardianOptions": {
+          "target": "com.amazonaws.sesv2#GuardianOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies additional settings for your VDM configuration as applicable to the\n            Guardian.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that defines the VDM settings that apply to emails that you send using the\n            configuration set.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#VerificationError": {
+      "type": "enum",
+      "members": {
+        "SERVICE_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SERVICE_ERROR"
+          }
+        },
+        "DNS_SERVER_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DNS_SERVER_ERROR"
+          }
+        },
+        "HOST_NOT_FOUND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HOST_NOT_FOUND"
+          }
+        },
+        "TYPE_NOT_FOUND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TYPE_NOT_FOUND"
+          }
+        },
+        "INVALID_VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INVALID_VALUE"
+          }
+        },
+        "REPLICATION_ACCESS_DENIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REPLICATION_ACCESS_DENIED"
+          }
+        },
+        "REPLICATION_PRIMARY_NOT_FOUND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REPLICATION_PRIMARY_NOT_FOUND"
+          }
+        },
+        "REPLICATION_PRIMARY_BYO_DKIM_NOT_SUPPORTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REPLICATION_PRIMARY_BYO_DKIM_NOT_SUPPORTED"
+          }
+        },
+        "REPLICATION_REPLICA_AS_PRIMARY_NOT_SUPPORTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REPLICATION_REPLICA_AS_PRIMARY_NOT_SUPPORTED"
+          }
+        },
+        "REPLICATION_PRIMARY_INVALID_REGION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REPLICATION_PRIMARY_INVALID_REGION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#VerificationInfo": {
+      "type": "structure",
+      "members": {
+        "LastCheckedTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The last time a verification attempt was made for this identity.</p>"
+          }
+        },
+        "LastSuccessTimestamp": {
+          "target": "com.amazonaws.sesv2#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The last time a successful verification was made for this identity.</p>"
+          }
+        },
+        "ErrorType": {
+          "target": "com.amazonaws.sesv2#VerificationError",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the reason for the failure describing why Amazon SES was not able to successfully\n            verify the identity. Below are the possible values: </p>\n         <ul>\n            <li>\n               <p>\n                  <code>INVALID_VALUE</code> \u2013 Amazon SES was able to find the record, but the\n                    value contained within the record was invalid. Ensure you have published the\n                    correct values for the record.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TYPE_NOT_FOUND</code> \u2013 The queried hostname exists but does not\n                    have the requested type of DNS record. Ensure that you have published the\n                    correct type of DNS record.</p>\n            </li>\n            <li>\n               <p>\n                  <code>HOST_NOT_FOUND</code> \u2013 The queried hostname does not exist or was\n                    not reachable at the time of the request. Ensure that you have published the\n                    required DNS record(s). </p>\n            </li>\n            <li>\n               <p>\n                  <code>SERVICE_ERROR</code> \u2013 A temporary issue is preventing Amazon SES from\n                    determining the verification status of the domain.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DNS_SERVER_ERROR</code> \u2013 The DNS server encountered an issue and\n                    was unable to complete the request.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REPLICATION_ACCESS_DENIED</code> \u2013 The verification failed because the user does not\n                    have the required permissions to replicate the DKIM key from the primary region. Ensure you have the\n                    necessary permissions in both primary and replica regions.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>REPLICATION_PRIMARY_NOT_FOUND</code> \u2013 The verification failed because no corresponding\n                    identity was found in the specified primary region. Ensure the identity exists in the primary region\n                    before attempting replication.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>REPLICATION_PRIMARY_BYO_DKIM_NOT_SUPPORTED</code> \u2013 The verification failed because the\n                    identity in the primary region is configured with Bring Your Own DKIM (BYODKIM). DKIM key\n                    replication is only supported for identities using Easy DKIM.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>REPLICATION_REPLICA_AS_PRIMARY_NOT_SUPPORTED</code> \u2013 The verification failed because\n                    the specified primary identity is a replica of another identity, and multi-level replication is not\n                    supported; the primary identity must be a non-replica identity.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>REPLICATION_PRIMARY_INVALID_REGION</code> \u2013 The verification failed due to an invalid\n                    primary region specified. Ensure you provide a valid Amazon Web Services region where Amazon SES is available and different\n                    from the replica region.\n                </p>\n            </li>\n         </ul>"
+          }
+        },
+        "SOARecord": {
+          "target": "com.amazonaws.sesv2#SOARecord",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains information about the start of authority (SOA) record\n            associated with the identity.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains additional information about the verification status for the\n            identity.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#VerificationStatus": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "SUCCESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCESS"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "TEMPORARY_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEMPORARY_FAILURE"
+          }
+        },
+        "NOT_STARTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NOT_STARTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.sesv2#Volume": {
+      "type": "long",
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about inbox placement volume.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#VolumeStatistics": {
+      "type": "structure",
+      "members": {
+        "InboxRawCount": {
+          "target": "com.amazonaws.sesv2#Volume",
+          "traits": {
+            "smithy.api#documentation": "<p>The total number of emails that arrived in recipients' inboxes.</p>"
+          }
+        },
+        "SpamRawCount": {
+          "target": "com.amazonaws.sesv2#Volume",
+          "traits": {
+            "smithy.api#documentation": "<p>The total number of emails that arrived in recipients' spam or junk mail\n            folders.</p>"
+          }
+        },
+        "ProjectedInbox": {
+          "target": "com.amazonaws.sesv2#Volume",
+          "traits": {
+            "smithy.api#documentation": "<p>An estimate of the percentage of emails sent from the current domain that will arrive\n            in recipients' inboxes.</p>"
+          }
+        },
+        "ProjectedSpam": {
+          "target": "com.amazonaws.sesv2#Volume",
+          "traits": {
+            "smithy.api#documentation": "<p>An estimate of the percentage of emails sent from the current domain that will arrive\n            in recipients' spam or junk mail folders.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains information about the amount of email that was delivered to\n            recipients.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#WarmupStatus": {
+      "type": "enum",
+      "members": {
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "DONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DONE"
+          }
+        },
+        "NOT_APPLICABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NOT_APPLICABLE"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The warmup status of a dedicated IP.</p>"
+      }
+    },
+    "com.amazonaws.sesv2#WebsiteURL": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1000
+        },
+        "smithy.api#pattern": "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$",
+        "smithy.api#sensitive": {}
+      }
+    }
+  }
+}

--- a/crates/fakecloud-conformance/Cargo.toml
+++ b/crates/fakecloud-conformance/Cargo.toml
@@ -35,6 +35,7 @@ aws-sdk-secretsmanager = "1"
 aws-sdk-cloudwatchlogs = "1"
 aws-sdk-kms = "1"
 aws-sdk-cloudformation = "1"
+aws-sdk-sesv2 = "1"
 aws-credential-types = "1"
 aws-types = "1"
 tokio = { workspace = true }

--- a/crates/fakecloud-conformance/src/audit.rs
+++ b/crates/fakecloud-conformance/src/audit.rs
@@ -20,6 +20,7 @@ fn service_source_files(project_root: &Path) -> Vec<(String, Vec<PathBuf>)> {
         ("logs", "logs", &["service.rs"]),
         ("kms", "kms", &["service.rs"]),
         ("cloudformation", "cloudformation", &["service.rs"]),
+        ("ses", "ses", &["service.rs"]),
     ];
 
     mappings

--- a/crates/fakecloud-conformance/tests/helpers/mod.rs
+++ b/crates/fakecloud-conformance/tests/helpers/mod.rs
@@ -107,6 +107,10 @@ impl TestServer {
         aws_sdk_cloudformation::Client::new(&self.aws_config().await)
     }
 
+    pub async fn sesv2_client(&self) -> aws_sdk_sesv2::Client {
+        aws_sdk_sesv2::Client::new(&self.aws_config().await)
+    }
+
     pub async fn s3_client(&self) -> aws_sdk_s3::Client {
         let config = self.aws_config().await;
         let s3_config = aws_sdk_s3::config::Builder::from(&config)

--- a/crates/fakecloud-conformance/tests/ses.rs
+++ b/crates/fakecloud-conformance/tests/ses.rs
@@ -1,0 +1,347 @@
+mod helpers;
+
+use aws_sdk_sesv2::types::{
+    Body, Content, Destination, EmailContent, EmailTemplateContent, Message, Template,
+};
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+// -- Account --
+
+#[test_action("ses", "GetAccount", checksum = "3104b701")]
+#[tokio::test]
+async fn ses_get_account() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    let resp = client.get_account().send().await.unwrap();
+    assert!(resp.sending_enabled());
+    let quota = resp.send_quota().unwrap();
+    assert!(quota.max24_hour_send() > 0.0);
+    assert!(quota.max_send_rate() > 0.0);
+}
+
+// -- Email Identity CRUD --
+
+#[test_action("ses", "CreateEmailIdentity", checksum = "1ff0be27")]
+#[test_action("ses", "GetEmailIdentity", checksum = "a298f1a4")]
+#[test_action("ses", "ListEmailIdentities", checksum = "3301504d")]
+#[test_action("ses", "DeleteEmailIdentity", checksum = "7b850c25")]
+#[tokio::test]
+async fn ses_identity_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    // Create
+    let resp = client
+        .create_email_identity()
+        .email_identity("test@example.com")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.verified_for_sending_status());
+    assert_eq!(resp.identity_type().unwrap().as_str(), "EMAIL_ADDRESS");
+
+    // Get — verify auto-verified and DKIM
+    let get = client
+        .get_email_identity()
+        .email_identity("test@example.com")
+        .send()
+        .await
+        .unwrap();
+    assert!(get.verified_for_sending_status());
+    assert_eq!(
+        get.dkim_attributes().unwrap().status().unwrap().as_str(),
+        "SUCCESS"
+    );
+
+    // List
+    let list = client.list_email_identities().send().await.unwrap();
+    assert_eq!(list.email_identities().len(), 1);
+
+    // Delete
+    client
+        .delete_email_identity()
+        .email_identity("test@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client.list_email_identities().send().await.unwrap();
+    assert!(list.email_identities().is_empty());
+}
+
+// -- Configuration Set CRUD --
+
+#[test_action("ses", "CreateConfigurationSet", checksum = "a48841bc")]
+#[test_action("ses", "GetConfigurationSet", checksum = "00b213d2")]
+#[test_action("ses", "ListConfigurationSets", checksum = "31486196")]
+#[test_action("ses", "DeleteConfigurationSet", checksum = "3c50e07a")]
+#[tokio::test]
+async fn ses_configuration_set_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_configuration_set()
+        .configuration_set_name("my-config")
+        .send()
+        .await
+        .unwrap();
+
+    let get = client
+        .get_configuration_set()
+        .configuration_set_name("my-config")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.configuration_set_name(), Some("my-config"));
+
+    let list = client.list_configuration_sets().send().await.unwrap();
+    assert_eq!(list.configuration_sets().len(), 1);
+
+    client
+        .delete_configuration_set()
+        .configuration_set_name("my-config")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client.list_configuration_sets().send().await.unwrap();
+    assert!(list.configuration_sets().is_empty());
+}
+
+// -- Email Template CRUD --
+
+#[test_action("ses", "CreateEmailTemplate", checksum = "0f6b9b5f")]
+#[test_action("ses", "GetEmailTemplate", checksum = "24e82803")]
+#[test_action("ses", "UpdateEmailTemplate", checksum = "53fcbe68")]
+#[test_action("ses", "ListEmailTemplates", checksum = "d266ac1a")]
+#[test_action("ses", "DeleteEmailTemplate", checksum = "92237e2c")]
+#[tokio::test]
+async fn ses_template_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_template()
+        .template_name("welcome")
+        .template_content(
+            EmailTemplateContent::builder()
+                .subject("Welcome {{name}}")
+                .html("<h1>Hello {{name}}</h1>")
+                .text("Hello {{name}}")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let get = client
+        .get_email_template()
+        .template_name("welcome")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.template_name(), "welcome");
+    assert_eq!(
+        get.template_content().unwrap().subject().unwrap(),
+        "Welcome {{name}}"
+    );
+
+    client
+        .update_email_template()
+        .template_name("welcome")
+        .template_content(
+            EmailTemplateContent::builder()
+                .subject("Updated {{name}}")
+                .html("<h1>Updated</h1>")
+                .text("Updated")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let get = client
+        .get_email_template()
+        .template_name("welcome")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        get.template_content().unwrap().subject().unwrap(),
+        "Updated {{name}}"
+    );
+
+    let list = client.list_email_templates().send().await.unwrap();
+    assert_eq!(list.templates_metadata().len(), 1);
+
+    client
+        .delete_email_template()
+        .template_name("welcome")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client.list_email_templates().send().await.unwrap();
+    assert!(list.templates_metadata().is_empty());
+}
+
+// -- SendEmail --
+
+#[test_action("ses", "SendEmail", checksum = "364cd183")]
+#[tokio::test]
+async fn ses_send_email() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("recipient@example.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Test Subject").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Hello").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert!(!resp.message_id().unwrap().is_empty());
+}
+
+// -- SendEmail with template --
+
+#[tokio::test]
+async fn ses_send_email_with_template() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_email_template()
+        .template_name("greet")
+        .template_content(
+            EmailTemplateContent::builder()
+                .subject("Hello {{name}}")
+                .text("Hi {{name}}")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("recipient@example.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .template(
+                    Template::builder()
+                        .template_name("greet")
+                        .template_data(r#"{"name":"World"}"#)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert!(!resp.message_id().unwrap().is_empty());
+}
+
+// -- SendBulkEmail --
+
+#[test_action("ses", "SendBulkEmail", checksum = "a88f124e")]
+#[tokio::test]
+async fn ses_send_bulk_email() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_email_template()
+        .template_name("bulk-tmpl")
+        .template_content(
+            EmailTemplateContent::builder()
+                .subject("Hello {{name}}")
+                .text("Hi {{name}}")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .send_bulk_email()
+        .from_email_address("sender@example.com")
+        .default_content(
+            aws_sdk_sesv2::types::BulkEmailContent::builder()
+                .template(
+                    Template::builder()
+                        .template_name("bulk-tmpl")
+                        .template_data(r#"{"name":"Default"}"#)
+                        .build(),
+                )
+                .build(),
+        )
+        .bulk_email_entries(
+            aws_sdk_sesv2::types::BulkEmailEntry::builder()
+                .destination(Destination::builder().to_addresses("a@example.com").build())
+                .build(),
+        )
+        .bulk_email_entries(
+            aws_sdk_sesv2::types::BulkEmailEntry::builder()
+                .destination(Destination::builder().to_addresses("b@example.com").build())
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.bulk_email_entry_results().len(), 2);
+    for result in resp.bulk_email_entry_results() {
+        assert_eq!(result.status().unwrap().as_str(), "SUCCESS");
+        assert!(result.message_id().is_some());
+    }
+}

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -233,7 +233,9 @@ fn build_error_response_with_fields(
             request_id,
             extra_fields,
         ),
-        AwsProtocol::Json => fakecloud_aws::error::json_error_response(status, code, message),
+        AwsProtocol::Json | AwsProtocol::RestJson => {
+            fakecloud_aws::error::json_error_response(status, code, message)
+        }
     };
 
     Response::builder()

--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AwsProtocol {
     /// Query protocol: form-encoded body, Action param, XML response.
-    /// Used by: SQS, SNS, IAM, STS, SES.
+    /// Used by: SQS, SNS, IAM, STS.
     Query,
     /// JSON protocol: JSON body, X-Amz-Target header, JSON response.
     /// Used by: SSM, EventBridge, DynamoDB, SecretsManager, KMS, CloudWatch Logs.
@@ -14,11 +14,16 @@ pub enum AwsProtocol {
     /// REST protocol: HTTP method + path-based routing, XML responses.
     /// Used by: S3, API Gateway, Route53.
     Rest,
+    /// REST-JSON protocol: HTTP method + path-based routing, JSON responses.
+    /// Used by: Lambda, SES v2.
+    RestJson,
 }
 
-/// Services that use REST protocol (detected from SigV4 credential scope).
-/// Lambda uses REST-style routing (method + path) rather than X-Amz-Target.
-const REST_SERVICES: &[&str] = &["s3", "lambda", "ses"];
+/// Services that use REST protocol with XML responses (detected from SigV4 credential scope).
+const REST_XML_SERVICES: &[&str] = &["s3"];
+
+/// Services that use REST protocol with JSON responses (detected from SigV4 credential scope).
+const REST_JSON_SERVICES: &[&str] = &["lambda", "ses"];
 
 /// Detected service name and action from an incoming HTTP request.
 #[derive(Debug)]
@@ -69,13 +74,13 @@ pub fn detect_service(
         }
     }
 
-    // 4. Fallback: check auth header for REST-style services (S3, etc.)
+    // 4. Fallback: check auth header for REST-style services (S3, Lambda, SES, etc.)
     if let Some(service) = extract_service_from_auth(headers) {
-        if REST_SERVICES.contains(&service.as_str()) {
+        if let Some(protocol) = rest_protocol_for(&service) {
             return Some(DetectedRequest {
                 service,
                 action: String::new(), // REST services determine action from method+path
-                protocol: AwsProtocol::Rest,
+                protocol,
             });
         }
     }
@@ -86,11 +91,11 @@ pub fn detect_service(
         let parts: Vec<&str> = credential.split('/').collect();
         if parts.len() >= 4 {
             let service = parts[3].to_string();
-            if REST_SERVICES.contains(&service.as_str()) {
+            if let Some(protocol) = rest_protocol_for(&service) {
                 return Some(DetectedRequest {
                     service,
                     action: String::new(),
-                    protocol: AwsProtocol::Rest,
+                    protocol,
                 });
             }
         }
@@ -135,6 +140,17 @@ fn parse_amz_target(target: &str) -> Option<DetectedRequest> {
         action: action.to_string(),
         protocol: AwsProtocol::Json,
     })
+}
+
+/// Returns the REST protocol variant for a service, or None if not a REST service.
+fn rest_protocol_for(service: &str) -> Option<AwsProtocol> {
+    if REST_XML_SERVICES.contains(&service) {
+        Some(AwsProtocol::Rest)
+    } else if REST_JSON_SERVICES.contains(&service) {
+        Some(AwsProtocol::RestJson)
+    } else {
+        None
+    }
 }
 
 /// Infer service from the action name when no SigV4 auth is present.

--- a/crates/fakecloud-ses/src/service.rs
+++ b/crates/fakecloud-ses/src/service.rs
@@ -380,6 +380,7 @@ impl SesV2Service {
             text_body: body["TemplateContent"]["Text"]
                 .as_str()
                 .map(|s| s.to_string()),
+            created_at: Utc::now(),
         };
 
         state.templates.insert(template_name, template);
@@ -395,7 +396,7 @@ impl SesV2Service {
             .map(|t| {
                 json!({
                     "TemplateName": t.template_name,
-                    "CreatedTimestamp": Utc::now().timestamp() as f64,
+                    "CreatedTimestamp": t.created_at.timestamp() as f64,
                 })
             })
             .collect();
@@ -481,6 +482,18 @@ impl SesV2Service {
     fn send_email(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body: Value = Self::parse_body(req)?;
 
+        if !body["Content"].is_object()
+            || (!body["Content"]["Simple"].is_object()
+                && !body["Content"]["Raw"].is_object()
+                && !body["Content"]["Template"].is_object())
+        {
+            return Ok(Self::json_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "Content is required and must contain Simple, Raw, or Template",
+            ));
+        }
+
         let from = body["FromEmailAddress"].as_str().unwrap_or("").to_string();
 
         let to = extract_string_array(&body["Destination"]["ToAddresses"]);
@@ -543,10 +556,16 @@ impl SesV2Service {
 
         let from = body["FromEmailAddress"].as_str().unwrap_or("").to_string();
 
-        let entries = body["BulkEmailEntries"]
-            .as_array()
-            .cloned()
-            .unwrap_or_default();
+        let entries = match body["BulkEmailEntries"].as_array() {
+            Some(arr) if !arr.is_empty() => arr.clone(),
+            _ => {
+                return Ok(Self::json_error(
+                    StatusCode::BAD_REQUEST,
+                    "BadRequestException",
+                    "BulkEmailEntries is required and must not be empty",
+                ));
+            }
+        };
 
         let mut results = Vec::new();
 

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -18,6 +18,7 @@ pub struct EmailTemplate {
     pub subject: Option<String>,
     pub html_body: Option<String>,
     pub text_body: Option<String>,
+    pub created_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/scripts/update-aws-models.sh
+++ b/scripts/update-aws-models.sh
@@ -34,6 +34,7 @@ SERVICES=(
     [cloudwatch-logs]=cloudwatch-logs
     [kms]=kms
     [cloudformation]=cloudformation
+    [sesv2]=sesv2
 )
 
 # Sparse checkout only the models we need


### PR DESCRIPTION
## Summary

- Add SES v2 Smithy model and conformance tests covering all 16 implemented actions (747/747 audit pass)
- Add `RestJson` protocol variant so dispatch-level errors return JSON instead of S3 XML for SES and Lambda
- Validate SendEmail requires Content and SendBulkEmail requires non-empty entries
- Store `created_at` on EmailTemplate for stable ListEmailTemplates timestamps

## Test plan

- [x] `cargo test -p fakecloud-conformance --test ses` — 7 conformance tests pass
- [x] `cargo run -p fakecloud-conformance -- audit` — 747/747 PASS (16/16 SES)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean