### PR TITLE
feat: SES v2 event fanout (SNS/EventBridge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,6 +1759,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ fakecloud is now listening at `http://localhost:4566`.
 | **CloudWatch Logs** | 113 | Groups, streams, filtering, deliveries, transformers, query language, anomaly detection |
 | **KMS** | 53 | Encryption, key management, aliases, grants, real ECDH and key import |
 | **CloudFormation** | 8 | Template parsing, resource provisioning, custom resources via Lambda |
-| **SES v2** | 97 | Identities, templates, configuration sets, contact lists, contacts, send email, tagging, suppression list, event destinations, identity policies, DKIM/feedback/mail-from attributes, config set options, custom verification email templates, template rendering, dedicated IP pools & IPs, multi-region endpoints, account settings, import/export jobs, tenants, reputation entities, metrics |
+| **SES v2** | 97 | Identities, templates, configuration sets, contact lists, contacts, send email, tagging, suppression list, event destinations, identity policies, DKIM/feedback/mail-from attributes, config set options, custom verification email templates, template rendering, dedicated IP pools & IPs, multi-region endpoints, account settings, import/export jobs, tenants, reputation entities, metrics, event fanout (SNS/EventBridge), mailbox simulator |
 
 ### Cross-Service Integration
 
@@ -125,6 +125,7 @@ integration tests:
 - **S3 -> SNS/SQS/Lambda**: Bucket notifications on object create/delete
 - **SQS -> Lambda**: Event source mapping polls and invokes
 - **SecretsManager -> Lambda**: Rotation invokes Lambda for all 4 steps
+- **SES -> SNS/EventBridge**: Email event fanout (send, delivery, bounce, complaint) via configured event destinations
 - **CloudFormation -> Lambda**: Custom resources invoke via ServiceToken
 - **S3 Lifecycle**: Background expiration and storage class transitions
 - **EventBridge Scheduler**: Cron and rate-based rules fire on schedule

--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -11,6 +11,8 @@ pub struct DeliveryBus {
     sqs_sender: Option<Arc<dyn SqsDelivery>>,
     /// Publish a message to an SNS topic by ARN.
     sns_sender: Option<Arc<dyn SnsDelivery>>,
+    /// Put an event onto an EventBridge bus.
+    eventbridge_sender: Option<Arc<dyn EventBridgeDelivery>>,
     /// Invoke a Lambda function by ARN.
     lambda_invoker: Option<Arc<dyn LambdaDelivery>>,
 }
@@ -52,6 +54,13 @@ pub trait SnsDelivery: Send + Sync {
     fn publish_to_topic(&self, topic_arn: &str, message: &str, subject: Option<&str>);
 }
 
+/// Trait for putting events onto an EventBridge bus from cross-service integrations.
+pub trait EventBridgeDelivery: Send + Sync {
+    /// Put an event onto the specified event bus.
+    /// The implementation should handle rule matching and target delivery.
+    fn put_event(&self, source: &str, detail_type: &str, detail: &str, event_bus_name: &str);
+}
+
 /// Trait for invoking Lambda functions from cross-service integrations.
 pub trait LambdaDelivery: Send + Sync {
     /// Invoke a Lambda function with the given payload.
@@ -68,6 +77,7 @@ impl DeliveryBus {
         Self {
             sqs_sender: None,
             sns_sender: None,
+            eventbridge_sender: None,
             lambda_invoker: None,
         }
     }
@@ -79,6 +89,11 @@ impl DeliveryBus {
 
     pub fn with_sns(mut self, sender: Arc<dyn SnsDelivery>) -> Self {
         self.sns_sender = Some(sender);
+        self
+    }
+
+    pub fn with_eventbridge(mut self, sender: Arc<dyn EventBridgeDelivery>) -> Self {
+        self.eventbridge_sender = Some(sender);
         self
     }
 
@@ -123,6 +138,19 @@ impl DeliveryBus {
     pub fn publish_to_sns(&self, topic_arn: &str, message: &str, subject: Option<&str>) {
         if let Some(ref sender) = self.sns_sender {
             sender.publish_to_topic(topic_arn, message, subject);
+        }
+    }
+
+    /// Put an event onto an EventBridge bus.
+    pub fn put_event_to_eventbridge(
+        &self,
+        source: &str,
+        detail_type: &str,
+        detail: &str,
+        event_bus_name: &str,
+    ) {
+        if let Some(ref sender) = self.eventbridge_sender {
+            sender.put_event(source, detail_type, detail, event_bus_name);
         }
     }
 

--- a/crates/fakecloud-e2e/tests/ses.rs
+++ b/crates/fakecloud-e2e/tests/ses.rs
@@ -3,12 +3,12 @@ mod helpers;
 use aws_sdk_sesv2::types::{
     BatchGetMetricDataQuery, BehaviorOnMxFailure, Body, Content, DataFormat, Destination,
     DkimSigningAttributes, DkimSigningAttributesOrigin, EmailContent, EmailTemplateContent,
-    EventDestinationDefinition, EventType, ExportDataSource, ExportDestination, ExportMetric,
-    FeatureStatus, HttpsPolicy, ImportDataSource, ImportDestination, MailType, Message, Metric,
-    MetricDimensionName, MetricNamespace, MetricsDataSource, RawMessage, ReputationEntityType,
-    RouteDetails, ScalingMode, SendingStatus, SnsDestination, SubscriptionStatus,
-    SuppressionListDestination, SuppressionListImportAction, SuppressionListReason, Tag, Template,
-    TlsPolicy, Topic, TopicPreference, VdmAttributes,
+    EventBridgeDestination, EventDestinationDefinition, EventType, ExportDataSource,
+    ExportDestination, ExportMetric, FeatureStatus, HttpsPolicy, ImportDataSource,
+    ImportDestination, MailType, Message, Metric, MetricDimensionName, MetricNamespace,
+    MetricsDataSource, RawMessage, ReputationEntityType, RouteDetails, ScalingMode, SendingStatus,
+    SnsDestination, SubscriptionStatus, SuppressionListDestination, SuppressionListImportAction,
+    SuppressionListReason, Tag, Template, TlsPolicy, Topic, TopicPreference, VdmAttributes,
 };
 use helpers::TestServer;
 
@@ -2257,4 +2257,494 @@ async fn ses_batch_get_metric_data() {
     assert_eq!(resp.results().len(), 1);
     assert_eq!(resp.results()[0].id().unwrap(), "q1");
     assert!(resp.errors().is_empty());
+}
+
+// ── Event Fanout Tests ──────────────────────────────────────────────────
+
+/// Send an email with an SNS event destination → verify the SNS topic
+/// received the event notification by subscribing an SQS queue and
+/// checking messages.
+#[tokio::test]
+async fn ses_event_fanout_sns_destination() {
+    let server = TestServer::start().await;
+    let ses = server.sesv2_client().await;
+    let sns = server.sns_client().await;
+    let sqs = server.sqs_client().await;
+
+    // 1. Create SNS topic
+    let topic = sns.create_topic().name("ses-events").send().await.unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    // 2. Create SQS queue and subscribe it to the SNS topic
+    let queue = sqs
+        .create_queue()
+        .queue_name("ses-event-sink")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let queue_attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = queue_attrs
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&queue_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // 3. Create config set + SNS event destination
+    ses.create_configuration_set()
+        .configuration_set_name("fanout-test")
+        .send()
+        .await
+        .unwrap();
+
+    ses.create_configuration_set_event_destination()
+        .configuration_set_name("fanout-test")
+        .event_destination_name("sns-dest")
+        .event_destination(
+            EventDestinationDefinition::builder()
+                .enabled(true)
+                .matching_event_types(EventType::Send)
+                .matching_event_types(EventType::Delivery)
+                .sns_destination(
+                    SnsDestination::builder()
+                        .topic_arn(&topic_arn)
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // 4. Create identity + send email with ConfigurationSetName
+    ses.create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    ses.send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("recipient@example.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Test fanout").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Hello!").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .configuration_set_name("fanout-test")
+        .send()
+        .await
+        .unwrap();
+
+    // 5. Receive messages from SQS — should have at least 2 (Send + Delivery)
+    // Give a tiny delay for delivery
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let msgs = sqs
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+
+    // We expect 2 messages: one for Send, one for Delivery
+    assert!(
+        msgs.messages().len() >= 2,
+        "Expected at least 2 SNS notifications (Send + Delivery), got {}",
+        msgs.messages().len()
+    );
+
+    // Parse SNS envelopes and check the event payloads
+    let mut event_types: Vec<String> = Vec::new();
+    for msg in msgs.messages() {
+        let envelope: serde_json::Value = serde_json::from_str(msg.body().unwrap()).unwrap();
+        let inner: serde_json::Value =
+            serde_json::from_str(envelope["Message"].as_str().unwrap()).unwrap();
+        event_types.push(inner["eventType"].as_str().unwrap().to_string());
+        // Verify mail metadata
+        assert_eq!(inner["mail"]["source"], "sender@example.com");
+        assert!(inner["mail"]["messageId"].is_string());
+    }
+    event_types.sort();
+    assert!(event_types.contains(&"Delivery".to_string()));
+    assert!(event_types.contains(&"Send".to_string()));
+}
+
+/// Send to bounce@simulator.amazonses.com → verify Bounce event is
+/// published to configured SNS topic.
+#[tokio::test]
+async fn ses_event_fanout_bounce_simulator() {
+    let server = TestServer::start().await;
+    let ses = server.sesv2_client().await;
+    let sns = server.sns_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Set up SNS topic + SQS subscriber
+    let topic = sns
+        .create_topic()
+        .name("ses-bounce-events")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    let queue = sqs
+        .create_queue()
+        .queue_name("ses-bounce-sink")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let queue_attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = queue_attrs
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&queue_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Config set with BOUNCE event type
+    ses.create_configuration_set()
+        .configuration_set_name("bounce-test")
+        .send()
+        .await
+        .unwrap();
+
+    ses.create_configuration_set_event_destination()
+        .configuration_set_name("bounce-test")
+        .event_destination_name("bounce-sns")
+        .event_destination(
+            EventDestinationDefinition::builder()
+                .enabled(true)
+                .matching_event_types(EventType::Send)
+                .matching_event_types(EventType::Bounce)
+                .sns_destination(
+                    SnsDestination::builder()
+                        .topic_arn(&topic_arn)
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    ses.create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    // Send to bounce simulator address
+    ses.send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("bounce@simulator.amazonses.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Bounce test").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Will bounce").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .configuration_set_name("bounce-test")
+        .send()
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let msgs = sqs
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+
+    // Should have Send + Bounce events
+    assert!(
+        msgs.messages().len() >= 2,
+        "Expected at least 2 messages (Send + Bounce), got {}",
+        msgs.messages().len()
+    );
+
+    let mut event_types: Vec<String> = Vec::new();
+    for msg in msgs.messages() {
+        let envelope: serde_json::Value = serde_json::from_str(msg.body().unwrap()).unwrap();
+        let inner: serde_json::Value =
+            serde_json::from_str(envelope["Message"].as_str().unwrap()).unwrap();
+        event_types.push(inner["eventType"].as_str().unwrap().to_string());
+    }
+    assert!(event_types.contains(&"Bounce".to_string()));
+    assert!(event_types.contains(&"Send".to_string()));
+
+    // Verify the bounce event has correct structure
+    for msg in msgs.messages() {
+        let envelope: serde_json::Value = serde_json::from_str(msg.body().unwrap()).unwrap();
+        let inner: serde_json::Value =
+            serde_json::from_str(envelope["Message"].as_str().unwrap()).unwrap();
+        if inner["eventType"] == "Bounce" {
+            assert_eq!(inner["bounce"]["bounceType"], "Permanent");
+            assert!(inner["bounce"]["bouncedRecipients"].is_array());
+        }
+    }
+}
+
+/// Send to suppressionlist@simulator → verify address gets added to
+/// suppression list, then sending to it again generates a Bounce.
+#[tokio::test]
+async fn ses_event_fanout_suppression_list_simulator() {
+    let server = TestServer::start().await;
+    let ses = server.sesv2_client().await;
+
+    ses.create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    ses.create_configuration_set()
+        .configuration_set_name("suppress-test")
+        .send()
+        .await
+        .unwrap();
+
+    // No event destination needed — we just verify the suppression list behavior
+
+    // Send to suppressionlist simulator
+    ses.send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("suppressionlist@simulator.amazonses.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Suppress test").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Will suppress").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .configuration_set_name("suppress-test")
+        .send()
+        .await
+        .unwrap();
+
+    // Verify the address was added to suppression list
+    let suppressed = ses
+        .get_suppressed_destination()
+        .email_address("suppressionlist@simulator.amazonses.com")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        suppressed.suppressed_destination().unwrap().reason(),
+        &SuppressionListReason::Bounce
+    );
+}
+
+/// EventBridge destination: verify events land on the default event bus.
+#[tokio::test]
+async fn ses_event_fanout_eventbridge_destination() {
+    let server = TestServer::start().await;
+    let ses = server.sesv2_client().await;
+    let eb = server.eventbridge_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create SQS queue for EventBridge target
+    let queue = sqs
+        .create_queue()
+        .queue_name("ses-eb-sink")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let queue_attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = queue_attrs
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+
+    // Create EventBridge rule matching aws.ses events on default bus
+    eb.put_rule()
+        .name("ses-events-rule")
+        .event_bus_name("default")
+        .event_pattern(r#"{"source":["aws.ses"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    eb.put_targets()
+        .rule("ses-events-rule")
+        .event_bus_name("default")
+        .targets(
+            aws_sdk_eventbridge::types::Target::builder()
+                .id("sqs-target")
+                .arn(&queue_arn)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Create SES config set with EventBridge destination
+    ses.create_configuration_set()
+        .configuration_set_name("eb-fanout-test")
+        .send()
+        .await
+        .unwrap();
+
+    ses.create_configuration_set_event_destination()
+        .configuration_set_name("eb-fanout-test")
+        .event_destination_name("eb-dest")
+        .event_destination(
+            EventDestinationDefinition::builder()
+                .enabled(true)
+                .matching_event_types(EventType::Send)
+                .matching_event_types(EventType::Delivery)
+                .event_bridge_destination(
+                    EventBridgeDestination::builder()
+                        .event_bus_arn("arn:aws:events:us-east-1:123456789012:event-bus/default")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    ses.create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    // Send email
+    ses.send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("recipient@example.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("EB fanout").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Hello via EB").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .configuration_set_name("eb-fanout-test")
+        .send()
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Check SQS for EventBridge-delivered events
+    let msgs = sqs
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(
+        msgs.messages().len() >= 2,
+        "Expected at least 2 EventBridge->SQS messages, got {}",
+        msgs.messages().len()
+    );
+
+    // Verify the event structure
+    for msg in msgs.messages() {
+        let event: serde_json::Value = serde_json::from_str(msg.body().unwrap()).unwrap();
+        assert_eq!(event["source"], "aws.ses");
+        assert_eq!(event["detail-type"], "SES Email Sending");
+        // detail is already a JSON object in the EventBridge event envelope
+        let detail = &event["detail"];
+        assert!(detail["eventType"].is_string());
+        assert_eq!(detail["mail"]["source"], "sender@example.com");
+    }
 }

--- a/crates/fakecloud-eventbridge/src/delivery.rs
+++ b/crates/fakecloud-eventbridge/src/delivery.rs
@@ -1,0 +1,98 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use fakecloud_core::delivery::{DeliveryBus, EventBridgeDelivery};
+
+use crate::service::matches_pattern;
+use crate::state::{PutEvent, SharedEventBridgeState};
+
+/// Implements EventBridgeDelivery so other services (SES) can put events
+/// on an EventBridge bus with full rule matching and target delivery.
+pub struct EventBridgeDeliveryImpl {
+    state: SharedEventBridgeState,
+    delivery: Arc<DeliveryBus>,
+}
+
+impl EventBridgeDeliveryImpl {
+    pub fn new(state: SharedEventBridgeState, delivery: Arc<DeliveryBus>) -> Self {
+        Self { state, delivery }
+    }
+}
+
+impl EventBridgeDelivery for EventBridgeDeliveryImpl {
+    fn put_event(&self, source: &str, detail_type: &str, detail: &str, event_bus_name: &str) {
+        let event_id = uuid::Uuid::new_v4().to_string();
+        let now = Utc::now();
+
+        let event = PutEvent {
+            event_id: event_id.clone(),
+            source: source.to_string(),
+            detail_type: detail_type.to_string(),
+            detail: detail.to_string(),
+            event_bus_name: event_bus_name.to_string(),
+            time: now,
+            resources: Vec::new(),
+        };
+
+        let mut state = self.state.write();
+        state.events.push(event);
+
+        // Find matching rules and their targets
+        let account_id = state.account_id.clone();
+        let region = state.region.clone();
+        let matching_targets: Vec<_> = state
+            .rules
+            .values()
+            .filter(|r| {
+                r.event_bus_name == event_bus_name
+                    && r.state == "ENABLED"
+                    && matches_pattern(
+                        r.event_pattern.as_deref(),
+                        source,
+                        detail_type,
+                        detail,
+                        &account_id,
+                        &region,
+                        &[],
+                    )
+            })
+            .flat_map(|r| r.targets.clone())
+            .collect();
+
+        // Drop the lock before delivering
+        drop(state);
+
+        if matching_targets.is_empty() {
+            return;
+        }
+
+        // Build the EventBridge event envelope
+        let detail_value: serde_json::Value =
+            serde_json::from_str(detail).unwrap_or(serde_json::json!({}));
+        let event_json = serde_json::json!({
+            "version": "0",
+            "id": event_id,
+            "source": source,
+            "account": account_id,
+            "detail-type": detail_type,
+            "detail": detail_value,
+            "time": now.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            "region": region,
+            "resources": [],
+        });
+        let event_str = event_json.to_string();
+
+        for target in matching_targets {
+            let arn = &target.arn;
+            if arn.contains(":sqs:") {
+                self.delivery.send_to_sqs(arn, &event_str, &HashMap::new());
+            } else if arn.contains(":sns:") {
+                self.delivery
+                    .publish_to_sns(arn, &event_str, Some(detail_type));
+            }
+            // Lambda and other targets could be added here
+        }
+    }
+}

--- a/crates/fakecloud-eventbridge/src/lib.rs
+++ b/crates/fakecloud-eventbridge/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod delivery;
 pub mod scheduler;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -3540,7 +3540,7 @@ fn build_auth_params_response(auth_type: &str, params: &Value) -> Value {
 // ─── Event Pattern Matching ─────────────────────────────────────────
 
 /// Match an event against an EventBridge event pattern.
-fn matches_pattern(
+pub fn matches_pattern(
     pattern_json: Option<&str>,
     source: &str,
     detail_type: &str,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -168,6 +168,7 @@ async fn main() {
     );
 
     // Step 3: S3 delivery (S3 notifications can push to SQS, SNS, and Lambda)
+    let sns_delivery_for_ses = sns_delivery.clone();
     let delivery_for_s3 = {
         let mut bus = DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())
@@ -179,6 +180,7 @@ async fn main() {
     };
 
     // Step 4: Logs delivery (subscription filters can push to SQS)
+    let sqs_delivery_for_ses = sqs_delivery.clone();
     let delivery_for_logs = Arc::new(DeliveryBus::new().with_sqs(sqs_delivery));
 
     // Clone state refs for internal endpoints
@@ -237,6 +239,7 @@ async fn main() {
     registry.register(Arc::new(eb_service));
 
     // Spawn the EventBridge scheduler as a background task
+    let eb_state_for_ses = eb_state.clone();
     let mut scheduler = fakecloud_eventbridge::scheduler::Scheduler::new(eb_state, delivery_for_eb)
         .with_lambda(lambda_state.clone())
         .with_logs(logs_state.clone());
@@ -273,7 +276,25 @@ async fn main() {
     registry.register(Arc::new(
         S3Service::new(s3_state.clone(), delivery_for_s3).with_kms(kms_state),
     ));
-    registry.register(Arc::new(SesV2Service::new(ses_state)));
+    // SES delivery bus (event fanout to SNS topics and EventBridge buses)
+    let eb_delivery_for_ses = Arc::new(
+        fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
+            eb_state_for_ses,
+            Arc::new(DeliveryBus::new().with_sqs(sqs_delivery_for_ses)),
+        ),
+    );
+    let delivery_for_ses = Arc::new(
+        DeliveryBus::new()
+            .with_sns(sns_delivery_for_ses)
+            .with_eventbridge(eb_delivery_for_ses),
+    );
+    let ses_delivery_ctx = fakecloud_ses::fanout::SesDeliveryContext {
+        ses_state: ses_state.clone(),
+        delivery_bus: delivery_for_ses,
+    };
+    registry.register(Arc::new(
+        SesV2Service::new(ses_state).with_delivery(ses_delivery_ctx),
+    ));
 
     // Spawn background tasks
     let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state);

--- a/crates/fakecloud-ses/Cargo.toml
+++ b/crates/fakecloud-ses/Cargo.toml
@@ -18,6 +18,7 @@ parking_lot = { workspace = true }
 percent-encoding = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -1,0 +1,450 @@
+//! SES event fanout: publishes send/delivery/bounce/complaint events
+//! to configured event destinations (SNS topics, EventBridge buses).
+
+use chrono::Utc;
+use serde_json::json;
+use std::sync::Arc;
+
+use fakecloud_core::delivery::DeliveryBus;
+
+use crate::state::{EventDestination, SentEmail, SharedSesState, SuppressedDestination};
+
+/// Shared references needed for cross-service event delivery.
+#[derive(Clone)]
+pub struct SesDeliveryContext {
+    pub ses_state: SharedSesState,
+    pub delivery_bus: Arc<DeliveryBus>,
+}
+
+/// Mailbox simulator addresses.
+const BOUNCE_ADDR: &str = "bounce@simulator.amazonses.com";
+const COMPLAINT_ADDR: &str = "complaint@simulator.amazonses.com";
+#[cfg(test)]
+const SUCCESS_ADDR: &str = "success@simulator.amazonses.com";
+const SUPPRESSION_ADDR: &str = "suppressionlist@simulator.amazonses.com";
+
+/// The event types we generate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SesEventType {
+    Send,
+    Delivery,
+    Bounce,
+    Complaint,
+}
+
+impl SesEventType {
+    fn as_str(self) -> &'static str {
+        match self {
+            SesEventType::Send => "SEND",
+            SesEventType::Delivery => "DELIVERY",
+            SesEventType::Bounce => "BOUNCE",
+            SesEventType::Complaint => "COMPLAINT",
+        }
+    }
+
+    fn event_type_name(self) -> &'static str {
+        match self {
+            SesEventType::Send => "Send",
+            SesEventType::Delivery => "Delivery",
+            SesEventType::Bounce => "Bounce",
+            SesEventType::Complaint => "Complaint",
+        }
+    }
+}
+
+/// Build the SES event JSON payload matching the AWS notification format.
+pub fn build_ses_event(event_type: SesEventType, email: &SentEmail) -> serde_json::Value {
+    let mut event = json!({
+        "eventType": event_type.event_type_name(),
+        "mail": {
+            "messageId": email.message_id,
+            "source": email.from,
+            "destination": email.to,
+            "timestamp": email.timestamp.to_rfc3339(),
+        },
+    });
+
+    // Add event-type-specific detail blocks
+    match event_type {
+        SesEventType::Send => {
+            event["send"] = json!({});
+        }
+        SesEventType::Delivery => {
+            event["delivery"] = json!({
+                "timestamp": Utc::now().to_rfc3339(),
+                "recipients": email.to,
+                "processingTimeMillis": 42,
+                "smtpResponse": "250 2.0.0 Ok",
+            });
+        }
+        SesEventType::Bounce => {
+            let bounced: Vec<serde_json::Value> = email
+                .to
+                .iter()
+                .map(|addr| {
+                    json!({
+                        "emailAddress": addr,
+                        "action": "failed",
+                        "status": "5.1.1",
+                        "diagnosticCode": "smtp; 550 5.1.1 user unknown",
+                    })
+                })
+                .collect();
+            event["bounce"] = json!({
+                "bounceType": "Permanent",
+                "bounceSubType": "General",
+                "bouncedRecipients": bounced,
+                "timestamp": Utc::now().to_rfc3339(),
+            });
+        }
+        SesEventType::Complaint => {
+            let complained: Vec<serde_json::Value> = email
+                .to
+                .iter()
+                .map(|addr| json!({ "emailAddress": addr }))
+                .collect();
+            event["complaint"] = json!({
+                "complainedRecipients": complained,
+                "complaintFeedbackType": "abuse",
+                "timestamp": Utc::now().to_rfc3339(),
+            });
+        }
+    }
+
+    event
+}
+
+/// Determine which event types to generate based on recipient addresses.
+/// Returns the list of event types to emit and whether to add to suppression list.
+pub fn classify_recipients(recipients: &[String]) -> (Vec<SesEventType>, bool) {
+    let mut events = Vec::new();
+    let mut suppress = false;
+
+    // Check for simulator addresses in any recipient
+    let has_bounce = recipients.iter().any(|r| r == BOUNCE_ADDR);
+    let has_complaint = recipients.iter().any(|r| r == COMPLAINT_ADDR);
+    let has_suppression = recipients.iter().any(|r| r == SUPPRESSION_ADDR);
+    // success@simulator is the default behavior, no special handling needed
+
+    if has_bounce {
+        events.push(SesEventType::Send);
+        events.push(SesEventType::Bounce);
+    } else if has_complaint {
+        events.push(SesEventType::Send);
+        events.push(SesEventType::Delivery);
+        events.push(SesEventType::Complaint);
+    } else if has_suppression {
+        events.push(SesEventType::Send);
+        events.push(SesEventType::Bounce);
+        suppress = true;
+    } else {
+        // Normal send or success@simulator
+        events.push(SesEventType::Send);
+        events.push(SesEventType::Delivery);
+    }
+
+    (events, suppress)
+}
+
+/// Check if any recipient is on the suppression list.
+/// Returns the suppressed address if found.
+pub fn check_suppression_list(ses_state: &SharedSesState, recipients: &[String]) -> Option<String> {
+    let state = ses_state.read();
+    for addr in recipients {
+        if state.suppressed_destinations.contains_key(addr) {
+            return Some(addr.clone());
+        }
+    }
+    None
+}
+
+/// Resolve the configuration set name for an email send.
+/// Checks the explicit request param first, then the identity's default.
+pub fn resolve_config_set(
+    ses_state: &SharedSesState,
+    explicit_config_set: Option<&str>,
+    from_address: &str,
+) -> Option<String> {
+    if let Some(name) = explicit_config_set {
+        return Some(name.to_string());
+    }
+
+    // Check identity's default configuration set
+    let state = ses_state.read();
+    if let Some(identity) = state.identities.get(from_address) {
+        return identity.configuration_set_name.clone();
+    }
+    // Also check domain identity
+    if let Some(at_pos) = from_address.find('@') {
+        let domain = &from_address[at_pos + 1..];
+        if let Some(identity) = state.identities.get(domain) {
+            return identity.configuration_set_name.clone();
+        }
+    }
+    None
+}
+
+/// Get enabled event destinations for a configuration set that match the given event type.
+fn get_matching_destinations(
+    ses_state: &SharedSesState,
+    config_set_name: &str,
+    event_type: SesEventType,
+) -> Vec<EventDestination> {
+    let state = ses_state.read();
+    let event_type_str = event_type.as_str();
+
+    state
+        .event_destinations
+        .get(config_set_name)
+        .map(|dests| {
+            dests
+                .iter()
+                .filter(|d| d.enabled && d.matching_event_types.iter().any(|t| t == event_type_str))
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Fan out a single event to all matching destinations.
+fn deliver_event(
+    ctx: &SesDeliveryContext,
+    event: &serde_json::Value,
+    event_type: SesEventType,
+    config_set_name: &str,
+) {
+    let destinations = get_matching_destinations(&ctx.ses_state, config_set_name, event_type);
+
+    for dest in destinations {
+        // SNS destination
+        if let Some(ref sns_dest) = dest.sns_destination {
+            if let Some(topic_arn) = sns_dest["TopicArn"].as_str() {
+                let message = event.to_string();
+                tracing::info!(
+                    topic_arn = %topic_arn,
+                    event_type = ?event_type,
+                    "SES event fanout -> SNS"
+                );
+                ctx.delivery_bus.publish_to_sns(
+                    topic_arn,
+                    &message,
+                    Some("Amazon SES Email Event"),
+                );
+            }
+        }
+
+        // EventBridge destination
+        if dest.event_bridge_destination.is_some() {
+            let detail = event.to_string();
+            tracing::info!(
+                event_type = ?event_type,
+                "SES event fanout -> EventBridge"
+            );
+            ctx.delivery_bus.put_event_to_eventbridge(
+                "aws.ses",
+                "SES Email Sending",
+                &detail,
+                "default",
+            );
+        }
+    }
+}
+
+/// Process event fanout for a sent email.
+///
+/// This is the main entry point called from SendEmail / SendBulkEmail.
+/// It:
+/// 1. Checks the suppression list (returns true if suppressed → caller should bounce)
+/// 2. Classifies recipients for mailbox simulator behavior
+/// 3. Generates appropriate events
+/// 4. Fans out to configured destinations
+///
+/// Returns `true` if the email was suppressed (caller should handle accordingly).
+pub fn process_send_events(
+    ctx: &SesDeliveryContext,
+    email: &SentEmail,
+    config_set_name: Option<&str>,
+) -> bool {
+    let config_set = match resolve_config_set(&ctx.ses_state, config_set_name, &email.from) {
+        Some(cs) => cs,
+        None => return false, // No config set, no event destinations to fan out to
+    };
+
+    // Check suppression list
+    if let Some(suppressed_addr) = check_suppression_list(&ctx.ses_state, &email.to) {
+        tracing::info!(
+            address = %suppressed_addr,
+            "SES: recipient is on suppression list, generating bounce"
+        );
+        let bounce_event = build_ses_event(SesEventType::Bounce, email);
+        deliver_event(ctx, &bounce_event, SesEventType::Bounce, &config_set);
+        return true;
+    }
+
+    // Classify recipients for simulator behavior
+    let (event_types, add_to_suppression) = classify_recipients(&email.to);
+
+    // Handle suppression list addition
+    if add_to_suppression {
+        let mut state = ctx.ses_state.write();
+        for addr in &email.to {
+            if addr == SUPPRESSION_ADDR {
+                state.suppressed_destinations.insert(
+                    addr.clone(),
+                    SuppressedDestination {
+                        email_address: addr.clone(),
+                        reason: "BOUNCE".to_string(),
+                        last_update_time: Utc::now(),
+                    },
+                );
+            }
+        }
+    }
+
+    // Generate and deliver events
+    for event_type in event_types {
+        let event = build_ses_event(event_type, email);
+        deliver_event(ctx, &event, event_type, &config_set);
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_normal_recipients() {
+        let (events, suppress) = classify_recipients(&["user@example.com".to_string()]);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0], SesEventType::Send);
+        assert_eq!(events[1], SesEventType::Delivery);
+        assert!(!suppress);
+    }
+
+    #[test]
+    fn classify_bounce_simulator() {
+        let (events, suppress) = classify_recipients(&[BOUNCE_ADDR.to_string()]);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0], SesEventType::Send);
+        assert_eq!(events[1], SesEventType::Bounce);
+        assert!(!suppress);
+    }
+
+    #[test]
+    fn classify_complaint_simulator() {
+        let (events, suppress) = classify_recipients(&[COMPLAINT_ADDR.to_string()]);
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0], SesEventType::Send);
+        assert_eq!(events[1], SesEventType::Delivery);
+        assert_eq!(events[2], SesEventType::Complaint);
+        assert!(!suppress);
+    }
+
+    #[test]
+    fn classify_suppression_simulator() {
+        let (events, suppress) = classify_recipients(&[SUPPRESSION_ADDR.to_string()]);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0], SesEventType::Send);
+        assert_eq!(events[1], SesEventType::Bounce);
+        assert!(suppress);
+    }
+
+    #[test]
+    fn classify_success_simulator() {
+        let (events, suppress) = classify_recipients(&[SUCCESS_ADDR.to_string()]);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0], SesEventType::Send);
+        assert_eq!(events[1], SesEventType::Delivery);
+        assert!(!suppress);
+    }
+
+    #[test]
+    fn build_send_event_format() {
+        let email = SentEmail {
+            message_id: "test-msg-id".to_string(),
+            from: "sender@example.com".to_string(),
+            to: vec!["recipient@example.com".to_string()],
+            cc: vec![],
+            bcc: vec![],
+            subject: Some("Hello".to_string()),
+            html_body: None,
+            text_body: None,
+            raw_data: None,
+            template_name: None,
+            template_data: None,
+            timestamp: Utc::now(),
+        };
+        let event = build_ses_event(SesEventType::Send, &email);
+        assert_eq!(event["eventType"], "Send");
+        assert_eq!(event["mail"]["messageId"], "test-msg-id");
+        assert_eq!(event["mail"]["source"], "sender@example.com");
+        assert!(event["send"].is_object());
+    }
+
+    #[test]
+    fn build_bounce_event_format() {
+        let email = SentEmail {
+            message_id: "bounce-msg".to_string(),
+            from: "sender@example.com".to_string(),
+            to: vec!["bounce@simulator.amazonses.com".to_string()],
+            cc: vec![],
+            bcc: vec![],
+            subject: None,
+            html_body: None,
+            text_body: None,
+            raw_data: None,
+            template_name: None,
+            template_data: None,
+            timestamp: Utc::now(),
+        };
+        let event = build_ses_event(SesEventType::Bounce, &email);
+        assert_eq!(event["eventType"], "Bounce");
+        assert_eq!(event["bounce"]["bounceType"], "Permanent");
+        assert!(event["bounce"]["bouncedRecipients"].is_array());
+    }
+
+    #[test]
+    fn build_delivery_event_format() {
+        let email = SentEmail {
+            message_id: "deliver-msg".to_string(),
+            from: "sender@example.com".to_string(),
+            to: vec!["user@example.com".to_string()],
+            cc: vec![],
+            bcc: vec![],
+            subject: None,
+            html_body: None,
+            text_body: None,
+            raw_data: None,
+            template_name: None,
+            template_data: None,
+            timestamp: Utc::now(),
+        };
+        let event = build_ses_event(SesEventType::Delivery, &email);
+        assert_eq!(event["eventType"], "Delivery");
+        assert!(event["delivery"]["timestamp"].is_string());
+        assert_eq!(event["delivery"]["smtpResponse"], "250 2.0.0 Ok");
+    }
+
+    #[test]
+    fn build_complaint_event_format() {
+        let email = SentEmail {
+            message_id: "complaint-msg".to_string(),
+            from: "sender@example.com".to_string(),
+            to: vec!["complaint@simulator.amazonses.com".to_string()],
+            cc: vec![],
+            bcc: vec![],
+            subject: None,
+            html_body: None,
+            text_body: None,
+            raw_data: None,
+            template_name: None,
+            template_data: None,
+            timestamp: Utc::now(),
+        };
+        let event = build_ses_event(SesEventType::Complaint, &email);
+        assert_eq!(event["eventType"], "Complaint");
+        assert_eq!(event["complaint"]["complaintFeedbackType"], "abuse");
+    }
+}

--- a/crates/fakecloud-ses/src/lib.rs
+++ b/crates/fakecloud-ses/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod fanout;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-ses/src/service.rs
+++ b/crates/fakecloud-ses/src/service.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
+use crate::fanout::SesDeliveryContext;
 use crate::state::{
     AccountDetails, ConfigurationSet, Contact, ContactList, CustomVerificationEmailTemplate,
     DedicatedIp, DedicatedIpPool, EmailIdentity, EmailTemplate, EventDestination, ExportJob,
@@ -15,11 +16,21 @@ use crate::state::{
 
 pub struct SesV2Service {
     state: SharedSesState,
+    delivery_ctx: Option<SesDeliveryContext>,
 }
 
 impl SesV2Service {
     pub fn new(state: SharedSesState) -> Self {
-        Self { state }
+        Self {
+            state,
+            delivery_ctx: None,
+        }
+    }
+
+    /// Attach a delivery context for cross-service event fanout.
+    pub fn with_delivery(mut self, ctx: SesDeliveryContext) -> Self {
+        self.delivery_ctx = Some(ctx);
+        self
     }
 
     /// Determine the action from the HTTP method and path segments.
@@ -1090,6 +1101,8 @@ impl SesV2Service {
         let cc = extract_string_array(&body["Destination"]["CcAddresses"]);
         let bcc = extract_string_array(&body["Destination"]["BccAddresses"]);
 
+        let config_set_name = body["ConfigurationSetName"].as_str().map(|s| s.to_string());
+
         let (subject, html_body, text_body, raw_data, template_name, template_data) =
             if body["Content"]["Simple"].is_object() {
                 let simple = &body["Content"]["Simple"];
@@ -1131,6 +1144,11 @@ impl SesV2Service {
             template_data,
             timestamp: Utc::now(),
         };
+
+        // Event fanout: check suppression list, generate events, deliver to destinations
+        if let Some(ref ctx) = self.delivery_ctx {
+            crate::fanout::process_send_events(ctx, &sent, config_set_name.as_deref());
+        }
 
         self.state.write().sent_emails.push(sent);
 
@@ -2809,6 +2827,7 @@ impl SesV2Service {
         let body: Value = Self::parse_body(req)?;
 
         let from = body["FromEmailAddress"].as_str().unwrap_or("").to_string();
+        let config_set_name = body["ConfigurationSetName"].as_str().map(|s| s.to_string());
 
         let entries = match body["BulkEmailEntries"].as_array() {
             Some(arr) if !arr.is_empty() => arr.clone(),
@@ -2853,6 +2872,11 @@ impl SesV2Service {
                 template_data,
                 timestamp: Utc::now(),
             };
+
+            // Event fanout for each bulk entry
+            if let Some(ref ctx) = self.delivery_ctx {
+                crate::fanout::process_send_events(ctx, &sent, config_set_name.as_deref());
+            }
 
             self.state.write().sent_emails.push(sent);
 


### PR DESCRIPTION
## Summary

- Wire SendEmail/SendBulkEmail to publish simulated events (Send, Delivery, Bounce, Complaint) through configured event destinations
- SNS destinations: publish event payloads to configured SNS topics
- EventBridge destinations: inject events onto the default event bus with full rule matching and target delivery
- Mailbox simulator: bounce@, complaint@, success@, suppressionlist@simulator.amazonses.com addresses generate appropriate event types
- Suppression list enforcement: sending to a suppressed address generates a Bounce event

## Implementation details

- New `EventBridgeDelivery` trait in fakecloud-core for cross-service event injection
- `EventBridgeDeliveryImpl` in fakecloud-eventbridge handles rule matching and delivery to SQS/SNS targets
- SES `fanout` module with event generation, recipient classification, and delivery logic
- SES service wired with a `DeliveryBus` that has both SNS and EventBridge delivery

## Test plan

- [x] Unit tests: event classification (normal, bounce, complaint, suppression, success simulator)
- [x] Unit tests: event payload format (Send, Delivery, Bounce, Complaint)
- [x] E2E test: SNS event destination receives Send + Delivery events via SQS subscriber
- [x] E2E test: bounce simulator generates Bounce event delivered to SNS
- [x] E2E test: suppression list simulator adds address to suppression list
- [x] E2E test: EventBridge destination delivers events via rule-matched SQS target
- [x] All existing tests pass (cargo clippy, cargo fmt, cargo test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SES v2 event fanout to SNS and EventBridge. SendEmail/SendBulkEmail now emit Send, Delivery, Bounce, and Complaint events via configuration set destinations.

- **New Features**
  - SES publishes events to SNS topics and to EventBridge (default bus) with full rule matching and delivery to SQS/SNS targets.
  - Mailbox simulator: bounce@, complaint@, success@, suppressionlist@simulator.amazonses.com trigger the expected events; suppressionlist also adds the address to the suppression list.
  - Configuration set resolution supports explicit request value or identity default.
  - Core wiring: new `EventBridgeDelivery` trait in `fakecloud-core`, `EventBridgeDeliveryImpl` in `fakecloud-eventbridge`, and `DeliveryBus` gains EventBridge support. Server wires SES with a bus that delivers to SNS and EventBridge.

- **Dependencies**
  - Add `tracing` to `fakecloud-ses`.

<sup>Written for commit 3b10aa06a2733790fc675bdd177b19587309cc45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

