### PR TITLE
fix(cognito): validate pool ID in admin challenge and ExplicitAuthFlows in admin auth

### DIFF
--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -1355,6 +1355,26 @@ impl CognitoService {
             ));
         }
 
+        // Validate ExplicitAuthFlows allows this auth flow
+        let allowed = match auth_flow {
+            "ADMIN_NO_SRP_AUTH" => client
+                .explicit_auth_flows
+                .iter()
+                .any(|f| f == "ADMIN_NO_SRP_AUTH" || f == "ALLOW_ADMIN_USER_PASSWORD_AUTH"),
+            "ADMIN_USER_PASSWORD_AUTH" => client
+                .explicit_auth_flows
+                .iter()
+                .any(|f| f == "ADMIN_USER_PASSWORD_AUTH" || f == "ALLOW_ADMIN_USER_PASSWORD_AUTH"),
+            _ => false,
+        };
+        if !allowed {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "Client is not allowed for this auth flow.",
+            ));
+        }
+
         // Validate user exists and is enabled
         let user = state
             .users
@@ -1680,10 +1700,25 @@ impl CognitoService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
 
-        let _pool_id = require_str(&body, "UserPoolId")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
         let client_id = require_str(&body, "ClientId")?;
         let challenge_name = require_str(&body, "ChallengeName")?;
         let session = require_str(&body, "Session")?;
+
+        // Validate session's pool ID matches the provided one
+        {
+            let state = self.state.read();
+            if let Some(session_data) = state.sessions.get(session) {
+                if session_data.user_pool_id != pool_id {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "NotAuthorizedException",
+                        "Invalid session.",
+                    ));
+                }
+            }
+            // If session doesn't exist, handle_auth_challenge_response will return the error
+        }
 
         self.handle_auth_challenge_response(client_id, challenge_name, session, &body)
     }


### PR DESCRIPTION
## Summary

Addresses 2 Cubic review issues from PR #155:

- **AdminRespondToAuthChallenge**: validate that provided UserPoolId matches the session's pool ID (was silently discarded as `_pool_id`)
- **AdminInitiateAuth**: validate that client's ExplicitAuthFlows includes the requested admin auth flow (ADMIN_NO_SRP_AUTH / ALLOW_ADMIN_USER_PASSWORD_AUTH)

## Test plan

- [x] `cargo test -p fakecloud-cognito` — 29 unit tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens admin auth checks in `fakecloud-cognito` by validating client `ExplicitAuthFlows` and enforcing user pool ID matching for challenge responses. Blocks invalid or cross-pool admin auth with clear errors.

- **Bug Fixes**
  - AdminInitiateAuth: reject flows not allowed by the client’s `ExplicitAuthFlows` (supports `ADMIN_NO_SRP_AUTH`, `ADMIN_USER_PASSWORD_AUTH`, and `ALLOW_ADMIN_USER_PASSWORD_AUTH`) with `InvalidParameterException`.
  - AdminRespondToAuthChallenge: reject when the session’s pool ID doesn’t match the provided `UserPoolId` with `NotAuthorizedException`.

<sup>Written for commit 7ccdb14c284cff413e02ca5889cd6ed548bd93b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

