### PR TITLE
feat(cognito): implement self-service user operations

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -6,61 +6,61 @@
       "passed": 549,
       "total": 549
     },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
-    },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
-    },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
-    },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "sts": {
-      "passed": 438,
-      "total": 438
+    "s3": {
+      "passed": 3620,
+      "total": 3620
     },
     "lambda": {
       "passed": 3347,
       "total": 3347
     },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
+    "sns": {
+      "passed": 1027,
+      "total": 1027
     },
     "iam": {
       "passed": 5962,
       "total": 5962
     },
+    "logs": {
+      "passed": 3911,
+      "total": 3911
+    },
+    "kms": {
+      "passed": 2196,
+      "total": 2196
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
     "ses": {
       "passed": 2858,
       "total": 2858
     },
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
+    },
+    "sts": {
+      "passed": 438,
+      "total": 438
+    },
+    "events": {
+      "passed": 2108,
+      "total": 2108
+    },
     "cognito-idp": {
       "passed": 4450,
       "total": 4479
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
     }
   }
 }

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -76,6 +76,13 @@ impl AwsService for CognitoService {
             "AdminRemoveUserFromGroup" => self.admin_remove_user_from_group(&req),
             "AdminListGroupsForUser" => self.admin_list_groups_for_user(&req),
             "ListUsersInGroup" => self.list_users_in_group(&req),
+            "GetUser" => self.get_user(&req),
+            "DeleteUser" => self.delete_user(&req),
+            "UpdateUserAttributes" => self.update_user_attributes(&req),
+            "DeleteUserAttributes" => self.delete_user_attributes(&req),
+            "GetUserAttributeVerificationCode" => self.get_user_attribute_verification_code(&req),
+            "VerifyUserAttribute" => self.verify_user_attribute(&req),
+            "ResendConfirmationCode" => self.resend_confirmation_code(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "cognito-idp",
                 &req.action,
@@ -126,6 +133,13 @@ impl AwsService for CognitoService {
             "AdminRemoveUserFromGroup",
             "AdminListGroupsForUser",
             "ListUsersInGroup",
+            "GetUser",
+            "DeleteUser",
+            "UpdateUserAttributes",
+            "DeleteUserAttributes",
+            "GetUserAttributeVerificationCode",
+            "VerifyUserAttribute",
+            "ResendConfirmationCode",
         ]
     }
 }
@@ -872,6 +886,7 @@ impl CognitoService {
             password: None,
             temporary_password,
             confirmation_code: None,
+            attribute_verification_codes: HashMap::new(),
         };
 
         let response = user_to_json(&user);
@@ -1994,6 +2009,7 @@ impl CognitoService {
             password: Some(password.to_string()),
             temporary_password: None,
             confirmation_code: None,
+            attribute_verification_codes: HashMap::new(),
         };
 
         pool_users.insert(username.to_string(), user);
@@ -2880,6 +2896,396 @@ impl CognitoService {
         }
 
         Ok(AwsResponse::ok_json(response))
