### PR TITLE
refactor: use Arn type for ARN construction in service crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,6 +1643,7 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
+ "fakecloud-aws",
  "fakecloud-core",
  "http 1.4.0",
  "parking_lot",

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
@@ -466,7 +467,7 @@ impl EventBridgeService {
         let statement = json!({
             "Sid": statement_id,
             "Effect": "Allow",
-            "Principal": { "AWS": format!("arn:aws:iam::{principal}:root") },
+            "Principal": { "AWS": Arn::global("iam", principal, "root").to_string() },
             "Action": action,
             "Resource": bus.arn,
         });
@@ -3883,7 +3884,13 @@ pub fn deliver_to_logs(
         .entry(group_name.to_string())
         .or_insert_with(|| fakecloud_logs::state::LogGroup {
             name: group_name.to_string(),
-            arn: format!("arn:aws:logs:{region}:{account_id}:log-group:{group_name}"),
+            arn: Arn::new(
+                "logs",
+                &region,
+                &account_id,
+                &format!("log-group:{group_name}"),
+            )
+            .to_string(),
             creation_time: ts_millis,
             retention_in_days: None,
             kms_key_id: None,

--- a/crates/fakecloud-eventbridge/src/state.rs
+++ b/crates/fakecloud-eventbridge/src/state.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use fakecloud_aws::arn::Arn;
 use parking_lot::RwLock;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -190,7 +191,8 @@ pub struct EventBridgeState {
 impl EventBridgeState {
     pub fn new(account_id: &str, region: &str) -> Self {
         let now = Utc::now();
-        let default_bus_arn = format!("arn:aws:events:{region}:{account_id}:event-bus/default");
+        let default_bus_arn =
+            Arn::new("events", region, account_id, "event-bus/default").to_string();
         let mut buses = HashMap::new();
         buses.insert(
             "default".to_string(),

--- a/crates/fakecloud-kms/Cargo.toml
+++ b/crates/fakecloud-kms/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 version.workspace = true
 
 [dependencies]
+fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -7,6 +7,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -190,7 +191,7 @@ fn default_key_policy(account_id: &str) -> String {
             {
                 "Sid": "Enable IAM User Permissions",
                 "Effect": "Allow",
-                "Principal": {"AWS": format!("arn:aws:iam::{account_id}:root")},
+                "Principal": {"AWS": Arn::global("iam", account_id, "root").to_string()},
                 "Action": "kms:*",
                 "Resource": "*",
             }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -5,6 +5,7 @@ use http::StatusCode;
 use serde_json::Value;
 use std::collections::HashMap;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
@@ -302,7 +303,7 @@ impl SnsService {
         let tags = parse_tags(req);
 
         let mut state = self.state.write();
-        let topic_arn = format!("arn:aws:sns:{}:{}:{}", req.region, state.account_id, name);
+        let topic_arn = Arn::new("sns", &req.region, &state.account_id, &name).to_string();
 
         if !state.topics.contains_key(&topic_arn) {
             let mut attributes = HashMap::new();
@@ -1904,12 +1905,12 @@ impl SnsService {
 
         // Build principal
         let principal = if account_ids.len() == 1 {
-            Value::String(format!("arn:aws:iam::{}:root", account_ids[0]))
+            Value::String(Arn::global("iam", &account_ids[0], "root").to_string())
         } else {
             Value::Array(
                 account_ids
                     .iter()
-                    .map(|id| Value::String(format!("arn:aws:iam::{}:root", id)))
+                    .map(|id| Value::String(Arn::global("iam", id, "root").to_string()))
                     .collect(),
             )
         };

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 use sha2::Sha256;
 use std::collections::{HashMap, VecDeque};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
 use crate::state::{MessageAttribute, RedrivePolicy, SharedSqsState, SqsMessage, SqsQueue};
@@ -2297,7 +2298,7 @@ impl SqsService {
                 "Sid": label,
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": format!("arn:aws:iam::{account_id}:root")
+                    "AWS": Arn::global("iam", account_id, "root").to_string()
                 },
                 "Action": action_value,
                 "Resource": queue.arn,

--- a/crates/fakecloud-ssm/src/service/automation.rs
+++ b/crates/fakecloud-ssm/src/service/automation.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -80,7 +81,7 @@ impl SsmService {
             targets,
             max_concurrency,
             max_errors,
-            executed_by: format!("arn:aws:iam::{account_id}:root"),
+            executed_by: Arn::global("iam", &account_id, "root").to_string(),
             step_executions: Vec::new(),
             automation_subtype: None,
             runbooks: Vec::new(),
@@ -280,7 +281,7 @@ impl SsmService {
             targets: Vec::new(),
             max_concurrency: None,
             max_errors: None,
-            executed_by: format!("arn:aws:iam::{account_id}:root"),
+            executed_by: Arn::global("iam", &account_id, "root").to_string(),
             step_executions: Vec::new(),
             automation_subtype: Some("ChangeRequest".to_string()),
             runbooks,

--- a/crates/fakecloud-ssm/src/service/misc.rs
+++ b/crates/fakecloud-ssm/src/service/misc.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use serde_json::json;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -54,7 +55,7 @@ impl SsmService {
                     "SettingValue": setting.setting_value,
                     "LastModifiedDate": setting.last_modified_date.timestamp_millis() as f64 / 1000.0,
                     "LastModifiedUser": setting.last_modified_user,
-                    "ARN": format!("arn:aws:ssm:{}:{}:servicesetting/{}", state.region, state.account_id, setting.setting_id),
+                    "ARN": Arn::new("ssm", &state.region, &state.account_id, &format!("servicesetting/{}", setting.setting_id)).to_string(),
                     "Status": setting.status,
                 }
             })))
@@ -66,7 +67,7 @@ impl SsmService {
                     "SettingValue": get_default_service_setting(setting_id),
                     "LastModifiedDate": Utc::now().timestamp_millis() as f64 / 1000.0,
                     "LastModifiedUser": "System",
-                    "ARN": format!("arn:aws:ssm:{}:{}:servicesetting/{}", state.region, state.account_id, setting_id),
+                    "ARN": Arn::new("ssm", &state.region, &state.account_id, &format!("servicesetting/{setting_id}")).to_string(),
                     "Status": "Default",
                 }
             })))
@@ -93,7 +94,7 @@ impl SsmService {
                 "SettingValue": default_value,
                 "LastModifiedDate": Utc::now().timestamp_millis() as f64 / 1000.0,
                 "LastModifiedUser": "System",
-                "ARN": format!("arn:aws:ssm:{}:{}:servicesetting/{}", state.region, state.account_id, setting_id),
+                "ARN": Arn::new("ssm", &state.region, &state.account_id, &format!("servicesetting/{setting_id}")).to_string(),
                 "Status": "Default",
             }
         })))
@@ -124,7 +125,7 @@ impl SsmService {
                 setting_id,
                 setting_value,
                 last_modified_date: now,
-                last_modified_user: format!("arn:aws:iam::{}:root", account_id),
+                last_modified_user: Arn::global("iam", &account_id, "root").to_string(),
                 status: "Customized".to_string(),
             },
         );

--- a/crates/fakecloud-ssm/src/service/ops.rs
+++ b/crates/fakecloud-ssm/src/service/ops.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -79,8 +80,8 @@ impl SsmService {
             tags,
             created_time: now,
             last_modified_time: now,
-            created_by: format!("arn:aws:iam::{}:root", state.account_id),
-            last_modified_by: format!("arn:aws:iam::{}:root", state.account_id),
+            created_by: Arn::global("iam", &state.account_id, "root").to_string(),
+            last_modified_by: Arn::global("iam", &state.account_id, "root").to_string(),
             ops_item_type,
             planned_start_time: None,
             planned_end_time: None,
@@ -158,7 +159,7 @@ impl SsmService {
         }
 
         item.last_modified_time = Utc::now();
-        item.last_modified_by = format!("arn:aws:iam::{}:root", account_id);
+        item.last_modified_by = Arn::global("iam", &account_id, "root").to_string();
 
         Ok(json_resp(json!({})))
     }
@@ -287,9 +288,9 @@ impl SsmService {
             resource_type,
             resource_uri,
             created_time: now,
-            created_by: format!("arn:aws:iam::{account_id}:root"),
+            created_by: Arn::global("iam", &account_id, "root").to_string(),
             last_modified_time: now,
-            last_modified_by: format!("arn:aws:iam::{account_id}:root"),
+            last_modified_by: Arn::global("iam", &account_id, "root").to_string(),
         });
 
         Ok(json_resp(json!({ "AssociationId": association_id })))

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -1166,11 +1167,12 @@ pub(super) fn remove_param(
 }
 
 pub(super) fn param_arn(region: &str, account_id: &str, name: &str) -> String {
-    if name.starts_with('/') {
-        format!("arn:aws:ssm:{region}:{account_id}:parameter{name}")
+    let resource = if name.starts_with('/') {
+        format!("parameter{name}")
     } else {
-        format!("arn:aws:ssm:{region}:{account_id}:parameter/{name}")
-    }
+        format!("parameter/{name}")
+    };
+    Arn::new("ssm", region, account_id, &resource).to_string()
 }
 
 /// Rewrite the region component of a parameter ARN.

