### PR TITLE
refactor: extract shared tag CRUD helpers into fakecloud-core

### DIFF
--- a/crates/fakecloud-core/src/lib.rs
+++ b/crates/fakecloud-core/src/lib.rs
@@ -3,4 +3,5 @@ pub mod dispatch;
 pub mod protocol;
 pub mod registry;
 pub mod service;
+pub mod tags;
 pub mod validation;

--- a/crates/fakecloud-core/src/tags.rs
+++ b/crates/fakecloud-core/src/tags.rs
@@ -27,10 +27,11 @@ pub fn apply_tags(
     key_field: &str,
     value_field: &str,
 ) -> Result<(), String> {
-    let field = &body[tags_field];
-    if field.is_null() {
+    let obj = body.as_object();
+    let field = obj.and_then(|o| o.get(tags_field));
+    let Some(field) = field else {
         return Ok(());
-    }
+    };
     let tags = field.as_array().ok_or_else(|| tags_field.to_string())?;
     for tag in tags {
         if let (Some(k), Some(v)) = (tag[key_field].as_str(), tag[value_field].as_str()) {
@@ -52,10 +53,11 @@ pub fn remove_tags(
     body: &Value,
     keys_field: &str,
 ) -> Result<(), String> {
-    let field = &body[keys_field];
-    if field.is_null() {
+    let obj = body.as_object();
+    let field = obj.and_then(|o| o.get(keys_field));
+    let Some(field) = field else {
         return Ok(());
-    }
+    };
     let keys = field.as_array().ok_or_else(|| keys_field.to_string())?;
     for key in keys {
         if let Some(k) = key.as_str() {
@@ -137,6 +139,13 @@ mod tests {
     }
 
     #[test]
+    fn apply_tags_errors_on_explicit_null() {
+        let mut tags = HashMap::new();
+        let body = json!({ "Tags": null });
+        assert!(apply_tags(&mut tags, &body, "Tags", "Key", "Value").is_err());
+    }
+
+    #[test]
     fn remove_tags_removes_matching_keys() {
         let mut tags = HashMap::new();
         tags.insert("a".to_string(), "1".to_string());
@@ -163,6 +172,13 @@ mod tests {
     fn remove_tags_errors_on_non_array() {
         let mut tags = HashMap::new();
         let body = json!({ "TagKeys": 42 });
+        assert!(remove_tags(&mut tags, &body, "TagKeys").is_err());
+    }
+
+    #[test]
+    fn remove_tags_errors_on_explicit_null() {
+        let mut tags = HashMap::new();
+        let body = json!({ "TagKeys": null });
         assert!(remove_tags(&mut tags, &body, "TagKeys").is_err());
     }
 

--- a/crates/fakecloud-core/src/tags.rs
+++ b/crates/fakecloud-core/src/tags.rs
@@ -1,0 +1,171 @@
+//! Shared tag CRUD helpers for JSON-protocol services.
+//!
+//! Most AWS JSON-protocol services represent tags as an array of objects
+//! with key/value fields (e.g. `[{"Key": "env", "Value": "prod"}]`) and
+//! store them internally as `HashMap<String, String>`. This module provides
+//! helpers to parse, apply, remove, and serialise those tags so that
+//! individual service crates don't have to duplicate the logic.
+
+use std::collections::HashMap;
+
+use serde_json::{json, Value};
+
+/// Parse a JSON tags array and insert each tag into `existing_tags`.
+///
+/// `tags_field` is the name of the JSON field inside `body` that holds
+/// the tags array (e.g. `"Tags"`).  Each element is expected to have
+/// `key_field` and `value_field` string properties (typically `"Key"` /
+/// `"Value"`, but KMS uses `"TagKey"` / `"TagValue"`).
+///
+/// Tags with missing or non-string key/value pairs are silently skipped.
+pub fn apply_tags(
+    existing_tags: &mut HashMap<String, String>,
+    body: &Value,
+    tags_field: &str,
+    key_field: &str,
+    value_field: &str,
+) {
+    if let Some(tags) = body[tags_field].as_array() {
+        for tag in tags {
+            if let (Some(k), Some(v)) = (tag[key_field].as_str(), tag[value_field].as_str()) {
+                existing_tags.insert(k.to_string(), v.to_string());
+            }
+        }
+    }
+}
+
+/// Parse a JSON tag-keys array and remove matching keys from `existing_tags`.
+///
+/// `keys_field` is the name of the JSON field inside `body` that holds
+/// the keys array (e.g. `"TagKeys"`).  Each element is expected to be a
+/// plain string.
+pub fn remove_tags(existing_tags: &mut HashMap<String, String>, body: &Value, keys_field: &str) {
+    if let Some(keys) = body[keys_field].as_array() {
+        for key in keys {
+            if let Some(k) = key.as_str() {
+                existing_tags.remove(k);
+            }
+        }
+    }
+}
+
+/// Convert a tag map into a sorted JSON array of `{key_field: k, value_field: v}` objects.
+///
+/// The output is sorted by key so that responses are deterministic.
+pub fn tags_to_json(
+    tags: &HashMap<String, String>,
+    key_field: &str,
+    value_field: &str,
+) -> Vec<Value> {
+    let mut sorted: Vec<(&String, &String)> = tags.iter().collect();
+    sorted.sort_by_key(|(k, _)| (*k).clone());
+    sorted
+        .into_iter()
+        .map(|(k, v)| json!({ key_field: k, value_field: v }))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn apply_tags_inserts_and_overwrites() {
+        let mut tags = HashMap::new();
+        tags.insert("existing".to_string(), "old".to_string());
+
+        let body = json!({
+            "Tags": [
+                {"Key": "existing", "Value": "new"},
+                {"Key": "added", "Value": "val"},
+            ]
+        });
+
+        apply_tags(&mut tags, &body, "Tags", "Key", "Value");
+
+        assert_eq!(tags.get("existing").unwrap(), "new");
+        assert_eq!(tags.get("added").unwrap(), "val");
+    }
+
+    #[test]
+    fn apply_tags_skips_invalid_entries() {
+        let mut tags = HashMap::new();
+        let body = json!({
+            "Tags": [
+                {"Key": "good", "Value": "val"},
+                {"Key": 123, "Value": "bad_key"},
+                {"NoKey": "x", "Value": "missing_key"},
+            ]
+        });
+
+        apply_tags(&mut tags, &body, "Tags", "Key", "Value");
+
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags.get("good").unwrap(), "val");
+    }
+
+    #[test]
+    fn apply_tags_noop_when_field_missing() {
+        let mut tags = HashMap::new();
+        let body = json!({});
+        apply_tags(&mut tags, &body, "Tags", "Key", "Value");
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn remove_tags_removes_matching_keys() {
+        let mut tags = HashMap::new();
+        tags.insert("a".to_string(), "1".to_string());
+        tags.insert("b".to_string(), "2".to_string());
+        tags.insert("c".to_string(), "3".to_string());
+
+        let body = json!({ "TagKeys": ["a", "c", "nonexistent"] });
+        remove_tags(&mut tags, &body, "TagKeys");
+
+        assert_eq!(tags.len(), 1);
+        assert!(tags.contains_key("b"));
+    }
+
+    #[test]
+    fn remove_tags_noop_when_field_missing() {
+        let mut tags = HashMap::new();
+        tags.insert("a".to_string(), "1".to_string());
+        let body = json!({});
+        remove_tags(&mut tags, &body, "TagKeys");
+        assert_eq!(tags.len(), 1);
+    }
+
+    #[test]
+    fn tags_to_json_produces_sorted_array() {
+        let mut tags = HashMap::new();
+        tags.insert("z_key".to_string(), "z_val".to_string());
+        tags.insert("a_key".to_string(), "a_val".to_string());
+
+        let result = tags_to_json(&tags, "Key", "Value");
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0]["Key"], "a_key");
+        assert_eq!(result[0]["Value"], "a_val");
+        assert_eq!(result[1]["Key"], "z_key");
+        assert_eq!(result[1]["Value"], "z_val");
+    }
+
+    #[test]
+    fn tags_to_json_with_custom_field_names() {
+        let mut tags = HashMap::new();
+        tags.insert("mykey".to_string(), "myval".to_string());
+
+        let result = tags_to_json(&tags, "TagKey", "TagValue");
+
+        assert_eq!(result[0]["TagKey"], "mykey");
+        assert_eq!(result[0]["TagValue"], "myval");
+    }
+
+    #[test]
+    fn tags_to_json_empty_map() {
+        let tags = HashMap::new();
+        let result = tags_to_json(&tags, "Key", "Value");
+        assert!(result.is_empty());
+    }
+}

--- a/crates/fakecloud-core/src/tags.rs
+++ b/crates/fakecloud-core/src/tags.rs
@@ -18,20 +18,26 @@ use serde_json::{json, Value};
 /// `"Value"`, but KMS uses `"TagKey"` / `"TagValue"`).
 ///
 /// Tags with missing or non-string key/value pairs are silently skipped.
+///
+/// Returns `Err(field_name)` if the field is present but not an array.
 pub fn apply_tags(
     existing_tags: &mut HashMap<String, String>,
     body: &Value,
     tags_field: &str,
     key_field: &str,
     value_field: &str,
-) {
-    if let Some(tags) = body[tags_field].as_array() {
-        for tag in tags {
-            if let (Some(k), Some(v)) = (tag[key_field].as_str(), tag[value_field].as_str()) {
-                existing_tags.insert(k.to_string(), v.to_string());
-            }
+) -> Result<(), String> {
+    let field = &body[tags_field];
+    if field.is_null() {
+        return Ok(());
+    }
+    let tags = field.as_array().ok_or_else(|| tags_field.to_string())?;
+    for tag in tags {
+        if let (Some(k), Some(v)) = (tag[key_field].as_str(), tag[value_field].as_str()) {
+            existing_tags.insert(k.to_string(), v.to_string());
         }
     }
+    Ok(())
 }
 
 /// Parse a JSON tag-keys array and remove matching keys from `existing_tags`.
@@ -39,14 +45,24 @@ pub fn apply_tags(
 /// `keys_field` is the name of the JSON field inside `body` that holds
 /// the keys array (e.g. `"TagKeys"`).  Each element is expected to be a
 /// plain string.
-pub fn remove_tags(existing_tags: &mut HashMap<String, String>, body: &Value, keys_field: &str) {
-    if let Some(keys) = body[keys_field].as_array() {
-        for key in keys {
-            if let Some(k) = key.as_str() {
-                existing_tags.remove(k);
-            }
+///
+/// Returns `Err(field_name)` if the field is present but not an array.
+pub fn remove_tags(
+    existing_tags: &mut HashMap<String, String>,
+    body: &Value,
+    keys_field: &str,
+) -> Result<(), String> {
+    let field = &body[keys_field];
+    if field.is_null() {
+        return Ok(());
+    }
+    let keys = field.as_array().ok_or_else(|| keys_field.to_string())?;
+    for key in keys {
+        if let Some(k) = key.as_str() {
+            existing_tags.remove(k);
         }
     }
+    Ok(())
 }
 
 /// Convert a tag map into a sorted JSON array of `{key_field: k, value_field: v}` objects.
@@ -82,7 +98,7 @@ mod tests {
             ]
         });
 
-        apply_tags(&mut tags, &body, "Tags", "Key", "Value");
+        apply_tags(&mut tags, &body, "Tags", "Key", "Value").unwrap();
 
         assert_eq!(tags.get("existing").unwrap(), "new");
         assert_eq!(tags.get("added").unwrap(), "val");
@@ -99,7 +115,7 @@ mod tests {
             ]
         });
 
-        apply_tags(&mut tags, &body, "Tags", "Key", "Value");
+        apply_tags(&mut tags, &body, "Tags", "Key", "Value").unwrap();
 
         assert_eq!(tags.len(), 1);
         assert_eq!(tags.get("good").unwrap(), "val");
@@ -109,8 +125,15 @@ mod tests {
     fn apply_tags_noop_when_field_missing() {
         let mut tags = HashMap::new();
         let body = json!({});
-        apply_tags(&mut tags, &body, "Tags", "Key", "Value");
+        apply_tags(&mut tags, &body, "Tags", "Key", "Value").unwrap();
         assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn apply_tags_errors_on_non_array() {
+        let mut tags = HashMap::new();
+        let body = json!({ "Tags": "not_an_array" });
+        assert!(apply_tags(&mut tags, &body, "Tags", "Key", "Value").is_err());
     }
 
     #[test]
@@ -121,7 +144,7 @@ mod tests {
         tags.insert("c".to_string(), "3".to_string());
 
         let body = json!({ "TagKeys": ["a", "c", "nonexistent"] });
-        remove_tags(&mut tags, &body, "TagKeys");
+        remove_tags(&mut tags, &body, "TagKeys").unwrap();
 
         assert_eq!(tags.len(), 1);
         assert!(tags.contains_key("b"));
@@ -132,8 +155,15 @@ mod tests {
         let mut tags = HashMap::new();
         tags.insert("a".to_string(), "1".to_string());
         let body = json!({});
-        remove_tags(&mut tags, &body, "TagKeys");
+        remove_tags(&mut tags, &body, "TagKeys").unwrap();
         assert_eq!(tags.len(), 1);
+    }
+
+    #[test]
+    fn remove_tags_errors_on_non_array() {
+        let mut tags = HashMap::new();
+        let body = json!({ "TagKeys": 42 });
+        assert!(remove_tags(&mut tags, &body, "TagKeys").is_err());
     }
 
     #[test]

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -1031,22 +1031,12 @@ impl DynamoDbService {
     fn tag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let resource_arn = require_str(&body, "ResourceArn")?;
-        let tags_arr = body["Tags"].as_array().ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationException",
-                "Tags is required",
-            )
-        })?;
+        validate_required("Tags", &body["Tags"])?;
 
         let mut state = self.state.write();
         let table = find_table_by_arn_mut(&mut state.tables, resource_arn)?;
 
-        for tag in tags_arr {
-            if let (Some(k), Some(v)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
-                table.tags.insert(k.to_string(), v.to_string());
-            }
-        }
+        fakecloud_core::tags::apply_tags(&mut table.tags, &body, "Tags", "Key", "Value");
 
         Self::ok_json(json!({}))
     }
@@ -1054,22 +1044,12 @@ impl DynamoDbService {
     fn untag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let resource_arn = require_str(&body, "ResourceArn")?;
-        let tag_keys = body["TagKeys"].as_array().ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationException",
-                "TagKeys is required",
-            )
-        })?;
+        validate_required("TagKeys", &body["TagKeys"])?;
 
         let mut state = self.state.write();
         let table = find_table_by_arn_mut(&mut state.tables, resource_arn)?;
 
-        for key in tag_keys {
-            if let Some(k) = key.as_str() {
-                table.tags.remove(k);
-            }
-        }
+        fakecloud_core::tags::remove_tags(&mut table.tags, &body, "TagKeys");
 
         Self::ok_json(json!({}))
     }
@@ -1081,11 +1061,7 @@ impl DynamoDbService {
         let state = self.state.read();
         let table = find_table_by_arn(&state.tables, resource_arn)?;
 
-        let tags: Vec<Value> = table
-            .tags
-            .iter()
-            .map(|(k, v)| json!({"Key": k, "Value": v}))
-            .collect();
+        let tags = fakecloud_core::tags::tags_to_json(&table.tags, "Key", "Value");
 
         Self::ok_json(json!({ "Tags": tags }))
     }

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -1036,7 +1036,15 @@ impl DynamoDbService {
         let mut state = self.state.write();
         let table = find_table_by_arn_mut(&mut state.tables, resource_arn)?;
 
-        fakecloud_core::tags::apply_tags(&mut table.tags, &body, "Tags", "Key", "Value");
+        fakecloud_core::tags::apply_tags(&mut table.tags, &body, "Tags", "Key", "Value").map_err(
+            |f| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("{f} must be a list"),
+                )
+            },
+        )?;
 
         Self::ok_json(json!({}))
     }
@@ -1049,7 +1057,13 @@ impl DynamoDbService {
         let mut state = self.state.write();
         let table = find_table_by_arn_mut(&mut state.tables, resource_arn)?;
 
-        fakecloud_core::tags::remove_tags(&mut table.tags, &body, "TagKeys");
+        fakecloud_core::tags::remove_tags(&mut table.tags, &body, "TagKeys").map_err(|f| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!("{f} must be a list"),
+            )
+        })?;
 
         Self::ok_json(json!({}))
     }

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -2097,17 +2097,11 @@ impl EventBridgeService {
             .ok_or_else(|| missing("ResourceARN"))?;
         validate_string_length("resourceARN", arn, 1, 1600)?;
         validate_required("Tags", &body["Tags"])?;
-        let tags = body["Tags"].as_array().ok_or_else(|| missing("Tags"))?;
 
         let mut state = self.state.write();
-
         let tag_map = find_tags_mut(&mut state, arn)?;
 
-        for tag in tags {
-            if let (Some(key), Some(val)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
-                tag_map.insert(key.to_string(), val.to_string());
-            }
-        }
+        fakecloud_core::tags::apply_tags(tag_map, &body, "Tags", "Key", "Value");
 
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -2120,18 +2114,11 @@ impl EventBridgeService {
             .ok_or_else(|| missing("ResourceARN"))?;
         validate_string_length("resourceARN", arn, 1, 1600)?;
         validate_required("TagKeys", &body["TagKeys"])?;
-        let tag_keys = body["TagKeys"]
-            .as_array()
-            .ok_or_else(|| missing("TagKeys"))?;
 
         let mut state = self.state.write();
         let tag_map = find_tags_mut(&mut state, arn)?;
 
-        for key in tag_keys {
-            if let Some(k) = key.as_str() {
-                tag_map.remove(k);
-            }
-        }
+        fakecloud_core::tags::remove_tags(tag_map, &body, "TagKeys");
 
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -2147,10 +2134,7 @@ impl EventBridgeService {
         let state = self.state.read();
         let tag_map = find_tags(&state, arn)?;
 
-        let tags: Vec<Value> = tag_map
-            .iter()
-            .map(|(k, v)| json!({"Key": k, "Value": v}))
-            .collect();
+        let tags = fakecloud_core::tags::tags_to_json(tag_map, "Key", "Value");
 
         Ok(AwsResponse::ok_json(json!({ "Tags": tags })))
     }

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -2101,7 +2101,13 @@ impl EventBridgeService {
         let mut state = self.state.write();
         let tag_map = find_tags_mut(&mut state, arn)?;
 
-        fakecloud_core::tags::apply_tags(tag_map, &body, "Tags", "Key", "Value");
+        fakecloud_core::tags::apply_tags(tag_map, &body, "Tags", "Key", "Value").map_err(|f| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!("{f} must be a list"),
+            )
+        })?;
 
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -2118,7 +2124,13 @@ impl EventBridgeService {
         let mut state = self.state.write();
         let tag_map = find_tags_mut(&mut state, arn)?;
 
-        fakecloud_core::tags::remove_tags(tag_map, &body, "TagKeys");
+        fakecloud_core::tags::remove_tags(tag_map, &body, "TagKeys").map_err(|f| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!("{f} must be a list"),
+            )
+        })?;
 
         Ok(AwsResponse::ok_json(json!({})))
     }

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -1365,8 +1365,6 @@ impl KmsService {
             )
         })?;
 
