### PR TITLE
fix(dynamodb): include table PK in LastEvaluatedKey for GSI queries

### DIFF
--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -623,10 +623,32 @@ impl DynamoDbService {
             }
         }
 
-        // Apply ExclusiveStartKey: skip items up to and including the start key
+        // For GSI queries, we need the table's primary key attributes to uniquely
+        // identify items (GSI keys are not unique).
+        let table_pk_hash = table.hash_key_name().to_string();
+        let table_pk_range = table.range_key_name().map(|s| s.to_string());
+        let is_gsi_query = index_name.is_some()
+            && (hash_key_name != table_pk_hash
+                || range_key_name.as_deref() != table_pk_range.as_deref());
+
+        // Apply ExclusiveStartKey: skip items up to and including the start key.
+        // For GSI queries the start key contains both index keys and table PK, so
+        // we must match on ALL of them to find the exact item.
         if let Some(ref start_key) = exclusive_start_key {
             if let Some(pos) = matched.iter().position(|item| {
-                item_matches_key(item, start_key, &hash_key_name, range_key_name.as_deref())
+                let index_match =
+                    item_matches_key(item, start_key, &hash_key_name, range_key_name.as_deref());
+                if is_gsi_query {
+                    index_match
+                        && item_matches_key(
+                            item,
+                            start_key,
+                            &table_pk_hash,
+                            table_pk_range.as_deref(),
+                        )
+                } else {
+                    index_match
+                }
             }) {
                 matched = matched.split_off(pos + 1);
             }
@@ -648,11 +670,20 @@ impl DynamoDbService {
             false
         };
 
-        // Build LastEvaluatedKey from the last returned item if there are more results
+        // Build LastEvaluatedKey from the last returned item if there are more results.
+        // For GSI queries, include both the index keys and the table's primary key
+        // so the item can be uniquely identified on resume.
         let last_evaluated_key = if has_more {
-            matched
-                .last()
-                .map(|item| extract_key_for_schema(item, &hash_key_name, range_key_name.as_deref()))
+            matched.last().map(|item| {
+                let mut key =
+                    extract_key_for_schema(item, &hash_key_name, range_key_name.as_deref());
+                if is_gsi_query {
+                    let table_key =
+                        extract_key_for_schema(item, &table_pk_hash, table_pk_range.as_deref());
+                    key.extend(table_key);
+                }
+                key
+            })
         } else {
             None
         };
@@ -6227,6 +6258,143 @@ mod tests {
         assert!(
             body["LastEvaluatedKey"].is_null(),
             "should not have LastEvaluatedKey when all items fit"
+        );
+    }
+
+    fn create_gsi_table(svc: &DynamoDbService) {
+        let req = make_request(
+            "CreateTable",
+            json!({
+                "TableName": "gsi-table",
+                "KeySchema": [
+                    { "AttributeName": "pk", "KeyType": "HASH" }
+                ],
+                "AttributeDefinitions": [
+                    { "AttributeName": "pk", "AttributeType": "S" },
+                    { "AttributeName": "gsi_pk", "AttributeType": "S" },
+                    { "AttributeName": "gsi_sk", "AttributeType": "S" }
+                ],
+                "BillingMode": "PAY_PER_REQUEST",
+                "GlobalSecondaryIndexes": [
+                    {
+                        "IndexName": "gsi-index",
+                        "KeySchema": [
+                            { "AttributeName": "gsi_pk", "KeyType": "HASH" },
+                            { "AttributeName": "gsi_sk", "KeyType": "RANGE" }
+                        ],
+                        "Projection": { "ProjectionType": "ALL" }
+                    }
+                ]
+            }),
+        );
+        svc.create_table(&req).unwrap();
+    }
+
+    #[test]
+    fn gsi_query_last_evaluated_key_includes_table_pk() {
+        let svc = make_service();
+        create_gsi_table(&svc);
+
+        // Insert 3 items with the SAME GSI key but different table PKs
+        for i in 0..3 {
+            let req = make_request(
+                "PutItem",
+                json!({
+                    "TableName": "gsi-table",
+                    "Item": {
+                        "pk": { "S": format!("item{i}") },
+                        "gsi_pk": { "S": "shared" },
+                        "gsi_sk": { "S": "sort" }
+                    }
+                }),
+            );
+            svc.put_item(&req).unwrap();
+        }
+
+        // Query GSI with Limit=1 to trigger pagination
+        let req = make_request(
+            "Query",
+            json!({
+                "TableName": "gsi-table",
+                "IndexName": "gsi-index",
+                "KeyConditionExpression": "gsi_pk = :v",
+                "ExpressionAttributeValues": { ":v": { "S": "shared" } },
+                "Limit": 1
+            }),
+        );
+        let resp = svc.query(&req).unwrap();
+        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(body["Count"], 1);
+        let lek = &body["LastEvaluatedKey"];
+        assert!(lek.is_object(), "should have LastEvaluatedKey");
+        // Must contain the index keys
+        assert!(lek["gsi_pk"].is_object(), "LEK must contain gsi_pk");
+        assert!(lek["gsi_sk"].is_object(), "LEK must contain gsi_sk");
+        // Must also contain the table PK
+        assert!(
+            lek["pk"].is_object(),
+            "LEK must contain table PK for GSI queries"
+        );
+    }
+
+    #[test]
+    fn gsi_query_pagination_returns_all_items() {
+        let svc = make_service();
+        create_gsi_table(&svc);
+
+        // Insert 4 items with the SAME GSI key but different table PKs
+        for i in 0..4 {
+            let req = make_request(
+                "PutItem",
+                json!({
+                    "TableName": "gsi-table",
+                    "Item": {
+                        "pk": { "S": format!("item{i:03}") },
+                        "gsi_pk": { "S": "shared" },
+                        "gsi_sk": { "S": "sort" }
+                    }
+                }),
+            );
+            svc.put_item(&req).unwrap();
+        }
+
+        // Paginate through all items with Limit=2
+        let mut all_pks = Vec::new();
+        let mut lek: Option<Value> = None;
+
+        loop {
+            let mut query = json!({
+                "TableName": "gsi-table",
+                "IndexName": "gsi-index",
+                "KeyConditionExpression": "gsi_pk = :v",
+                "ExpressionAttributeValues": { ":v": { "S": "shared" } },
+                "Limit": 2
+            });
+            if let Some(ref start_key) = lek {
+                query["ExclusiveStartKey"] = start_key.clone();
+            }
+
+            let req = make_request("Query", query);
+            let resp = svc.query(&req).unwrap();
+            let body: Value = serde_json::from_slice(&resp.body).unwrap();
+
+            for item in body["Items"].as_array().unwrap() {
+                let pk = item["pk"]["S"].as_str().unwrap().to_string();
+                all_pks.push(pk);
+            }
+
+            if body["LastEvaluatedKey"].is_object() {
+                lek = Some(body["LastEvaluatedKey"].clone());
+            } else {
+                break;
+            }
+        }
+
+        all_pks.sort();
+        assert_eq!(
+            all_pks,
+            vec!["item000", "item001", "item002", "item003"],
+            "pagination should return all items without duplicates"
         );
     }
 }

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -2,9 +2,10 @@ mod helpers;
 
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, BillingMode, ContributorInsightsAction, Delete,
-    DeleteRequest, Get, KeySchemaElement, KeyType, PointInTimeRecoverySpecification,
-    ProvisionedThroughput, Put, PutRequest, Replica, ScalarAttributeType, Tag,
-    TimeToLiveSpecification, TransactGetItem, TransactWriteItem, WriteRequest,
+    DeleteRequest, Get, GlobalSecondaryIndex, KeySchemaElement, KeyType,
+    PointInTimeRecoverySpecification, Projection, ProjectionType, ProvisionedThroughput, Put,
+    PutRequest, Replica, ScalarAttributeType, Tag, TimeToLiveSpecification, TransactGetItem,
+    TransactWriteItem, WriteRequest,
 };
 use helpers::TestServer;
 use std::collections::HashMap;
