### PR TITLE
feat: add Cognito testing/simulation APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ fakecloud exposes `/_fakecloud/*` endpoints for testing behaviors that AWS runs 
 | `/_fakecloud/s3/notifications` | GET | List all S3 notification events. |
 | `/_fakecloud/ses/emails` | GET | List all sent SES emails. |
 | `/_fakecloud/ses/inbound` | POST | Simulate receiving an inbound email. Evaluates receipt rules and executes actions. |
+| `/_fakecloud/cognito/confirmation-codes` | GET | List all pending confirmation codes across all pools and users. |
+| `/_fakecloud/cognito/confirmation-codes/{pool_id}/{username}` | GET | Get confirmation codes for a specific user. |
+| `/_fakecloud/cognito/confirm-user` | POST | Force-confirm a user. Body: `{"userPoolId": "...", "username": "..."}`. |
+| `/_fakecloud/cognito/tokens` | GET | List all active access and refresh tokens (without exposing token strings). |
+| `/_fakecloud/cognito/expire-tokens` | POST | Expire tokens. Body: `{"userPoolId": "...", "username": "..."}` (both optional). |
+| `/_fakecloud/cognito/auth-events` | GET | List all auth events (sign-up, sign-in, failures, password changes). |
 | `/_fakecloud/reset` | POST | Reset all state across all services. |
 | `/_fakecloud/reset/{service}` | POST | Reset only the specified service's state. Returns `{"reset": "service_name"}`. |
 