+    }
+
+    // ── Self-service user operations ───────────────────────────────────
+
+    fn get_user(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+
+        let state = self.state.read();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+        let pool_id = &token_data.user_pool_id;
+        let username = &token_data.username;
+
+        let user = state
+            .users
+            .get(pool_id)
+            .and_then(|users| users.get(username.as_str()))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid access token.",
+                )
+            })?;
+
+        let response = json!({
+            "Username": user.username,
+            "UserAttributes": user.attributes.iter().map(|a| {
+                json!({ "Name": a.name, "Value": a.value })
+            }).collect::<Vec<Value>>(),
+            "UserCreateDate": user.user_create_date.timestamp() as f64,
+            "UserLastModifiedDate": user.user_last_modified_date.timestamp() as f64,
+            "UserStatus": user.user_status,
+            "MFAOptions": [],
+        });
+
+        Ok(AwsResponse::ok_json(response))
+    }
+
+    fn delete_user(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+
+        let mut state = self.state.write();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+        let pool_id = token_data.user_pool_id.clone();
+        let username = token_data.username.clone();
+
+        // Delete the user
+        let pool_users = state.users.get_mut(&pool_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+
+        if pool_users.remove(&username).is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            ));
+        }
+
+        // Clean up access tokens for this user
+        state
+            .access_tokens
+            .retain(|_, v| !(v.user_pool_id == pool_id && v.username == username));
+
+        // Clean up refresh tokens for this user
+        state
+            .refresh_tokens
+            .retain(|_, v| !(v.user_pool_id == pool_id && v.username == username));
+
+        // Clean up sessions for this user
+        state
+            .sessions
+            .retain(|_, v| !(v.user_pool_id == pool_id && v.username == username));
+
+        // Clean up group memberships for the deleted user
+        if let Some(pool_groups) = state.user_groups.get_mut(&pool_id) {
+            pool_groups.remove(&username);
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn update_user_attributes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+        let new_attrs = parse_user_attributes(&body["UserAttributes"]);
+
+        let mut state = self.state.write();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+        let pool_id = token_data.user_pool_id.clone();
+        let username = token_data.username.clone();
+
+        let user = state
+            .users
+            .get_mut(&pool_id)
+            .and_then(|users| users.get_mut(&username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid access token.",
+                )
+            })?;
+
+        for new_attr in new_attrs {
+            if let Some(existing) = user.attributes.iter_mut().find(|a| a.name == new_attr.name) {
+                existing.value = new_attr.value;
+            } else {
+                user.attributes.push(new_attr);
+            }
+        }
+
+        user.user_last_modified_date = Utc::now();
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn delete_user_attributes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+        let attr_names = parse_string_array(&body["UserAttributeNames"]);
+
+        let mut state = self.state.write();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+        let pool_id = token_data.user_pool_id.clone();
+        let username = token_data.username.clone();
+
+        let user = state
+            .users
+            .get_mut(&pool_id)
+            .and_then(|users| users.get_mut(&username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid access token.",
+                )
+            })?;
+
+        user.attributes.retain(|a| !attr_names.contains(&a.name));
+        user.user_last_modified_date = Utc::now();
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn get_user_attribute_verification_code(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+        let attribute_name = require_str(&body, "AttributeName")?;
+
+        let mut state = self.state.write();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+        let pool_id = token_data.user_pool_id.clone();
+        let username = token_data.username.clone();
+
+        let user = state
+            .users
+            .get_mut(&pool_id)
+            .and_then(|users| users.get_mut(&username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid access token.",
+                )
+            })?;
+
+        let code = generate_confirmation_code();
+        user.attribute_verification_codes
+            .insert(attribute_name.to_string(), code);
+
+        // Determine delivery details based on attribute
+        let (delivery_medium, destination) = if attribute_name == "phone_number" {
+            let phone = user
+                .attributes
+                .iter()
+                .find(|a| a.name == "phone_number")
+                .map(|a| {
+                    // Mask phone: show last 4 digits
+                    let len = a.value.len();
+                    if len > 4 {
+                        format!("{}***{}", &a.value[..1], &a.value[len - 4..])
+                    } else {
+                        "***".to_string()
+                    }
+                })
+                .unwrap_or_else(|| "***".to_string());
+            ("SMS", phone)
+        } else {
+            let email = user
+                .attributes
+                .iter()
+                .find(|a| a.name == "email")
+                .map(|a| {
+                    if let Some(at_pos) = a.value.find('@') {
+                        let first = &a.value[..1];
+                        let domain = &a.value[at_pos..];
+                        format!("{first}***{domain}")
+                    } else {
+                        "***".to_string()
+                    }
+                })
+                .unwrap_or_else(|| "***".to_string());
+            ("EMAIL", email)
+        };
+
+        Ok(AwsResponse::ok_json(json!({
+            "CodeDeliveryDetails": {
+                "Destination": destination,
+                "DeliveryMedium": delivery_medium,
+                "AttributeName": attribute_name
+            }
+        })))
+    }
+
+    fn verify_user_attribute(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+        let attribute_name = require_str(&body, "AttributeName")?;
+        let code = require_str(&body, "Code")?;
+
+        let mut state = self.state.write();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+        let pool_id = token_data.user_pool_id.clone();
+        let username = token_data.username.clone();
+
+        let user = state
+            .users
+            .get_mut(&pool_id)
+            .and_then(|users| users.get_mut(&username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid access token.",
+                )
+            })?;
+
+        // Validate the code
+        let stored_code = user
+            .attribute_verification_codes
+            .get(attribute_name)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "CodeMismatchException",
+                    "Invalid verification code provided, please try again.",
+                )
+            })?;
+
+        if stored_code != code {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "CodeMismatchException",
+                "Invalid verification code provided, please try again.",
+            ));
+        }
+
+        // Remove the used code
+        user.attribute_verification_codes.remove(attribute_name);
+
+        // Set the corresponding verified attribute to true
+        let verified_attr_name = format!("{attribute_name}_verified");
+        if let Some(existing) = user
+            .attributes
+            .iter_mut()
+            .find(|a| a.name == verified_attr_name)
+        {
+            existing.value = "true".to_string();
+        } else {
+            user.attributes.push(UserAttribute {
+                name: verified_attr_name,
+                value: "true".to_string(),
+            });
+        }
+
+        user.user_last_modified_date = Utc::now();
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn resend_confirmation_code(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let client_id = require_str(&body, "ClientId")?;
+        let username = require_str(&body, "Username")?;
+
+        let mut state = self.state.write();
+
+        // Find pool from client
+        let client = state.user_pool_clients.get(client_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool client {client_id} does not exist."),
+            )
+        })?;
+        let pool_id = client.user_pool_id.clone();
+
+        let user = state
+            .users
+            .get_mut(&pool_id)
+            .and_then(|users| users.get_mut(username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "UserNotFoundException",
+                    "User does not exist.",
+                )
+            })?;
+
+        let code = generate_confirmation_code();
+        user.confirmation_code = Some(code);
+
+        // Find email from user attributes for CodeDeliveryDetails
+        let email = user
+            .attributes
+            .iter()
+            .find(|a| a.name == "email")
+            .map(|a| a.value.clone());
+
+        let destination = email
+            .map(|e| {
+                if let Some(at_pos) = e.find('@') {
+                    let first = &e[..1];
+                    let domain = &e[at_pos..];
+                    format!("{first}***{domain}")
+                } else {
+                    "***".to_string()
+                }
+            })
+            .unwrap_or_else(|| "***".to_string());
+
+        Ok(AwsResponse::ok_json(json!({
+            "CodeDeliveryDetails": {
+                "Destination": destination,
+                "DeliveryMedium": "EMAIL",
+                "AttributeName": "email"
+            }
+        })))
     }
 }
 