-        let tags = body["Tags"].as_array();
-
         let mut state = self.state.write();
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -1375,13 +1373,8 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
-        if let Some(tags) = tags {
-            for tag in tags {
-                if let (Some(k), Some(v)) = (tag["TagKey"].as_str(), tag["TagValue"].as_str()) {
-                    key.tags.insert(k.to_string(), v.to_string());
-                }
-            }
-        }
+
+        fakecloud_core::tags::apply_tags(&mut key.tags, &body, "Tags", "TagKey", "TagValue");
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
@@ -1398,8 +1391,6 @@ impl KmsService {
             )
         })?;
 
-        let tag_keys = body["TagKeys"].as_array();
-
         let mut state = self.state.write();
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -1408,13 +1399,8 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
-        if let Some(tag_keys) = tag_keys {
-            for tag_key in tag_keys {
-                if let Some(k) = tag_key.as_str() {
-                    key.tags.remove(k);
-                }
-            }
-        }
+
+        fakecloud_core::tags::remove_tags(&mut key.tags, &body, "TagKeys");
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
@@ -1439,17 +1425,7 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
-        let mut sorted_tags: Vec<(&String, &String)> = key.tags.iter().collect();
-        sorted_tags.sort_by_key(|(k, _)| (*k).clone());
-        let tags: Vec<Value> = sorted_tags
-            .iter()
-            .map(|(k, v)| {
-                json!({
-                    "TagKey": k,
-                    "TagValue": v,
-                })
-            })
-            .collect();
+        let tags = fakecloud_core::tags::tags_to_json(&key.tags, "TagKey", "TagValue");
 
         Ok(AwsResponse::json(
             StatusCode::OK,

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -1374,7 +1374,14 @@ impl KmsService {
             )
         })?;
 
