### PR TITLE
feat(cognito): implement resource server and domain operations

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -2,61 +2,61 @@
   "variants_passed": 42164,
   "total_variants": 42193,
   "per_service": {
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "cognito-idp": {
-      "passed": 4450,
-      "total": 4479
-    },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
-    },
     "iam": {
       "passed": 5962,
       "total": 5962
-    },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
-    },
-    "sts": {
-      "passed": 438,
-      "total": 438
-    },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
-    },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
     },
     "sns": {
       "passed": 1027,
       "total": 1027
     },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
+    "s3": {
+      "passed": 3620,
+      "total": 3620
     },
     "events": {
       "passed": 2108,
       "total": 2108
     },
+    "logs": {
+      "passed": 3911,
+      "total": 3911
+    },
+    "sts": {
+      "passed": 438,
+      "total": 438
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "cognito-idp": {
+      "passed": 4450,
+      "total": 4479
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
+    },
+    "ses": {
+      "passed": 2858,
+      "total": 2858
+    },
     "sqs": {
       "passed": 549,
       "total": 549
+    },
+    "kms": {
+      "passed": 2196,
+      "total": 2196
     },
     "ssm": {
       "passed": 5303,

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -4219,7 +4219,7 @@ impl CognitoService {
     fn update_user_pool_domain(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
 
-        let _pool_id = require_str(&body, "UserPoolId")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
         let domain = require_str(&body, "Domain")?;
 
         let custom_domain_config =
@@ -4239,6 +4239,14 @@ impl CognitoService {
             )
         })?;
 
+        if d.user_pool_id != pool_id {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Domain {domain} does not exist."),
+            ));
+        }
+
         d.custom_domain_config = custom_domain_config;
 
         Ok(AwsResponse::ok_json(json!({})))
