### PR TITLE
feat(cognito): implement identity provider operations

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -2,57 +2,21 @@
   "variants_passed": 42164,
   "total_variants": 42193,
   "per_service": {
-    "ses": {
-      "passed": 2858,
-      "total": 2858
-    },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
     },
     "cognito-idp": {
       "passed": 4450,
       "total": 4479
     },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
+    "ses": {
+      "passed": 2858,
+      "total": 2858
     },
     "iam": {
       "passed": 5962,
       "total": 5962
-    },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
     },
     "kms": {
       "passed": 2196,
@@ -61,6 +25,42 @@
     "sts": {
       "passed": 438,
       "total": 438
+    },
+    "logs": {
+      "passed": 3911,
+      "total": 3911
+    },
+    "s3": {
+      "passed": 3620,
+      "total": 3620
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "events": {
+      "passed": 2108,
+      "total": 2108
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
     }
   }
 }

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -12,9 +12,9 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 
 use crate::state::{
     default_schema_attributes, AccessTokenData, AccountRecoverySetting, AdminCreateUserConfig,
-    EmailConfiguration, Group, InviteMessageTemplate, MfaPreferences, PasswordPolicy, PoolPolicies,
-    RecoveryOption, RefreshTokenData, SchemaAttribute, SessionData, SharedCognitoState,
-    SmsConfiguration, SmsMfaConfiguration, SoftwareTokenMfaConfiguration,
+    EmailConfiguration, Group, IdentityProvider, InviteMessageTemplate, MfaPreferences,
+    PasswordPolicy, PoolPolicies, RecoveryOption, RefreshTokenData, SchemaAttribute, SessionData,
+    SharedCognitoState, SmsConfiguration, SmsMfaConfiguration, SoftwareTokenMfaConfiguration,
     StringAttributeConstraints, TokenValidityUnits, User, UserAttribute, UserPool, UserPoolClient,
 };
 
@@ -90,6 +90,11 @@ impl AwsService for CognitoService {
             "SetUserMFAPreference" => self.set_user_mfa_preference(&req),
             "AssociateSoftwareToken" => self.associate_software_token(&req),
             "VerifySoftwareToken" => self.verify_software_token(&req),
+            "CreateIdentityProvider" => self.create_identity_provider(&req),
+            "DescribeIdentityProvider" => self.describe_identity_provider(&req),
+            "UpdateIdentityProvider" => self.update_identity_provider(&req),
+            "DeleteIdentityProvider" => self.delete_identity_provider(&req),
+            "ListIdentityProviders" => self.list_identity_providers(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "cognito-idp",
                 &req.action,
@@ -153,6 +158,11 @@ impl AwsService for CognitoService {
             "SetUserMFAPreference",
             "AssociateSoftwareToken",
             "VerifySoftwareToken",
+            "CreateIdentityProvider",
+            "DescribeIdentityProvider",
+            "UpdateIdentityProvider",
+            "DeleteIdentityProvider",
+            "ListIdentityProviders",
         ]
     }
 }
@@ -398,6 +408,9 @@ impl CognitoService {
         // Remove associated groups and user-group associations
         state.groups.remove(pool_id);
         state.user_groups.remove(pool_id);
+
+        // Remove associated identity providers
+        state.identity_providers.remove(pool_id);
 
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -3675,6 +3688,242 @@ impl CognitoService {
             "Status": "SUCCESS",
         })))
     }
