### PR TITLE
refactor: consolidate xml_escape into single canonical implementation

### DIFF
--- a/crates/fakecloud-aws/src/error.rs
+++ b/crates/fakecloud-aws/src/error.rs
@@ -105,13 +105,7 @@ pub fn s3_xml_error_response_with_fields(
     (status, "application/xml".to_string(), Bytes::from(buffer))
 }
 
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
-}
+use crate::xml::xml_escape;
 
 #[cfg(test)]
 mod tests {

--- a/crates/fakecloud-aws/src/xml.rs
+++ b/crates/fakecloud-aws/src/xml.rs
@@ -2,3 +2,27 @@
 pub fn wrap_xml(inner: &str) -> String {
     format!("<?xml version=\"1.0\" encoding=\"UTF-8\"?>{inner}")
 }
+
+/// Escape a string for safe embedding in XML content.
+///
+/// Handles the five standard XML entities plus control characters that are
+/// invalid in XML 1.0 (everything below U+0020 except `\t`, `\n`, `\r`).
+pub fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            // XML 1.0 allows \t, \n, \r as valid characters; all other control chars
+            // need to be encoded as numeric character references.
+            c if (c as u32) < 0x20 && c != '\t' && c != '\n' && c != '\r' => {
+                out.push_str(&format!("&#x{:X};", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}

--- a/crates/fakecloud-cloudformation/src/xml_responses.rs
+++ b/crates/fakecloud-cloudformation/src/xml_responses.rs
@@ -1,11 +1,6 @@
 use crate::state::{Stack, StackResource};
 
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
+use fakecloud_aws::xml::xml_escape;
 
 pub fn create_stack_response(stack_id: &str, request_id: &str) -> String {
     format!(

--- a/crates/fakecloud-iam/src/iam_service.rs
+++ b/crates/fakecloud-iam/src/iam_service.rs
@@ -417,12 +417,7 @@ fn title_case_service(s: &str) -> String {
         .collect::<String>()
 }
 
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
+use fakecloud_aws::xml::xml_escape;
 
 fn url_encode(s: &str) -> String {
     use std::fmt::Write;

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -2,12 +2,7 @@ use base64::Engine;
 
 use crate::state::{IamAccessKey, IamPolicy, IamRole, IamUser};
 
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
+use fakecloud_aws::xml::xml_escape;
 
 /// URL-encode a policy document for XML embedding (like AWS does).
 fn url_encode_policy(s: &str) -> String {

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -1174,25 +1174,7 @@ pub(crate) fn url_encode_s3_key(s: &str) -> String {
     out
 }
 
-pub(crate) fn xml_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&apos;"),
-            // XML 1.0 allows \t, \n, \r as valid characters; all other control chars
-            // need to be encoded as numeric character references.
-            c if (c as u32) < 0x20 && c != '\t' && c != '\n' && c != '\r' => {
-                out.push_str(&format!("&#x{:X};", c as u32));
-            }
-            c => out.push(c),
-        }
-    }
-    out
-}
+pub(crate) use fakecloud_aws::xml::xml_escape;
 
 pub(crate) fn extract_user_metadata(
     headers: &HeaderMap,

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -174,13 +174,7 @@ fn json_response(body: Value) -> AwsResponse {
     AwsResponse::json(StatusCode::OK, serde_json::to_string(&body).unwrap())
 }
 
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
-}
+use fakecloud_aws::xml::xml_escape;
 
 fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
     format!(


### PR DESCRIPTION
## Summary

- Move the most complete `xml_escape` implementation (from S3, handles control chars) to `fakecloud-aws::xml::xml_escape`
- Replace 6 inconsistent local definitions across SQS, IAM (x2), CloudFormation, S3, and fakecloud-aws error module
- Fixes correctness issue: CloudFormation's version was missing single-quote escaping

## Test plan

- [x] All 132 unit tests across affected crates pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized XML escaping with a single `xml_escape` in `fakecloud-aws::xml` for consistent, correct output. Replaces six local versions and fixes missing single-quote escaping in CloudFormation.

- **Refactors**
  - Added `xml_escape` to `fakecloud-aws::xml` and switched `fakecloud-s3`, `fakecloud-sqs`, `fakecloud-iam` (service and XML responses), `fakecloud-cloudformation`, and `fakecloud-aws` errors to use it.
  - Implementation includes XML 1.0 control-character handling.

- **Bug Fixes**
  - Escapes single quotes in `fakecloud-cloudformation` responses.
  - Uniform control-character escaping across all services.

<sup>Written for commit 9b441bd3a89a354d776ad4abbc1adfd35e2b2f1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