@@ -2100,5 +2101,155 @@ async fn dynamodb_query_no_pagination_when_all_fit() {
     assert!(
         resp.last_evaluated_key().is_none(),
         "LastEvaluatedKey should be absent when all items fit"
+    );
+}
+
+#[tokio::test]
+async fn dynamodb_gsi_query_pagination() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    // Create a table with a GSI
+    client
+        .create_table()
+        .table_name("GsiPagTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("gsi_pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("gsi_sk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_indexes(
+            GlobalSecondaryIndex::builder()
+                .index_name("gsi-index")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("gsi_pk")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("gsi_sk")
+                        .key_type(KeyType::Range)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::All)
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Insert 4 items with the same GSI key but different table PKs
+    for i in 0..4 {
+        client
+            .put_item()
+            .table_name("GsiPagTable")
+            .item("pk", AttributeValue::S(format!("item{i:03}")))
+            .item("gsi_pk", AttributeValue::S("shared".to_string()))
+            .item("gsi_sk", AttributeValue::S("sort".to_string()))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // First page: query GSI with limit=2
+    let resp = client
+        .query()
+        .table_name("GsiPagTable")
+        .index_name("gsi-index")
+        .key_condition_expression("gsi_pk = :v")
+        .expression_attribute_values(":v", AttributeValue::S("shared".to_string()))
+        .limit(2)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.count(), 2);
+    let lek = resp
+        .last_evaluated_key()
+        .expect("should have LastEvaluatedKey");
+    // LEK must include both index keys AND table PK
+    assert!(
+        lek.contains_key("gsi_pk"),
+        "LastEvaluatedKey should contain gsi_pk"
+    );
+    assert!(
+        lek.contains_key("gsi_sk"),
+        "LastEvaluatedKey should contain gsi_sk"
+    );
+    assert!(
+        lek.contains_key("pk"),
+        "LastEvaluatedKey should contain table PK for GSI queries"
+    );
+
+    // Paginate through all items and collect PKs
+    let mut all_pks: Vec<String> = resp
+        .items()
+        .iter()
+        .map(|item| item["pk"].as_s().unwrap().clone())
+        .collect();
+
+    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> =
+        resp.last_evaluated_key().map(|m| m.to_owned());
+
+    while exclusive_start_key.is_some() {
+        let mut q = client
+            .query()
+            .table_name("GsiPagTable")
+            .index_name("gsi-index")
+            .key_condition_expression("gsi_pk = :v")
+            .expression_attribute_values(":v", AttributeValue::S("shared".to_string()))
+            .limit(2);
+
+        for (k, v) in exclusive_start_key.as_ref().unwrap() {
+            q = q.exclusive_start_key(k.clone(), v.clone());
+        }
+
+        let resp = q.send().await.unwrap();
+
+        for item in resp.items() {
+            all_pks.push(item["pk"].as_s().unwrap().clone());
+        }
+
+        exclusive_start_key = resp.last_evaluated_key().map(|m| m.to_owned());
+    }
+
+    all_pks.sort();
+    assert_eq!(
+        all_pks,
+        vec!["item000", "item001", "item002", "item003"],
+        "GSI pagination should return all items without duplicates"
     );
 }