+
+    // ── Identity Provider operations ──────────────────────────────────
+
+    fn create_identity_provider(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let provider_name = require_str(&body, "ProviderName")?;
+        let provider_type = require_str(&body, "ProviderType")?;
+
+        validate_provider_type(provider_type)?;
+
+        let provider_details = parse_string_map(&body["ProviderDetails"]);
+        let attribute_mapping = parse_string_map(&body["AttributeMapping"]);
+        let idp_identifiers = body["IdpIdentifiers"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let pool_providers = state
+            .identity_providers
+            .entry(pool_id.to_string())
+            .or_default();
+        if pool_providers.contains_key(provider_name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "DuplicateProviderException",
+                format!(
+                    "A provider with the name {provider_name} already exists in this user pool."
+                ),
+            ));
+        }
+
+        let now = Utc::now();
+        let idp = IdentityProvider {
+            user_pool_id: pool_id.to_string(),
+            provider_name: provider_name.to_string(),
+            provider_type: provider_type.to_string(),
+            provider_details,
+            attribute_mapping,
+            idp_identifiers,
+            creation_date: now,
+            last_modified_date: now,
+        };
+
+        pool_providers.insert(provider_name.to_string(), idp.clone());
+
+        Ok(AwsResponse::ok_json(json!({
+            "IdentityProvider": identity_provider_to_json(&idp)
+        })))
+    }
+
+    fn describe_identity_provider(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let provider_name = require_str(&body, "ProviderName")?;
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let idp = state
+            .identity_providers
+            .get(pool_id)
+            .and_then(|providers| providers.get(provider_name))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Identity provider {provider_name} does not exist."),
+                )
+            })?;
+
+        Ok(AwsResponse::ok_json(json!({
+            "IdentityProvider": identity_provider_to_json(idp)
+        })))
+    }
+
+    fn update_identity_provider(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let provider_name = require_str(&body, "ProviderName")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let idp = state
+            .identity_providers
+            .get_mut(pool_id)
+            .and_then(|providers| providers.get_mut(provider_name))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Identity provider {provider_name} does not exist."),
+                )
+            })?;
+
+        if body["ProviderDetails"].is_object() {
+            idp.provider_details = parse_string_map(&body["ProviderDetails"]);
+        }
+        if body["AttributeMapping"].is_object() {
+            idp.attribute_mapping = parse_string_map(&body["AttributeMapping"]);
+        }
+        if let Some(arr) = body["IdpIdentifiers"].as_array() {
+            idp.idp_identifiers = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect();
+        }
+        idp.last_modified_date = Utc::now();
+
+        let idp = idp.clone();
+
+        Ok(AwsResponse::ok_json(json!({
+            "IdentityProvider": identity_provider_to_json(&idp)
+        })))
+    }
+
+    fn delete_identity_provider(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let provider_name = require_str(&body, "ProviderName")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let removed = state
+            .identity_providers
+            .get_mut(pool_id)
+            .and_then(|providers| providers.remove(provider_name));
+
+        if removed.is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Identity provider {provider_name} does not exist."),
+            ));
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn list_identity_providers(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let max_results = body["MaxResults"].as_i64().unwrap_or(60).clamp(1, 60) as usize;
+        let next_token = body["NextToken"].as_str();
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let empty = HashMap::new();
+        let pool_providers = state.identity_providers.get(pool_id).unwrap_or(&empty);
+
+        let mut providers: Vec<&IdentityProvider> = pool_providers.values().collect();
+        providers.sort_by_key(|p| p.creation_date);
+
+        let start_idx = if let Some(token) = next_token {
+            providers
+                .iter()
+                .position(|p| p.provider_name == token)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        let page: Vec<Value> = providers
+            .iter()
+            .skip(start_idx)
+            .take(max_results)
+            .map(|p| {
+                json!({
+                    "ProviderName": p.provider_name,
+                    "ProviderType": p.provider_type,
+                    "CreationDate": p.creation_date.timestamp() as f64,
+                    "LastModifiedDate": p.last_modified_date.timestamp() as f64,
+                })
+            })
+            .collect();
+
+        let has_more = start_idx + max_results < providers.len();
+        let mut response = json!({ "Providers": page });
+        if has_more {
+            if let Some(last) = providers.get(start_idx + max_results) {
+                response["NextToken"] = json!(last.provider_name);
+            }
+        }
+
+        Ok(AwsResponse::ok_json(response))
+    }
 }
 
 /// Generate a pool ID in the format `{region}_{9 random alphanumeric chars}`.
@@ -3994,6 +4243,58 @@ fn group_to_json(group: &Group) -> Value {
         val["RoleArn"] = json!(arn);
     }
     val
