### PR TITLE
feat(cognito): implement device management, tags, and import job operations

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -2,65 +2,65 @@
   "variants_passed": 42164,
   "total_variants": 42193,
   "per_service": {
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
     "s3": {
       "passed": 3620,
       "total": 3620
-    },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
-    },
-    "sts": {
-      "passed": 438,
-      "total": 438
-    },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
-    },
-    "cognito-idp": {
-      "passed": 4450,
-      "total": 4479
     },
     "secretsmanager": {
       "passed": 852,
       "total": 852
     },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
     },
-    "sqs": {
-      "passed": 549,
-      "total": 549
+    "cognito-idp": {
+      "passed": 4450,
+      "total": 4479
+    },
+    "logs": {
+      "passed": 3911,
+      "total": 3911
+    },
+    "events": {
+      "passed": 2108,
+      "total": 2108
     },
     "kms": {
       "passed": 2196,
       "total": 2196
     },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
+    },
+    "sts": {
+      "passed": 438,
+      "total": 438
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
     "ssm": {
       "passed": 5303,
       "total": 5303
+    },
+    "ses": {
+      "passed": 2858,
+      "total": 2858
     }
   }
 }

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -12,11 +12,12 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 
 use crate::state::{
     default_schema_attributes, AccessTokenData, AccountRecoverySetting, AdminCreateUserConfig,
-    CustomDomainConfig, EmailConfiguration, Group, IdentityProvider, InviteMessageTemplate,
+    CustomDomainConfig, Device, EmailConfiguration, Group, IdentityProvider, InviteMessageTemplate,
     MfaPreferences, PasswordPolicy, PoolPolicies, RecoveryOption, RefreshTokenData, ResourceServer,
     ResourceServerScope, SchemaAttribute, SessionData, SharedCognitoState, SmsConfiguration,
     SmsMfaConfiguration, SoftwareTokenMfaConfiguration, StringAttributeConstraints,
-    TokenValidityUnits, User, UserAttribute, UserPool, UserPoolClient, UserPoolDomain,
+    TokenValidityUnits, User, UserAttribute, UserImportJob, UserPool, UserPoolClient,
+    UserPoolDomain,
 };
 
 pub struct CognitoService {
@@ -105,6 +106,18 @@ impl AwsService for CognitoService {
             "DescribeUserPoolDomain" => self.describe_user_pool_domain(&req),
             "UpdateUserPoolDomain" => self.update_user_pool_domain(&req),
             "DeleteUserPoolDomain" => self.delete_user_pool_domain(&req),
+            "AdminGetDevice" => self.admin_get_device(&req),
+            "AdminListDevices" => self.admin_list_devices(&req),
+            "AdminForgetDevice" => self.admin_forget_device(&req),
+            "AdminUpdateDeviceStatus" => self.admin_update_device_status(&req),
+            "ConfirmDevice" => self.confirm_device(&req),
+            "TagResource" => self.tag_resource(&req),
+            "UntagResource" => self.untag_resource(&req),
+            "ListTagsForResource" => self.list_tags_for_resource(&req),
+            "GetCSVHeader" => self.get_csv_header(&req),
+            "CreateUserImportJob" => self.create_user_import_job(&req),
+            "DescribeUserImportJob" => self.describe_user_import_job(&req),
+            "ListUserImportJobs" => self.list_user_import_jobs(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "cognito-idp",
                 &req.action,
@@ -182,6 +195,18 @@ impl AwsService for CognitoService {
             "DescribeUserPoolDomain",
             "UpdateUserPoolDomain",
             "DeleteUserPoolDomain",
+            "AdminGetDevice",
+            "AdminListDevices",
+            "AdminForgetDevice",
+            "AdminUpdateDeviceStatus",
+            "ConfirmDevice",
+            "TagResource",
+            "UntagResource",
+            "ListTagsForResource",
+            "GetCSVHeader",
+            "CreateUserImportJob",
+            "DescribeUserImportJob",
+            "ListUserImportJobs",
         ]
     }
 }
@@ -436,6 +461,16 @@ impl CognitoService {
 
         // Remove associated domains
         state.domains.retain(|_, d| d.user_pool_id != pool_id);
+
+        // Remove associated tags (match by pool ARN)
+        let arn_prefix = format!(
+            "arn:aws:cognito-idp:{}:{}:userpool/{}",
+            state.region, state.account_id, pool_id
+        );
+        state.tags.remove(&arn_prefix);
+
+        // Remove associated import jobs
+        state.import_jobs.remove(pool_id);
 
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -943,6 +978,7 @@ impl CognitoService {
             mfa_preferences: None,
             totp_secret: None,
             totp_verified: false,
+            devices: HashMap::new(),
         };
 
         let response = user_to_json(&user);
@@ -2069,6 +2105,7 @@ impl CognitoService {
             mfa_preferences: None,
             totp_secret: None,
             totp_verified: false,
+            devices: HashMap::new(),
         };
 
         pool_users.insert(username.to_string(), user);
@@ -4275,6 +4312,493 @@ impl CognitoService {
 
         Ok(AwsResponse::ok_json(json!({})))
     }
+
+    // ── Device Management ───────────────────────────────────────────────
+
+    fn admin_get_device(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let username = require_str(&body, "Username")?;
+        let device_key = require_str(&body, "DeviceKey")?;
+
+        let state = self.state.read();
+
+        let users = state.users.get(pool_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            )
+        })?;
+
+        let user = users.get(username).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User {username} does not exist."),
+            )
+        })?;
+
+        let device = user.devices.get(device_key).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Device {device_key} does not exist."),
+            )
+        })?;
+
+        Ok(AwsResponse::ok_json(json!({
+            "Device": device_to_json(device)
+        })))
+    }
+
+    fn admin_list_devices(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let username = require_str(&body, "Username")?;
+        let limit = body["Limit"].as_i64().unwrap_or(10).clamp(1, 60) as usize;
+        let pagination_token = body["PaginationToken"].as_str();
+
+        let state = self.state.read();
+
+        let users = state.users.get(pool_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            )
+        })?;
+
+        let user = users.get(username).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User {username} does not exist."),
+            )
+        })?;
+
+        let mut devices: Vec<&Device> = user.devices.values().collect();
+        devices.sort_by(|a, b| a.device_create_date.cmp(&b.device_create_date));
+
+        let start = pagination_token
+            .and_then(|t| devices.iter().position(|d| d.device_key == t))
+            .unwrap_or(0);
+
+        let page = &devices[start..devices.len().min(start + limit)];
+        let next_token = if start + limit < devices.len() {
+            devices.get(start + limit).map(|d| d.device_key.clone())
+        } else {
+            None
+        };
+
+        let mut result = json!({
+            "Devices": page.iter().map(|d| device_to_json(d)).collect::<Vec<_>>()
+        });
+        if let Some(token) = next_token {
+            result["PaginationToken"] = json!(token);
+        }
+
+        Ok(AwsResponse::ok_json(result))
+    }
+
+    fn admin_forget_device(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let username = require_str(&body, "Username")?;
+        let device_key = require_str(&body, "DeviceKey")?;
+
+        let mut state = self.state.write();
+
+        let users = state.users.get_mut(pool_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            )
+        })?;
+
+        let user = users.get_mut(username).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User {username} does not exist."),
+            )
+        })?;
+
+        if user.devices.remove(device_key).is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Device {device_key} does not exist."),
+            ));
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn admin_update_device_status(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let username = require_str(&body, "Username")?;
+        let device_key = require_str(&body, "DeviceKey")?;
+        let status = body["DeviceRememberedStatus"]
+            .as_str()
+            .map(|s| s.to_string());
+
+        let mut state = self.state.write();
+
+        let users = state.users.get_mut(pool_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            )
+        })?;
+
+        let user = users.get_mut(username).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User {username} does not exist."),
+            )
+        })?;
+
+        let device = user.devices.get_mut(device_key).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Device {device_key} does not exist."),
+            )
+        })?;
+
+        device.device_remembered_status = status;
+        device.device_last_modified_date = Utc::now();
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn confirm_device(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+        let device_key = require_str(&body, "DeviceKey")?;
+        let device_name = body["DeviceName"].as_str();
+
+        let mut state = self.state.write();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+        let pool_id = token_data.user_pool_id.clone();
+        let username = token_data.username.clone();
+
+        let user = state
+            .users
+            .get_mut(&pool_id)
+            .and_then(|users| users.get_mut(&username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid access token.",
+                )
+            })?;
+
+        let now = Utc::now();
+        let mut device_attributes = HashMap::new();
+        if let Some(name) = device_name {
+            device_attributes.insert("device_name".to_string(), name.to_string());
+        }
+
+        user.devices.insert(
+            device_key.to_string(),
+            Device {
+                device_key: device_key.to_string(),
+                device_attributes,
+                device_create_date: now,
+                device_last_modified_date: now,
+                device_last_authenticated_date: Some(now),
+                device_remembered_status: None,
+            },
+        );
+
+        Ok(AwsResponse::ok_json(json!({
+            "UserConfirmationNecessary": false
+        })))
+    }
+
+    // ── Tags ────────────────────────────────────────────────────────────
+
+    fn tag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let resource_arn = require_str(&body, "ResourceArn")?;
+
+        let tags: HashMap<String, String> = body["Tags"]
+            .as_object()
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut state = self.state.write();
+
+        // Validate that the ARN matches a known user pool
+        let pool_exists = state.user_pools.values().any(|p| p.arn == resource_arn);
+        if !pool_exists {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Resource {resource_arn} not found."),
+            ));
+        }
+
+        let existing = state.tags.entry(resource_arn.to_string()).or_default();
+        for (k, v) in tags {
+            existing.insert(k, v);
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn untag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let resource_arn = require_str(&body, "ResourceArn")?;
+
+        let tag_keys: Vec<String> = body["TagKeys"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut state = self.state.write();
+
+        let pool_exists = state.user_pools.values().any(|p| p.arn == resource_arn);
+        if !pool_exists {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Resource {resource_arn} not found."),
+            ));
+        }
+
+        if let Some(tags) = state.tags.get_mut(resource_arn) {
+            for key in &tag_keys {
+                tags.remove(key);
+            }
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn list_tags_for_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let resource_arn = require_str(&body, "ResourceArn")?;
+
+        let state = self.state.read();
+
+        let pool_exists = state.user_pools.values().any(|p| p.arn == resource_arn);
+        if !pool_exists {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Resource {resource_arn} not found."),
+            ));
+        }
+
+        let tags = state.tags.get(resource_arn).cloned().unwrap_or_default();
+
+        Ok(AwsResponse::ok_json(json!({ "Tags": tags })))
+    }
+
+    // ── Import Jobs ─────────────────────────────────────────────────────
+
+    fn get_csv_header(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+
+        let state = self.state.read();
+
+        let pool = state.user_pools.get(pool_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            )
+        })?;
+
+        let csv_header: Vec<String> = pool
+            .schema_attributes
+            .iter()
+            .map(|a| a.name.clone())
+            .collect();
+
+        Ok(AwsResponse::ok_json(json!({
+            "UserPoolId": pool_id,
+            "CSVHeader": csv_header
+        })))
+    }
+
+    fn create_user_import_job(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let job_name = require_str(&body, "JobName")?;
+        let cw_role_arn = require_str(&body, "CloudWatchLogsRoleArn")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let job_id = format!("import-{}", Uuid::new_v4());
+        let now = Utc::now();
+
+        let job = UserImportJob {
+            job_id: job_id.clone(),
+            job_name: job_name.to_string(),
+            user_pool_id: pool_id.to_string(),
+            cloud_watch_logs_role_arn: cw_role_arn.to_string(),
+            status: "Created".to_string(),
+            creation_date: now,
+            start_date: None,
+            completion_date: None,
+            pre_signed_url: Some(format!(
+                "https://fakecloud-import.s3.amazonaws.com/{pool_id}/{job_id}/upload.csv"
+            )),
+        };
+
+        let resp = import_job_to_json(&job);
+
+        state
+            .import_jobs
+            .entry(pool_id.to_string())
+            .or_default()
+            .insert(job_id, job);
+
+        Ok(AwsResponse::ok_json(json!({
+            "UserImportJob": resp
+        })))
+    }
+
+    fn describe_user_import_job(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let job_id = require_str(&body, "JobId")?;
+
+        let state = self.state.read();
+
+        let job = state
+            .import_jobs
+            .get(pool_id)
+            .and_then(|jobs| jobs.get(job_id))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Import job {job_id} does not exist."),
+                )
+            })?;
+
+        Ok(AwsResponse::ok_json(json!({
+            "UserImportJob": import_job_to_json(job)
+        })))
+    }
+
+    fn list_user_import_jobs(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let max_results = body["MaxResults"].as_i64().unwrap_or(10).clamp(1, 60) as usize;
+        let pagination_token = body["PaginationToken"].as_str();
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let mut jobs: Vec<&UserImportJob> = state
+            .import_jobs
+            .get(pool_id)
+            .map(|m| m.values().collect())
+            .unwrap_or_default();
+        jobs.sort_by(|a, b| a.creation_date.cmp(&b.creation_date));
+
+        let start = pagination_token
+            .and_then(|t| jobs.iter().position(|j| j.job_id == t))
+            .unwrap_or(0);
+
+        let page = &jobs[start..jobs.len().min(start + max_results)];
+        let next_token = if start + max_results < jobs.len() {
+            jobs.get(start + max_results).map(|j| j.job_id.clone())
+        } else {
+            None
+        };
+
+        let mut result = json!({
+            "UserImportJobs": page.iter().map(|j| import_job_to_json(j)).collect::<Vec<_>>()
+        });
+        if let Some(token) = next_token {
+            result["PaginationToken"] = json!(token);
+        }
+
+        Ok(AwsResponse::ok_json(result))
+    }
+}
+
+fn device_to_json(device: &Device) -> Value {
+    let attrs: Vec<Value> = device
+        .device_attributes
+        .iter()
+        .map(|(k, v)| json!({"Name": k, "Value": v}))
+        .collect();
+
+    let mut obj = json!({
+        "DeviceKey": device.device_key,
+        "DeviceAttributes": attrs,
+        "DeviceCreateDate": device.device_create_date.timestamp() as f64,
+        "DeviceLastModifiedDate": device.device_last_modified_date.timestamp() as f64,
+    });
+    if let Some(auth_date) = device.device_last_authenticated_date {
+        obj["DeviceLastAuthenticatedDate"] = json!(auth_date.timestamp() as f64);
+    }
+    obj
+}
+
+fn import_job_to_json(job: &UserImportJob) -> Value {
+    let mut obj = json!({
+        "JobId": job.job_id,
+        "JobName": job.job_name,
+        "UserPoolId": job.user_pool_id,
+        "CloudWatchLogsRoleArn": job.cloud_watch_logs_role_arn,
+        "Status": job.status,
+        "CreationDate": job.creation_date.timestamp() as f64,
+    });
+    if let Some(url) = &job.pre_signed_url {
+        obj["PreSignedUrl"] = json!(url);
+    }
+    if let Some(d) = job.start_date {
+        obj["StartDate"] = json!(d.timestamp() as f64);
+    }
+    if let Some(d) = job.completion_date {
+        obj["CompletionDate"] = json!(d.timestamp() as f64);
+    }
+    obj
 }
 
 /// Generate a pool ID in the format `{region}_{9 random alphanumeric chars}`.
