### PR TITLE
docs: refresh README and website for SDK launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Part of the [faisca project family](https://faisca.dev).
 
 - Run your app against normal AWS SDKs, CLI tools, and IaC
 - Stay fully local with no AWS account, no auth token, and no paid tier
-- Assert what happened with first-party fakecloud SDKs for TypeScript, Python, and Go
+- Assert what happened with first-party fakecloud SDKs for TypeScript, Python, Go, and Rust
 - Test cross-service behavior like SES -> SNS/EventBridge, S3 -> SQS/SNS/Lambda, and SQS -> Lambda
 - Use a fast single binary or Docker image, depending on your setup
 
@@ -67,6 +67,7 @@ an account-gated platform in the middle.
 | TypeScript | `npm install fakecloud` | [`sdks/typescript/README.md`](sdks/typescript/README.md) |
 | Python | `pip install fakecloud` | [`sdks/python/README.md`](sdks/python/README.md) |
 | Go | `go get github.com/faiscadev/fakecloud/sdks/go` | [`sdks/go/README.md`](sdks/go/README.md) |
+| Rust | `cargo add fakecloud-sdk` | [`crates/fakecloud-sdk`](crates/fakecloud-sdk) |
 
 Example test flow:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <strong>fakecloud</strong><br>
-  <em>Local AWS emulator for integration tests. Free forever.</em>
+  <em>Local AWS cloud emulator. Free forever.</em>
 </p>
 
 <p align="center">
@@ -23,15 +23,20 @@ Part of the [faisca project family](https://faisca.dev).
 ## Why teams use fakecloud
 
 - Run your app against normal AWS SDKs, CLI tools, and IaC
+- Stay fully local with no AWS account, no auth token, and no paid tier
 - Assert what happened with first-party fakecloud SDKs for TypeScript, Python, and Go
 - Test cross-service behavior like SES -> SNS/EventBridge, S3 -> SQS/SNS/Lambda, and SQS -> Lambda
-- Stay fully local with no AWS account, no auth token, and no paid tier
 - Use a fast single binary or Docker image, depending on your setup
 
 ## Why fakecloud?
 
 In March 2026, LocalStack replaced its open-source Community Edition with a
 proprietary image that requires an account and auth token.
+
+fakecloud exists for teams that want a fully local workflow with real AWS APIs,
+no sign-in step, and no paid wall around core development services. The SDKs
+build on top of that by making the `/_fakecloud/*` endpoints easier to use in
+tests; they are an extra layer, not the whole story.
 
 ### Comparison
 
@@ -53,7 +58,9 @@ proprietary image that requires an account and auth token.
 
 fakecloud now ships SDKs for the introspection and simulation API, so your tests
 can use normal AWS clients for application behavior and a fakecloud client for
-assertions and time control.
+assertions and time control. They complement the main value proposition: a local
+AWS emulator you can run directly, compare against AWS behavior, and use without
+an account-gated platform in the middle.
 
 | Language | Install | Docs |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <strong>fakecloud</strong><br>
-  <em>Local AWS cloud emulator. Free forever.</em>
+  <em>Local AWS emulator for integration tests. Free forever.</em>
 </p>
 
 <p align="center">
@@ -13,11 +13,20 @@
 
 ---
 
-fakecloud is a free, open-source local AWS cloud emulator. It runs on a single port
-(`4566`), requires no account or auth token, and aims to faithfully replicate
-AWS service behavior for local development and testing.
+fakecloud is a free, open-source local AWS emulator for integration testing and
+local development. It runs on a single port (`4566`), requires no account or
+auth token, and aims to faithfully replicate AWS behavior where it matters:
+real API compatibility, cross-service wiring, and test-friendly introspection.
 
 Part of the [faisca project family](https://faisca.dev).
+
+## Why teams use fakecloud
+
+- Run your app against normal AWS SDKs, CLI tools, and IaC
+- Assert what happened with first-party fakecloud SDKs for TypeScript, Python, and Go
+- Test cross-service behavior like SES -> SNS/EventBridge, S3 -> SQS/SNS/Lambda, and SQS -> Lambda
+- Stay fully local with no AWS account, no auth token, and no paid tier
+- Use a fast single binary or Docker image, depending on your setup
 
 ## Why fakecloud?
 
@@ -40,7 +49,36 @@ proprietary image that requires an account and auth token.
 | SES v2 | 97 operations | [Paid only](https://docs.localstack.cloud/references/licensing/) |
 | SES inbound email | Real receipt rule action execution | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) |
 
+## First-party SDKs
+
+fakecloud now ships SDKs for the introspection and simulation API, so your tests
+can use normal AWS clients for application behavior and a fakecloud client for
+assertions and time control.
+
+| Language | Install | Docs |
+|---|---|---|
+| TypeScript | `npm install fakecloud` | [`sdks/typescript/README.md`](sdks/typescript/README.md) |
+| Python | `pip install fakecloud` | [`sdks/python/README.md`](sdks/python/README.md) |
+| Go | `go get github.com/faiscadev/fakecloud/sdks/go` | [`sdks/go/README.md`](sdks/go/README.md) |
+
+Example test flow:
+
+```ts
+import { FakeCloud } from "fakecloud";
+
+const fc = new FakeCloud("http://localhost:4566");
+
+// Your app talks to fakecloud through the normal AWS SDK.
+// Then your test can assert the side effects directly.
+const { emails } = await fc.ses.getEmails();
+expect(emails).toHaveLength(1);
+
+await fc.reset();
+```
+
 ## Quick Start
+
+Start fakecloud locally:
 
 ### Install script (recommended)
 
@@ -96,6 +134,14 @@ docker compose up
 ```
 
 fakecloud is now listening at `http://localhost:4566`.
+
+Point your usual AWS SDK or CLI at `http://localhost:4566` with any dummy
+credentials, then use a fakecloud SDK when you want to inspect state or trigger
+background processors:
+
+```sh
+aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name my-queue
+```
 
 ## Supported Services
 
@@ -162,7 +208,7 @@ curl http://localhost:4566/_fakecloud/health
 ```json
 {
   "status": "ok",
-  "version": "0.3.0",
+  "version": "0.5.1",
   "services": ["cloudformation", "cognito-idp", "dynamodb", "sqs", "sns", "events", "iam", "sts", "ssm", "lambda", "secretsmanager", "logs", "kms", "s3", "ses"]
 }
 ```
@@ -232,6 +278,14 @@ Protocol handling:
 - SigV4 signatures are parsed for service routing but never validated
 
 ## Testing
+
+fakecloud is verified two ways:
+
+- **Conformance** checks AWS request/response shape and validation behavior
+- **E2E** checks real behavior across services using the official AWS SDKs
+
+For test code in your own app, the fakecloud SDKs provide a cleaner wrapper over
+the `/_fakecloud/*` endpoints for assertions, resets, and time-based processors.
 
 ```sh
 cargo test --workspace              # unit tests

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,7 +80,9 @@ Trigger things that normally come from AWS infrastructure or external systems.
 
 ### SDKs
 
-Client libraries for TypeScript, Python, Go, Rust, and Java will wrap the `/_fakecloud/*` endpoints for cleaner test code. The HTTP APIs are stable and usable directly.
+TypeScript, Python, and Go SDKs now wrap the `/_fakecloud/*` endpoints for
+cleaner test code. Future SDK work, if we need it, will likely focus on Rust and
+Java.
 
 ## Design principles
 

--- a/crates/fakecloud-sdk/Cargo.toml
+++ b/crates/fakecloud-sdk/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fakecloud-sdk"
 description = "Client SDK for fakecloud — local AWS cloud emulator"
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/fakecloud-sdk/README.md
+++ b/crates/fakecloud-sdk/README.md
@@ -1,0 +1,48 @@
+# fakecloud-sdk
+
+Rust client SDK for [fakecloud](https://github.com/faiscadev/fakecloud), a local AWS cloud emulator.
+
+The crate wraps fakecloud's introspection and simulation API (`/_fakecloud/*`) so Rust tests can inspect emulator state, reset services, and trigger time-based processors without going through raw HTTP calls.
+
+## Installation
+
+```bash
+cargo add fakecloud-sdk
+```
+
+## Quick Start
+
+```rust
+use fakecloud_sdk::FakeCloud;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let fc = FakeCloud::new("http://localhost:4566");
+
+    let health = fc.health().await?;
+    println!("{}", health.version);
+
+    fc.reset().await?;
+
+    let emails = fc.ses().get_emails().await?;
+    println!("sent {} emails", emails.emails.len());
+
+    Ok(())
+}
+```
+
+## What It Covers
+
+- health and reset endpoints
+- SES email inspection and inbound simulation
+- SNS and SQS message inspection
+- EventBridge history and manual rule firing
+- S3 notifications and lifecycle ticks
+- DynamoDB TTL and Secrets Manager rotation ticks
+- Lambda invocation and warm-container inspection
+- Cognito confirmation codes, token inspection, and auth event access
+
+## Repository
+
+- Project: <https://github.com/faiscadev/fakecloud>
+- Website: <https://fakecloud.dev>

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -215,6 +215,7 @@ nav {
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 24px;
+  min-width: 0;
   .label {
     font-family: var(--mono);
     font-size: 13px;
@@ -227,10 +228,15 @@ nav {
     font-size: 16px;
     margin-bottom: 10px;
     line-height: 1.4;
+    overflow-wrap: anywhere;
+    word-break: break-word;
     code {
       background: transparent;
       padding: 0;
       font-size: inherit;
+      white-space: normal;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
   }
   p {

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -109,7 +109,6 @@ nav {
   background: transparent;
   border: 1px solid var(--border);
   color: var(--text);
-  margin-left: 12px;
   &:hover { border-color: var(--text-muted); }
 }
 
@@ -127,10 +126,25 @@ nav {
   .tagline {
     font-size: clamp(18px, 3vw, 22px);
     color: var(--text-muted);
-    margin-bottom: 40px;
-    max-width: 520px;
+    margin-bottom: 16px;
+    max-width: 720px;
     margin-left: auto;
     margin-right: auto;
+  }
+  .hero-proof {
+    font-family: var(--mono);
+    font-size: 13px;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 36px;
+  }
+  .btn-group {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
   }
 }
 
@@ -187,6 +201,48 @@ nav {
   }
   h3 { font-size: 17px; margin-bottom: 6px; }
   p { font-size: 14px; color: var(--text-muted); line-height: 1.5; }
+}
+
+.sdk-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+  margin-top: 40px;
+}
+
+.sdk-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 24px;
+  .label {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+  }
+  h3 {
+    font-size: 16px;
+    margin-bottom: 10px;
+    line-height: 1.4;
+    code {
+      background: transparent;
+      padding: 0;
+      font-size: inherit;
+    }
+  }
+  p {
+    font-size: 14px;
+    color: var(--text-muted);
+    line-height: 1.6;
+    margin-bottom: 14px;
+  }
+  a {
+    font-size: 14px;
+    font-weight: 600;
+  }
 }
 
 // Copy button
@@ -370,7 +426,7 @@ footer {
   section { padding: 48px 0; }
   .hero { padding: 64px 0 48px; }
   .code-block { font-size: 13px; padding: 16px 18px; }
-  .btn-outline { margin-left: 0; margin-top: 12px; }
-  .hero .btn-group { display: flex; flex-direction: column; align-items: center; gap: 0; }
+  .hero .btn-group { flex-direction: column; align-items: stretch; }
+  .hero .btn-group .btn { width: 100%; max-width: 280px; }
   .blog-article { padding: 40px 16px; }
 }

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -24,6 +24,7 @@
     <a href="/" class="logo">fake<span>cloud</span></a>
     <div class="links">
       <a href="/#features">Features</a>
+      <a href="/#sdks">SDKs</a>
       <a href="/#quickstart">Quick Start</a>
       <a href="/#compare">Compare</a>
       <a href="/blog/">Blog</a>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -43,7 +43,7 @@
       <div class="feature">
         <div class="label">SDKs</div>
         <h3>First-party test clients</h3>
-        <p>TypeScript, Python, and Go SDKs wrap the <code>/_fakecloud/*</code> endpoints for resets, assertions, and manual control of async processors after your app has already used the normal AWS APIs.</p>
+        <p>TypeScript, Python, Go, and Rust SDKs wrap the <code>/_fakecloud/*</code> endpoints for resets, assertions, and manual control of async processors after your app has already used the normal AWS APIs.</p>
       </div>
       <div class="feature">
         <div class="label">Coverage</div>
@@ -78,19 +78,25 @@
         <div class="label">TypeScript</div>
         <h3><code>npm install fakecloud</code></h3>
         <p>Inspect SES emails, SNS messages, SQS queues, Lambda invocations, Cognito confirmation codes, and more.</p>
-        <a href="{{ config.extra.github }}/tree/main/sdks/typescript">View TypeScript SDK</a>
+        <a href="https://www.npmjs.com/package/fakecloud" target="_blank" rel="noopener noreferrer">View on npm</a>
       </div>
       <div class="sdk-card">
         <div class="label">Python</div>
         <h3><code>pip install fakecloud</code></h3>
         <p>Async and sync clients for pytest or app-level integration tests, with the same introspection and simulation coverage.</p>
-        <a href="{{ config.extra.github }}/tree/main/sdks/python">View Python SDK</a>
+        <a href="https://pypi.org/project/fakecloud/" target="_blank" rel="noopener noreferrer">View on PyPI</a>
       </div>
       <div class="sdk-card">
         <div class="label">Go</div>
         <h3><code>go get github.com/faiscadev/fakecloud/sdks/go</code></h3>
         <p>Context-friendly helpers for resets, event history, SES inbound simulation, and the rest of the fakecloud test surface.</p>
-        <a href="{{ config.extra.github }}/tree/main/sdks/go">View Go SDK</a>
+        <a href="https://pkg.go.dev/github.com/faiscadev/fakecloud/sdks/go" target="_blank" rel="noopener noreferrer">View on pkg.go.dev</a>
+      </div>
+      <div class="sdk-card">
+        <div class="label">Rust</div>
+        <h3><code>cargo add fakecloud-sdk</code></h3>
+        <p>Native Rust client for tests that need resets, state inspection, and direct access to the fakecloud introspection surface.</p>
+        <a href="https://crates.io/crates/fakecloud-sdk" target="_blank" rel="noopener noreferrer">View on crates.io</a>
       </div>
     </div>
   </div>
@@ -137,7 +143,7 @@
           <tr><td>Idle memory</td><td class="check">~10 MiB</td><td class="cross">~150 MiB</td></tr>
           <tr><td>Install size</td><td class="check">~19 MB binary</td><td class="cross">~1 GB Docker image</td></tr>
           <tr><td>AWS services</td><td>15</td><td>30+</td></tr>
-          <tr><td>Test assertion SDKs</td><td class="check">TypeScript, Python, Go</td><td class="cross">No equivalent first-party SDK layer</td></tr>
+          <tr><td>Test assertion SDKs</td><td class="check">TypeScript, Python, Go, Rust</td><td>Python, Java</td></tr>
           <tr><td>Cognito User Pools</td><td class="check">80 operations</td><td class="cross">Paid only</td></tr>
           <tr><td>SES v2</td><td class="check">97 operations</td><td class="cross">Paid only</td></tr>
           <tr><td>SES inbound email</td><td class="check">Real receipt rule actions</td><td class="cross">Stored but never executed</td></tr>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -1,16 +1,17 @@
 {% extends "base.html" %}
 
-{% block title %}fakecloud - Local AWS Cloud Emulator{% endblock %}
-{% block description %}fakecloud is a free, open-source local AWS cloud emulator. Single binary, no auth required, no paid tiers.{% endblock %}
+{% block title %}fakecloud - Local AWS Emulator For Integration Tests{% endblock %}
+{% block description %}fakecloud is a free, open-source local AWS emulator for integration tests. Single binary, no auth required, plus first-party SDKs for test assertions.{% endblock %}
 
 {% block content %}
 <section class="hero">
   <div class="container">
     <h1>fake<span>cloud</span></h1>
-    <p class="tagline">Local AWS cloud emulator. Free forever.</p>
+    <p class="tagline">Local AWS emulator for integration tests. Run your app with normal AWS clients, then assert behavior with fakecloud SDKs.</p>
+    <p class="hero-proof">15 services. 922 operations. 100% conformance across implemented APIs.</p>
     <div class="btn-group">
       <a href="#quickstart" class="btn">Get Started</a>
-      <a href="{{ config.extra.github }}" class="btn btn-outline">View on GitHub</a>
+      <a href="#sdks" class="btn btn-outline">Explore SDKs</a>
     </div>
   </div>
 </section>
@@ -20,10 +21,10 @@
     <h2 class="section-title">Why fakecloud?</h2>
     <div class="why-box">
       <p>
-        LocalStack replaced their open-source Community Edition with a proprietary image that requires an account and auth token. Their free tier is restricted to non-commercial use only.
+        fakecloud gives you a local AWS environment that behaves like infrastructure, not a mock. Your app uses the regular AWS SDK, CLI, and IaC tools. Your tests get extra superpowers through fakecloud's introspection and simulation API.
       </p>
       <p style="margin-top: 16px;">
-        <strong>fakecloud is the fix.</strong> A fast, lightweight emulator for the AWS services you actually use in local dev. No login, no license key, no cloud account. Just run it and point your SDK at localhost.
+        <strong>That means less guessing in tests.</strong> Start fakecloud, run the code you actually ship, inspect emails/messages/invocations after the fact, and force async AWS-style behavior to happen on demand.
       </p>
     </div>
   </div>
@@ -31,38 +32,65 @@
 
 <section id="features">
   <div class="container">
-    <h2 class="section-title">Built for local dev</h2>
-    <p class="section-sub">Focused scope, zero friction, actually works.</p>
+    <h2 class="section-title">Built for realistic local testing</h2>
+    <p class="section-sub">Real APIs for your app, purpose-built tooling for your tests.</p>
     <div class="features-grid">
       <div class="feature">
-        <div class="label">Simple</div>
-        <h3>Single binary</h3>
-        <p>One binary, one port, one command to run. Starts in under 100ms. Also available as a Docker image.</p>
+        <div class="label">Workflow</div>
+        <h3>Test what your app really does</h3>
+        <p>Use normal AWS clients against localhost, then verify the effects with fakecloud instead of stitching together polling, fixtures, or private test hooks.</p>
       </div>
       <div class="feature">
-        <div class="label">Open</div>
-        <h3>No auth required</h3>
-        <p>SigV4 signatures are parsed for routing but never validated. Use any dummy credentials.</p>
+        <div class="label">SDKs</div>
+        <h3>First-party test clients</h3>
+        <p>TypeScript, Python, and Go SDKs wrap the <code>/_fakecloud/*</code> endpoints for resets, assertions, and manual control of async processors.</p>
       </div>
       <div class="feature">
         <div class="label">Coverage</div>
         <h3>15 AWS services</h3>
-        <p>S3, SQS, SNS, EventBridge, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES, Cognito User Pools. The services local dev actually needs.</p>
+        <p>S3, SQS, SNS, EventBridge, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES, and Cognito User Pools.</p>
       </div>
       <div class="feature">
         <div class="label">Tested</div>
         <h3>Conformance tested</h3>
-        <p>34,856 auto-generated test variants at 100% conformance against official AWS Smithy models across all 983 API operations, plus 500+ handwritten conformance tests and 280+ native E2E tests.</p>
+        <p>100% conformance across all 922 implemented API operations, backed by model-driven conformance coverage plus end-to-end tests against the official AWS SDKs.</p>
       </div>
       <div class="feature">
-        <div class="label">Scheduling</div>
-        <h3>EventBridge rules</h3>
-        <p>Cron and rate-based scheduling that actually fires. Rules deliver to SQS and SNS targets on schedule.</p>
+        <div class="label">Real behavior</div>
+        <h3>Cross-service flows are wired up</h3>
+        <p>SES fanout, inbound email actions, S3 notifications, SQS to Lambda, EventBridge targets, and CloudFormation custom resources all exercise real service interactions.</p>
       </div>
       <div class="feature">
-        <div class="label">Wired up</div>
-        <h3>Cross-service delivery</h3>
-        <p>S3 bucket notifications deliver to SNS/SQS. SNS fans out to SQS. EventBridge rules target SQS/SNS. S3 lifecycle runs in the background. Services talk to each other like they do on real AWS.</p>
+        <div class="label">Simple</div>
+        <h3>No auth, no lock-in, no paid tier</h3>
+        <p>Run a single binary or Docker image, use any dummy credentials, and keep the whole workflow local without signing in to someone else's platform.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="sdks">
+  <div class="container">
+    <h2 class="section-title">SDKs for test assertions</h2>
+    <p class="section-sub">Keep using the AWS SDK in your app. Use fakecloud SDKs when your tests need visibility and control.</p>
+    <div class="sdk-grid">
+      <div class="sdk-card">
+        <div class="label">TypeScript</div>
+        <h3><code>npm install fakecloud</code></h3>
+        <p>Inspect SES emails, SNS messages, SQS queues, Lambda invocations, Cognito confirmation codes, and more.</p>
+        <a href="{{ config.extra.github }}/tree/main/sdks/typescript">View TypeScript SDK</a>
+      </div>
+      <div class="sdk-card">
+        <div class="label">Python</div>
+        <h3><code>pip install fakecloud</code></h3>
+        <p>Async and sync clients for pytest or app-level integration tests, with the same introspection and simulation coverage.</p>
+        <a href="{{ config.extra.github }}/tree/main/sdks/python">View Python SDK</a>
+      </div>
+      <div class="sdk-card">
+        <div class="label">Go</div>
+        <h3><code>go get github.com/faiscadev/fakecloud/sdks/go</code></h3>
+        <p>Context-friendly helpers for resets, event history, SES inbound simulation, and the rest of the fakecloud test surface.</p>
+        <a href="{{ config.extra.github }}/tree/main/sdks/go">View Go SDK</a>
       </div>
     </div>
   </div>
@@ -71,18 +99,18 @@
 <section id="quickstart">
   <div class="container">
     <h2 class="section-title">Quick Start</h2>
-    <p class="section-sub">One command. No signup. No config file.</p>
+    <p class="section-sub">Start fakecloud, point your AWS client at localhost, then assert what happened.</p>
     <div class="code-block">
       <span class="comment"># Install (no Cargo or Docker needed)</span><br>
       <span class="prompt">$ </span>curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash<br>
       <span class="prompt">$ </span>fakecloud<br>
       <br>
-      <span class="comment"># Or with Docker</span><br>
-      <span class="prompt">$ </span>docker run -p 4566:4566 ghcr.io/faiscadev/fakecloud<br>
-      <br>
-      <span class="comment"># Point any AWS SDK at localhost</span><br>
+      <span class="comment"># Your app uses the normal AWS SDK against localhost</span><br>
       <span class="prompt">$ </span>aws --endpoint-url http://localhost:4566 sqs create-queue \<br>
       &nbsp;&nbsp;&nbsp;&nbsp;--queue-name my-queue<br>
+      <br>
+      <span class="comment"># Your tests can inspect state through the fakecloud SDK</span><br>
+      <span class="prompt">$ </span>npm install fakecloud
     </div>
   </div>
 </section>
@@ -90,6 +118,7 @@
 <section id="compare">
   <div class="container">
     <h2 class="section-title">How it compares</h2>
+    <p class="section-sub">If you want a fully local workflow with real AWS APIs and no account requirement, fakecloud is built for that path.</p>
     <div class="table-wrap">
       <table>
         <thead>
@@ -104,10 +133,8 @@
           <tr><td>Auth required</td><td class="check">No</td><td class="cross">Yes (account + token)</td></tr>
           <tr><td>Commercial use</td><td class="check">Free</td><td class="cross">Paid plans only</td></tr>
           <tr><td>Docker required</td><td class="check">No (standalone binary)</td><td class="cross">Yes</td></tr>
-          <tr><td>Startup time</td><td class="check">~500ms</td><td class="cross">~3s</td></tr>
-          <tr><td>Idle memory</td><td class="check">~10 MiB</td><td class="cross">~150 MiB</td></tr>
-          <tr><td>Install size</td><td class="check">~19 MB binary</td><td class="cross">~1 GB Docker image</td></tr>
           <tr><td>AWS services</td><td>15</td><td>30+</td></tr>
+          <tr><td>Test assertion SDKs</td><td class="check">TypeScript, Python, Go</td><td class="cross">No equivalent first-party SDK layer</td></tr>
           <tr><td>Cognito User Pools</td><td class="check">80 operations</td><td class="cross">Paid only</td></tr>
           <tr><td>SES v2</td><td class="check">97 operations</td><td class="cross">Paid only</td></tr>
           <tr><td>SES inbound email</td><td class="check">Real receipt rule actions</td><td class="cross">Stored but never executed</td></tr>
@@ -120,7 +147,7 @@
 <section id="services">
   <div class="container">
     <h2 class="section-title">Supported services</h2>
-    <p class="section-sub">Every emulated API is tested against the official AWS SDK.</p>
+    <p class="section-sub">Every implemented API is covered by conformance and behavioral testing, with the service mix tuned for local development and integration tests.</p>
     <div class="services-grid">
       <div class="service"><div class="name">S3</div><div class="proto">REST protocol &middot; XML</div></div>
       <div class="service"><div class="name">SQS</div><div class="proto">Query protocol &middot; XML</div></div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 
-{% block title %}fakecloud - Local AWS Emulator For Integration Tests{% endblock %}
-{% block description %}fakecloud is a free, open-source local AWS emulator for integration tests. Single binary, no auth required, plus first-party SDKs for test assertions.{% endblock %}
+{% block title %}fakecloud - Local AWS Cloud Emulator{% endblock %}
+{% block description %}fakecloud is a free, open-source local AWS cloud emulator. Single binary, no auth required, no paid tier, plus first-party SDKs for test assertions.{% endblock %}
 
 {% block content %}
 <section class="hero">
   <div class="container">
     <h1>fake<span>cloud</span></h1>
-    <p class="tagline">Local AWS emulator for integration tests. Run your app with normal AWS clients, then assert behavior with fakecloud SDKs.</p>
+    <p class="tagline">Local AWS cloud emulator for integration tests. Run your app with normal AWS clients, stay fully local, and use fakecloud SDKs when your tests need deeper visibility.</p>
     <p class="hero-proof">15 services. 922 operations. 100% conformance across implemented APIs.</p>
     <div class="btn-group">
       <a href="#quickstart" class="btn">Get Started</a>
-      <a href="#sdks" class="btn btn-outline">Explore SDKs</a>
+      <a href="#compare" class="btn btn-outline">Why fakecloud</a>
     </div>
   </div>
 </section>
@@ -21,10 +21,10 @@
     <h2 class="section-title">Why fakecloud?</h2>
     <div class="why-box">
       <p>
-        fakecloud gives you a local AWS environment that behaves like infrastructure, not a mock. Your app uses the regular AWS SDK, CLI, and IaC tools. Your tests get extra superpowers through fakecloud's introspection and simulation API.
+        fakecloud gives you a local AWS environment that behaves like infrastructure, not a mock. Your app uses the regular AWS SDK, CLI, and IaC tools. Unlike today's LocalStack Community setup, you do not need an account, auth token, or paid plan just to keep core development flows local.
       </p>
       <p style="margin-top: 16px;">
-        <strong>That means less guessing in tests.</strong> Start fakecloud, run the code you actually ship, inspect emails/messages/invocations after the fact, and force async AWS-style behavior to happen on demand.
+        <strong>The SDKs make that workflow nicer, not narrower.</strong> Start fakecloud, run the code you actually ship, inspect emails/messages/invocations after the fact, and force async AWS-style behavior to happen on demand.
       </p>
     </div>
   </div>
@@ -43,7 +43,7 @@
       <div class="feature">
         <div class="label">SDKs</div>
         <h3>First-party test clients</h3>
-        <p>TypeScript, Python, and Go SDKs wrap the <code>/_fakecloud/*</code> endpoints for resets, assertions, and manual control of async processors.</p>
+        <p>TypeScript, Python, and Go SDKs wrap the <code>/_fakecloud/*</code> endpoints for resets, assertions, and manual control of async processors after your app has already used the normal AWS APIs.</p>
       </div>
       <div class="feature">
         <div class="label">Coverage</div>
@@ -72,7 +72,7 @@
 <section id="sdks">
   <div class="container">
     <h2 class="section-title">SDKs for test assertions</h2>
-    <p class="section-sub">Keep using the AWS SDK in your app. Use fakecloud SDKs when your tests need visibility and control.</p>
+    <p class="section-sub">Keep using the AWS SDK in your app. Use fakecloud SDKs when your tests need visibility and control on top of the emulator itself.</p>
     <div class="sdk-grid">
       <div class="sdk-card">
         <div class="label">TypeScript</div>
@@ -118,7 +118,7 @@
 <section id="compare">
   <div class="container">
     <h2 class="section-title">How it compares</h2>
-    <p class="section-sub">If you want a fully local workflow with real AWS APIs and no account requirement, fakecloud is built for that path.</p>
+    <p class="section-sub">If you want a fully local workflow with real AWS APIs and no account requirement, fakecloud is built for that path. The SDKs are an extra testing advantage, not a replacement for that positioning.</p>
     <div class="table-wrap">
       <table>
         <thead>
@@ -133,6 +133,9 @@
           <tr><td>Auth required</td><td class="check">No</td><td class="cross">Yes (account + token)</td></tr>
           <tr><td>Commercial use</td><td class="check">Free</td><td class="cross">Paid plans only</td></tr>
           <tr><td>Docker required</td><td class="check">No (standalone binary)</td><td class="cross">Yes</td></tr>
+          <tr><td>Startup time</td><td class="check">~500ms</td><td class="cross">~3s</td></tr>
+          <tr><td>Idle memory</td><td class="check">~10 MiB</td><td class="cross">~150 MiB</td></tr>
+          <tr><td>Install size</td><td class="check">~19 MB binary</td><td class="cross">~1 GB Docker image</td></tr>
           <tr><td>AWS services</td><td>15</td><td>30+</td></tr>
           <tr><td>Test assertion SDKs</td><td class="check">TypeScript, Python, Go</td><td class="cross">No equivalent first-party SDK layer</td></tr>
           <tr><td>Cognito User Pools</td><td class="check">80 operations</td><td class="cross">Paid only</td></tr>


### PR DESCRIPTION
## Summary
- reposition fakecloud around the new SDK-enabled testing workflow
- refresh the README to highlight first-party TypeScript, Python, and Go SDKs
- update the homepage copy and nav to foreground SDKs and integration-testing use cases
- fix the stale roadmap note that still described SDKs as future work

## Testing
- not run (content and template changes only)
- unable to run a local Zola build here because  is not installed in this environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes README, ROADMAP, and website for the SDK launch, now including Rust, and refocuses copy on realistic local testing: your app uses AWS SDKs; `fakecloud` SDKs handle test assertions and control.

- **Docs & Website**
  - README: adds “Why teams use fakecloud,” a “First‑party SDKs” table (`fakecloud` for TypeScript/Python, `github.com/faiscadev/fakecloud/sdks/go` for Go, `fakecloud-sdk` for Rust), a short test flow, an AWS CLI example in Quick Start, clearer Testing notes (conformance + E2E), and refreshed numbers (922 operations, version 0.5.1). Messaging states SDKs complement normal AWS clients.
  - Rust SDK: adds `crates/fakecloud-sdk/README.md` and sets `readme` in the crate; website SDKs section includes a Rust card linking to crates.io.
  - Website: new “SDKs for test assertions” section with cards and links (TS/Python/Go/Rust); “SDKs” added to nav; meta description updated; hero/tagline revised for integration tests with a proof line; buttons tweaked (“Why fakecloud”); Quick Start shows using AWS clients first, then a `fakecloud` SDK; compare table adds a “Test assertion SDKs” row; copy tightened across features/services.
  - Styles: adds SDK grid/card styles, hero proof line, and a more responsive hero button group.
  - ROADMAP: marks TypeScript/Python/Go SDKs as shipped; notes future focus on Rust/Java.

<sup>Written for commit 73318f04a6715de082267691a8226a3a9ac441cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

