### PR TITLE
feat(cognito): implement group management operations

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -2,65 +2,65 @@
   "variants_passed": 42164,
   "total_variants": 42193,
   "per_service": {
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
     "kms": {
       "passed": 2196,
       "total": 2196
-    },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
     },
     "events": {
       "passed": 2108,
       "total": 2108
     },
-    "sts": {
-      "passed": 438,
-      "total": 438
+    "sns": {
+      "passed": 1027,
+      "total": 1027
     },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
+    "logs": {
+      "passed": 3911,
+      "total": 3911
+    },
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
     },
     "cloudformation": {
       "passed": 3420,
       "total": 3420
     },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
-    },
-    "cognito-idp": {
-      "passed": 4450,
-      "total": 4479
-    },
     "dynamodb": {
       "passed": 2123,
       "total": 2123
     },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
+    "sts": {
+      "passed": 438,
+      "total": 438
     },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
     },
-    "sqs": {
-      "passed": 549,
-      "total": 549
+    "s3": {
+      "passed": 3620,
+      "total": 3620
     },
     "secretsmanager": {
       "passed": 852,
       "total": 852
     },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
+    "iam": {
+      "passed": 5962,
+      "total": 5962
+    },
+    "ses": {
+      "passed": 2858,
+      "total": 2858
+    },
+    "cognito-idp": {
+      "passed": 4450,
+      "total": 4479
     }
   }
 }

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -995,6 +995,11 @@ impl CognitoService {
             ));
         }
 
+        // Clean up group memberships for the deleted user
+        if let Some(pool_groups) = state.user_groups.get_mut(pool_id) {
+            pool_groups.remove(username);
+        }
+
         Ok(AwsResponse::ok_json(json!({})))
     }
 
@@ -3160,7 +3165,7 @@ fn parse_user_attributes(val: &Value) -> Vec<UserAttribute> {
         .unwrap_or_default()
 }
 
