### PR TITLE
docs: add Cognito User Pools service to documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ cargo fmt --check                        # format check
 - `fakecloud` — binary entry point (clap CLI, Axum server)
 - `fakecloud-core` — AwsService trait, ServiceRegistry, request dispatch, protocol parsing
 - `fakecloud-aws` — shared AWS types (ARNs, error builders, SigV4 parser)
-- `fakecloud-{sqs,sns,eventbridge,iam,ssm,dynamodb,lambda,secretsmanager,s3,logs,kms,cloudformation,ses}` — individual service implementations
+- `fakecloud-{sqs,sns,eventbridge,iam,ssm,dynamodb,lambda,secretsmanager,s3,logs,kms,cloudformation,ses,cognito}` — individual service implementations
 - `fakecloud-e2e` — E2E tests using aws-sdk-rust and AWS CLI
 
 ## Conventions
@@ -39,6 +39,6 @@ cargo fmt --check                        # format check
 
 ### AWS Protocol Notes
 - Query protocol (SQS, SNS, IAM, STS, CloudFormation, SES v1): form-encoded body, `Action` param, XML responses
-- JSON protocol (SSM, EventBridge, DynamoDB, Secrets Manager, CloudWatch Logs, KMS): JSON body, `X-Amz-Target` header, JSON responses
+- JSON protocol (SSM, EventBridge, DynamoDB, Secrets Manager, CloudWatch Logs, KMS, Cognito User Pools): JSON body, `X-Amz-Target` header, JSON responses
 - REST protocol (S3, Lambda, SES v2): HTTP method + path-based routing, XML/JSON responses
 - SigV4 signatures are parsed for routing but never validated

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ proprietary image that requires an account and auth token.
 | Startup time | ~500ms | ~3s |
 | Idle memory | ~10 MiB | ~150 MiB |
 | Install size | ~19 MB binary | ~1 GB Docker image |
