### PR TITLE
feat: simulation endpoints for S3, Lambda, SNS, and per-service reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,21 @@ fakecloud exposes `/_fakecloud/*` endpoints for testing behaviors that AWS runs 
 |---|---|---|
 | `/_fakecloud/dynamodb/ttl-processor/tick` | POST | Expire DynamoDB items whose TTL attribute is in the past. Returns `{"expiredItems": N}`. |
 | `/_fakecloud/secretsmanager/rotation-scheduler/tick` | POST | Rotate secrets whose rotation schedule is due. Returns `{"rotatedSecrets": ["name", ...]}`. |
+| `/_fakecloud/s3/lifecycle-processor/tick` | POST | Run one S3 lifecycle processing tick. Returns `{"processedBuckets": N, "expiredObjects": N, "transitionedObjects": N}`. |
+| `/_fakecloud/sqs/expiration-processor/tick` | POST | Expire SQS messages past retention period. Returns `{"expiredMessages": N}`. |
+| `/_fakecloud/sqs/{queue_name}/force-dlq` | POST | Force-move messages exceeding maxReceiveCount to DLQ. Returns `{"movedMessages": N}`. |
+| `/_fakecloud/events/fire-rule` | POST | Fire an EventBridge rule regardless of state. Body: `{"busName": "...", "ruleName": "..."}`. |
 | `/_fakecloud/lambda/invocations` | GET | List all Lambda invocations (introspection). |
+| `/_fakecloud/lambda/warm-containers` | GET | List all warm Lambda containers. Returns `{"containers": [...]}`. |
+| `/_fakecloud/lambda/{function-name}/evict-container` | POST | Evict a warm Lambda container (forces cold start). Returns `{"evicted": true/false}`. |
 | `/_fakecloud/sns/messages` | GET | List all published SNS messages. |
+| `/_fakecloud/sns/pending-confirmations` | GET | List SNS subscriptions pending confirmation. Returns `{"pendingConfirmations": [...]}`. |
+| `/_fakecloud/sns/confirm-subscription` | POST | Force-confirm an SNS subscription. Body: `{"subscriptionArn": "..."}`. Returns `{"confirmed": true}`. |
 | `/_fakecloud/sqs/messages` | GET | List all SQS messages across queues. |
 | `/_fakecloud/events/history` | GET | List all EventBridge events and deliveries. |
 | `/_fakecloud/s3/notifications` | GET | List all S3 notification events. |
 | `/_fakecloud/ses/emails` | GET | List all sent SES emails. |
+| `/_fakecloud/reset/{service}` | POST | Reset only the specified service's state. Returns `{"reset": "service_name"}`. |
 
 ## Architecture
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -230,6 +230,7 @@ impl ResourceProvisioner {
             owner: state.account_id.clone(),
             attributes: HashMap::new(),
             confirmed: true,
+            confirmation_token: None,
         };
 
         state.subscriptions.insert(sub_arn.clone(), subscription);

--- a/crates/fakecloud-conformance/tests/sns.rs
+++ b/crates/fakecloud-conformance/tests/sns.rs
@@ -146,21 +146,19 @@ async fn sns_confirm_subscription() {
         .unwrap();
     let arn = topic.topic_arn().unwrap();
 
-    // Subscribe an HTTP endpoint to create a pending subscription
-    client
+    // Subscribe an SQS endpoint — SQS subscriptions auto-confirm in fakecloud,
+    // but we can still call ConfirmSubscription on any subscription.
+    // Use a fake token; fakecloud accepts the subscription ARN as a valid token.
+    let sub = client
         .subscribe()
         .topic_arn(arn)
-        .protocol("http")
-        .endpoint("http://example.com/hook")
+        .protocol("sqs")
+        .endpoint("arn:aws:sqs:us-east-1:000000000000:confirm-queue")
         .send()
         .await
         .unwrap();
-    // HTTP subscriptions return "pending confirmation" instead of a real ARN,
-    // so we list subscriptions to get the actual ARN
-    let subs = client.list_subscriptions().send().await.unwrap();
-    let sub_arn = subs.subscriptions()[0].subscription_arn().unwrap();
+    let sub_arn = sub.subscription_arn().unwrap();
 
-    // AWS accepts the subscription ARN as a valid confirmation token
     let resp = client
         .confirm_subscription()
         .topic_arn(arn)

--- a/crates/fakecloud-conformance/tests/sns.rs
+++ b/crates/fakecloud-conformance/tests/sns.rs
@@ -146,10 +146,25 @@ async fn sns_confirm_subscription() {
         .unwrap();
     let arn = topic.topic_arn().unwrap();
 
+    // Subscribe an HTTP endpoint to create a pending subscription
+    client
+        .subscribe()
+        .topic_arn(arn)
+        .protocol("http")
+        .endpoint("http://example.com/hook")
+        .send()
+        .await
+        .unwrap();
+    // HTTP subscriptions return "pending confirmation" instead of a real ARN,
+    // so we list subscriptions to get the actual ARN
+    let subs = client.list_subscriptions().send().await.unwrap();
+    let sub_arn = subs.subscriptions()[0].subscription_arn().unwrap();
+
+    // AWS accepts the subscription ARN as a valid confirmation token
     let resp = client
         .confirm_subscription()
         .topic_arn(arn)
-        .token("fake-token")
+        .token(sub_arn)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-e2e/tests/multiservice.rs
+++ b/crates/fakecloud-e2e/tests/multiservice.rs
@@ -449,3 +449,71 @@ async fn get_queue_arn(sqs: &aws_sdk_sqs::Client, queue_url: &str) -> String {
         .unwrap()
         .to_string()
 }
+
+/// Per-service reset: resetting SQS should leave SNS state intact.
+#[tokio::test]
+async fn per_service_reset_sqs_leaves_sns() {
+    let server = TestServer::start().await;
+    let sqs = server.sqs_client().await;
+    let sns = server.sns_client().await;
+    let http_client = reqwest::Client::new();
+
+    // Create an SQS queue
+    sqs.create_queue()
+        .queue_name("reset-test-queue")
+        .send()
+        .await
+        .unwrap();
+
+    // Create an SNS topic
+    let topic_resp = sns
+        .create_topic()
+        .name("reset-test-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic_resp.topic_arn().unwrap().to_string();
+
+    // Verify both exist
+    assert_eq!(
+        sqs.list_queues().send().await.unwrap().queue_urls().len(),
+        1
+    );
+    assert_eq!(sns.list_topics().send().await.unwrap().topics().len(), 1);
+
+    // Reset only SQS
+    let url = format!("{}/_fakecloud/reset/sqs", server.endpoint());
+    let resp: serde_json::Value = http_client
+        .post(&url)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(resp["reset"], "sqs");
+
+    // Verify SQS queue is gone
+    assert_eq!(
+        sqs.list_queues().send().await.unwrap().queue_urls().len(),
+        0
+    );
+
+    // Verify SNS topic still exists
+    let topics = sns.list_topics().send().await.unwrap();
+    assert_eq!(topics.topics().len(), 1);
+    assert_eq!(topics.topics()[0].topic_arn().unwrap(), topic_arn);
+}
+
+/// Per-service reset: unknown service returns 404.
+#[tokio::test]
+async fn per_service_reset_unknown_service_returns_404() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    let url = format!("{}/_fakecloud/reset/nonexistent", server.endpoint());
+    let resp = http_client.post(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 404);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["error"].as_str().unwrap().contains("Unknown service"));
+}

--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -3926,3 +3926,91 @@ async fn s3_introspection_notifications() {
     assert_eq!(notif["eventType"], "s3:ObjectCreated:Put");
     assert!(!notif["timestamp"].as_str().unwrap().is_empty());
 }
+
+#[tokio::test]
+async fn s3_simulation_lifecycle_tick_expires_objects() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+    let http_client = reqwest::Client::new();
+
+    // Create bucket
+    client
+        .create_bucket()
+        .bucket("lifecycle-tick-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // Set lifecycle config that expires objects after 0 days via CLI
+    let lifecycle_json = r#"{
+        "Rules": [
+            {
+                "ID": "expire-all",
+                "Filter": {"Prefix": ""},
+                "Status": "Enabled",
+                "Expiration": {"Days": 0}
+            }
+        ]
+    }"#;
+
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "put-bucket-lifecycle-configuration",
+            "--bucket",
+            "lifecycle-tick-bucket",
+            "--lifecycle-configuration",
+            lifecycle_json,
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "put lifecycle failed: {}",
+        output.stderr_text()
+    );
+
+    // Put an object
+    client
+        .put_object()
+        .bucket("lifecycle-tick-bucket")
+        .key("ephemeral.txt")
+        .body(ByteStream::from_static(b"will be deleted"))
+        .send()
+        .await
+        .unwrap();
+
+    // Verify object exists
+    let resp = client
+        .list_objects_v2()
+        .bucket("lifecycle-tick-bucket")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.key_count().unwrap_or(0), 1);
+
+    // Call the lifecycle tick endpoint
+    let url = format!(
+        "{}/_fakecloud/s3/lifecycle-processor/tick",
+        server.endpoint()
+    );
+    let resp: serde_json::Value = http_client
+        .post(&url)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(resp["processedBuckets"], 1);
+    assert_eq!(resp["expiredObjects"], 1);
+    assert_eq!(resp["transitionedObjects"], 0);
+
+    // Verify object was deleted
+    let resp = client
+        .list_objects_v2()
+        .bucket("lifecycle-tick-bucket")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.key_count().unwrap_or(0), 0);
+}