@@ -3939,6 +4345,7 @@ mod tests {
             password: None,
             temporary_password: None,
             confirmation_code: None,
+            attribute_verification_codes: HashMap::new(),
         };
 
         let filter = parse_filter_expression(r#"username = "testuser""#).unwrap();
@@ -3967,6 +4374,7 @@ mod tests {
             password: None,
             temporary_password: None,
             confirmation_code: None,
+            attribute_verification_codes: HashMap::new(),
         };
 
         let filter = parse_filter_expression(r#"email = "test@example.com""#).unwrap();
@@ -3992,6 +4400,7 @@ mod tests {
             password: None,
             temporary_password: None,
             confirmation_code: None,
+            attribute_verification_codes: HashMap::new(),
         };
 
         let filter =
@@ -4517,6 +4926,438 @@ mod tests {
             let groups = s.user_groups.get(&pool_id).unwrap();
             let user_groups = groups.get("testuser").unwrap();
             assert!(!user_groups.contains(&"admins".to_string()));
+        }
+    }
+
+    #[test]
+    fn self_service_get_user_via_access_token() {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(crate::state::CognitoState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        let svc = CognitoService::new(state.clone());
+
+        // Create pool
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "CreateUserPool".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(r#"{"PoolName":"test"}"#),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        let pool_resp = svc.create_user_pool(&req).unwrap();
+        let pool_json: Value =
+            serde_json::from_str(core::str::from_utf8(&pool_resp.body).unwrap()).unwrap();
+        let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap().to_string();
+
+        // Create user
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "AdminCreateUser".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "UserPoolId": pool_id,
+                    "Username": "selfuser",
+                    "UserAttributes": [
+                        {"Name": "email", "Value": "self@example.com"}
+                    ]
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        svc.admin_create_user(&req).unwrap();
+
+        // Manually insert an access token
+        {
+            let mut s = state.write();
+            s.access_tokens.insert(
+                "test-access-token".to_string(),
+                crate::state::AccessTokenData {
+                    user_pool_id: pool_id.clone(),
+                    username: "selfuser".to_string(),
+                    client_id: "test-client".to_string(),
+                    issued_at: Utc::now(),
+                },
+            );
+        }
+
+        // GetUser with valid token
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "GetUser".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({"AccessToken": "test-access-token"})).unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        let resp = svc.get_user(&req).unwrap();
+        let resp_json: Value =
+            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+        assert_eq!(resp_json["Username"], "selfuser");
+
+        // GetUser with invalid token
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "GetUser".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({"AccessToken": "invalid-token"})).unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        match svc.get_user(&req) {
+            Err(e) => assert_eq!(e.code(), "NotAuthorizedException"),
+            Ok(_) => panic!("Expected NotAuthorizedException"),
+        }
+    }
+
+    #[test]
+    fn self_service_delete_user_cleans_up_tokens() {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(crate::state::CognitoState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        let svc = CognitoService::new(state.clone());
+
+        // Create pool
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "CreateUserPool".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(r#"{"PoolName":"test"}"#),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        let pool_resp = svc.create_user_pool(&req).unwrap();
+        let pool_json: Value =
+            serde_json::from_str(core::str::from_utf8(&pool_resp.body).unwrap()).unwrap();
+        let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap().to_string();
+
+        // Create user
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "AdminCreateUser".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "UserPoolId": pool_id,
+                    "Username": "deluser"
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        svc.admin_create_user(&req).unwrap();
+
+        // Insert access token and refresh token
+        {
+            let mut s = state.write();
+            s.access_tokens.insert(
+                "del-token".to_string(),
+                crate::state::AccessTokenData {
+                    user_pool_id: pool_id.clone(),
+                    username: "deluser".to_string(),
+                    client_id: "test-client".to_string(),
+                    issued_at: Utc::now(),
+                },
+            );
+            s.refresh_tokens.insert(
+                "del-refresh".to_string(),
+                crate::state::RefreshTokenData {
+                    user_pool_id: pool_id.clone(),
+                    username: "deluser".to_string(),
+                    client_id: "test-client".to_string(),
+                    issued_at: Utc::now(),
+                },
+            );
+        }
+
+        // Delete user via self-service
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "DeleteUser".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({"AccessToken": "del-token"})).unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        svc.delete_user(&req).unwrap();
+
+        // Verify cleanup
+        let s = state.read();
+        assert!(s.access_tokens.is_empty());
+        assert!(s.refresh_tokens.is_empty());
+        assert!(s
+            .users
+            .get(&pool_id)
+            .and_then(|u| u.get("deluser"))
+            .is_none());
+    }
+
+    #[test]
+    fn verify_user_attribute_with_correct_code() {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(crate::state::CognitoState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        let svc = CognitoService::new(state.clone());
+
+        // Create pool
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "CreateUserPool".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(r#"{"PoolName":"test"}"#),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        let pool_resp = svc.create_user_pool(&req).unwrap();
+        let pool_json: Value =
+            serde_json::from_str(core::str::from_utf8(&pool_resp.body).unwrap()).unwrap();
+        let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap().to_string();
+
+        // Create user with email
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "AdminCreateUser".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "UserPoolId": pool_id,
+                    "Username": "verifyuser",
+                    "UserAttributes": [{"Name": "email", "Value": "verify@example.com"}]
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        svc.admin_create_user(&req).unwrap();
+
+        // Insert access token
+        {
+            let mut s = state.write();
+            s.access_tokens.insert(
+                "verify-token".to_string(),
+                crate::state::AccessTokenData {
+                    user_pool_id: pool_id.clone(),
+                    username: "verifyuser".to_string(),
+                    client_id: "test-client".to_string(),
+                    issued_at: Utc::now(),
+                },
+            );
+        }
+
+        // Get verification code
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "GetUserAttributeVerificationCode".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "AccessToken": "verify-token",
+                    "AttributeName": "email"
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        let resp = svc.get_user_attribute_verification_code(&req).unwrap();
+        let resp_json: Value =
+            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+        assert_eq!(resp_json["CodeDeliveryDetails"]["DeliveryMedium"], "EMAIL");
+        assert_eq!(resp_json["CodeDeliveryDetails"]["AttributeName"], "email");
+
+        // Read the code from state
+        let code = {
+            let s = state.read();
+            let user = s.users.get(&pool_id).unwrap().get("verifyuser").unwrap();
+            user.attribute_verification_codes
+                .get("email")
+                .unwrap()
+                .clone()
+        };
+
+        // Verify with correct code
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "VerifyUserAttribute".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "AccessToken": "verify-token",
+                    "AttributeName": "email",
+                    "Code": code
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        svc.verify_user_attribute(&req).unwrap();
+
+        // Verify email_verified is set
+        let s = state.read();
+        let user = s.users.get(&pool_id).unwrap().get("verifyuser").unwrap();
+        let email_verified = user
+            .attributes
+            .iter()
+            .find(|a| a.name == "email_verified")
+            .unwrap();
+        assert_eq!(email_verified.value, "true");
+
+        // Verify with wrong code should fail
+        drop(s);
+        // First get a new code
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "GetUserAttributeVerificationCode".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "AccessToken": "verify-token",
+                    "AttributeName": "email"
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        svc.get_user_attribute_verification_code(&req).unwrap();
+
+        let req = AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: "VerifyUserAttribute".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_string(&json!({
+                    "AccessToken": "verify-token",
+                    "AttributeName": "email",
+                    "Code": "000000"
+                }))
+                .unwrap(),
+            ),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        };
+        match svc.verify_user_attribute(&req) {
+            Err(e) => assert_eq!(e.code(), "CodeMismatchException"),
+            Ok(_) => panic!("Expected CodeMismatchException"),
         }
     }
 }

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -2213,7 +2213,7 @@ impl CognitoService {
             .map(|e| {
                 // Mask email: show first char + *** + @domain
                 if let Some(at_pos) = e.find('@') {
-                    let first = &e[..1];
+                    let first = e.chars().next().unwrap_or('*');
                     let domain = &e[at_pos..];
                     format!("{first}***{domain}")
                 } else {
@@ -3121,7 +3121,9 @@ impl CognitoService {
                     // Mask phone: show last 4 digits
                     let len = a.value.len();
                     if len > 4 {
-                        format!("{}***{}", &a.value[..1], &a.value[len - 4..])
+                        let first: String = a.value.chars().take(1).collect();
+                        let last4: String = a.value.chars().skip(len.saturating_sub(4)).collect();
+                        format!("{first}***{last4}")
                     } else {
                         "***".to_string()
                     }
@@ -3135,7 +3137,7 @@ impl CognitoService {
                 .find(|a| a.name == "email")
                 .map(|a| {
                     if let Some(at_pos) = a.value.find('@') {
-                        let first = &a.value[..1];
+                        let first = a.value.chars().next().unwrap_or('*');
                         let domain = &a.value[at_pos..];
                         format!("{first}***{domain}")
                     } else {
@@ -3270,7 +3272,7 @@ impl CognitoService {
         let destination = email
             .map(|e| {
                 if let Some(at_pos) = e.find('@') {
-                    let first = &e[..1];
+                    let first = e.chars().next().unwrap_or('*');
                     let domain = &e[at_pos..];
                     format!("{first}***{domain}")
                 } else {

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -236,6 +236,8 @@ pub struct User {
     pub password: Option<String>,
     pub temporary_password: Option<String>,
     pub confirmation_code: Option<String>,
+    /// attribute_name -> verification_code (for GetUserAttributeVerificationCode / VerifyUserAttribute)
+    pub attribute_verification_codes: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -1843,3 +1843,282 @@ async fn cognito_list_users_in_group() {
         .unwrap();
     assert_eq!(resp.users().len(), 2);
 }
+
+// ---------------------------------------------------------------------------
+// Self-service user operations
+// ---------------------------------------------------------------------------
+
+/// Helper: create pool + client + confirmed user, return (pool_id, client_id, access_token)
+async fn setup_authenticated_user(
+    client: &aws_sdk_cognitoidentityprovider::Client,
+    pool_name: &str,
+) -> (String, String, String) {
+    let pool = client
+        .create_user_pool()
+        .pool_name(pool_name)
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("self-client")
+        .explicit_auth_flows(
+            aws_sdk_cognitoidentityprovider::types::ExplicitAuthFlowsType::AllowUserPasswordAuth,
+        )
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("selfuser")
+        .send()
+        .await
+        .unwrap();
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("selfuser")
+        .password("SelfPass1!")
+        .permanent(true)
+        .send()
+        .await
+        .unwrap();
+
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "selfuser")
+        .auth_parameters("PASSWORD", "SelfPass1!")
+        .send()
+        .await
+        .unwrap();
+    let access_token = auth
+        .authentication_result()
+        .unwrap()
+        .access_token()
+        .unwrap()
+        .to_string();
+
+    (pool_id, client_id, access_token)
+}
+
+#[test_action("cognito-idp", "GetUser", checksum = "43ac140c")]
+#[tokio::test]
+async fn cognito_get_user_self() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let (_pool_id, _client_id, access_token) =
+        setup_authenticated_user(&client, "getuser-self-pool").await;
+
+    let resp = client
+        .get_user()
+        .access_token(&access_token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.username(), "selfuser");
+}
+
+#[test_action("cognito-idp", "DeleteUser", checksum = "f81d91ec")]
+#[tokio::test]
+async fn cognito_delete_user_self() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let (_pool_id, _client_id, access_token) =
+        setup_authenticated_user(&client, "deluser-self-pool").await;
+
+    client
+        .delete_user()
+        .access_token(&access_token)
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .get_user()
+        .access_token(&access_token)
+        .send()
+        .await
+        .unwrap_err();
+    assert!(err.into_service_error().is_not_authorized_exception());
+}
+
+#[test_action("cognito-idp", "UpdateUserAttributes", checksum = "23608e20")]
+#[test_action("cognito-idp", "DeleteUserAttributes", checksum = "f40bb25d")]
+#[tokio::test]
+async fn cognito_update_delete_user_attributes_self() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let (_pool_id, _client_id, access_token) =
+        setup_authenticated_user(&client, "attrs-self-pool").await;
+
+    client
+        .update_user_attributes()
+        .access_token(&access_token)
+        .user_attributes(
+            aws_sdk_cognitoidentityprovider::types::AttributeType::builder()
+                .name("email")
+                .value("self@example.com")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let user = client
+        .get_user()
+        .access_token(&access_token)
+        .send()
+        .await
+        .unwrap();
+    assert!(user
+        .user_attributes()
+        .iter()
+        .any(|a| a.name() == "email" && a.value() == Some("self@example.com")));
+
+    client
+        .delete_user_attributes()
+        .access_token(&access_token)
+        .user_attribute_names("email")
+        .send()
+        .await
+        .unwrap();
+
+    let user2 = client
+        .get_user()
+        .access_token(&access_token)
+        .send()
+        .await
+        .unwrap();
+    assert!(!user2.user_attributes().iter().any(|a| a.name() == "email"));
+}
+
+#[test_action(
+    "cognito-idp",
+    "GetUserAttributeVerificationCode",
+    checksum = "717d600d"
+)]
+#[test_action("cognito-idp", "VerifyUserAttribute", checksum = "fc368ddf")]
+#[tokio::test]
+async fn cognito_verify_user_attribute() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let (pool_id, _client_id, access_token) =
+        setup_authenticated_user(&client, "verify-attr-pool").await;
+
+    // Set an email first
+    client
+        .update_user_attributes()
+        .access_token(&access_token)
+        .user_attributes(
+            aws_sdk_cognitoidentityprovider::types::AttributeType::builder()
+                .name("email")
+                .value("verify@example.com")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .get_user_attribute_verification_code()
+        .access_token(&access_token)
+        .attribute_name("email")
+        .send()
+        .await
+        .unwrap();
+
+    // Get code via introspection
+    let code_resp: serde_json::Value = reqwest::get(format!(
+        "{}/_fakecloud/cognito/confirmation-codes/{}/selfuser",
+        server.endpoint(),
+        pool_id
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+    let code = code_resp["confirmationCode"].as_str().unwrap().to_string();
+
+    client
+        .verify_user_attribute()
+        .access_token(&access_token)
+        .attribute_name("email")
+        .code(&code)
+        .send()
+        .await
+        .unwrap();
+
+    let user = client
+        .get_user()
+        .access_token(&access_token)
+        .send()
+        .await
+        .unwrap();
+    assert!(user
+        .user_attributes()
+        .iter()
+        .any(|a| a.name() == "email_verified" && a.value() == Some("true")));
+}
+
+#[test_action("cognito-idp", "ResendConfirmationCode", checksum = "7cece340")]
+#[tokio::test]
+async fn cognito_resend_confirmation_code() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("resend-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("resend-client")
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("resenduser")
+        .password("Resend1234!")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .resend_confirmation_code()
+        .client_id(&client_id)
+        .username("resenduser")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.code_delivery_details().is_some());
+}

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -2053,7 +2053,10 @@ async fn cognito_verify_user_attribute() {
     .json()
     .await
     .unwrap();
-    let code = code_resp["confirmationCode"].as_str().unwrap().to_string();
+    let code = code_resp["attributeVerificationCodes"]["email"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
     client
         .verify_user_attribute()

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -2,9 +2,9 @@ mod helpers;
 use helpers::TestServer;
 
 use aws_sdk_cognitoidentityprovider::types::{
-    AccountRecoverySettingType, AttributeType, ChallengeNameType, ExplicitAuthFlowsType,
-    PasswordPolicyType, RecoveryOptionNameType, RecoveryOptionType, UserPoolPolicyType,
-    UserStatusType,
+    AccountRecoverySettingType, AttributeType, ChallengeNameType, DeliveryMediumType,
+    ExplicitAuthFlowsType, PasswordPolicyType, RecoveryOptionNameType, RecoveryOptionType,
+    UserPoolPolicyType, UserStatusType,
 };
 
 #[tokio::test]
@@ -2488,4 +2488,422 @@ async fn cognito_list_groups_for_user() {
         err.is_err(),
         "Listing groups for non-existent user should fail"
     );
+}
+
+// Helper: create pool + client + user + auth, return (server, client, pool_id, client_id, access_token)
+async fn setup_authed_user(
+    pool_name: &str,
+    client_name: &str,
+    username: &str,
+    password: &str,
+    email: &str,
+) -> (
+    TestServer,
+    aws_sdk_cognitoidentityprovider::Client,
+    String,
+    String,
+    String,
+) {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool_result = client
+        .create_user_pool()
+        .pool_name(pool_name)
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool_result.user_pool().unwrap().id().unwrap().to_string();
+
+    let client_result = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name(client_name)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowAdminUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = client_result
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username(username)
+        .user_attributes(
+            AttributeType::builder()
+                .name("email")
+                .value(email)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create user");
+
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username(username)
+        .password(password)
+        .permanent(true)
+        .send()
+        .await
+        .expect("set password");
+
+    let auth_result = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", username)
+        .auth_parameters("PASSWORD", password)
+        .send()
+        .await
+        .expect("auth");
+
+    let access_token = auth_result
+        .authentication_result()
+        .unwrap()
+        .access_token()
+        .unwrap()
+        .to_string();
+
+    (server, client, pool_id, client_id, access_token)
+}
+
+#[tokio::test]
+async fn cognito_get_user() {
+    let (_server, client, _pool_id, _client_id, access_token) = setup_authed_user(
+        "getuser-pool",
+        "getuser-client",
+        "getuser",
+        "mypasswd",
+        "get@example.com",
+    )
+    .await;
+
+    let result = client
+        .get_user()
+        .access_token(&access_token)
+        .send()
+        .await
+        .expect("get user");
+
+    assert_eq!(result.username(), "getuser");
+
+    // Check attributes contain email
+    let attrs = result.user_attributes();
+    let email_attr = attrs.iter().find(|a| a.name() == "email");
+    assert!(email_attr.is_some(), "Should have email attribute");
+    assert_eq!(email_attr.unwrap().value(), Some("get@example.com"));
+
+    // Invalid token should fail
+    let err = client.get_user().access_token("bad-token").send().await;
+    assert!(err.is_err(), "Invalid token should fail");
+}
+
+#[tokio::test]
+async fn cognito_delete_user_self() {
+    let (_server, client, pool_id, _client_id, access_token) = setup_authed_user(
+        "delself-pool",
+        "delself-client",
+        "delself",
+        "mypasswd",
+        "del@example.com",
+    )
+    .await;
+
+    // Delete self
+    client
+        .delete_user()
+        .access_token(&access_token)
+        .send()
+        .await
+        .expect("delete user");
+
+    // GetUser should fail now
+    let err = client.get_user().access_token(&access_token).send().await;
+    assert!(err.is_err(), "Get user after delete should fail");
+
+    // Admin get user should also fail
+    let err = client
+        .admin_get_user()
+        .user_pool_id(&pool_id)
+        .username("delself")
+        .send()
+        .await;
+    assert!(err.is_err(), "Admin get user after delete should fail");
+}
+
+#[tokio::test]
+async fn cognito_update_delete_user_attributes_self() {
+    let (_server, client, _pool_id, _client_id, access_token) = setup_authed_user(
+        "upattr-pool",
+        "upattr-client",
+        "upattr",
+        "mypasswd",
+        "old@example.com",
+    )
+    .await;
+
+    // Update email attribute
+    client
+        .update_user_attributes()
+        .access_token(&access_token)
+        .user_attributes(
+            AttributeType::builder()
+                .name("email")
+                .value("new@example.com")
+                .build()
+                .unwrap(),
+        )
+        .user_attributes(
+            AttributeType::builder()
+                .name("custom:team")
+                .value("engineering")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("update user attributes");
+
+    // Verify via GetUser
+    let user = client
+        .get_user()
+        .access_token(&access_token)
+        .send()
+        .await
+        .expect("get user");
+
+    let attrs = user.user_attributes();
+    let email = attrs.iter().find(|a| a.name() == "email").unwrap();
+    assert_eq!(email.value(), Some("new@example.com"));
+    let team = attrs.iter().find(|a| a.name() == "custom:team").unwrap();
+    assert_eq!(team.value(), Some("engineering"));
+
+    // Delete email attribute
+    client
+        .delete_user_attributes()
+        .access_token(&access_token)
+        .user_attribute_names("email")
+        .send()
+        .await
+        .expect("delete user attributes");
+
+    // Verify email is gone
+    let user2 = client
+        .get_user()
+        .access_token(&access_token)
+        .send()
+        .await
+        .expect("get user after delete attr");
+
+    let attrs2 = user2.user_attributes();
+    assert!(
+        attrs2.iter().find(|a| a.name() == "email").is_none(),
+        "email attribute should be deleted"
+    );
+    // custom:team should still be there
+    assert!(
+        attrs2.iter().find(|a| a.name() == "custom:team").is_some(),
+        "custom:team should remain"
+    );
+}
+
+#[tokio::test]
+async fn cognito_verify_user_attribute() {
+    let (_server, client, pool_id, _client_id, access_token) = setup_authed_user(
+        "verify-pool",
+        "verify-client",
+        "verifyuser",
+        "mypasswd",
+        "verify@example.com",
+    )
+    .await;
+
+    // Get verification code
+    let code_result = client
+        .get_user_attribute_verification_code()
+        .access_token(&access_token)
+        .attribute_name("email")
+        .send()
+        .await
+        .expect("get verification code");
+
+    let delivery = code_result.code_delivery_details().unwrap();
+    assert_eq!(
+        delivery.delivery_medium().unwrap(),
+        &DeliveryMediumType::Email
+    );
+    assert_eq!(delivery.attribute_name().unwrap(), "email");
+    let dest = delivery.destination().unwrap();
+    assert!(dest.contains("***"), "Destination should be masked: {dest}");
+
+    // Wrong code should fail with CodeMismatchException
+    let err = client
+        .verify_user_attribute()
+        .access_token(&access_token)
+        .attribute_name("email")
+        .code("000000")
+        .send()
+        .await;
+    assert!(err.is_err(), "Wrong code should fail");
+
+    // Verify email_verified is not yet set
+    let user = client
+        .admin_get_user()
+        .user_pool_id(&pool_id)
+        .username("verifyuser")
+        .send()
+        .await
+        .expect("admin get user");
+
+    let attrs = user.user_attributes();
+    let email_verified = attrs.iter().find(|a| a.name() == "email_verified");
+    assert!(
+        email_verified.is_none() || email_verified.unwrap().value() != Some("true"),
+        "email should not be verified yet"
+    );
+
+    // Invalid token should fail
+    let err = client
+        .get_user_attribute_verification_code()
+        .access_token("bad-token")
+        .attribute_name("email")
+        .send()
+        .await;
+    assert!(err.is_err(), "Invalid token should fail");
+}
+
+#[tokio::test]
+async fn cognito_resend_confirmation_code() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    // Create pool with relaxed policy
+    let pool_result = client
+        .create_user_pool()
+        .pool_name("resend-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool_result.user_pool().unwrap().id().unwrap().to_string();
+
+    let client_result = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("resend-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = client_result
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    // Sign up user
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("resenduser")
+        .password("mypasswd")
+        .user_attributes(
+            AttributeType::builder()
+                .name("email")
+                .value("resend@example.com")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("sign up");
+
+    // Resend confirmation code
+    let result = client
+        .resend_confirmation_code()
+        .client_id(&client_id)
+        .username("resenduser")
+        .send()
+        .await
+        .expect("resend confirmation code");
+
+    let delivery = result.code_delivery_details().unwrap();
+    assert_eq!(
+        delivery.delivery_medium().unwrap(),
+        &DeliveryMediumType::Email
+    );
+    assert_eq!(delivery.attribute_name().unwrap(), "email");
+    let dest = delivery.destination().unwrap();
+    assert!(dest.contains("***"), "Destination should be masked: {dest}");
+    assert!(
+        dest.contains("@example.com"),
+        "Should contain domain: {dest}"
+    );
+
+    // Confirm with any code (confirm_sign_up accepts any code)
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("resenduser")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm sign up");
+
+    // Auth should work now
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "resenduser")
+        .auth_parameters("PASSWORD", "mypasswd")
+        .send()
+        .await;
+    assert!(auth.is_ok(), "Auth after confirm should work");
+
+    // Resend for non-existent user should fail
+    let err = client
+        .resend_confirmation_code()
+        .client_id(&client_id)
+        .username("nosuchuser")
+        .send()
+        .await;
+    assert!(err.is_err(), "Resend for non-existent user should fail");
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -719,12 +719,18 @@ async fn main() {
                     let cs = cs.clone();
                     async move {
                         let state = cs.read();
-                        let code = state
+                        let user = state
                             .users
                             .get(&pool_id)
-                            .and_then(|users| users.get(&username))
-                            .and_then(|user| user.confirmation_code.clone());
-                        axum::Json(serde_json::json!({ "confirmationCode": code }))
+                            .and_then(|users| users.get(&username));
+                        let code = user.and_then(|u| u.confirmation_code.clone());
+                        let attr_codes: serde_json::Value = user
+                            .map(|u| serde_json::json!(u.attribute_verification_codes))
+                            .unwrap_or(serde_json::json!({}));
+                        axum::Json(serde_json::json!({
+                            "confirmationCode": code,
+                            "attributeVerificationCodes": attr_codes
+                        }))
                     }
                 }
             }),


### PR DESCRIPTION
## Summary

- 7 new Cognito operations: GetUser, DeleteUser, UpdateUserAttributes, DeleteUserAttributes, GetUserAttributeVerificationCode, VerifyUserAttribute, ResendConfirmationCode
- All use access token authentication (not admin API)
- Real behavior: attribute verification codes, email_verified/phone_number_verified flags, self-delete with full cleanup (tokens, sessions, group memberships)
- 3 new unit tests (37 total), 5 new E2E tests (37 total), 7 new conformance tests (48/48 coverage)

## Test plan

- [x] `cargo test -p fakecloud-cognito` — 37 unit tests pass
- [x] `cargo test -p fakecloud-e2e --test cognito` — 37 E2E tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Conformance audit: 48/48 cognito-idp actions covered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements seven self-service `cognito-idp` user operations using access tokens, with real verification flows and full cleanup. Also fixes UTF‑8-safe masking for delivery details and exposes attribute verification codes in the introspection endpoint.

- **New Features**
  - Access-token auth for: GetUser, DeleteUser, UpdateUserAttributes, DeleteUserAttributes, GetUserAttributeVerificationCode, VerifyUserAttribute, ResendConfirmationCode.
  - Attribute verification: generate/validate codes; set email_verified/phone_number_verified; masked CodeDeliveryDetails.
  - DeleteUser cleans up access/refresh tokens, sessions, and group memberships.
  - Tests: +unit/E2E/conformance; Cognito actions covered 48/48.

- **Bug Fixes**
  - Use UTF‑8-safe character extraction when masking email/phone to handle multibyte characters and avoid panics.
  - Introspection endpoint now returns attribute verification codes for users to support verification flows in tests.

<sup>Written for commit 096883395c618f3bc015663ba1b9f9c86f3a9ec1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