-        fakecloud_core::tags::apply_tags(&mut key.tags, &body, "Tags", "TagKey", "TagValue");
+        fakecloud_core::tags::apply_tags(&mut key.tags, &body, "Tags", "TagKey", "TagValue")
+            .map_err(|f| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("{f} must be a list"),
+                )
+            })?;
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
@@ -1400,7 +1407,13 @@ impl KmsService {
             )
         })?;
 
-        fakecloud_core::tags::remove_tags(&mut key.tags, &body, "TagKeys");
+        fakecloud_core::tags::remove_tags(&mut key.tags, &body, "TagKeys").map_err(|f| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!("{f} must be a list"),
+            )
+        })?;
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }

--- a/crates/fakecloud-ssm/src/service/tags.rs
+++ b/crates/fakecloud-ssm/src/service/tags.rs
@@ -110,7 +110,13 @@ impl SsmService {
 
         let mut state = self.state.write();
         let tag_map = Self::resolve_tags_mut(&mut state, resource_type, resource_id)?;
-        tags::apply_tags(tag_map, &body, "Tags", "Key", "Value");
+        tags::apply_tags(tag_map, &body, "Tags", "Key", "Value").map_err(|f| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!("{f} must be a list"),
+            )
+        })?;
 
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -129,7 +135,13 @@ impl SsmService {
 
         let mut state = self.state.write();
         let tag_map = Self::resolve_tags_mut(&mut state, resource_type, resource_id)?;
-        tags::remove_tags(tag_map, &body, "TagKeys");
+        tags::remove_tags(tag_map, &body, "TagKeys").map_err(|f| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!("{f} must be a list"),
+            )
+        })?;
 
         Ok(AwsResponse::ok_json(json!({})))
     }