--- a/crates/fakecloud-e2e/tests/sns.rs
+++ b/crates/fakecloud-e2e/tests/sns.rs
@@ -821,3 +821,88 @@ async fn sns_introspection_messages() {
     assert!(!msg["messageId"].as_str().unwrap().is_empty());
     assert!(!msg["timestamp"].as_str().unwrap().is_empty());
 }
+
+#[tokio::test]
+async fn sns_simulation_http_subscription_pending_and_confirm() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+    let http_client = reqwest::Client::new();
+
+    // Create topic
+    let resp = client
+        .create_topic()
+        .name("http-confirm-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = resp.topic_arn().unwrap().to_string();
+
+    // Subscribe with HTTP protocol (should be pending)
+    let sub_resp = client
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("http")
+        .endpoint("http://example.com/webhook")
+        .send()
+        .await
+        .unwrap();
+    // HTTP subscriptions return "pending confirmation" as the ARN
+    let sub_arn_str = sub_resp.subscription_arn().unwrap_or_default().to_string();
+    assert_eq!(sub_arn_str, "pending confirmation");
+
+    // List pending confirmations
+    let url = format!("{}/_fakecloud/sns/pending-confirmations", server.endpoint());
+    let resp: serde_json::Value = http_client
+        .get(&url)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let pending = resp["pendingConfirmations"].as_array().unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0]["topicArn"], topic_arn);
+    assert_eq!(pending[0]["protocol"], "http");
+    assert_eq!(pending[0]["endpoint"], "http://example.com/webhook");
+    let actual_sub_arn = pending[0]["subscriptionArn"].as_str().unwrap().to_string();
+
+    // Force confirm via simulation endpoint
+    let confirm_url = format!("{}/_fakecloud/sns/confirm-subscription", server.endpoint());
+    let resp: serde_json::Value = http_client
+        .post(&confirm_url)
+        .json(&serde_json::json!({ "subscriptionArn": actual_sub_arn }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(resp["confirmed"], true);
+
+    // Verify no more pending
+    let resp: serde_json::Value = http_client
+        .get(&url)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let pending = resp["pendingConfirmations"].as_array().unwrap();
+    assert!(pending.is_empty());
+
+    // Verify the subscription is now listed normally (not "pending confirmation")
+    let subs = client
+        .list_subscriptions_by_topic()
+        .topic_arn(&topic_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(subs.subscriptions().len(), 1);
+    let sub = &subs.subscriptions()[0];
+    assert_ne!(
+        sub.subscription_arn().unwrap_or_default(),
+        "pending confirmation"
+    );
+}

--- a/crates/fakecloud-e2e/tests/sns.rs
+++ b/crates/fakecloud-e2e/tests/sns.rs
@@ -618,15 +618,61 @@ async fn sns_confirm_subscription() {
         .unwrap();
     let topic_arn = topic.topic_arn().unwrap().to_string();
 
-    // ConfirmSubscription with a fake token should succeed (stub)
+    // Subscribe an HTTP endpoint (starts as pending confirmation)
+    client
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("http")
+        .endpoint("http://example.com/hook")
+        .send()
+        .await
+        .unwrap();
+
+    // Get the token from the pending-confirmations simulation endpoint
+    let http = reqwest::Client::new();
+    let pending_url = format!(
+        "{}/_fakecloud/sns/pending-confirmations",
+        server.endpoint()
+    );
+    let pending: serde_json::Value = http
+        .get(&pending_url)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let token = pending["pendingConfirmations"][0]["token"]
+        .as_str()
+        .expect("pending subscription should have a token")
+        .to_string();
+
+    // ConfirmSubscription with the real token
     let resp = client
         .confirm_subscription()
         .topic_arn(&topic_arn)
-        .token("fake-confirmation-token")
+        .token(&token)
         .send()
         .await
         .unwrap();
     assert!(resp.subscription_arn().is_some());
+
+    // Verify no more pending confirmations
+    let pending: serde_json::Value = http
+        .get(&pending_url)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        pending["pendingConfirmations"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "subscription should no longer be pending after confirmation"
+    );
 }
 
 /// Regression: binary message attributes should be preserved when delivered to SQS

--- a/crates/fakecloud-e2e/tests/sns.rs
+++ b/crates/fakecloud-e2e/tests/sns.rs
@@ -630,10 +630,7 @@ async fn sns_confirm_subscription() {
 
     // Get the token from the pending-confirmations simulation endpoint
     let http = reqwest::Client::new();
-    let pending_url = format!(
-        "{}/_fakecloud/sns/pending-confirmations",
-        server.endpoint()
-    );
+    let pending_url = format!("{}/_fakecloud/sns/pending-confirmations", server.endpoint());
     let pending: serde_json::Value = http
         .get(&pending_url)
         .send()

--- a/crates/fakecloud-lambda/src/runtime.rs
+++ b/crates/fakecloud-lambda/src/runtime.rs
@@ -360,6 +360,50 @@ impl ContainerRuntime {
         }
     }
 
+    /// List all warm containers and their metadata for introspection.
+    pub fn list_warm_containers(
+        &self,
+        lambda_state: &crate::state::SharedLambdaState,
+    ) -> Vec<serde_json::Value> {
+        let containers = self.containers.read();
+        let state = lambda_state.read();
+        containers
+            .iter()
+            .map(|(name, container)| {
+                let runtime = state
+                    .functions
+                    .get(name)
+                    .map(|f| f.runtime.clone())
+                    .unwrap_or_default();
+                let last_used = container.last_used.read();
+                let idle_secs = last_used.elapsed().as_secs();
+                serde_json::json!({
+                    "functionName": name,
+                    "runtime": runtime,
+                    "containerId": container.container_id,
+                    "lastUsedSecsAgo": idle_secs,
+                })
+            })
+            .collect()
+    }
+
+    /// Evict (stop and remove) the warm container for a specific function.
+    /// Returns true if a container was found and evicted.
+    pub async fn evict_container(&self, function_name: &str) -> bool {
+        let container = self.containers.write().remove(function_name);
+        if let Some(container) = container {
+            tracing::info!(
+                function = %function_name,
+                container_id = %container.container_id,
+                "evicting Lambda container via simulation API"
+            );
+            self.remove_container(&container.container_id).await;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Background loop that stops containers idle longer than `ttl`.
     pub async fn run_cleanup_loop(self: Arc<Self>, ttl: Duration) {
         let mut interval = tokio::time::interval(Duration::from_secs(30));

--- a/crates/fakecloud-s3/src/lib.rs
+++ b/crates/fakecloud-s3/src/lib.rs
@@ -2,4 +2,5 @@ pub mod inventory;
 pub mod lifecycle;
 pub mod logging;
 pub mod service;
+pub mod simulation;
 pub mod state;

--- a/crates/fakecloud-s3/src/lifecycle.rs
+++ b/crates/fakecloud-s3/src/lifecycle.rs
@@ -28,7 +28,7 @@ impl LifecycleProcessor {
         }
     }
 
-    fn tick(&self) {
+    pub fn tick(&self) {
         let now = Utc::now();
         let today = now.date_naive();
 

--- a/crates/fakecloud-s3/src/simulation.rs
+++ b/crates/fakecloud-s3/src/simulation.rs
@@ -1,0 +1,218 @@
+use crate::lifecycle::LifecycleProcessor;
+use crate::state::SharedS3State;
+
+/// Result of a lifecycle processor tick.
+pub struct LifecycleTickResult {
+    pub processed_buckets: u64,
+    pub expired_objects: u64,
+    pub transitioned_objects: u64,
+}
+
+/// Snapshot of a bucket's objects before processing.
+struct BucketSnapshot {
+    name: String,
+    object_count: usize,
+    storage_classes: Vec<(String, String)>,
+}
+
+/// Run one tick of the S3 lifecycle processor and return statistics.
+pub fn tick_lifecycle(state: &SharedS3State) -> LifecycleTickResult {
+    // Snapshot object counts and storage classes before processing
+    let (buckets_with_lifecycle, before_snapshot) = {
+        let s = state.read();
+        let mut count = 0u64;
+        let mut snapshot: Vec<BucketSnapshot> = Vec::new();
+        for bucket in s.buckets.values() {
+            let classes: Vec<(String, String)> = bucket
+                .objects
+                .iter()
+                .map(|(k, o)| (k.clone(), o.storage_class.clone()))
+                .collect();
+            snapshot.push(BucketSnapshot {
+                name: bucket.name.clone(),
+                object_count: bucket.objects.len(),
+                storage_classes: classes,
+            });
+            if bucket.lifecycle_config.is_some() {
+                count += 1;
+            }
+        }
+        (count, snapshot)
+    };
+
+    // Run the processor tick
+    let processor = LifecycleProcessor::new(state.clone());
+    processor.tick();
+
+    // Compute diffs
+    let mut expired_objects = 0u64;
+    let mut transitioned_objects = 0u64;
+
+    let s = state.read();
+    for snap in &before_snapshot {
+        let bucket = match s.buckets.get(&snap.name) {
+            Some(b) => b,
+            None => continue,
+        };
+
+        // Count expired (deleted) objects
+        let after_count = bucket.objects.len();
+        if snap.object_count > after_count {
+            expired_objects += (snap.object_count - after_count) as u64;
+        }
+
+        // Count transitioned objects (storage class changed)
+        for (key, old_class) in &snap.storage_classes {
+            if let Some(obj) = bucket.objects.get(key) {
+                if &obj.storage_class != old_class {
+                    transitioned_objects += 1;
+                }
+            }
+        }
+    }
+
+    LifecycleTickResult {
+        processed_buckets: buckets_with_lifecycle,
+        expired_objects,
+        transitioned_objects,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{S3Bucket, S3Object, S3State};
+    use bytes::Bytes;
+    use chrono::{Duration, Utc};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn make_state() -> SharedS3State {
+        Arc::new(RwLock::new(S3State::new("123456789012", "us-east-1")))
+    }
+
+    fn make_object(key: &str, age_days: i64) -> S3Object {
+        S3Object {
+            key: key.to_string(),
+            data: Bytes::from("test"),
+            content_type: "application/octet-stream".to_string(),
+            etag: "\"abc\"".to_string(),
+            size: 4,
+            last_modified: Utc::now() - Duration::days(age_days),
+            metadata: HashMap::new(),
+            storage_class: "STANDARD".to_string(),
+            tags: HashMap::new(),
+            acl_grants: Vec::new(),
+            acl_owner_id: None,
+            parts_count: None,
+            part_sizes: None,
+            sse_algorithm: None,
+            sse_kms_key_id: None,
+            bucket_key_enabled: None,
+            version_id: None,
+            is_delete_marker: false,
+            content_encoding: None,
+            website_redirect_location: None,
+            restore_ongoing: None,
+            restore_expiry: None,
+            checksum_algorithm: None,
+            checksum_value: None,
+            lock_mode: None,
+            lock_retain_until: None,
+            lock_legal_hold: None,
+        }
+    }
+
+    #[test]
+    fn tick_lifecycle_expires_objects() {
+        let state = make_state();
+
+        {
+            let mut s = state.write();
+            let mut bucket = S3Bucket::new("test-bucket", "us-east-1", "123456789012");
+            bucket.lifecycle_config = Some(
+                r#"<LifecycleConfiguration>
+                    <Rule>
+                        <Filter><Prefix></Prefix></Filter>
+                        <Status>Enabled</Status>
+                        <Expiration><Days>1</Days></Expiration>
+                    </Rule>
+                </LifecycleConfiguration>"#
+                    .to_string(),
+            );
+            bucket
+                .objects
+                .insert("old-file.txt".to_string(), make_object("old-file.txt", 5));
+            bucket
+                .objects
+                .insert("new-file.txt".to_string(), make_object("new-file.txt", 0));
+            s.buckets.insert("test-bucket".to_string(), bucket);
+        }
+
+        let result = tick_lifecycle(&state);
+        assert_eq!(result.processed_buckets, 1);
+        assert_eq!(result.expired_objects, 1);
+        assert_eq!(result.transitioned_objects, 0);
+
+        let s = state.read();
+        let bucket = s.buckets.get("test-bucket").unwrap();
+        assert_eq!(bucket.objects.len(), 1);
+        assert!(bucket.objects.contains_key("new-file.txt"));
+    }
+
+    #[test]
+    fn tick_lifecycle_transitions_objects() {
+        let state = make_state();
+
+        {
+            let mut s = state.write();
+            let mut bucket = S3Bucket::new("trans-bucket", "us-east-1", "123456789012");
+            bucket.lifecycle_config = Some(
+                r#"<LifecycleConfiguration>
+                    <Rule>
+                        <Filter><Prefix></Prefix></Filter>
+                        <Status>Enabled</Status>
+                        <Transition>
+                            <Days>1</Days>
+                            <StorageClass>GLACIER</StorageClass>
+                        </Transition>
+                    </Rule>
+                </LifecycleConfiguration>"#
+                    .to_string(),
+            );
+            bucket
+                .objects
+                .insert("old-file.txt".to_string(), make_object("old-file.txt", 5));
+            s.buckets.insert("trans-bucket".to_string(), bucket);
+        }
+
+        let result = tick_lifecycle(&state);
+        assert_eq!(result.processed_buckets, 1);
+        assert_eq!(result.expired_objects, 0);
+        assert_eq!(result.transitioned_objects, 1);
+
+        let s = state.read();
+        let obj = s.buckets["trans-bucket"]
+            .objects
+            .get("old-file.txt")
+            .unwrap();
+        assert_eq!(obj.storage_class, "GLACIER");
+    }
+
+    #[test]
+    fn tick_lifecycle_no_config_returns_zero() {
+        let state = make_state();
+
+        {
+            let mut s = state.write();
+            let bucket = S3Bucket::new("empty-bucket", "us-east-1", "123456789012");
+            s.buckets.insert("empty-bucket".to_string(), bucket);
+        }
+
+        let result = tick_lifecycle(&state);
+        assert_eq!(result.processed_buckets, 0);
+        assert_eq!(result.expired_objects, 0);
+        assert_eq!(result.transitioned_objects, 0);
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -206,6 +206,12 @@ async fn main() {
     let eb_sim_lambda_state = Some(lambda_state.clone());
     let eb_sim_logs_state = Some(logs_state.clone());
     let eb_sim_container_runtime = container_runtime.clone();
+    let s3_sim_lifecycle_state = s3_state.clone();
+    let lambda_sim_warm_state = lambda_state.clone();
+    let lambda_sim_warm_runtime = container_runtime.clone();
+    let lambda_sim_evict_runtime = container_runtime.clone();
+    let sns_sim_pending_state = sns_state.clone();
+    let sns_sim_confirm_state = sns_state.clone();
 
     // Clone state for reset endpoint before moving into services
     let reset_state = ResetState {
@@ -365,7 +371,7 @@ async fn main() {
         .route(
             "/_reset",
             axum::routing::post({
-                let s = reset_state;
+                let s = reset_state.clone();
                 move || async move { s.reset() }
             }),
         )
@@ -729,6 +735,99 @@ async fn main() {
                 }
             }),
         )
+        .route(
+            "/_fakecloud/s3/lifecycle-processor/tick",
+            axum::routing::post({
+                let ss = s3_sim_lifecycle_state;
+                move || async move {
+                    let result = fakecloud_s3::simulation::tick_lifecycle(&ss);
+                    axum::Json(serde_json::json!({
+                        "processedBuckets": result.processed_buckets,
+                        "expiredObjects": result.expired_objects,
+                        "transitionedObjects": result.transitioned_objects,
+                    }))
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/lambda/warm-containers",
+            axum::routing::get({
+                let ls = lambda_sim_warm_state;
+                let rt = lambda_sim_warm_runtime;
+                move || async move {
+                    let containers: Vec<serde_json::Value> = if let Some(ref rt) = rt {
+                        rt.list_warm_containers(&ls)
+                    } else {
+                        Vec::new()
+                    };
+                    axum::Json(serde_json::json!({ "containers": containers }))
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/lambda/{function_name}/evict-container",
+            axum::routing::post({
+                let rt = lambda_sim_evict_runtime;
+                move |axum::extract::Path(function_name): axum::extract::Path<String>| async move {
+                    if let Some(ref rt) = rt {
+                        let evicted = rt.evict_container(&function_name).await;
+                        axum::Json(serde_json::json!({ "evicted": evicted }))
+                    } else {
+                        axum::Json(serde_json::json!({ "evicted": false }))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/sns/pending-confirmations",
+            axum::routing::get({
+                let ss = sns_sim_pending_state;
+                move || async move {
+                    let pending = fakecloud_sns::simulation::list_pending_confirmations(&ss);
+                    let items: Vec<serde_json::Value> = pending
+                        .iter()
+                        .map(|p| {
+                            serde_json::json!({
+                                "subscriptionArn": p.subscription_arn,
+                                "topicArn": p.topic_arn,
+                                "protocol": p.protocol,
+                                "endpoint": p.endpoint,
+                            })
+                        })
+                        .collect();
+                    axum::Json(serde_json::json!({ "pendingConfirmations": items }))
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/sns/confirm-subscription",
+            axum::routing::post({
+                let ss = sns_sim_confirm_state;
+                move |axum::Json(body): axum::Json<serde_json::Value>| async move {
+                    let sub_arn = body["subscriptionArn"].as_str().unwrap_or("");
+                    let confirmed = fakecloud_sns::simulation::confirm_subscription(&ss, sub_arn);
+                    axum::Json(serde_json::json!({ "confirmed": confirmed }))
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/reset/{service}",
+            axum::routing::post({
+                let s = reset_state.clone();
+                move |axum::extract::Path(service): axum::extract::Path<String>| async move {
+                    match s.reset_service(&service) {
+                        Ok(()) => (
+                            axum::http::StatusCode::OK,
+                            axum::Json(serde_json::json!({ "reset": service })),
+                        ),
+                        Err(msg) => (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({ "error": msg })),
+                        ),
+                    }
+                }
+            }),
+        )
         .fallback(dispatch::dispatch)
         .layer(Extension(Arc::new(registry)))
         .layer(Extension(Arc::new(config)))
@@ -768,6 +867,76 @@ struct ResetState {
 }
 
 impl ResetState {
+    fn reset_service(&self, service: &str) -> Result<(), String> {
+        match service {
+            "iam" | "sts" => {
+                self.iam.write().reset();
+            }
+            "sqs" => {
+                let mut s = self.sqs.write();
+                s.queues.clear();
+                s.name_to_url.clear();
+            }
+            "sns" => {
+                let mut s = self.sns.write();
+                s.reset();
+                s.seed_default_opted_out();
+            }
+            "events" | "eventbridge" => {
+                let mut eb = self.eb.write();
+                eb.rules.clear();
+                eb.events.clear();
+                eb.archives.clear();
+                eb.connections.clear();
+                eb.api_destinations.clear();
+                eb.replays.clear();
+                eb.buses.retain(|name, _| name == "default");
+                eb.lambda_invocations.clear();
+                eb.log_deliveries.clear();
+                eb.step_function_executions.clear();
+            }
+            "ssm" => {
+                self.ssm.write().reset();
+            }
+            "dynamodb" => {
+                self.dynamodb.write().reset();
+            }
+            "lambda" => {
+                self.lambda.write().reset();
+                if let Some(ref rt) = self.container_runtime {
+                    let rt = rt.clone();
+                    tokio::spawn(async move { rt.stop_all().await });
+                }
+            }
+            "secretsmanager" => {
+                self.secretsmanager.write().reset();
+            }
+            "s3" => {
+                self.s3.write().reset();
+            }
+            "logs" => {
+                self.logs.write().reset();
+            }
+            "kms" => {
+                self.kms.write().reset();
+            }
+            "cloudformation" => {
+                self.cloudformation.write().reset();
+            }
+            "ses" => {
+                self.ses.write().reset();
+            }
+            "cognito" => {
+                self.cognito.write().reset();
+            }
+            _ => {
+                return Err(format!("Unknown service: {service}"));
+            }
+        }
+        tracing::info!(service = %service, "service state reset via per-service reset API");
+        Ok(())
+    }
+
     fn reset(&self) -> axum::Json<serde_json::Value> {
         self.iam.write().reset();
         self.sqs.write().queues.clear();

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -792,6 +792,7 @@ async fn main() {
                                 "topicArn": p.topic_arn,
                                 "protocol": p.protocol,
                                 "endpoint": p.endpoint,
+                                "token": p.token,
                             })
                         })
                         .collect();

--- a/crates/fakecloud-sns/src/lib.rs
+++ b/crates/fakecloud-sns/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod delivery;
 pub mod service;
+pub mod simulation;
 pub mod state;

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -660,6 +660,14 @@ impl SnsService {
 
         let sub_arn = format!("{}:{}", topic_arn, uuid::Uuid::new_v4());
 
+        // HTTP/HTTPS subscriptions start as pending (require confirmation)
+        let confirmed = protocol != "http" && protocol != "https";
+        let response_arn = if confirmed {
+            sub_arn.clone()
+        } else {
+            "pending confirmation".to_string()
+        };
+
         let sub = SnsSubscription {
             subscription_arn: sub_arn.clone(),
             topic_arn,
@@ -667,7 +675,7 @@ impl SnsService {
             endpoint,
             owner: account_id,
             attributes,
-            confirmed: true,
+            confirmed,
         };
 
         state.subscriptions.insert(sub_arn.clone(), sub);
@@ -676,7 +684,7 @@ impl SnsService {
             &format!(
                 r#"<SubscribeResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <SubscribeResult>
-    <SubscriptionArn>{sub_arn}</SubscriptionArn>
+    <SubscriptionArn>{response_arn}</SubscriptionArn>
   </SubscribeResult>
   <ResponseMetadata>
     <RequestId>{}</RequestId>
@@ -692,13 +700,18 @@ impl SnsService {
         let topic_arn = required(req, "TopicArn")?;
         let _token = required(req, "Token")?;
 
-        let state = self.state.read();
+        let mut state = self.state.write();
         let sub_arn = state
             .subscriptions
             .values()
-            .find(|s| s.topic_arn == topic_arn)
+            .find(|s| s.topic_arn == topic_arn && !s.confirmed)
             .map(|s| s.subscription_arn.clone())
             .unwrap_or_else(|| format!("{}:{}", topic_arn, uuid::Uuid::new_v4()));
+
+        // Mark the subscription as confirmed
+        if let Some(sub) = state.subscriptions.get_mut(&sub_arn) {
+            sub.confirmed = true;
+        }
 
         Ok(xml_resp(
             &format!(
@@ -2664,6 +2677,11 @@ fn format_attr(name: &str, value: &str) -> String {
 }
 
 fn format_sub_member(sub: &SnsSubscription) -> String {
+    let display_arn = if sub.confirmed {
+        &sub.subscription_arn
+    } else {
+        "PendingConfirmation"
+    };
     format!(
         r#"      <member>
         <SubscriptionArn>{}</SubscriptionArn>
@@ -2672,7 +2690,7 @@ fn format_sub_member(sub: &SnsSubscription) -> String {
         <Endpoint>{}</Endpoint>
         <Owner>{}</Owner>
       </member>"#,
-        sub.subscription_arn, sub.topic_arn, sub.protocol, sub.endpoint, sub.owner,
+        display_arn, sub.topic_arn, sub.protocol, sub.endpoint, sub.owner,
     )
 }
 

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -668,6 +668,13 @@ impl SnsService {
             "pending confirmation".to_string()
         };
 
+        // Generate a confirmation token for pending subscriptions
+        let confirmation_token = if !confirmed {
+            Some(uuid::Uuid::new_v4().to_string())
+        } else {
+            None
+        };
+
         let sub = SnsSubscription {
             subscription_arn: sub_arn.clone(),
             topic_arn,
@@ -676,6 +683,7 @@ impl SnsService {
             owner: account_id,
             attributes,
             confirmed,
+            confirmation_token,
         };
 
         state.subscriptions.insert(sub_arn.clone(), sub);
@@ -698,15 +706,25 @@ impl SnsService {
 
     fn confirm_subscription(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let topic_arn = required(req, "TopicArn")?;
-        let _token = required(req, "Token")?;
+        let token = required(req, "Token")?;
 
         let mut state = self.state.write();
         let sub_arn = state
             .subscriptions
             .values()
-            .find(|s| s.topic_arn == topic_arn && !s.confirmed)
+            .find(|s| {
+                s.topic_arn == topic_arn
+                    && !s.confirmed
+                    && s.confirmation_token.as_deref() == Some(&token)
+            })
             .map(|s| s.subscription_arn.clone())
-            .unwrap_or_else(|| format!("{}:{}", topic_arn, uuid::Uuid::new_v4()));
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "NotFound",
+                    format!("No pending subscription found for token: {token}"),
+                )
+            })?;
 
         // Mark the subscription as confirmed
         if let Some(sub) = state.subscriptions.get_mut(&sub_arn) {
@@ -4404,13 +4422,36 @@ mod tests {
 
     #[test]
     fn confirm_subscription_returns_arn() {
-        let (svc, _state) = make_sns();
+        let (svc, state) = make_sns();
         assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "confirm-topic")])));
 
         let topic_arn = "arn:aws:sns:us-east-1:123456789012:confirm-topic";
+
+        // Subscribe an HTTP endpoint (starts as pending)
+        assert_ok(&svc.subscribe(&sns_request(
+            "Subscribe",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Protocol", "http"),
+                ("Endpoint", "http://example.com/hook"),
+            ],
+        )));
+
+        // Get the token from the pending subscription
+        let token = {
+            let s = state.read();
+            s.subscriptions
+                .values()
+                .find(|sub| sub.topic_arn == topic_arn && !sub.confirmed)
+                .expect("should have a pending subscription")
+                .confirmation_token
+                .clone()
+                .expect("pending subscription should have a token")
+        };
+
         let req = sns_request(
             "ConfirmSubscription",
-            vec![("TopicArn", topic_arn), ("Token", "fake-token")],
+            vec![("TopicArn", topic_arn), ("Token", &token)],
         );
         let result = svc.confirm_subscription(&req);
         assert_ok(&result);
@@ -4419,6 +4460,104 @@ mod tests {
             body.contains("<SubscriptionArn>"),
             "Should return a SubscriptionArn"
         );
+
+        // Verify the subscription is now confirmed
+        let s = state.read();
+        let sub = s
+            .subscriptions
+            .values()
+            .find(|sub| sub.topic_arn == topic_arn)
+            .expect("subscription should exist");
+        assert!(sub.confirmed, "subscription should be confirmed");
+    }
+
+    #[test]
+    fn confirm_subscription_rejects_invalid_token() {
+        let (svc, _state) = make_sns();
+        assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "confirm-topic")])));
+
+        let topic_arn = "arn:aws:sns:us-east-1:123456789012:confirm-topic";
+
+        // Subscribe an HTTP endpoint (starts as pending)
+        assert_ok(&svc.subscribe(&sns_request(
+            "Subscribe",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Protocol", "http"),
+                ("Endpoint", "http://example.com/hook"),
+            ],
+        )));
+
+        // Try to confirm with wrong token
+        let req = sns_request(
+            "ConfirmSubscription",
+            vec![("TopicArn", topic_arn), ("Token", "wrong-token")],
+        );
+        let result = svc.confirm_subscription(&req);
+        assert!(result.is_err(), "Should reject invalid token");
+    }
+
+    #[test]
+    fn confirm_subscription_matches_correct_pending_sub() {
+        let (svc, state) = make_sns();
+        assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "multi-topic")])));
+
+        let topic_arn = "arn:aws:sns:us-east-1:123456789012:multi-topic";
+
+        // Subscribe two HTTP endpoints (both start as pending)
+        assert_ok(&svc.subscribe(&sns_request(
+            "Subscribe",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Protocol", "http"),
+                ("Endpoint", "http://first.example.com/hook"),
+            ],
+        )));
+        assert_ok(&svc.subscribe(&sns_request(
+            "Subscribe",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Protocol", "http"),
+                ("Endpoint", "http://second.example.com/hook"),
+            ],
+        )));
+
+        // Get the token for the second subscription
+        let (second_arn, second_token) = {
+            let s = state.read();
+            let sub = s
+                .subscriptions
+                .values()
+                .find(|sub| sub.endpoint == "http://second.example.com/hook")
+                .expect("should have second subscription");
+            (
+                sub.subscription_arn.clone(),
+                sub.confirmation_token.clone().unwrap(),
+            )
+        };
+
+        // Confirm using the second subscription's token
+        let req = sns_request(
+            "ConfirmSubscription",
+            vec![("TopicArn", topic_arn), ("Token", &second_token)],
+        );
+        let result = svc.confirm_subscription(&req);
+        assert_ok(&result);
+        let body = response_body(&result);
+        assert!(
+            body.contains(&second_arn),
+            "Should return the second subscription's ARN"
+        );
+
+        // Verify only the second subscription is confirmed
+        let s = state.read();
+        for sub in s.subscriptions.values() {
+            if sub.endpoint == "http://second.example.com/hook" {
+                assert!(sub.confirmed, "second subscription should be confirmed");
+            } else {
+                assert!(!sub.confirmed, "first subscription should still be pending");
+            }
+        }
     }
 
     // --- CreateTopic / DeleteTopic / ListTopics ---

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -709,13 +709,15 @@ impl SnsService {
         let token = required(req, "Token")?;
 
         let mut state = self.state.write();
+        // AWS accepts both the confirmation token and the subscription ARN as the Token parameter
         let sub_arn = state
             .subscriptions
             .values()
             .find(|s| {
                 s.topic_arn == topic_arn
                     && !s.confirmed
-                    && s.confirmation_token.as_deref() == Some(&token)
+                    && (s.confirmation_token.as_deref() == Some(&token)
+                        || s.subscription_arn == token)
             })
             .map(|s| s.subscription_arn.clone())
             .ok_or_else(|| {
@@ -4558,6 +4560,52 @@ mod tests {
                 assert!(!sub.confirmed, "first subscription should still be pending");
             }
         }
+    }
+
+    #[test]
+    fn confirm_subscription_accepts_sub_arn_as_token() {
+        let (svc, state) = make_sns();
+        assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "arn-token")])));
+
+        let topic_arn = "arn:aws:sns:us-east-1:123456789012:arn-token";
+
+        // Subscribe an HTTP endpoint (starts as pending)
+        assert_ok(&svc.subscribe(&sns_request(
+            "Subscribe",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Protocol", "http"),
+                ("Endpoint", "http://example.com/hook"),
+            ],
+        )));
+
+        // Get the subscription ARN
+        let sub_arn = {
+            let s = state.read();
+            s.subscriptions
+                .values()
+                .find(|sub| sub.topic_arn == topic_arn)
+                .expect("should have a subscription")
+                .subscription_arn
+                .clone()
+        };
+
+        // Confirm using the subscription ARN as the token (AWS-compatible behavior)
+        let req = sns_request(
+            "ConfirmSubscription",
+            vec![("TopicArn", topic_arn), ("Token", &sub_arn)],
+        );
+        let result = svc.confirm_subscription(&req);
+        assert_ok(&result);
+
+        // Verify the subscription is now confirmed
+        let s = state.read();
+        let sub = s
+            .subscriptions
+            .values()
+            .find(|sub| sub.topic_arn == topic_arn)
+            .expect("subscription should exist");
+        assert!(sub.confirmed, "subscription should be confirmed");
     }
 
     // --- CreateTopic / DeleteTopic / ListTopics ---

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -709,13 +709,13 @@ impl SnsService {
         let token = required(req, "Token")?;
 
         let mut state = self.state.write();
-        // AWS accepts both the confirmation token and the subscription ARN as the Token parameter
+        // AWS accepts both the confirmation token and the subscription ARN as the Token parameter.
+        // Confirming an already-confirmed subscription is a no-op (idempotent).
         let sub_arn = state
             .subscriptions
             .values()
             .find(|s| {
                 s.topic_arn == topic_arn
-                    && !s.confirmed
                     && (s.confirmation_token.as_deref() == Some(&token)
                         || s.subscription_arn == token)
             })

--- a/crates/fakecloud-sns/src/simulation.rs
+++ b/crates/fakecloud-sns/src/simulation.rs
@@ -7,6 +7,7 @@ pub struct PendingConfirmation {
     pub topic_arn: String,
     pub protocol: String,
     pub endpoint: String,
+    pub token: Option<String>,
 }
 
 /// List all subscriptions that are pending confirmation.
@@ -20,6 +21,7 @@ pub fn list_pending_confirmations(state: &SharedSnsState) -> Vec<PendingConfirma
             topic_arn: sub.topic_arn.clone(),
             protocol: sub.protocol.clone(),
             endpoint: sub.endpoint.clone(),
+            token: sub.confirmation_token.clone(),
         })
         .collect()
 }
@@ -72,6 +74,11 @@ mod tests {
                 owner: "123456789012".to_string(),
                 attributes: HashMap::new(),
                 confirmed,
+                confirmation_token: if confirmed {
+                    None
+                } else {
+                    Some(uuid::Uuid::new_v4().to_string())
+                },
             },
         );
         sub_arn

--- a/crates/fakecloud-sns/src/simulation.rs
+++ b/crates/fakecloud-sns/src/simulation.rs
@@ -1,0 +1,134 @@
+use crate::state::SharedSnsState;
+
+/// A pending subscription confirmation.
+#[derive(Debug, Clone)]
+pub struct PendingConfirmation {
+    pub subscription_arn: String,
+    pub topic_arn: String,
+    pub protocol: String,
+    pub endpoint: String,
+}
+
+/// List all subscriptions that are pending confirmation.
+pub fn list_pending_confirmations(state: &SharedSnsState) -> Vec<PendingConfirmation> {
+    let s = state.read();
+    s.subscriptions
+        .values()
+        .filter(|sub| !sub.confirmed)
+        .map(|sub| PendingConfirmation {
+            subscription_arn: sub.subscription_arn.clone(),
+            topic_arn: sub.topic_arn.clone(),
+            protocol: sub.protocol.clone(),
+            endpoint: sub.endpoint.clone(),
+        })
+        .collect()
+}
+
+/// Force-confirm a subscription by its ARN. Returns true if the
+/// subscription was found and confirmed (or was already confirmed).
+pub fn confirm_subscription(state: &SharedSnsState, subscription_arn: &str) -> bool {
+    let mut s = state.write();
+    match s.subscriptions.get_mut(subscription_arn) {
+        Some(sub) => {
+            sub.confirmed = true;
+            true
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::SnsState;
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn make_state() -> SharedSnsState {
+        Arc::new(RwLock::new(SnsState::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4566",
+        )))
+    }
+
+    fn add_subscription(
+        state: &SharedSnsState,
+        topic_arn: &str,
+        protocol: &str,
+        endpoint: &str,
+        confirmed: bool,
+    ) -> String {
+        let sub_arn = format!("{}:{}", topic_arn, uuid::Uuid::new_v4());
+        let mut s = state.write();
+        s.subscriptions.insert(
+            sub_arn.clone(),
+            crate::state::SnsSubscription {
+                subscription_arn: sub_arn.clone(),
+                topic_arn: topic_arn.to_string(),
+                protocol: protocol.to_string(),
+                endpoint: endpoint.to_string(),
+                owner: "123456789012".to_string(),
+                attributes: HashMap::new(),
+                confirmed,
+            },
+        );
+        sub_arn
+    }
+
+    #[test]
+    fn list_pending_finds_unconfirmed() {
+        let state = make_state();
+        let topic_arn = "arn:aws:sns:us-east-1:123456789012:my-topic";
+        add_subscription(&state, topic_arn, "http", "http://example.com/hook", false);
+        add_subscription(
+            &state,
+            topic_arn,
+            "sqs",
+            "arn:aws:sqs:us-east-1:123456789012:q",
+            true,
+        );
+
+        let pending = list_pending_confirmations(&state);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].protocol, "http");
+        assert_eq!(pending[0].endpoint, "http://example.com/hook");
+    }
+
+    #[test]
+    fn list_pending_returns_empty_when_all_confirmed() {
+        let state = make_state();
+        let topic_arn = "arn:aws:sns:us-east-1:123456789012:my-topic";
+        add_subscription(
+            &state,
+            topic_arn,
+            "sqs",
+            "arn:aws:sqs:us-east-1:123456789012:q",
+            true,
+        );
+
+        let pending = list_pending_confirmations(&state);
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn confirm_subscription_sets_confirmed() {
+        let state = make_state();
+        let topic_arn = "arn:aws:sns:us-east-1:123456789012:my-topic";
+        let sub_arn = add_subscription(&state, topic_arn, "http", "http://example.com/hook", false);
+
+        assert!(!state.read().subscriptions[&sub_arn].confirmed);
+
+        let result = confirm_subscription(&state, &sub_arn);
+        assert!(result);
+        assert!(state.read().subscriptions[&sub_arn].confirmed);
+    }
+
+    #[test]
+    fn confirm_subscription_returns_false_for_unknown() {
+        let state = make_state();
+        let result = confirm_subscription(&state, "arn:aws:sns:us-east-1:123456789012:nope:xxx");
+        assert!(!result);
+    }
+}

--- a/crates/fakecloud-sns/src/state.rs
+++ b/crates/fakecloud-sns/src/state.rs
@@ -22,6 +22,8 @@ pub struct SnsSubscription {
     pub owner: String,
     pub attributes: HashMap<String, String>,
     pub confirmed: bool,
+    /// Token used for HTTP/HTTPS subscription confirmation.
+    pub confirmation_token: Option<String>,
 }
 
 /// An SNS message attribute (key-value with a data type).


### PR DESCRIPTION
## Summary
- **S3 lifecycle processor tick** (`POST /_fakecloud/s3/lifecycle-processor/tick`): runs one lifecycle processing cycle immediately, returning `processedBuckets`, `expiredObjects`, and `transitionedObjects` counts
- **Lambda container management** (`GET /_fakecloud/lambda/warm-containers`, `POST /_fakecloud/lambda/{fn}/evict-container`): list warm containers and force-evict them for cold start testing
- **SNS subscription confirmation** (`GET /_fakecloud/sns/pending-confirmations`, `POST /_fakecloud/sns/confirm-subscription`): HTTP/HTTPS subscriptions now start as pending; force-confirm them via simulation API
- **Per-service reset** (`POST /_fakecloud/reset/{service}`): reset only one service's state without affecting others

## Test plan
- [x] S3 lifecycle tick E2E test: create bucket with lifecycle rule, put object, tick, verify deletion
- [x] SNS pending confirmation E2E test: subscribe HTTP endpoint, verify pending, force confirm, verify confirmed
- [x] Per-service reset E2E test: create SQS queue + SNS topic, reset SQS only, verify SNS survives
- [x] Per-service reset 404 test: unknown service returns 404
- [x] Unit tests for S3 lifecycle simulation (expiration, transition, no-config)
- [x] Unit tests for SNS confirmation simulation (list pending, confirm, unknown ARN)
- [x] All 790+ existing unit tests pass
- [x] All existing E2E tests pass (SNS, SQS, S3, multiservice)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds simulation endpoints for S3 lifecycle ticks, Lambda warm container control, SNS subscription confirmation, and a per-service reset API. ConfirmSubscription now validates tokens, accepts the subscription ARN as the token, matches the correct pending subscription, and is idempotent.

- New Features
  - S3 lifecycle tick: POST `/_fakecloud/s3/lifecycle-processor/tick` → returns `processedBuckets`, `expiredObjects`, `transitionedObjects`.
  - Lambda containers: GET `/_fakecloud/lambda/warm-containers` lists warm containers; POST `/_fakecloud/lambda/{function-name}/evict-container` forces a cold start (`{"evicted": true|false}`).
  - SNS confirmations: GET `/_fakecloud/sns/pending-confirmations` lists pending (includes `token`); POST `/_fakecloud/sns/confirm-subscription` force-confirms by ARN. HTTP/HTTPS subscriptions start pending, and AWS `ConfirmSubscription` now matches by `Token` or subscription ARN and is idempotent.
  - Per-service reset: POST `/_fakecloud/reset/{service}` resets a single service (`{"reset": "service"}`); unknown services return 404 with `{"error": "..."}`.

- Migration
  - Update tests that assumed HTTP/HTTPS SNS subscriptions auto-confirm or that any token is accepted. Fetch the `token` from `/_fakecloud/sns/pending-confirmations` and call `ConfirmSubscription`, pass the subscription ARN to `ConfirmSubscription`, or use `/_fakecloud/sns/confirm-subscription` to force-confirm.

<sup>Written for commit a6797521b7bba3e93b9d661862e0ebbbf612dd56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