@@ -4247,17 +4255,22 @@ impl CognitoService {
     fn delete_user_pool_domain(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
 
-        let _pool_id = require_str(&body, "UserPoolId")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
         let domain = require_str(&body, "Domain")?;
 
         let mut state = self.state.write();
 
-        if state.domains.remove(domain).is_none() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ResourceNotFoundException",
-                format!("Domain {domain} does not exist."),
-            ));
+        match state.domains.get(domain) {
+            Some(d) if d.user_pool_id == pool_id => {
+                state.domains.remove(domain);
+            }
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Domain {domain} does not exist."),
+                ));
+            }
         }
 
         Ok(AwsResponse::ok_json(json!({})))

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -12,10 +12,11 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 
 use crate::state::{
     default_schema_attributes, AccessTokenData, AccountRecoverySetting, AdminCreateUserConfig,
-    EmailConfiguration, Group, IdentityProvider, InviteMessageTemplate, MfaPreferences,
-    PasswordPolicy, PoolPolicies, RecoveryOption, RefreshTokenData, SchemaAttribute, SessionData,
-    SharedCognitoState, SmsConfiguration, SmsMfaConfiguration, SoftwareTokenMfaConfiguration,
-    StringAttributeConstraints, TokenValidityUnits, User, UserAttribute, UserPool, UserPoolClient,
+    CustomDomainConfig, EmailConfiguration, Group, IdentityProvider, InviteMessageTemplate,
+    MfaPreferences, PasswordPolicy, PoolPolicies, RecoveryOption, RefreshTokenData, ResourceServer,
+    ResourceServerScope, SchemaAttribute, SessionData, SharedCognitoState, SmsConfiguration,
+    SmsMfaConfiguration, SoftwareTokenMfaConfiguration, StringAttributeConstraints,
+    TokenValidityUnits, User, UserAttribute, UserPool, UserPoolClient, UserPoolDomain,
 };
 
 pub struct CognitoService {
@@ -95,6 +96,15 @@ impl AwsService for CognitoService {
             "UpdateIdentityProvider" => self.update_identity_provider(&req),
             "DeleteIdentityProvider" => self.delete_identity_provider(&req),
             "ListIdentityProviders" => self.list_identity_providers(&req),
+            "CreateResourceServer" => self.create_resource_server(&req),
+            "DescribeResourceServer" => self.describe_resource_server(&req),
+            "UpdateResourceServer" => self.update_resource_server(&req),
+            "DeleteResourceServer" => self.delete_resource_server(&req),
+            "ListResourceServers" => self.list_resource_servers(&req),
+            "CreateUserPoolDomain" => self.create_user_pool_domain(&req),
+            "DescribeUserPoolDomain" => self.describe_user_pool_domain(&req),
+            "UpdateUserPoolDomain" => self.update_user_pool_domain(&req),
+            "DeleteUserPoolDomain" => self.delete_user_pool_domain(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "cognito-idp",
                 &req.action,
@@ -163,6 +173,15 @@ impl AwsService for CognitoService {
             "UpdateIdentityProvider",
             "DeleteIdentityProvider",
             "ListIdentityProviders",
+            "CreateResourceServer",
+            "DescribeResourceServer",
+            "UpdateResourceServer",
+            "DeleteResourceServer",
+            "ListResourceServers",
+            "CreateUserPoolDomain",
+            "DescribeUserPoolDomain",
+            "UpdateUserPoolDomain",
+            "DeleteUserPoolDomain",
         ]
     }
 }
@@ -411,6 +430,12 @@ impl CognitoService {
 
         // Remove associated identity providers
         state.identity_providers.remove(pool_id);
+
+        // Remove associated resource servers
+        state.resource_servers.remove(pool_id);
+
+        // Remove associated domains
+        state.domains.retain(|_, d| d.user_pool_id != pool_id);
 
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -3924,6 +3949,319 @@ impl CognitoService {
 
         Ok(AwsResponse::ok_json(response))
     }
+
+    // ── Resource Servers ──────────────────────────────────────────────
+
+    fn create_resource_server(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let identifier = require_str(&body, "Identifier")?;
+        let name = require_str(&body, "Name")?;
+
+        let scopes = parse_resource_server_scopes(&body["Scopes"]);
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let pool_servers = state
+            .resource_servers
+            .entry(pool_id.to_string())
+            .or_default();
+        if pool_servers.contains_key(identifier) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                format!(
+                    "A resource server with identifier {identifier} already exists in this user pool."
+                ),
+            ));
+        }
+
+        let rs = ResourceServer {
+            user_pool_id: pool_id.to_string(),
+            identifier: identifier.to_string(),
+            name: name.to_string(),
+            scopes,
+        };
+
+        pool_servers.insert(identifier.to_string(), rs.clone());
+
+        Ok(AwsResponse::ok_json(json!({
+            "ResourceServer": resource_server_to_json(&rs)
+        })))
+    }
+
+    fn describe_resource_server(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let identifier = require_str(&body, "Identifier")?;
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let rs = state
+            .resource_servers
+            .get(pool_id)
+            .and_then(|m| m.get(identifier))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Resource server {identifier} does not exist."),
+                )
+            })?;
+
+        Ok(AwsResponse::ok_json(json!({
+            "ResourceServer": resource_server_to_json(rs)
+        })))
+    }
+
+    fn update_resource_server(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let identifier = require_str(&body, "Identifier")?;
+        let name = require_str(&body, "Name")?;
+        let scopes = parse_resource_server_scopes(&body["Scopes"]);
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let rs = state
+            .resource_servers
+            .get_mut(pool_id)
+            .and_then(|m| m.get_mut(identifier))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Resource server {identifier} does not exist."),
+                )
+            })?;
+
+        rs.name = name.to_string();
+        rs.scopes = scopes;
+
+        Ok(AwsResponse::ok_json(json!({
+            "ResourceServer": resource_server_to_json(rs)
+        })))
+    }
+
+    fn delete_resource_server(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let identifier = require_str(&body, "Identifier")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let removed = state
+            .resource_servers
+            .get_mut(pool_id)
+            .and_then(|m| m.remove(identifier));
+
+        if removed.is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Resource server {identifier} does not exist."),
+            ));
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn list_resource_servers(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50).clamp(1, 50) as usize;
+        let next_token = body["NextToken"].as_str();
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let empty = HashMap::new();
+        let pool_servers = state.resource_servers.get(pool_id).unwrap_or(&empty);
+
+        let mut servers: Vec<&ResourceServer> = pool_servers.values().collect();
+        servers.sort_by_key(|s| &s.identifier);
+
+        let start_idx = if let Some(token) = next_token {
+            servers
+                .iter()
+                .position(|s| s.identifier == token)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        let page: Vec<Value> = servers
+            .iter()
+            .skip(start_idx)
+            .take(max_results)
+            .map(|s| resource_server_to_json(s))
+            .collect();
+
+        let has_more = start_idx + max_results < servers.len();
+        let mut response = json!({ "ResourceServers": page });
+        if has_more {
+            if let Some(last) = servers.get(start_idx + max_results) {
+                response["NextToken"] = json!(last.identifier);
+            }
+        }
+
+        Ok(AwsResponse::ok_json(response))
+    }
+
+    // ── Domains ───────────────────────────────────────────────────────
+
+    fn create_user_pool_domain(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let domain = require_str(&body, "Domain")?;
+
+        let custom_domain_config =
+            body["CustomDomainConfig"]["CertificateArn"]
+                .as_str()
+                .map(|arn| CustomDomainConfig {
+                    certificate_arn: arn.to_string(),
+                });
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        if state.domains.contains_key(domain) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                format!("Domain {domain} is already associated with a user pool."),
+            ));
+        }
+
+        let domain_obj = UserPoolDomain {
+            user_pool_id: pool_id.to_string(),
+            domain: domain.to_string(),
+            status: "ACTIVE".to_string(),
+            custom_domain_config,
+            creation_date: Utc::now(),
+        };
+
+        state.domains.insert(domain.to_string(), domain_obj);
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn describe_user_pool_domain(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let domain = require_str(&body, "Domain")?;
+
+        let state = self.state.read();
+
+        // AWS returns empty DomainDescription if not found (no error)
+        let description = match state.domains.get(domain) {
+            Some(d) => domain_description_to_json(d, &state.account_id),
+            None => json!({}),
+        };
+
+        Ok(AwsResponse::ok_json(json!({
+            "DomainDescription": description
+        })))
+    }
+
+    fn update_user_pool_domain(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let _pool_id = require_str(&body, "UserPoolId")?;
+        let domain = require_str(&body, "Domain")?;
+
+        let custom_domain_config =
+            body["CustomDomainConfig"]["CertificateArn"]
+                .as_str()
+                .map(|arn| CustomDomainConfig {
+                    certificate_arn: arn.to_string(),
+                });
+
+        let mut state = self.state.write();
+
+        let d = state.domains.get_mut(domain).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Domain {domain} does not exist."),
+            )
+        })?;
+
+        d.custom_domain_config = custom_domain_config;
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn delete_user_pool_domain(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+
+        let _pool_id = require_str(&body, "UserPoolId")?;
+        let domain = require_str(&body, "Domain")?;
+
+        let mut state = self.state.write();
+
+        if state.domains.remove(domain).is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Domain {domain} does not exist."),
+            ));
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
 }
 
 /// Generate a pool ID in the format `{region}_{9 random alphanumeric chars}`.
