### PR TITLE
fix(sns): replace expect() on user-derived input with proper error handling

### DIFF
--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -905,9 +905,14 @@ impl SnsService {
         });
 
         // Resolve the actual message per protocol for MessageStructure=json
-        // Validation already happened above, so unwrap is safe here
         let parsed_structure: Option<Value> = if message_structure.as_deref() == Some("json") {
-            Some(serde_json::from_str(&message).expect("already validated"))
+            Some(serde_json::from_str(&message).map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    "Invalid parameter: Message Structure - No JSON message body is parseable",
+                )
+            })?)
         } else {
             None
         };
@@ -1297,9 +1302,14 @@ impl SnsService {
             });
 
             // Resolve message for SQS via MessageStructure=json
-            // Validation already happened above, so unwrap is safe here
             let parsed_structure: Option<Value> = if structure.as_deref() == Some("json") {
-                Some(serde_json::from_str(message).expect("already validated"))
+                Some(serde_json::from_str(message).map_err(|_| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameter",
+                        "Invalid parameter: Message Structure - No JSON message body is parseable",
+                    )
+                })?)
             } else {
                 None
             };


### PR DESCRIPTION
## Summary

- Replace 2 `expect("already validated")` calls in SNS `Publish` and `PublishBatch` with proper `AwsServiceError` returns
- If earlier JSON validation has a bug, the server now returns an `InvalidParameter` error instead of panicking

## Test plan

- [x] All 7 SNS unit tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent panics in SNS `Publish` and `PublishBatch` by replacing `expect()` on user-supplied JSON with proper error handling. If `MessageStructure=json` parsing fails, the API now returns a 400 `InvalidParameter` error instead of crashing.

<sup>Written for commit 858795979af4bfd77a74182b08e09826bd318c96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

