### PR TITLE
feat(cognito): implement password and session management operations

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -2,53 +2,33 @@
   "variants_passed": 42164,
   "total_variants": 42193,
   "per_service": {
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
+    "kms": {
+      "passed": 2196,
+      "total": 2196
     },
     "logs": {
       "passed": 3911,
       "total": 3911
     },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "events": {
+      "passed": 2108,
+      "total": 2108
+    },
     "sts": {
       "passed": 438,
       "total": 438
-    },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
     },
     "ses": {
       "passed": 2858,
       "total": 2858
     },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
     },
     "s3": {
       "passed": 3620,
@@ -58,9 +38,29 @@
       "passed": 4450,
       "total": 4479
     },
-    "events": {
-      "passed": 2108,
-      "total": 2108
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
+    },
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
     }
   }
 }

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -2393,7 +2393,6 @@ fn generate_client_id() -> String {
         .to_lowercase()
 }
 
-/// Generate a client secret: 51 base64 characters (like AWS).
 /// Generate a 6-digit confirmation code for password reset flows.
 fn generate_confirmation_code() -> String {
     // Use UUID bytes to generate a numeric code
@@ -2403,6 +2402,7 @@ fn generate_confirmation_code() -> String {
     format!("{:06}", num % 1_000_000)
 }
 
+/// Generate a client secret: 51 base64 characters (like AWS).
 fn generate_client_secret() -> String {
     use base64::Engine;
     // Generate enough random bytes via UUIDs to produce 51+ base64 chars

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -9,10 +9,10 @@ use uuid::Uuid;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
 use crate::state::{
-    default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig, EmailConfiguration,
-    InviteMessageTemplate, PasswordPolicy, PoolPolicies, RecoveryOption, RefreshTokenData,
-    SchemaAttribute, SessionData, SharedCognitoState, SmsConfiguration, StringAttributeConstraints,
-    TokenValidityUnits, User, UserAttribute, UserPool, UserPoolClient,
+    default_schema_attributes, AccessTokenData, AccountRecoverySetting, AdminCreateUserConfig,
+    EmailConfiguration, InviteMessageTemplate, PasswordPolicy, PoolPolicies, RecoveryOption,
+    RefreshTokenData, SchemaAttribute, SessionData, SharedCognitoState, SmsConfiguration,
+    StringAttributeConstraints, TokenValidityUnits, User, UserAttribute, UserPool, UserPoolClient,
 };
 
 pub struct CognitoService {
@@ -59,6 +59,12 @@ impl AwsService for CognitoService {
             "SignUp" => self.sign_up(&req),
             "ConfirmSignUp" => self.confirm_sign_up(&req),
             "AdminConfirmSignUp" => self.admin_confirm_sign_up(&req),
+            "ChangePassword" => self.change_password(&req),
+            "ForgotPassword" => self.forgot_password(&req),
+            "ConfirmForgotPassword" => self.confirm_forgot_password(&req),
+            "AdminResetUserPassword" => self.admin_reset_user_password(&req),
+            "GlobalSignOut" => self.global_sign_out(&req),
+            "AdminUserGlobalSignOut" => self.admin_user_global_sign_out(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "cognito-idp",
                 &req.action,
@@ -94,6 +100,12 @@ impl AwsService for CognitoService {
             "SignUp",
             "ConfirmSignUp",
             "AdminConfirmSignUp",
+            "ChangePassword",
+            "ForgotPassword",
+            "ConfirmForgotPassword",
+            "AdminResetUserPassword",
+            "GlobalSignOut",
+            "AdminUserGlobalSignOut",
         ]
     }
 }
@@ -835,6 +847,7 @@ impl CognitoService {
             user_last_modified_date: now,
             password: None,
             temporary_password,
+            confirmation_code: None,
         };
 
         let response = user_to_json(&user);
@@ -1450,6 +1463,17 @@ impl CognitoService {
             },
         );
 
+        // Store access token
+        state.access_tokens.insert(
+            tokens.access_token.clone(),
+            AccessTokenData {
+                user_pool_id: pool_id.to_string(),
+                username: username.to_string(),
+                client_id: client_id.to_string(),
+                issued_at: Utc::now(),
+            },
+        );
+
         Ok(AwsResponse::ok_json(json!({
             "AuthenticationResult": {
                 "AccessToken": tokens.access_token,
@@ -1592,6 +1616,16 @@ impl CognitoService {
                     },
                 );
 
+                state.access_tokens.insert(
+                    tokens.access_token.clone(),
+                    AccessTokenData {
+                        user_pool_id: pool_id.to_string(),
+                        username: username.to_string(),
+                        client_id: client_id.to_string(),
+                        issued_at: Utc::now(),
+                    },
+                );
+
                 Ok(AwsResponse::ok_json(json!({
                     "AuthenticationResult": {
                         "AccessToken": tokens.access_token,
@@ -1666,6 +1700,16 @@ impl CognitoService {
                 let sub = user.sub.clone();
                 let tokens =
                     generate_tokens(&token_pool_id, client_id, &sub, &token_username, &region);
+
+                state.access_tokens.insert(
+                    tokens.access_token.clone(),
+                    AccessTokenData {
+                        user_pool_id: token_pool_id,
+                        username: token_username,
+                        client_id: client_id.to_string(),
+                        issued_at: Utc::now(),
+                    },
+                );
 
                 Ok(AwsResponse::ok_json(json!({
                     "AuthenticationResult": {
@@ -1814,6 +1858,16 @@ impl CognitoService {
                 state.refresh_tokens.insert(
                     tokens.refresh_token.clone(),
                     RefreshTokenData {
+                        user_pool_id: pool_id.clone(),
+                        username: username.clone(),
+                        client_id: client_id.to_string(),
+                        issued_at: Utc::now(),
+                    },
+                );
+
+                state.access_tokens.insert(
+                    tokens.access_token.clone(),
+                    AccessTokenData {
                         user_pool_id: pool_id,
                         username,
                         client_id: client_id.to_string(),
@@ -1910,6 +1964,7 @@ impl CognitoService {
             user_last_modified_date: now,
             password: Some(password.to_string()),
             temporary_password: None,
+            confirmation_code: None,
         };
 
         pool_users.insert(username.to_string(), user);
@@ -1998,6 +2053,318 @@ impl CognitoService {
 
         Ok(AwsResponse::ok_json(json!({})))
     }
+
+    fn change_password(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let access_token = require_str(&body, "AccessToken")?;
+        let previous_password = require_str(&body, "PreviousPassword")?;
+        let proposed_password = require_str(&body, "ProposedPassword")?;
+
+        let mut state = self.state.write();
+
+        // Look up user from access token
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+        let pool_id = token_data.user_pool_id.clone();
+        let username = token_data.username.clone();
+
+        // Validate password against pool policy
+        let password_policy = state
+            .user_pools
+            .get(&pool_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    "User pool does not exist.",
+                )
+            })?
+            .policies
+            .password_policy
+            .clone();
+
+        let user = state
+            .users
+            .get_mut(&pool_id)
+            .and_then(|users| users.get_mut(&username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid access token.",
+                )
+            })?;
+
+        // Verify previous password
+        let password_matches = match (&user.password, &user.temporary_password) {
+            (Some(p), _) if p == previous_password => true,
+            (_, Some(tp)) if tp == previous_password => true,
+            _ => false,
+        };
+        if !password_matches {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Incorrect username or password.",
+            ));
+        }
+
+        validate_password(proposed_password, &password_policy)?;
+
+        user.password = Some(proposed_password.to_string());
+        user.temporary_password = None;
+        user.user_last_modified_date = Utc::now();
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn forgot_password(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let client_id = require_str(&body, "ClientId")?;
+        let username = require_str(&body, "Username")?;
+
+        let mut state = self.state.write();
+
+        // Find pool from client
+        let client = state.user_pool_clients.get(client_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool client {client_id} does not exist."),
+            )
+        })?;
+        let pool_id = client.user_pool_id.clone();
+
+        let user = state
+            .users
+            .get_mut(&pool_id)
+            .and_then(|users| users.get_mut(username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "UserNotFoundException",
+                    "User does not exist.",
+                )
+            })?;
+
+        let code = generate_confirmation_code();
+        user.confirmation_code = Some(code);
+
+        // Find email from user attributes for CodeDeliveryDetails
+        let email = user
+            .attributes
+            .iter()
+            .find(|a| a.name == "email")
+            .map(|a| a.value.clone());
+
+        let destination = email
+            .map(|e| {
+                // Mask email: show first char + *** + @domain
+                if let Some(at_pos) = e.find('@') {
+                    let first = &e[..1];
+                    let domain = &e[at_pos..];
+                    format!("{first}***{domain}")
+                } else {
+                    "***".to_string()
+                }
+            })
+            .unwrap_or_else(|| "***".to_string());
+
+        Ok(AwsResponse::ok_json(json!({
+            "CodeDeliveryDetails": {
+                "Destination": destination,
+                "DeliveryMedium": "EMAIL",
+                "AttributeName": "email"
+            }
+        })))
+    }
+
+    fn confirm_forgot_password(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let client_id = require_str(&body, "ClientId")?;
+        let username = require_str(&body, "Username")?;
+        let confirmation_code = require_str(&body, "ConfirmationCode")?;
+        let password = require_str(&body, "Password")?;
+
+        let mut state = self.state.write();
+
+        // Find pool from client
+        let client = state.user_pool_clients.get(client_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool client {client_id} does not exist."),
+            )
+        })?;
+        let pool_id = client.user_pool_id.clone();
+
+        // Validate password against pool policy
+        let password_policy = state
+            .user_pools
+            .get(&pool_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    "User pool does not exist.",
+                )
+            })?
+            .policies
+            .password_policy
+            .clone();
+
+        let user = state
+            .users
+            .get_mut(&pool_id)
+            .and_then(|users| users.get_mut(username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "UserNotFoundException",
+                    "User does not exist.",
+                )
+            })?;
+
+        // Validate confirmation code
+        match &user.confirmation_code {
+            Some(code) if code == confirmation_code => {}
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "CodeMismatchException",
+                    "Invalid verification code provided, please try again.",
+                ));
+            }
+        }
+
+        validate_password(password, &password_policy)?;
+
+        user.password = Some(password.to_string());
+        user.temporary_password = None;
+        user.confirmation_code = None;
+        user.user_status = "CONFIRMED".to_string();
+        user.user_last_modified_date = Utc::now();
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn admin_reset_user_password(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let username = require_str(&body, "Username")?;
+
+        let mut state = self.state.write();
+
+        // Validate pool exists
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let user = state
+            .users
+            .get_mut(pool_id)
+            .and_then(|users| users.get_mut(username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "UserNotFoundException",
+                    "User does not exist.",
+                )
+            })?;
+
+        user.user_status = "RESET_REQUIRED".to_string();
+        user.confirmation_code = Some(generate_confirmation_code());
+        user.user_last_modified_date = Utc::now();
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn global_sign_out(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let access_token = require_str(&body, "AccessToken")?;
+
+        let mut state = self.state.write();
+
+        // Look up user from access token
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+        let pool_id = token_data.user_pool_id.clone();
+        let username = token_data.username.clone();
+
+        // Invalidate all refresh tokens for this user
+        state
+            .refresh_tokens
+            .retain(|_, v| !(v.user_pool_id == pool_id && v.username == username));
+
+        // Invalidate all access tokens for this user
+        state
+            .access_tokens
+            .retain(|_, v| !(v.user_pool_id == pool_id && v.username == username));
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn admin_user_global_sign_out(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let username = require_str(&body, "Username")?;
+
+        let mut state = self.state.write();
+
+        // Validate pool exists
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        // Validate user exists
+        if !state
+            .users
+            .get(pool_id)
+            .is_some_and(|users| users.contains_key(username))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "UserNotFoundException",
+                "User does not exist.",
+            ));
+        }
+
+        // Invalidate all refresh tokens for this user
+        state
+            .refresh_tokens
+            .retain(|_, v| !(v.user_pool_id == pool_id && v.username == username));
+
+        // Invalidate all access tokens for this user
+        state
+            .access_tokens
+            .retain(|_, v| !(v.user_pool_id == pool_id && v.username == username));
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
 }
 
 /// Generate a pool ID in the format `{region}_{9 random alphanumeric chars}`.
@@ -2027,6 +2394,15 @@ fn generate_client_id() -> String {
 }
 
 /// Generate a client secret: 51 base64 characters (like AWS).
+/// Generate a 6-digit confirmation code for password reset flows.
+fn generate_confirmation_code() -> String {
+    // Use UUID bytes to generate a numeric code
+    let uuid = Uuid::new_v4();
+    let bytes = uuid.as_bytes();
+    let num = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    format!("{:06}", num % 1_000_000)
+}
+
 fn generate_client_secret() -> String {
     use base64::Engine;
     // Generate enough random bytes via UUIDs to produce 51+ base64 chars
@@ -3026,6 +3402,7 @@ mod tests {
             user_last_modified_date: Utc::now(),
             password: None,
             temporary_password: None,
+            confirmation_code: None,
         };
 
         let filter = parse_filter_expression(r#"username = "testuser""#).unwrap();
@@ -3053,6 +3430,7 @@ mod tests {
             user_last_modified_date: Utc::now(),
             password: None,
             temporary_password: None,
+            confirmation_code: None,
         };
 
         let filter = parse_filter_expression(r#"email = "test@example.com""#).unwrap();
@@ -3077,6 +3455,7 @@ mod tests {
             user_last_modified_date: Utc::now(),
             password: None,
             temporary_password: None,
+            confirmation_code: None,
         };
 
         let filter =
@@ -3323,5 +3702,62 @@ mod tests {
         assert_eq!(session.len(), 36);
         let parts: Vec<&str> = session.split('-').collect();
         assert_eq!(parts.len(), 5);
+    }
+
+    #[test]
+    fn confirmation_code_is_six_digits() {
+        for _ in 0..100 {
+            let code = generate_confirmation_code();
+            assert_eq!(code.len(), 6, "Code should be 6 chars: {code}");
+            assert!(
+                code.chars().all(|c| c.is_ascii_digit()),
+                "Code should be all digits: {code}"
+            );
+        }
+    }
+
+    #[test]
+    fn confirmation_code_uniqueness() {
+        let code1 = generate_confirmation_code();
+        // Generate many codes and check we get at least some different ones
+        let mut found_different = false;
+        for _ in 0..20 {
+            if generate_confirmation_code() != code1 {
+                found_different = true;
+                break;
+            }
+        }
+        assert!(found_different, "Codes should vary across calls");
+    }
+
+    #[test]
+    fn access_token_lookup() {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(crate::state::CognitoState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        {
+            let mut s = state.write();
+            s.access_tokens.insert(
+                "test-access-token".to_string(),
+                AccessTokenData {
+                    user_pool_id: "us-east-1_TestPool1".to_string(),
+                    username: "testuser".to_string(),
+                    client_id: "testclient123".to_string(),
+                    issued_at: Utc::now(),
+                },
+            );
+        }
+
+        let s = state.read();
+        let token_data = s.access_tokens.get("test-access-token");
+        assert!(token_data.is_some());
+        let data = token_data.unwrap();
+        assert_eq!(data.user_pool_id, "us-east-1_TestPool1");
+        assert_eq!(data.username, "testuser");
+        assert_eq!(data.client_id, "testclient123");
+
+        // Non-existent token returns None
+        assert!(!s.access_tokens.contains_key("nonexistent"));
     }
 }

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -18,6 +18,8 @@ pub struct CognitoState {
     pub refresh_tokens: HashMap<String, RefreshTokenData>,
     /// session_token -> SessionData
     pub sessions: HashMap<String, SessionData>,
+    /// access_token -> AccessTokenData
+    pub access_tokens: HashMap<String, AccessTokenData>,
 }
 
 impl CognitoState {
@@ -30,6 +32,7 @@ impl CognitoState {
             users: HashMap::new(),
             refresh_tokens: HashMap::new(),
             sessions: HashMap::new(),
+            access_tokens: HashMap::new(),
         }
     }
 
@@ -39,10 +42,18 @@ impl CognitoState {
         self.users.clear();
         self.refresh_tokens.clear();
         self.sessions.clear();
+        self.access_tokens.clear();
     }
 }
 
 pub struct RefreshTokenData {
+    pub user_pool_id: String,
+    pub username: String,
+    pub client_id: String,
+    pub issued_at: DateTime<Utc>,
+}
+
+pub struct AccessTokenData {
     pub user_pool_id: String,
     pub username: String,
     pub client_id: String,
@@ -216,6 +227,7 @@ pub struct User {
     pub user_last_modified_date: DateTime<Utc>,
     pub password: Option<String>,
     pub temporary_password: Option<String>,
+    pub confirmation_code: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -1056,3 +1056,314 @@ async fn cognito_admin_confirm_sign_up() {
         .unwrap();
     assert_eq!(user.user_status().unwrap().as_str(), "CONFIRMED");
 }
+
+// ---------------------------------------------------------------------------
+// Password & Session Management
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "ChangePassword", checksum = "037ca3c2")]
+#[tokio::test]
+async fn cognito_change_password() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("chgpwd-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("chgpwd-client")
+        .explicit_auth_flows(
+            aws_sdk_cognitoidentityprovider::types::ExplicitAuthFlowsType::AllowUserPasswordAuth,
+        )
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("chguser")
+        .send()
+        .await
+        .unwrap();
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("chguser")
+        .password("OldPass1!")
+        .permanent(true)
+        .send()
+        .await
+        .unwrap();
+
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "chguser")
+        .auth_parameters("PASSWORD", "OldPass1!")
+        .send()
+        .await
+        .unwrap();
+    let access_token = auth
+        .authentication_result()
+        .unwrap()
+        .access_token()
+        .unwrap()
+        .to_string();
+
+    client
+        .change_password()
+        .access_token(&access_token)
+        .previous_password("OldPass1!")
+        .proposed_password("NewPass1!")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cognito-idp", "ForgotPassword", checksum = "e64c387b")]
+#[test_action("cognito-idp", "ConfirmForgotPassword", checksum = "1246f324")]
+#[tokio::test]
+async fn cognito_forgot_password_flow() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("forgot-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("forgot-client")
+        .explicit_auth_flows(
+            aws_sdk_cognitoidentityprovider::types::ExplicitAuthFlowsType::AllowUserPasswordAuth,
+        )
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("forgotuser")
+        .send()
+        .await
+        .unwrap();
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("forgotuser")
+        .password("OldPass1!")
+        .permanent(true)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .forgot_password()
+        .client_id(&client_id)
+        .username("forgotuser")
+        .send()
+        .await
+        .unwrap();
+
+    // Get confirmation code via introspection
+    let code_resp: serde_json::Value = reqwest::get(format!(
+        "{}/_fakecloud/cognito/confirmation-codes/{}/forgotuser",
+        server.endpoint(),
+        pool_id
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+    let code = code_resp["confirmationCode"].as_str().unwrap().to_string();
+
+    client
+        .confirm_forgot_password()
+        .client_id(&client_id)
+        .username("forgotuser")
+        .confirmation_code(&code)
+        .password("ResetPass1!")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cognito-idp", "AdminResetUserPassword", checksum = "00b62940")]
+#[tokio::test]
+async fn cognito_admin_reset_user_password() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("reset-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("resetuser")
+        .send()
+        .await
+        .unwrap();
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("resetuser")
+        .password("Pass1234!")
+        .permanent(true)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .admin_reset_user_password()
+        .user_pool_id(&pool_id)
+        .username("resetuser")
+        .send()
+        .await
+        .unwrap();
+
+    let user = client
+        .admin_get_user()
+        .user_pool_id(&pool_id)
+        .username("resetuser")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(user.user_status().unwrap().as_str(), "RESET_REQUIRED");
+}
+
+#[test_action("cognito-idp", "GlobalSignOut", checksum = "1b6afd7d")]
+#[tokio::test]
+async fn cognito_global_sign_out() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("signout-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("signout-client")
+        .explicit_auth_flows(
+            aws_sdk_cognitoidentityprovider::types::ExplicitAuthFlowsType::AllowUserPasswordAuth,
+        )
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("signoutuser")
+        .send()
+        .await
+        .unwrap();
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("signoutuser")
+        .password("Pass1234!")
+        .permanent(true)
+        .send()
+        .await
+        .unwrap();
+
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "signoutuser")
+        .auth_parameters("PASSWORD", "Pass1234!")
+        .send()
+        .await
+        .unwrap();
+    let access_token = auth
+        .authentication_result()
+        .unwrap()
+        .access_token()
+        .unwrap()
+        .to_string();
+
+    client
+        .global_sign_out()
+        .access_token(&access_token)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cognito-idp", "AdminUserGlobalSignOut", checksum = "8461322c")]
+#[tokio::test]
+async fn cognito_admin_user_global_sign_out() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("adminsignout-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("adminsignout")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .admin_user_global_sign_out()
+        .user_pool_id(&pool_id)
+        .username("adminsignout")
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -1133,6 +1133,28 @@ async fn cognito_change_password() {
         .send()
         .await
         .unwrap();
+
+    // Auth with old password should fail
+    let old_auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "chguser")
+        .auth_parameters("PASSWORD", "OldPass1!")
+        .send()
+        .await;
+    assert!(old_auth.is_err(), "Old password should no longer work");
+
+    // Auth with new password should succeed
+    let new_auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "chguser")
+        .auth_parameters("PASSWORD", "NewPass1!")
+        .send()
+        .await;
+    assert!(new_auth.is_ok(), "New password should work");
 }
 
 #[test_action("cognito-idp", "ForgotPassword", checksum = "e64c387b")]
@@ -1286,6 +1308,9 @@ async fn cognito_global_sign_out() {
         .explicit_auth_flows(
             aws_sdk_cognitoidentityprovider::types::ExplicitAuthFlowsType::AllowUserPasswordAuth,
         )
+        .explicit_auth_flows(
+            aws_sdk_cognitoidentityprovider::types::ExplicitAuthFlowsType::AllowRefreshTokenAuth,
+        )
         .send()
         .await
         .unwrap();
@@ -1322,12 +1347,9 @@ async fn cognito_global_sign_out() {
         .send()
         .await
         .unwrap();
-    let access_token = auth
-        .authentication_result()
-        .unwrap()
-        .access_token()
-        .unwrap()
-        .to_string();
+    let auth_result = auth.authentication_result().unwrap();
+    let access_token = auth_result.access_token().unwrap().to_string();
+    let refresh_token = auth_result.refresh_token().unwrap().to_string();
 
     client
         .global_sign_out()
@@ -1335,6 +1357,19 @@ async fn cognito_global_sign_out() {
         .send()
         .await
         .unwrap();
+
+    // Verify refresh token no longer works after sign out
+    let refresh_auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::RefreshTokenAuth)
+        .auth_parameters("REFRESH_TOKEN", &refresh_token)
+        .send()
+        .await;
+    assert!(
+        refresh_auth.is_err(),
+        "Refresh token should be invalid after global sign out"
+    );
 }
 
 #[test_action("cognito-idp", "AdminUserGlobalSignOut", checksum = "8461322c")]
@@ -1351,6 +1386,26 @@ async fn cognito_admin_user_global_sign_out() {
         .unwrap();
     let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
 
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("adminsignout-client")
+        .explicit_auth_flows(
+            aws_sdk_cognitoidentityprovider::types::ExplicitAuthFlowsType::AllowUserPasswordAuth,
+        )
+        .explicit_auth_flows(
+            aws_sdk_cognitoidentityprovider::types::ExplicitAuthFlowsType::AllowRefreshTokenAuth,
+        )
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
     client
         .admin_create_user()
         .user_pool_id(&pool_id)
@@ -1358,6 +1413,32 @@ async fn cognito_admin_user_global_sign_out() {
         .send()
         .await
         .unwrap();
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("adminsignout")
+        .password("Pass1234!")
+        .permanent(true)
+        .send()
+        .await
+        .unwrap();
+
+    // Authenticate to get a refresh token
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "adminsignout")
+        .auth_parameters("PASSWORD", "Pass1234!")
+        .send()
+        .await
+        .unwrap();
+    let refresh_token = auth
+        .authentication_result()
+        .unwrap()
+        .refresh_token()
+        .unwrap()
+        .to_string();
 
     client
         .admin_user_global_sign_out()
@@ -1366,4 +1447,17 @@ async fn cognito_admin_user_global_sign_out() {
         .send()
         .await
         .unwrap();
+
+    // Verify refresh token no longer works after admin sign out
+    let refresh_auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::RefreshTokenAuth)
+        .auth_parameters("REFRESH_TOKEN", &refresh_token)
+        .send()
+        .await;
+    assert!(
+        refresh_auth.is_err(),
+        "Refresh token should be invalid after admin global sign out"
+    );
 }

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -4,6 +4,7 @@ use helpers::TestServer;
 use aws_sdk_cognitoidentityprovider::types::{
     AccountRecoverySettingType, AttributeType, ChallengeNameType, ExplicitAuthFlowsType,
     PasswordPolicyType, RecoveryOptionNameType, RecoveryOptionType, UserPoolPolicyType,
+    UserStatusType,
 };
 
 #[tokio::test]
@@ -1505,5 +1506,553 @@ async fn cognito_auth_wrong_password() {
         err_str.contains("NotAuthorizedException")
             || err_str.contains("Incorrect username or password"),
         "Error should be NotAuthorizedException: {err_str}"
+    );
+}
+
+#[tokio::test]
+async fn cognito_change_password() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    // Create pool with relaxed policy
+    let pool_result = client
+        .create_user_pool()
+        .pool_name("chpw-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool_result.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create client
+    let client_result = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("chpw-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowAdminUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = client_result
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    // Create user and set password
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("chpwuser")
+        .send()
+        .await
+        .expect("create user");
+
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("chpwuser")
+        .password("oldpass")
+        .permanent(true)
+        .send()
+        .await
+        .expect("set password");
+
+    // Auth to get access token
+    let auth_result = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "chpwuser")
+        .auth_parameters("PASSWORD", "oldpass")
+        .send()
+        .await
+        .expect("auth");
+
+    let access_token = auth_result
+        .authentication_result()
+        .unwrap()
+        .access_token()
+        .unwrap()
+        .to_string();
+
+    // Change password
+    client
+        .change_password()
+        .access_token(&access_token)
+        .previous_password("oldpass")
+        .proposed_password("newpass")
+        .send()
+        .await
+        .expect("change password");
+
+    // Auth with new password should work
+    let auth2 = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "chpwuser")
+        .auth_parameters("PASSWORD", "newpass")
+        .send()
+        .await;
+    assert!(auth2.is_ok(), "Auth with new password should work");
+
+    // Auth with old password should fail
+    let auth3 = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "chpwuser")
+        .auth_parameters("PASSWORD", "oldpass")
+        .send()
+        .await;
+    assert!(auth3.is_err(), "Auth with old password should fail");
+}
+
+#[tokio::test]
+async fn cognito_forgot_password_flow() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    // Create pool with relaxed policy
+    let pool_result = client
+        .create_user_pool()
+        .pool_name("forgot-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool_result.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create client
+    let client_result = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("forgot-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowAdminUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowUserPasswordAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = client_result
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    // Create user with email
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("forgotuser")
+        .user_attributes(
+            AttributeType::builder()
+                .name("email")
+                .value("user@example.com")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create user");
+
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("forgotuser")
+        .password("oldpass")
+        .permanent(true)
+        .send()
+        .await
+        .expect("set password");
+
+    // Call ForgotPassword
+    let forgot_result = client
+        .forgot_password()
+        .client_id(&client_id)
+        .username("forgotuser")
+        .send()
+        .await
+        .expect("forgot password");
+
+    // Check CodeDeliveryDetails
+    let delivery = forgot_result.code_delivery_details().unwrap();
+    assert_eq!(delivery.delivery_medium().unwrap().as_str(), "EMAIL");
+    assert_eq!(delivery.attribute_name().unwrap(), "email");
+    let destination = delivery.destination().unwrap();
+    assert!(
+        destination.contains("***"),
+        "Destination should be masked: {destination}"
+    );
+
+    // Get confirmation code from introspection endpoint
+    let http_client = reqwest::Client::new();
+    let code_resp = http_client
+        .get(format!(
+            "{}/_fakecloud/cognito/confirmation-codes/{}/forgotuser",
+            server.endpoint(),
+            pool_id
+        ))
+        .send()
+        .await
+        .expect("get confirmation code");
+    let code_json: serde_json::Value = code_resp.json().await.unwrap();
+    let code = code_json["confirmationCode"].as_str().unwrap().to_string();
+    assert_eq!(code.len(), 6, "Code should be 6 digits");
+
+    // Confirm forgot password with wrong code should fail
+    let bad_confirm = client
+        .confirm_forgot_password()
+        .client_id(&client_id)
+        .username("forgotuser")
+        .confirmation_code("000000")
+        .password("newpass")
+        .send()
+        .await;
+    if code != "000000" {
+        assert!(bad_confirm.is_err(), "Wrong code should fail");
+    }
+
+    // Confirm forgot password with correct code
+    client
+        .confirm_forgot_password()
+        .client_id(&client_id)
+        .username("forgotuser")
+        .confirmation_code(&code)
+        .password("newpass")
+        .send()
+        .await
+        .expect("confirm forgot password");
+
+    // Auth with new password should work
+    let auth = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "forgotuser")
+        .auth_parameters("PASSWORD", "newpass")
+        .send()
+        .await;
+    assert!(auth.is_ok(), "Auth with new password should work");
+
+    // Auth with old password should fail
+    let auth_old = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "forgotuser")
+        .auth_parameters("PASSWORD", "oldpass")
+        .send()
+        .await;
+    assert!(auth_old.is_err(), "Auth with old password should fail");
+}
+
+#[tokio::test]
+async fn cognito_admin_reset_user_password() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    // Create pool
+    let pool_result = client
+        .create_user_pool()
+        .pool_name("reset-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool_result.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create user and set password
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("resetuser")
+        .send()
+        .await
+        .expect("create user");
+
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("resetuser")
+        .password("mypass")
+        .permanent(true)
+        .send()
+        .await
+        .expect("set password");
+
+    // Verify status is CONFIRMED
+    let get1 = client
+        .admin_get_user()
+        .user_pool_id(&pool_id)
+        .username("resetuser")
+        .send()
+        .await
+        .expect("get user");
+    assert_eq!(get1.user_status(), Some(&UserStatusType::Confirmed));
+
+    // Admin reset user password
+    client
+        .admin_reset_user_password()
+        .user_pool_id(&pool_id)
+        .username("resetuser")
+        .send()
+        .await
+        .expect("admin reset user password");
+
+    // Verify status is RESET_REQUIRED
+    let get2 = client
+        .admin_get_user()
+        .user_pool_id(&pool_id)
+        .username("resetuser")
+        .send()
+        .await
+        .expect("get user after reset");
+    assert_eq!(get2.user_status(), Some(&UserStatusType::ResetRequired));
+}
+
+#[tokio::test]
+async fn cognito_global_sign_out() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    // Create pool with relaxed policy
+    let pool_result = client
+        .create_user_pool()
+        .pool_name("signout-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool_result.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create client with user password auth + refresh token flows
+    let client_result = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("signout-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowAdminUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = client_result
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    // Create user and set password
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("signoutuser")
+        .send()
+        .await
+        .expect("create user");
+
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("signoutuser")
+        .password("mypass")
+        .permanent(true)
+        .send()
+        .await
+        .expect("set password");
+
+    // Auth to get tokens
+    let auth_result = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "signoutuser")
+        .auth_parameters("PASSWORD", "mypass")
+        .send()
+        .await
+        .expect("auth");
+
+    let auth = auth_result.authentication_result().unwrap();
+    let access_token = auth.access_token().unwrap().to_string();
+    let refresh_token = auth.refresh_token().unwrap().to_string();
+
+    // Global sign out
+    client
+        .global_sign_out()
+        .access_token(&access_token)
+        .send()
+        .await
+        .expect("global sign out");
+
+    // Refresh token should no longer work
+    let refresh_err = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::RefreshTokenAuth)
+        .auth_parameters("REFRESH_TOKEN", &refresh_token)
+        .send()
+        .await;
+    assert!(
+        refresh_err.is_err(),
+        "Refresh token should be invalidated after sign out"
+    );
+}
+
+#[tokio::test]
+async fn cognito_admin_user_global_sign_out() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    // Create pool with relaxed policy
+    let pool_result = client
+        .create_user_pool()
+        .pool_name("admin-signout-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool_result.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create client
+    let client_result = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("admin-signout-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowAdminUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = client_result
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    // Create user and set password
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("adminsignoutuser")
+        .send()
+        .await
+        .expect("create user");
+
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("adminsignoutuser")
+        .password("mypass")
+        .permanent(true)
+        .send()
+        .await
+        .expect("set password");
+
+    // Auth to get tokens
+    let auth_result = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "adminsignoutuser")
+        .auth_parameters("PASSWORD", "mypass")
+        .send()
+        .await
+        .expect("auth");
+
+    let auth = auth_result.authentication_result().unwrap();
+    let refresh_token = auth.refresh_token().unwrap().to_string();
+
+    // Admin user global sign out
+    client
+        .admin_user_global_sign_out()
+        .user_pool_id(&pool_id)
+        .username("adminsignoutuser")
+        .send()
+        .await
+        .expect("admin user global sign out");
+
+    // Refresh token should no longer work
+    let refresh_err = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::RefreshTokenAuth)
+        .auth_parameters("REFRESH_TOKEN", &refresh_token)
+        .send()
+        .await;
+    assert!(
+        refresh_err.is_err(),
+        "Refresh token should be invalidated after admin sign out"
     );
 }

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -1731,17 +1731,20 @@ async fn cognito_forgot_password_flow() {
     assert_eq!(code.len(), 6, "Code should be 6 digits");
 
     // Confirm forgot password with wrong code should fail
+    let wrong_code = if code.starts_with('9') {
+        "000001".to_string()
+    } else {
+        "999999".to_string()
+    };
     let bad_confirm = client
         .confirm_forgot_password()
         .client_id(&client_id)
         .username("forgotuser")
-        .confirmation_code("000000")
+        .confirmation_code(&wrong_code)
         .password("newpass")
         .send()
         .await;
-    if code != "000000" {
-        assert!(bad_confirm.is_err(), "Wrong code should fail");
-    }
+    assert!(bad_confirm.is_err(), "Wrong code should fail");
 
     // Confirm forgot password with correct code
     client

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -627,6 +627,27 @@ async fn main() {
                 }
             }),
         )
+        .route(
+            "/_fakecloud/cognito/confirmation-codes/{pool_id}/{username}",
+            axum::routing::get({
+                let cs = cognito_state.clone();
+                move |axum::extract::Path((pool_id, username)): axum::extract::Path<(
+                    String,
+                    String,
+                )>| {
+                    let cs = cs.clone();
+                    async move {
+                        let state = cs.read();
+                        let code = state
+                            .users
+                            .get(&pool_id)
+                            .and_then(|users| users.get(&username))
+                            .and_then(|user| user.confirmation_code.clone());
+                        axum::Json(serde_json::json!({ "confirmationCode": code }))
+                    }
+                }
+            }),
+        )
         .fallback(dispatch::dispatch)
         .layer(Extension(Arc::new(registry)))
         .layer(Extension(Arc::new(config)))


### PR DESCRIPTION
## Summary

- 6 new Cognito operations: ChangePassword, ForgotPassword, ConfirmForgotPassword, AdminResetUserPassword, GlobalSignOut, AdminUserGlobalSignOut
- Access token tracking for user lookup from tokens
- Confirmation code generation and validation (6-digit codes)
- Token invalidation on sign-out (both refresh and access tokens)
- Introspection endpoint `/_fakecloud/cognito/confirmation-codes/{pool_id}/{username}` for test access to confirmation codes
- 2 new unit tests (32 total), 5 new E2E tests (27 total), 6 new conformance tests (32/32 coverage)

## Test plan

- [x] `cargo test -p fakecloud-cognito` — 32 unit tests pass
- [x] `cargo test -p fakecloud-e2e --test cognito` — 27 E2E tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Conformance audit: 32/32 cognito-idp actions covered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full password change/reset and global sign-out flows to the Cognito emulator to mirror AWS behavior. Adds access-token tracking and a test-only endpoint to read reset codes.

- **New Features**
  - Implemented: ChangePassword, ForgotPassword, ConfirmForgotPassword, AdminResetUserPassword, GlobalSignOut, AdminUserGlobalSignOut.
  - Track access tokens to resolve users from tokens across auth flows.
  - Generate and validate 6‑digit confirmation codes for password resets.
  - Invalidate refresh and access tokens on sign-out.
  - Test-only endpoint: `/_fakecloud/cognito/confirmation-codes/{pool_id}/{username}` to fetch the current code.
  - Expanded unit, E2E, and conformance tests (Cognito actions now 32/32).

- **Bug Fixes**
  - Fixed `axum` 0.8 route parameter syntax for the confirmation-codes endpoint; tightened test assertions and doc comments.

<sup>Written for commit 67c412b7bee97c35abdcdd0b7af7a016a110dacf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