@@ -4295,6 +4633,60 @@ fn parse_string_map(val: &Value) -> HashMap<String, String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn parse_resource_server_scopes(val: &Value) -> Vec<ResourceServerScope> {
+    val.as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| {
+                    let name = v["ScopeName"].as_str()?;
+                    let desc = v["ScopeDescription"].as_str().unwrap_or("");
+                    Some(ResourceServerScope {
+                        scope_name: name.to_string(),
+                        scope_description: desc.to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn resource_server_to_json(rs: &ResourceServer) -> Value {
+    let scopes: Vec<Value> = rs
+        .scopes
+        .iter()
+        .map(|s| {
+            json!({
+                "ScopeName": s.scope_name,
+                "ScopeDescription": s.scope_description,
+            })
+        })
+        .collect();
+
+    json!({
+        "UserPoolId": rs.user_pool_id,
+        "Identifier": rs.identifier,
+        "Name": rs.name,
+        "Scopes": scopes,
+    })
+}
+
+fn domain_description_to_json(d: &UserPoolDomain, account_id: &str) -> Value {
+    let mut val = json!({
+        "UserPoolId": d.user_pool_id,
+        "AWSAccountId": account_id,
+        "Domain": d.domain,
+        "Status": d.status,
+        "Version": "20130630",
+    });
+    if let Some(ref config) = d.custom_domain_config {
+        val["CustomDomainConfig"] = json!({
+            "CertificateArn": config.certificate_arn,
+        });
+        val["CloudFrontDistribution"] = json!(format!("d111111abcdef8.cloudfront.net"));
+    }
+    val
 }
 
 /// Convert a User to the JSON format AWS returns (for ListUsers and AdminCreateUser response).
@@ -6288,6 +6680,60 @@ mod tests {
                 svc.create_identity_provider(&req).is_ok(),
                 "ProviderType {provider_type} should be valid"
             );
+        }
+    }
+
+    #[test]
+    fn resource_server_identifier_uniqueness() {
+        let (svc, pool_id) = setup_svc_with_pool();
+
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "Identifier": "https://api.example.com",
+            "Name": "My API",
+            "Scopes": [{"ScopeName": "read", "ScopeDescription": "Read access"}]
+        }))
+        .unwrap();
+        let req = make_req("CreateResourceServer", &body);
+        svc.create_resource_server(&req).unwrap();
+
+        // Duplicate identifier should fail
+        let body2 = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "Identifier": "https://api.example.com",
+            "Name": "My API 2",
+            "Scopes": []
+        }))
+        .unwrap();
+        let req2 = make_req("CreateResourceServer", &body2);
+        match svc.create_resource_server(&req2) {
+            Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+            Ok(_) => panic!("Expected InvalidParameterException for duplicate identifier"),
+        }
+    }
+
+    #[test]
+    fn domain_uniqueness() {
+        let (svc, pool_id) = setup_svc_with_pool();
+
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "Domain": "my-unique-domain"
+        }))
+        .unwrap();
+        let req = make_req("CreateUserPoolDomain", &body);
+        svc.create_user_pool_domain(&req).unwrap();
+
+        // Duplicate domain should fail
+        let body2 = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "Domain": "my-unique-domain"
+        }))
+        .unwrap();
+        let req2 = make_req("CreateUserPoolDomain", &body2);
+        match svc.create_user_pool_domain(&req2) {
+            Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+            Ok(_) => panic!("Expected InvalidParameterException for duplicate domain"),
         }
     }
 }

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -26,6 +26,10 @@ pub struct CognitoState {
     pub user_groups: HashMap<String, HashMap<String, Vec<String>>>,
     /// pool_id -> (provider_name -> IdentityProvider)
     pub identity_providers: HashMap<String, HashMap<String, IdentityProvider>>,
+    /// pool_id -> (identifier -> ResourceServer)
+    pub resource_servers: HashMap<String, HashMap<String, ResourceServer>>,
+    /// domain -> UserPoolDomain
+    pub domains: HashMap<String, UserPoolDomain>,
 }
 
 impl CognitoState {
@@ -42,6 +46,8 @@ impl CognitoState {
             groups: HashMap::new(),
             user_groups: HashMap::new(),
             identity_providers: HashMap::new(),
+            resource_servers: HashMap::new(),
+            domains: HashMap::new(),
         }
     }
 
