### PR TITLE
refactor: extract shared body parsing and response helpers into fakecloud-core

### DIFF
--- a/crates/fakecloud-core/src/service.rs
+++ b/crates/fakecloud-core/src/service.rs
@@ -24,6 +24,13 @@ pub struct AwsRequest {
     pub access_key_id: Option<String>,
 }
 
+impl AwsRequest {
+    /// Parse the request body as JSON, returning `Value::Null` on failure.
+    pub fn json_body(&self) -> serde_json::Value {
+        serde_json::from_slice(&self.body).unwrap_or(serde_json::Value::Null)
+    }
+}
+
 /// A response from a service handler.
 pub struct AwsResponse {
     pub status: StatusCode,
@@ -49,6 +56,11 @@ impl AwsResponse {
             body: body.into(),
             headers: HeaderMap::new(),
         }
+    }
+
+    /// Convenience constructor for a 200 OK JSON response from a `serde_json::Value`.
+    pub fn ok_json(value: serde_json::Value) -> Self {
+        Self::json(StatusCode::OK, serde_json::to_vec(&value).unwrap())
     }
 }
 

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -46,10 +46,7 @@ impl DynamoDbService {
     }
 
     fn ok_json(body: Value) -> Result<AwsResponse, AwsServiceError> {
-        Ok(AwsResponse::json(
-            StatusCode::OK,
-            serde_json::to_vec(&body).unwrap(),
-        ))
+        Ok(AwsResponse::ok_json(body))
     }
 
     // ── Table Operations ────────────────────────────────────────────────

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -189,14 +189,6 @@ impl AwsService for EventBridgeService {
     }
 }
 
