### PR TITLE
feat: add rds instance deletion

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -109,6 +109,38 @@ async fn rds_describe_db_instances() {
     );
 }
 
+#[test_action("rds", "DeleteDBInstance", checksum = "22909663")]
+#[tokio::test]
+async fn rds_delete_db_instance() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client).await;
+
+    let response = client
+        .delete_db_instance()
+        .db_instance_identifier("conf-rds-db")
+        .skip_final_snapshot(true)
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    assert_eq!(instance.db_instance_identifier(), Some("conf-rds-db"));
+    assert_eq!(instance.db_instance_status(), Some("deleting"));
+
+    let error = client
+        .describe_db_instances()
+        .db_instance_identifier("conf-rds-db")
+        .send()
+        .await
+        .expect_err("instance should be deleted");
+    assert_eq!(
+        error.into_service_error().meta().code(),
+        Some("DBInstanceNotFound")
+    );
+}
+
 #[test_action("rds", "AddTagsToResource", checksum = "79e71104")]
 #[tokio::test]
 async fn rds_add_tags_to_resource() {

--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -141,6 +141,26 @@ async fn rds_delete_db_instance() {
     );
 }
 
+#[tokio::test]
+async fn rds_delete_db_instance_rejects_deletion_protection() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance_with_deletion_protection(&client, "conf-rds-protected-db", true).await;
+
+    let error = client
+        .delete_db_instance()
+        .db_instance_identifier("conf-rds-protected-db")
+        .skip_final_snapshot(true)
+        .send()
+        .await
+        .expect_err("deletion protection should block deletion");
+    assert_eq!(
+        error.into_service_error().meta().code(),
+        Some("InvalidDBInstanceState")
+    );
+}
+
 #[test_action("rds", "AddTagsToResource", checksum = "79e71104")]
 #[tokio::test]
 async fn rds_add_tags_to_resource() {
@@ -275,15 +295,24 @@ async fn rds_remove_tags_from_resource() {
 async fn create_instance(
     client: &aws_sdk_rds::Client,
 ) -> aws_sdk_rds::operation::create_db_instance::CreateDbInstanceOutput {
+    create_instance_with_deletion_protection(client, "conf-rds-db", false).await
+}
+
+async fn create_instance_with_deletion_protection(
+    client: &aws_sdk_rds::Client,
+    db_instance_identifier: &str,
+    deletion_protection: bool,
+) -> aws_sdk_rds::operation::create_db_instance::CreateDbInstanceOutput {
     client
         .create_db_instance()
-        .db_instance_identifier("conf-rds-db")
+        .db_instance_identifier(db_instance_identifier)
         .allocated_storage(20)
         .db_instance_class("db.t3.micro")
         .engine("postgres")
         .engine_version("16.3")
         .master_username("admin")
         .master_user_password("secret123")
+        .deletion_protection(deletion_protection)
         .db_name("appdb")
         .send()
         .await

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -154,6 +154,36 @@ async fn rds_tag_roundtrip() {
     assert_eq!(listed.tag_list()[0].key(), Some("team"));
 }
 
+#[tokio::test]
+async fn rds_delete_db_instance() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client, "orders-delete-db").await;
+
+    let response = client
+        .delete_db_instance()
+        .db_instance_identifier("orders-delete-db")
+        .skip_final_snapshot(true)
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    assert_eq!(instance.db_instance_status(), Some("deleting"));
+
+    let error = client
+        .describe_db_instances()
+        .db_instance_identifier("orders-delete-db")
+        .send()
+        .await
+        .expect_err("instance should be gone");
+    assert_eq!(
+        error.into_service_error().meta().code(),
+        Some("DBInstanceNotFound")
+    );
+}
+
 async fn create_instance(
     client: &aws_sdk_rds::Client,
     db_instance_identifier: &str,

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -184,9 +184,45 @@ async fn rds_delete_db_instance() {
     );
 }
 
+#[tokio::test]
+async fn rds_delete_db_instance_respects_deletion_protection() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance_with_deletion_protection(&client, "orders-protected-db", true).await;
+
+    let error = client
+        .delete_db_instance()
+        .db_instance_identifier("orders-protected-db")
+        .skip_final_snapshot(true)
+        .send()
+        .await
+        .expect_err("deletion protection should block deletion");
+    assert_eq!(
+        error.into_service_error().meta().code(),
+        Some("InvalidDBInstanceState")
+    );
+
+    let response = client
+        .describe_db_instances()
+        .db_instance_identifier("orders-protected-db")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.db_instances().len(), 1);
+}
+
 async fn create_instance(
     client: &aws_sdk_rds::Client,
     db_instance_identifier: &str,
+) -> aws_sdk_rds::operation::create_db_instance::CreateDbInstanceOutput {
+    create_instance_with_deletion_protection(client, db_instance_identifier, false).await
+}
+
+async fn create_instance_with_deletion_protection(
+    client: &aws_sdk_rds::Client,
+    db_instance_identifier: &str,
+    deletion_protection: bool,
 ) -> aws_sdk_rds::operation::create_db_instance::CreateDbInstanceOutput {
     client
         .create_db_instance()
@@ -197,6 +233,7 @@ async fn create_instance(
         .engine_version("16.3")
         .master_username("admin")
         .master_user_password("secret123")
+        .deletion_protection(deletion_protection)
         .db_name("appdb")
         .send()
         .await

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -17,6 +17,7 @@ const RDS_NS: &str = "http://rds.amazonaws.com/doc/2014-10-31/";
 const SUPPORTED_ACTIONS: &[&str] = &[
     "AddTagsToResource",
     "CreateDBInstance",
+    "DeleteDBInstance",
     "DescribeDBEngineVersions",
     "DescribeDBInstances",
     "DescribeOrderableDBInstanceOptions",
@@ -53,6 +54,7 @@ impl AwsService for RdsService {
         match request.action.as_str() {
             "AddTagsToResource" => self.add_tags_to_resource(&request),
             "CreateDBInstance" => self.create_db_instance(&request).await,
+            "DeleteDBInstance" => self.delete_db_instance(&request).await,
             "DescribeDBEngineVersions" => self.describe_db_engine_versions(&request),
             "DescribeDBInstances" => self.describe_db_instances(&request),
             "DescribeOrderableDBInstanceOptions" => {
@@ -169,6 +171,72 @@ impl RdsService {
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, Some("creating"))
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    async fn delete_db_instance(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let db_instance_identifier = required_param(request, "DBInstanceIdentifier")?;
+        let skip_final_snapshot =
+            parse_optional_bool(optional_param(request, "SkipFinalSnapshot").as_deref())?
+                .unwrap_or(false);
+        let final_db_snapshot_identifier = optional_param(request, "FinalDBSnapshotIdentifier");
+
+        if skip_final_snapshot && final_db_snapshot_identifier.is_some() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterCombination",
+                "FinalDBSnapshotIdentifier cannot be specified when SkipFinalSnapshot is enabled.",
+            ));
+        }
+        if !skip_final_snapshot {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterCombination",
+                "SkipFinalSnapshot must be enabled until final snapshot support is implemented.",
+            ));
+        }
+
+        let instance = {
+            let mut state = self.state.write();
+            let instance = state
+                .instances
+                .remove(&db_instance_identifier)
+                .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
+
+            if instance.deletion_protection {
+                state
+                    .instances
+                    .insert(db_instance_identifier.clone(), instance.clone());
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidDBInstanceState",
+                    format!(
+                        "DBInstance {} cannot be deleted because deletion protection is enabled.",
+                        db_instance_identifier
+                    ),
+                ));
+            }
+
+            instance
+        };
+
+        if let Some(runtime) = &self.runtime {
+            runtime.stop_container(&db_instance_identifier).await;
+        }
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DeleteDBInstance",
+                &format!(
+                    "<DBInstance>{}</DBInstance>",
+                    db_instance_xml(&instance, Some("deleting"))
                 ),
                 &request.request_id,
             ),


### PR DESCRIPTION
## Summary
- implement DeleteDBInstance for RDS DB instances with deletion protection checks and container teardown
- return a deleting DBInstance response while immediately removing the instance from local state
- add conformance and E2E coverage for delete flows

## Validation
- cargo fmt --all
- cargo build
- cargo test -p fakecloud-rds --lib
- cargo test -p fakecloud-conformance --test rds
- cargo test -p fakecloud-e2e --test rds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add RDS instance deletion via `DeleteDBInstance`, with container teardown and immediate local removal. Adds coverage for deletion protection behavior.

- New Features
  - Added `DeleteDBInstance` to supported actions in `fakecloud-rds`.
  - Requires `SkipFinalSnapshot=true`; rejects `FinalDBSnapshotIdentifier` and non-skipped deletes with `InvalidParameterCombination`.
  - Respects deletion protection; returns `InvalidDBInstanceState` and leaves the instance intact.
  - Response includes the instance with status `deleting`; subsequent describe returns `DBInstanceNotFound`.
  - Added conformance and E2E tests in `fakecloud-conformance` and `fakecloud-e2e`, including checks that protected instances are not deleted.

<sup>Written for commit e6fdd61ae3c3b6de159745bd801e427428ccb8cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