+}
+
+fn identity_provider_to_json(idp: &IdentityProvider) -> Value {
+    let mut val = json!({
+        "UserPoolId": idp.user_pool_id,
+        "ProviderName": idp.provider_name,
+        "ProviderType": idp.provider_type,
+        "CreationDate": idp.creation_date.timestamp() as f64,
+        "LastModifiedDate": idp.last_modified_date.timestamp() as f64,
+    });
+    if !idp.provider_details.is_empty() {
+        val["ProviderDetails"] = json!(idp.provider_details);
+    }
+    if !idp.attribute_mapping.is_empty() {
+        val["AttributeMapping"] = json!(idp.attribute_mapping);
+    }
+    if !idp.idp_identifiers.is_empty() {
+        val["IdpIdentifiers"] = json!(idp.idp_identifiers);
+    }
+    val
+}
+
+const VALID_PROVIDER_TYPES: &[&str] = &[
+    "SAML",
+    "Facebook",
+    "Google",
+    "LoginWithAmazon",
+    "SignInWithApple",
+    "OIDC",
+];
+
+fn validate_provider_type(provider_type: &str) -> Result<(), AwsServiceError> {
+    if !VALID_PROVIDER_TYPES.contains(&provider_type) {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterException",
+            format!(
+                "Invalid ProviderType: {provider_type}. Must be one of: SAML, Facebook, Google, LoginWithAmazon, SignInWithApple, OIDC"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn parse_string_map(val: &Value) -> HashMap<String, String> {
+    val.as_object()
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Convert a User to the JSON format AWS returns (for ListUsers and AdminCreateUser response).
@@ -5893,5 +6194,100 @@ mod tests {
         assert!(prefs.software_token_preferred);
         assert!(!prefs.sms_enabled);
         assert!(!prefs.sms_preferred);
+    }
+
+    fn make_req(action: &str, body: &str) -> AwsRequest {
+        AwsRequest {
+            service: "cognito-idp".to_string(),
+            action: action.to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(body.to_string()),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+        }
+    }
+
+    fn setup_svc_with_pool() -> (CognitoService, String) {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(crate::state::CognitoState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        let svc = CognitoService::new(state);
+        let req = make_req("CreateUserPool", r#"{"PoolName":"test"}"#);
+        let resp = svc.create_user_pool(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
+        (svc, pool_id)
+    }
+
+    #[test]
+    fn identity_provider_name_uniqueness() {
+        let (svc, pool_id) = setup_svc_with_pool();
+
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "ProviderName": "MyGoogle",
+            "ProviderType": "Google",
+            "ProviderDetails": {"client_id": "123", "client_secret": "secret"}
+        }))
+        .unwrap();
+        let req = make_req("CreateIdentityProvider", &body);
+        svc.create_identity_provider(&req).unwrap();
+
+        // Duplicate name should fail
+        let req2 = make_req("CreateIdentityProvider", &body);
+        match svc.create_identity_provider(&req2) {
+            Err(e) => assert_eq!(e.code(), "DuplicateProviderException"),
+            Ok(_) => panic!("Expected DuplicateProviderException"),
+        }
+    }
+
+    #[test]
+    fn identity_provider_type_validation() {
+        let (svc, pool_id) = setup_svc_with_pool();
+
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "ProviderName": "MyInvalid",
+            "ProviderType": "InvalidType",
+            "ProviderDetails": {}
+        }))
+        .unwrap();
+        let req = make_req("CreateIdentityProvider", &body);
+        match svc.create_identity_provider(&req) {
+            Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+            Ok(_) => panic!("Expected InvalidParameterException"),
+        }
+
+        // Valid types should all work
+        for provider_type in &[
+            "SAML",
+            "Facebook",
+            "Google",
+            "LoginWithAmazon",
+            "SignInWithApple",
+            "OIDC",
+        ] {
+            let body = serde_json::to_string(&json!({
+                "UserPoolId": pool_id,
+                "ProviderName": format!("prov_{provider_type}"),
+                "ProviderType": provider_type,
+                "ProviderDetails": {}
+            }))
+            .unwrap();
+            let req = make_req("CreateIdentityProvider", &body);
+            assert!(
+                svc.create_identity_provider(&req).is_ok(),
+                "ProviderType {provider_type} should be valid"
+            );
+        }
     }
 }

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -24,6 +24,8 @@ pub struct CognitoState {
     pub groups: HashMap<String, HashMap<String, Group>>,
     /// pool_id -> (username -> [group_names])
     pub user_groups: HashMap<String, HashMap<String, Vec<String>>>,
+    /// pool_id -> (provider_name -> IdentityProvider)
+    pub identity_providers: HashMap<String, HashMap<String, IdentityProvider>>,
 }
 
 impl CognitoState {
@@ -39,6 +41,7 @@ impl CognitoState {
             access_tokens: HashMap::new(),
             groups: HashMap::new(),
             user_groups: HashMap::new(),
+            identity_providers: HashMap::new(),
         }
     }
 