-/// Convert a User to the JSON format AWS returns (for ListUsers and AdminCreateUser response).
+/// Convert a Group to the JSON format AWS returns.
 fn group_to_json(group: &Group) -> Value {
     let mut val = json!({
         "GroupName": group.group_name,
@@ -3180,6 +3185,7 @@ fn group_to_json(group: &Group) -> Value {
     val
 }
 
+/// Convert a User to the JSON format AWS returns (for ListUsers and AdminCreateUser response).
 fn user_to_json(user: &User) -> Value {
     json!({
         "Username": user.username,

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use base64::Engine;
 use chrono::Utc;
@@ -10,7 +12,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 
 use crate::state::{
     default_schema_attributes, AccessTokenData, AccountRecoverySetting, AdminCreateUserConfig,
-    EmailConfiguration, InviteMessageTemplate, PasswordPolicy, PoolPolicies, RecoveryOption,
+    EmailConfiguration, Group, InviteMessageTemplate, PasswordPolicy, PoolPolicies, RecoveryOption,
     RefreshTokenData, SchemaAttribute, SessionData, SharedCognitoState, SmsConfiguration,
     StringAttributeConstraints, TokenValidityUnits, User, UserAttribute, UserPool, UserPoolClient,
 };
@@ -65,6 +67,15 @@ impl AwsService for CognitoService {
             "AdminResetUserPassword" => self.admin_reset_user_password(&req),
             "GlobalSignOut" => self.global_sign_out(&req),
             "AdminUserGlobalSignOut" => self.admin_user_global_sign_out(&req),
+            "CreateGroup" => self.create_group(&req),
+            "DeleteGroup" => self.delete_group(&req),
+            "GetGroup" => self.get_group(&req),
+            "UpdateGroup" => self.update_group(&req),
+            "ListGroups" => self.list_groups(&req),
+            "AdminAddUserToGroup" => self.admin_add_user_to_group(&req),
+            "AdminRemoveUserFromGroup" => self.admin_remove_user_from_group(&req),
+            "AdminListGroupsForUser" => self.admin_list_groups_for_user(&req),
+            "ListUsersInGroup" => self.list_users_in_group(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "cognito-idp",
                 &req.action,
@@ -106,6 +117,15 @@ impl AwsService for CognitoService {
             "AdminResetUserPassword",
             "GlobalSignOut",
             "AdminUserGlobalSignOut",
+            "CreateGroup",
+            "DeleteGroup",
+            "GetGroup",
+            "UpdateGroup",
+            "ListGroups",
+            "AdminAddUserToGroup",
+            "AdminRemoveUserFromGroup",
+            "AdminListGroupsForUser",
+            "ListUsersInGroup",
         ]
     }
 }
@@ -345,6 +365,10 @@ impl CognitoService {
         state
             .user_pool_clients
             .retain(|_, c| c.user_pool_id != pool_id);
+
+        // Remove associated groups and user-group associations
+        state.groups.remove(pool_id);
+        state.user_groups.remove(pool_id);
 
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -2365,6 +2389,493 @@ impl CognitoService {
 
         Ok(AwsResponse::ok_json(json!({})))
     }
+
+    // ── Group management ────────────────────────────────────────────────
+
+    fn create_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let group_name = require_str(&body, "GroupName")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let description = body["Description"].as_str().map(|s| s.to_string());
+        let precedence = body["Precedence"].as_i64();
+        let role_arn = body["RoleArn"].as_str().map(|s| s.to_string());
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let pool_groups = state.groups.entry(pool_id.to_string()).or_default();
+        if pool_groups.contains_key(group_name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "GroupExistsException",
+                format!("A group with the name {group_name} already exists."),
+            ));
+        }
+
+        let now = Utc::now();
+        let group = Group {
+            group_name: group_name.to_string(),
+            user_pool_id: pool_id.to_string(),
+            description: description.clone(),
+            precedence,
+            role_arn: role_arn.clone(),
+            creation_date: now,
+            last_modified_date: now,
+        };
+
+        pool_groups.insert(group_name.to_string(), group.clone());
+
+        Ok(AwsResponse::ok_json(json!({
+            "Group": group_to_json(&group)
+        })))
+    }
+
+    fn delete_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let group_name = require_str(&body, "GroupName")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let removed = state
+            .groups
+            .get_mut(pool_id)
+            .and_then(|groups| groups.remove(group_name));
+
+        if removed.is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "Group not found.",
+            ));
+        }
+
+        // Remove group from all user-group associations in this pool
+        if let Some(pool_user_groups) = state.user_groups.get_mut(pool_id) {
+            for group_list in pool_user_groups.values_mut() {
+                group_list.retain(|g| g != group_name);
+            }
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn get_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let group_name = require_str(&body, "GroupName")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let group = state
+            .groups
+            .get(pool_id)
+            .and_then(|groups| groups.get(group_name))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    "Group not found.",
+                )
+            })?;
+
+        Ok(AwsResponse::ok_json(json!({
+            "Group": group_to_json(group)
+        })))
+    }
+
+    fn update_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let group_name = require_str(&body, "GroupName")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let group = state
+            .groups
+            .get_mut(pool_id)
+            .and_then(|groups| groups.get_mut(group_name))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    "Group not found.",
+                )
+            })?;
+
+        if let Some(desc) = body["Description"].as_str() {
+            group.description = Some(desc.to_string());
+        }
+        if let Some(prec) = body["Precedence"].as_i64() {
+            group.precedence = Some(prec);
+        }
+        if let Some(arn) = body["RoleArn"].as_str() {
+            group.role_arn = Some(arn.to_string());
+        }
+
+        group.last_modified_date = Utc::now();
+
+        let group_json = group_to_json(group);
+
+        Ok(AwsResponse::ok_json(json!({
+            "Group": group_json
+        })))
+    }
+
+    fn list_groups(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let limit = body["Limit"].as_i64().unwrap_or(60).clamp(1, 60) as usize;
+        let next_token = body["NextToken"].as_str();
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let empty = std::collections::HashMap::new();
+        let pool_groups = state.groups.get(pool_id).unwrap_or(&empty);
+
+        let mut groups: Vec<&Group> = pool_groups.values().collect();
+        groups.sort_by_key(|g| g.creation_date);
+
+        let start_idx = if let Some(token) = next_token {
+            groups
+                .iter()
+                .position(|g| g.group_name == token)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        let page: Vec<Value> = groups
+            .iter()
+            .skip(start_idx)
+            .take(limit)
+            .map(|g| group_to_json(g))
+            .collect();
+
+        let has_more = start_idx + limit < groups.len();
+        let mut response = json!({ "Groups": page });
+        if has_more {
+            if let Some(last_group) = groups.get(start_idx + limit) {
+                response["NextToken"] = json!(last_group.group_name);
+            }
+        }
+
+        Ok(AwsResponse::ok_json(response))
+    }
+
+    fn admin_add_user_to_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let username = require_str(&body, "Username")?;
+        let group_name = require_str(&body, "GroupName")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        // Validate user exists
+        if !state
+            .users
+            .get(pool_id)
+            .is_some_and(|users| users.contains_key(username))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "UserNotFoundException",
+                "User does not exist.",
+            ));
+        }
+
+        // Validate group exists
+        if !state
+            .groups
+            .get(pool_id)
+            .is_some_and(|groups| groups.contains_key(group_name))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "Group not found.",
+            ));
+        }
+
+        let user_group_list = state
+            .user_groups
+            .entry(pool_id.to_string())
+            .or_default()
+            .entry(username.to_string())
+            .or_default();
+
+        if !user_group_list.contains(&group_name.to_string()) {
+            user_group_list.push(group_name.to_string());
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn admin_remove_user_from_group(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let username = require_str(&body, "Username")?;
+        let group_name = require_str(&body, "GroupName")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        // Validate user exists
+        if !state
+            .users
+            .get(pool_id)
+            .is_some_and(|users| users.contains_key(username))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "UserNotFoundException",
+                "User does not exist.",
+            ));
+        }
+
+        // Validate group exists
+        if !state
+            .groups
+            .get(pool_id)
+            .is_some_and(|groups| groups.contains_key(group_name))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "Group not found.",
+            ));
+        }
+
+        if let Some(user_group_list) = state
+            .user_groups
+            .get_mut(pool_id)
+            .and_then(|m| m.get_mut(username))
+        {
+            user_group_list.retain(|g| g != group_name);
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn admin_list_groups_for_user(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let username = require_str(&body, "Username")?;
+        let limit = body["Limit"].as_i64().unwrap_or(60).clamp(1, 60) as usize;
+        let next_token = body["NextToken"].as_str();
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        // Validate user exists
+        if !state
+            .users
+            .get(pool_id)
+            .is_some_and(|users| users.contains_key(username))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "UserNotFoundException",
+                "User does not exist.",
+            ));
+        }
+
+        let empty_user_groups: HashMap<String, Vec<String>> = HashMap::new();
+        let empty_group_list: Vec<String> = Vec::new();
+        let user_group_names = state
+            .user_groups
+            .get(pool_id)
+            .unwrap_or(&empty_user_groups)
+            .get(username)
+            .unwrap_or(&empty_group_list);
+
+        let empty_groups: HashMap<String, Group> = HashMap::new();
+        let pool_groups = state.groups.get(pool_id).unwrap_or(&empty_groups);
+
+        // Collect and sort groups by creation date
+        let mut groups: Vec<&Group> = user_group_names
+            .iter()
+            .filter_map(|name| pool_groups.get(name))
+            .collect();
+        groups.sort_by_key(|g| g.creation_date);
+
+        let start_idx = if let Some(token) = next_token {
+            groups
+                .iter()
+                .position(|g| g.group_name == token)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        let page: Vec<Value> = groups
+            .iter()
+            .skip(start_idx)
+            .take(limit)
+            .map(|g| group_to_json(g))
+            .collect();
+
+        let has_more = start_idx + limit < groups.len();
+        let mut response = json!({ "Groups": page });
+        if has_more {
+            if let Some(last_group) = groups.get(start_idx + limit) {
+                response["NextToken"] = json!(last_group.group_name);
+            }
+        }
+
+        Ok(AwsResponse::ok_json(response))
+    }
+
+    fn list_users_in_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let group_name = require_str(&body, "GroupName")?;
+        let limit = body["Limit"].as_i64().unwrap_or(60).clamp(1, 60) as usize;
+        let next_token = body["NextToken"].as_str();
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        // Validate group exists
+        if !state
+            .groups
+            .get(pool_id)
+            .is_some_and(|groups| groups.contains_key(group_name))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "Group not found.",
+            ));
+        }
+
+        let empty_user_groups: HashMap<String, Vec<String>> = HashMap::new();
+        let pool_user_groups = state.user_groups.get(pool_id).unwrap_or(&empty_user_groups);
+
+        // Find all usernames that belong to this group
+        let mut usernames_in_group: Vec<&str> = pool_user_groups
+            .iter()
+            .filter(|(_, groups)| groups.contains(&group_name.to_string()))
+            .map(|(username, _)| username.as_str())
+            .collect();
+        usernames_in_group.sort();
+
+        let empty_users = std::collections::HashMap::new();
+        let pool_users = state.users.get(pool_id).unwrap_or(&empty_users);
+
+        // Sort by creation date for consistent pagination
+        let mut users_in_group: Vec<&User> = usernames_in_group
+            .iter()
+            .filter_map(|username| pool_users.get(*username))
+            .collect();
+        users_in_group.sort_by_key(|u| u.user_create_date);
+
+        let start_idx = if let Some(token) = next_token {
+            users_in_group
+                .iter()
+                .position(|u| u.username == token)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        let page: Vec<Value> = users_in_group
+            .iter()
+            .skip(start_idx)
+            .take(limit)
+            .map(|u| user_to_json(u))
+            .collect();
+
+        let has_more = start_idx + limit < users_in_group.len();
+        let mut response = json!({ "Users": page });
+        if has_more {
+            if let Some(last_user) = users_in_group.get(start_idx + limit) {
+                response["NextToken"] = json!(last_user.username);
+            }
+        }
+
+        Ok(AwsResponse::ok_json(response))
+    }
 }
 
 /// Generate a pool ID in the format `{region}_{9 random alphanumeric chars}`.
