### PR TITLE
refactor: extract shared pagination helper into fakecloud-core

### DIFF
--- a/crates/fakecloud-core/src/lib.rs
+++ b/crates/fakecloud-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod delivery;
 pub mod dispatch;
+pub mod pagination;
 pub mod protocol;
 pub mod registry;
 pub mod service;

--- a/crates/fakecloud-core/src/pagination.rs
+++ b/crates/fakecloud-core/src/pagination.rs
@@ -8,6 +8,7 @@ pub fn paginate<T: Clone>(
     next_token: Option<&str>,
     max_results: usize,
 ) -> (Vec<T>, Option<String>) {
+    let max_results = max_results.max(1);
     let offset: usize = next_token.and_then(|s| s.parse().ok()).unwrap_or(0);
     let page = if offset < items.len() {
         &items[offset..]
@@ -74,6 +75,14 @@ mod tests {
         let (page, token) = paginate(&items, Some("not_a_number"), 3);
         assert_eq!(page, vec![0, 1, 2]);
         assert_eq!(token, Some("3".to_string()));
+    }
+
+    #[test]
+    fn zero_max_results_returns_one_item() {
+        let items: Vec<i32> = (0..5).collect();
+        let (page, token) = paginate(&items, None, 0);
+        assert_eq!(page, vec![0]);
+        assert_eq!(token, Some("1".to_string()));
     }
 
     #[test]

--- a/crates/fakecloud-core/src/pagination.rs
+++ b/crates/fakecloud-core/src/pagination.rs
@@ -1,0 +1,86 @@
+/// Offset-based pagination helper for AWS list operations.
+///
+/// Parses `next_token` as a numeric offset (defaulting to 0 if `None` or unparseable),
+/// slices `items` starting at that offset, and returns at most `max_results` items
+/// along with an optional next token for the following page.
+pub fn paginate<T: Clone>(
+    items: &[T],
+    next_token: Option<&str>,
+    max_results: usize,
+) -> (Vec<T>, Option<String>) {
+    let offset: usize = next_token.and_then(|s| s.parse().ok()).unwrap_or(0);
+    let page = if offset < items.len() {
+        &items[offset..]
+    } else {
+        &[][..]
+    };
+    let has_more = page.len() > max_results;
+    let result: Vec<T> = page.iter().take(max_results).cloned().collect();
+    let token = if has_more {
+        Some((offset + max_results).to_string())
+    } else {
+        None
+    };
+    (result, token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_page() {
+        let items: Vec<i32> = (0..10).collect();
+        let (page, token) = paginate(&items, None, 3);
+        assert_eq!(page, vec![0, 1, 2]);
+        assert_eq!(token, Some("3".to_string()));
+    }
+
+    #[test]
+    fn middle_page() {
+        let items: Vec<i32> = (0..10).collect();
+        let (page, token) = paginate(&items, Some("3"), 3);
+        assert_eq!(page, vec![3, 4, 5]);
+        assert_eq!(token, Some("6".to_string()));
+    }
+
+    #[test]
+    fn last_page() {
+        let items: Vec<i32> = (0..10).collect();
+        let (page, token) = paginate(&items, Some("9"), 3);
+        assert_eq!(page, vec![9]);
+        assert_eq!(token, None);
+    }
+
+    #[test]
+    fn exact_page_boundary() {
+        let items: Vec<i32> = (0..6).collect();
+        let (page, token) = paginate(&items, Some("3"), 3);
+        assert_eq!(page, vec![3, 4, 5]);
+        assert_eq!(token, None);
+    }
+
+    #[test]
+    fn offset_beyond_items() {
+        let items: Vec<i32> = (0..3).collect();
+        let (page, token) = paginate(&items, Some("100"), 3);
+        assert!(page.is_empty());
+        assert_eq!(token, None);
+    }
+
+    #[test]
+    fn invalid_token_defaults_to_zero() {
+        let items: Vec<i32> = (0..5).collect();
+        let (page, token) = paginate(&items, Some("not_a_number"), 3);
+        assert_eq!(page, vec![0, 1, 2]);
+        assert_eq!(token, Some("3".to_string()));
+    }
+
+    #[test]
+    fn empty_items() {
+        let items: Vec<i32> = vec![];
+        let (page, token) = paginate(&items, None, 10);
+        assert!(page.is_empty());
+        assert_eq!(token, None);
+    }
+}

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::delivery::DeliveryBus;
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -343,35 +344,31 @@ impl EventBridgeService {
         validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
-        let offset: usize = match body["NextToken"].as_str() {
-            Some(t) => t.parse().map_err(|_| {
+        if let Some(t) = body["NextToken"].as_str() {
+            t.parse::<usize>().map_err(|_| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "InvalidNextTokenException",
                     format!("Invalid NextToken value: '{t}'"),
                 )
-            })?,
-            None => 0,
-        };
+            })?;
+        }
 
         let state = self.state.read();
-        let filtered: Vec<Value> = state
+        let all: Vec<Value> = state
             .buses
             .values()
             .filter(|b| match name_prefix {
                 Some(prefix) => b.name.starts_with(prefix),
                 None => true,
             })
-            .skip(offset)
-            .take(limit + 1)
             .map(|b| json!({ "Name": b.name, "Arn": b.arn }))
             .collect();
 
-        let has_more = filtered.len() > limit;
-        let buses: Vec<Value> = filtered.into_iter().take(limit).collect();
+        let (buses, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "EventBuses": buses });
-        if has_more {
-            resp["NextToken"] = json!((offset + limit).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -1172,18 +1169,12 @@ impl EventBridgeService {
         validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
-        let offset: usize = body["NextToken"]
-            .as_str()
-            .map(|t| t.parse().unwrap_or(0))
-            .unwrap_or(0);
 
         let state = self.state.read();
-        let filtered: Vec<Value> = state
+        let all: Vec<Value> = state
             .partner_event_sources
             .values()
             .filter(|ps| ps.name.starts_with(name_prefix))
-            .skip(offset)
-            .take(limit + 1)
             .map(|ps| {
                 json!({
                     "Arn": ps.arn,
@@ -1192,11 +1183,10 @@ impl EventBridgeService {
             })
             .collect();
 
-        let has_more = filtered.len() > limit;
-        let sources: Vec<Value> = filtered.into_iter().take(limit).collect();
+        let (sources, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "PartnerEventSources": sources });
-        if has_more {
-            resp["NextToken"] = json!((offset + limit).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -1303,21 +1293,15 @@ impl EventBridgeService {
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
-        let offset: usize = body["NextToken"]
-            .as_str()
-            .map(|t| t.parse().unwrap_or(0))
-            .unwrap_or(0);
 
         let state = self.state.read();
-        let filtered: Vec<Value> = state
+        let all: Vec<Value> = state
             .partner_event_sources
             .values()
             .filter(|ps| match name_prefix {
                 Some(prefix) => ps.name.starts_with(prefix),
                 None => true,
             })
-            .skip(offset)
-            .take(limit + 1)
             .map(|ps| {
                 json!({
                     "Arn": ps.arn,
@@ -1329,11 +1313,10 @@ impl EventBridgeService {
             })
             .collect();
 
-        let has_more = filtered.len() > limit;
-        let sources: Vec<Value> = filtered.into_iter().take(limit).collect();
+        let (sources, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "EventSources": sources });
-        if has_more {
-            resp["NextToken"] = json!((offset + limit).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -1596,21 +1579,15 @@ impl EventBridgeService {
         validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 1, 100)?;
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["MaxResults"].as_i64().unwrap_or(100) as usize;
-        let offset: usize = body["NextToken"]
-            .as_str()
-            .map(|t| t.parse().unwrap_or(0))
-            .unwrap_or(0);
 
         let state = self.state.read();
-        let filtered: Vec<Value> = state
+        let all: Vec<Value> = state
             .endpoints
             .values()
             .filter(|ep| match name_prefix {
                 Some(prefix) => ep.name.starts_with(prefix),
                 None => true,
             })
-            .skip(offset)
-            .take(limit + 1)
             .map(|ep| {
                 let mut obj = json!({
                     "Name": ep.name,
@@ -1629,11 +1606,10 @@ impl EventBridgeService {
             })
             .collect();
 
-        let has_more = filtered.len() > limit;
-        let endpoints: Vec<Value> = filtered.into_iter().take(limit).collect();
+        let (endpoints, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "Endpoints": endpoints });
-        if has_more {
-            resp["NextToken"] = json!((offset + limit).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -2379,13 +2355,9 @@ impl EventBridgeService {
         }
 
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
-        let offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|t| t.parse().ok())
-            .unwrap_or(0);
 
         let state = self.state.read();
-        let filtered: Vec<Value> = state
+        let all: Vec<Value> = state
             .archives
             .values()
             .filter(|a| {
@@ -2399,8 +2371,6 @@ impl EventBridgeService {
                     true
                 }
             })
-            .skip(offset)
-            .take(limit + 1)
             .map(|a| {
                 json!({
                     "ArchiveName": a.name,
@@ -2414,11 +2384,10 @@ impl EventBridgeService {
             })
             .collect();
 
-        let has_more = filtered.len() > limit;
-        let archives: Vec<Value> = filtered.into_iter().take(limit).collect();
+        let (archives, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "Archives": archives });
-        if has_more {
-            resp["NextToken"] = json!((offset + limit).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -2620,13 +2589,9 @@ impl EventBridgeService {
         let name_prefix = body["NamePrefix"].as_str();
         let connection_state = body["ConnectionState"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
-        let offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|t| t.parse().ok())
-            .unwrap_or(0);
 
         let state = self.state.read();
-        let filtered: Vec<Value> = state
+        let all: Vec<Value> = state
             .connections
             .values()
             .filter(|c| {
@@ -2642,8 +2607,6 @@ impl EventBridgeService {
                 }
                 true
             })
-            .skip(offset)
-            .take(limit + 1)
             .map(|c| {
                 json!({
                     "ConnectionArn": c.arn,
@@ -2657,11 +2620,10 @@ impl EventBridgeService {
             })
             .collect();
 
-        let has_more = filtered.len() > limit;
-        let conns: Vec<Value> = filtered.into_iter().take(limit).collect();
+        let (conns, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "Connections": conns });
-        if has_more {
-            resp["NextToken"] = json!((offset + limit).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -2846,13 +2808,9 @@ impl EventBridgeService {
         let name_prefix = body["NamePrefix"].as_str();
         let connection_arn = body["ConnectionArn"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
-        let offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|t| t.parse().ok())
-            .unwrap_or(0);
 
         let state = self.state.read();
-        let filtered: Vec<Value> = state
+        let all: Vec<Value> = state
             .api_destinations
             .values()
             .filter(|d| {
@@ -2868,8 +2826,6 @@ impl EventBridgeService {
                 }
                 true
             })
-            .skip(offset)
-            .take(limit + 1)
             .map(|d| {
                 let mut obj = json!({
                     "ApiDestinationArn": d.arn,
@@ -2888,11 +2844,10 @@ impl EventBridgeService {
             })
             .collect();
 
-        let has_more = filtered.len() > limit;
-        let dests: Vec<Value> = filtered.into_iter().take(limit).collect();
+        let (dests, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "ApiDestinations": dests });
-        if has_more {
-            resp["NextToken"] = json!((offset + limit).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -3342,13 +3297,9 @@ impl EventBridgeService {
         }
 
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
-        let offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|t| t.parse().ok())
-            .unwrap_or(0);
 
         let state = self.state.read();
-        let filtered: Vec<Value> = state
+        let all: Vec<Value> = state
             .replays
             .values()
             .filter(|r| {
@@ -3362,8 +3313,6 @@ impl EventBridgeService {
                     true
                 }
             })
-            .skip(offset)
-            .take(limit + 1)
             .map(|r| {
                 let mut obj = json!({
                     "EventSourceArn": r.event_source_arn,
@@ -3380,11 +3329,10 @@ impl EventBridgeService {
             })
             .collect();
 
-        let has_more = filtered.len() > limit;
-        let replays: Vec<Value> = filtered.into_iter().take(limit).collect();
+        let (replays, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "Replays": replays });
-        if has_more {
-            resp["NextToken"] = json!((offset + limit).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -355,17 +355,20 @@ impl EventBridgeService {
         }
 
         let state = self.state.read();
-        let all: Vec<Value> = state
+        let filtered: Vec<&_> = state
             .buses
             .values()
             .filter(|b| match name_prefix {
                 Some(prefix) => b.name.starts_with(prefix),
                 None => true,
             })
-            .map(|b| json!({ "Name": b.name, "Arn": b.arn }))
             .collect();
 
-        let (buses, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
+        let (page, next_token) = paginate(&filtered, body["NextToken"].as_str(), limit);
+        let buses: Vec<Value> = page
+            .iter()
+            .map(|b| json!({ "Name": b.name, "Arn": b.arn }))
+            .collect();
         let mut resp = json!({ "EventBuses": buses });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-ssm/src/service/associations.rs
+++ b/crates/fakecloud-ssm/src/service/associations.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -268,10 +269,6 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
 
         let state = self.state.read();
         let all: Vec<Value> = state
@@ -302,17 +299,10 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all.len() {
-            &all[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let items: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (items, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "Associations": items });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
         Ok(AwsResponse::ok_json(resp))
     }
@@ -410,10 +400,6 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("AssociationId"))?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
 
         let state = self.state.read();
         let assoc = state.associations.get(association_id).ok_or_else(|| {
@@ -459,17 +445,10 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all.len() {
-            &all[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let items: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (items, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "AssociationVersions": items });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
         Ok(AwsResponse::ok_json(resp))
     }

--- a/crates/fakecloud-ssm/src/service/commands.rs
+++ b/crates/fakecloud-ssm/src/service/commands.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -160,10 +161,6 @@ impl SsmService {
         validate_optional_string_length("CommandId", body["CommandId"].as_str(), 36, 36)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
         let command_id = body["CommandId"].as_str();
         let instance_id = body["InstanceId"].as_str();
 
@@ -218,17 +215,11 @@ impl SsmService {
             }
         }
 
-        let page = if next_token_offset < all_commands.len() {
-            &all_commands[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let commands: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (commands, next_token) =
+            paginate(&all_commands, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "Commands": commands });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -305,10 +296,6 @@ impl SsmService {
         validate_optional_string_length("CommandId", body["CommandId"].as_str(), 36, 36)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
         let command_id = body["CommandId"].as_str();
 
         let state = self.state.read();
@@ -337,17 +324,11 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all_invocations.len() {
-            &all_invocations[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let invocations: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (invocations, next_token) =
+            paginate(&all_invocations, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "CommandInvocations": invocations });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))

--- a/crates/fakecloud-ssm/src/service/compliance.rs
+++ b/crates/fakecloud-ssm/src/service/compliance.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use serde_json::{json, Value};
 
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -94,10 +95,6 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
 
         let resource_ids: Vec<&str> = body["ResourceIds"]
             .as_array()
@@ -144,16 +141,10 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all_items.len() {
-            &all_items[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let items: Vec<Value> = page.iter().take(max_results).cloned().collect();
+        let (items, next_token) = paginate(&all_items, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "ComplianceItems": items });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
         Ok(AwsResponse::ok_json(resp))
     }

--- a/crates/fakecloud-ssm/src/service/documents.rs
+++ b/crates/fakecloud-ssm/src/service/documents.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -509,10 +510,6 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(10) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
         let filters = body["Filters"].as_array();
 
         let state = self.state.read();
@@ -571,20 +568,9 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all_docs.len() {
-            &all_docs[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let result: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (result, next_token) = paginate(&all_docs, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "DocumentIdentifiers": result });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
-        } else {
-            resp["NextToken"] = json!("");
-        }
+        resp["NextToken"] = json!(next_token.unwrap_or_default());
 
         Ok(AwsResponse::ok_json(resp))
     }
@@ -728,10 +714,6 @@ impl SsmService {
         let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
 
         let state = self.state.read();
         let doc = state
@@ -755,17 +737,10 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all.len() {
-            &all[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let items: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (items, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "DocumentVersions": items });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
         Ok(AwsResponse::ok_json(resp))
     }

--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -107,10 +108,6 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 10, 100)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
         let filters = body["Filters"].as_array();
 
         let state = self.state.read();
@@ -171,17 +168,10 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all_windows.len() {
-            &all_windows[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let windows: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (windows, next_token) = paginate(&all_windows, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "WindowIdentities": windows });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -922,10 +912,6 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
 
         let state = self.state.read();
         let all: Vec<Value> = state
@@ -946,16 +932,10 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all.len() {
-            &all[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let items: Vec<Value> = page.iter().take(max_results).cloned().collect();
+        let (items, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "WindowExecutions": items });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
         Ok(AwsResponse::ok_json(resp))
     }

--- a/crates/fakecloud-ssm/src/service/ops.rs
+++ b/crates/fakecloud-ssm/src/service/ops.rs
@@ -5,6 +5,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_aws::arn::Arn;
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -184,10 +185,6 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
 
         let state = self.state.read();
         let all: Vec<Value> = state
@@ -217,17 +214,10 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all.len() {
-            &all[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let items: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (items, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "OpsItemSummaries": items });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
         Ok(AwsResponse::ok_json(resp))
     }

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -5,6 +5,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_aws::arn::Arn;
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -577,10 +578,6 @@ impl SsmService {
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
         let filters = body["ParameterFilters"].as_array().cloned();
         let max_results = body["MaxResults"].as_i64().unwrap_or(10) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
 
         // Validate MaxResults
         if max_results > 10 {
@@ -656,21 +653,16 @@ impl SsmService {
             .filter(|p| apply_parameter_filters(p, filters.as_ref()))
             .collect();
 
-        let page = if next_token_offset < all_params.len() {
-            &all_params[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() >= max_results;
-        let parameters: Vec<Value> = page
+        let (page_params, next_token) =
+            paginate(&all_params, body["NextToken"].as_str(), max_results);
+        let parameters: Vec<Value> = page_params
             .iter()
-            .take(max_results)
             .map(|p| param_to_json(p, true, with_decryption, &req.region))
             .collect();
 
         let mut resp = json!({ "Parameters": parameters });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -727,10 +719,6 @@ impl SsmService {
         let param_filters = body["ParameterFilters"].as_array().cloned();
         let old_filters = body["Filters"].as_array().cloned();
         let max_results = body["MaxResults"].as_i64().unwrap_or(10) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
 
         // Can't use both Filters and ParameterFilters
         if param_filters.is_some() && old_filters.is_some() {
@@ -786,21 +774,16 @@ impl SsmService {
             .filter(|p| apply_old_filters(p, old_filters.as_ref()))
             .collect();
 
-        let page = if next_token_offset < all_params.len() {
-            &all_params[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() >= max_results;
-        let parameters: Vec<Value> = page
+        let (page_params, next_token) =
+            paginate(&all_params, body["NextToken"].as_str(), max_results);
+        let parameters: Vec<Value> = page_params
             .iter()
-            .take(max_results)
             .map(|p| param_to_describe_json(p, &req.region))
             .collect();
 
         let mut resp = json!({ "Parameters": parameters });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -814,10 +797,6 @@ impl SsmService {
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
         let max_results = body["MaxResults"].as_i64();
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
 
         // Validate MaxResults
         if let Some(mr) = max_results {
@@ -898,17 +877,10 @@ impl SsmService {
         current["Labels"] = json!(current_labels);
         all_history.push(current);
 
-        let page = if next_token_offset < all_history.len() {
-            &all_history[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() >= max_results;
-        let result: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (result, next_token) = paginate(&all_history, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "Parameters": result });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))

--- a/crates/fakecloud-ssm/src/service/patches.rs
+++ b/crates/fakecloud-ssm/src/service/patches.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -188,10 +189,6 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 100)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
         let filters = body["Filters"].as_array();
 
         let state = self.state.read();
@@ -243,17 +240,11 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all_baselines.len() {
-            &all_baselines[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let baselines: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (baselines, next_token) =
+            paginate(&all_baselines, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "BaselineIdentities": baselines });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))
@@ -479,10 +470,6 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 100)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
-        let next_token_offset: usize = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
         let filters = body["Filters"].as_array();
 
         let state = self.state.read();
@@ -535,17 +522,11 @@ impl SsmService {
             })
             .collect();
 
-        let page = if next_token_offset < all_mappings.len() {
-            &all_mappings[next_token_offset..]
-        } else {
-            &[]
-        };
-        let has_more = page.len() > max_results;
-        let mappings: Vec<Value> = page.iter().take(max_results).cloned().collect();
-
+        let (mappings, next_token) =
+            paginate(&all_mappings, body["NextToken"].as_str(), max_results);
         let mut resp = json!({ "Mappings": mappings });
-        if has_more {
-            resp["NextToken"] = json!((next_token_offset + max_results).to_string());
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
         }
 
         Ok(AwsResponse::ok_json(resp))


### PR DESCRIPTION
## Summary

- Add `paginate<T: Clone>()` helper to `fakecloud-core::pagination` with 7 unit tests
- Replace 21 instances of offset-based pagination boilerplate across SSM (13) and EventBridge (8)
- Net reduction of ~116 lines
- Logs service not modified (uses name-based cursor tokens, not offset-based)

## Test plan

- [x] 7 new pagination unit tests pass
- [x] All SSM tests pass (67)
- [x] All EventBridge tests pass (57)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared offset-based pagination helper into `fakecloud-core` and refactored SSM and EventBridge list operations to use it. This reduces boilerplate, standardizes `NextToken`, and prevents infinite loops when `MaxResults` is 0.

- **Refactors**
  - Added `fakecloud-core::pagination::paginate<T>()` (7 tests) and replaced offset-based implementations across `fakecloud-ssm` and `fakecloud-eventbridge`. Logs service unchanged (uses name-based cursors).

- **Bug Fixes**
  - Clamp `max_results` to at least 1 in `paginate()` to avoid infinite pagination loops.
  - `ListEventBuses`: paginate filtered references before JSON mapping; invalid `NextToken` now returns `InvalidNextTokenException`.

<sup>Written for commit c9a6d4b67b51ca9be503a4094087a66f218145f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

