### PR TITLE
feat: scaffold kinesis service wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,6 +1482,7 @@ dependencies = [
  "fakecloud-dynamodb",
  "fakecloud-eventbridge",
  "fakecloud-iam",
+ "fakecloud-kinesis",
  "fakecloud-kms",
  "fakecloud-lambda",
  "fakecloud-logs",
@@ -1711,6 +1712,18 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "fakecloud-kinesis"
+version = "0.5.1"
+dependencies = [
+ "async-trait",
+ "fakecloud-core",
+ "http 1.4.0",
+ "parking_lot",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/fakecloud-cloudformation",
     "crates/fakecloud-ses",
     "crates/fakecloud-cognito",
+    "crates/fakecloud-kinesis",
     "crates/fakecloud-sdk",
     "crates/fakecloud-e2e",
     "crates/fakecloud-conformance",
@@ -82,4 +83,5 @@ fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.5.1" }
 fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.5.1" }
 fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.5.1" }
 fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.5.1" }
+fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.5.1" }
 fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.5.1" }

--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -133,6 +133,7 @@ fn parse_amz_target(target: &str) -> Option<DetectedRequest> {
         s if s.starts_with("secretsmanager") => "secretsmanager",
         s if s.starts_with("TrentService") => "kms",
         s if s.starts_with("AWSCognitoIdentityProviderService") => "cognito-idp",
+        s if s.starts_with("Kinesis_20131202") => "kinesis",
         _ => return None,
     };
 
@@ -295,6 +296,14 @@ mod tests {
         let result = parse_amz_target("AmazonSSM.GetParameter").unwrap();
         assert_eq!(result.service, "ssm");
         assert_eq!(result.action, "GetParameter");
+    }
+
+    #[test]
+    fn parse_amz_target_kinesis() {
+        let result = parse_amz_target("Kinesis_20131202.ListStreams").unwrap();
+        assert_eq!(result.service, "kinesis");
+        assert_eq!(result.action, "ListStreams");
+        assert_eq!(result.protocol, AwsProtocol::Json);
     }
 
     #[test]

--- a/crates/fakecloud-e2e/tests/sdk.rs
+++ b/crates/fakecloud-e2e/tests/sdk.rs
@@ -24,6 +24,10 @@ async fn sdk_health() {
         resp.services.contains(&"sqs".to_string()),
         "should contain sqs"
     );
+    assert!(
+        resp.services.contains(&"kinesis".to_string()),
+        "should contain kinesis"
+    );
 }
 
 // ── Reset (global) ─────────────────────────────────────────────────
@@ -101,6 +105,15 @@ async fn sdk_reset_service_sqs() {
         msgs.queues.is_empty(),
         "SQS should be empty after reset_service"
     );
+}
+
+#[tokio::test]
+async fn sdk_reset_service_kinesis() {
+    let server = TestServer::start().await;
+    let fc = FakeCloud::new(server.endpoint());
+
+    let resp = fc.reset_service("kinesis").await.expect("reset kinesis");
+    assert_eq!(resp.reset, "kinesis");
 }
 
 // ── SQS ────────────────────────────────────────────────────────────