@@ -51,6 +54,7 @@ impl CognitoState {
         self.access_tokens.clear();
         self.groups.clear();
         self.user_groups.clear();
+        self.identity_providers.clear();
     }
 }
 
@@ -277,6 +281,18 @@ pub struct Group {
     pub description: Option<String>,
     pub precedence: Option<i64>,
     pub role_arn: Option<String>,
+    pub creation_date: DateTime<Utc>,
+    pub last_modified_date: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IdentityProvider {
+    pub user_pool_id: String,
+    pub provider_name: String,
+    pub provider_type: String,
+    pub provider_details: HashMap<String, String>,
+    pub attribute_mapping: HashMap<String, String>,
+    pub idp_identifiers: Vec<String>,
     pub creation_date: DateTime<Utc>,
     pub last_modified_date: DateTime<Utc>,
 }

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -2258,3 +2258,199 @@ async fn cognito_associate_verify_software_token() {
         Some(&aws_sdk_cognitoidentityprovider::types::VerifySoftwareTokenResponseType::Success),
     );
 }
+
+// ---------------------------------------------------------------------------
+// Identity Providers
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "CreateIdentityProvider", checksum = "59c9c181")]
+#[tokio::test]
+async fn cognito_create_identity_provider() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("idp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let resp = client
+        .create_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("TestOIDC")
+        .provider_type(aws_sdk_cognitoidentityprovider::types::IdentityProviderTypeType::Oidc)
+        .provider_details("client_id", "test-client")
+        .provider_details("authorize_scopes", "openid")
+        .send()
+        .await
+        .unwrap();
+    let idp = resp.identity_provider().unwrap();
+    assert_eq!(idp.provider_name().unwrap(), "TestOIDC");
+}
+
+#[test_action("cognito-idp", "DescribeIdentityProvider", checksum = "94a4d7f7")]
+#[tokio::test]
+async fn cognito_describe_identity_provider() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("descidp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("DescOIDC")
+        .provider_type(aws_sdk_cognitoidentityprovider::types::IdentityProviderTypeType::Oidc)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("DescOIDC")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.identity_provider().unwrap().provider_name().unwrap(),
+        "DescOIDC"
+    );
+}
+
+#[test_action("cognito-idp", "UpdateIdentityProvider", checksum = "7addfa0c")]
+#[tokio::test]
+async fn cognito_update_identity_provider() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("updidp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("UpdOIDC")
+        .provider_type(aws_sdk_cognitoidentityprovider::types::IdentityProviderTypeType::Oidc)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("UpdOIDC")
+        .provider_details("client_id", "updated-client")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("UpdOIDC")
+        .send()
+        .await
+        .unwrap();
+    let idp = resp.identity_provider().unwrap();
+    assert_eq!(
+        idp.provider_details().unwrap().get("client_id").map(|v| v.as_str()),
+        Some("updated-client")
+    );
+}
+
+#[test_action("cognito-idp", "DeleteIdentityProvider", checksum = "9d54dc37")]
+#[tokio::test]
+async fn cognito_delete_identity_provider() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("delidp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("DelOIDC")
+        .provider_type(aws_sdk_cognitoidentityprovider::types::IdentityProviderTypeType::Oidc)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("DelOIDC")
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .describe_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("DelOIDC")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(err.into_service_error().is_resource_not_found_exception());
+}
+
+#[test_action("cognito-idp", "ListIdentityProviders", checksum = "b9551ba1")]
+#[tokio::test]
+async fn cognito_list_identity_providers() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("listidp-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("IDP1")
+        .provider_type(aws_sdk_cognitoidentityprovider::types::IdentityProviderTypeType::Oidc)
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_identity_provider()
+        .user_pool_id(&pool_id)
+        .provider_name("IDP2")
+        .provider_type(aws_sdk_cognitoidentityprovider::types::IdentityProviderTypeType::Saml)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_identity_providers()
+        .user_pool_id(&pool_id)
+        .max_results(10)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.providers().len(), 2);
+}

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -2368,7 +2368,10 @@ async fn cognito_update_identity_provider() {
         .unwrap();
     let idp = resp.identity_provider().unwrap();
     assert_eq!(
-        idp.provider_details().unwrap().get("client_id").map(|v| v.as_str()),
+        idp.provider_details()
+            .unwrap()
+            .get("client_id")
+            .map(|v| v.as_str()),
         Some("updated-client")
     );
 }

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -3,9 +3,9 @@ use helpers::TestServer;
 
 use aws_sdk_cognitoidentityprovider::types::{
     AccountRecoverySettingType, AttributeType, ChallengeNameType, DeliveryMediumType,
-    ExplicitAuthFlowsType, PasswordPolicyType, RecoveryOptionNameType, RecoveryOptionType,
-    SmsMfaSettingsType, SoftwareTokenMfaConfigType, SoftwareTokenMfaSettingsType, UserPoolMfaType,
-    UserPoolPolicyType, UserStatusType,
+    ExplicitAuthFlowsType, IdentityProviderTypeType, PasswordPolicyType, RecoveryOptionNameType,
+    RecoveryOptionType, SmsMfaSettingsType, SoftwareTokenMfaConfigType,
+    SoftwareTokenMfaSettingsType, UserPoolMfaType, UserPoolPolicyType, UserStatusType,
 };
 
 #[tokio::test]