-fn parse_body(req: &AwsRequest) -> Value {
-    serde_json::from_slice(&req.body).unwrap_or(Value::Object(Default::default()))
-}
-
-fn json_resp(body: Value) -> AwsResponse {
-    AwsResponse::json(StatusCode::OK, serde_json::to_string(&body).unwrap())
-}
-
 fn parse_tags(body: &Value) -> HashMap<String, String> {
     let mut tags = HashMap::new();
     if let Some(arr) = body["Tags"].as_array() {
@@ -240,7 +232,7 @@ fn target_to_json(t: &EventTarget) -> Value {
 // ─── Event Bus Operations ───────────────────────────────────────────
 impl EventBridgeService {
     fn create_event_bus(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -319,11 +311,11 @@ impl EventBridgeService {
         };
         state.buses.insert(name, bus);
 
-        Ok(json_resp(json!({ "EventBusArn": arn })))
+        Ok(AwsResponse::ok_json(json!({ "EventBusArn": arn })))
     }
 
     fn delete_event_bus(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 256)?;
@@ -340,11 +332,11 @@ impl EventBridgeService {
         state.buses.remove(name);
         state.rules.retain(|k, _| k.0 != name);
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn list_event_buses(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 256)?;
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
         validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
@@ -381,11 +373,11 @@ impl EventBridgeService {
             resp["NextToken"] = json!((offset + limit).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn describe_event_bus(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("name", body["Name"].as_str(), 1, 1600)?;
         let name = body["Name"].as_str().unwrap_or("default");
 
@@ -418,13 +410,13 @@ impl EventBridgeService {
             resp["DeadLetterConfig"] = dlc.clone();
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     // ─── Permission Operations ──────────────────────────────────────────
 
     fn put_permission(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("eventBusName", body["EventBusName"].as_str(), 1, 256)?;
         validate_optional_string_length("action", body["Action"].as_str(), 1, 64)?;
         validate_optional_string_length("principal", body["Principal"].as_str(), 1, 12)?;
@@ -445,7 +437,7 @@ impl EventBridgeService {
         if let Some(policy_str) = body["Policy"].as_str() {
             if let Ok(policy) = serde_json::from_str::<Value>(policy_str) {
                 bus.policy = Some(policy);
-                return Ok(json_resp(json!({})));
+                return Ok(AwsResponse::ok_json(json!({})));
             }
         }
 
@@ -482,11 +474,11 @@ impl EventBridgeService {
             stmts.push(statement);
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn remove_permission(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("statementId", body["StatementId"].as_str(), 1, 64)?;
         validate_optional_string_length("eventBusName", body["EventBusName"].as_str(), 1, 256)?;
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
@@ -505,7 +497,7 @@ impl EventBridgeService {
 
         if remove_all {
             bus.policy = None;
-            return Ok(json_resp(json!({})));
+            return Ok(AwsResponse::ok_json(json!({})));
         }
 
         let policy = bus.policy.as_mut().ok_or_else(|| {
@@ -531,13 +523,13 @@ impl EventBridgeService {
             }
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     // ─── Rule Operations ────────────────────────────────────────────────
 
     fn put_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -645,11 +637,11 @@ impl EventBridgeService {
         };
 
         state.rules.insert(key, rule);
-        Ok(json_resp(json!({ "RuleArn": arn })))
+        Ok(AwsResponse::ok_json(json!({ "RuleArn": arn })))
     }
 
     fn delete_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -672,11 +664,11 @@ impl EventBridgeService {
         }
 
         state.rules.remove(&key);
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn list_rules(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 64)?;
         validate_optional_string_length("eventBusName", body["EventBusName"].as_str(), 1, 1600)?;
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
@@ -747,11 +739,11 @@ impl EventBridgeService {
             resp["NextToken"] = json!(token);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn describe_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -800,11 +792,11 @@ impl EventBridgeService {
             resp["CreatedBy"] = json!(state.account_id);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn enable_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -824,11 +816,11 @@ impl EventBridgeService {
         })?;
 
         rule.state = "ENABLED".to_string();
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn disable_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -848,13 +840,13 @@ impl EventBridgeService {
         })?;
 
         rule.state = "DISABLED".to_string();
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     // ─── Target Operations ──────────────────────────────────────────────
 
     fn put_targets(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Rule", &body["Rule"])?;
         let rule_name = body["Rule"].as_str().ok_or_else(|| missing("Rule"))?;
         validate_string_length("rule", rule_name, 1, 64)?;
@@ -911,14 +903,14 @@ impl EventBridgeService {
             rule.targets.push(et);
         }
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "FailedEntryCount": 0,
             "FailedEntries": [],
         })))
     }
 
     fn remove_targets(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Rule", &body["Rule"])?;
         let rule_name = body["Rule"].as_str().ok_or_else(|| missing("Rule"))?;
         validate_string_length("rule", rule_name, 1, 64)?;
@@ -946,14 +938,14 @@ impl EventBridgeService {
 
         rule.targets.retain(|t| !target_ids.contains(&t.id));
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "FailedEntryCount": 0,
             "FailedEntries": [],
         })))
     }
 
     fn list_targets_by_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Rule", &body["Rule"])?;
         let rule_name = body["Rule"].as_str().ok_or_else(|| missing("Rule"))?;
         validate_string_length("rule", rule_name, 1, 64)?;
@@ -1000,11 +992,11 @@ impl EventBridgeService {
             resp["NextToken"] = json!(token);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn list_rule_names_by_target(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("TargetArn", &body["TargetArn"])?;
         let target_arn = body["TargetArn"]
             .as_str()
@@ -1053,7 +1045,7 @@ impl EventBridgeService {
             resp["NextToken"] = json!(token);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     // ─── Partner Event Sources ────────────���───────────────────────────
@@ -1062,7 +1054,7 @@ impl EventBridgeService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -1099,14 +1091,14 @@ impl EventBridgeService {
         };
         state.partner_event_sources.insert(name.clone(), ps);
 
-        Ok(json_resp(json!({ "EventSourceArn": arn })))
+        Ok(AwsResponse::ok_json(json!({ "EventSourceArn": arn })))
     }
 
     fn delete_partner_event_source(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -1139,14 +1131,14 @@ impl EventBridgeService {
             }
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn describe_partner_event_source(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -1163,14 +1155,14 @@ impl EventBridgeService {
             )
         })?;
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "Arn": ps.arn,
             "Name": ps.name,
         })))
     }
 
     fn list_partner_event_sources(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("namePrefix", &body["NamePrefix"])?;
         let name_prefix = body["NamePrefix"]
             .as_str()
@@ -1206,14 +1198,14 @@ impl EventBridgeService {
             resp["NextToken"] = json!((offset + limit).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn list_partner_event_source_accounts(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("EventSourceName", &body["EventSourceName"])?;
         let event_source_name = body["EventSourceName"]
             .as_str()
@@ -1230,13 +1222,13 @@ impl EventBridgeService {
             .map(|ps| json!({ "Account": ps.account }))
             .collect();
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "PartnerEventSourceAccounts": accounts
         })))
     }
 
     fn activate_event_source(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -1253,11 +1245,11 @@ impl EventBridgeService {
         })?;
         ps.state = "ACTIVE".to_string();
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn deactivate_event_source(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -1274,11 +1266,11 @@ impl EventBridgeService {
         })?;
         ps.state = "INACTIVE".to_string();
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn describe_event_source(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -1294,7 +1286,7 @@ impl EventBridgeService {
             )
         })?;
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "Arn": ps.arn,
             "Name": ps.name,
             "CreatedBy": ps.account,
@@ -1304,7 +1296,7 @@ impl EventBridgeService {
     }
 
     fn list_event_sources(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 256)?;
         validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
@@ -1343,11 +1335,11 @@ impl EventBridgeService {
             resp["NextToken"] = json!((offset + limit).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn put_partner_events(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Entries", &body["Entries"])?;
         let entries = body["Entries"]
             .as_array()
@@ -1359,7 +1351,7 @@ impl EventBridgeService {
             result_entries.push(json!({ "EventId": event_id }));
         }
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "FailedEntryCount": 0,
             "Entries": result_entries,
         })))
@@ -1368,7 +1360,7 @@ impl EventBridgeService {
     // ─── TestEventPattern ────────────────────────────────────────────────
 
     fn test_event_pattern(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("EventPattern", &body["EventPattern"])?;
         validate_required("Event", &body["Event"])?;
         let event_pattern = body["EventPattern"]
@@ -1421,13 +1413,13 @@ impl EventBridgeService {
             &resources,
         );
 
-        Ok(json_resp(json!({ "Result": result })))
+        Ok(AwsResponse::ok_json(json!({ "Result": result })))
     }
 
     // ─── UpdateEventBus ─────────────────────────────────────────────────
 
     fn update_event_bus(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("description", body["Description"].as_str(), 0, 512)?;
         validate_optional_string_length(
             "kmsKeyIdentifier",
@@ -1460,7 +1452,7 @@ impl EventBridgeService {
         let arn = bus.arn.clone();
         let bus_name = bus.name.clone();
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "Arn": arn,
             "Name": bus_name,
         })))
@@ -1469,7 +1461,7 @@ impl EventBridgeService {
     // ─── Endpoint Operations ────────────────────────────────────────────
 
     fn create_endpoint(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -1535,11 +1527,11 @@ impl EventBridgeService {
             resp["RoleArn"] = json!(ra);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn delete_endpoint(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
@@ -1552,11 +1544,11 @@ impl EventBridgeService {
             )
         })?;
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn describe_endpoint(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
@@ -1592,11 +1584,11 @@ impl EventBridgeService {
             resp["RoleArn"] = json!(ra);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn list_endpoints(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 64)?;
         validate_optional_string_length("homeRegion", body["HomeRegion"].as_str(), 9, 20)?;
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
@@ -1643,11 +1635,11 @@ impl EventBridgeService {
             resp["NextToken"] = json!((offset + limit).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn update_endpoint(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
@@ -1686,13 +1678,13 @@ impl EventBridgeService {
             "EventBuses": ep.event_buses,
         });
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     // ─── DeauthorizeConnection ──────────────────────────────────────────
 
     fn deauthorize_connection(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -1717,13 +1709,13 @@ impl EventBridgeService {
             "LastAuthorizedTime": conn.last_authorized_time.timestamp() as f64,
         });
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     // ─── PutEvents ──────────────────────────────────────────────────────
 
     fn put_events(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Entries", &body["Entries"])?;
         validate_optional_string_length("endpointId", body["EndpointId"].as_str(), 1, 50)?;
         let entries = body["Entries"]
@@ -2091,13 +2083,13 @@ impl EventBridgeService {
             "Entries": result_entries,
         });
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     // ─── Tagging ────────────────────────────────────────────────────────
 
     fn tag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ResourceARN", &body["ResourceARN"])?;
         let arn = body["ResourceARN"]
             .as_str()
@@ -2116,11 +2108,11 @@ impl EventBridgeService {
             }
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn untag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ResourceARN", &body["ResourceARN"])?;
         let arn = body["ResourceARN"]
             .as_str()
@@ -2140,11 +2132,11 @@ impl EventBridgeService {
             }
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn list_tags_for_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ResourceARN", &body["ResourceARN"])?;
         let arn = body["ResourceARN"]
             .as_str()
@@ -2159,13 +2151,13 @@ impl EventBridgeService {
             .map(|(k, v)| json!({"Key": k, "Value": v}))
             .collect();
 
-        Ok(json_resp(json!({ "Tags": tags })))
+        Ok(AwsResponse::ok_json(json!({ "Tags": tags })))
     }
 
     // ─── Archive Operations ─────────────────────────────────────────────
 
     fn create_archive(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ArchiveName", &body["ArchiveName"])?;
         let name = body["ArchiveName"]
             .as_str()
@@ -2287,7 +2279,7 @@ impl EventBridgeService {
         let key = (bus_name, rule_name);
         state.rules.insert(key, archive_rule);
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ArchiveArn": arn,
             "CreationTime": now.timestamp() as f64,
             "State": "ENABLED",
@@ -2295,7 +2287,7 @@ impl EventBridgeService {
     }
 
     fn describe_archive(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ArchiveName", &body["ArchiveName"])?;
         let name = body["ArchiveName"]
             .as_str()
@@ -2328,11 +2320,11 @@ impl EventBridgeService {
             resp["EventPattern"] = json!(ep);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn list_archives(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 48)?;
         validate_optional_string_length(
             "eventSourceArn",
@@ -2428,11 +2420,11 @@ impl EventBridgeService {
             resp["NextToken"] = json!((offset + limit).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn update_archive(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ArchiveName", &body["ArchiveName"])?;
         let name = body["ArchiveName"]
             .as_str()
@@ -2468,7 +2460,7 @@ impl EventBridgeService {
             archive.retention_days = days;
         }
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ArchiveArn": archive.arn,
             "CreationTime": archive.creation_time.timestamp() as f64,
             "State": archive.state,
@@ -2476,7 +2468,7 @@ impl EventBridgeService {
     }
 
     fn delete_archive(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ArchiveName", &body["ArchiveName"])?;
         let name = body["ArchiveName"]
             .as_str()
@@ -2498,13 +2490,13 @@ impl EventBridgeService {
         let rule_name = format!("Events-Archive-{name}");
         state.rules.retain(|k, _| k.1 != rule_name);
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     // ─── Connection Operations ──────────────────────────────────────────
 
     fn create_connection(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -2558,7 +2550,7 @@ impl EventBridgeService {
         };
         state.connections.insert(name, conn);
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ConnectionArn": arn,
             "ConnectionState": "AUTHORIZED",
             "CreationTime": now.timestamp() as f64,
@@ -2567,7 +2559,7 @@ impl EventBridgeService {
     }
 
     fn describe_connection(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -2600,11 +2592,11 @@ impl EventBridgeService {
             resp["Description"] = json!(desc);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn list_connections(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 64)?;
         validate_optional_enum(
             "connectionState",
@@ -2671,11 +2663,11 @@ impl EventBridgeService {
             resp["NextToken"] = json!((offset + limit).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn update_connection(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -2706,7 +2698,7 @@ impl EventBridgeService {
         }
         conn.last_modified_time = Utc::now();
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ConnectionArn": conn.arn,
             "ConnectionState": conn.connection_state,
             "CreationTime": conn.creation_time.timestamp() as f64,
@@ -2716,7 +2708,7 @@ impl EventBridgeService {
     }
 
     fn delete_connection(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -2730,7 +2722,7 @@ impl EventBridgeService {
             )
         })?;
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ConnectionArn": conn.arn,
             "ConnectionState": conn.connection_state,
             "CreationTime": conn.creation_time.timestamp() as f64,
@@ -2742,7 +2734,7 @@ impl EventBridgeService {
     // ─── API Destination Operations ─────────────────────────────────────
 
     fn create_api_destination(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -2800,7 +2792,7 @@ impl EventBridgeService {
         };
         state.api_destinations.insert(name, dest);
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ApiDestinationArn": arn,
             "ApiDestinationState": "ACTIVE",
             "CreationTime": now.timestamp() as f64,
@@ -2809,7 +2801,7 @@ impl EventBridgeService {
     }
 
     fn describe_api_destination(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -2840,11 +2832,11 @@ impl EventBridgeService {
             resp["InvocationRateLimitPerSecond"] = json!(rate);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn list_api_destinations(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 64)?;
         validate_optional_string_length("connectionArn", body["ConnectionArn"].as_str(), 1, 1600)?;
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
@@ -2902,11 +2894,11 @@ impl EventBridgeService {
             resp["NextToken"] = json!((offset + limit).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn update_api_destination(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -2953,7 +2945,7 @@ impl EventBridgeService {
         }
         dest.last_modified_time = Utc::now();
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ApiDestinationArn": dest.arn,
             "ApiDestinationState": dest.state,
             "CreationTime": dest.creation_time.timestamp() as f64,
@@ -2962,7 +2954,7 @@ impl EventBridgeService {
     }
 
     fn delete_api_destination(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
@@ -2977,13 +2969,13 @@ impl EventBridgeService {
         }
         state.api_destinations.remove(name);
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     // ─── Replay Operations ──────────────────────────────────────────────
 
     fn start_replay(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ReplayName", &body["ReplayName"])?;
         let name = body["ReplayName"]
             .as_str()
@@ -3250,7 +3242,7 @@ impl EventBridgeService {
             }
         }
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ReplayArn": arn,
             "ReplayStartTime": now.timestamp() as f64,
             "State": "STARTING",
@@ -3258,7 +3250,7 @@ impl EventBridgeService {
     }
 
     fn describe_replay(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ReplayName", &body["ReplayName"])?;
         let name = body["ReplayName"]
             .as_str()
@@ -3291,11 +3283,11 @@ impl EventBridgeService {
             resp["ReplayEndTime"] = json!(end.timestamp() as f64);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn list_replays(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("namePrefix", body["NamePrefix"].as_str(), 1, 64)?;
         validate_optional_string_length(
             "eventSourceArn",
@@ -3394,11 +3386,11 @@ impl EventBridgeService {
             resp["NextToken"] = json!((offset + limit).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     fn cancel_replay(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ReplayName", &body["ReplayName"])?;
         let name = body["ReplayName"]
             .as_str()
@@ -3426,7 +3418,7 @@ impl EventBridgeService {
         let arn = replay.arn.clone();
         replay.state = "CANCELLED".to_string();
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ReplayArn": arn,
             "State": "CANCELLING",
         })))

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -178,10 +178,6 @@ impl AwsService for KmsService {
     }
 }
 
-fn body_json(req: &AwsRequest) -> Value {
-    serde_json::from_slice(&req.body).unwrap_or(Value::Null)
-}
-
 fn default_key_policy(account_id: &str) -> String {
     serde_json::to_string(&json!({
         "Version": "2012-10-17",
@@ -319,7 +315,7 @@ impl KmsService {
     }
 
     fn create_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         validate_optional_string_length(
             "customKeyStoreId",
@@ -455,7 +451,7 @@ impl KmsService {
     }
 
     fn describe_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id_input = body["KeyId"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -494,7 +490,7 @@ impl KmsService {
     }
 
     fn list_keys(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         validate_optional_json_range("limit", &body["Limit"], 1, 1000)?;
         validate_optional_string_length("marker", body["Marker"].as_str(), 1, 320)?;
@@ -545,7 +541,7 @@ impl KmsService {
     }
 
     fn enable_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let resolved = self.resolve_required_key(&body)?;
 
         let mut state = self.state.write();
@@ -563,7 +559,7 @@ impl KmsService {
     }
 
     fn disable_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let resolved = self.resolve_required_key(&body)?;
 
         let mut state = self.state.write();
@@ -581,7 +577,7 @@ impl KmsService {
     }
 
     fn schedule_key_deletion(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let resolved = self.resolve_required_key(&body)?;
         let pending_days = body["PendingWindowInDays"].as_i64().unwrap_or(30);
 
@@ -612,7 +608,7 @@ impl KmsService {
     }
 
     fn cancel_key_deletion(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let resolved = self.resolve_required_key(&body)?;
 
         let mut state = self.state.write();
@@ -636,7 +632,7 @@ impl KmsService {
     }
 
     fn encrypt(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let plaintext_b64 = body["Plaintext"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -719,7 +715,7 @@ impl KmsService {
     }
 
     fn decrypt(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let ciphertext_b64 = body["CiphertextBlob"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -838,7 +834,7 @@ impl KmsService {
     }
 
     fn re_encrypt(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let ciphertext_b64 = body["CiphertextBlob"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -996,7 +992,7 @@ impl KmsService {
     }
 
     fn generate_data_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
@@ -1047,7 +1043,7 @@ impl KmsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
@@ -1091,7 +1087,7 @@ impl KmsService {
     }
 
     fn generate_random(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         // CustomKeyStoreId is accepted for API compatibility but has no effect on
         // random number generation in this emulator.
@@ -1119,7 +1115,7 @@ impl KmsService {
     }
 
     fn create_alias(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let alias_name = body["AliasName"]
             .as_str()
             .ok_or_else(|| {
@@ -1234,7 +1230,7 @@ impl KmsService {
     }
 
     fn delete_alias(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let alias_name = body["AliasName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1268,7 +1264,7 @@ impl KmsService {
     }
 
     fn update_alias(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let alias_name = body["AliasName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1307,7 +1303,7 @@ impl KmsService {
     }
 
     fn list_aliases(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         validate_optional_json_range("limit", &body["Limit"], 1, 100)?;
         validate_optional_string_length("marker", body["Marker"].as_str(), 1, 320)?;
@@ -1357,7 +1353,7 @@ impl KmsService {
     }
 
     fn tag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
@@ -1390,7 +1386,7 @@ impl KmsService {
     }
 
     fn untag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
@@ -1423,7 +1419,7 @@ impl KmsService {
     }
 
     fn list_resource_tags(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
@@ -1465,7 +1461,7 @@ impl KmsService {
     }
 
     fn update_key_description(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let resolved = self.resolve_required_key(&body)?;
         let description = body["Description"].as_str().unwrap_or("").to_string();
 
@@ -1483,7 +1479,7 @@ impl KmsService {
     }
 
     fn get_key_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         // For key policy operations, aliases should not work
@@ -1522,7 +1518,7 @@ impl KmsService {
     }
 
     fn put_key_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         // For key policy operations, aliases should not work
@@ -1558,7 +1554,7 @@ impl KmsService {
     }
 
     fn list_key_policies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let _resolved = self.resolve_required_key(&body)?;
 
         Ok(AwsResponse::json(
@@ -1572,7 +1568,7 @@ impl KmsService {
     }
 
     fn get_key_rotation_status(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         // Aliases should fail for rotation operations
@@ -1611,7 +1607,7 @@ impl KmsService {
     }
 
     fn enable_key_rotation(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         if key_id.starts_with("alias/") {
@@ -1644,7 +1640,7 @@ impl KmsService {
     }
 
     fn disable_key_rotation(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         if key_id.starts_with("alias/") {
@@ -1677,7 +1673,7 @@ impl KmsService {
     }
 
     fn rotate_key_on_demand(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let resolved = self.resolve_required_key(&body)?;
 
         let mut state = self.state.write();
@@ -1706,7 +1702,7 @@ impl KmsService {
     }
 
     fn list_key_rotations(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let resolved = self.resolve_required_key(&body)?;
         validate_optional_json_range("limit", &body["Limit"], 1, 1000)?;
         let limit = body["Limit"].as_i64().unwrap_or(1000) as usize;
@@ -1760,7 +1756,7 @@ impl KmsService {
     }
 
     fn sign(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let message_b64 = body["Message"].as_str().unwrap_or("");
         let signing_algorithm = body["SigningAlgorithm"].as_str().unwrap_or("");
@@ -1847,7 +1843,7 @@ impl KmsService {
     }
 
     fn verify(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let message_b64 = body["Message"].as_str().unwrap_or("");
         let signature_b64 = body["Signature"].as_str().unwrap_or("");
@@ -1950,7 +1946,7 @@ impl KmsService {
     }
 
     fn get_public_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
@@ -1996,7 +1992,7 @@ impl KmsService {
     }
 
     fn create_grant(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
@@ -2051,7 +2047,7 @@ impl KmsService {
     }
 
     fn list_grants(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
@@ -2090,7 +2086,7 @@ impl KmsService {
     }
 
     fn list_retirable_grants(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         validate_required("RetiringPrincipal", &body["RetiringPrincipal"])?;
         let retiring_principal = body["RetiringPrincipal"].as_str().ok_or_else(|| {
@@ -2150,7 +2146,7 @@ impl KmsService {
     }
 
     fn revoke_grant(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let grant_id = body["GrantId"].as_str().unwrap_or("");
 
@@ -2182,7 +2178,7 @@ impl KmsService {
     }
 
     fn retire_grant(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let grant_token = body["GrantToken"].as_str();
         let grant_id = body["GrantId"].as_str();
         let key_id = body["KeyId"].as_str();
@@ -2217,7 +2213,7 @@ impl KmsService {
     }
 
     fn generate_mac(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let mac_algorithm = body["MacAlgorithm"].as_str().unwrap_or("").to_string();
         let message_b64 = body["Message"].as_str().unwrap_or("");
@@ -2276,7 +2272,7 @@ impl KmsService {
     }
 
     fn verify_mac(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let mac_algorithm = body["MacAlgorithm"].as_str().unwrap_or("").to_string();
         let message_b64 = body["Message"].as_str().unwrap_or("");
@@ -2338,7 +2334,7 @@ impl KmsService {
     }
 
     fn replicate_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let replica_region = body["ReplicaRegion"].as_str().unwrap_or("").to_string();
 
@@ -2448,7 +2444,7 @@ impl KmsService {
     }
 
     fn generate_data_key_pair(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let key_pair_spec = body["KeyPairSpec"]
             .as_str()
@@ -2510,7 +2506,7 @@ impl KmsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let key_pair_spec = body["KeyPairSpec"]
             .as_str()
@@ -2567,7 +2563,7 @@ impl KmsService {
     }
 
     fn derive_shared_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let _key_agreement_algorithm = body["KeyAgreementAlgorithm"]
             .as_str()
@@ -2645,7 +2641,7 @@ impl KmsService {
     }
 
     fn get_parameters_for_import(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
@@ -2695,7 +2691,7 @@ impl KmsService {
     }
 
     fn import_key_material(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let _import_token = body["ImportToken"].as_str().ok_or_else(|| {
@@ -2770,7 +2766,7 @@ impl KmsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
         let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
@@ -2807,7 +2803,7 @@ impl KmsService {
     }
 
     fn update_primary_region(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
         let primary_region = body["PrimaryRegion"]
             .as_str()
@@ -2856,7 +2852,7 @@ impl KmsService {
     }
 
     fn create_custom_key_store(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         let name = body["CustomKeyStoreName"]
             .as_str()
@@ -2927,7 +2923,7 @@ impl KmsService {
     }
 
     fn delete_custom_key_store(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         let store_id = body["CustomKeyStoreId"]
             .as_str()
@@ -2964,7 +2960,7 @@ impl KmsService {
     }
 
     fn describe_custom_key_stores(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_string_length(
             "customKeyStoreName",
             body["CustomKeyStoreName"].as_str(),
@@ -3036,7 +3032,7 @@ impl KmsService {
     }
 
     fn connect_custom_key_store(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         let store_id = body["CustomKeyStoreId"]
             .as_str()
@@ -3068,7 +3064,7 @@ impl KmsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         let store_id = body["CustomKeyStoreId"]
             .as_str()
@@ -3097,7 +3093,7 @@ impl KmsService {
     }
 
     fn update_custom_key_store(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         let store_id = body["CustomKeyStoreId"]
             .as_str()

--- a/crates/fakecloud-logs/src/service/anomaly.rs
+++ b/crates/fakecloud-logs/src/service/anomaly.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use super::{body_json, LogsService};
+use super::LogsService;
 use chrono::Utc;
 
 use crate::state::AnomalyDetector;
@@ -16,7 +16,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_string_length("detectorName", body["detectorName"].as_str(), 1, 2048)?;
         validate_optional_enum_value(
             "evaluationFrequency",
@@ -97,7 +97,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let arn = body["anomalyDetectorArn"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -143,7 +143,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let arn = body["anomalyDetectorArn"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -168,7 +168,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_string_length(
             "filterLogGroupArn",
             body["filterLogGroupArn"].as_str(),
@@ -219,7 +219,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let arn = body["anomalyDetectorArn"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -266,7 +266,7 @@ impl LogsService {
     }
 
     pub(crate) fn list_anomalies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_string_length(
             "anomalyDetectorArn",
             body["anomalyDetectorArn"].as_str(),
@@ -288,7 +288,7 @@ impl LogsService {
     }
 
     pub(crate) fn update_anomaly(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_required("anomalyDetectorArn", &body["anomalyDetectorArn"])?;
         validate_optional_string_length(
             "anomalyDetectorArn",

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -5,7 +5,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
 use super::dd_config_json;
-use super::{body_json, require_str, LogsService};
+use super::{require_str, LogsService};
 use crate::state::{Delivery, DeliveryDestination, DeliverySource};
 
 impl LogsService {
@@ -15,7 +15,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["name"]
             .as_str()
             .ok_or_else(|| {
@@ -140,7 +140,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["name"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -179,7 +179,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
 
@@ -210,7 +210,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["name"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -237,7 +237,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["deliveryDestinationName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -285,7 +285,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["deliveryDestinationName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -326,7 +326,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["deliveryDestinationName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -357,7 +357,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["name"]
             .as_str()
             .ok_or_else(|| {
@@ -490,7 +490,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["name"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -530,7 +530,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
 
@@ -560,7 +560,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["name"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -586,7 +586,7 @@ impl LogsService {
     // ---- Deliveries ----
 
     pub(crate) fn create_delivery(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let delivery_source_name = body["deliverySourceName"]
             .as_str()
             .ok_or_else(|| {
@@ -736,7 +736,7 @@ impl LogsService {
     }
 
     pub(crate) fn get_delivery(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let delivery_id = body["id"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -776,7 +776,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
 
@@ -803,7 +803,7 @@ impl LogsService {
     }
 
     pub(crate) fn delete_delivery(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let delivery_id = body["id"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -830,7 +830,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let id = require_str(&body, "id")?;
 
         let state = self.state.read();
@@ -851,7 +851,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_string_length("service", body["service"].as_str(), 1, 255)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;

--- a/crates/fakecloud-logs/src/service/destinations.rs
+++ b/crates/fakecloud-logs/src/service/destinations.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use super::{body_json, LogsService};
+use super::LogsService;
 use chrono::Utc;
 
 use crate::state::Destination;
@@ -13,7 +13,7 @@ impl LogsService {
     // ---- Destinations ----
 
     pub(crate) fn put_destination(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let destination_name = body["destinationName"]
             .as_str()
             .ok_or_else(|| {
@@ -101,7 +101,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let prefix = body["DestinationNamePrefix"].as_str().unwrap_or("");
 
         validate_optional_string_length(
@@ -143,7 +143,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["destinationName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -170,7 +170,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["destinationName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-logs/src/service/exports.rs
+++ b/crates/fakecloud-logs/src/service/exports.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use super::{body_json, LogsService};
+use super::LogsService;
 use crate::state::ExportTask;
 
 impl LogsService {
@@ -14,7 +14,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_name = body["logGroupName"]
             .as_str()
             .ok_or_else(|| {
@@ -127,7 +127,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let task_id_filter = body["taskId"].as_str();
 
         validate_optional_string_length("taskId", task_id_filter, 1, 512)?;
@@ -202,7 +202,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let task_id = body["taskId"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -238,7 +238,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let key_prefix = body["keyPrefix"].as_str().unwrap_or("");
 
         let state = self.state.read();

--- a/crates/fakecloud-logs/src/service/filters.rs
+++ b/crates/fakecloud-logs/src/service/filters.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use super::{body_json, matches_filter_pattern, validation_error, LogsService};
+use super::{matches_filter_pattern, validation_error, LogsService};
 use chrono::Utc;
 
 use crate::state::{MetricFilter, MetricTransformation, SubscriptionFilter};
@@ -16,7 +16,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -104,7 +104,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -161,7 +161,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -212,7 +212,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let filter_name = body["filterName"]
             .as_str()
             .ok_or_else(|| {
@@ -309,7 +309,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let filter_name_prefix = body["filterNamePrefix"].as_str();
         let log_group_name = body["logGroupName"].as_str();
         let metric_name = body["metricName"].as_str();
@@ -390,7 +390,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let filter_name = body["filterName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -426,7 +426,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let filter_pattern = body["filterPattern"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-logs/src/service/groups.rs
+++ b/crates/fakecloud-logs/src/service/groups.rs
@@ -6,7 +6,7 @@ use fakecloud_core::validation::*;
 
 use chrono::Utc;
 
-use super::{body_json, LogsService};
+use super::LogsService;
 use super::{extract_log_group_from_arn, resolve_log_group_name};
 
 use crate::state::LogGroup;
@@ -18,7 +18,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["logGroupName"]
             .as_str()
             .ok_or_else(|| {
@@ -85,7 +85,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -122,7 +122,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let prefix = body["logGroupNamePrefix"].as_str().unwrap_or("");
         let pattern = body["logGroupNamePattern"].as_str().unwrap_or("");
         let limit = body["limit"].as_i64().unwrap_or(50) as usize;
@@ -214,7 +214,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -251,7 +251,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -282,7 +282,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_name = body["logGroupName"].as_str();
         let resource_identifier = body["resourceIdentifier"].as_str();
         let kms_key_id = body["kmsKeyId"]
@@ -325,7 +325,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_name = body["logGroupName"].as_str();
         let resource_identifier = body["resourceIdentifier"].as_str();
 
@@ -357,7 +357,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_id = body["logGroupName"]
             .as_str()
             .or_else(|| body["logGroupIdentifier"].as_str())
@@ -406,7 +406,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_id = body["logGroupIdentifier"]
             .as_str()
             .ok_or_else(|| {
@@ -448,7 +448,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_required("groupBy", &body["groupBy"])?;
         validate_optional_enum_value(
             "groupBy",
@@ -479,7 +479,7 @@ impl LogsService {
     }
 
     pub(crate) fn list_log_groups(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let prefix = body["logGroupNamePrefix"].as_str().unwrap_or("");
         let pattern = body["logGroupNamePattern"].as_str().unwrap_or("");
         let limit = body["limit"].as_i64().unwrap_or(50) as usize;

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use super::{body_json, require_str, LogsService};
+use super::{require_str, LogsService};
 use chrono::Utc;
 
 use crate::state::{ImportTask, Integration, LookupTable, ScheduledQuery};
@@ -14,7 +14,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let import_source_arn = require_str(&body, "importSourceArn")?;
         let import_role_arn = require_str(&body, "importRoleArn")?;
         validate_string_length("importRoleArn", import_role_arn, 1, 2048)?;
@@ -45,7 +45,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_string_length("importId", body["importId"].as_str(), 1, 256)?;
         validate_optional_enum_value(
             "importStatus",
@@ -78,7 +78,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let import_id = require_str(&body, "importId")?;
         validate_string_length("importId", import_id, 1, 256)?;
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
@@ -94,7 +94,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let import_id = require_str(&body, "importId")?;
 
         let mut state = self.state.write();
@@ -114,7 +114,7 @@ impl LogsService {
     // -- Integrations --
 
     pub(crate) fn put_integration(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_required("resourceConfig", &body["resourceConfig"])?;
         let integration_name = require_str(&body, "integrationName")?;
         validate_string_length("integrationName", integration_name, 1, 50)?;
@@ -147,7 +147,7 @@ impl LogsService {
     }
 
     pub(crate) fn get_integration(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let integration_name = require_str(&body, "integrationName")?;
 
         let state = self.state.read();
@@ -173,7 +173,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let integration_name = require_str(&body, "integrationName")?;
         validate_string_length("integrationName", integration_name, 1, 50)?;
 
@@ -186,7 +186,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_string_length(
             "integrationNamePrefix",
             body["integrationNamePrefix"].as_str(),
@@ -224,7 +224,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let lookup_table_name = require_str(&body, "lookupTableName")?;
         validate_string_length("lookupTableName", lookup_table_name, 1, 256)?;
         let table_body = require_str(&body, "tableBody")?;
@@ -261,7 +261,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let lookup_table_arn = require_str(&body, "lookupTableArn")?;
 
         let state = self.state.read();
@@ -289,7 +289,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_string_length(
             "lookupTableNamePrefix",
             body["lookupTableNamePrefix"].as_str(),
@@ -320,7 +320,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let lookup_table_arn = require_str(&body, "lookupTableArn")?;
 
         let mut state = self.state.write();
@@ -332,7 +332,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let lookup_table_arn = require_str(&body, "lookupTableArn")?;
         let table_body = require_str(&body, "tableBody")?;
 
@@ -357,7 +357,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = require_str(&body, "name")?;
         validate_string_length("name", name, 1, 255)?;
         validate_optional_string_length("description", body["description"].as_str(), 0, 1024)?;
@@ -417,7 +417,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let identifier = require_str(&body, "identifier")?;
 
         let state = self.state.read();
@@ -446,7 +446,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let _identifier = require_str(&body, "identifier")?;
         validate_required("startTime", &body["startTime"])?;
         validate_required("endTime", &body["endTime"])?;
@@ -465,7 +465,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_range_i64("maxResults", body["maxResults"].as_i64(), 1, 1000)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
         validate_optional_enum_value("state", &body["state"], &["ENABLED", "DISABLED"])?;
@@ -491,7 +491,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let identifier = require_str(&body, "identifier")?;
 
         let mut state = self.state.write();
@@ -503,7 +503,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let identifier = require_str(&body, "identifier")?;
         let query_string = require_str(&body, "queryString")?;
         let query_language = require_str(&body, "queryLanguage")?;
@@ -531,7 +531,7 @@ impl LogsService {
     // -- Misc stubs --
 
     pub(crate) fn start_live_tail(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_required("logGroupIdentifiers", &body["logGroupIdentifiers"])?;
         validate_optional_string_length(
             "logEventFilterPattern",
@@ -558,7 +558,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_required(
             "bearerTokenAuthenticationEnabled",
             &body["bearerTokenAuthenticationEnabled"],
@@ -577,7 +577,7 @@ impl LogsService {
     }
 
     pub(crate) fn get_log_object(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_required("logObjectPointer", &body["logObjectPointer"])?;
         validate_optional_string_length(
             "logObjectPointer",
@@ -590,7 +590,7 @@ impl LogsService {
     }
 
     pub(crate) fn get_log_fields(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_required("dataSourceName", &body["dataSourceName"])?;
         validate_required("dataSourceType", &body["dataSourceType"])?;
         // Stub: return empty log fields
@@ -604,7 +604,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_required("dataSource", &body["dataSource"])?;
         let integration_arn = require_str(&body, "integrationArn")?;
         let data_source = body["dataSource"].clone();
@@ -628,7 +628,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let integration_arn = require_str(&body, "integrationArn")?;
         validate_optional_range_i64("maxResults", body["maxResults"].as_i64(), 1, 100)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
@@ -659,7 +659,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let identifier = require_str(&body, "identifier")?;
         validate_string_length("identifier", identifier, 1, 2048)?;
         // No-op stub (we don't track detailed enough to remove specific sources)

--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -285,10 +285,6 @@ impl AwsService for LogsService {
     }
 }
 
-fn body_json(req: &AwsRequest) -> Value {
-    serde_json::from_slice(&req.body).unwrap_or(Value::Null)
-}
-
 fn require_str<'a>(body: &'a Value, field: &str) -> Result<&'a str, AwsServiceError> {
     body[field].as_str().ok_or_else(|| {
         AwsServiceError::aws_error(

--- a/crates/fakecloud-logs/src/service/policies.rs
+++ b/crates/fakecloud-logs/src/service/policies.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use super::{body_json, LogsService};
+use super::LogsService;
 use chrono::Utc;
 
 use super::extract_log_group_from_arn;
@@ -18,7 +18,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let policy_name = body["policyName"]
             .as_str()
             .ok_or_else(|| {
@@ -80,7 +80,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
         validate_optional_enum_value(
@@ -118,7 +118,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let policy_name = body["policyName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -145,7 +145,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_enum_value(
             "policyType",
             &body["policyType"],
@@ -225,7 +225,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_enum_value(
             "policyType",
             &body["policyType"],
@@ -282,7 +282,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let policy_name = body["policyName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -317,7 +317,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_id = body["logGroupIdentifier"]
             .as_str()
             .ok_or_else(|| {
@@ -382,7 +382,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_id = body["logGroupIdentifier"]
             .as_str()
             .ok_or_else(|| {
@@ -433,7 +433,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_id = body["logGroupIdentifier"]
             .as_str()
             .ok_or_else(|| {
@@ -484,7 +484,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_id = body["logGroupIdentifier"]
             .as_str()
             .ok_or_else(|| {
@@ -565,7 +565,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
         let log_group_ids = body["logGroupIdentifiers"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -607,7 +607,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_id = body["logGroupIdentifier"]
             .as_str()
             .ok_or_else(|| {
@@ -656,7 +656,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
         // Validate that logGroupIdentifiers is provided
         let _log_group_ids = body["logGroupIdentifiers"].as_array().ok_or_else(|| {
@@ -677,7 +677,7 @@ impl LogsService {
     // ---- Transformers ----
 
     pub(crate) fn put_transformer(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_id = body["logGroupIdentifier"]
             .as_str()
             .ok_or_else(|| {
@@ -728,7 +728,7 @@ impl LogsService {
     }
 
     pub(crate) fn get_transformer(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_id = body["logGroupIdentifier"]
             .as_str()
             .ok_or_else(|| {
@@ -780,7 +780,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_id = body["logGroupIdentifier"]
             .as_str()
             .ok_or_else(|| {
@@ -821,7 +821,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let transformer_config = body.get("transformerConfig").ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use super::{body_json, require_str, LogsService};
+use super::{require_str, LogsService};
 use chrono::Utc;
 
 use crate::query;
@@ -14,7 +14,7 @@ impl LogsService {
     // ---- Queries ----
 
     pub(crate) fn start_query(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -66,7 +66,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let query_id = body["queryId"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -126,7 +126,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_name = body["logGroupName"].as_str();
         let status_filter = body["status"].as_str();
 
@@ -192,7 +192,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["name"]
             .as_str()
             .ok_or_else(|| {
@@ -269,7 +269,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name_prefix = body["queryDefinitionNamePrefix"].as_str().unwrap_or("");
         validate_optional_string_length(
             "queryDefinitionNamePrefix",
@@ -311,7 +311,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let qd_id = body["queryDefinitionId"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -332,7 +332,7 @@ impl LogsService {
     }
 
     pub(crate) fn stop_query(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let query_id = body["queryId"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -365,7 +365,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let query_id = require_str(&body, "queryId")?;
         validate_string_length("queryId", query_id, 1, 256)?;
         validate_optional_range_i64("maxResults", body["maxResults"].as_i64(), 50, 500)?;

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use super::{body_json, validation_error, LogsService};
+use super::{validation_error, LogsService};
 use base64::Engine;
 use chrono::Utc;
 use flate2::write::GzEncoder;
@@ -23,7 +23,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let group_name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -91,7 +91,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let group_name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -134,7 +134,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         // Support both logGroupName and logGroupIdentifier
         let group_name = if let Some(name) = body["logGroupName"].as_str() {
@@ -283,7 +283,7 @@ impl LogsService {
     // ---- Log Events ----
 
     pub(crate) fn put_log_events(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let group_name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -549,7 +549,7 @@ impl LogsService {
     }
 
     pub(crate) fn get_log_events(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
 
         // Support both logGroupName and logGroupIdentifier
         let group_name = if let Some(name) = body["logGroupName"].as_str() {
@@ -752,7 +752,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let log_group_identifier = body["logGroupIdentifier"].as_str();
         let log_group_name = body["logGroupName"].as_str();
         let filter_pattern = body["filterPattern"].as_str().unwrap_or("");
@@ -925,7 +925,7 @@ impl LogsService {
     }
 
     pub(crate) fn get_log_record(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let _log_record_pointer = body["logRecordPointer"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-logs/src/service/tags.rs
+++ b/crates/fakecloud-logs/src/service/tags.rs
@@ -4,13 +4,13 @@ use serde_json::json;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use super::{body_json, LogsService};
+use super::LogsService;
 
 impl LogsService {
     // ---- Tags (legacy) ----
 
     pub(crate) fn tag_log_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -48,7 +48,7 @@ impl LogsService {
     }
 
     pub(crate) fn untag_log_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -89,7 +89,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let name = body["logGroupName"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -118,7 +118,7 @@ impl LogsService {
     // ---- Tags (new API: TagResource/UntagResource/ListTagsForResource) ----
 
     pub(crate) fn tag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let arn = body["resourceArn"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -172,7 +172,7 @@ impl LogsService {
     }
 
     pub(crate) fn untag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let arn = body["resourceArn"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -229,7 +229,7 @@ impl LogsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = body_json(req);
+        let body = req.json_body();
         let arn = body["resourceArn"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -37,7 +37,7 @@ impl SecretsManagerService {
     }
 
     fn create_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         validate_required("Name", &body["Name"])?;
         let name = body["Name"]
             .as_str()
@@ -87,7 +87,7 @@ impl SecretsManagerService {
                         if !has_value {
                             response.as_object_mut().unwrap().remove("VersionId");
                         }
-                        return Ok(AwsResponse::json(StatusCode::OK, response.to_string()));
+                        return Ok(AwsResponse::ok_json(response));
                     } else {
                         return Err(AwsServiceError::aws_error(
                             StatusCode::BAD_REQUEST,
@@ -172,11 +172,11 @@ impl SecretsManagerService {
             response["VersionId"] = json!(vid);
         }
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn get_secret_value(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
         validate_optional_string_length("versionId", body["VersionId"].as_str(), 32, 64)?;
         validate_optional_string_length("versionStage", body["VersionStage"].as_str(), 1, 256)?;
@@ -261,11 +261,11 @@ impl SecretsManagerService {
             response["SecretBinary"] = json!(base64_encode(b));
         }
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn put_secret_value(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
         validate_optional_string_length(
             "clientRequestToken",
@@ -325,7 +325,7 @@ impl SecretsManagerService {
                     "VersionId": version_id,
                     "VersionStages": existing_version.stages,
                 });
-                return Ok(AwsResponse::json(StatusCode::OK, response.to_string()));
+                return Ok(AwsResponse::ok_json(response));
             } else {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -406,11 +406,11 @@ impl SecretsManagerService {
             "VersionStages": version_stages,
         });
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn update_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
         validate_optional_string_length(
             "clientRequestToken",
@@ -470,7 +470,7 @@ impl SecretsManagerService {
                         "Name": secret.name,
                         "VersionId": vid,
                     });
-                    return Ok(AwsResponse::json(StatusCode::OK, response.to_string()));
+                    return Ok(AwsResponse::ok_json(response));
                 } else {
                     return Err(AwsServiceError::aws_error(
                         StatusCode::BAD_REQUEST,
@@ -519,11 +519,11 @@ impl SecretsManagerService {
             response["VersionId"] = json!(vid);
         }
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn delete_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let force_delete = body["ForceDeleteWithoutRecovery"]
@@ -566,7 +566,7 @@ impl SecretsManagerService {
                         "Name": name,
                         "DeletionDate": deletion_date.timestamp_millis() as f64 / 1000.0,
                     });
-                    return Ok(AwsResponse::json(StatusCode::OK, response.to_string()));
+                    return Ok(AwsResponse::ok_json(response));
                 }
                 Err(_) => {
                     // For force delete of non-existent secret, AWS returns success
@@ -583,7 +583,7 @@ impl SecretsManagerService {
                         "Name": secret_id,
                         "DeletionDate": deletion_date.timestamp_millis() as f64 / 1000.0,
                     });
-                    return Ok(AwsResponse::json(StatusCode::OK, response.to_string()));
+                    return Ok(AwsResponse::ok_json(response));
                 }
             }
         }
@@ -610,11 +610,11 @@ impl SecretsManagerService {
             "DeletionDate": deletion_date.timestamp_millis() as f64 / 1000.0,
         });
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn restore_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let mut state = self.state.write();
@@ -629,11 +629,11 @@ impl SecretsManagerService {
             "Name": secret.name,
         });
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn describe_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let state = self.state.read();
@@ -699,11 +699,11 @@ impl SecretsManagerService {
             }
         }
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn list_secrets(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 4096)?;
         validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 1, 100)?;
         validate_optional_enum("sortBy", body["SortBy"].as_str(), &["name", "created-date"])?;
@@ -857,11 +857,11 @@ impl SecretsManagerService {
             }
         }
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn tag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let new_tags = parse_tags(&body["Tags"]);
@@ -885,7 +885,7 @@ impl SecretsManagerService {
     }
 
     fn untag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let tag_keys: Vec<String> = body["TagKeys"]
@@ -906,7 +906,7 @@ impl SecretsManagerService {
     }
 
     fn list_secret_version_ids(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 4096)?;
 
@@ -931,11 +931,11 @@ impl SecretsManagerService {
             "Versions": versions,
         });
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn get_random_password(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let length = body["PasswordLength"].as_i64().unwrap_or(32) as usize;
 
         if length < 4 {
@@ -1061,14 +1061,14 @@ impl SecretsManagerService {
             "RandomPassword": password,
         });
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn rotate_secret(
         &self,
         req: &AwsRequest,
     ) -> Result<(AwsResponse, Option<RotationInvocation>), AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         // Validate ClientRequestToken
@@ -1196,14 +1196,11 @@ impl SecretsManagerService {
             "VersionId": version_id,
         });
 
-        Ok((
-            AwsResponse::json(StatusCode::OK, response.to_string()),
-            invocation,
-        ))
+        Ok((AwsResponse::ok_json(response), invocation))
     }
 
     fn cancel_rotate_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let mut state = self.state.write();
@@ -1232,14 +1229,14 @@ impl SecretsManagerService {
             "Name": secret.name,
         });
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn update_secret_version_stage(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
         let version_stage = body["VersionStage"]
             .as_str()
@@ -1331,11 +1328,11 @@ impl SecretsManagerService {
             "Name": secret.name,
         });
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn batch_get_secret_value(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 4096)?;
         let secret_id_list = body["SecretIdList"].as_array();
         let filters = body["Filters"].as_array();
@@ -1494,11 +1491,11 @@ impl SecretsManagerService {
             response.as_object_mut().unwrap().remove("Errors");
         }
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn get_resource_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let state = self.state.read();
@@ -1513,11 +1510,11 @@ impl SecretsManagerService {
             response["ResourcePolicy"] = json!(policy);
         }
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn validate_resource_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         validate_optional_string_length("secretId", body["SecretId"].as_str(), 1, 2048)?;
         validate_required("ResourcePolicy", &body["ResourcePolicy"])?;
         let policy_str = body["ResourcePolicy"].as_str().ok_or_else(|| {
@@ -1539,11 +1536,11 @@ impl SecretsManagerService {
             "PolicyValidationPassed": true,
             "ValidationErrors": [],
         });
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn put_resource_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
         validate_required("ResourcePolicy", &body["ResourcePolicy"])?;
         validate_optional_string_length(
@@ -1563,11 +1560,11 @@ impl SecretsManagerService {
             "Name": secret.name,
         });
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn delete_resource_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let mut state = self.state.write();
@@ -1579,14 +1576,14 @@ impl SecretsManagerService {
             "Name": secret.name,
         });
 
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn replicate_secret_to_regions(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let state = self.state.read();
@@ -1596,14 +1593,14 @@ impl SecretsManagerService {
             "ARN": secret.arn,
             "ReplicationStatus": [],
         });
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn remove_regions_from_replication(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let state = self.state.read();
@@ -1613,14 +1610,14 @@ impl SecretsManagerService {
             "ARN": secret.arn,
             "ReplicationStatus": [],
         });
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn stop_replication_to_replica(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
         let state = self.state.read();
@@ -1629,7 +1626,7 @@ impl SecretsManagerService {
         let response = json!({
             "ARN": secret.arn,
         });
-        Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+        Ok(AwsResponse::ok_json(response))
     }
 
     /// Find a secret by name, full ARN, or partial ARN (mutable).

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -170,10 +170,6 @@ fn val_as_i64(v: &Value) -> Option<i64> {
         .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
 }
 
-fn json_response(body: Value) -> AwsResponse {
-    AwsResponse::json(StatusCode::OK, serde_json::to_string(&body).unwrap())
-}
-
 use fakecloud_aws::xml::xml_escape;
 
 fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
@@ -198,7 +194,7 @@ fn xml_metadata_only(action: &str, request_id: &str) -> AwsResponse {
 
 fn sqs_response(action: &str, body: Value, request_id: &str, is_query: bool) -> AwsResponse {
     if !is_query {
-        return json_response(body);
+        return AwsResponse::ok_json(body);
     }
     match action {
         "CreateQueue" => {

--- a/crates/fakecloud-ssm/src/service/associations.rs
+++ b/crates/fakecloud-ssm/src/service/associations.rs
@@ -9,7 +9,7 @@ use fakecloud_core::validation::*;
 
 use crate::state::{SsmAssociation, SsmAssociationVersion};
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn create_association_inner(&self, body: &Value) -> Result<Value, AwsServiceError> {
@@ -178,16 +178,18 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let resp = self.create_association_inner(&body)?;
-        Ok(json_resp(json!({ "AssociationDescription": resp })))
+        Ok(AwsResponse::ok_json(
+            json!({ "AssociationDescription": resp }),
+        ))
     }
 
     pub(super) fn describe_association(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let association_id = body["AssociationId"].as_str();
         let name = body["Name"].as_str();
         let instance_id = body["InstanceId"].as_str();
@@ -205,7 +207,7 @@ impl SsmService {
         };
 
         match assoc {
-            Some(a) => Ok(json_resp(
+            Some(a) => Ok(AwsResponse::ok_json(
                 json!({ "AssociationDescription": association_to_json(a) }),
             )),
             None => Err(AwsServiceError::aws_error(
@@ -220,7 +222,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let association_id = body["AssociationId"].as_str();
         let name = body["Name"].as_str();
         let instance_id = body["InstanceId"].as_str();
@@ -249,7 +251,7 @@ impl SsmService {
         match key {
             Some(k) => {
                 state.associations.remove(&k);
-                Ok(json_resp(json!({})))
+                Ok(AwsResponse::ok_json(json!({})))
             }
             None => Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -263,7 +265,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let next_token_offset: usize = body["NextToken"]
@@ -312,14 +314,14 @@ impl SsmService {
         if has_more {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn update_association(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let association_id = body["AssociationId"]
             .as_str()
             .ok_or_else(|| missing("AssociationId"))?;
@@ -394,14 +396,16 @@ impl SsmService {
         });
 
         let resp = association_to_json(assoc);
-        Ok(json_resp(json!({ "AssociationDescription": resp })))
+        Ok(AwsResponse::ok_json(
+            json!({ "AssociationDescription": resp }),
+        ))
     }
 
     pub(super) fn list_association_versions(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let association_id = body["AssociationId"]
             .as_str()
             .ok_or_else(|| missing("AssociationId"))?;
@@ -467,14 +471,14 @@ impl SsmService {
         if has_more {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn update_association_status(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let instance_id = body["InstanceId"]
             .as_str()
@@ -503,26 +507,28 @@ impl SsmService {
         assoc.status_date = Utc::now();
 
         let resp = association_to_json(assoc);
-        Ok(json_resp(json!({ "AssociationDescription": resp })))
+        Ok(AwsResponse::ok_json(
+            json!({ "AssociationDescription": resp }),
+        ))
     }
 
     pub(super) fn start_associations_once(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let _association_ids = body["AssociationIds"]
             .as_array()
             .ok_or_else(|| missing("AssociationIds"))?;
         // No-op: return success
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn create_association_batch(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length(
             "AssociationDispatchAssumeRole",
             body["AssociationDispatchAssumeRole"].as_str(),
@@ -551,7 +557,7 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "Successful": successful,
             "Failed": failed,
         })))
@@ -561,20 +567,20 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let _association_id = body["AssociationId"]
             .as_str()
             .ok_or_else(|| missing("AssociationId"))?;
         // Return empty list — associations don't actually run
-        Ok(json_resp(json!({ "AssociationExecutions": [] })))
+        Ok(AwsResponse::ok_json(json!({ "AssociationExecutions": [] })))
     }
 
     pub(super) fn describe_association_execution_targets(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let _association_id = body["AssociationId"]
             .as_str()
@@ -582,7 +588,9 @@ impl SsmService {
         let _execution_id = body["ExecutionId"]
             .as_str()
             .ok_or_else(|| missing("ExecutionId"))?;
-        Ok(json_resp(json!({ "AssociationExecutionTargets": [] })))
+        Ok(AwsResponse::ok_json(
+            json!({ "AssociationExecutionTargets": [] }),
+        ))
     }
 
     // -----------------------------------------------------------------------
@@ -593,7 +601,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 5)?;
         let instance_id = body["InstanceId"]
             .as_str()
@@ -623,14 +631,16 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "Associations": associations })))
+        Ok(AwsResponse::ok_json(
+            json!({ "Associations": associations }),
+        ))
     }
 
     pub(super) fn describe_instance_associations_status(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let instance_id = body["InstanceId"]
             .as_str()
@@ -663,7 +673,7 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(
+        Ok(AwsResponse::ok_json(
             json!({ "InstanceAssociationStatusInfos": statuses }),
         ))
     }

--- a/crates/fakecloud-ssm/src/service/automation.rs
+++ b/crates/fakecloud-ssm/src/service/automation.rs
@@ -9,14 +9,14 @@ use fakecloud_core::validation::*;
 
 use crate::state::{AutomationExecution, ExecutionPreview};
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn start_automation_execution(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("ClientToken", body["ClientToken"].as_str(), 36, 36)?;
         validate_optional_string_length("MaxConcurrency", body["MaxConcurrency"].as_str(), 1, 7)?;
         validate_optional_string_length("MaxErrors", body["MaxErrors"].as_str(), 1, 7)?;
@@ -92,14 +92,16 @@ impl SsmService {
             .automation_executions
             .insert(exec_id.clone(), execution);
 
-        Ok(json_resp(json!({ "AutomationExecutionId": exec_id })))
+        Ok(AwsResponse::ok_json(
+            json!({ "AutomationExecutionId": exec_id }),
+        ))
     }
 
     pub(super) fn stop_automation_execution(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let exec_id = body["AutomationExecutionId"]
             .as_str()
             .ok_or_else(|| missing("AutomationExecutionId"))?;
@@ -119,14 +121,14 @@ impl SsmService {
         exec.automation_execution_status = "Cancelled".to_string();
         exec.execution_end_time = Some(Utc::now());
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn get_automation_execution(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let exec_id = body["AutomationExecutionId"]
             .as_str()
             .ok_or_else(|| missing("AutomationExecutionId"))?;
@@ -140,7 +142,7 @@ impl SsmService {
             )
         })?;
 
-        Ok(json_resp(
+        Ok(AwsResponse::ok_json(
             json!({ "AutomationExecution": automation_execution_to_json(exec) }),
         ))
     }
@@ -149,7 +151,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let state = self.state.read();
         let items: Vec<Value> = state
@@ -168,7 +170,7 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(
+        Ok(AwsResponse::ok_json(
             json!({ "AutomationExecutionMetadataList": items }),
         ))
     }
@@ -177,7 +179,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let exec_id = body["AutomationExecutionId"]
             .as_str()
             .ok_or_else(|| missing("AutomationExecutionId"))?;
@@ -206,14 +208,14 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "StepExecutions": steps })))
+        Ok(AwsResponse::ok_json(json!({ "StepExecutions": steps })))
     }
 
     pub(super) fn send_automation_signal(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let exec_id = body["AutomationExecutionId"]
             .as_str()
             .ok_or_else(|| missing("AutomationExecutionId"))?;
@@ -230,14 +232,14 @@ impl SsmService {
             ));
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn start_change_request_execution(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("ClientToken", body["ClientToken"].as_str(), 36, 36)?;
         validate_optional_string_length(
             "ChangeRequestName",
@@ -292,14 +294,16 @@ impl SsmService {
             .automation_executions
             .insert(exec_id.clone(), execution);
 
-        Ok(json_resp(json!({ "AutomationExecutionId": exec_id })))
+        Ok(AwsResponse::ok_json(
+            json!({ "AutomationExecutionId": exec_id }),
+        ))
     }
 
     pub(super) fn start_execution_preview(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let document_name = body["DocumentName"]
             .as_str()
             .ok_or_else(|| missing("DocumentName"))?
@@ -321,14 +325,16 @@ impl SsmService {
         };
         state.execution_previews.insert(preview_id.clone(), preview);
 
-        Ok(json_resp(json!({ "ExecutionPreviewId": preview_id })))
+        Ok(AwsResponse::ok_json(
+            json!({ "ExecutionPreviewId": preview_id }),
+        ))
     }
 
     pub(super) fn get_execution_preview(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let preview_id = body["ExecutionPreviewId"]
             .as_str()
             .ok_or_else(|| missing("ExecutionPreviewId"))?;
@@ -342,7 +348,7 @@ impl SsmService {
             )
         })?;
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ExecutionPreviewId": preview.execution_preview_id,
             "Status": preview.status,
             "EndedAt": preview.created_time.timestamp_millis() as f64 / 1000.0,

--- a/crates/fakecloud-ssm/src/service/commands.rs
+++ b/crates/fakecloud-ssm/src/service/commands.rs
@@ -9,11 +9,11 @@ use fakecloud_core::validation::*;
 
 use crate::state::SsmCommand;
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn send_command(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let document_name = body["DocumentName"]
             .as_str()
             .ok_or_else(|| missing("DocumentName"))?
@@ -152,11 +152,11 @@ impl SsmService {
             cmd_obj["TimeoutSeconds"] = json!(t);
         }
 
-        Ok(json_resp(json!({ "Command": cmd_obj })))
+        Ok(AwsResponse::ok_json(json!({ "Command": cmd_obj })))
     }
 
     pub(super) fn list_commands(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("CommandId", body["CommandId"].as_str(), 36, 36)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
@@ -231,14 +231,14 @@ impl SsmService {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_command_invocation(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let command_id = body["CommandId"]
             .as_str()
             .ok_or_else(|| missing("CommandId"))?;
@@ -283,7 +283,7 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "CommandId": cmd.command_id,
             "InstanceId": instance_id,
             "DocumentName": cmd.document_name,
@@ -301,7 +301,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("CommandId", body["CommandId"].as_str(), 36, 36)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
@@ -350,11 +350,11 @@ impl SsmService {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn cancel_command(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let command_id = body["CommandId"]
             .as_str()
             .ok_or_else(|| missing("CommandId"))?;
@@ -369,7 +369,7 @@ impl SsmService {
             cmd.status = "Cancelled".to_string();
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     // ===== Maintenance Window operations =====

--- a/crates/fakecloud-ssm/src/service/compliance.rs
+++ b/crates/fakecloud-ssm/src/service/compliance.rs
@@ -7,14 +7,14 @@ use fakecloud_core::validation::*;
 
 use crate::state::ComplianceItem;
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn put_compliance_items(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("ResourceId", body["ResourceId"].as_str(), 1, 100)?;
         validate_optional_string_length("ResourceType", body["ResourceType"].as_str(), 1, 50)?;
         validate_optional_string_length("ComplianceType", body["ComplianceType"].as_str(), 1, 100)?;
@@ -84,14 +84,14 @@ impl SsmService {
             });
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn list_compliance_items(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let next_token_offset: usize = body["NextToken"]
@@ -155,14 +155,14 @@ impl SsmService {
         if has_more {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn list_compliance_summaries(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let state = self.state.read();
 
@@ -196,14 +196,16 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "ComplianceSummaryItems": summaries })))
+        Ok(AwsResponse::ok_json(
+            json!({ "ComplianceSummaryItems": summaries }),
+        ))
     }
 
     pub(super) fn list_resource_compliance_summaries(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let state = self.state.read();
 
@@ -243,7 +245,7 @@ impl SsmService {
             )
             .collect();
 
-        Ok(json_resp(
+        Ok(AwsResponse::ok_json(
             json!({ "ResourceComplianceSummaryItems": summaries }),
         ))
     }

--- a/crates/fakecloud-ssm/src/service/documents.rs
+++ b/crates/fakecloud-ssm/src/service/documents.rs
@@ -10,11 +10,11 @@ use fakecloud_core::validation::*;
 use crate::state::{SsmDocument, SsmDocumentVersion, SsmResourcePolicy};
 use sha2::{Digest, Sha256};
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn create_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"]
             .as_str()
             .ok_or_else(|| missing("Name"))?
@@ -144,11 +144,13 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({ "DocumentDescription": desc_json })))
+        Ok(AwsResponse::ok_json(
+            json!({ "DocumentDescription": desc_json }),
+        ))
     }
 
     pub(super) fn get_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let version = body["DocumentVersion"].as_str();
         let version_name = body["VersionName"].as_str();
@@ -221,11 +223,11 @@ impl SsmService {
             resp["VersionName"] = json!(vn);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn delete_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let doc_version = body["DocumentVersion"].as_str();
         let version_name = body["VersionName"].as_str();
@@ -278,11 +280,11 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn update_document(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let content = body["Content"]
             .as_str()
@@ -383,14 +385,16 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({ "DocumentDescription": desc_json })))
+        Ok(AwsResponse::ok_json(
+            json!({ "DocumentDescription": desc_json }),
+        ))
     }
 
     pub(super) fn describe_document(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
         let state = self.state.read();
@@ -452,14 +456,14 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({ "Document": desc_json })))
+        Ok(AwsResponse::ok_json(json!({ "Document": desc_json })))
     }
 
     pub(super) fn update_document_default_version(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let version = body["DocumentVersion"]
             .as_str()
@@ -498,11 +502,11 @@ impl SsmService {
             desc["DefaultVersionName"] = json!(vn);
         }
 
-        Ok(json_resp(json!({ "Description": desc })))
+        Ok(AwsResponse::ok_json(json!({ "Description": desc })))
     }
 
     pub(super) fn list_documents(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(10) as usize;
         let next_token_offset: usize = body["NextToken"]
@@ -582,14 +586,14 @@ impl SsmService {
             resp["NextToken"] = json!("");
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn describe_document_permission(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
         let state = self.state.read();
@@ -603,7 +607,7 @@ impl SsmService {
 
         let account_ids = doc.permissions.get("Share").cloned().unwrap_or_default();
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "AccountIds": account_ids,
             "AccountSharingInfoList": account_ids.iter().map(|id| json!({
                 "AccountId": id,
@@ -616,7 +620,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let permission_type = body["PermissionType"].as_str().unwrap_or("Share");
         let accounts_to_add = body["AccountIdsToAdd"].as_array();
@@ -712,7 +716,7 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     // ===== Command operations =====
@@ -721,7 +725,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let next_token_offset: usize = body["NextToken"]
@@ -763,14 +767,14 @@ impl SsmService {
         if has_more {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn list_document_metadata_history(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let _name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_required("Metadata", &body["Metadata"])?;
         validate_optional_enum("Metadata", body["Metadata"].as_str(), &["DocumentReviews"])?;
@@ -780,7 +784,7 @@ impl SsmService {
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
 
         // Stub: return empty metadata
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "Name": _name,
             "Author": "",
             "Metadata": {
@@ -793,7 +797,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
         let state = self.state.read();
@@ -802,7 +806,7 @@ impl SsmService {
         }
 
         // Stub: accept but do nothing
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     // -----------------------------------------------------------------------
@@ -813,7 +817,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("ResourceArn", body["ResourceArn"].as_str(), 20, 2048)?;
         let resource_arn = body["ResourceArn"]
             .as_str()
@@ -849,7 +853,7 @@ impl SsmService {
                 existing.policy = policy;
                 let new_hash = format!("{:x}", md5::compute(existing.policy.as_bytes()));
                 existing.policy_hash = new_hash.clone();
-                return Ok(json_resp(json!({
+                return Ok(AwsResponse::ok_json(json!({
                     "PolicyId": pid,
                     "PolicyHash": new_hash,
                 })));
@@ -866,7 +870,7 @@ impl SsmService {
             resource_arn,
         });
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "PolicyId": new_id,
             "PolicyHash": new_hash,
         })))
@@ -876,7 +880,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("ResourceArn", body["ResourceArn"].as_str(), 20, 2048)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let resource_arn = body["ResourceArn"]
@@ -897,14 +901,14 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "Policies": policies })))
+        Ok(AwsResponse::ok_json(json!({ "Policies": policies })))
     }
 
     pub(super) fn delete_resource_policy(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let resource_arn = body["ResourceArn"]
             .as_str()
             .ok_or_else(|| missing("ResourceArn"))?;
@@ -931,7 +935,7 @@ impl SsmService {
                     ));
                 }
                 state.resource_policies.remove(i);
-                Ok(json_resp(json!({})))
+                Ok(AwsResponse::ok_json(json!({})))
             }
             None => Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-ssm/src/service/instances.rs
+++ b/crates/fakecloud-ssm/src/service/instances.rs
@@ -9,14 +9,14 @@ use fakecloud_core::validation::*;
 
 use crate::state::SsmActivation;
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn create_activation(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("IamRole", body["IamRole"].as_str(), 0, 64)?;
         validate_optional_string_length("Description", body["Description"].as_str(), 0, 256)?;
         validate_optional_string_length(
@@ -74,7 +74,7 @@ impl SsmService {
         };
         state.activations.insert(activation_id.clone(), activation);
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ActivationId": activation_id,
             "ActivationCode": activation_code,
         })))
@@ -84,7 +84,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let activation_id = body["ActivationId"]
             .as_str()
             .ok_or_else(|| missing("ActivationId"))?;
@@ -98,14 +98,14 @@ impl SsmService {
             ));
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn describe_activations(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let state = self.state.read();
         let activations: Vec<Value> = state
@@ -140,14 +140,16 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "ActivationList": activations })))
+        Ok(AwsResponse::ok_json(
+            json!({ "ActivationList": activations }),
+        ))
     }
 
     pub(super) fn deregister_managed_instance(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("InstanceId", body["InstanceId"].as_str(), 20, 124)?;
         let instance_id = body["InstanceId"]
             .as_str()
@@ -157,14 +159,14 @@ impl SsmService {
         state.managed_instances.remove(instance_id);
         // AWS doesn't error on non-existent instances
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn describe_instance_information(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 5, 50)?;
         let state = self.state.read();
         let instances: Vec<Value> = state
@@ -189,14 +191,16 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "InstanceInformationList": instances })))
+        Ok(AwsResponse::ok_json(
+            json!({ "InstanceInformationList": instances }),
+        ))
     }
 
     pub(super) fn describe_instance_properties(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 5, 1000)?;
         let state = self.state.read();
         let instances: Vec<Value> = state
@@ -218,14 +222,16 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "InstanceProperties": instances })))
+        Ok(AwsResponse::ok_json(
+            json!({ "InstanceProperties": instances }),
+        ))
     }
 
     pub(super) fn update_managed_instance_role(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let instance_id = body["InstanceId"]
             .as_str()
             .ok_or_else(|| missing("InstanceId"))?;
@@ -247,28 +253,28 @@ impl SsmService {
             })?;
         instance.iam_role = iam_role;
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     // ── Other ─────────────────────────────────────────────────────
 
     pub(super) fn list_nodes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SyncName", body["SyncName"].as_str(), 1, 64)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        Ok(json_resp(json!({ "Nodes": [] })))
+        Ok(AwsResponse::ok_json(json!({ "Nodes": [] })))
     }
 
     pub(super) fn list_nodes_summary(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SyncName", body["SyncName"].as_str(), 1, 64)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let _aggregators = body["Aggregators"]
             .as_array()
             .ok_or_else(|| missing("Aggregators"))?;
-        Ok(json_resp(json!({ "Summary": [] })))
+        Ok(AwsResponse::ok_json(json!({ "Summary": [] })))
     }
 }

--- a/crates/fakecloud-ssm/src/service/inventory.rs
+++ b/crates/fakecloud-ssm/src/service/inventory.rs
@@ -8,11 +8,11 @@ use fakecloud_core::validation::*;
 
 use crate::state::{InventoryDeletion, InventoryEntry, InventoryItem};
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn put_inventory(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let instance_id = body["InstanceId"]
             .as_str()
             .ok_or_else(|| missing("InstanceId"))?
@@ -88,13 +88,13 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(
+        Ok(AwsResponse::ok_json(
             json!({ "Message": "Inventory was saved successfully" }),
         ))
     }
 
     pub(super) fn get_inventory(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let state = self.state.read();
         let entities: Vec<Value> = state
@@ -122,14 +122,14 @@ impl SsmService {
                 })
             })
             .collect();
-        Ok(json_resp(json!({ "Entities": entities })))
+        Ok(AwsResponse::ok_json(json!({ "Entities": entities })))
     }
 
     pub(super) fn get_inventory_schema(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("TypeName", body["TypeName"].as_str(), 0, 100)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 50, 200)?;
         // Return standard inventory type schemas
@@ -177,14 +177,14 @@ impl SsmService {
                 ]
             }),
         ];
-        Ok(json_resp(json!({ "Schemas": schemas })))
+        Ok(AwsResponse::ok_json(json!({ "Schemas": schemas })))
     }
 
     pub(super) fn list_inventory_entries(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("TypeName", body["TypeName"].as_str(), 1, 100)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let instance_id = body["InstanceId"]
@@ -221,7 +221,7 @@ impl SsmService {
             .map(|i| i.schema_version.as_str())
             .unwrap_or("1.0");
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "TypeName": type_name,
             "InstanceId": instance_id,
             "SchemaVersion": schema_version,
@@ -234,7 +234,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("TypeName", body["TypeName"].as_str(), 1, 100)?;
         validate_optional_enum(
             "SchemaDeleteOption",
@@ -271,7 +271,7 @@ impl SsmService {
             last_status_update_time: now,
         });
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "DeletionId": deletion_id,
             "TypeName": type_name,
             "DeletionSummary": {
@@ -286,7 +286,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let state = self.state.read();
         let deletions: Vec<Value> = state
@@ -304,7 +304,9 @@ impl SsmService {
                 })
             })
             .collect();
-        Ok(json_resp(json!({ "InventoryDeletions": deletions })))
+        Ok(AwsResponse::ok_json(
+            json!({ "InventoryDeletions": deletions }),
+        ))
     }
 
     // ── Compliance ────────────────────────────────────────────────

--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -8,14 +8,14 @@ use fakecloud_core::validation::*;
 
 use crate::state::{MaintenanceWindow, MaintenanceWindowTarget, MaintenanceWindowTask};
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn create_maintenance_window(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"]
             .as_str()
             .ok_or_else(|| missing("Name"))?
@@ -70,7 +70,7 @@ impl SsmService {
                 .values()
                 .find(|mw| mw.client_token.as_deref() == Some(token))
             {
-                return Ok(json_resp(json!({ "WindowId": existing.id })));
+                return Ok(AwsResponse::ok_json(json!({ "WindowId": existing.id })));
             }
         }
 
@@ -97,14 +97,14 @@ impl SsmService {
 
         state.maintenance_windows.insert(window_id.clone(), mw);
 
-        Ok(json_resp(json!({ "WindowId": window_id })))
+        Ok(AwsResponse::ok_json(json!({ "WindowId": window_id })))
     }
 
     pub(super) fn describe_maintenance_windows(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 10, 100)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let next_token_offset: usize = body["NextToken"]
@@ -184,14 +184,14 @@ impl SsmService {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_maintenance_window(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -227,14 +227,14 @@ impl SsmService {
             resp["EndDate"] = json!(ed);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn delete_maintenance_window(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -245,14 +245,14 @@ impl SsmService {
             return Err(mw_not_found(window_id));
         }
 
-        Ok(json_resp(json!({ "WindowId": window_id })))
+        Ok(AwsResponse::ok_json(json!({ "WindowId": window_id })))
     }
 
     pub(super) fn update_maintenance_window(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -305,14 +305,14 @@ impl SsmService {
             resp["Description"] = json!(desc);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn register_target_with_maintenance_window(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -351,14 +351,14 @@ impl SsmService {
         };
         mw.targets.push(target);
 
-        Ok(json_resp(json!({ "WindowTargetId": target_id })))
+        Ok(AwsResponse::ok_json(json!({ "WindowTargetId": target_id })))
     }
 
     pub(super) fn deregister_target_from_maintenance_window(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -374,7 +374,7 @@ impl SsmService {
 
         mw.targets.retain(|t| t.window_target_id != target_id);
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "WindowId": window_id,
             "WindowTargetId": target_id,
         })))
@@ -384,7 +384,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -418,14 +418,14 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "Targets": targets })))
+        Ok(AwsResponse::ok_json(json!({ "Targets": targets })))
     }
 
     pub(super) fn register_task_with_maintenance_window(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -472,14 +472,14 @@ impl SsmService {
         };
         mw.tasks.push(task);
 
-        Ok(json_resp(json!({ "WindowTaskId": task_id })))
+        Ok(AwsResponse::ok_json(json!({ "WindowTaskId": task_id })))
     }
 
     pub(super) fn deregister_task_from_maintenance_window(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -495,7 +495,7 @@ impl SsmService {
 
         mw.tasks.retain(|t| t.window_task_id != task_id);
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "WindowId": window_id,
             "WindowTaskId": task_id,
         })))
@@ -505,7 +505,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -547,7 +547,7 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "Tasks": tasks })))
+        Ok(AwsResponse::ok_json(json!({ "Tasks": tasks })))
     }
 
     // ===== Patch Baseline operations =====
@@ -556,7 +556,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -610,14 +610,14 @@ impl SsmService {
             resp["OwnerInformation"] = json!(oi);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn update_maintenance_window_task(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -686,14 +686,14 @@ impl SsmService {
             resp["MaxErrors"] = json!(me);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_maintenance_window_task(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let window_id = body["WindowId"]
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
@@ -743,14 +743,14 @@ impl SsmService {
             resp["ServiceRoleArn"] = json!(sra);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_maintenance_window_execution(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let execution_id = body["WindowExecutionId"]
             .as_str()
             .ok_or_else(|| missing("WindowExecutionId"))?;
@@ -779,14 +779,14 @@ impl SsmService {
             resp["EndTime"] = json!(end.timestamp_millis() as f64 / 1000.0);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_maintenance_window_execution_task(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let execution_id = body["WindowExecutionId"]
             .as_str()
             .ok_or_else(|| missing("WindowExecutionId"))?;
@@ -829,14 +829,14 @@ impl SsmService {
             resp["EndTime"] = json!(end.timestamp_millis() as f64 / 1000.0);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_maintenance_window_execution_task_invocation(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let execution_id = body["WindowExecutionId"]
             .as_str()
             .ok_or_else(|| missing("WindowExecutionId"))?;
@@ -908,14 +908,14 @@ impl SsmService {
             resp["StatusDetails"] = json!(sd);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn describe_maintenance_window_executions(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("WindowId", body["WindowId"].as_str(), 20, 20)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 10, 100)?;
         let window_id = body["WindowId"]
@@ -957,14 +957,14 @@ impl SsmService {
         if has_more {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn describe_maintenance_window_execution_tasks(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length(
             "WindowExecutionId",
             body["WindowExecutionId"].as_str(),
@@ -1002,14 +1002,16 @@ impl SsmService {
             })
             .unwrap_or_default();
 
-        Ok(json_resp(json!({ "WindowExecutionTaskIdentities": tasks })))
+        Ok(AwsResponse::ok_json(
+            json!({ "WindowExecutionTaskIdentities": tasks }),
+        ))
     }
 
     pub(super) fn describe_maintenance_window_execution_task_invocations(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length(
             "WindowExecutionId",
             body["WindowExecutionId"].as_str(),
@@ -1052,7 +1054,7 @@ impl SsmService {
             })
             .unwrap_or_default();
 
-        Ok(json_resp(
+        Ok(AwsResponse::ok_json(
             json!({ "WindowExecutionTaskInvocationIdentities": invocations }),
         ))
     }
@@ -1061,7 +1063,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("WindowId", body["WindowId"].as_str(), 20, 20)?;
         validate_optional_enum(
             "ResourceType",
@@ -1069,14 +1071,16 @@ impl SsmService {
             &["INSTANCE", "RESOURCE_GROUP"],
         )?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, i64::MAX)?;
-        Ok(json_resp(json!({ "ScheduledWindowExecutions": [] })))
+        Ok(AwsResponse::ok_json(
+            json!({ "ScheduledWindowExecutions": [] }),
+        ))
     }
 
     pub(super) fn describe_maintenance_windows_for_target(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_enum(
             "ResourceType",
             body["ResourceType"].as_str(),
@@ -1132,14 +1136,14 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "WindowIdentities": windows })))
+        Ok(AwsResponse::ok_json(json!({ "WindowIdentities": windows })))
     }
 
     pub(super) fn cancel_maintenance_window_execution(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let execution_id = body["WindowExecutionId"]
             .as_str()
             .ok_or_else(|| missing("WindowExecutionId"))?;
@@ -1159,7 +1163,9 @@ impl SsmService {
 
         exec.status = "CANCELLING".to_string();
 
-        Ok(json_resp(json!({ "WindowExecutionId": execution_id })))
+        Ok(AwsResponse::ok_json(
+            json!({ "WindowExecutionId": execution_id }),
+        ))
     }
 
     // ── Patch Management Details ──────────────────────────────────

--- a/crates/fakecloud-ssm/src/service/misc.rs
+++ b/crates/fakecloud-ssm/src/service/misc.rs
@@ -6,17 +6,17 @@ use fakecloud_core::validation::*;
 
 use crate::state::SsmServiceSetting;
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn get_connection_status(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("Target", body["Target"].as_str(), 1, 400)?;
         let target = body["Target"].as_str().ok_or_else(|| missing("Target"))?;
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "Target": target,
             "Status": "connected",
         })))
@@ -26,11 +26,11 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let _calendar_names = body["CalendarNames"]
             .as_array()
             .ok_or_else(|| missing("CalendarNames"))?;
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "State": "OPEN",
             "AtTime": Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
         })))
@@ -40,7 +40,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SettingId", body["SettingId"].as_str(), 1, 1000)?;
         let setting_id = body["SettingId"]
             .as_str()
@@ -48,7 +48,7 @@ impl SsmService {
 
         let state = self.state.read();
         if let Some(setting) = state.service_settings.get(setting_id) {
-            Ok(json_resp(json!({
+            Ok(AwsResponse::ok_json(json!({
                 "ServiceSetting": {
                     "SettingId": setting.setting_id,
                     "SettingValue": setting.setting_value,
@@ -60,7 +60,7 @@ impl SsmService {
             })))
         } else {
             // Return sensible default for known settings
-            Ok(json_resp(json!({
+            Ok(AwsResponse::ok_json(json!({
                 "ServiceSetting": {
                     "SettingId": setting_id,
                     "SettingValue": get_default_service_setting(setting_id),
@@ -77,7 +77,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SettingId", body["SettingId"].as_str(), 1, 1000)?;
         let setting_id = body["SettingId"]
             .as_str()
@@ -87,7 +87,7 @@ impl SsmService {
         state.service_settings.remove(setting_id);
 
         let default_value = get_default_service_setting(setting_id);
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ServiceSetting": {
                 "SettingId": setting_id,
                 "SettingValue": default_value,
@@ -103,7 +103,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SettingId", body["SettingId"].as_str(), 1, 1000)?;
         validate_optional_string_length("SettingValue", body["SettingValue"].as_str(), 1, 4096)?;
         let setting_id = body["SettingId"]
@@ -129,7 +129,7 @@ impl SsmService {
             },
         );
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     // ── Inventory ─────────────────────────────────────────────────

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -16,7 +16,6 @@ mod tags;
 
 use async_trait::async_trait;
 use http::StatusCode;
-use serde_json::Value;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
@@ -421,14 +420,6 @@ impl AwsService for SsmService {
     }
 }
 
-fn parse_body(req: &AwsRequest) -> Value {
-    serde_json::from_slice(&req.body).unwrap_or(Value::Object(Default::default()))
-}
-
-fn json_resp(body: Value) -> AwsResponse {
-    AwsResponse::json(StatusCode::OK, serde_json::to_string(&body).unwrap())
-}
-
 fn missing(name: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,
@@ -441,7 +432,7 @@ fn missing(name: &str) -> AwsServiceError {
 mod tests {
     use super::*;
     use parking_lot::RwLock;
-    use serde_json::json;
+    use serde_json::{json, Value};
     use std::collections::HashMap;
     use std::sync::Arc;
 

--- a/crates/fakecloud-ssm/src/service/ops.rs
+++ b/crates/fakecloud-ssm/src/service/ops.rs
@@ -9,11 +9,11 @@ use fakecloud_core::validation::*;
 
 use crate::state::{OpsItemRelatedItem, OpsMetadataEntry, SsmOpsItem};
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn create_ops_item(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("Description", &body["Description"])?;
         validate_optional_string_length("Title", body["Title"].as_str(), 1, 1024)?;
         validate_optional_string_length("Source", body["Source"].as_str(), 1, 128)?;
@@ -90,11 +90,11 @@ impl SsmService {
 
         state.ops_items.insert(ops_item_id.clone(), item);
 
-        Ok(json_resp(json!({ "OpsItemId": ops_item_id })))
+        Ok(AwsResponse::ok_json(json!({ "OpsItemId": ops_item_id })))
     }
 
     pub(super) fn get_ops_item(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let ops_item_id = body["OpsItemId"]
             .as_str()
             .ok_or_else(|| missing("OpsItemId"))?;
@@ -108,11 +108,13 @@ impl SsmService {
             )
         })?;
 
-        Ok(json_resp(json!({ "OpsItem": ops_item_to_json(item) })))
+        Ok(AwsResponse::ok_json(
+            json!({ "OpsItem": ops_item_to_json(item) }),
+        ))
     }
 
     pub(super) fn update_ops_item(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let ops_item_id = body["OpsItemId"]
             .as_str()
             .ok_or_else(|| missing("OpsItemId"))?;
@@ -160,25 +162,25 @@ impl SsmService {
         item.last_modified_time = Utc::now();
         item.last_modified_by = format!("arn:aws:iam::{}:root", account_id);
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn delete_ops_item(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let ops_item_id = body["OpsItemId"]
             .as_str()
             .ok_or_else(|| missing("OpsItemId"))?;
 
         let mut state = self.state.write();
         state.ops_items.remove(ops_item_id);
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn describe_ops_items(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let next_token_offset: usize = body["NextToken"]
@@ -226,7 +228,7 @@ impl SsmService {
         if has_more {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     // -----------------------------------------------------------------------
@@ -234,10 +236,10 @@ impl SsmService {
     // -----------------------------------------------------------------------
 
     pub(super) fn get_ops_summary(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SyncName", body["SyncName"].as_str(), 1, 64)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        Ok(json_resp(json!({ "Entities": [] })))
+        Ok(AwsResponse::ok_json(json!({ "Entities": [] })))
     }
 
     // ── OpsItem Related Items ─────────────────────────────────────
@@ -246,7 +248,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let ops_item_id = body["OpsItemId"]
             .as_str()
             .ok_or_else(|| missing("OpsItemId"))?
@@ -292,14 +294,16 @@ impl SsmService {
             last_modified_by: format!("arn:aws:iam::{account_id}:root"),
         });
 
-        Ok(json_resp(json!({ "AssociationId": association_id })))
+        Ok(AwsResponse::ok_json(
+            json!({ "AssociationId": association_id }),
+        ))
     }
 
     pub(super) fn disassociate_ops_item_related_item(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let ops_item_id = body["OpsItemId"]
             .as_str()
             .ok_or_else(|| missing("OpsItemId"))?;
@@ -320,14 +324,14 @@ impl SsmService {
             ));
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn list_ops_item_related_items(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let state = self.state.read();
         let ops_item_id = body["OpsItemId"].as_str();
@@ -351,14 +355,14 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "Summaries": items })))
+        Ok(AwsResponse::ok_json(json!({ "Summaries": items })))
     }
 
     pub(super) fn list_ops_item_events(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let state = self.state.read();
 
@@ -393,7 +397,7 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "Summaries": events })))
+        Ok(AwsResponse::ok_json(json!({ "Summaries": events })))
     }
 
     // ── OpsMetadata ───────────────────────────────────────────────
@@ -402,7 +406,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("ResourceId", body["ResourceId"].as_str(), 1, 1024)?;
         let resource_id = body["ResourceId"]
             .as_str()
@@ -435,14 +439,14 @@ impl SsmService {
         };
         state.ops_metadata.insert(arn.clone(), entry);
 
-        Ok(json_resp(json!({ "OpsMetadataArn": arn })))
+        Ok(AwsResponse::ok_json(json!({ "OpsMetadataArn": arn })))
     }
 
     pub(super) fn get_ops_metadata(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let arn = body["OpsMetadataArn"]
             .as_str()
             .ok_or_else(|| missing("OpsMetadataArn"))?;
@@ -456,7 +460,7 @@ impl SsmService {
             )
         })?;
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "ResourceId": entry.resource_id,
             "Metadata": entry.metadata,
         })))
@@ -466,7 +470,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let arn = body["OpsMetadataArn"]
             .as_str()
             .ok_or_else(|| missing("OpsMetadataArn"))?;
@@ -493,14 +497,14 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({ "OpsMetadataArn": arn })))
+        Ok(AwsResponse::ok_json(json!({ "OpsMetadataArn": arn })))
     }
 
     pub(super) fn delete_ops_metadata(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let arn = body["OpsMetadataArn"]
             .as_str()
             .ok_or_else(|| missing("OpsMetadataArn"))?;
@@ -514,14 +518,14 @@ impl SsmService {
             ));
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn list_ops_metadata(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let state = self.state.read();
         let items: Vec<Value> = state
@@ -536,7 +540,7 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "OpsMetadataList": items })))
+        Ok(AwsResponse::ok_json(json!({ "OpsMetadataList": items })))
     }
 
     // ── Automation ────────────────────────────────────────────────

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -9,11 +9,11 @@ use fakecloud_core::validation::*;
 
 use crate::state::{SsmParameter, SsmParameterVersion};
 
-use super::{json_resp, missing, parse_body, SsmService, PARAMETER_VERSION_LIMIT};
+use super::{missing, SsmService, PARAMETER_VERSION_LIMIT};
 
 impl SsmService {
     pub(super) fn put_parameter(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"]
             .as_str()
             .ok_or_else(|| missing("Name"))?
@@ -175,7 +175,7 @@ impl SsmService {
             }
 
             let resp_tier = existing.tier.clone();
-            return Ok(json_resp(json!({
+            return Ok(AwsResponse::ok_json(json!({
                 "Version": existing.version,
                 "Tier": resp_tier,
             })));
@@ -222,7 +222,7 @@ impl SsmService {
         };
 
         state.parameters.insert(name, param);
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "Version": 1,
             "Tier": tier,
         })))
@@ -300,7 +300,7 @@ impl SsmService {
             ssm_state.account_id, raw_name
         );
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "Parameter": {
                 "Name": raw_name,
                 "Type": "SecureString",
@@ -315,7 +315,7 @@ impl SsmService {
     }
 
     pub(super) fn get_parameter(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let raw_name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
 
@@ -338,7 +338,7 @@ impl SsmService {
         // Handle ARN-style names directly (they contain many colons)
         if raw_name.starts_with("arn:aws:ssm:") {
             let param = resolve_param_by_name_or_arn(&state, raw_name)?;
-            return Ok(json_resp(json!({
+            return Ok(AwsResponse::ok_json(json!({
                 "Parameter": param_to_json(param, true, with_decryption, &req.region),
             })));
         }
@@ -355,12 +355,12 @@ impl SsmService {
             .map_err(|_| param_not_found(raw_name))?;
 
         match selector {
-            ParamSelector::None => Ok(json_resp(json!({
+            ParamSelector::None => Ok(AwsResponse::ok_json(json!({
                 "Parameter": param_to_json(param, true, with_decryption, &req.region),
             }))),
             ParamSelector::Version(ver) => {
                 if param.version == ver {
-                    return Ok(json_resp(json!({
+                    return Ok(AwsResponse::ok_json(json!({
                         "Parameter": param_to_json(param, true, with_decryption, &req.region),
                     })));
                 }
@@ -379,7 +379,7 @@ impl SsmService {
                     } else {
                         v["Value"] = json!(hist.value);
                     }
-                    return Ok(json_resp(json!({ "Parameter": v })));
+                    return Ok(AwsResponse::ok_json(json!({ "Parameter": v })));
                 }
                 Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -396,7 +396,7 @@ impl SsmService {
                 for (ver, labels) in &param.labels {
                     if labels.contains(&label) {
                         if *ver == param.version {
-                            return Ok(json_resp(json!({
+                            return Ok(AwsResponse::ok_json(json!({
                                 "Parameter": param_to_json(param, true, with_decryption, &req.region),
                             })));
                         }
@@ -414,7 +414,7 @@ impl SsmService {
                             } else {
                                 v["Value"] = json!(hist.value);
                             }
-                            return Ok(json_resp(json!({ "Parameter": v })));
+                            return Ok(AwsResponse::ok_json(json!({ "Parameter": v })));
                         }
                     }
                 }
@@ -433,7 +433,7 @@ impl SsmService {
     }
 
     pub(super) fn get_parameters(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let names = body["Names"].as_array().ok_or_else(|| missing("Names"))?;
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
 
@@ -560,7 +560,7 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "Parameters": parameters,
             "InvalidParameters": invalid,
         })))
@@ -570,7 +570,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let path = body["Path"].as_str().ok_or_else(|| missing("Path"))?;
         let recursive = body["Recursive"].as_bool().unwrap_or(false);
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
@@ -672,14 +672,14 @@ impl SsmService {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn delete_parameter(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
         let mut state = self.state.write();
@@ -687,14 +687,14 @@ impl SsmService {
             return Err(param_not_found(name));
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn delete_parameters(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let names = body["Names"].as_array().ok_or_else(|| missing("Names"))?;
 
         let mut state = self.state.write();
@@ -711,7 +711,7 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "DeletedParameters": deleted,
             "InvalidParameters": invalid,
         })))
@@ -721,7 +721,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let param_filters = body["ParameterFilters"].as_array().cloned();
         let old_filters = body["Filters"].as_array().cloned();
@@ -802,14 +802,14 @@ impl SsmService {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_parameter_history(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
         let max_results = body["MaxResults"].as_i64();
@@ -910,14 +910,14 @@ impl SsmService {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn label_parameter_version(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let labels = body["Labels"].as_array().ok_or_else(|| missing("Labels"))?;
         let version = if body["ParameterVersion"].is_null() {
@@ -990,7 +990,7 @@ impl SsmService {
             }
         }
         if !invalid_labels.is_empty() {
-            return Ok(json_resp(json!({
+            return Ok(AwsResponse::ok_json(json!({
                 "InvalidLabels": invalid_labels,
                 "ParameterVersion": target_version,
             })));
@@ -1038,7 +1038,7 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "InvalidLabels": [],
             "ParameterVersion": target_version,
         })))
@@ -1048,7 +1048,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let labels = body["Labels"].as_array().ok_or_else(|| missing("Labels"))?;
         let version_opt = if body["ParameterVersion"].is_null() {
@@ -1107,7 +1107,7 @@ impl SsmService {
         // Clean up empty entries
         param.labels.retain(|_, v| !v.is_empty());
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "InvalidLabels": invalid,
             "RemovedLabels": label_strings.iter().filter(|l| !invalid.contains(l)).collect::<Vec<_>>(),
         })))

--- a/crates/fakecloud-ssm/src/service/patches.rs
+++ b/crates/fakecloud-ssm/src/service/patches.rs
@@ -8,14 +8,14 @@ use fakecloud_core::validation::*;
 
 use crate::state::{PatchBaseline, PatchGroup};
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn create_patch_baseline(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let name = body["Name"]
             .as_str()
             .ok_or_else(|| missing("Name"))?
@@ -129,7 +129,7 @@ impl SsmService {
                 .values()
                 .find(|pb| pb.client_token.as_deref() == Some(token))
             {
-                return Ok(json_resp(json!({ "BaselineId": existing.id })));
+                return Ok(AwsResponse::ok_json(json!({ "BaselineId": existing.id })));
             }
         }
 
@@ -158,14 +158,14 @@ impl SsmService {
 
         state.patch_baselines.insert(baseline_id.clone(), pb);
 
-        Ok(json_resp(json!({ "BaselineId": baseline_id })))
+        Ok(AwsResponse::ok_json(json!({ "BaselineId": baseline_id })))
     }
 
     pub(super) fn delete_patch_baseline(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let baseline_id = body["BaselineId"]
             .as_str()
             .ok_or_else(|| missing("BaselineId"))?;
@@ -178,14 +178,14 @@ impl SsmService {
             .patch_groups
             .retain(|pg| pg.baseline_id != baseline_id);
 
-        Ok(json_resp(json!({ "BaselineId": baseline_id })))
+        Ok(AwsResponse::ok_json(json!({ "BaselineId": baseline_id })))
     }
 
     pub(super) fn describe_patch_baselines(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 100)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let next_token_offset: usize = body["NextToken"]
@@ -256,14 +256,14 @@ impl SsmService {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_patch_baseline(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let baseline_id = body["BaselineId"]
             .as_str()
             .ok_or_else(|| missing("BaselineId"))?;
@@ -306,14 +306,14 @@ impl SsmService {
             resp["AvailableSecurityUpdatesComplianceStatus"] = json!(status);
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn register_patch_baseline_for_patch_group(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let baseline_id = body["BaselineId"]
             .as_str()
             .ok_or_else(|| missing("BaselineId"))?
@@ -361,7 +361,7 @@ impl SsmService {
             patch_group: patch_group.clone(),
         });
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "BaselineId": baseline_id,
             "PatchGroup": patch_group,
         })))
@@ -371,7 +371,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let baseline_id = body["BaselineId"]
             .as_str()
             .ok_or_else(|| missing("BaselineId"))?;
@@ -404,7 +404,7 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "BaselineId": baseline_id,
             "PatchGroup": patch_group,
         })))
@@ -414,7 +414,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let patch_group = body["PatchGroup"]
             .as_str()
             .ok_or_else(|| missing("PatchGroup"))?;
@@ -454,7 +454,7 @@ impl SsmService {
         });
 
         if let Some(pg) = found {
-            Ok(json_resp(json!({
+            Ok(AwsResponse::ok_json(json!({
                 "BaselineId": pg.baseline_id,
                 "PatchGroup": pg.patch_group,
                 "OperatingSystem": operating_system,
@@ -468,7 +468,7 @@ impl SsmService {
             if let Some(baseline_id) = default_patch_baseline(&req.region, operating_system) {
                 resp["BaselineId"] = json!(baseline_id);
             }
-            Ok(json_resp(resp))
+            Ok(AwsResponse::ok_json(resp))
         }
     }
 
@@ -476,7 +476,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 100)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let next_token_offset: usize = body["NextToken"]
@@ -548,7 +548,7 @@ impl SsmService {
             resp["NextToken"] = json!((next_token_offset + max_results).to_string());
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     // -----------------------------------------------------------------------
@@ -559,7 +559,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let baseline_id = body["BaselineId"]
             .as_str()
             .ok_or_else(|| missing("BaselineId"))?;
@@ -631,65 +631,65 @@ impl SsmService {
             resp["GlobalFilters"] = gf.clone();
         }
 
-        Ok(json_resp(resp))
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn describe_instance_patch_states(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 10, 100)?;
         let _instance_ids = body["InstanceIds"]
             .as_array()
             .ok_or_else(|| missing("InstanceIds"))?;
         // Return empty - no real instances in emulator
-        Ok(json_resp(json!({ "InstancePatchStates": [] })))
+        Ok(AwsResponse::ok_json(json!({ "InstancePatchStates": [] })))
     }
 
     pub(super) fn describe_instance_patch_states_for_patch_group(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("PatchGroup", body["PatchGroup"].as_str(), 1, 256)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 10, 100)?;
         let _patch_group = body["PatchGroup"]
             .as_str()
             .ok_or_else(|| missing("PatchGroup"))?;
-        Ok(json_resp(json!({ "InstancePatchStates": [] })))
+        Ok(AwsResponse::ok_json(json!({ "InstancePatchStates": [] })))
     }
 
     pub(super) fn describe_instance_patches(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 10, 100)?;
         let _instance_id = body["InstanceId"]
             .as_str()
             .ok_or_else(|| missing("InstanceId"))?;
-        Ok(json_resp(json!({ "Patches": [] })))
+        Ok(AwsResponse::ok_json(json!({ "Patches": [] })))
     }
 
     pub(super) fn describe_effective_patches_for_patch_baseline(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("BaselineId", body["BaselineId"].as_str(), 20, 128)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 100)?;
         let _baseline_id = body["BaselineId"]
             .as_str()
             .ok_or_else(|| missing("BaselineId"))?;
-        Ok(json_resp(json!({ "EffectivePatches": [] })))
+        Ok(AwsResponse::ok_json(json!({ "EffectivePatches": [] })))
     }
 
     pub(super) fn get_deployable_patch_snapshot_for_instance(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SnapshotId", body["SnapshotId"].as_str(), 36, 36)?;
         let instance_id = body["InstanceId"]
             .as_str()
@@ -698,7 +698,7 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("SnapshotId"))?;
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "InstanceId": instance_id,
             "SnapshotId": snapshot_id,
             "Product": "{}",
@@ -712,12 +712,12 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("PatchGroup", body["PatchGroup"].as_str(), 1, 256)?;
         let _patch_group = body["PatchGroup"]
             .as_str()
             .ok_or_else(|| missing("PatchGroup"))?;
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "Instances": 0,
             "InstancesWithInstalledPatches": 0,
             "InstancesWithInstalledOtherPatches": 0,
@@ -737,7 +737,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("OperatingSystem", &body["OperatingSystem"])?;
         validate_optional_enum(
             "OperatingSystem",
@@ -779,14 +779,14 @@ impl SsmService {
             &["OS", "APPLICATION"],
         )?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        Ok(json_resp(json!({ "Properties": [] })))
+        Ok(AwsResponse::ok_json(json!({ "Properties": [] })))
     }
 
     pub(super) fn get_default_patch_baseline(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_enum(
             "OperatingSystem",
             body["OperatingSystem"].as_str(),
@@ -814,7 +814,7 @@ impl SsmService {
 
         // Check if a custom default has been registered
         if let Some(ref baseline_id) = state.default_patch_baseline_id {
-            return Ok(json_resp(json!({
+            return Ok(AwsResponse::ok_json(json!({
                 "BaselineId": baseline_id,
                 "OperatingSystem": operating_system,
             })));
@@ -823,7 +823,7 @@ impl SsmService {
         // Otherwise look up from defaults
         let baseline_id =
             default_patch_baseline(&state.region, operating_system).unwrap_or_default();
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "BaselineId": baseline_id,
             "OperatingSystem": operating_system,
         })))
@@ -833,7 +833,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let baseline_id = body["BaselineId"]
             .as_str()
             .ok_or_else(|| missing("BaselineId"))?
@@ -853,7 +853,7 @@ impl SsmService {
         }
 
         state.default_patch_baseline_id = Some(baseline_id.clone());
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "BaselineId": baseline_id,
         })))
     }
@@ -862,9 +862,9 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 100)?;
-        Ok(json_resp(json!({ "Patches": [] })))
+        Ok(AwsResponse::ok_json(json!({ "Patches": [] })))
     }
 }
 

--- a/crates/fakecloud-ssm/src/service/resource_sync.rs
+++ b/crates/fakecloud-ssm/src/service/resource_sync.rs
@@ -7,14 +7,14 @@ use fakecloud_core::validation::*;
 
 use crate::state::ResourceDataSync;
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn create_resource_data_sync(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SyncName", body["SyncName"].as_str(), 1, 64)?;
         let sync_name = body["SyncName"]
             .as_str()
@@ -44,14 +44,14 @@ impl SsmService {
         };
         state.resource_data_syncs.insert(sync_name, sync);
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn delete_resource_data_sync(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SyncName", body["SyncName"].as_str(), 1, 64)?;
         let sync_name = body["SyncName"]
             .as_str()
@@ -66,14 +66,14 @@ impl SsmService {
             ));
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn list_resource_data_sync(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SyncType", body["SyncType"].as_str(), 1, 64)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let state = self.state.read();
@@ -107,14 +107,16 @@ impl SsmService {
                 v
             })
             .collect();
-        Ok(json_resp(json!({ "ResourceDataSyncItems": syncs })))
+        Ok(AwsResponse::ok_json(
+            json!({ "ResourceDataSyncItems": syncs }),
+        ))
     }
 
     pub(super) fn update_resource_data_sync(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let sync_name = body["SyncName"]
             .as_str()
             .ok_or_else(|| missing("SyncName"))?;
@@ -140,7 +142,7 @@ impl SsmService {
         sync.sync_source = Some(sync_source);
         sync.sync_last_modified_time = Utc::now();
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     // ── GetOpsSummary ─────────────────────────────────────────────

--- a/crates/fakecloud-ssm/src/service/sessions.rs
+++ b/crates/fakecloud-ssm/src/service/sessions.rs
@@ -7,11 +7,11 @@ use fakecloud_core::validation::*;
 
 use crate::state::SsmSession;
 
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn start_session(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("Target", body["Target"].as_str(), 1, 400)?;
         validate_optional_string_length("Reason", body["Reason"].as_str(), 1, 256)?;
         let target = body["Target"]
@@ -37,7 +37,7 @@ impl SsmService {
         };
         state.sessions.insert(session_id.clone(), session);
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "SessionId": session_id,
             "TokenValue": format!("token-{session_id}"),
             "StreamUrl": format!("wss://ssm.us-east-1.amazonaws.com/session/{session_id}"),
@@ -45,7 +45,7 @@ impl SsmService {
     }
 
     pub(super) fn resume_session(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let session_id = body["SessionId"]
             .as_str()
             .ok_or_else(|| missing("SessionId"))?;
@@ -59,7 +59,7 @@ impl SsmService {
             )
         })?;
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "SessionId": session.session_id,
             "TokenValue": format!("token-{}", session.session_id),
             "StreamUrl": format!("wss://ssm.us-east-1.amazonaws.com/session/{}", session.session_id),
@@ -70,7 +70,7 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("SessionId", body["SessionId"].as_str(), 1, 96)?;
         let session_id = body["SessionId"]
             .as_str()
@@ -83,14 +83,14 @@ impl SsmService {
         }
         // AWS TerminateSession doesn't error on non-existent sessions
 
-        Ok(json_resp(json!({ "SessionId": session_id })))
+        Ok(AwsResponse::ok_json(json!({ "SessionId": session_id })))
     }
 
     pub(super) fn describe_sessions(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_enum("State", body["State"].as_str(), &["Active", "History"])?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 200)?;
         let state_filter = body["State"].as_str().ok_or_else(|| missing("State"))?;
@@ -122,14 +122,14 @@ impl SsmService {
             })
             .collect();
 
-        Ok(json_resp(json!({ "Sessions": sessions })))
+        Ok(AwsResponse::ok_json(json!({ "Sessions": sessions })))
     }
 
     pub(super) fn start_access_request(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_optional_string_length("Reason", body["Reason"].as_str(), 1, 256)?;
         let _reason = body["Reason"].as_str().ok_or_else(|| missing("Reason"))?;
         let _targets = body["Targets"]
@@ -140,19 +140,21 @@ impl SsmService {
         state.session_counter += 1;
         let access_request_id = format!("ar-{:012x}", state.session_counter);
 
-        Ok(json_resp(json!({ "AccessRequestId": access_request_id })))
+        Ok(AwsResponse::ok_json(
+            json!({ "AccessRequestId": access_request_id }),
+        ))
     }
 
     pub(super) fn get_access_token(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let _access_request_id = body["AccessRequestId"]
             .as_str()
             .ok_or_else(|| missing("AccessRequestId"))?;
 
-        Ok(json_resp(json!({
+        Ok(AwsResponse::ok_json(json!({
             "AccessRequestStatus": "Approved",
             "Credentials": {
                 "AccessKeyId": "AKIAIOSFODNN7EXAMPLE",

--- a/crates/fakecloud-ssm/src/service/tags.rs
+++ b/crates/fakecloud-ssm/src/service/tags.rs
@@ -5,14 +5,14 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
 use super::parameters::{lookup_param, lookup_param_mut};
-use super::{json_resp, missing, parse_body, SsmService};
+use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn add_tags_to_resource(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let resource_type = body["ResourceType"].as_str().unwrap_or("Parameter");
         let resource_id = body["ResourceId"]
             .as_str()
@@ -81,14 +81,14 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn remove_tags_from_resource(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         validate_required("ResourceType", &body["ResourceType"])?;
         let resource_type = body["ResourceType"].as_str().unwrap_or("Parameter");
         let resource_id = body["ResourceId"]
@@ -160,14 +160,14 @@ impl SsmService {
             }
         }
 
-        Ok(json_resp(json!({})))
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     pub(super) fn list_tags_for_resource(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = parse_body(req);
+        let body = req.json_body();
         let resource_type = body["ResourceType"].as_str().unwrap_or("Parameter");
         let resource_id = body["ResourceId"]
             .as_str()
@@ -235,7 +235,7 @@ impl SsmService {
             ka.cmp(kb)
         });
 
-        Ok(json_resp(json!({ "TagList": tags })))
+        Ok(AwsResponse::ok_json(json!({ "TagList": tags })))
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `AwsRequest::json_body()` and `AwsResponse::ok_json()` methods to fakecloud-core
- Replace local `parse_body()`/`json_resp()`/`body_json()`/`json_response()` definitions across 8 service crates
- SecretManager: replaced 23 inline `serde_json::from_slice` + 26 inline `AwsResponse::json(StatusCode::OK, ...)` calls
- Skipped: SES/DynamoDB `parse_body()` (return Result with service-specific errors), SQS `parse_body()` (query protocol fallback)

## Test plan

- [x] All 528 workspace unit tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted shared JSON body parsing and OK JSON response helpers into `fakecloud-core` and replaced duplicate helpers across services to simplify code and standardize behavior.

- **Refactors**
  - Added `AwsRequest::json_body()` and `AwsResponse::ok_json()` in `fakecloud-core`.
  - Swapped local helpers in `fakecloud-eventbridge`, `fakecloud-kms`, `fakecloud-logs`, `fakecloud-secretsmanager`, `fakecloud-ssm`, and JSON paths in `fakecloud-sqs`.
  - Kept service-specific parsing in `fakecloud-dynamodb` (error mapping) and SQS query protocol; SES unchanged.
  - Standardized invalid JSON to return `serde_json::Value::Null` via `json_body()`.

<sup>Written for commit 6c91a80e22f50616aa6c985e7b27535059d66d55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