--- a/crates/fakecloud-cognito/src/service.rs
+++ b/crates/fakecloud-cognito/src/service.rs
@@ -12,12 +12,12 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 
 use crate::state::{
     default_schema_attributes, AccessTokenData, AccountRecoverySetting, AdminCreateUserConfig,
-    CustomDomainConfig, Device, EmailConfiguration, Group, IdentityProvider, InviteMessageTemplate,
-    MfaPreferences, PasswordPolicy, PoolPolicies, RecoveryOption, RefreshTokenData, ResourceServer,
-    ResourceServerScope, SchemaAttribute, SessionData, SharedCognitoState, SmsConfiguration,
-    SmsMfaConfiguration, SoftwareTokenMfaConfiguration, StringAttributeConstraints,
-    TokenValidityUnits, User, UserAttribute, UserImportJob, UserPool, UserPoolClient,
-    UserPoolDomain,
+    AuthEvent, CustomDomainConfig, Device, EmailConfiguration, Group, IdentityProvider,
+    InviteMessageTemplate, MfaPreferences, PasswordPolicy, PoolPolicies, RecoveryOption,
+    RefreshTokenData, ResourceServer, ResourceServerScope, SchemaAttribute, SessionData,
+    SharedCognitoState, SmsConfiguration, SmsMfaConfiguration, SoftwareTokenMfaConfiguration,
+    StringAttributeConstraints, TokenValidityUnits, User, UserAttribute, UserImportJob, UserPool,
+    UserPoolClient, UserPoolDomain,
 };
 
 pub struct CognitoService {
@@ -1552,6 +1552,14 @@ impl CognitoService {
             _ => false,
         };
         if !password_matches {
+            state.auth_events.push(AuthEvent {
+                event_type: "SIGN_IN_FAILURE".to_string(),
+                username: username.to_string(),
+                user_pool_id: pool_id.to_string(),
+                client_id: Some(client_id.to_string()),
+                timestamp: Utc::now(),
+                success: false,
+            });
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -1609,6 +1617,15 @@ impl CognitoService {
                 issued_at: Utc::now(),
             },
         );
+
+        state.auth_events.push(AuthEvent {
+            event_type: "SIGN_IN".to_string(),
+            username: username.to_string(),
+            user_pool_id: pool_id.to_string(),
+            client_id: Some(client_id.to_string()),
+            timestamp: Utc::now(),
+            success: true,
+        });
 
         Ok(AwsResponse::ok_json(json!({
             "AuthenticationResult": {
@@ -1708,6 +1725,14 @@ impl CognitoService {
                     _ => false,
                 };
                 if !password_matches {
+                    state.auth_events.push(AuthEvent {
+                        event_type: "SIGN_IN_FAILURE".to_string(),
+                        username: username.to_string(),
+                        user_pool_id: pool_id.to_string(),
+                        client_id: Some(client_id.to_string()),
+                        timestamp: Utc::now(),
+                        success: false,
+                    });
                     return Err(AwsServiceError::aws_error(
                         StatusCode::BAD_REQUEST,
                         "NotAuthorizedException",
@@ -1761,6 +1786,15 @@ impl CognitoService {
                         issued_at: Utc::now(),
                     },
                 );
+
+                state.auth_events.push(AuthEvent {
+                    event_type: "SIGN_IN".to_string(),
+                    username: username.to_string(),
+                    user_pool_id: pool_id.to_string(),
+                    client_id: Some(client_id.to_string()),
+                    timestamp: Utc::now(),
+                    success: true,
+                });
 
                 Ok(AwsResponse::ok_json(json!({
                     "AuthenticationResult": {
@@ -2110,6 +2144,15 @@ impl CognitoService {
 
         pool_users.insert(username.to_string(), user);
 
+        state.auth_events.push(AuthEvent {
+            event_type: "SIGN_UP".to_string(),
+            username: username.to_string(),
+            user_pool_id: pool_id,
+            client_id: Some(client_id.to_string()),
+            timestamp: Utc::now(),
+            success: true,
+        });
+
         Ok(AwsResponse::ok_json(json!({
             "UserConfirmed": false,
             "UserSub": sub
@@ -2262,6 +2305,15 @@ impl CognitoService {
         user.temporary_password = None;
         user.user_last_modified_date = Utc::now();
 
+        state.auth_events.push(AuthEvent {
+            event_type: "PASSWORD_CHANGE".to_string(),
+            username,
+            user_pool_id: pool_id,
+            client_id: None,
+            timestamp: Utc::now(),
+            success: true,
+        });
+
         Ok(AwsResponse::ok_json(json!({})))
     }
 
@@ -2317,6 +2369,15 @@ impl CognitoService {
                 }
             })
             .unwrap_or_else(|| "***".to_string());
+
+        state.auth_events.push(AuthEvent {
+            event_type: "FORGOT_PASSWORD".to_string(),
+            username: username.to_string(),
+            user_pool_id: pool_id,
+            client_id: Some(client_id.to_string()),
+            timestamp: Utc::now(),
+            success: true,
+        });
 
         Ok(AwsResponse::ok_json(json!({
             "CodeDeliveryDetails": {
@@ -7426,5 +7487,150 @@ mod tests {
         let resp = svc.list_user_import_jobs(&req).unwrap();
         let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
         assert_eq!(resp_body["UserImportJobs"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn auth_events_recorded_on_sign_up() {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(crate::state::CognitoState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        let svc = CognitoService::new(state.clone());
+
+        // Create pool and client
+        let req = make_req("CreateUserPool", r#"{"PoolName": "evpool"}"#);
+        let resp = svc.create_user_pool(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
+
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "ClientName": "evclient",
+            "ExplicitAuthFlows": ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+        }))
+        .unwrap();
+        let req = make_req("CreateUserPoolClient", &body);
+        let resp = svc.create_user_pool_client(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let client_id = resp_body["UserPoolClient"]["ClientId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Sign up
+        let body = serde_json::to_string(&json!({
+            "ClientId": client_id,
+            "Username": "testevuser",
+            "Password": "P@ssw0rd!",
+            "UserAttributes": [{"Name": "email", "Value": "test@example.com"}]
+        }))
+        .unwrap();
+        let req = make_req("SignUp", &body);
+        svc.sign_up(&req).unwrap();
+
+        // Check auth events
+        let st = state.read();
+        assert_eq!(st.auth_events.len(), 1);
+        assert_eq!(st.auth_events[0].event_type, "SIGN_UP");
+        assert_eq!(st.auth_events[0].username, "testevuser");
+        assert!(st.auth_events[0].success);
+    }
+
+    #[test]
+    fn auth_events_recorded_on_sign_in_and_failure() {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(crate::state::CognitoState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        let svc = CognitoService::new(state.clone());
+
+        // Create pool, client, user
+        let req = make_req("CreateUserPool", r#"{"PoolName": "authpool"}"#);
+        let resp = svc.create_user_pool(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
+
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "ClientName": "authclient",
+            "ExplicitAuthFlows": ["ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+        }))
+        .unwrap();
+        let req = make_req("CreateUserPoolClient", &body);
+        let resp = svc.create_user_pool_client(&req).unwrap();
+        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let client_id = resp_body["UserPoolClient"]["ClientId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Create user and set permanent password
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "Username": "authuser",
+            "TemporaryPassword": "TempP@ss1!"
+        }))
+        .unwrap();
+        let req = make_req("AdminCreateUser", &body);
+        svc.admin_create_user(&req).unwrap();
+
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "Username": "authuser",
+            "Password": "P@ssw0rd!",
+            "Permanent": true
+        }))
+        .unwrap();
+        let req = make_req("AdminSetUserPassword", &body);
+        svc.admin_set_user_password(&req).unwrap();
+
+        // Successful auth
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "ClientId": client_id,
+            "AuthFlow": "ADMIN_USER_PASSWORD_AUTH",
+            "AuthParameters": {"USERNAME": "authuser", "PASSWORD": "P@ssw0rd!"}
+        }))
+        .unwrap();
+        let req = make_req("AdminInitiateAuth", &body);
+        svc.admin_initiate_auth(&req).unwrap();
+
+        // Failed auth
+        let body = serde_json::to_string(&json!({
+            "UserPoolId": pool_id,
+            "ClientId": client_id,
+            "AuthFlow": "ADMIN_USER_PASSWORD_AUTH",
+            "AuthParameters": {"USERNAME": "authuser", "PASSWORD": "WrongPass!"}
+        }))
+        .unwrap();
+        let req = make_req("AdminInitiateAuth", &body);
+        let _ = svc.admin_initiate_auth(&req);
+
+        // Check events
+        let st = state.read();
+        assert_eq!(st.auth_events.len(), 2);
+        assert_eq!(st.auth_events[0].event_type, "SIGN_IN");
+        assert!(st.auth_events[0].success);
+        assert_eq!(st.auth_events[1].event_type, "SIGN_IN_FAILURE");
+        assert!(!st.auth_events[1].success);
+    }
+
+    #[test]
+    fn auth_events_cleared_on_reset() {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(crate::state::CognitoState::new(
+            "123456789012",
+            "us-east-1",
+        )));
+        state.write().auth_events.push(AuthEvent {
+            event_type: "SIGN_UP".to_string(),
+            username: "test".to_string(),
+            user_pool_id: "pool".to_string(),
+            client_id: None,
+            timestamp: Utc::now(),
+            success: true,
+        });
+        assert_eq!(state.read().auth_events.len(), 1);
+        state.write().reset();
+        assert!(state.read().auth_events.is_empty());
     }
 }

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -34,6 +34,18 @@ pub struct CognitoState {
     pub tags: HashMap<String, HashMap<String, String>>,
     /// pool_id -> (job_id -> UserImportJob)
     pub import_jobs: HashMap<String, HashMap<String, UserImportJob>>,
+    /// Auth events for introspection
+    pub auth_events: Vec<AuthEvent>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthEvent {
+    pub event_type: String,
+    pub username: String,
+    pub user_pool_id: String,
+    pub client_id: Option<String>,
+    pub timestamp: DateTime<Utc>,
+    pub success: bool,
 }
 
 impl CognitoState {
@@ -54,6 +66,7 @@ impl CognitoState {
             domains: HashMap::new(),
             tags: HashMap::new(),
             import_jobs: HashMap::new(),
+            auth_events: Vec::new(),
         }
     }
 
@@ -71,6 +84,7 @@ impl CognitoState {
         self.domains.clear();
         self.tags.clear();
         self.import_jobs.clear();
+        self.auth_events.clear();
     }
 }
 

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -4226,3 +4226,399 @@ async fn cognito_get_csv_header() {
         .await;
     assert!(err.is_err(), "Should fail for non-existent pool");
 }
+
+// --- Simulation / Testing API tests ---
+
+#[tokio::test]
+async fn cognito_simulation_confirmation_codes_and_force_confirm() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let http = reqwest::Client::new();
+
+    // Create pool + client
+    let pool = client
+        .create_user_pool()
+        .pool_name("sim-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("sim-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    // Sign up a user
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("simuser")
+        .password("P@ssw0rd!")
+        .user_attributes(
+            AttributeType::builder()
+                .name("email")
+                .value("sim@example.com")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("sign up");
+
+    // List all confirmation codes (should be empty initially since SignUp doesn't auto-generate codes)
+    let resp: serde_json::Value = http
+        .get(format!(
+            "{}/_fakecloud/cognito/confirmation-codes",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let codes = resp["codes"].as_array().unwrap();
+    assert!(
+        codes.is_empty(),
+        "Should have no codes before ForgotPassword"
+    );
+
+    // Force-confirm user so we can then trigger ForgotPassword
+    let confirm_resp: serde_json::Value = http
+        .post(format!(
+            "{}/_fakecloud/cognito/confirm-user",
+            server.endpoint()
+        ))
+        .json(&serde_json::json!({
+            "userPoolId": pool_id,
+            "username": "simuser"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(confirm_resp["confirmed"], true);
+
+    // Verify user is now CONFIRMED via AdminGetUser
+    let user = client
+        .admin_get_user()
+        .user_pool_id(&pool_id)
+        .username("simuser")
+        .send()
+        .await
+        .expect("get user");
+    assert_eq!(
+        user.user_status(),
+        Some(&UserStatusType::Confirmed),
+        "User should be CONFIRMED after force-confirm"
+    );
+
+    // Trigger ForgotPassword to create a confirmation code
+    client
+        .forgot_password()
+        .client_id(&client_id)
+        .username("simuser")
+        .send()
+        .await
+        .expect("forgot password");
+
+    // List codes again - should now have the forgot password code
+    let resp: serde_json::Value = http
+        .get(format!(
+            "{}/_fakecloud/cognito/confirmation-codes",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let codes = resp["codes"].as_array().unwrap();
+    assert!(
+        codes.iter().any(|c| c["username"] == "simuser"),
+        "Should have simuser's code: {codes:?}"
+    );
+
+    // Force-confirm non-existent user should 404
+    let resp = http
+        .post(format!(
+            "{}/_fakecloud/cognito/confirm-user",
+            server.endpoint()
+        ))
+        .json(&serde_json::json!({
+            "userPoolId": pool_id,
+            "username": "nonexistent"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn cognito_simulation_tokens_and_expire() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let http = reqwest::Client::new();
+
+    // Create pool + client
+    let pool = client
+        .create_user_pool()
+        .pool_name("token-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("token-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowAdminUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    // Create and confirm user
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("tokenuser")
+        .temporary_password("TempP@ss1!")
+        .send()
+        .await
+        .expect("create user");
+
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("tokenuser")
+        .password("P@ssw0rd!")
+        .permanent(true)
+        .send()
+        .await
+        .expect("set password");
+
+    // Authenticate user
+    client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "tokenuser")
+        .auth_parameters("PASSWORD", "P@ssw0rd!")
+        .send()
+        .await
+        .expect("auth");
+
+    // List tokens
+    let resp: serde_json::Value = http
+        .get(format!("{}/_fakecloud/cognito/tokens", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let tokens = resp["tokens"].as_array().unwrap();
+    let access_count = tokens.iter().filter(|t| t["type"] == "access").count();
+    let refresh_count = tokens.iter().filter(|t| t["type"] == "refresh").count();
+    assert!(access_count >= 1, "Should have at least 1 access token");
+    assert!(refresh_count >= 1, "Should have at least 1 refresh token");
+
+    // All tokens should belong to tokenuser
+    for t in tokens {
+        assert_eq!(t["username"], "tokenuser");
+        assert_eq!(t["poolId"], pool_id);
+        assert!(t["issuedAt"].as_i64().unwrap() > 0);
+    }
+
+    // Expire tokens for this user
+    let resp: serde_json::Value = http
+        .post(format!(
+            "{}/_fakecloud/cognito/expire-tokens",
+            server.endpoint()
+        ))
+        .json(&serde_json::json!({
+            "userPoolId": pool_id,
+            "username": "tokenuser"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let expired = resp["expiredTokens"].as_u64().unwrap();
+    assert!(
+        expired >= 2,
+        "Should expire at least access + refresh token, got {expired}"
+    );
+
+    // Verify tokens are gone
+    let resp: serde_json::Value = http
+        .get(format!("{}/_fakecloud/cognito/tokens", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let tokens = resp["tokens"].as_array().unwrap();
+    assert!(tokens.is_empty(), "Tokens should be empty after expiration");
+}
+
+#[tokio::test]
+async fn cognito_simulation_auth_events() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let http = reqwest::Client::new();
+
+    // Create pool + client
+    let pool = client
+        .create_user_pool()
+        .pool_name("events-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("events-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowAdminUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    // Sign up user
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("evuser")
+        .password("P@ssw0rd!")
+        .user_attributes(
+            AttributeType::builder()
+                .name("email")
+                .value("ev@example.com")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("sign up");
+
+    // Confirm user
+    client
+        .admin_confirm_sign_up()
+        .user_pool_id(&pool_id)
+        .username("evuser")
+        .send()
+        .await
+        .expect("confirm");
+
+    // Successful sign in
+    client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "evuser")
+        .auth_parameters("PASSWORD", "P@ssw0rd!")
+        .send()
+        .await
+        .expect("sign in");
+
+    // Failed sign in with wrong password
+    let _err = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "evuser")
+        .auth_parameters("PASSWORD", "WrongPass1!")
+        .send()
+        .await;
+
+    // List auth events
+    let resp: serde_json::Value = http
+        .get(format!(
+            "{}/_fakecloud/cognito/auth-events",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let events = resp["events"].as_array().unwrap();
+
+    // Should have: SIGN_UP, SIGN_IN, SIGN_IN_FAILURE
+    let event_types: Vec<&str> = events
+        .iter()
+        .map(|e| e["eventType"].as_str().unwrap())
+        .collect();
+
+    assert!(
+        event_types.contains(&"SIGN_UP"),
+        "Should have SIGN_UP event: {event_types:?}"
+    );
+    assert!(
+        event_types.contains(&"SIGN_IN"),
+        "Should have SIGN_IN event: {event_types:?}"
+    );
+    assert!(
+        event_types.contains(&"SIGN_IN_FAILURE"),
+        "Should have SIGN_IN_FAILURE event: {event_types:?}"
+    );
+
+    // Verify event details
+    let signup = events.iter().find(|e| e["eventType"] == "SIGN_UP").unwrap();
+    assert_eq!(signup["username"], "evuser");
+    assert_eq!(signup["userPoolId"], pool_id);
+    assert_eq!(signup["success"], true);
+    assert!(signup["timestamp"].as_i64().unwrap() > 0);
+
+    let failure = events
+        .iter()
+        .find(|e| e["eventType"] == "SIGN_IN_FAILURE")
+        .unwrap();
+    assert_eq!(failure["username"], "evuser");
+    assert_eq!(failure["success"], false);
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -213,6 +213,13 @@ async fn main() {
     let sns_sim_pending_state = sns_state.clone();
     let sns_sim_confirm_state = sns_state.clone();
 
+    // Clone state refs for Cognito simulation endpoints
+    let cognito_codes_state = cognito_state.clone();
+    let cognito_confirm_state = cognito_state.clone();
+    let cognito_tokens_state = cognito_state.clone();
+    let cognito_expire_state = cognito_state.clone();
+    let cognito_events_state = cognito_state.clone();
+
     // Clone state for reset endpoint before moving into services
     let reset_state = ResetState {
         iam: iam_state.clone(),
@@ -737,6 +744,176 @@ async fn main() {
                             "confirmationCode": code,
                             "attributeVerificationCodes": attr_codes
                         }))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/cognito/confirmation-codes",
+            axum::routing::get({
+                let cs = cognito_codes_state;
+                move || {
+                    let cs = cs.clone();
+                    async move {
+                        let state = cs.read();
+                        let mut codes = Vec::new();
+                        for (pool_id, users) in &state.users {
+                            for (username, user) in users {
+                                if let Some(code) = &user.confirmation_code {
+                                    codes.push(serde_json::json!({
+                                        "poolId": pool_id,
+                                        "username": username,
+                                        "code": code,
+                                        "type": "signup"
+                                    }));
+                                }
+                                for (attr, code) in &user.attribute_verification_codes {
+                                    codes.push(serde_json::json!({
+                                        "poolId": pool_id,
+                                        "username": username,
+                                        "code": code,
+                                        "type": "attribute_verification",
+                                        "attribute": attr
+                                    }));
+                                }
+                            }
+                        }
+                        axum::Json(serde_json::json!({ "codes": codes }))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/cognito/confirm-user",
+            axum::routing::post({
+                let cs = cognito_confirm_state;
+                move |axum::Json(body): axum::Json<serde_json::Value>| {
+                    let cs = cs.clone();
+                    async move {
+                        let pool_id = body["userPoolId"].as_str().unwrap_or("").to_string();
+                        let username = body["username"].as_str().unwrap_or("").to_string();
+                        let mut state = cs.write();
+                        let user = state
+                            .users
+                            .get_mut(&pool_id)
+                            .and_then(|users| users.get_mut(&username));
+                        match user {
+                            Some(user) => {
+                                user.user_status = "CONFIRMED".to_string();
+                                user.confirmation_code = None;
+                                user.user_last_modified_date = chrono::Utc::now();
+                                (
+                                    axum::http::StatusCode::OK,
+                                    axum::Json(serde_json::json!({ "confirmed": true })),
+                                )
+                            }
+                            None => (
+                                axum::http::StatusCode::NOT_FOUND,
+                                axum::Json(serde_json::json!({
+                                    "confirmed": false,
+                                    "error": "User not found"
+                                })),
+                            ),
+                        }
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/cognito/tokens",
+            axum::routing::get({
+                let cs = cognito_tokens_state;
+                move || {
+                    let cs = cs.clone();
+                    async move {
+                        let state = cs.read();
+                        let mut tokens = Vec::new();
+                        for data in state.access_tokens.values() {
+                            tokens.push(serde_json::json!({
+                                "type": "access",
+                                "username": data.username,
+                                "poolId": data.user_pool_id,
+                                "clientId": data.client_id,
+                                "issuedAt": data.issued_at.timestamp()
+                            }));
+                        }
+                        for data in state.refresh_tokens.values() {
+                            tokens.push(serde_json::json!({
+                                "type": "refresh",
+                                "username": data.username,
+                                "poolId": data.user_pool_id,
+                                "clientId": data.client_id,
+                                "issuedAt": data.issued_at.timestamp()
+                            }));
+                        }
+                        axum::Json(serde_json::json!({ "tokens": tokens }))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/cognito/expire-tokens",
+            axum::routing::post({
+                let cs = cognito_expire_state;
+                move |axum::Json(body): axum::Json<serde_json::Value>| {
+                    let cs = cs.clone();
+                    async move {
+                        let pool_id = body["userPoolId"].as_str().map(|s| s.to_string());
+                        let username = body["username"].as_str().map(|s| s.to_string());
+                        let mut state = cs.write();
+                        let mut expired = 0usize;
+
+                        let matches = |p: &str, u: &str| -> bool {
+                            pool_id.as_ref().is_none_or(|pid| pid == p)
+                                && username.as_ref().is_none_or(|un| un == u)
+                        };
+
+                        let before_access = state.access_tokens.len();
+                        state
+                            .access_tokens
+                            .retain(|_, v| !matches(&v.user_pool_id, &v.username));
+                        expired += before_access - state.access_tokens.len();
+
+                        let before_refresh = state.refresh_tokens.len();
+                        state
+                            .refresh_tokens
+                            .retain(|_, v| !matches(&v.user_pool_id, &v.username));
+                        expired += before_refresh - state.refresh_tokens.len();
+
+                        let before_sessions = state.sessions.len();
+                        state
+                            .sessions
+                            .retain(|_, v| !matches(&v.user_pool_id, &v.username));
+                        expired += before_sessions - state.sessions.len();
+
+                        axum::Json(serde_json::json!({ "expiredTokens": expired }))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/cognito/auth-events",
+            axum::routing::get({
+                let cs = cognito_events_state;
+                move || {
+                    let cs = cs.clone();
+                    async move {
+                        let state = cs.read();
+                        let events: Vec<serde_json::Value> = state
+                            .auth_events
+                            .iter()
+                            .map(|e| {
+                                serde_json::json!({
+                                    "eventType": e.event_type,
+                                    "username": e.username,
+                                    "userPoolId": e.user_pool_id,
+                                    "clientId": e.client_id,
+                                    "timestamp": e.timestamp.timestamp(),
+                                    "success": e.success
+                                })
+                            })
+                            .collect();
+                        axum::Json(serde_json::json!({ "events": events }))
                     }
                 }
             }),


### PR DESCRIPTION
## Summary

- Add 5 new `/_fakecloud/cognito/*` simulation/introspection endpoints: list all confirmation codes, force-confirm user, list tokens, expire tokens, and auth events tracking
- Record auth events (SIGN_UP, SIGN_IN, SIGN_IN_FAILURE, PASSWORD_CHANGE, FORGOT_PASSWORD) in CognitoState for introspection
- Add `AuthEvent` struct to cognito state with proper reset support

## Test plan

- [x] E2E test: sign up user, list confirmation codes, force-confirm, verify status via AdminGetUser
- [x] E2E test: authenticate user, list tokens, expire tokens, verify count
- [x] E2E test: sign up, sign in, fail sign in with wrong password, list auth events, verify all 3 recorded
- [x] Unit tests for auth event recording on sign-up, sign-in success/failure, and reset clearing
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` passes (all existing tests unaffected)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cognito testing endpoints to inspect confirmation codes, tokens, and auth history, plus controls to force-confirm users and expire tokens. This improves local debugging and E2E testing for Cognito flows.

- **New Features**
  - Added `/_fakecloud/cognito/*` endpoints: `confirmation-codes` (list codes), `confirm-user` (force confirm), `tokens` (list token metadata only), `expire-tokens` (expire by pool/user), and `auth-events` (list auth history).
  - Recorded auth events in state for sign-up, sign-in (success/failure), password changes, and forgot password; cleared by reset.

<sup>Written for commit 62d601e7f28aec28db1f5f40882b99ccdc5c115e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

