### PR TITLE
feat: SQS expiration/force-DLQ and EventBridge fire-rule simulation

### DIFF
--- a/crates/fakecloud-e2e/tests/eventbridge.rs
+++ b/crates/fakecloud-e2e/tests/eventbridge.rs
@@ -1079,3 +1079,103 @@ async fn eventbridge_introspection_history() {
     assert!(resp["deliveries"]["lambda"].is_array());
     assert!(resp["deliveries"]["logs"].is_array());
 }
+
+#[tokio::test]
+async fn eb_simulation_fire_rule_to_sqs() {
+    let server = TestServer::start().await;
+    let eb_client = server.eventbridge_client().await;
+    let sqs_client = server.sqs_client().await;
+
+    // Create SQS queue to use as target
+    let q_resp = sqs_client
+        .create_queue()
+        .queue_name("fire-rule-target")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = q_resp.queue_url().unwrap().to_string();
+
+    // Get queue ARN
+    let q_attrs = sqs_client
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = q_attrs
+        .attributes()
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .clone();
+
+    // Create a scheduled rule on the default bus
+    eb_client
+        .put_rule()
+        .name("test-fire-rule")
+        .schedule_expression("rate(1 hour)")
+        .state(RuleState::Enabled)
+        .send()
+        .await
+        .unwrap();
+
+    // Add SQS target
+    eb_client
+        .put_targets()
+        .rule("test-fire-rule")
+        .targets(
+            Target::builder()
+                .id("sqs-target")
+                .arn(&queue_arn)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Fire the rule via simulation endpoint
+    let url = format!("{}/_fakecloud/events/fire-rule", server.endpoint());
+    let resp: serde_json::Value = reqwest::Client::new()
+        .post(&url)
+        .json(&serde_json::json!({
+            "busName": "default",
+            "ruleName": "test-fire-rule"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let targets = resp["targets"].as_array().unwrap();
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0]["type"], "sqs");
+    assert_eq!(targets[0]["arn"], queue_arn);
+
+    // Verify message appeared in SQS queue
+    let recv = sqs_client
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(recv.messages().len(), 1);
+    let body: serde_json::Value = serde_json::from_str(recv.messages()[0].body().unwrap()).unwrap();
+    assert_eq!(body["source"], "aws.events");
+    assert_eq!(body["detail-type"], "Scheduled Event");
+
+    // Verify event recorded in introspection
+    let history_url = format!("{}/_fakecloud/events/history", server.endpoint());
+    let history: serde_json::Value = reqwest::get(&history_url)
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let events = history["events"].as_array().unwrap();
+    assert!(events.iter().any(|e| e["source"] == "aws.events"));
+}

--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -1206,3 +1206,143 @@ async fn sqs_introspection_messages() {
     assert!(!messages[0]["messageId"].as_str().unwrap().is_empty());
     assert!(!messages[0]["createdAt"].as_str().unwrap().is_empty());
 }
+
+#[tokio::test]
+async fn sqs_simulation_expiration_tick() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+
+    // Create queue with very short retention period (1 second)
+    let resp = client
+        .create_queue()
+        .queue_name("expire-queue")
+        .attributes(QueueAttributeName::MessageRetentionPeriod, "1")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = resp.queue_url().unwrap().to_string();
+
+    // Send a message
+    client
+        .send_message()
+        .queue_url(&queue_url)
+        .message_body("will expire")
+        .send()
+        .await
+        .unwrap();
+
+    // Wait for message to expire
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Call the expiration tick endpoint
+    let url = format!(
+        "{}/_fakecloud/sqs/expiration-processor/tick",
+        server.endpoint()
+    );
+    let resp: serde_json::Value = reqwest::Client::new()
+        .post(&url)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(resp["expiredMessages"].as_u64().unwrap() >= 1);
+
+    // Verify message is gone
+    let recv = client
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(recv.messages().len(), 0);
+}
+
+#[tokio::test]
+async fn sqs_simulation_force_dlq() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+
+    // Create DLQ
+    let dlq_resp = client
+        .create_queue()
+        .queue_name("my-dlq")
+        .send()
+        .await
+        .unwrap();
+    let dlq_url = dlq_resp.queue_url().unwrap().to_string();
+
+    // Get DLQ ARN
+    let dlq_attrs = client
+        .get_queue_attributes()
+        .queue_url(&dlq_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let dlq_arn = dlq_attrs
+        .attributes()
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .clone();
+
+    // Create source queue with redrive policy (maxReceiveCount=1)
+    let redrive_policy =
+        serde_json::json!({"deadLetterTargetArn": dlq_arn, "maxReceiveCount": 1}).to_string();
+    let src_resp = client
+        .create_queue()
+        .queue_name("src-queue")
+        .attributes(QueueAttributeName::RedrivePolicy, &redrive_policy)
+        .send()
+        .await
+        .unwrap();
+    let src_url = src_resp.queue_url().unwrap().to_string();
+
+    // Send a message
+    client
+        .send_message()
+        .queue_url(&src_url)
+        .message_body("hello dlq")
+        .send()
+        .await
+        .unwrap();
+
+    // Receive the message once (increments receive count to 1)
+    let recv = client
+        .receive_message()
+        .queue_url(&src_url)
+        .max_number_of_messages(1)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(recv.messages().len(), 1);
+
+    // Wait for visibility timeout to expire so message returns to queue
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Call force-dlq endpoint
+    let url = format!("{}/_fakecloud/sqs/src-queue/force-dlq", server.endpoint());
+    let resp: serde_json::Value = reqwest::Client::new()
+        .post(&url)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(resp["movedMessages"].as_u64().unwrap(), 1);
+
+    // Verify message appeared in DLQ
+    let dlq_recv = client
+        .receive_message()
+        .queue_url(&dlq_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dlq_recv.messages().len(), 1);
+    assert_eq!(dlq_recv.messages()[0].body().unwrap(), "hello dlq");
+}

--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -1312,17 +1312,15 @@ async fn sqs_simulation_force_dlq() {
         .await
         .unwrap();
 
-    // Receive the message twice to exceed maxReceiveCount (count goes to 2 > 1)
-    for _ in 0..2 {
-        let recv = client
-            .receive_message()
-            .queue_url(&src_url)
-            .max_number_of_messages(1)
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(recv.messages().len(), 1);
-    }
+    // Receive the message once so receive_count reaches maxReceiveCount (1 >= 1)
+    let recv = client
+        .receive_message()
+        .queue_url(&src_url)
+        .max_number_of_messages(1)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(recv.messages().len(), 1);
 
     // Call force-dlq endpoint
     let url = format!("{}/_fakecloud/sqs/src-queue/force-dlq", server.endpoint());

--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -1289,13 +1289,15 @@ async fn sqs_simulation_force_dlq() {
         .unwrap()
         .clone();
 
-    // Create source queue with redrive policy (maxReceiveCount=1)
+    // Create source queue with redrive policy (maxReceiveCount=1) and a 0s
+    // visibility timeout so messages return to the queue immediately after receive.
     let redrive_policy =
         serde_json::json!({"deadLetterTargetArn": dlq_arn, "maxReceiveCount": 1}).to_string();
     let src_resp = client
         .create_queue()
         .queue_name("src-queue")
         .attributes(QueueAttributeName::RedrivePolicy, &redrive_policy)
+        .attributes(QueueAttributeName::VisibilityTimeout, "0")
         .send()
         .await
         .unwrap();
@@ -1310,18 +1312,17 @@ async fn sqs_simulation_force_dlq() {
         .await
         .unwrap();
 
-    // Receive the message once (increments receive count to 1)
-    let recv = client
-        .receive_message()
-        .queue_url(&src_url)
-        .max_number_of_messages(1)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(recv.messages().len(), 1);
-
-    // Wait for visibility timeout to expire so message returns to queue
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // Receive the message twice to exceed maxReceiveCount (count goes to 2 > 1)
+    for _ in 0..2 {
+        let recv = client
+            .receive_message()
+            .queue_url(&src_url)
+            .max_number_of_messages(1)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(recv.messages().len(), 1);
+    }
 
     // Call force-dlq endpoint
     let url = format!("{}/_fakecloud/sqs/src-queue/force-dlq", server.endpoint());

--- a/crates/fakecloud-eventbridge/src/lib.rs
+++ b/crates/fakecloud-eventbridge/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod delivery;
 pub mod scheduler;
 pub mod service;
+pub mod simulation;
 pub mod state;

--- a/crates/fakecloud-eventbridge/src/simulation.rs
+++ b/crates/fakecloud-eventbridge/src/simulation.rs
@@ -1,0 +1,296 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::Utc;
+use serde_json::json;
+
+use fakecloud_core::delivery::DeliveryBus;
+use fakecloud_lambda::state::{LambdaInvocation, SharedLambdaState};
+use fakecloud_logs::state::SharedLogsState;
+
+use crate::state::{EventTarget, SharedEventBridgeState};
+
+/// Result of firing a rule via simulation.
+#[derive(Debug)]
+pub struct FiredTarget {
+    /// The target type (e.g. "sqs", "sns", "lambda", "logs").
+    pub target_type: String,
+    /// The target ARN.
+    pub arn: String,
+}
+
+/// Fire a specific rule by bus name and rule name, delivering to all its
+/// targets regardless of the rule's enabled/disabled state.
+///
+/// Returns `Ok(targets)` with the list of targets that were delivered to,
+/// or `Err(message)` if the bus or rule doesn't exist.
+pub fn fire_rule(
+    state: &SharedEventBridgeState,
+    delivery: &Arc<DeliveryBus>,
+    lambda_state: &Option<SharedLambdaState>,
+    logs_state: &Option<SharedLogsState>,
+    container_runtime: &Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
+    bus_name: &str,
+    rule_name: &str,
+) -> Result<Vec<FiredTarget>, String> {
+    let (targets, account_id, region) = {
+        let state = state.read();
+
+        // Verify bus exists
+        if !state.buses.contains_key(bus_name) {
+            return Err(format!("Event bus '{bus_name}' not found"));
+        }
+
+        let key = (bus_name.to_string(), rule_name.to_string());
+        let rule = match state.rules.get(&key) {
+            Some(r) => r,
+            None => return Err(format!("Rule '{rule_name}' not found on bus '{bus_name}'")),
+        };
+
+        (
+            rule.targets.clone(),
+            state.account_id.clone(),
+            state.region.clone(),
+        )
+    };
+
+    if targets.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let now = Utc::now();
+    let event_id = uuid::Uuid::new_v4().to_string();
+
+    // Build the scheduled-event envelope (same shape as the real scheduler)
+    let event_json = json!({
+        "version": "0",
+        "id": event_id,
+        "source": "aws.events",
+        "account": account_id,
+        "detail-type": "Scheduled Event",
+        "detail": {},
+        "time": now.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        "region": region,
+        "resources": [],
+    });
+    let event_str = event_json.to_string();
+
+    // Record the event in state
+    {
+        let mut s = state.write();
+        s.events.push(crate::state::PutEvent {
+            event_id: event_id.clone(),
+            source: "aws.events".to_string(),
+            detail_type: "Scheduled Event".to_string(),
+            detail: "{}".to_string(),
+            event_bus_name: bus_name.to_string(),
+            time: now,
+            resources: Vec::new(),
+        });
+    }
+
+    let mut fired = Vec::new();
+
+    for target in &targets {
+        let arn = &target.arn;
+        let body_str = resolve_target_body(target, &event_json, &event_str);
+
+        if arn.contains(":sqs:") {
+            delivery.send_to_sqs(arn, &body_str, &HashMap::new());
+            fired.push(FiredTarget {
+                target_type: "sqs".to_string(),
+                arn: arn.clone(),
+            });
+        } else if arn.contains(":sns:") {
+            delivery.publish_to_sns(arn, &body_str, Some("Scheduled Event"));
+            fired.push(FiredTarget {
+                target_type: "sns".to_string(),
+                arn: arn.clone(),
+            });
+        } else if arn.contains(":lambda:") {
+            let mut s = state.write();
+            s.lambda_invocations.push(crate::state::LambdaInvocation {
+                function_arn: arn.clone(),
+                payload: body_str.clone(),
+                timestamp: now,
+            });
+            drop(s);
+            if let Some(ref ls) = lambda_state {
+                ls.write().invocations.push(LambdaInvocation {
+                    function_arn: arn.clone(),
+                    payload: body_str.clone(),
+                    timestamp: now,
+                    source: "aws:events".to_string(),
+                });
+            }
+            crate::service::invoke_lambda_async(container_runtime, lambda_state, arn, &body_str);
+            fired.push(FiredTarget {
+                target_type: "lambda".to_string(),
+                arn: arn.clone(),
+            });
+        } else if arn.contains(":logs:") {
+            let mut s = state.write();
+            s.log_deliveries.push(crate::state::LogDelivery {
+                log_group_arn: arn.clone(),
+                payload: body_str.clone(),
+                timestamp: now,
+            });
+            drop(s);
+            if let Some(ref log_state) = logs_state {
+                crate::service::deliver_to_logs(log_state, arn, &body_str, now);
+            }
+            fired.push(FiredTarget {
+                target_type: "logs".to_string(),
+                arn: arn.clone(),
+            });
+        }
+    }
+
+    Ok(fired)
+}
+
+/// Compute the message body for a target, applying InputTransformer / Input /
+/// InputPath if present.
+fn resolve_target_body(
+    target: &EventTarget,
+    _event_json: &serde_json::Value,
+    event_str: &str,
+) -> String {
+    if let Some(ref input) = target.input {
+        input.clone()
+    } else if let Some(ref _input_path) = target.input_path {
+        // Simplified: just use event_str for now
+        event_str.to_string()
+    } else {
+        event_str.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{EventBridgeState, EventRule};
+    use parking_lot::RwLock;
+
+    fn make_state() -> SharedEventBridgeState {
+        Arc::new(RwLock::new(EventBridgeState::new(
+            "123456789012",
+            "us-east-1",
+        )))
+    }
+
+    fn add_rule(
+        state: &SharedEventBridgeState,
+        bus: &str,
+        name: &str,
+        enabled: bool,
+        targets: Vec<EventTarget>,
+    ) {
+        let mut s = state.write();
+        let key = (bus.to_string(), name.to_string());
+        s.rules.insert(
+            key,
+            EventRule {
+                name: name.to_string(),
+                arn: format!("arn:aws:events:us-east-1:123456789012:rule/{bus}/{name}"),
+                event_bus_name: bus.to_string(),
+                event_pattern: None,
+                schedule_expression: Some("rate(1 minute)".to_string()),
+                state: if enabled { "ENABLED" } else { "DISABLED" }.to_string(),
+                description: None,
+                role_arn: None,
+                managed_by: None,
+                created_by: None,
+                targets,
+                tags: HashMap::new(),
+                last_fired: None,
+            },
+        );
+    }
+
+    #[test]
+    fn fire_rule_with_valid_rule() {
+        let state = make_state();
+        let delivery = Arc::new(DeliveryBus::new());
+
+        add_rule(
+            &state,
+            "default",
+            "my-rule",
+            true,
+            vec![EventTarget {
+                id: "t1".to_string(),
+                arn: "arn:aws:sqs:us-east-1:123456789012:target-queue".to_string(),
+                input: None,
+                input_path: None,
+                input_transformer: None,
+                sqs_parameters: None,
+            }],
+        );
+
+        let result = fire_rule(&state, &delivery, &None, &None, &None, "default", "my-rule");
+        let targets = result.unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].target_type, "sqs");
+        assert_eq!(
+            targets[0].arn,
+            "arn:aws:sqs:us-east-1:123456789012:target-queue"
+        );
+
+        // Verify event was recorded
+        let s = state.read();
+        assert!(s.events.iter().any(|e| e.source == "aws.events"));
+    }
+
+    #[test]
+    fn fire_rule_nonexistent_rule() {
+        let state = make_state();
+        let delivery = Arc::new(DeliveryBus::new());
+
+        let result = fire_rule(
+            &state,
+            &delivery,
+            &None,
+            &None,
+            &None,
+            "default",
+            "no-such-rule",
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn fire_rule_disabled_still_fires() {
+        let state = make_state();
+        let delivery = Arc::new(DeliveryBus::new());
+
+        add_rule(
+            &state,
+            "default",
+            "disabled-rule",
+            false, // DISABLED
+            vec![EventTarget {
+                id: "t1".to_string(),
+                arn: "arn:aws:sqs:us-east-1:123456789012:target-queue".to_string(),
+                input: None,
+                input_path: None,
+                input_transformer: None,
+                sqs_parameters: None,
+            }],
+        );
+
+        let result = fire_rule(
+            &state,
+            &delivery,
+            &None,
+            &None,
+            &None,
+            "default",
+            "disabled-rule",
+        );
+        // Simulation overrides disabled state
+        let targets = result.unwrap();
+        assert_eq!(targets.len(), 1);
+    }
+}

--- a/crates/fakecloud-eventbridge/src/simulation.rs
+++ b/crates/fakecloud-eventbridge/src/simulation.rs
@@ -96,7 +96,24 @@ pub fn fire_rule(
         let body_str = resolve_target_body(target, &event_json, &event_str);
 
         if arn.contains(":sqs:") {
-            delivery.send_to_sqs(arn, &body_str, &HashMap::new());
+            // Extract MessageGroupId from SqsParameters if present (required for FIFO queues)
+            let message_group_id = target
+                .sqs_parameters
+                .as_ref()
+                .and_then(|sp| sp["MessageGroupId"].as_str())
+                .map(|s| s.to_string());
+
+            if message_group_id.is_some() {
+                delivery.send_to_sqs_with_attrs(
+                    arn,
+                    &body_str,
+                    &HashMap::new(),
+                    message_group_id.as_deref(),
+                    None,
+                );
+            } else {
+                delivery.send_to_sqs(arn, &body_str, &HashMap::new());
+            }
             fired.push(FiredTarget {
                 target_type: "sqs".to_string(),
                 arn: arn.clone(),
@@ -149,21 +166,38 @@ pub fn fire_rule(
     Ok(fired)
 }
 
-/// Compute the message body for a target, applying InputTransformer / Input /
-/// InputPath if present.
+/// Compute the message body for a target, applying Input / InputPath if
+/// present.
+///
+/// **Limitations**: `InputTransformer` is not yet implemented — if a target
+/// has one configured, we fall through to the full event envelope. Real AWS
+/// evaluates the `InputPathsMap` + `InputTemplate` to build the payload;
+/// implementing that requires a JSONPath evaluator. `InputPath` supports
+/// only the simple `$.field` case (single top-level key); deeper paths
+/// fall back to the full event.
 fn resolve_target_body(
     target: &EventTarget,
-    _event_json: &serde_json::Value,
+    event_json: &serde_json::Value,
     event_str: &str,
 ) -> String {
     if let Some(ref input) = target.input {
-        input.clone()
-    } else if let Some(ref _input_path) = target.input_path {
-        // Simplified: just use event_str for now
-        event_str.to_string()
-    } else {
-        event_str.to_string()
+        return input.clone();
     }
+
+    if let Some(ref input_path) = target.input_path {
+        // Support simple top-level JSONPath like "$.detail"
+        if let Some(key) = input_path.strip_prefix("$.") {
+            if !key.contains('.') && !key.contains('[') {
+                if let Some(val) = event_json.get(key) {
+                    return val.to_string();
+                }
+            }
+        }
+    }
+
+    // InputTransformer is not yet supported — fall through to full event.
+
+    event_str.to_string()
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -196,6 +196,15 @@ async fn main() {
     let eb_introspection_state = eb_state.clone();
     let s3_introspection_state = s3_state.clone();
 
+    // Clone state refs for simulation endpoints
+    let sqs_sim_expiration_state = sqs_state.clone();
+    let sqs_sim_force_dlq_state = sqs_state.clone();
+    let eb_sim_state = eb_state.clone();
+    let eb_sim_delivery = delivery_for_eb.clone();
+    let eb_sim_lambda_state = Some(lambda_state.clone());
+    let eb_sim_logs_state = Some(logs_state.clone());
+    let eb_sim_container_runtime = container_runtime.clone();
+
     // Clone state for reset endpoint before moving into services
     let reset_state = ResetState {
         iam: iam_state.clone(),
@@ -576,6 +585,78 @@ async fn main() {
                             "logs": log_deliveries,
                         },
                     }))
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/sqs/expiration-processor/tick",
+            axum::routing::post({
+                let ss = sqs_sim_expiration_state;
+                move || async move {
+                    let expired = fakecloud_sqs::simulation::tick_expiration(&ss);
+                    axum::Json(serde_json::json!({ "expiredMessages": expired }))
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/sqs/{queue_name}/force-dlq",
+            axum::routing::post({
+                let ss = sqs_sim_force_dlq_state;
+                move |axum::extract::Path(queue_name): axum::extract::Path<String>| async move {
+                    let moved = fakecloud_sqs::simulation::force_dlq(&ss, &queue_name);
+                    axum::Json(serde_json::json!({ "movedMessages": moved }))
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/events/fire-rule",
+            axum::routing::post({
+                let es = eb_sim_state;
+                let delivery = eb_sim_delivery;
+                let lambda_state = eb_sim_lambda_state;
+                let logs_state = eb_sim_logs_state;
+                let container_runtime = eb_sim_container_runtime;
+                move |axum::Json(body): axum::Json<serde_json::Value>| async move {
+                    let bus_name = body["busName"].as_str().unwrap_or("default");
+                    let rule_name = match body["ruleName"].as_str() {
+                        Some(n) => n,
+                        None => {
+                            return (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                axum::Json(serde_json::json!({ "error": "ruleName is required" })),
+                            );
+                        }
+                    };
+
+                    match fakecloud_eventbridge::simulation::fire_rule(
+                        &es,
+                        &delivery,
+                        &lambda_state,
+                        &logs_state,
+                        &container_runtime,
+                        bus_name,
+                        rule_name,
+                    ) {
+                        Ok(targets) => {
+                            let target_list: Vec<serde_json::Value> = targets
+                                .iter()
+                                .map(|t| {
+                                    serde_json::json!({
+                                        "type": t.target_type,
+                                        "arn": t.arn,
+                                    })
+                                })
+                                .collect();
+                            (
+                                axum::http::StatusCode::OK,
+                                axum::Json(serde_json::json!({ "targets": target_list })),
+                            )
+                        }
+                        Err(msg) => (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({ "error": msg })),
+                        ),
+                    }
                 }
             }),
         )

--- a/crates/fakecloud-sqs/src/lib.rs
+++ b/crates/fakecloud-sqs/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod delivery;
 pub mod service;
+pub mod simulation;
 pub mod state;

--- a/crates/fakecloud-sqs/src/simulation.rs
+++ b/crates/fakecloud-sqs/src/simulation.rs
@@ -75,9 +75,11 @@ pub fn force_dlq(state: &SharedSqsState, queue_name: &str) -> u64 {
     let queue = state.queues.get_mut(&queue_url).unwrap();
     let mut to_move = Vec::new();
 
+    // force-dlq intentionally uses >= (not >) to move messages at the threshold,
+    // since the purpose is to force DLQ delivery without waiting for another receive
     let mut remaining = std::collections::VecDeque::new();
     while let Some(msg) = queue.messages.pop_front() {
-        if msg.receive_count > max_receive_count {
+        if msg.receive_count >= max_receive_count {
             to_move.push(msg);
         } else {
             remaining.push_back(msg);
@@ -88,7 +90,7 @@ pub fn force_dlq(state: &SharedSqsState, queue_name: &str) -> u64 {
     // Also check in-flight messages
     let mut remaining_inflight = Vec::new();
     for msg in queue.inflight.drain(..) {
-        if msg.receive_count > max_receive_count {
+        if msg.receive_count >= max_receive_count {
             to_move.push(msg);
         } else {
             remaining_inflight.push(msg);

--- a/crates/fakecloud-sqs/src/simulation.rs
+++ b/crates/fakecloud-sqs/src/simulation.rs
@@ -1,0 +1,283 @@
+use chrono::Utc;
+
+use crate::state::SharedSqsState;
+
+/// Run the expiration processor across all queues.
+///
+/// Iterates every queue and removes messages (from both the pending and
+/// in-flight collections) whose age exceeds the queue's
+/// `MessageRetentionPeriod` attribute. Returns the total number of
+/// expired messages removed.
+pub fn tick_expiration(state: &SharedSqsState) -> u64 {
+    let mut total = 0u64;
+    let now = Utc::now();
+
+    let mut state = state.write();
+    for queue in state.queues.values_mut() {
+        let retention_seconds: i64 = queue
+            .attributes
+            .get("MessageRetentionPeriod")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(345600); // default 4 days
+
+        let before = queue.messages.len() + queue.inflight.len();
+
+        queue
+            .messages
+            .retain(|m| (now - m.created_at).num_seconds() < retention_seconds);
+        queue
+            .inflight
+            .retain(|m| (now - m.created_at).num_seconds() < retention_seconds);
+
+        let after = queue.messages.len() + queue.inflight.len();
+        total += (before - after) as u64;
+    }
+
+    total
+}
+
+/// Force-move messages that have exceeded `maxReceiveCount` to the DLQ.
+///
+/// Looks up the queue by name, checks its redrive policy, then moves any
+/// messages (pending or in-flight) whose `receive_count` is >=
+/// `maxReceiveCount` to the configured dead-letter queue. Returns the
+/// number of messages moved.
+///
+/// If the queue has no redrive policy, or the DLQ does not exist, this
+/// is a no-op returning 0.
+pub fn force_dlq(state: &SharedSqsState, queue_name: &str) -> u64 {
+    let mut state = state.write();
+
+    // Resolve queue URL from name
+    let queue_url = match state.name_to_url.get(queue_name) {
+        Some(url) => url.clone(),
+        None => return 0,
+    };
+
+    // Extract redrive policy before mutating
+    let redrive = match state.queues.get(&queue_url) {
+        Some(q) => match &q.redrive_policy {
+            Some(rp) => (rp.dead_letter_target_arn.clone(), rp.max_receive_count),
+            None => return 0,
+        },
+        None => return 0,
+    };
+
+    let (dlq_arn, max_receive_count) = redrive;
+
+    // Check that the DLQ exists
+    let dlq_url = match state.queues.values().find(|q| q.arn == dlq_arn) {
+        Some(q) => q.queue_url.clone(),
+        None => return 0,
+    };
+
+    // Collect messages to move from pending queue
+    let queue = state.queues.get_mut(&queue_url).unwrap();
+    let mut to_move = Vec::new();
+
+    let mut remaining = std::collections::VecDeque::new();
+    while let Some(msg) = queue.messages.pop_front() {
+        if msg.receive_count >= max_receive_count {
+            to_move.push(msg);
+        } else {
+            remaining.push_back(msg);
+        }
+    }
+    queue.messages = remaining;
+
+    // Also check in-flight messages
+    let mut remaining_inflight = Vec::new();
+    for msg in queue.inflight.drain(..) {
+        if msg.receive_count >= max_receive_count {
+            to_move.push(msg);
+        } else {
+            remaining_inflight.push(msg);
+        }
+    }
+    queue.inflight = remaining_inflight;
+
+    let moved = to_move.len() as u64;
+
+    // Move to DLQ
+    let dlq = state.queues.get_mut(&dlq_url).unwrap();
+    for mut msg in to_move {
+        // Reset visibility and receipt handle when moving to DLQ
+        msg.visible_at = None;
+        msg.receipt_handle = None;
+        dlq.messages.push_back(msg);
+    }
+
+    moved
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{RedrivePolicy, SqsMessage, SqsQueue, SqsState};
+    use chrono::Duration;
+    use parking_lot::RwLock;
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::Arc;
+
+    fn make_state() -> SharedSqsState {
+        Arc::new(RwLock::new(SqsState::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4566",
+        )))
+    }
+
+    fn make_message(body: &str, age_seconds: i64, receive_count: u32) -> SqsMessage {
+        SqsMessage {
+            message_id: uuid::Uuid::new_v4().to_string(),
+            receipt_handle: None,
+            body: body.to_string(),
+            md5_of_body: String::new(),
+            sent_timestamp: 0,
+            attributes: HashMap::new(),
+            message_attributes: HashMap::new(),
+            visible_at: None,
+            receive_count,
+            message_group_id: None,
+            message_dedup_id: None,
+            created_at: Utc::now() - Duration::seconds(age_seconds),
+            sequence_number: None,
+        }
+    }
+
+    fn add_queue(state: &SharedSqsState, name: &str, retention: Option<&str>) -> String {
+        let mut s = state.write();
+        let url = format!("http://localhost:4566/123456789012/{name}");
+        let arn = format!("arn:aws:sqs:us-east-1:123456789012:{name}");
+        let mut attrs = HashMap::new();
+        if let Some(r) = retention {
+            attrs.insert("MessageRetentionPeriod".to_string(), r.to_string());
+        }
+        let queue = SqsQueue {
+            queue_name: name.to_string(),
+            queue_url: url.clone(),
+            arn,
+            created_at: Utc::now(),
+            messages: VecDeque::new(),
+            inflight: Vec::new(),
+            attributes: attrs,
+            is_fifo: false,
+            dedup_cache: HashMap::new(),
+            redrive_policy: None,
+            tags: HashMap::new(),
+            next_sequence_number: 0,
+            permission_labels: Vec::new(),
+            receipt_handle_map: HashMap::new(),
+        };
+        s.queues.insert(url.clone(), queue);
+        s.name_to_url.insert(name.to_string(), url.clone());
+        url
+    }
+
+    #[test]
+    fn expiration_removes_old_messages() {
+        let state = make_state();
+        let url = add_queue(&state, "test-q", Some("60")); // 60s retention
+
+        {
+            let mut s = state.write();
+            let q = s.queues.get_mut(&url).unwrap();
+            q.messages.push_back(make_message("old", 120, 0)); // 120s old > 60s retention
+        }
+
+        let expired = tick_expiration(&state);
+        assert_eq!(expired, 1);
+
+        let s = state.read();
+        assert_eq!(s.queues[&url].messages.len(), 0);
+    }
+
+    #[test]
+    fn expiration_keeps_young_messages() {
+        let state = make_state();
+        let url = add_queue(&state, "test-q", Some("60")); // 60s retention
+
+        {
+            let mut s = state.write();
+            let q = s.queues.get_mut(&url).unwrap();
+            q.messages.push_back(make_message("young", 10, 0)); // 10s old < 60s retention
+        }
+
+        let expired = tick_expiration(&state);
+        assert_eq!(expired, 0);
+
+        let s = state.read();
+        assert_eq!(s.queues[&url].messages.len(), 1);
+    }
+
+    #[test]
+    fn force_dlq_moves_over_max_receive_count() {
+        let state = make_state();
+        let dlq_url = add_queue(&state, "my-dlq", None);
+        let src_url = add_queue(&state, "src-q", None);
+
+        let dlq_arn = {
+            let s = state.read();
+            s.queues[&dlq_url].arn.clone()
+        };
+
+        // Set redrive policy on source
+        {
+            let mut s = state.write();
+            let q = s.queues.get_mut(&src_url).unwrap();
+            q.redrive_policy = Some(RedrivePolicy {
+                dead_letter_target_arn: dlq_arn,
+                max_receive_count: 2,
+            });
+            // Message received 3 times (>= maxReceiveCount of 2)
+            q.messages.push_back(make_message("over", 5, 3));
+        }
+
+        let moved = force_dlq(&state, "src-q");
+        assert_eq!(moved, 1);
+
+        let s = state.read();
+        assert_eq!(s.queues[&src_url].messages.len(), 0);
+        assert_eq!(s.queues[&dlq_url].messages.len(), 1);
+        assert_eq!(s.queues[&dlq_url].messages[0].body, "over");
+    }
+
+    #[test]
+    fn force_dlq_keeps_under_max_receive_count() {
+        let state = make_state();
+        let dlq_url = add_queue(&state, "my-dlq", None);
+        let src_url = add_queue(&state, "src-q", None);
+
+        let dlq_arn = {
+            let s = state.read();
+            s.queues[&dlq_url].arn.clone()
+        };
+
+        {
+            let mut s = state.write();
+            let q = s.queues.get_mut(&src_url).unwrap();
+            q.redrive_policy = Some(RedrivePolicy {
+                dead_letter_target_arn: dlq_arn,
+                max_receive_count: 3,
+            });
+            // Message received 1 time (< maxReceiveCount of 3)
+            q.messages.push_back(make_message("under", 5, 1));
+        }
+
+        let moved = force_dlq(&state, "src-q");
+        assert_eq!(moved, 0);
+
+        let s = state.read();
+        assert_eq!(s.queues[&src_url].messages.len(), 1);
+        assert_eq!(s.queues[&dlq_url].messages.len(), 0);
+    }
+
+    #[test]
+    fn force_dlq_no_redrive_policy_is_noop() {
+        let state = make_state();
+        add_queue(&state, "no-policy-q", None);
+
+        let moved = force_dlq(&state, "no-policy-q");
+        assert_eq!(moved, 0);
+    }
+}

--- a/crates/fakecloud-sqs/src/simulation.rs
+++ b/crates/fakecloud-sqs/src/simulation.rs
@@ -39,7 +39,7 @@ pub fn tick_expiration(state: &SharedSqsState) -> u64 {
 /// Force-move messages that have exceeded `maxReceiveCount` to the DLQ.
 ///
 /// Looks up the queue by name, checks its redrive policy, then moves any
-/// messages (pending or in-flight) whose `receive_count` is >=
+/// messages (pending or in-flight) whose `receive_count` exceeds
 /// `maxReceiveCount` to the configured dead-letter queue. Returns the
 /// number of messages moved.
 ///
@@ -77,7 +77,7 @@ pub fn force_dlq(state: &SharedSqsState, queue_name: &str) -> u64 {
 
     let mut remaining = std::collections::VecDeque::new();
     while let Some(msg) = queue.messages.pop_front() {
-        if msg.receive_count >= max_receive_count {
+        if msg.receive_count > max_receive_count {
             to_move.push(msg);
         } else {
             remaining.push_back(msg);
@@ -88,7 +88,7 @@ pub fn force_dlq(state: &SharedSqsState, queue_name: &str) -> u64 {
     // Also check in-flight messages
     let mut remaining_inflight = Vec::new();
     for msg in queue.inflight.drain(..) {
-        if msg.receive_count >= max_receive_count {
+        if msg.receive_count > max_receive_count {
             to_move.push(msg);
         } else {
             remaining_inflight.push(msg);


### PR DESCRIPTION
## Summary

- Add SQS simulation endpoints: `POST /_fakecloud/sqs/expiration-processor/tick` removes expired messages across all queues, `POST /_fakecloud/sqs/{queue-name}/force-dlq` moves over-received messages to DLQ
- Add EventBridge simulation endpoint: `POST /_fakecloud/events/fire-rule` fires a rule immediately with delivery to all targets (SQS, SNS, Lambda, Logs), regardless of enabled/disabled state
- Unit tests for all simulation functions (8 tests) and E2E tests exercising the HTTP endpoints (3 tests)

## Test plan

- [x] Unit tests: SQS expiration removes old messages, keeps young messages
- [x] Unit tests: SQS force-DLQ moves over-limit messages, keeps under-limit, no-op without redrive policy
- [x] Unit tests: EventBridge fire-rule delivers to targets, errors on missing rule, fires disabled rules
- [x] E2E test: SQS expiration tick with short retention period
- [x] E2E test: SQS force-DLQ with maxReceiveCount=1
- [x] E2E test: EventBridge fire-rule delivers to SQS target, verifies introspection
- [x] cargo clippy --workspace -- -D warnings
- [x] cargo fmt --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds simulation endpoints to expire SQS messages, force DLQ moves, and fire EventBridge rules on demand for deterministic tests. Endpoints are opt-in and do not change normal behavior.

- **New Features**
  - POST `/_fakecloud/sqs/expiration-processor/tick`: Remove messages older than `MessageRetentionPeriod` across all queues; returns `{"expiredMessages": n}`.
  - POST `/_fakecloud/sqs/{queue-name}/force-dlq`: Move messages with `receiveCount >= maxReceiveCount` to the queue’s DLQ; no-op if no redrive policy; returns `{"movedMessages": n}`.
  - POST `/_fakecloud/events/fire-rule`: Trigger a rule immediately on a bus (ignores enabled state) and deliver to all targets (SQS, SNS, Lambda, Logs); supports `Input` and simple `InputPath` (`$.field`), passes `SqsParameters.MessageGroupId` to FIFO SQS targets; returns `{"targets":[{type, arn}]}` and records the event in introspection.

<sup>Written for commit 1c6747965fe61b55536902e4b014765ebb8f0cc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

