### PR TITLE
feat: scaffold rds service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,7 @@ dependencies = [
  "fakecloud-kms",
  "fakecloud-lambda",
  "fakecloud-logs",
+ "fakecloud-rds",
  "fakecloud-s3",
  "fakecloud-sdk",
  "fakecloud-secretsmanager",
@@ -1816,6 +1817,17 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "fakecloud-rds"
+version = "0.5.1"
+dependencies = [
+ "async-trait",
+ "fakecloud-core",
+ "parking_lot",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/fakecloud-ses",
     "crates/fakecloud-cognito",
     "crates/fakecloud-kinesis",
+    "crates/fakecloud-rds",
     "crates/fakecloud-sdk",
     "crates/fakecloud-e2e",
     "crates/fakecloud-conformance",
@@ -84,4 +85,5 @@ fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version =
 fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.5.1" }
 fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.5.1" }
 fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.5.1" }
+fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.5.1" }
 fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.5.1" }

--- a/aws-models/service-map.json
+++ b/aws-models/service-map.json
@@ -62,5 +62,9 @@
   "cognito-identity-provider": {
     "repo_dir": "cognito-identity-provider",
     "service_name": "cognito-idp"
+  },
+  "rds": {
+    "repo_dir": "rds",
+    "service_name": "rds"
   }
 }

--- a/crates/fakecloud-rds/Cargo.toml
+++ b/crates/fakecloud-rds/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fakecloud-rds"
+description = "Amazon RDS implementation for FakeCloud"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+version.workspace = true
+
+[dependencies]
+fakecloud-core = { workspace = true }
+async-trait = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/fakecloud-rds/src/lib.rs
+++ b/crates/fakecloud-rds/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod service;
+pub mod state;

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+
+use crate::state::SharedRdsState;
+
+pub struct RdsService {
+    state: SharedRdsState,
+}
+
+impl RdsService {
+    pub fn new(state: SharedRdsState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl AwsService for RdsService {
+    fn service_name(&self) -> &str {
+        "rds"
+    }
+
+    async fn handle(&self, request: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let _ = &self.state;
+        Err(AwsServiceError::action_not_implemented(
+            self.service_name(),
+            &request.action,
+        ))
+    }
+
+    fn supported_actions(&self) -> &[&str] {
+        &[]
+    }
+}

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+pub type SharedRdsState = Arc<RwLock<RdsState>>;
+
+#[derive(Debug, Clone)]
+pub struct DbInstance {
+    pub db_instance_identifier: String,
+}
+
+#[derive(Debug)]
+pub struct RdsState {
+    pub account_id: String,
+    pub region: String,
+    pub instances: HashMap<String, DbInstance>,
+}
+
+impl RdsState {
+    pub fn new(account_id: &str, region: &str) -> Self {
+        Self {
+            account_id: account_id.to_string(),
+            region: region.to_string(),
+            instances: HashMap::new(),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.instances.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DbInstance, RdsState};
+
+    #[test]
+    fn new_initializes_account_and_region() {
+        let state = RdsState::new("123456789012", "us-east-1");
+
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "us-east-1");
+        assert!(state.instances.is_empty());
+    }
+
+    #[test]
+    fn reset_clears_instances() {
+        let mut state = RdsState::new("123456789012", "us-east-1");
+        state.instances.insert(
+            "db-1".to_string(),
+            DbInstance {
+                db_instance_identifier: "db-1".to_string(),
+            },
+        );
+
+        state.reset();
+
+        assert!(state.instances.is_empty());
+    }
+}

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -31,6 +31,7 @@ fakecloud-cloudformation = { workspace = true }
 fakecloud-ses = { workspace = true }
 fakecloud-cognito = { workspace = true }
 fakecloud-kinesis = { workspace = true }
+fakecloud-rds = { workspace = true }
 fakecloud-sdk = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -25,6 +25,7 @@ use fakecloud_kinesis::service::KinesisService;
 use fakecloud_kms::service::KmsService;
 use fakecloud_lambda::service::LambdaService;
 use fakecloud_logs::service::LogsService;
+use fakecloud_rds::service::RdsService;
 use fakecloud_s3::service::S3Service;
 use fakecloud_secretsmanager::service::SecretsManagerService;
 use fakecloud_ses::service::SesV2Service;
@@ -141,6 +142,9 @@ async fn main() {
     let kinesis_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_kinesis::state::KinesisState::new(&cli.account_id, &cli.region),
     ));
+    let rds_state = Arc::new(parking_lot::RwLock::new(
+        fakecloud_rds::state::RdsState::new(&cli.account_id, &cli.region),
+    ));
 
     // Cross-service delivery bus
     // Step 1: SQS delivery (SNS and EventBridge can push messages into SQS queues)
@@ -242,6 +246,7 @@ async fn main() {
         ses: ses_state.clone(),
         cognito: cognito_state.clone(),
         kinesis: kinesis_state.clone(),
+        rds: rds_state.clone(),
         container_runtime: container_runtime.clone(),
     };
 
@@ -350,6 +355,7 @@ async fn main() {
         CognitoService::new(cognito_state.clone()).with_delivery(cognito_delivery_ctx),
     ));
     registry.register(Arc::new(KinesisService::new(kinesis_state)));
+    registry.register(Arc::new(RdsService::new(rds_state)));
 
     // Spawn background tasks
     let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state);
@@ -1047,6 +1053,7 @@ struct ResetState {
     ses: fakecloud_ses::state::SharedSesState,
     cognito: fakecloud_cognito::state::SharedCognitoState,
     kinesis: fakecloud_kinesis::state::SharedKinesisState,
+    rds: fakecloud_rds::state::SharedRdsState,
     container_runtime: Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
 }
 