-| AWS services | 14 | 30+ |
+| AWS services | 15 | 30+ |
+| Cognito User Pools | 80 operations | [Paid only](https://docs.localstack.cloud/references/licensing/) |
 | SES v2 | 97 operations | [Paid only](https://docs.localstack.cloud/references/licensing/) |
 | SES inbound email | Real receipt rule action execution | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) |
 
@@ -98,7 +99,7 @@ fakecloud is now listening at `http://localhost:4566`.
 
 ## Supported Services
 
-14 AWS services, 842 API operations:
+15 AWS services, 922 API operations:
 
 | Service | Actions | Highlights |
 |---|---|---|
@@ -116,6 +117,7 @@ fakecloud is now listening at `http://localhost:4566`.
 | **KMS** | 53 | Encryption, key management, aliases, grants, real ECDH and key import |
 | **CloudFormation** | 8 | Template parsing, resource provisioning, custom resources via Lambda |
 | **SES** | 111 | **v2** (97 ops): identities, templates, configuration sets, contact lists, send email, suppression list, event destinations, DKIM/feedback/mail-from attributes, dedicated IP pools, account settings, import/export jobs, event fanout (SNS/EventBridge), mailbox simulator. **v1 inbound** (14 ops): receipt rule sets, receipt rules, receipt filters, inbound email pipeline with S3/SNS/Lambda actions |
+| **Cognito User Pools** | 80 | User pools, app clients, users, groups, MFA, identity providers, resource servers, domains, devices, authentication flows, password management |
 
 ### Cross-Service Integration
 
@@ -161,7 +163,7 @@ curl http://localhost:4566/_fakecloud/health
 {
   "status": "ok",
   "version": "0.3.0",
-  "services": ["cloudformation", "dynamodb", "sqs", "sns", "events", "iam", "sts", "ssm", "lambda", "secretsmanager", "logs", "kms", "s3", "ses"]
+  "services": ["cloudformation", "cognito-idp", "dynamodb", "sqs", "sns", "events", "iam", "sts", "ssm", "lambda", "secretsmanager", "logs", "kms", "s3", "ses"]
 }
 ```
 
@@ -213,11 +215,12 @@ fakecloud is organized as a Cargo workspace:
 | `fakecloud-kms` | KMS implementation |
 | `fakecloud-cloudformation` | CloudFormation implementation |
 | `fakecloud-ses` | SES implementation (v2 REST + v1 inbound Query) |
+| `fakecloud-cognito` | Cognito User Pools implementation |
 | `fakecloud-e2e` | End-to-end tests using aws-sdk-rust |
 
 Protocol handling:
 - **Query protocol** (SQS, SNS, IAM, STS, CloudFormation, SES v1): form-encoded body, `Action` parameter, XML responses
-- **JSON protocol** (SSM, EventBridge, DynamoDB, Secrets Manager, CloudWatch Logs, KMS): JSON body, `X-Amz-Target` header, JSON responses
+- **JSON protocol** (SSM, EventBridge, DynamoDB, Secrets Manager, CloudWatch Logs, KMS, Cognito User Pools): JSON body, `X-Amz-Target` header, JSON responses
 - **REST protocol** (S3, Lambda, SES v2): HTTP method + path-based routing, XML/JSON responses
 - **SES v1 inbound** uses Query protocol for receipt rule/filter operations
 - SigV4 signatures are parsed for service routing but never validated
@@ -236,7 +239,7 @@ server per test.
 
 ## Roadmap
 
-See [ROADMAP.md](ROADMAP.md) for what's coming next: Cognito, Kinesis, RDS, ECS, ElastiCache, and more.
+See [ROADMAP.md](ROADMAP.md) for what's coming next: Kinesis, RDS, ECS, ElastiCache, and more.
 
 ## Contributing
 
@@ -256,7 +259,7 @@ Contributions are welcome.
 **fakecloud is** a free, open-source local AWS emulator for integration testing and
 local development. For every service it implements, the goal is 100% behavioral
 parity with real AWS — verified by 34,000+ automated conformance test variants
-against official AWS Smithy models across all API operations. 14 services,
+against official AWS Smithy models across all API operations. 15 services,
 100% conformance.
 
 **fakecloud is not** a production-ready cloud replacement. It's not designed to

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,10 +4,6 @@ fakecloud's goal is to be the best free AWS emulator for integration testing and
 
 For every service we implement, the standard is the same: full API coverage, real behavior (not stubs), conformance testing against AWS Smithy models, and cross-service integrations where applicable.
 
-## Currently shipping
-
-**Cognito** — User Pools and Identity Pools. Authentication and authorization testing without real AWS credentials.
-
 ## Up next
 
 ### Kinesis

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -4,7 +4,7 @@
 
 ## Overview
 
-fakecloud emulates 14 AWS services locally for integration testing and development. It is a single Rust binary — no Docker required, no signup, starts in under 100ms. Point any AWS SDK or the AWS CLI at `http://localhost:4566` with dummy credentials.
+fakecloud emulates 15 AWS services locally for integration testing and development. It is a single Rust binary — no Docker required, no signup, starts in under 100ms. Point any AWS SDK or the AWS CLI at `http://localhost:4566` with dummy credentials.
 
 Key design principles:
 - **Correctness over coverage**: Every implemented service targets 100% behavioral parity with real AWS, verified by automated conformance tests against AWS Smithy models
@@ -70,7 +70,7 @@ fakecloud listens at `http://localhost:4566`.
 ### Health check
 ```sh
 curl http://localhost:4566/_fakecloud/health
-# Returns: {"status":"ok","version":"0.3.0","services":["cloudformation","dynamodb","sqs","sns","events","iam","sts","ssm","lambda","secretsmanager","logs","kms","s3","ses"]}
+# Returns: {"status":"ok","version":"0.3.0","services":["cloudformation","cognito-idp","dynamodb","sqs","sns","events","iam","sts","ssm","lambda","secretsmanager","logs","kms","s3","ses"]}
 ```
 
 ## Using with AWS SDKs
@@ -275,6 +275,14 @@ Protocol: Query (form-encoded body, `Action` parameter, XML responses)
 
 Features: email event fanout to SNS topics and EventBridge buses via configured event destinations, mailbox simulator (bounce@simulator.amazonses.com, complaint@, suppressionlist@), inbound email pipeline via /_fakecloud/ses/inbound endpoint that evaluates receipt rules and executes S3/SNS/Lambda actions.
 
+### Cognito User Pools (80 actions)
+
+User pool management, app clients, user management, groups, authentication flows, password and session management, MFA/software tokens, identity providers, resource servers, domains, device management, tags, and import jobs.
+
+Features: user pools with configurable policies, app client CRUD, user signup/confirmation/admin-create, authentication with USER_PASSWORD_AUTH and ADMIN_NO_SRP_AUTH flows, group management with precedence, MFA with software TOTP, identity provider federation (SAML, OIDC, social), resource servers with custom scopes, custom and managed domain configuration, device tracking, user import jobs.
+
+Protocol: JSON (JSON body, `X-Amz-Target` header, JSON responses)
+
 ## Cross-Service Integration
 
 fakecloud implements real cross-service message delivery:
@@ -293,7 +301,7 @@ fakecloud implements real cross-service message delivery:
 fakecloud handles three AWS protocol families:
 
 - **Query protocol** (SQS, SNS, IAM, STS, CloudFormation, SES v1): form-encoded body with `Action` parameter, XML responses
-- **JSON protocol** (SSM, EventBridge, DynamoDB, Secrets Manager, CloudWatch Logs, KMS): JSON body, `X-Amz-Target` header, JSON responses
+- **JSON protocol** (SSM, EventBridge, DynamoDB, Secrets Manager, CloudWatch Logs, KMS, Cognito User Pools): JSON body, `X-Amz-Target` header, JSON responses
 - **REST protocol** (S3, Lambda, SES v2): HTTP method + path-based routing, XML or JSON responses
 
 SigV4 signatures are parsed for service routing but never validated. Use any dummy credentials.

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -3,7 +3,7 @@
 > fakecloud is a free, open-source local AWS cloud emulator written in Rust. It runs on a single port (4566), requires no account or auth token, and aims for 100% behavioral parity with real AWS on every service it implements. It is an open-source alternative to LocalStack, which went proprietary in March 2026.
 
 - Single binary, no Docker required, starts in under 100ms
-- 14 AWS services: S3, SQS, SNS, EventBridge, IAM/STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES
+- 15 AWS services: S3, SQS, SNS, EventBridge, IAM/STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES, Cognito User Pools
 - Cross-service delivery: S3 notifications to SNS/SQS, SNS fan-out to SQS, EventBridge rules to SNS/SQS
 - Scheduled EventBridge rules (cron and rate) that actually fire
 - Conformance tested against real AWS behavior
@@ -36,6 +36,7 @@
 - [KMS](https://github.com/faiscadev/fakecloud#kms-16-actions): 16 actions — keys, encryption/decryption, aliases, data key generation
 - [CloudFormation](https://github.com/faiscadev/fakecloud#cloudformation-8-actions): 8 actions — stacks, resource provisioning, template parsing, intrinsic functions
 - [SES](https://github.com/faiscadev/fakecloud#supported-services): 111 actions — v2 (97 ops): identities, templates, configuration sets, send email, event fanout, mailbox simulator. v1 inbound (14 ops): receipt rules, receipt filters, inbound email pipeline with S3/SNS/Lambda actions
+- [Cognito User Pools](https://github.com/faiscadev/fakecloud#supported-services): 80 actions — user pools, app clients, users, groups, MFA, identity providers, resource servers, domains, devices, authentication flows
 
 ## Optional
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -46,8 +46,8 @@
       </div>
       <div class="feature">
         <div class="label">Coverage</div>
-        <h3>14 AWS services</h3>
-        <p>S3, SQS, SNS, EventBridge, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES. The services local dev actually needs.</p>
+        <h3>15 AWS services</h3>
+        <p>S3, SQS, SNS, EventBridge, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES, Cognito User Pools. The services local dev actually needs.</p>
       </div>
       <div class="feature">
         <div class="label">Tested</div>
@@ -107,7 +107,8 @@
           <tr><td>Startup time</td><td class="check">~500ms</td><td class="cross">~3s</td></tr>
           <tr><td>Idle memory</td><td class="check">~10 MiB</td><td class="cross">~150 MiB</td></tr>
           <tr><td>Install size</td><td class="check">~19 MB binary</td><td class="cross">~1 GB Docker image</td></tr>
-          <tr><td>AWS services</td><td>14</td><td>30+</td></tr>
+          <tr><td>AWS services</td><td>15</td><td>30+</td></tr>
+          <tr><td>Cognito User Pools</td><td class="check">80 operations</td><td class="cross">Paid only</td></tr>
           <tr><td>SES v2</td><td class="check">97 operations</td><td class="cross">Paid only</td></tr>
           <tr><td>SES inbound email</td><td class="check">Real receipt rule actions</td><td class="cross">Stored but never executed</td></tr>
         </tbody>
@@ -134,6 +135,7 @@
       <div class="service"><div class="name">KMS</div><div class="proto">JSON protocol</div></div>
       <div class="service"><div class="name">CloudFormation</div><div class="proto">Query protocol</div></div>
       <div class="service"><div class="name">SES</div><div class="proto">REST + Query protocol</div></div>
+      <div class="service"><div class="name">Cognito User Pools</div><div class="proto">JSON protocol</div></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

- Add Cognito User Pools (80 ops) to README, website, CLAUDE.md, llms.txt, llms-full.txt
- Update total service count to 15 and operation count to 922
- Add Cognito to LocalStack comparison table (paid-only in Community)
- Update architecture and protocol notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cognito User Pools to the docs (80 operations) and updates totals to 15 services / 922 operations.
Updates README, website, and reference files to include the service, `fakecloud-cognito` workspace entry, health check output, JSON protocol notes, LocalStack comparison (paid-only), and roadmap.

<sup>Written for commit 2a19b5b2f5c8544e37aa66433ec1f6f31b3acfa4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