--- a/crates/fakecloud-ssm/src/service/sessions.rs
+++ b/crates/fakecloud-ssm/src/service/sessions.rs
@@ -2,6 +2,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -32,7 +33,7 @@ impl SsmService {
             status: "Connected".to_string(),
             start_date: now,
             end_date: None,
-            owner: format!("arn:aws:iam::{account_id}:root"),
+            owner: Arn::global("iam", &account_id, "root").to_string(),
             reason,
         };
         state.sessions.insert(session_id.clone(), session);


### PR DESCRIPTION
## Summary

- Replace 21 inline `format!("arn:aws:...")` calls with `Arn::new()`/`Arn::global()` from fakecloud-aws across 5 service crates
- Converted: SSM (14), EventBridge (2), SNS (3), SQS (1), KMS (1)
- Remaining (for follow-up): IAM, S3, Logs (~7 instances)
- Skipped unusual patterns like empty-segment ARNs that don't map cleanly to the type

## Test plan

- [x] All workspace tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardize ARN construction by using the typed `Arn` API from `fakecloud-aws`, replacing ad-hoc string formats across service crates. This reduces duplication and prevents malformed ARNs.

- **Refactors**
  - Replaced 21 inline `format!("arn:aws:...")` calls with `Arn::new()`/`Arn::global()` in `fakecloud-ssm`, `fakecloud-eventbridge`, `fakecloud-sns`, `fakecloud-sqs`, and `fakecloud-kms`.
  - Updated SSM helpers and policy principals to use `Arn`; behavior unchanged. Follow-up: convert remaining spots in IAM, S3, and Logs.

- **Dependencies**
  - Added `fakecloud-aws` to `fakecloud-kms`.

<sup>Written for commit 5cff31897481d4515a46d6645c53b2013caba654. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