--- a/crates/fakecloud-ssm/src/service/tags.rs
+++ b/crates/fakecloud-ssm/src/service/tags.rs
@@ -1,13 +1,102 @@
+use std::collections::HashMap;
+
 use http::StatusCode;
-use serde_json::{json, Value};
+use serde_json::json;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+use fakecloud_core::tags;
 use fakecloud_core::validation::*;
 
 use super::parameters::{lookup_param, lookup_param_mut};
 use super::{missing, SsmService};
 
+const INVALID_RESOURCE_TYPE_MSG: &str = " is not a valid resource type. \
+    Valid resource types are: ManagedInstance, MaintenanceWindow, \
+    Parameter, PatchBaseline, OpsItem, Document.";
+
 impl SsmService {
+    /// Resolve a mutable reference to the tag map for the given SSM resource.
+    fn resolve_tags_mut<'a>(
+        state: &'a mut crate::state::SsmState,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<&'a mut HashMap<String, String>, AwsServiceError> {
+        match resource_type {
+            "Parameter" => {
+                let param = lookup_param_mut(&mut state.parameters, resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+                Ok(&mut param.tags)
+            }
+            "Document" => {
+                let doc = state
+                    .documents
+                    .get_mut(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+                Ok(&mut doc.tags)
+            }
+            "MaintenanceWindow" => {
+                let mw = state
+                    .maintenance_windows
+                    .get_mut(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+                Ok(&mut mw.tags)
+            }
+            "PatchBaseline" => {
+                let pb = state
+                    .patch_baselines
+                    .get_mut(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+                Ok(&mut pb.tags)
+            }
+            _ => Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidResourceType",
+                format!("{resource_type}{INVALID_RESOURCE_TYPE_MSG}"),
+            )),
+        }
+    }
+
+    /// Resolve an immutable reference to the tag map for the given SSM resource.
+    fn resolve_tags<'a>(
+        state: &'a crate::state::SsmState,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<&'a HashMap<String, String>, AwsServiceError> {
+        match resource_type {
+            "Parameter" => {
+                let param = lookup_param(&state.parameters, resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+                Ok(&param.tags)
+            }
+            "Document" => {
+                let doc = state
+                    .documents
+                    .get(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+                Ok(&doc.tags)
+            }
+            "MaintenanceWindow" => {
+                let mw = state
+                    .maintenance_windows
+                    .get(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+                Ok(&mw.tags)
+            }
+            "PatchBaseline" => {
+                let pb = state
+                    .patch_baselines
+                    .get(resource_id)
+                    .ok_or_else(|| invalid_resource_id(resource_id))?;
+                Ok(&pb.tags)
+            }
+            _ => Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidResourceType",
+                format!("{resource_type}{INVALID_RESOURCE_TYPE_MSG}"),
+            )),
+        }
+    }
+
     pub(super) fn add_tags_to_resource(
         &self,
         req: &AwsRequest,
@@ -17,69 +106,11 @@ impl SsmService {
         let resource_id = body["ResourceId"]
             .as_str()
             .ok_or_else(|| missing("ResourceId"))?;
-        let tags = body["Tags"].as_array().ok_or_else(|| missing("Tags"))?;
+        validate_required("Tags", &body["Tags"])?;
 
         let mut state = self.state.write();
-
-        match resource_type {
-            "Parameter" => {
-                let param = lookup_param_mut(&mut state.parameters, resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-
-                for tag in tags {
-                    if let (Some(key), Some(val)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
-                        param.tags.insert(key.to_string(), val.to_string());
-                    }
-                }
-            }
-            "Document" => {
-                let doc = state
-                    .documents
-                    .get_mut(resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-
-                for tag in tags {
-                    if let (Some(key), Some(val)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
-                        doc.tags.insert(key.to_string(), val.to_string());
-                    }
-                }
-            }
-            "MaintenanceWindow" => {
-                let mw = state
-                    .maintenance_windows
-                    .get_mut(resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-
-                for tag in tags {
-                    if let (Some(key), Some(val)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
-                        mw.tags.insert(key.to_string(), val.to_string());
-                    }
-                }
-            }
-            "PatchBaseline" => {
-                let pb = state
-                    .patch_baselines
-                    .get_mut(resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-
-                for tag in tags {
-                    if let (Some(key), Some(val)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
-                        pb.tags.insert(key.to_string(), val.to_string());
-                    }
-                }
-            }
-            _ => {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidResourceType",
-                    format!(
-                        "{resource_type} is not a valid resource type. \
-                         Valid resource types are: ManagedInstance, MaintenanceWindow, \
-                         Parameter, PatchBaseline, OpsItem, Document."
-                    ),
-                ));
-            }
-        }
+        let tag_map = Self::resolve_tags_mut(&mut state, resource_type, resource_id)?;
+        tags::apply_tags(tag_map, &body, "Tags", "Key", "Value");
 
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -94,71 +125,11 @@ impl SsmService {
         let resource_id = body["ResourceId"]
             .as_str()
             .ok_or_else(|| missing("ResourceId"))?;
-        let tag_keys = body["TagKeys"]
-            .as_array()
-            .ok_or_else(|| missing("TagKeys"))?;
+        validate_required("TagKeys", &body["TagKeys"])?;
 
         let mut state = self.state.write();
-
-        match resource_type {
-            "Parameter" => {
-                let param = lookup_param_mut(&mut state.parameters, resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-
-                for key in tag_keys {
-                    if let Some(k) = key.as_str() {
-                        param.tags.remove(k);
-                    }
-                }
-            }
-            "Document" => {
-                let doc = state
-                    .documents
-                    .get_mut(resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-
-                for key in tag_keys {
-                    if let Some(k) = key.as_str() {
-                        doc.tags.remove(k);
-                    }
-                }
-            }
-            "MaintenanceWindow" => {
-                let mw = state
-                    .maintenance_windows
-                    .get_mut(resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-
-                for key in tag_keys {
-                    if let Some(k) = key.as_str() {
-                        mw.tags.remove(k);
-                    }
-                }
-            }
-            "PatchBaseline" => {
-                let pb = state
-                    .patch_baselines
-                    .get_mut(resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-
-                for key in tag_keys {
-                    if let Some(k) = key.as_str() {
-                        pb.tags.remove(k);
-                    }
-                }
-            }
-            _ => {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidResourceType",
-                    format!(
-                        "{resource_type} is not a valid resource type. \
-                         Valid resource types are: ManagedInstance, MaintenanceWindow, \
-                         Parameter, PatchBaseline, OpsItem, Document."
-                    ),
-                ));
-            }
-        }
+        let tag_map = Self::resolve_tags_mut(&mut state, resource_type, resource_id)?;
+        tags::remove_tags(tag_map, &body, "TagKeys");
 
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -174,68 +145,10 @@ impl SsmService {
             .ok_or_else(|| missing("ResourceId"))?;
 
         let state = self.state.read();
+        let tag_map = Self::resolve_tags(&state, resource_type, resource_id)?;
+        let result = tags::tags_to_json(tag_map, "Key", "Value");
 
-        let tags: Vec<Value> = match resource_type {
-            "Parameter" => {
-                let param = lookup_param(&state.parameters, resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-                param
-                    .tags
-                    .iter()
-                    .map(|(k, v)| json!({"Key": k, "Value": v}))
-                    .collect()
-            }
-            "Document" => {
-                let doc = state
-                    .documents
-                    .get(resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-                doc.tags
-                    .iter()
-                    .map(|(k, v)| json!({"Key": k, "Value": v}))
-                    .collect()
-            }
-            "MaintenanceWindow" => {
-                let mw = state
-                    .maintenance_windows
-                    .get(resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-                mw.tags
-                    .iter()
-                    .map(|(k, v)| json!({"Key": k, "Value": v}))
-                    .collect()
-            }
-            "PatchBaseline" => {
-                let pb = state
-                    .patch_baselines
-                    .get(resource_id)
-                    .ok_or_else(|| invalid_resource_id(resource_id))?;
-                pb.tags
-                    .iter()
-                    .map(|(k, v)| json!({"Key": k, "Value": v}))
-                    .collect()
-            }
-            _ => {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidResourceType",
-                    format!(
-                        "{resource_type} is not a valid resource type. \
-                         Valid resource types are: ManagedInstance, MaintenanceWindow, \
-                         Parameter, PatchBaseline, OpsItem, Document."
-                    ),
-                ));
-            }
-        };
-
-        let mut tags = tags;
-        tags.sort_by(|a, b| {
-            let ka = a["Key"].as_str().unwrap_or("");
-            let kb = b["Key"].as_str().unwrap_or("");
-            ka.cmp(kb)
-        });
-
-        Ok(AwsResponse::ok_json(json!({ "TagList": tags })))
+        Ok(AwsResponse::ok_json(json!({ "TagList": result })))
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `apply_tags()`, `remove_tags()`, `tags_to_json()` helpers to `fakecloud-core::tags` with 7 unit tests
- Refactor tag operations in DynamoDB, EventBridge, KMS, and SSM to use shared helpers
- Configurable key/value field names (handles KMS `TagKey`/`TagValue` vs standard `Key`/`Value`)
- SSM additionally gets `resolve_tags_mut`/`resolve_tags` to deduplicate 3x repeated 4-way resource type dispatch
- Net reduction of ~150 lines

Skipped: SNS (XML protocol), SecretManager (Vec-based tags), Logs (map-style tags)

## Test plan

- [x] 7 new tag helper unit tests pass
- [x] All 536 workspace tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized tag CRUD in `fakecloud-core::tags` and updated DynamoDB, EventBridge, KMS, and SSM to use it. Validation is stricter: explicit null or non-list tag fields return `ValidationException`; missing fields are a no-op, and total code drops by ~150 lines.

- **Refactors**
  - Added `apply_tags()`, `remove_tags()`, `tags_to_json()` with 7 unit tests.
  - Supports custom key/value fields (KMS `TagKey`/`TagValue`) and deterministic tag JSON.
  - SSM: added `resolve_tags_mut`/`resolve_tags` to dedupe resource-type dispatch.
  - Skipped: SNS (XML), Secrets Manager (Vec tags), Logs (map-style tags).

- **Bug Fixes**
  - Validate `Tags`/`TagKeys` are arrays; explicit `null` or wrong types now error with `ValidationException`, while absent fields do nothing.

<sup>Written for commit f2c491e94d6eedf89da9d362a6b9a4f1b3449c5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