@@ -2650,6 +3161,25 @@ fn parse_user_attributes(val: &Value) -> Vec<UserAttribute> {
 }
 
 /// Convert a User to the JSON format AWS returns (for ListUsers and AdminCreateUser response).
+fn group_to_json(group: &Group) -> Value {
+    let mut val = json!({
+        "GroupName": group.group_name,
+        "UserPoolId": group.user_pool_id,
+        "CreationDate": group.creation_date.timestamp() as f64,
+        "LastModifiedDate": group.last_modified_date.timestamp() as f64,
+    });
+    if let Some(ref desc) = group.description {
+        val["Description"] = json!(desc);
+    }
+    if let Some(prec) = group.precedence {
+        val["Precedence"] = json!(prec);
+    }
+    if let Some(ref arn) = group.role_arn {
+        val["RoleArn"] = json!(arn);
+    }
+    val
+}
+
 fn user_to_json(user: &User) -> Value {
     json!({
         "Username": user.username,
@@ -3759,5 +4289,228 @@ mod tests {
 
         // Non-existent token returns None
         assert!(!s.access_tokens.contains_key("nonexistent"));
+    }
+
+    #[test]
+    fn group_name_uniqueness() {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(crate::state::CognitoState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        let svc = CognitoService::new(state.clone());
+
+        // Create a pool first
+        let create_pool_req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "CreateUserPool".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({ "PoolName": "test-pool" })).unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        let resp = svc.create_user_pool(&create_pool_req).unwrap();
+        let resp_json: Value =
+            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+        let pool_id = resp_json["UserPool"]["Id"].as_str().unwrap().to_string();
+
+        // Create a group
+        let create_group_req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "CreateGroup".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "UserPoolId": pool_id,
+                    "GroupName": "admins"
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        let result = svc.create_group(&create_group_req);
+        assert!(result.is_ok());
+
+        // Creating the same group again should fail with GroupExistsException
+        let result = svc.create_group(&create_group_req);
+        match result {
+            Err(e) => {
+                let msg = format!("{e:?}");
+                assert!(
+                    msg.contains("GroupExistsException"),
+                    "Should be GroupExistsException: {msg}"
+                );
+            }
+            Ok(_) => panic!("Expected GroupExistsException"),
+        }
+    }
+
+    #[test]
+    fn user_group_association() {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(crate::state::CognitoState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        let svc = CognitoService::new(state.clone());
+
+        // Create a pool
+        let create_pool_req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "CreateUserPool".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({ "PoolName": "test-pool" })).unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        let resp = svc.create_user_pool(&create_pool_req).unwrap();
+        let resp_json: Value =
+            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+        let pool_id = resp_json["UserPool"]["Id"].as_str().unwrap().to_string();
+
+        // Create a user
+        let create_user_req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "AdminCreateUser".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "UserPoolId": pool_id,
+                    "Username": "testuser"
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        svc.admin_create_user(&create_user_req).unwrap();
+
+        // Create a group
+        let create_group_req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "CreateGroup".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "UserPoolId": pool_id,
+                    "GroupName": "admins"
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        svc.create_group(&create_group_req).unwrap();
+
+        // Add user to group
+        let add_req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "AdminAddUserToGroup".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "UserPoolId": pool_id,
+                    "Username": "testuser",
+                    "GroupName": "admins"
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        svc.admin_add_user_to_group(&add_req).unwrap();
+
+        // Verify membership via state
+        {
+            let s = state.read();
+            let groups = s.user_groups.get(&pool_id).unwrap();
+            let user_groups = groups.get("testuser").unwrap();
+            assert!(user_groups.contains(&"admins".to_string()));
+        }
+
+        // Remove user from group
+        let remove_req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "AdminRemoveUserFromGroup".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "UserPoolId": pool_id,
+                    "Username": "testuser",
+                    "GroupName": "admins"
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        svc.admin_remove_user_from_group(&remove_req).unwrap();
+
+        // Verify no longer in group
+        {
+            let s = state.read();
+            let groups = s.user_groups.get(&pool_id).unwrap();
+            let user_groups = groups.get("testuser").unwrap();
+            assert!(!user_groups.contains(&"admins".to_string()));
+        }
     }
 }

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -20,6 +20,10 @@ pub struct CognitoState {
     pub sessions: HashMap<String, SessionData>,
     /// access_token -> AccessTokenData
     pub access_tokens: HashMap<String, AccessTokenData>,
+    /// pool_id -> (group_name -> Group)
+    pub groups: HashMap<String, HashMap<String, Group>>,
+    /// pool_id -> (username -> [group_names])
+    pub user_groups: HashMap<String, HashMap<String, Vec<String>>>,
 }
 
 impl CognitoState {
@@ -33,6 +37,8 @@ impl CognitoState {
             refresh_tokens: HashMap::new(),
             sessions: HashMap::new(),
             access_tokens: HashMap::new(),
+            groups: HashMap::new(),
+            user_groups: HashMap::new(),
         }
     }
 
@@ -43,6 +49,8 @@ impl CognitoState {
         self.refresh_tokens.clear();
         self.sessions.clear();
         self.access_tokens.clear();
+        self.groups.clear();
+        self.user_groups.clear();
     }
 }
 
@@ -234,6 +242,17 @@ pub struct User {
 pub struct UserAttribute {
     pub name: String,
     pub value: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Group {
+    pub group_name: String,
+    pub user_pool_id: String,
+    pub description: Option<String>,
+    pub precedence: Option<i64>,
+    pub role_arn: Option<String>,
+    pub creation_date: DateTime<Utc>,
+    pub last_modified_date: DateTime<Utc>,
 }
 
 /// Generate default schema attributes that AWS adds to every user pool.

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -1461,3 +1461,383 @@ async fn cognito_admin_user_global_sign_out() {
         "Refresh token should be invalid after admin global sign out"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Groups
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "CreateGroup", checksum = "8458f036")]
+#[tokio::test]
+async fn cognito_create_group() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("grp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let resp = client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("admins")
+        .description("Admin group")
+        .precedence(1)
+        .send()
+        .await
+        .unwrap();
+    let group = resp.group().unwrap();
+    assert_eq!(group.group_name().unwrap(), "admins");
+    assert_eq!(group.description().unwrap(), "Admin group");
+}
+
+#[test_action("cognito-idp", "GetGroup", checksum = "a81d68fe")]
+#[tokio::test]
+async fn cognito_get_group() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("getgrp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("readers")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_group()
+        .user_pool_id(&pool_id)
+        .group_name("readers")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.group().unwrap().group_name().unwrap(), "readers");
+}
+
+#[test_action("cognito-idp", "UpdateGroup", checksum = "8c9b60d7")]
+#[tokio::test]
+async fn cognito_update_group() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("updgrp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("editors")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_group()
+        .user_pool_id(&pool_id)
+        .group_name("editors")
+        .description("Updated editors")
+        .precedence(5)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_group()
+        .user_pool_id(&pool_id)
+        .group_name("editors")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.group().unwrap().description().unwrap(),
+        "Updated editors"
+    );
+}
+
+#[test_action("cognito-idp", "DeleteGroup", checksum = "ac33ddbb")]
+#[tokio::test]
+async fn cognito_delete_group() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("delgrp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("tempgrp")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_group()
+        .user_pool_id(&pool_id)
+        .group_name("tempgrp")
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .get_group()
+        .user_pool_id(&pool_id)
+        .group_name("tempgrp")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(err.into_service_error().is_resource_not_found_exception());
+}
+
+#[test_action("cognito-idp", "ListGroups", checksum = "75858aba")]
+#[tokio::test]
+async fn cognito_list_groups() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("listgrp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("g1")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("g2")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_groups()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.groups().len(), 2);
+}
+
+#[test_action("cognito-idp", "AdminAddUserToGroup", checksum = "5fec870a")]
+#[test_action("cognito-idp", "AdminRemoveUserFromGroup", checksum = "90421bbd")]
+#[tokio::test]
+async fn cognito_admin_add_remove_user_to_group() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("usergrp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("grpuser")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("devs")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .admin_add_user_to_group()
+        .user_pool_id(&pool_id)
+        .username("grpuser")
+        .group_name("devs")
+        .send()
+        .await
+        .unwrap();
+
+    let users = client
+        .list_users_in_group()
+        .user_pool_id(&pool_id)
+        .group_name("devs")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(users.users().len(), 1);
+
+    client
+        .admin_remove_user_from_group()
+        .user_pool_id(&pool_id)
+        .username("grpuser")
+        .group_name("devs")
+        .send()
+        .await
+        .unwrap();
+
+    let users2 = client
+        .list_users_in_group()
+        .user_pool_id(&pool_id)
+        .group_name("devs")
+        .send()
+        .await
+        .unwrap();
+    assert!(users2.users().is_empty());
+}
+
+#[test_action("cognito-idp", "AdminListGroupsForUser", checksum = "ab20831c")]
+#[tokio::test]
+async fn cognito_admin_list_groups_for_user() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("grpforuser-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("multigrp")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("team-a")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("team-b")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .admin_add_user_to_group()
+        .user_pool_id(&pool_id)
+        .username("multigrp")
+        .group_name("team-a")
+        .send()
+        .await
+        .unwrap();
+    client
+        .admin_add_user_to_group()
+        .user_pool_id(&pool_id)
+        .username("multigrp")
+        .group_name("team-b")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .admin_list_groups_for_user()
+        .user_pool_id(&pool_id)
+        .username("multigrp")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.groups().len(), 2);
+}
+
+#[test_action("cognito-idp", "ListUsersInGroup", checksum = "c3ee8bcd")]
+#[tokio::test]
+async fn cognito_list_users_in_group() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("usrsingrp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("qa")
+        .send()
+        .await
+        .unwrap();
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("qa1")
+        .send()
+        .await
+        .unwrap();
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("qa2")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .admin_add_user_to_group()
+        .user_pool_id(&pool_id)
+        .username("qa1")
+        .group_name("qa")
+        .send()
+        .await
+        .unwrap();
+    client
+        .admin_add_user_to_group()
+        .user_pool_id(&pool_id)
+        .username("qa2")
+        .group_name("qa")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_users_in_group()
+        .user_pool_id(&pool_id)
+        .group_name("qa")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.users().len(), 2);
+}

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -1492,6 +1492,7 @@ async fn cognito_create_group() {
     let group = resp.group().unwrap();
     assert_eq!(group.group_name().unwrap(), "admins");
     assert_eq!(group.description().unwrap(), "Admin group");
+    assert_eq!(group.precedence().unwrap(), 1);
 }
 
 #[test_action("cognito-idp", "GetGroup", checksum = "a81d68fe")]