@@ -55,6 +61,8 @@ impl CognitoState {
         self.groups.clear();
         self.user_groups.clear();
         self.identity_providers.clear();
+        self.resource_servers.clear();
+        self.domains.clear();
     }
 }
 
@@ -295,6 +303,34 @@ pub struct IdentityProvider {
     pub idp_identifiers: Vec<String>,
     pub creation_date: DateTime<Utc>,
     pub last_modified_date: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ResourceServer {
+    pub user_pool_id: String,
+    pub identifier: String,
+    pub name: String,
+    pub scopes: Vec<ResourceServerScope>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ResourceServerScope {
+    pub scope_name: String,
+    pub scope_description: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UserPoolDomain {
+    pub user_pool_id: String,
+    pub domain: String,
+    pub status: String,
+    pub custom_domain_config: Option<CustomDomainConfig>,
+    pub creation_date: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CustomDomainConfig {
+    pub certificate_arn: String,
 }
 
 /// Generate default schema attributes that AWS adds to every user pool.

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -2457,3 +2457,234 @@ async fn cognito_list_identity_providers() {
         .unwrap();
     assert_eq!(resp.providers().len(), 2);
 }
+
+// ---------------------------------------------------------------------------
+// Resource Servers & Domains
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "CreateResourceServer", checksum = "b97cc403")]
+#[test_action("cognito-idp", "DescribeResourceServer", checksum = "67f1b947")]
+#[tokio::test]
+async fn cognito_create_describe_resource_server() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("rs-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let resp = client
+        .create_resource_server()
+        .user_pool_id(&pool_id)
+        .identifier("https://api.example.com")
+        .name("Example API")
+        .scopes(
+            aws_sdk_cognitoidentityprovider::types::ResourceServerScopeType::builder()
+                .scope_name("read")
+                .scope_description("Read access")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.resource_server().unwrap().name().unwrap(),
+        "Example API"
+    );
+
+    let desc = client
+        .describe_resource_server()
+        .user_pool_id(&pool_id)
+        .identifier("https://api.example.com")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        desc.resource_server().unwrap().identifier().unwrap(),
+        "https://api.example.com"
+    );
+}
+
+#[test_action("cognito-idp", "UpdateResourceServer", checksum = "5e9ce1ee")]
+#[test_action("cognito-idp", "DeleteResourceServer", checksum = "ad92e082")]
+#[tokio::test]
+async fn cognito_update_delete_resource_server() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("updrs-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_resource_server()
+        .user_pool_id(&pool_id)
+        .identifier("https://api2.example.com")
+        .name("API 2")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_resource_server()
+        .user_pool_id(&pool_id)
+        .identifier("https://api2.example.com")
+        .name("Updated API 2")
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_resource_server()
+        .user_pool_id(&pool_id)
+        .identifier("https://api2.example.com")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        desc.resource_server().unwrap().name().unwrap(),
+        "Updated API 2"
+    );
+
+    client
+        .delete_resource_server()
+        .user_pool_id(&pool_id)
+        .identifier("https://api2.example.com")
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .describe_resource_server()
+        .user_pool_id(&pool_id)
+        .identifier("https://api2.example.com")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(err.into_service_error().is_resource_not_found_exception());
+}
+
+#[test_action("cognito-idp", "ListResourceServers", checksum = "5c4ebddb")]
+#[tokio::test]
+async fn cognito_list_resource_servers() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("listrs-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_resource_server()
+        .user_pool_id(&pool_id)
+        .identifier("https://rs1.example.com")
+        .name("RS1")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_resource_server()
+        .user_pool_id(&pool_id)
+        .identifier("https://rs2.example.com")
+        .name("RS2")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_resource_servers()
+        .user_pool_id(&pool_id)
+        .max_results(10)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.resource_servers().len(), 2);
+}
+
+#[test_action("cognito-idp", "CreateUserPoolDomain", checksum = "28b91b3c")]
+#[test_action("cognito-idp", "DescribeUserPoolDomain", checksum = "6ecd5522")]
+#[tokio::test]
+async fn cognito_create_describe_domain() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("domain-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_user_pool_domain()
+        .user_pool_id(&pool_id)
+        .domain("my-test-domain")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_user_pool_domain()
+        .domain("my-test-domain")
+        .send()
+        .await
+        .unwrap();
+    let desc = resp.domain_description().unwrap();
+    assert_eq!(desc.domain().unwrap(), "my-test-domain");
+    assert_eq!(desc.user_pool_id().unwrap(), pool_id);
+}
+
+#[test_action("cognito-idp", "UpdateUserPoolDomain", checksum = "03177020")]
+#[test_action("cognito-idp", "DeleteUserPoolDomain", checksum = "f25ae5ad")]
+#[tokio::test]
+async fn cognito_update_delete_domain() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("deldomain-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .create_user_pool_domain()
+        .user_pool_id(&pool_id)
+        .domain("del-test-domain")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_user_pool_domain()
+        .user_pool_id(&pool_id)
+        .domain("del-test-domain")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_user_pool_domain()
+        .domain("del-test-domain")
+        .send()
+        .await
+        .unwrap();
+    // AWS returns empty description for non-existent domains
+    assert!(resp.domain_description().unwrap().user_pool_id().is_none());
+}

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -3,9 +3,10 @@ use helpers::TestServer;
 
 use aws_sdk_cognitoidentityprovider::types::{
     AccountRecoverySettingType, AttributeType, ChallengeNameType, DeliveryMediumType,
-    ExplicitAuthFlowsType, IdentityProviderTypeType, PasswordPolicyType, RecoveryOptionNameType,
-    RecoveryOptionType, SmsMfaSettingsType, SoftwareTokenMfaConfigType,
-    SoftwareTokenMfaSettingsType, UserPoolMfaType, UserPoolPolicyType, UserStatusType,
+    DomainStatusType, ExplicitAuthFlowsType, IdentityProviderTypeType,
+    PasswordPolicyType, RecoveryOptionNameType, RecoveryOptionType, ResourceServerScopeType,
+    SmsMfaSettingsType, SoftwareTokenMfaConfigType, SoftwareTokenMfaSettingsType, UserPoolMfaType,
+    UserPoolPolicyType, UserStatusType,
 };
 
 #[tokio::test]