@@ -1116,6 +1123,9 @@ impl ResetState {
             "kinesis" => {
                 self.kinesis.write().reset();
             }
+            "rds" => {
+                self.rds.write().reset();
+            }
             _ => {
                 return Err(format!("Unknown service: {service}"));
             }
@@ -1162,6 +1172,7 @@ impl ResetState {
         self.ses.write().reset();
         self.cognito.write().reset();
         self.kinesis.write().reset();
+        self.rds.write().reset();
         tracing::info!("state reset via reset API");
         axum::Json(types::ResetResponse {
             status: "ok".to_string(),
@@ -1174,4 +1185,93 @@ async fn shutdown_signal() {
         .await
         .expect("failed to install Ctrl+C handler");
     tracing::info!("shutting down");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use fakecloud_rds::state::{DbInstance, RdsState};
+
+    use super::ResetState;
+
+    #[test]
+    fn reset_service_clears_rds_state() {
+        let mut rds = RdsState::new("123456789012", "us-east-1");
+        rds.instances.insert(
+            "db-1".to_string(),
+            DbInstance {
+                db_instance_identifier: "db-1".to_string(),
+            },
+        );
+
+        let state = ResetState {
+            iam: Arc::new(parking_lot::RwLock::new(
+                fakecloud_iam::state::IamState::new("123456789012"),
+            )),
+            sqs: Arc::new(parking_lot::RwLock::new(
+                fakecloud_sqs::state::SqsState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+            )),
+            sns: Arc::new(parking_lot::RwLock::new(
+                fakecloud_sns::state::SnsState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+            )),
+            eb: Arc::new(parking_lot::RwLock::new(
+                fakecloud_eventbridge::state::EventBridgeState::new("123456789012", "us-east-1"),
+            )),
+            ssm: Arc::new(parking_lot::RwLock::new(
+                fakecloud_ssm::state::SsmState::new("123456789012", "us-east-1"),
+            )),
+            dynamodb: Arc::new(parking_lot::RwLock::new(
+                fakecloud_dynamodb::state::DynamoDbState::new("123456789012", "us-east-1"),
+            )),
+            lambda: Arc::new(parking_lot::RwLock::new(
+                fakecloud_lambda::state::LambdaState::new("123456789012", "us-east-1"),
+            )),
+            secretsmanager: Arc::new(parking_lot::RwLock::new(
+                fakecloud_secretsmanager::state::SecretsManagerState::new(
+                    "123456789012",
+                    "us-east-1",
+                ),
+            )),
+            s3: Arc::new(parking_lot::RwLock::new(fakecloud_s3::state::S3State::new(
+                "123456789012",
+                "us-east-1",
+            ))),
+            logs: Arc::new(parking_lot::RwLock::new(
+                fakecloud_logs::state::LogsState::new("123456789012", "us-east-1"),
+            )),
+            kms: Arc::new(parking_lot::RwLock::new(
+                fakecloud_kms::state::KmsState::new("123456789012", "us-east-1"),
+            )),
+            cloudformation: Arc::new(parking_lot::RwLock::new(
+                fakecloud_cloudformation::state::CloudFormationState::new(
+                    "123456789012",
+                    "us-east-1",
+                ),
+            )),
+            ses: Arc::new(parking_lot::RwLock::new(
+                fakecloud_ses::state::SesState::new("123456789012", "us-east-1"),
+            )),
+            cognito: Arc::new(parking_lot::RwLock::new(
+                fakecloud_cognito::state::CognitoState::new("123456789012", "us-east-1"),
+            )),
+            kinesis: Arc::new(parking_lot::RwLock::new(
+                fakecloud_kinesis::state::KinesisState::new("123456789012", "us-east-1"),
+            )),
+            rds: Arc::new(parking_lot::RwLock::new(rds)),
+            container_runtime: None,
+        };
+
+        state.reset_service("rds").expect("reset rds");
+
+        assert!(state.rds.read().instances.is_empty());
+    }
 }

--- a/scripts/update-aws-models.sh
+++ b/scripts/update-aws-models.sh
@@ -36,6 +36,7 @@ SERVICES=(
     "cloudformation:cloudformation"
     "sesv2:sesv2"
     "cognito-identity-provider:cognito-identity-provider"
+    "rds:rds"
 )
 
 # Sparse checkout only the models we need


### PR DESCRIPTION
## Summary
- add a new `fakecloud-rds` crate with initial state and service skeleton
- wire RDS into the workspace, server registry, reset flow, and model sync config
- add minimal unit coverage for RDS state and reset behavior

## Validation
- cargo fmt --all
- cargo test -p fakecloud-rds -p fakecloud --lib --bins
- cargo build
- cargo test -p fakecloud-conformance --test cloudformation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded the RDS service with a new `fakecloud-rds` crate and integrated it into the server, reset flow, and AWS model sync. Provides initial state and service skeleton; no RDS actions implemented yet.

- **New Features**
  - Added `fakecloud-rds` crate with `RdsService`, `RdsState` (with `DbInstance`), and tests.
  - Wired RDS into `fakecloud-server`: state init, service registry, reset API/reset-all; added test to verify reset clears instances.
  - Included RDS in workspace and server dependencies.
  - Updated model sync: added RDS to `aws-models/service-map.json` and `scripts/update-aws-models.sh`.

<sup>Written for commit 3ebd9a58750413e20d367ef4dea0ea84d4358a31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

