### PR TITLE
fix: address kinesis iterator review issues

### DIFF
--- a/crates/fakecloud-e2e/tests/kinesis.rs
+++ b/crates/fakecloud-e2e/tests/kinesis.rs
@@ -302,3 +302,105 @@ async fn kinesis_latest_iterator_starts_after_existing_records() {
     assert_eq!(records.records().len(), 1);
     assert_eq!(records.records()[0].partition_key(), "key");
 }
+
+#[tokio::test]
+async fn kinesis_iterator_can_be_retried_before_expiry() {
+    let server = TestServer::start().await;
+    let client = server.kinesis_client().await;
+
+    client
+        .create_stream()
+        .stream_name("retryable")
+        .shard_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    let write = client
+        .put_record()
+        .stream_name("retryable")
+        .partition_key("key")
+        .data(Blob::new(b"payload"))
+        .send()
+        .await
+        .unwrap();
+
+    let iterator = client
+        .get_shard_iterator()
+        .stream_name("retryable")
+        .shard_id(write.shard_id())
+        .shard_iterator_type(ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let shard_iterator = iterator.shard_iterator().unwrap().to_string();
+
+    let first = client
+        .get_records()
+        .shard_iterator(&shard_iterator)
+        .limit(1)
+        .send()
+        .await
+        .unwrap();
+    let retried = client
+        .get_records()
+        .shard_iterator(&shard_iterator)
+        .limit(1)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(first.records().len(), 1);
+    assert_eq!(retried.records().len(), 1);
+}
+
+#[tokio::test]
+async fn kinesis_reports_millis_behind_latest_when_limit_truncates() {
+    let server = TestServer::start().await;
+    let client = server.kinesis_client().await;
+
+    client
+        .create_stream()
+        .stream_name("lag")
+        .shard_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_record()
+        .stream_name("lag")
+        .partition_key("key")
+        .data(Blob::new(b"one"))
+        .send()
+        .await
+        .unwrap();
+    let write = client
+        .put_record()
+        .stream_name("lag")
+        .partition_key("key")
+        .data(Blob::new(b"two"))
+        .send()
+        .await
+        .unwrap();
+
+    let iterator = client
+        .get_shard_iterator()
+        .stream_name("lag")
+        .shard_id(write.shard_id())
+        .shard_iterator_type(ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+
+    let records = client
+        .get_records()
+        .shard_iterator(iterator.shard_iterator().unwrap())
+        .limit(1)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(records.records().len(), 1);
+    assert!(records.millis_behind_latest().unwrap_or_default() > 0);
+}

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -295,11 +295,15 @@ impl KinesisService {
             })
             .collect();
 
+        let millis_behind_latest = if end_index < shard.records.len() {
+            1
+        } else {
+            0
+        };
         let next_iterator = state.insert_iterator(&lease.stream_name, &lease.shard_id, end_index);
-        state.iterators.remove(&iterator);
 
         Ok(AwsResponse::ok_json(json!({
-            "MillisBehindLatest": 0,
+            "MillisBehindLatest": millis_behind_latest,
             "NextShardIterator": next_iterator,
             "Records": records,
         })))
@@ -799,5 +803,25 @@ mod tests {
 
         let index = shard_iterator_start_index(&shard, "LATEST", &json!({})).unwrap();
         assert_eq!(index, 2);
+    }
+
+    #[test]
+    fn insert_iterator_purges_expired_leases() {
+        let mut state = crate::state::KinesisState::new("123456789012", "us-east-1");
+        state.iterators.insert(
+            "expired".to_string(),
+            crate::state::ShardIteratorLease {
+                iterator_token: "expired".to_string(),
+                stream_name: "stream".to_string(),
+                shard_id: "shardId-000000000000".to_string(),
+                next_record_index: 0,
+                expires_at: Utc::now() - chrono::Duration::minutes(1),
+            },
+        );
+
+        let token = state.insert_iterator("stream", "shardId-000000000000", 0);
+
+        assert!(state.iterators.contains_key(&token));
+        assert!(!state.iterators.contains_key("expired"));
     }
 }

--- a/crates/fakecloud-kinesis/src/state.rs
+++ b/crates/fakecloud-kinesis/src/state.rs
@@ -81,6 +81,8 @@ impl KinesisState {
         shard_id: &str,
         next_record_index: usize,
     ) -> String {
+        self.iterators
+            .retain(|_, lease| lease.expires_at >= Utc::now());
         let token = format!(
             "{}:{}:{}:{}:{}",
             stream_name,


### PR DESCRIPTION
## Summary
- fix the Kinesis iterator lifetime behavior identified by cubic so shard iterators remain usable until expiry
- report non-zero `MillisBehindLatest` when `GetRecords` leaves unread records in the shard
- purge expired iterator leases when creating new iterators and add focused regression tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kinesis shard iterator lifetime and lag reporting. Iterators remain usable until expiry, MillisBehindLatest reflects unread records, and expired iterator leases are purged.

- **Bug Fixes**
  - Keep iterator leases active across GetRecords to allow retrying the same iterator before expiry.
  - Set MillisBehindLatest > 0 when more records remain after a limited read.
  - Purge expired iterator leases when creating new iterators to prevent stale tokens.

<sup>Written for commit 9072e6e255bbf6858a9b8694fe355d3c984a9a97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