@@ -1569,6 +1570,7 @@ async fn cognito_update_group() {
         resp.group().unwrap().description().unwrap(),
         "Updated editors"
     );
+    assert_eq!(resp.group().unwrap().precedence().unwrap(), 5);
 }
 
 #[test_action("cognito-idp", "DeleteGroup", checksum = "ac33ddbb")]

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -2059,3 +2059,433 @@ async fn cognito_admin_user_global_sign_out() {
         "Refresh token should be invalidated after admin sign out"
     );
 }
+
+// ── Group management E2E tests ──────────────────────────────────────
+
+#[tokio::test]
+async fn cognito_create_get_group() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("group-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create a group with all fields
+    let result = client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("admins")
+        .description("Admin group")
+        .precedence(1)
+        .role_arn("arn:aws:iam::123456789012:role/AdminRole")
+        .send()
+        .await
+        .expect("create group");
+
+    let group = result.group().unwrap();
+    assert_eq!(group.group_name().unwrap(), "admins");
+    assert_eq!(group.user_pool_id().unwrap(), pool_id);
+    assert_eq!(group.description().unwrap(), "Admin group");
+    assert_eq!(group.precedence(), Some(1));
+    assert_eq!(
+        group.role_arn().unwrap(),
+        "arn:aws:iam::123456789012:role/AdminRole"
+    );
+
+    // Get the group
+    let get_result = client
+        .get_group()
+        .user_pool_id(&pool_id)
+        .group_name("admins")
+        .send()
+        .await
+        .expect("get group");
+
+    let got = get_result.group().unwrap();
+    assert_eq!(got.group_name().unwrap(), "admins");
+    assert_eq!(got.description().unwrap(), "Admin group");
+    assert_eq!(got.precedence(), Some(1));
+
+    // Get non-existent group should fail
+    let err = client
+        .get_group()
+        .user_pool_id(&pool_id)
+        .group_name("nonexistent")
+        .send()
+        .await;
+    assert!(err.is_err(), "Getting non-existent group should fail");
+
+    // Creating duplicate group should fail with GroupExistsException
+    let dup_err = client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("admins")
+        .send()
+        .await;
+    assert!(dup_err.is_err(), "Duplicate group should fail");
+}
+
+#[tokio::test]
+async fn cognito_update_delete_group() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("upd-group-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("editors")
+        .description("Editor group")
+        .precedence(5)
+        .send()
+        .await
+        .expect("create group");
+
+    // Update the group
+    let updated = client
+        .update_group()
+        .user_pool_id(&pool_id)
+        .group_name("editors")
+        .description("Updated editors")
+        .precedence(10)
+        .role_arn("arn:aws:iam::123456789012:role/EditorRole")
+        .send()
+        .await
+        .expect("update group");
+
+    let g = updated.group().unwrap();
+    assert_eq!(g.description().unwrap(), "Updated editors");
+    assert_eq!(g.precedence(), Some(10));
+    assert_eq!(
+        g.role_arn().unwrap(),
+        "arn:aws:iam::123456789012:role/EditorRole"
+    );
+
+    // Delete the group
+    client
+        .delete_group()
+        .user_pool_id(&pool_id)
+        .group_name("editors")
+        .send()
+        .await
+        .expect("delete group");
+
+    // Getting deleted group should fail
+    let err = client
+        .get_group()
+        .user_pool_id(&pool_id)
+        .group_name("editors")
+        .send()
+        .await;
+    assert!(err.is_err(), "Deleted group should not be found");
+
+    // Deleting again should fail
+    let del_err = client
+        .delete_group()
+        .user_pool_id(&pool_id)
+        .group_name("editors")
+        .send()
+        .await;
+    assert!(del_err.is_err(), "Double delete should fail");
+}
+
+#[tokio::test]
+async fn cognito_list_groups() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("list-groups-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create several groups
+    for name in &["alpha", "beta", "gamma", "delta"] {
+        client
+            .create_group()
+            .user_pool_id(&pool_id)
+            .group_name(*name)
+            .send()
+            .await
+            .expect("create group");
+    }
+
+    // List all groups
+    let list = client
+        .list_groups()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .expect("list groups");
+
+    let groups = list.groups();
+    assert_eq!(groups.len(), 4, "Should have 4 groups");
+
+    // List with limit for pagination
+    let page1 = client
+        .list_groups()
+        .user_pool_id(&pool_id)
+        .limit(2)
+        .send()
+        .await
+        .expect("list groups page 1");
+
+    assert_eq!(page1.groups().len(), 2);
+    assert!(
+        page1.next_token().is_some(),
+        "Should have next token for page 2"
+    );
+
+    let page2 = client
+        .list_groups()
+        .user_pool_id(&pool_id)
+        .limit(2)
+        .next_token(page1.next_token().unwrap())
+        .send()
+        .await
+        .expect("list groups page 2");
+
+    assert_eq!(page2.groups().len(), 2);
+
+    // Collect all group names across pages
+    let mut all_names: Vec<String> = page1
+        .groups()
+        .iter()
+        .chain(page2.groups().iter())
+        .map(|g| g.group_name().unwrap().to_string())
+        .collect();
+    all_names.sort();
+    assert_eq!(all_names, vec!["alpha", "beta", "delta", "gamma"]);
+}
+
+#[tokio::test]
+async fn cognito_add_remove_user_to_group() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("user-group-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create user and group
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("groupuser")
+        .send()
+        .await
+        .expect("create user");
+
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("testers")
+        .send()
+        .await
+        .expect("create group");
+
+    // Add user to group
+    client
+        .admin_add_user_to_group()
+        .user_pool_id(&pool_id)
+        .username("groupuser")
+        .group_name("testers")
+        .send()
+        .await
+        .expect("add user to group");
+
+    // List users in group
+    let users_in_group = client
+        .list_users_in_group()
+        .user_pool_id(&pool_id)
+        .group_name("testers")
+        .send()
+        .await
+        .expect("list users in group");
+
+    assert_eq!(users_in_group.users().len(), 1);
+    assert_eq!(users_in_group.users()[0].username().unwrap(), "groupuser");
+
+    // Adding same user again should be idempotent
+    client
+        .admin_add_user_to_group()
+        .user_pool_id(&pool_id)
+        .username("groupuser")
+        .group_name("testers")
+        .send()
+        .await
+        .expect("add user to group again (idempotent)");
+
+    // Still only 1 user
+    let users_again = client
+        .list_users_in_group()
+        .user_pool_id(&pool_id)
+        .group_name("testers")
+        .send()
+        .await
+        .expect("list users");
+    assert_eq!(users_again.users().len(), 1);
+
+    // Remove user from group
+    client
+        .admin_remove_user_from_group()
+        .user_pool_id(&pool_id)
+        .username("groupuser")
+        .group_name("testers")
+        .send()
+        .await
+        .expect("remove user from group");
+
+    // List users in group should be empty
+    let users_empty = client
+        .list_users_in_group()
+        .user_pool_id(&pool_id)
+        .group_name("testers")
+        .send()
+        .await
+        .expect("list users after removal");
+    assert!(
+        users_empty.users().is_empty(),
+        "Group should be empty after removal"
+    );
+
+    // Adding user to non-existent group should fail
+    let err = client
+        .admin_add_user_to_group()
+        .user_pool_id(&pool_id)
+        .username("groupuser")
+        .group_name("nonexistent")
+        .send()
+        .await;
+    assert!(err.is_err(), "Adding to non-existent group should fail");
+
+    // Adding non-existent user to group should fail
+    let err2 = client
+        .admin_add_user_to_group()
+        .user_pool_id(&pool_id)
+        .username("nosuchuser")
+        .group_name("testers")
+        .send()
+        .await;
+    assert!(err2.is_err(), "Adding non-existent user should fail");
+}
+
+#[tokio::test]
+async fn cognito_list_groups_for_user() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("multi-group-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create user
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("multiuser")
+        .send()
+        .await
+        .expect("create user");
+
+    // Create multiple groups and add user to them
+    for name in &["group-a", "group-b", "group-c"] {
+        client
+            .create_group()
+            .user_pool_id(&pool_id)
+            .group_name(*name)
+            .send()
+            .await
+            .expect("create group");
+
+        client
+            .admin_add_user_to_group()
+            .user_pool_id(&pool_id)
+            .username("multiuser")
+            .group_name(*name)
+            .send()
+            .await
+            .expect("add user to group");
+    }
+
+    // List groups for user
+    let result = client
+        .admin_list_groups_for_user()
+        .user_pool_id(&pool_id)
+        .username("multiuser")
+        .send()
+        .await
+        .expect("list groups for user");
+
+    let groups = result.groups();
+    assert_eq!(groups.len(), 3, "User should be in 3 groups");
+
+    let mut names: Vec<String> = groups
+        .iter()
+        .map(|g| g.group_name().unwrap().to_string())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["group-a", "group-b", "group-c"]);
+
+    // Remove user from one group and verify
+    client
+        .admin_remove_user_from_group()
+        .user_pool_id(&pool_id)
+        .username("multiuser")
+        .group_name("group-b")
+        .send()
+        .await
+        .expect("remove from group-b");
+
+    let result2 = client
+        .admin_list_groups_for_user()
+        .user_pool_id(&pool_id)
+        .username("multiuser")
+        .send()
+        .await
+        .expect("list groups for user after removal");
+
+    assert_eq!(result2.groups().len(), 2);
+    let mut names2: Vec<String> = result2
+        .groups()
+        .iter()
+        .map(|g| g.group_name().unwrap().to_string())
+        .collect();
+    names2.sort();
+    assert_eq!(names2, vec!["group-a", "group-c"]);
+
+    // List groups for non-existent user should fail
+    let err = client
+        .admin_list_groups_for_user()
+        .user_pool_id(&pool_id)
+        .username("nosuchuser")
+        .send()
+        .await;
+    assert!(
+        err.is_err(),
+        "Listing groups for non-existent user should fail"
+    );
+}


