### PR TITLE
fix(conformance): add missing parameter_version to UnlabelParameterVersion test

### DIFF
--- a/crates/fakecloud-conformance/tests/ssm.rs
+++ b/crates/fakecloud-conformance/tests/ssm.rs
@@ -250,6 +250,7 @@ async fn ssm_label_unlabel_parameter_version() {
     client
         .unlabel_parameter_version()
         .name("/conf/label")
+        .parameter_version(1)
         .labels("prod")
         .send()
         .await


### PR DESCRIPTION
## Summary
- The handwritten conformance test for `UnlabelParameterVersion` was calling the API without `ParameterVersion`, which started failing after 16a05e5 correctly added required field validation matching the Smithy model.
- Adds `.parameter_version(1)` to the test call.

## Test plan
- [x] `cargo test -p fakecloud-conformance --test ssm -- ssm_label_unlabel_parameter_version` passes locally
- [ ] Conformance CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SSM conformance test by adding the required ParameterVersion to the UnlabelParameterVersion call. Uses `.parameter_version(1)` to match the Smithy model validation and stop the test from failing.

<sup>Written for commit 4f3e96f465017bf81bb5a40f6de3f4d8101a9bf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