@@ -5460,6 +5984,7 @@ mod tests {
             mfa_preferences: None,
             totp_secret: None,
             totp_verified: false,
+            devices: HashMap::new(),
         };
 
         let filter = parse_filter_expression(r#"username = "testuser""#).unwrap();
@@ -5492,6 +6017,7 @@ mod tests {
             mfa_preferences: None,
             totp_secret: None,
             totp_verified: false,
+            devices: HashMap::new(),
         };
 
         let filter = parse_filter_expression(r#"email = "test@example.com""#).unwrap();
@@ -5521,6 +6047,7 @@ mod tests {
             mfa_preferences: None,
             totp_secret: None,
             totp_verified: false,
+            devices: HashMap::new(),
         };
 
         let filter =
@@ -6748,5 +7275,153 @@ mod tests {
             Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
             Ok(_) => panic!("Expected InvalidParameterException for duplicate domain"),
         }
+    }
+
+    fn setup_svc_with_pool_and_user() -> (CognitoService, String, String) {
+        let (svc, pool_id) = setup_svc_with_pool();
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "Username": "deviceuser",
+            "TemporaryPassword": "Temp1234!"
+        }))
+        .unwrap();
+        let req = make_req("AdminCreateUser", &body);
+        svc.admin_create_user(&req).unwrap();
+        (svc, pool_id, "deviceuser".to_string())
+    }
+
+    #[test]
+    fn device_key_storage() {
+        let (svc, pool_id, username) = setup_svc_with_pool_and_user();
+
+        // Directly insert a device into the user's devices map
+        {
+            let mut state = svc.state.write();
+            let user = state
+                .users
+                .get_mut(&pool_id)
+                .unwrap()
+                .get_mut(&username)
+                .unwrap();
+            user.devices.insert(
+                "dev-key-1".to_string(),
+                Device {
+                    device_key: "dev-key-1".to_string(),
+                    device_attributes: HashMap::new(),
+                    device_create_date: Utc::now(),
+                    device_last_modified_date: Utc::now(),
+                    device_last_authenticated_date: None,
+                    device_remembered_status: None,
+                },
+            );
+        }
+
+        // AdminGetDevice
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "Username": username,
+            "DeviceKey": "dev-key-1"
+        }))
+        .unwrap();
+        let req = make_req("AdminGetDevice", &body);
+        let resp = svc.admin_get_device(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(resp_body["Device"]["DeviceKey"], "dev-key-1");
+
+        // AdminForgetDevice
+        let req = make_req("AdminForgetDevice", &body);
+        svc.admin_forget_device(&req).unwrap();
+
+        // Device should be gone
+        let req = make_req("AdminGetDevice", &body);
+        match svc.admin_get_device(&req) {
+            Err(e) => assert_eq!(e.code(), "ResourceNotFoundException"),
+            Ok(_) => panic!("Expected ResourceNotFoundException"),
+        }
+    }
+
+    #[test]
+    fn tag_management() {
+        let (svc, pool_id) = setup_svc_with_pool();
+        let state = svc.state.read();
+        let arn = state.user_pools.get(&pool_id).unwrap().arn.clone();
+        drop(state);
+
+        // Tag
+        let body = serde_json::to_string(&json!({
+            "ResourceArn": arn,
+            "Tags": {"env": "test", "team": "core"}
+        }))
+        .unwrap();
+        let req = make_req("TagResource", &body);
+        svc.tag_resource(&req).unwrap();
+
+        // List
+        let body = serde_json::to_string(&json!({"ResourceArn": arn})).unwrap();
+        let req = make_req("ListTagsForResource", &body);
+        let resp = svc.list_tags_for_resource(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(resp_body["Tags"]["env"], "test");
+        assert_eq!(resp_body["Tags"]["team"], "core");
+
+        // Untag
+        let body = serde_json::to_string(&json!({
+            "ResourceArn": arn,
+            "TagKeys": ["team"]
+        }))
+        .unwrap();
+        let req = make_req("UntagResource", &body);
+        svc.untag_resource(&req).unwrap();
+
+        // Verify
+        let body = serde_json::to_string(&json!({"ResourceArn": arn})).unwrap();
+        let req = make_req("ListTagsForResource", &body);
+        let resp = svc.list_tags_for_resource(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(resp_body["Tags"]["env"], "test");
+        assert!(resp_body["Tags"]["team"].is_null());
+    }
+
+    #[test]
+    fn import_job_creation() {
+        let (svc, pool_id) = setup_svc_with_pool();
+
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "JobName": "my-import",
+            "CloudWatchLogsRoleArn": "arn:aws:iam::123456789012:role/CognitoImport"
+        }))
+        .unwrap();
+        let req = make_req("CreateUserImportJob", &body);
+        let resp = svc.create_user_import_job(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let job = &resp_body["UserImportJob"];
+        assert_eq!(job["JobName"], "my-import");
+        assert_eq!(job["Status"], "Created");
+        assert!(job["JobId"].as_str().unwrap().starts_with("import-"));
+        assert!(job["PreSignedUrl"].as_str().is_some());
+
+        // Describe
+        let job_id = job["JobId"].as_str().unwrap();
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "JobId": job_id
+        }))
+        .unwrap();
+        let req = make_req("DescribeUserImportJob", &body);
+        let resp = svc.describe_user_import_job(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(resp_body["UserImportJob"]["JobName"], "my-import");
+
+        // List
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "MaxResults": 10
+        }))
+        .unwrap();
+        let req = make_req("ListUserImportJobs", &body);
+        let resp = svc.list_user_import_jobs(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        assert_eq!(resp_body["UserImportJobs"].as_array().unwrap().len(), 1);
     }
 }

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -4777,6 +4777,9 @@ fn device_to_json(device: &Device) -> Value {
     if let Some(auth_date) = device.device_last_authenticated_date {
         obj["DeviceLastAuthenticatedDate"] = json!(auth_date.timestamp() as f64);
     }
+    if let Some(ref status) = device.device_remembered_status {
+        obj["DeviceRememberedStatus"] = json!(status);
+    }
     obj
 }
 

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -30,6 +30,10 @@ pub struct CognitoState {
     pub resource_servers: HashMap<String, HashMap<String, ResourceServer>>,
     /// domain -> UserPoolDomain
     pub domains: HashMap<String, UserPoolDomain>,
+    /// resource_arn -> tags
+    pub tags: HashMap<String, HashMap<String, String>>,
+    /// pool_id -> (job_id -> UserImportJob)
+    pub import_jobs: HashMap<String, HashMap<String, UserImportJob>>,
 }
 
 impl CognitoState {
@@ -48,6 +52,8 @@ impl CognitoState {
             identity_providers: HashMap::new(),
             resource_servers: HashMap::new(),
             domains: HashMap::new(),
+            tags: HashMap::new(),
+            import_jobs: HashMap::new(),
         }
     }
 