@@ -3237,4 +3237,249 @@ async fn cognito_set_user_mfa_preference() {
         .send()
         .await;
     assert!(err.is_err(), "Should fail with invalid token");
+}
+
+#[tokio::test]
+async fn cognito_create_describe_identity_provider() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("idp-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap();
+
+    // Create an identity provider
+    let result = client
+        .create_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("MyGoogle")
+        .provider_type(IdentityProviderTypeType::Google)
+        .provider_details("client_id", "google-client-id")
+        .provider_details("client_secret", "google-secret")
+        .attribute_mapping("email", "email")
+        .idp_identifiers("google.example.com")
+        .send()
+        .await
+        .expect("create identity provider");
+
+    let idp = result.identity_provider().unwrap();
+    assert_eq!(idp.provider_name().unwrap(), "MyGoogle");
+    assert_eq!(
+        idp.provider_type().unwrap(),
+        &IdentityProviderTypeType::Google
+    );
+    let details = idp.provider_details().unwrap();
+    assert_eq!(details.get("client_id").unwrap(), "google-client-id");
+    let mapping = idp.attribute_mapping().unwrap();
+    assert_eq!(mapping.get("email").unwrap(), "email");
+    let identifiers = idp.idp_identifiers();
+    assert_eq!(identifiers, &["google.example.com"]);
+
+    // Describe it
+    let described = client
+        .describe_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("MyGoogle")
+        .send()
+        .await
+        .expect("describe identity provider");
+
+    let idp2 = described.identity_provider().unwrap();
+    assert_eq!(idp2.provider_name().unwrap(), "MyGoogle");
+    assert_eq!(
+        idp2.provider_type().unwrap(),
+        &IdentityProviderTypeType::Google
+    );
+
+    // Describe non-existent should fail
+    let err = client
+        .describe_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("DoesNotExist")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent provider");
+}
+
+#[tokio::test]
+async fn cognito_update_identity_provider() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("idp-update-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap();
+
+    client
+        .create_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("MySAML")
+        .provider_type(IdentityProviderTypeType::Saml)
+        .provider_details("MetadataURL", "https://example.com/saml")
+        .send()
+        .await
+        .expect("create identity provider");
+
+    // Update provider details
+    let updated = client
+        .update_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("MySAML")
+        .provider_details("MetadataURL", "https://new.example.com/saml")
+        .attribute_mapping("email", "saml:email")
+        .send()
+        .await
+        .expect("update identity provider");
+
+    let idp = updated.identity_provider().unwrap();
+    assert_eq!(idp.provider_name().unwrap(), "MySAML");
+    let details = idp.provider_details().unwrap();
+    assert_eq!(
+        details.get("MetadataURL").unwrap(),
+        "https://new.example.com/saml"
+    );
+    let mapping = idp.attribute_mapping().unwrap();
+    assert_eq!(mapping.get("email").unwrap(), "saml:email");
+
+    // Update non-existent should fail
+    let err = client
+        .update_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("DoesNotExist")
+        .provider_details("foo", "bar")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent provider");
+}
+
+#[tokio::test]
+async fn cognito_delete_identity_provider() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("idp-delete-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap();
+
+    client
+        .create_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("MyOIDC")
+        .provider_type(IdentityProviderTypeType::Oidc)
+        .provider_details("client_id", "oidc-id")
+        .provider_details("client_secret", "oidc-secret")
+        .provider_details("oidc_issuer", "https://auth.example.com")
+        .send()
+        .await
+        .expect("create identity provider");
+
+    // Delete it
+    client
+        .delete_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("MyOIDC")
+        .send()
+        .await
+        .expect("delete identity provider");
+
+    // Describe should now fail
+    let err = client
+        .describe_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("MyOIDC")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail after deletion");
+
+    // Delete again should fail
+    let err = client
+        .delete_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("MyOIDC")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for already-deleted provider");
+}
+
+#[tokio::test]
+async fn cognito_list_identity_providers() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("idp-list-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap();
+
+    // Create multiple providers
+    for (name, ptype) in &[
+        ("GoogleIdP", IdentityProviderTypeType::Google),
+        ("FacebookIdP", IdentityProviderTypeType::Facebook),
+        ("AppleIdP", IdentityProviderTypeType::SignInWithApple),
+    ] {
+        client
+            .create_identity_provider()
+            .user_pool_id(pool_id)
+            .provider_name(*name)
+            .provider_type(ptype.clone())
+            .provider_details("client_id", "test")
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("create {name}: {e}"));
+    }
+
+    // List all
+    let result = client
+        .list_identity_providers()
+        .user_pool_id(pool_id)
+        .max_results(10)
+        .send()
+        .await
+        .expect("list identity providers");
+
+    let providers = result.providers();
+    assert_eq!(providers.len(), 3);
+
+    let names: Vec<&str> = providers.iter().filter_map(|p| p.provider_name()).collect();
+    assert!(names.contains(&"GoogleIdP"));
+    assert!(names.contains(&"FacebookIdP"));
+    assert!(names.contains(&"AppleIdP"));
+
+    // List with pagination (max_results=1)
+    let page1 = client
+        .list_identity_providers()
+        .user_pool_id(pool_id)
+        .max_results(1)
+        .send()
+        .await
+        .expect("list page 1");
+
+    assert_eq!(page1.providers().len(), 1);
+    assert!(
+        page1.next_token().is_some(),
+        "Should have next_token with more results"
+    );
+
+    // List non-existent pool should fail
+    let err = client
+        .list_identity_providers()
+        .user_pool_id("us-east-1_NOTAPOOL")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent pool");
 }