@@ -3482,4 +3483,308 @@ async fn cognito_list_identity_providers() {
         .send()
         .await;
     assert!(err.is_err(), "Should fail for non-existent pool");
+}
+
+#[tokio::test]
+async fn cognito_create_describe_resource_server() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("rs-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap();
+
+    let scope = ResourceServerScopeType::builder()
+        .scope_name("read")
+        .scope_description("Read access")
+        .build()
+        .unwrap();
+
+    let result = client
+        .create_resource_server()
+        .user_pool_id(pool_id)
+        .identifier("https://api.example.com")
+        .name("My API")
+        .scopes(scope)
+        .send()
+        .await
+        .expect("create resource server");
+
+    let rs = result.resource_server().unwrap();
+    assert_eq!(rs.identifier().unwrap(), "https://api.example.com");
+    assert_eq!(rs.name().unwrap(), "My API");
+    assert_eq!(rs.scopes().len(), 1);
+    assert_eq!(rs.scopes()[0].scope_name(), "read");
+    assert_eq!(rs.scopes()[0].scope_description(), "Read access");
+
+    // Describe it
+    let described = client
+        .describe_resource_server()
+        .user_pool_id(pool_id)
+        .identifier("https://api.example.com")
+        .send()
+        .await
+        .expect("describe resource server");
+
+    let rs2 = described.resource_server().unwrap();
+    assert_eq!(rs2.identifier().unwrap(), "https://api.example.com");
+    assert_eq!(rs2.name().unwrap(), "My API");
+
+    // Describe non-existent should fail
+    let err = client
+        .describe_resource_server()
+        .user_pool_id(pool_id)
+        .identifier("https://nope.example.com")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent resource server");
+}
+
+#[tokio::test]
+async fn cognito_update_delete_resource_server() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("rs-update-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap();
+
+    client
+        .create_resource_server()
+        .user_pool_id(pool_id)
+        .identifier("https://api.example.com")
+        .name("My API")
+        .send()
+        .await
+        .expect("create resource server");
+
+    // Update with new scopes
+    let scope = ResourceServerScopeType::builder()
+        .scope_name("write")
+        .scope_description("Write access")
+        .build()
+        .unwrap();
+
+    let updated = client
+        .update_resource_server()
+        .user_pool_id(pool_id)
+        .identifier("https://api.example.com")
+        .name("My Updated API")
+        .scopes(scope)
+        .send()
+        .await
+        .expect("update resource server");
+
+    let rs = updated.resource_server().unwrap();
+    assert_eq!(rs.name().unwrap(), "My Updated API");
+    assert_eq!(rs.scopes().len(), 1);
+    assert_eq!(rs.scopes()[0].scope_name(), "write");
+
+    // Delete
+    client
+        .delete_resource_server()
+        .user_pool_id(pool_id)
+        .identifier("https://api.example.com")
+        .send()
+        .await
+        .expect("delete resource server");
+
+    // Describe after delete should fail
+    let err = client
+        .describe_resource_server()
+        .user_pool_id(pool_id)
+        .identifier("https://api.example.com")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail after delete");
+
+    // Delete non-existent should fail
+    let err = client
+        .delete_resource_server()
+        .user_pool_id(pool_id)
+        .identifier("https://api.example.com")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent resource server");
+}
+
+#[tokio::test]
+async fn cognito_list_resource_servers() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("rs-list-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap();
+
+    // Create multiple resource servers
+    for i in 0..3 {
+        client
+            .create_resource_server()
+            .user_pool_id(pool_id)
+            .identifier(format!("https://api{i}.example.com"))
+            .name(format!("API {i}"))
+            .send()
+            .await
+            .expect("create resource server");
+    }
+
+    // List all
+    let list = client
+        .list_resource_servers()
+        .user_pool_id(pool_id)
+        .send()
+        .await
+        .expect("list resource servers");
+
+    assert_eq!(list.resource_servers().len(), 3);
+
+    // List with pagination
+    let page1 = client
+        .list_resource_servers()
+        .user_pool_id(pool_id)
+        .max_results(1)
+        .send()
+        .await
+        .expect("list page 1");
+
+    assert_eq!(page1.resource_servers().len(), 1);
+    assert!(
+        page1.next_token().is_some(),
+        "Should have next_token with more results"
+    );
+
+    // List non-existent pool should fail
+    let err = client
+        .list_resource_servers()
+        .user_pool_id("us-east-1_NOTAPOOL")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent pool");
+}
+
+#[tokio::test]
+async fn cognito_create_describe_domain() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("domain-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap();
+
+    // Create a prefix domain
+    client
+        .create_user_pool_domain()
+        .user_pool_id(pool_id)
+        .domain("my-test-domain")
+        .send()
+        .await
+        .expect("create domain");
+
+    // Describe it
+    let described = client
+        .describe_user_pool_domain()
+        .domain("my-test-domain")
+        .send()
+        .await
+        .expect("describe domain");
+
+    let desc = described.domain_description().unwrap();
+    assert_eq!(desc.domain().unwrap(), "my-test-domain");
+    assert_eq!(desc.user_pool_id().unwrap(), pool_id);
+    assert_eq!(desc.status().unwrap(), &DomainStatusType::Active);
+
+    // Describe non-existent should return empty DomainDescription (not an error)
+    let result = client
+        .describe_user_pool_domain()
+        .domain("nonexistent-domain")
+        .send()
+        .await
+        .expect("describe non-existent should succeed");
+
+    let desc2 = result.domain_description().unwrap();
+    // domain field should be None for non-existent
+    assert!(
+        desc2.domain().is_none(),
+        "Non-existent domain should return empty description"
+    );
+
+    // Duplicate domain should fail
+    let err = client
+        .create_user_pool_domain()
+        .user_pool_id(pool_id)
+        .domain("my-test-domain")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for duplicate domain");
+}
+
+#[tokio::test]
+async fn cognito_delete_domain() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("domain-del-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap();
+
+    client
+        .create_user_pool_domain()
+        .user_pool_id(pool_id)
+        .domain("del-test-domain")
+        .send()
+        .await
+        .expect("create domain");
+
+    // Delete it
+    client
+        .delete_user_pool_domain()
+        .user_pool_id(pool_id)
+        .domain("del-test-domain")
+        .send()
+        .await
+        .expect("delete domain");
+
+    // Describe after delete should return empty
+    let result = client
+        .describe_user_pool_domain()
+        .domain("del-test-domain")
+        .send()
+        .await
+        .expect("describe after delete");
+
+    let desc = result.domain_description().unwrap();
+    assert!(
+        desc.domain().is_none(),
+        "Deleted domain should return empty description"
+    );
+
+    // Delete non-existent should fail
+    let err = client
+        .delete_user_pool_domain()
+        .user_pool_id(pool_id)
+        .domain("del-test-domain")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent domain");
 }

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -3,10 +3,10 @@ use helpers::TestServer;
 
 use aws_sdk_cognitoidentityprovider::types::{
     AccountRecoverySettingType, AttributeType, ChallengeNameType, DeliveryMediumType,
-    DomainStatusType, ExplicitAuthFlowsType, IdentityProviderTypeType,
-    PasswordPolicyType, RecoveryOptionNameType, RecoveryOptionType, ResourceServerScopeType,
-    SmsMfaSettingsType, SoftwareTokenMfaConfigType, SoftwareTokenMfaSettingsType, UserPoolMfaType,
-    UserPoolPolicyType, UserStatusType,
+    DomainStatusType, ExplicitAuthFlowsType, IdentityProviderTypeType, PasswordPolicyType,
+    RecoveryOptionNameType, RecoveryOptionType, ResourceServerScopeType, SmsMfaSettingsType,
+    SoftwareTokenMfaConfigType, SoftwareTokenMfaSettingsType, UserPoolMfaType, UserPoolPolicyType,
+    UserStatusType,
 };
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- 9 new Cognito operations: CreateResourceServer, DescribeResourceServer, UpdateResourceServer, DeleteResourceServer, ListResourceServers, CreateUserPoolDomain, DescribeUserPoolDomain, UpdateUserPoolDomain, DeleteUserPoolDomain
- Real behavior: custom scopes, domain configuration, cascade cleanup on pool delete, empty DomainDescription for non-existent domains (matching AWS)
- 2 new unit tests (44 total), 5 new E2E tests (50 total), 9 new conformance tests (68/68 coverage)

## Test plan

- [x] `cargo test -p fakecloud-cognito` — 44 unit tests pass
- [x] `cargo test -p fakecloud-e2e --test cognito` — 50 E2E tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Conformance audit: 68/68 cognito-idp actions covered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Cognito resource server and user pool domain APIs with AWS-accurate behavior. Adds custom scopes, domain config, cascade cleanup, and enforces domain ownership by `UserPoolId` on domain update/delete.

- **New Features**
  - Resource servers: Create, Describe, Update, Delete, List.
  - User pool domains: Create, Describe, Update, Delete.
  - AWS parity: custom scopes, domain uniqueness and `CustomDomainConfig` (certificate ARN), empty `DomainDescription` when not found, pagination for `ListResourceServers`, proper error types.
  - Cleanup: deleting a user pool removes its resource servers and domains.
  - Tests: +2 unit, +5 E2E, +9 conformance; `cargo clippy` clean.

- **Bug Fixes**
  - Validate `UserPoolId` ownership when updating or deleting domains (mismatches return ResourceNotFound), matching AWS.

<sup>Written for commit 4175635bac518fbbc0cb63c47a1829f64fe9a98f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