@@ -63,6 +69,8 @@ impl CognitoState {
         self.identity_providers.clear();
         self.resource_servers.clear();
         self.domains.clear();
+        self.tags.clear();
+        self.import_jobs.clear();
     }
 }
 
@@ -266,6 +274,7 @@ pub struct User {
     pub mfa_preferences: Option<MfaPreferences>,
     pub totp_secret: Option<String>,
     pub totp_verified: bool,
+    pub devices: HashMap<String, Device>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -331,6 +340,29 @@ pub struct UserPoolDomain {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CustomDomainConfig {
     pub certificate_arn: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Device {
+    pub device_key: String,
+    pub device_attributes: HashMap<String, String>,
+    pub device_create_date: DateTime<Utc>,
+    pub device_last_modified_date: DateTime<Utc>,
+    pub device_last_authenticated_date: Option<DateTime<Utc>>,
+    pub device_remembered_status: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UserImportJob {
+    pub job_id: String,
+    pub job_name: String,
+    pub user_pool_id: String,
+    pub cloud_watch_logs_role_arn: String,
+    pub status: String,
+    pub creation_date: DateTime<Utc>,
+    pub start_date: Option<DateTime<Utc>>,
+    pub completion_date: Option<DateTime<Utc>>,
+    pub pre_signed_url: Option<String>,
 }
 
 /// Generate default schema attributes that AWS adds to every user pool.

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -2688,3 +2688,229 @@ async fn cognito_update_delete_domain() {
     // AWS returns empty description for non-existent domains
     assert!(resp.domain_description().unwrap().user_pool_id().is_none());
 }
+
+// ---------------------------------------------------------------------------
+// Device Management
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "ConfirmDevice", checksum = "d2285f4d")]
+#[test_action("cognito-idp", "AdminGetDevice", checksum = "b7ff3b4f")]
+#[test_action("cognito-idp", "AdminListDevices", checksum = "52c1799f")]
+#[tokio::test]
+async fn cognito_device_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let (pool_id, _client_id, access_token) =
+        setup_authenticated_user(&client, "device-pool").await;
+
+    client
+        .confirm_device()
+        .access_token(&access_token)
+        .device_key("device-key-1")
+        .send()
+        .await
+        .unwrap();
+
+    let dev = client
+        .admin_get_device()
+        .user_pool_id(&pool_id)
+        .username("selfuser")
+        .device_key("device-key-1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dev.device().unwrap().device_key().unwrap(), "device-key-1");
+
+    let list = client
+        .admin_list_devices()
+        .user_pool_id(&pool_id)
+        .username("selfuser")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(list.devices().len(), 1);
+}
+
+#[test_action("cognito-idp", "AdminUpdateDeviceStatus", checksum = "4c7d9838")]
+#[test_action("cognito-idp", "AdminForgetDevice", checksum = "3383fe72")]
+#[tokio::test]
+async fn cognito_admin_update_forget_device() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let (pool_id, _client_id, access_token) =
+        setup_authenticated_user(&client, "devupd-pool").await;
+
+    client
+        .confirm_device()
+        .access_token(&access_token)
+        .device_key("dev-2")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .admin_update_device_status()
+        .user_pool_id(&pool_id)
+        .username("selfuser")
+        .device_key("dev-2")
+        .device_remembered_status(
+            aws_sdk_cognitoidentityprovider::types::DeviceRememberedStatusType::Remembered,
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .admin_forget_device()
+        .user_pool_id(&pool_id)
+        .username("selfuser")
+        .device_key("dev-2")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .admin_list_devices()
+        .user_pool_id(&pool_id)
+        .username("selfuser")
+        .send()
+        .await
+        .unwrap();
+    assert!(list.devices().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Tags
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "TagResource", checksum = "b19b19ae")]
+#[test_action("cognito-idp", "UntagResource", checksum = "3bd5fe69")]
+#[test_action("cognito-idp", "ListTagsForResource", checksum = "a72e0056")]
+#[tokio::test]
+async fn cognito_tag_untag_list() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("tag-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_arn = pool.user_pool().unwrap().arn().unwrap().to_string();
+
+    client
+        .tag_resource()
+        .resource_arn(&pool_arn)
+        .tags("env", "test")
+        .tags("team", "platform")
+        .send()
+        .await
+        .unwrap();
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(&pool_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(tags.tags().unwrap().get("env"), Some(&"test".to_string()));
+
+    client
+        .untag_resource()
+        .resource_arn(&pool_arn)
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+
+    let tags2 = client
+        .list_tags_for_resource()
+        .resource_arn(&pool_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags2.tags().unwrap().get("env").is_none());
+    assert_eq!(
+        tags2.tags().unwrap().get("team"),
+        Some(&"platform".to_string())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Import Jobs
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "CreateUserImportJob", checksum = "6cf3fba2")]
+#[test_action("cognito-idp", "DescribeUserImportJob", checksum = "1c8e4fe5")]
+#[test_action("cognito-idp", "ListUserImportJobs", checksum = "f4ef28a5")]
+#[tokio::test]
+async fn cognito_import_jobs() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("import-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let resp = client
+        .create_user_import_job()
+        .user_pool_id(&pool_id)
+        .job_name("test-import")
+        .cloud_watch_logs_role_arn("arn:aws:iam::123456789012:role/CognitoCloudWatchRole")
+        .send()
+        .await
+        .unwrap();
+    let job = resp.user_import_job().unwrap();
+    assert_eq!(job.job_name().unwrap(), "test-import");
+    let job_id = job.job_id().unwrap().to_string();
+
+    let desc = client
+        .describe_user_import_job()
+        .user_pool_id(&pool_id)
+        .job_id(&job_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        desc.user_import_job().unwrap().job_name().unwrap(),
+        "test-import"
+    );
+
+    let list = client
+        .list_user_import_jobs()
+        .user_pool_id(&pool_id)
+        .max_results(10)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(list.user_import_jobs().len(), 1);
+}
+
+#[test_action("cognito-idp", "GetCSVHeader", checksum = "c4b2b3d1")]
+#[tokio::test]
+async fn cognito_get_csv_header() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("csv-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let resp = client
+        .get_csv_header()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.user_pool_id().unwrap(), pool_id);
+    assert!(!resp.csv_header().is_empty());
+}

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -3,10 +3,10 @@ use helpers::TestServer;
 
 use aws_sdk_cognitoidentityprovider::types::{
     AccountRecoverySettingType, AttributeType, ChallengeNameType, DeliveryMediumType,
-    DomainStatusType, ExplicitAuthFlowsType, IdentityProviderTypeType, PasswordPolicyType,
-    RecoveryOptionNameType, RecoveryOptionType, ResourceServerScopeType, SmsMfaSettingsType,
-    SoftwareTokenMfaConfigType, SoftwareTokenMfaSettingsType, UserPoolMfaType, UserPoolPolicyType,
-    UserStatusType,
+    DeviceRememberedStatusType, DomainStatusType, ExplicitAuthFlowsType, IdentityProviderTypeType,
+    PasswordPolicyType, RecoveryOptionNameType, RecoveryOptionType, ResourceServerScopeType,
+    SmsMfaSettingsType, SoftwareTokenMfaConfigType, SoftwareTokenMfaSettingsType, UserPoolMfaType,
+    UserPoolPolicyType, UserStatusType,
 };
 
 #[tokio::test]
@@ -3787,4 +3787,442 @@ async fn cognito_delete_domain() {
         .send()
         .await;
     assert!(err.is_err(), "Should fail for non-existent domain");
+}
+
+// ── Device Management E2E Tests ─────────────────────────────────────
+
+/// Helper: create pool + client + user + auth, return (client, pool_id, username, access_token)
+async fn setup_pool_with_auth(
+    server: &TestServer,
+) -> (
+    aws_sdk_cognitoidentityprovider::Client,
+    String,
+    String,
+    String,
+) {
+    let client = server.cognito_client().await;
+
+    let pool_result = client
+        .create_user_pool()
+        .pool_name("device-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool_result.user_pool().unwrap().id().unwrap().to_string();
+
+    let client_result = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("dev-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowAdminUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = client_result
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("devuser")
+        .send()
+        .await
+        .expect("create user");
+
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("devuser")
+        .password("secret")
+        .permanent(true)
+        .send()
+        .await
+        .expect("set password");
+
+    let auth_result = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "devuser")
+        .auth_parameters("PASSWORD", "secret")
+        .send()
+        .await
+        .expect("auth");
+
+    let access_token = auth_result
+        .authentication_result()
+        .unwrap()
+        .access_token()
+        .unwrap()
+        .to_string();
+
+    (client, pool_id, "devuser".to_string(), access_token)
+}
+
+#[tokio::test]
+async fn cognito_confirm_admin_get_device() {
+    let server = TestServer::start().await;
+    let (client, pool_id, username, access_token) = setup_pool_with_auth(&server).await;
+
+    // Confirm a device
+    let confirm = client
+        .confirm_device()
+        .access_token(&access_token)
+        .device_key("test-device-key-1")
+        .device_name("My Phone")
+        .send()
+        .await
+        .expect("confirm device");
+    assert!(!confirm.user_confirmation_necessary());
+
+    // AdminGetDevice
+    let device = client
+        .admin_get_device()
+        .user_pool_id(&pool_id)
+        .username(&username)
+        .device_key("test-device-key-1")
+        .send()
+        .await
+        .expect("admin get device");
+
+    let dev = device.device().unwrap();
+    assert_eq!(dev.device_key().unwrap(), "test-device-key-1");
+    assert!(dev.device_create_date().is_some());
+
+    // Non-existent device should fail
+    let err = client
+        .admin_get_device()
+        .user_pool_id(&pool_id)
+        .username(&username)
+        .device_key("nonexistent")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent device");
+}
+
+#[tokio::test]
+async fn cognito_admin_list_devices() {
+    let server = TestServer::start().await;
+    let (client, pool_id, username, access_token) = setup_pool_with_auth(&server).await;
+
+    // Confirm two devices
+    for key in &["dev-a", "dev-b"] {
+        client
+            .confirm_device()
+            .access_token(&access_token)
+            .device_key(*key)
+            .send()
+            .await
+            .expect("confirm device");
+    }
+
+    // List devices
+    let list = client
+        .admin_list_devices()
+        .user_pool_id(&pool_id)
+        .username(&username)
+        .limit(10)
+        .send()
+        .await
+        .expect("admin list devices");
+
+    let devices = list.devices();
+    assert_eq!(devices.len(), 2, "Should have 2 devices");
+}
+
+#[tokio::test]
+async fn cognito_admin_forget_device() {
+    let server = TestServer::start().await;
+    let (client, pool_id, username, access_token) = setup_pool_with_auth(&server).await;
+
+    // Confirm a device
+    client
+        .confirm_device()
+        .access_token(&access_token)
+        .device_key("forget-me")
+        .send()
+        .await
+        .expect("confirm device");
+
+    // Forget it
+    client
+        .admin_forget_device()
+        .user_pool_id(&pool_id)
+        .username(&username)
+        .device_key("forget-me")
+        .send()
+        .await
+        .expect("admin forget device");
+
+    // Get should fail
+    let err = client
+        .admin_get_device()
+        .user_pool_id(&pool_id)
+        .username(&username)
+        .device_key("forget-me")
+        .send()
+        .await;
+    assert!(err.is_err(), "Device should be forgotten");
+
+    // Forgetting again should fail
+    let err = client
+        .admin_forget_device()
+        .user_pool_id(&pool_id)
+        .username(&username)
+        .device_key("forget-me")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for already-forgotten device");
+}
+
+#[tokio::test]
+async fn cognito_admin_update_device_status() {
+    let server = TestServer::start().await;
+    let (client, pool_id, username, access_token) = setup_pool_with_auth(&server).await;
+
+    // Confirm a device
+    client
+        .confirm_device()
+        .access_token(&access_token)
+        .device_key("status-dev")
+        .send()
+        .await
+        .expect("confirm device");
+
+    // Update status to remembered
+    client
+        .admin_update_device_status()
+        .user_pool_id(&pool_id)
+        .username(&username)
+        .device_key("status-dev")
+        .device_remembered_status(DeviceRememberedStatusType::Remembered)
+        .send()
+        .await
+        .expect("update device status");
+
+    // Update to not_remembered should also work
+    client
+        .admin_update_device_status()
+        .user_pool_id(&pool_id)
+        .username(&username)
+        .device_key("status-dev")
+        .device_remembered_status(DeviceRememberedStatusType::NotRemembered)
+        .send()
+        .await
+        .expect("update device status to not_remembered");
+
+    // Non-existent device should fail
+    let err = client
+        .admin_update_device_status()
+        .user_pool_id(&pool_id)
+        .username(&username)
+        .device_key("nonexistent")
+        .device_remembered_status(DeviceRememberedStatusType::Remembered)
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent device");
+}
+
+// ── Tags E2E Tests ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn cognito_tag_untag_list_tags() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool_result = client
+        .create_user_pool()
+        .pool_name("tag-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool = pool_result.user_pool().unwrap();
+    let pool_arn = pool.arn().unwrap().to_string();
+
+    // Tag
+    client
+        .tag_resource()
+        .resource_arn(&pool_arn)
+        .tags("env", "staging")
+        .tags("team", "platform")
+        .send()
+        .await
+        .expect("tag resource");
+
+    // List
+    let list = client
+        .list_tags_for_resource()
+        .resource_arn(&pool_arn)
+        .send()
+        .await
+        .expect("list tags");
+    let tags = list.tags().unwrap();
+    assert_eq!(tags.get("env").unwrap(), "staging");
+    assert_eq!(tags.get("team").unwrap(), "platform");
+
+    // Untag
+    client
+        .untag_resource()
+        .resource_arn(&pool_arn)
+        .tag_keys("team")
+        .send()
+        .await
+        .expect("untag resource");
+
+    // Verify
+    let list2 = client
+        .list_tags_for_resource()
+        .resource_arn(&pool_arn)
+        .send()
+        .await
+        .expect("list tags after untag");
+    let tags2 = list2.tags().unwrap();
+    assert_eq!(tags2.get("env").unwrap(), "staging");
+    assert!(tags2.get("team").is_none(), "team tag should be removed");
+
+    // Non-existent ARN should fail
+    let err = client
+        .list_tags_for_resource()
+        .resource_arn("arn:aws:cognito-idp:us-east-1:000000000000:userpool/nonexistent")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent resource");
+}
+
+// ── Import Jobs E2E Tests ───────────────────────────────────────────
+
+#[tokio::test]
+async fn cognito_create_describe_list_import_jobs() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool_result = client
+        .create_user_pool()
+        .pool_name("import-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool_result.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create import job
+    let create = client
+        .create_user_import_job()
+        .user_pool_id(&pool_id)
+        .job_name("test-import")
+        .cloud_watch_logs_role_arn("arn:aws:iam::123456789012:role/CognitoImportRole")
+        .send()
+        .await
+        .expect("create import job");
+
+    let job = create.user_import_job().unwrap();
+    assert_eq!(job.job_name().unwrap(), "test-import");
+    assert_eq!(job.status().unwrap().as_str(), "Created");
+    let job_id = job.job_id().unwrap().to_string();
+    assert!(job.pre_signed_url().is_some());
+
+    // Describe
+    let describe = client
+        .describe_user_import_job()
+        .user_pool_id(&pool_id)
+        .job_id(&job_id)
+        .send()
+        .await
+        .expect("describe import job");
+    let described = describe.user_import_job().unwrap();
+    assert_eq!(described.job_name().unwrap(), "test-import");
+    assert_eq!(described.user_pool_id().unwrap(), pool_id);
+
+    // Create another job
+    client
+        .create_user_import_job()
+        .user_pool_id(&pool_id)
+        .job_name("test-import-2")
+        .cloud_watch_logs_role_arn("arn:aws:iam::123456789012:role/CognitoImportRole")
+        .send()
+        .await
+        .expect("create second import job");
+
+    // List
+    let list = client
+        .list_user_import_jobs()
+        .user_pool_id(&pool_id)
+        .max_results(10)
+        .send()
+        .await
+        .expect("list import jobs");
+    assert_eq!(
+        list.user_import_jobs().len(),
+        2,
+        "Should have 2 import jobs"
+    );
+
+    // Describe non-existent should fail
+    let err = client
+        .describe_user_import_job()
+        .user_pool_id(&pool_id)
+        .job_id("nonexistent")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent job");
+}
+
+#[tokio::test]
+async fn cognito_get_csv_header() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool_result = client
+        .create_user_pool()
+        .pool_name("csv-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool_result.user_pool().unwrap().id().unwrap().to_string();
+
+    let csv = client
+        .get_csv_header()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .expect("get csv header");
+
+    assert_eq!(csv.user_pool_id().unwrap(), pool_id);
+    let headers = csv.csv_header();
+    assert!(!headers.is_empty(), "CSV headers should not be empty");
+    // Default schema includes 'sub', 'email', 'name', etc.
+    assert!(
+        headers.contains(&"sub".to_string()),
+        "Headers should contain 'sub'"
+    );
+    assert!(
+        headers.contains(&"email".to_string()),
+        "Headers should contain 'email'"
+    );
+
+    // Non-existent pool should fail
+    let err = client
+        .get_csv_header()
+        .user_pool_id("us-east-1_nonexistent")
+        .send()
+        .await;
+    assert!(err.is_err(), "Should fail for non-existent pool");
 }


### PR DESCRIPTION
## Summary

- 12 new Cognito operations across 3 categories:
  - **Devices (5):** AdminGetDevice, AdminListDevices, AdminForgetDevice, AdminUpdateDeviceStatus, ConfirmDevice
  - **Tags (3):** TagResource, UntagResource, ListTagsForResource
  - **Import Jobs (4):** GetCSVHeader, CreateUserImportJob, DescribeUserImportJob, ListUserImportJobs
- Real behavior: device tracking with remembered status, ARN-based tagging, import job lifecycle
- 3 new unit tests (47 total), 7 new E2E tests (57 total), 12 new conformance tests (80/80 coverage)

## Test plan

- [x] `cargo test -p fakecloud-cognito` — 47 unit tests pass
- [x] `cargo test -p fakecloud-e2e --test cognito` — 57 E2E tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Conformance audit: 80/80 cognito-idp actions covered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 12 Cognito operations to `fakecloud-cognito` for device management, tagging, and user import jobs, with realistic behaviors and full test coverage across `fakecloud-conformance` and `fakecloud-e2e`. Also fixes device JSON to include remembered status.

- **New Features**
  - Devices: `AdminGetDevice`, `AdminListDevices` (pagination), `AdminForgetDevice`, `AdminUpdateDeviceStatus`, `ConfirmDevice`. Stores per-user devices with timestamps and remembered status.
  - Tags: `TagResource`, `UntagResource`, `ListTagsForResource`. Validates pool ARN; cleans up tags on pool delete.
  - Import Jobs: `GetCSVHeader`, `CreateUserImportJob` (pre-signed URL, status Created), `DescribeUserImportJob`, `ListUserImportJobs` (pagination). Cleans up jobs on pool delete.

- **Bug Fixes**
  - Include `DeviceRememberedStatus` in device JSON output to match AWS behavior.

<sup>Written for commit 0f28838385e4695b5f5165ffdff67a6fbdc960cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