### PR DESCRIPTION
## Summary

- 5 new Cognito operations: CreateIdentityProvider, DescribeIdentityProvider, UpdateIdentityProvider, DeleteIdentityProvider, ListIdentityProviders
- Real behavior: SAML/OIDC/social provider config, attribute mapping, provider details, cascade cleanup on pool delete
- 2 new unit tests (42 total), 4 new E2E tests (45 total), 5 new conformance tests (59/59 coverage)

## Test plan

- [x] `cargo test -p fakecloud-cognito` — 42 unit tests pass
- [x] `cargo test -p fakecloud-e2e --test cognito` — 45 E2E tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Conformance audit: 59/59 cognito-idp actions covered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full support for Cognito user pool identity providers in `cognito-idp`: create, describe, update, delete, and list. Supports SAML/OIDC/social configs with attribute mapping and provider details, and cleans up providers on pool delete.

- **New Features**
  - Implements `CreateIdentityProvider`, `DescribeIdentityProvider`, `UpdateIdentityProvider`, `DeleteIdentityProvider`, `ListIdentityProviders`.
  - Validates `ProviderType` (SAML, OIDC, Facebook, Google, LoginWithAmazon, SignInWithApple) and prevents duplicate provider names per pool.
  - Handles `ProviderDetails`, `AttributeMapping`, and `IdpIdentifiers`; adds paginated listing with `MaxResults`/`NextToken`.
  - Cascades deletion of identity providers when a user pool is deleted.
  - Adds unit, E2E, and conformance tests for all new actions.

<sup>Written for commit bb7527ec4d5137bc13f90b2b71ffa0e0b72db97b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

