### PR TITLE
feat: simulation endpoints for DynamoDB TTL and SecretsManager rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,21 @@ curl http://localhost:4566/_fakecloud/health
 }
 ```
 
+## Simulation Endpoints
+
+fakecloud exposes `/_fakecloud/*` endpoints for testing behaviors that AWS runs asynchronously (TTL expiration, scheduled rotation, etc.). Call these to advance time-dependent processes on demand.
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/_fakecloud/dynamodb/ttl-processor/tick` | POST | Expire DynamoDB items whose TTL attribute is in the past. Returns `{"expiredItems": N}`. |
+| `/_fakecloud/secretsmanager/rotation-scheduler/tick` | POST | Rotate secrets whose rotation schedule is due. Returns `{"rotatedSecrets": ["name", ...]}`. |
+| `/_fakecloud/lambda/invocations` | GET | List all Lambda invocations (introspection). |
+| `/_fakecloud/sns/messages` | GET | List all published SNS messages. |
+| `/_fakecloud/sqs/messages` | GET | List all SQS messages across queues. |
+| `/_fakecloud/events/history` | GET | List all EventBridge events and deliveries. |
+| `/_fakecloud/s3/notifications` | GET | List all S3 notification events. |
+| `/_fakecloud/ses/emails` | GET | List all sent SES emails. |
+
 ## Architecture
 
 fakecloud is organized as a Cargo workspace:

--- a/crates/fakecloud-dynamodb/src/lib.rs
+++ b/crates/fakecloud-dynamodb/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod service;
 pub mod state;
+pub mod ttl;

--- a/crates/fakecloud-dynamodb/src/ttl.rs
+++ b/crates/fakecloud-dynamodb/src/ttl.rs
@@ -1,0 +1,248 @@
+use crate::state::SharedDynamoDbState;
+
+/// Process TTL expirations across all tables.
+///
+/// Iterates every table with TTL enabled, checks each item for the configured
+/// TTL attribute, and deletes items whose TTL value (epoch seconds as a Number)
+/// is less than the current time.
+///
+/// Returns the total number of expired (deleted) items.
+pub fn process_ttl_expirations(state: &SharedDynamoDbState) -> usize {
+    let now = chrono::Utc::now().timestamp();
+    process_ttl_expirations_at(state, now)
+}
+
+/// Same as [`process_ttl_expirations`] but accepts an explicit "now" timestamp,
+/// making it easy to test without time manipulation.
+pub fn process_ttl_expirations_at(state: &SharedDynamoDbState, now_epoch: i64) -> usize {
+    let mut total_expired = 0;
+    let mut state = state.write();
+
+    for table in state.tables.values_mut() {
+        if !table.ttl_enabled {
+            continue;
+        }
+
+        let ttl_attr = match &table.ttl_attribute {
+            Some(attr) => attr.clone(),
+            None => continue,
+        };
+
+        let before = table.items.len();
+        table.items.retain(|item| {
+            let av = match item.get(&ttl_attr) {
+                Some(v) => v,
+                None => return true, // no TTL attribute → keep
+            };
+
+            // TTL attribute must be a Number ({"N": "..."})
+            let epoch = match av.as_object().and_then(|obj| obj.get("N")) {
+                Some(n) => match n.as_str().and_then(|s| s.parse::<i64>().ok()) {
+                    Some(v) => v,
+                    None => return true, // non-numeric → keep
+                },
+                None => return true, // not a Number type → keep
+            };
+
+            // Keep if TTL is in the future (or exactly now)
+            epoch >= now_epoch
+        });
+        let removed = before - table.items.len();
+        if removed > 0 {
+            table.recalculate_stats();
+        }
+        total_expired += removed;
+    }
+
+    total_expired
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::*;
+    use parking_lot::RwLock;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn make_state() -> SharedDynamoDbState {
+        Arc::new(RwLock::new(DynamoDbState::new("123456789012", "us-east-1")))
+    }
+
+    fn make_table(name: &str, ttl_enabled: bool, ttl_attribute: Option<&str>) -> DynamoTable {
+        DynamoTable {
+            name: name.to_string(),
+            arn: format!("arn:aws:dynamodb:us-east-1:123456789012:table/{}", name),
+            key_schema: vec![KeySchemaElement {
+                attribute_name: "pk".to_string(),
+                key_type: "HASH".to_string(),
+            }],
+            attribute_definitions: vec![AttributeDefinition {
+                attribute_name: "pk".to_string(),
+                attribute_type: "S".to_string(),
+            }],
+            provisioned_throughput: ProvisionedThroughput {
+                read_capacity_units: 5,
+                write_capacity_units: 5,
+            },
+            items: vec![],
+            gsi: vec![],
+            lsi: vec![],
+            tags: HashMap::new(),
+            created_at: chrono::Utc::now(),
+            status: "ACTIVE".to_string(),
+            item_count: 0,
+            size_bytes: 0,
+            billing_mode: "PROVISIONED".to_string(),
+            ttl_attribute: ttl_attribute.map(|s| s.to_string()),
+            ttl_enabled,
+            resource_policy: None,
+            pitr_enabled: false,
+            kinesis_destinations: vec![],
+            contributor_insights_status: "DISABLED".to_string(),
+            contributor_insights_counters: HashMap::new(),
+        }
+    }
+
+    fn make_item(
+        pk: &str,
+        ttl_val: Option<serde_json::Value>,
+    ) -> HashMap<String, serde_json::Value> {
+        let mut item = HashMap::new();
+        item.insert("pk".to_string(), json!({"S": pk}));
+        if let Some(ttl) = ttl_val {
+            item.insert("ttl".to_string(), ttl);
+        }
+        item
+    }
+
+    #[test]
+    fn expired_item_is_deleted() {
+        let state = make_state();
+        let now = 1_000_000;
+
+        let mut table = make_table("t1", true, Some("ttl"));
+        // Item with TTL in the past
+        table
+            .items
+            .push(make_item("a", Some(json!({"N": "999999"}))));
+        state.write().tables.insert("t1".to_string(), table);
+
+        let count = process_ttl_expirations_at(&state, now);
+        assert_eq!(count, 1);
+        assert_eq!(state.read().tables["t1"].items.len(), 0);
+    }
+
+    #[test]
+    fn future_item_is_kept() {
+        let state = make_state();
+        let now = 1_000_000;
+
+        let mut table = make_table("t1", true, Some("ttl"));
+        // Item with TTL in the future
+        table
+            .items
+            .push(make_item("a", Some(json!({"N": "2000000"}))));
+        state.write().tables.insert("t1".to_string(), table);
+
+        let count = process_ttl_expirations_at(&state, now);
+        assert_eq!(count, 0);
+        assert_eq!(state.read().tables["t1"].items.len(), 1);
+    }
+
+    #[test]
+    fn ttl_disabled_table_untouched() {
+        let state = make_state();
+        let now = 1_000_000;
+
+        let mut table = make_table("t1", false, Some("ttl"));
+        table
+            .items
+            .push(make_item("a", Some(json!({"N": "999999"}))));
+        state.write().tables.insert("t1".to_string(), table);
+
+        let count = process_ttl_expirations_at(&state, now);
+        assert_eq!(count, 0);
+        assert_eq!(state.read().tables["t1"].items.len(), 1);
+    }
+
+    #[test]
+    fn item_without_ttl_attribute_kept() {
+        let state = make_state();
+        let now = 1_000_000;
+
+        let mut table = make_table("t1", true, Some("ttl"));
+        // Item without the TTL attribute at all
+        table.items.push(make_item("a", None));
+        state.write().tables.insert("t1".to_string(), table);
+
+        let count = process_ttl_expirations_at(&state, now);
+        assert_eq!(count, 0);
+        assert_eq!(state.read().tables["t1"].items.len(), 1);
+    }
+
+    #[test]
+    fn non_numeric_ttl_attribute_kept() {
+        let state = make_state();
+        let now = 1_000_000;
+
+        let mut table = make_table("t1", true, Some("ttl"));
+        // TTL attribute is a String, not a Number
+        table
+            .items
+            .push(make_item("a", Some(json!({"S": "not-a-number"}))));
+        state.write().tables.insert("t1".to_string(), table);
+
+        let count = process_ttl_expirations_at(&state, now);
+        assert_eq!(count, 0);
+        assert_eq!(state.read().tables["t1"].items.len(), 1);
+    }
+
+    #[test]
+    fn mixed_items_only_expired_deleted() {
+        let state = make_state();
+        let now = 1_000_000;
+
+        let mut table = make_table("t1", true, Some("ttl"));
+        table
+            .items
+            .push(make_item("expired1", Some(json!({"N": "500000"}))));
+        table
+            .items
+            .push(make_item("future1", Some(json!({"N": "2000000"}))));
+        table
+            .items
+            .push(make_item("expired2", Some(json!({"N": "999999"}))));
+        table.items.push(make_item("no-ttl", None));
+        table
+            .items
+            .push(make_item("string-ttl", Some(json!({"S": "oops"}))));
+        state.write().tables.insert("t1".to_string(), table);
+
+        let count = process_ttl_expirations_at(&state, now);
+        assert_eq!(count, 2);
+        assert_eq!(state.read().tables["t1"].items.len(), 3);
+    }
+
+    #[test]
+    fn stats_recalculated_after_expiration() {
+        let state = make_state();
+        let now = 1_000_000;
+
+        let mut table = make_table("t1", true, Some("ttl"));
+        table
+            .items
+            .push(make_item("a", Some(json!({"N": "500000"}))));
+        table
+            .items
+            .push(make_item("b", Some(json!({"N": "2000000"}))));
+        table.item_count = 2;
+        table.size_bytes = 100;
+        state.write().tables.insert("t1".to_string(), table);
+
+        process_ttl_expirations_at(&state, now);
+        let s = state.read();
+        assert_eq!(s.tables["t1"].item_count, 1);
+    }
+}

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -2253,3 +2253,139 @@ async fn dynamodb_gsi_query_pagination() {
         "GSI pagination should return all items without duplicates"
     );
 }
+
+/// TTL processor simulation: expired items are deleted, future items remain.
+#[tokio::test]
+async fn dynamodb_ttl_processor_tick() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    // Create table
+    client
+        .create_table()
+        .table_name("TtlTickTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Enable TTL on "ttl" attribute
+    client
+        .update_time_to_live()
+        .table_name("TtlTickTable")
+        .time_to_live_specification(
+            TimeToLiveSpecification::builder()
+                .attribute_name("ttl")
+                .enabled(true)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Put item with TTL far in the past (epoch 0)
+    client
+        .put_item()
+        .table_name("TtlTickTable")
+        .item("pk", AttributeValue::S("expired".to_string()))
+        .item("ttl", AttributeValue::N("0".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    // Put item with TTL far in the future (year ~2100)
+    client
+        .put_item()
+        .table_name("TtlTickTable")
+        .item("pk", AttributeValue::S("future".to_string()))
+        .item("ttl", AttributeValue::N("4102444800".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    // Put item without TTL attribute
+    client
+        .put_item()
+        .table_name("TtlTickTable")
+        .item("pk", AttributeValue::S("no-ttl".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    // Call the TTL processor tick endpoint
+    let http = reqwest::Client::new();
+    let resp = http
+        .post(format!(
+            "{}/_fakecloud/dynamodb/ttl-processor/tick",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["expiredItems"], 1,
+        "one expired item should be deleted"
+    );
+
+    // Verify the expired item is gone
+    let resp = client
+        .get_item()
+        .table_name("TtlTickTable")
+        .key("pk", AttributeValue::S("expired".to_string()))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.item().is_none(), "expired item should be deleted");
+
+    // Verify the future item still exists
+    let resp = client
+        .get_item()
+        .table_name("TtlTickTable")
+        .key("pk", AttributeValue::S("future".to_string()))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.item().is_some(), "future item should still exist");
+
+    // Verify the no-ttl item still exists
+    let resp = client
+        .get_item()
+        .table_name("TtlTickTable")
+        .key("pk", AttributeValue::S("no-ttl".to_string()))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.item().is_some(),
+        "item without TTL attribute should still exist"
+    );
+
+    // Second tick should find nothing to expire
+    let resp = http
+        .post(format!(
+            "{}/_fakecloud/dynamodb/ttl-processor/tick",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["expiredItems"], 0, "no more items to expire");
+}

--- a/crates/fakecloud-e2e/tests/secretsmanager.rs
+++ b/crates/fakecloud-e2e/tests/secretsmanager.rs
@@ -489,3 +489,68 @@ async fn secretsmanager_put_get_resource_policy() {
         .unwrap();
     assert!(resp.resource_policy().is_none());
 }
+
+/// Rotation scheduler simulation: secrets with due rotation are rotated.
+#[tokio::test]
+async fn secretsmanager_rotation_scheduler_tick() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+
+    // Create a secret
+    client
+        .create_secret()
+        .name("rotate-test")
+        .secret_string("original-value")
+        .send()
+        .await
+        .unwrap();
+
+    // Enable rotation with a 1-day interval (no Lambda ARN → simple rotation)
+    client
+        .rotate_secret()
+        .secret_id("rotate-test")
+        .rotation_rules(
+            aws_sdk_secretsmanager::types::RotationRulesType::builder()
+                .automatically_after_days(1)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // At this point last_rotated_at is "now", so a tick should NOT rotate again
+    let http = reqwest::Client::new();
+    let resp = http
+        .post(format!(
+            "{}/_fakecloud/secretsmanager/rotation-scheduler/tick",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let rotated = body["rotatedSecrets"].as_array().unwrap();
+    assert!(
+        rotated.is_empty(),
+        "rotation just happened, should not be due yet"
+    );
+
+    // Verify the response shape is correct
+    assert!(body.get("rotatedSecrets").is_some());
+    assert!(body["rotatedSecrets"].is_array());
+
+    // Verify describe shows rotation is enabled
+    let desc = client
+        .describe_secret()
+        .secret_id("rotate-test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desc.rotation_enabled(), Some(true));
+    assert!(desc.rotation_rules().is_some());
+    assert_eq!(
+        desc.rotation_rules().unwrap().automatically_after_days(),
+        Some(1)
+    );
+}

--- a/crates/fakecloud-secretsmanager/src/lib.rs
+++ b/crates/fakecloud-secretsmanager/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod rotation;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-secretsmanager/src/rotation.rs
+++ b/crates/fakecloud-secretsmanager/src/rotation.rs
@@ -1,0 +1,300 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use fakecloud_core::delivery::DeliveryBus;
+
+use crate::state::{SecretVersion, SharedSecretsManagerState};
+
+/// Check all secrets for due rotations and trigger them.
+///
+/// For each secret with `rotation_enabled == true`, checks whether
+/// `last_rotated_at + rotation_days <= now`. If so, performs the same
+/// rotation logic as `RotateSecret`: creates an AWSPENDING version and
+/// invokes the rotation Lambda through all four steps.
+///
+/// Returns the list of secret names that were rotated.
+pub async fn check_and_rotate(
+    state: &SharedSecretsManagerState,
+    delivery_bus: Option<&Arc<DeliveryBus>>,
+) -> Vec<String> {
+    let now = Utc::now();
+    let mut rotated = Vec::new();
+
+    // Collect secrets that need rotation while holding the lock briefly.
+    let due_secrets: Vec<DueSecret> = {
+        let state = state.read();
+        state
+            .secrets
+            .values()
+            .filter_map(|secret| {
+                if secret.deleted {
+                    return None;
+                }
+                if secret.rotation_enabled != Some(true) {
+                    return None;
+                }
+                let rules = secret.rotation_rules.as_ref()?;
+                let days = rules.automatically_after_days?;
+                let last = secret.last_rotated_at?;
+                let due_at = last + chrono::Duration::days(days);
+                if now < due_at {
+                    return None;
+                }
+                Some(DueSecret {
+                    name: secret.name.clone(),
+                    arn: secret.arn.clone(),
+                    lambda_arn: secret.rotation_lambda_arn.clone(),
+                })
+            })
+            .collect()
+    };
+
+    // Now perform rotation for each due secret.
+    for due in due_secrets {
+        let version_id = uuid::Uuid::new_v4().to_string();
+
+        // Mutate state: create pending version, update timestamps
+        let invocation = {
+            let mut state = state.write();
+            let secret = match state.secrets.get_mut(&due.name) {
+                Some(s) => s,
+                None => continue,
+            };
+
+            secret.last_rotated_at = Some(now);
+            secret.last_changed_at = now;
+
+            // Get current value to clone into pending version
+            let current_value = secret
+                .current_version_id
+                .as_ref()
+                .and_then(|vid| secret.versions.get(vid))
+                .cloned();
+
+            if let Some(cv) = current_value {
+                if due.lambda_arn.is_some() {
+                    // With Lambda: create AWSPENDING version
+                    let version = SecretVersion {
+                        version_id: version_id.clone(),
+                        secret_string: cv.secret_string.clone(),
+                        secret_binary: cv.secret_binary.clone(),
+                        stages: vec!["AWSPENDING".to_string()],
+                        created_at: now,
+                    };
+                    secret.versions.insert(version_id.clone(), version);
+                } else {
+                    // Without Lambda: simple rotation
+                    if let Some(old_vid) = secret.current_version_id.clone() {
+                        if let Some(old_v) = secret.versions.get_mut(&old_vid) {
+                            old_v.stages.retain(|s| s != "AWSCURRENT");
+                            if !old_v.stages.contains(&"AWSPREVIOUS".to_string()) {
+                                old_v.stages.push("AWSPREVIOUS".to_string());
+                            }
+                        }
+                    }
+                    let version = SecretVersion {
+                        version_id: version_id.clone(),
+                        secret_string: cv.secret_string.clone(),
+                        secret_binary: cv.secret_binary.clone(),
+                        stages: vec!["AWSCURRENT".to_string()],
+                        created_at: now,
+                    };
+                    secret.versions.insert(version_id.clone(), version);
+                    secret.current_version_id = Some(version_id.clone());
+                }
+            }
+
+            due.lambda_arn.as_ref().map(|arn| RotationInvocation {
+                lambda_arn: arn.clone(),
+                secret_arn: due.arn.clone(),
+                client_request_token: version_id.clone(),
+            })
+        };
+
+        // Invoke Lambda outside the lock
+        if let Some(inv) = invocation {
+            if let Some(bus) = delivery_bus {
+                for step in &["createSecret", "setSecret", "testSecret", "finishSecret"] {
+                    let payload = serde_json::json!({
+                        "SecretId": inv.secret_arn,
+                        "ClientRequestToken": inv.client_request_token,
+                        "Step": step,
+                    });
+                    let payload_str = payload.to_string();
+                    match bus.invoke_lambda(&inv.lambda_arn, &payload_str).await {
+                        Some(Ok(_)) => {}
+                        Some(Err(e)) => {
+                            tracing::warn!(
+                                step = step,
+                                error = %e,
+                                "scheduled rotation Lambda invocation failed"
+                            );
+                        }
+                        None => {
+                            tracing::warn!(
+                                lambda_arn = %inv.lambda_arn,
+                                step = step,
+                                "rotation Lambda delivery not configured; skipped"
+                            );
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        rotated.push(due.name);
+    }
+
+    rotated
+}
+
+struct DueSecret {
+    name: String,
+    arn: String,
+    lambda_arn: Option<String>,
+}
+
+struct RotationInvocation {
+    lambda_arn: String,
+    secret_arn: String,
+    client_request_token: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::*;
+    use chrono::Duration;
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn make_state() -> SharedSecretsManagerState {
+        Arc::new(RwLock::new(SecretsManagerState::new(
+            "123456789012",
+            "us-east-1",
+        )))
+    }
+
+    fn make_secret(
+        name: &str,
+        rotation_enabled: bool,
+        days: Option<i64>,
+        last_rotated_ago_days: Option<i64>,
+    ) -> Secret {
+        let now = Utc::now();
+        let last_rotated = last_rotated_ago_days.map(|d| now - Duration::days(d));
+        let version_id = "v1".to_string();
+
+        let mut versions = HashMap::new();
+        versions.insert(
+            version_id.clone(),
+            SecretVersion {
+                version_id: version_id.clone(),
+                secret_string: Some("secret-value".to_string()),
+                secret_binary: None,
+                stages: vec!["AWSCURRENT".to_string()],
+                created_at: now,
+            },
+        );
+
+        Secret {
+            name: name.to_string(),
+            arn: format!(
+                "arn:aws:secretsmanager:us-east-1:123456789012:secret:{}",
+                name
+            ),
+            description: None,
+            kms_key_id: None,
+            versions,
+            current_version_id: Some(version_id),
+            tags: vec![],
+            tags_ever_set: false,
+            deleted: false,
+            deletion_date: None,
+            created_at: now,
+            last_changed_at: now,
+            last_accessed_at: None,
+            rotation_enabled: Some(rotation_enabled),
+            rotation_lambda_arn: None, // no Lambda for unit tests
+            rotation_rules: days.map(|d| RotationRules {
+                automatically_after_days: Some(d),
+            }),
+            last_rotated_at: last_rotated,
+            resource_policy: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn rotation_due_triggers_rotation() {
+        let state = make_state();
+        // Rotation enabled, 1 day interval, last rotated 2 days ago → due
+        let secret = make_secret("due-secret", true, Some(1), Some(2));
+        state
+            .write()
+            .secrets
+            .insert("due-secret".to_string(), secret);
+
+        let rotated = check_and_rotate(&state, None).await;
+        assert_eq!(rotated, vec!["due-secret"]);
+
+        // Verify a new version was created (simple rotation without Lambda)
+        let s = state.read();
+        let secret = &s.secrets["due-secret"];
+        assert!(secret.versions.len() > 1, "new version should be created");
+    }
+
+    #[tokio::test]
+    async fn rotation_not_due_skipped() {
+        let state = make_state();
+        // Rotation enabled, 30 day interval, last rotated 1 day ago → not due
+        let secret = make_secret("not-due", true, Some(30), Some(1));
+        state.write().secrets.insert("not-due".to_string(), secret);
+
+        let rotated = check_and_rotate(&state, None).await;
+        assert!(rotated.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rotation_disabled_skipped() {
+        let state = make_state();
+        let secret = make_secret("disabled", false, Some(1), Some(2));
+        state.write().secrets.insert("disabled".to_string(), secret);
+
+        let rotated = check_and_rotate(&state, None).await;
+        assert!(rotated.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rotation_without_rules_skipped() {
+        let state = make_state();
+        let secret = make_secret("no-rules", true, None, Some(2));
+        state.write().secrets.insert("no-rules".to_string(), secret);
+
+        let rotated = check_and_rotate(&state, None).await;
+        assert!(rotated.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rotation_without_last_rotated_skipped() {
+        let state = make_state();
+        let secret = make_secret("no-last", true, Some(1), None);
+        state.write().secrets.insert("no-last".to_string(), secret);
+
+        let rotated = check_and_rotate(&state, None).await;
+        assert!(rotated.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deleted_secret_skipped() {
+        let state = make_state();
+        let mut secret = make_secret("deleted", true, Some(1), Some(2));
+        secret.deleted = true;
+        state.write().secrets.insert("deleted".to_string(), secret);
+
+        let rotated = check_and_rotate(&state, None).await;
+        assert!(rotated.is_empty());
+    }
+}

--- a/crates/fakecloud-secretsmanager/src/rotation.rs
+++ b/crates/fakecloud-secretsmanager/src/rotation.rs
@@ -55,7 +55,7 @@ pub async fn check_and_rotate(
         let version_id = uuid::Uuid::new_v4().to_string();
 
         // Mutate state: create pending version, update timestamps
-        let invocation = {
+        let (invocation, version_created) = {
             let mut state = state.write();
             let secret = match state.secrets.get_mut(&due.name) {
                 Some(s) => s,
@@ -71,6 +71,8 @@ pub async fn check_and_rotate(
                 .as_ref()
                 .and_then(|vid| secret.versions.get(vid))
                 .cloned();
+
+            let mut version_created = false;
 
             if let Some(cv) = current_value {
                 if due.lambda_arn.is_some() {
@@ -103,13 +105,20 @@ pub async fn check_and_rotate(
                     secret.versions.insert(version_id.clone(), version);
                     secret.current_version_id = Some(version_id.clone());
                 }
+                version_created = true;
             }
 
-            due.lambda_arn.as_ref().map(|arn| RotationInvocation {
-                lambda_arn: arn.clone(),
-                secret_arn: due.arn.clone(),
-                client_request_token: version_id.clone(),
-            })
+            let invocation = if version_created {
+                due.lambda_arn.as_ref().map(|arn| RotationInvocation {
+                    lambda_arn: arn.clone(),
+                    secret_arn: due.arn.clone(),
+                    client_request_token: version_id.clone(),
+                })
+            } else {
+                None
+            };
+
+            (invocation, version_created)
         };
 
         // Invoke Lambda outside the lock
@@ -144,7 +153,9 @@ pub async fn check_and_rotate(
             }
         }
 
-        rotated.push(due.name);
+        if version_created {
+            rotated.push(due.name);
+        }
     }
 
     rotated

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -195,6 +195,8 @@ async fn main() {
     let sqs_introspection_state = sqs_state.clone();
     let eb_introspection_state = eb_state.clone();
     let s3_introspection_state = s3_state.clone();
+    let dynamodb_ttl_state = dynamodb_state.clone();
+    let secretsmanager_rotation_state = secretsmanager_state.clone();
 
     // Clone state for reset endpoint before moving into services
     let reset_state = ResetState {
@@ -278,6 +280,7 @@ async fn main() {
         }
         Arc::new(bus)
     };
+    let delivery_for_rotation_scheduler = delivery_for_secretsmanager.clone();
     registry.register(Arc::new(
         SecretsManagerService::new(secretsmanager_state).with_delivery(delivery_for_secretsmanager),
     ));
@@ -598,6 +601,29 @@ async fn main() {
                         })
                         .collect();
                     axum::Json(serde_json::json!({ "notifications": notifications }))
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/dynamodb/ttl-processor/tick",
+            axum::routing::post({
+                let ds = dynamodb_ttl_state;
+                move || async move {
+                    let count = fakecloud_dynamodb::ttl::process_ttl_expirations(&ds);
+                    axum::Json(serde_json::json!({ "expiredItems": count }))
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/secretsmanager/rotation-scheduler/tick",
+            axum::routing::post({
+                let ss = secretsmanager_rotation_state;
+                let bus = delivery_for_rotation_scheduler;
+                move || async move {
+                    let rotated =
+                        fakecloud_secretsmanager::rotation::check_and_rotate(&ss, Some(&bus))
+                            .await;
+                    axum::Json(serde_json::json!({ "rotatedSecrets": rotated }))
                 }
             }),
         )


### PR DESCRIPTION
## Summary

- Add `POST /_fakecloud/dynamodb/ttl-processor/tick` endpoint that expires DynamoDB items whose TTL attribute (epoch seconds) is in the past, returning `{"expiredItems": N}`
- Add `POST /_fakecloud/secretsmanager/rotation-scheduler/tick` endpoint that triggers rotation for secrets whose schedule is due, returning `{"rotatedSecrets": ["name", ...]}`
- Both processors include thorough unit tests covering all edge cases (disabled TTL, missing attributes, non-numeric values, rotation not due, deleted secrets, etc.)
- E2E tests verify the full flow through the running server
- README updated with a new Simulation Endpoints section documenting all `/_fakecloud/*` endpoints

## Test plan

- [x] Unit tests: 7 TTL processor tests, 6 rotation scheduler tests — all pass
- [x] E2E tests: `dynamodb_ttl_processor_tick` and `secretsmanager_rotation_scheduler_tick` — both pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Full workspace unit test suite passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two simulation tick endpoints to trigger DynamoDB TTL expirations and Secrets Manager scheduled rotations for deterministic tests and faster local runs.

- **New Features**
  - POST `/_fakecloud/dynamodb/ttl-processor/tick`: expires items with past TTL; skips disabled TTL and missing/non-numeric attrs; returns `{"expiredItems": N}`.
  - POST `/_fakecloud/secretsmanager/rotation-scheduler/tick`: rotates due secrets; skips disabled, deleted, or not-due; runs Lambda steps when a rotation Lambda is set; returns `{"rotatedSecrets": ["name", ...]}`.
  - Unit + E2E tests added; README documents all `/_fakecloud/*` simulation endpoints.

- **Bug Fixes**
  - Rotation scheduler now skips Lambda steps and result reporting when no pending version is created, preventing false positives.

<sup>Written for commit 52a884fab02d8349608b6911b114d5b63a64700e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