### PR DESCRIPTION
## Summary

- When querying a Global Secondary Index, `LastEvaluatedKey` now includes both the table's primary key and the index keys (previously only index keys were returned)
- `ExclusiveStartKey` matching for GSI queries now uses the table PK in addition to index keys to uniquely identify the resume position
- This fixes pagination correctness when multiple items share the same GSI key values but have different table primary keys

## Test plan

- [x] Unit test: `gsi_query_last_evaluated_key_includes_table_pk` — verifies LEK contains table PK, GSI hash key, and GSI range key
- [x] Unit test: `gsi_query_pagination_returns_all_items` — paginates through 4 items with duplicate GSI keys, verifies all items returned without duplicates
- [x] E2E test: `dynamodb_gsi_query_pagination` — full SDK-based test creating a table with GSI, inserting items with duplicate GSI keys, paginating, and verifying completeness
- [x] All existing DynamoDB tests pass (39 unit tests)
- [x] Clippy and fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB GSI pagination by including the table primary key in `LastEvaluatedKey` and requiring `ExclusiveStartKey` to match both index and table keys. Prevents missing or duplicate items when multiple records share GSI key values.

- **Bug Fixes**
  - Include GSI hash/range keys + table PK in `LastEvaluatedKey` for GSI queries.
  - Match `ExclusiveStartKey` on both GSI keys and table PK to resume correctly.
  - Added unit tests for LEK contents and pagination, plus an SDK E2E test; all existing DynamoDB tests pass.

<sup>Written for commit 40987057f07ced350df3f0adefdb155b8071208a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