### PR DESCRIPTION
## Summary

- 9 new Cognito operations: CreateGroup, DeleteGroup, GetGroup, UpdateGroup, ListGroups, AdminAddUserToGroup, AdminRemoveUserFromGroup, AdminListGroupsForUser, ListUsersInGroup
- Real behavior: group precedence, role ARN, user-group associations, cascade cleanup on pool/group delete
- 2 new unit tests (34 total), 5 new E2E tests (32 total), 9 new conformance tests (41/41 coverage)

## Test plan

- [x] `cargo test -p fakecloud-cognito` — 34 unit tests pass
- [x] `cargo test -p fakecloud-e2e --test cognito` — 32 E2E tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Conformance audit: 41/41 cognito-idp actions covered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full Cognito group management to `fakecloud-cognito`, including group CRUD and user membership APIs with realistic behavior and pagination. Improves test coverage across unit, E2E, and conformance suites for all group operations.

- **New Features**
  - Implemented 9 `cognito-idp` actions: CreateGroup, DeleteGroup, GetGroup, UpdateGroup, ListGroups, AdminAddUserToGroup, AdminRemoveUserFromGroup, AdminListGroupsForUser, ListUsersInGroup.
  - Real behavior: group precedence, role ARN, user–group associations, and cascade cleanup on pool/group delete; pagination with Limit/NextToken; idempotent add-to-group.
  - State adds `groups` and `user_groups`; tests added across `fakecloud-cognito`, `fakecloud-e2e`, and conformance (+2 unit, +5 E2E, +9 conformance; 41/41 Cognito actions covered).

- **Bug Fixes**
  - Clear user’s group memberships on user delete; refined doc comments and test assertions.

<sup>Written for commit f2846638e4009c1cbd2cc7837a0bb6c0f4146870. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