--- a/crates/fakecloud-kinesis/Cargo.toml
+++ b/crates/fakecloud-kinesis/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fakecloud-kinesis"
+description = "Kinesis Data Streams implementation for FakeCloud"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+version.workspace = true
+
+[dependencies]
+fakecloud-core = { workspace = true }
+async-trait = { workspace = true }
+http = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/fakecloud-kinesis/src/lib.rs
+++ b/crates/fakecloud-kinesis/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod service;
+pub mod state;

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+
+use crate::state::SharedKinesisState;
+
+pub struct KinesisService {
+    state: SharedKinesisState,
+}
+
+impl KinesisService {
+    pub fn new(state: SharedKinesisState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl AwsService for KinesisService {
+    fn service_name(&self) -> &str {
+        "kinesis"
+    }
+
+    async fn handle(&self, request: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let _ = &self.state;
+        Err(AwsServiceError::action_not_implemented(
+            self.service_name(),
+            &request.action,
+        ))
+    }
+
+    fn supported_actions(&self) -> &[&str] {
+        &[]
+    }
+}

--- a/crates/fakecloud-kinesis/src/state.rs
+++ b/crates/fakecloud-kinesis/src/state.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+pub type SharedKinesisState = Arc<RwLock<KinesisState>>;
+
+pub struct KinesisState {
+    pub account_id: String,
+    pub region: String,
+    pub streams: HashMap<String, KinesisStream>,
+}
+
+pub struct KinesisStream {
+    pub stream_name: String,
+}
+
+impl KinesisState {
+    pub fn new(account_id: &str, region: &str) -> Self {
+        Self {
+            account_id: account_id.to_string(),
+            region: region.to_string(),
+            streams: HashMap::new(),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.streams.clear();
+    }
+}

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -30,6 +30,7 @@ fakecloud-kms = { workspace = true }
 fakecloud-cloudformation = { workspace = true }
 fakecloud-ses = { workspace = true }
 fakecloud-cognito = { workspace = true }
+fakecloud-kinesis = { workspace = true }
 fakecloud-sdk = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -21,6 +21,7 @@ use fakecloud_dynamodb::service::DynamoDbService;
 use fakecloud_eventbridge::service::EventBridgeService;
 use fakecloud_iam::iam_service::IamService;
 use fakecloud_iam::sts_service::StsService;
+use fakecloud_kinesis::service::KinesisService;
 use fakecloud_kms::service::KmsService;
 use fakecloud_lambda::service::LambdaService;
 use fakecloud_logs::service::LogsService;
@@ -137,6 +138,9 @@ async fn main() {
     let cognito_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_cognito::state::CognitoState::new(&cli.account_id, &cli.region),
     ));
+    let kinesis_state = Arc::new(parking_lot::RwLock::new(
+        fakecloud_kinesis::state::KinesisState::new(&cli.account_id, &cli.region),
+    ));
 
     // Cross-service delivery bus
     // Step 1: SQS delivery (SNS and EventBridge can push messages into SQS queues)
@@ -237,6 +241,7 @@ async fn main() {
         cloudformation: cloudformation_state.clone(),
         ses: ses_state.clone(),
         cognito: cognito_state.clone(),
+        kinesis: kinesis_state.clone(),
         container_runtime: container_runtime.clone(),
     };
 
@@ -344,6 +349,7 @@ async fn main() {
     registry.register(Arc::new(
         CognitoService::new(cognito_state.clone()).with_delivery(cognito_delivery_ctx),
     ));
+    registry.register(Arc::new(KinesisService::new(kinesis_state)));
 
     // Spawn background tasks
     let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state);
@@ -1040,6 +1046,7 @@ struct ResetState {
     cloudformation: fakecloud_cloudformation::state::SharedCloudFormationState,
     ses: fakecloud_ses::state::SharedSesState,
     cognito: fakecloud_cognito::state::SharedCognitoState,
+    kinesis: fakecloud_kinesis::state::SharedKinesisState,
     container_runtime: Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
 }
 
@@ -1106,6 +1113,9 @@ impl ResetState {
             "cognito" => {
                 self.cognito.write().reset();
             }
+            "kinesis" => {
+                self.kinesis.write().reset();
+            }
             _ => {
                 return Err(format!("Unknown service: {service}"));
             }
@@ -1151,6 +1161,7 @@ impl ResetState {
         self.cloudformation.write().reset();
         self.ses.write().reset();
         self.cognito.write().reset();
+        self.kinesis.write().reset();
         tracing::info!("state reset via reset API");
         axum::Json(types::ResetResponse {
             status: "ok".to_string(),


### PR DESCRIPTION
## Summary
- add a new `fakecloud-kinesis` crate with minimal state and service scaffolding for the first Kinesis slice
- wire Kinesis into JSON protocol detection, server registration, health output, and reset handling
- add focused tests for target detection and SDK-visible health/reset behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded a new Kinesis service and wired it into the server so we detect Kinesis JSON targets, show it in health, and support per-service/global resets. No Kinesis APIs are implemented yet; requests return NotImplemented.

- **New Features**
  - Added `fakecloud-kinesis` crate with minimal state and `KinesisService`.
  - JSON protocol detects `Kinesis_20131202.*`; unit test included.
  - Server registers Kinesis; health endpoint lists `kinesis`.
  - Reset API supports `service=kinesis` and global reset; e2e tests added.

<sup>Written for commit 7110bd06297297dfa95b3bcfe0e5233ba7735b6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

