### PR TITLE
feat: add rds modify and reboot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,6 +1892,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ reqwest = { version = "0.13", features = ["json"] }
 zip = "2"
 tempfile = "3"
 regex = "1"
+tokio-postgres = "0.7"
 
 # Internal crates
 fakecloud-core = { path = "crates/fakecloud-core", version = "0.5.1" }

--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -141,6 +141,48 @@ async fn rds_delete_db_instance() {
     );
 }
 
+#[test_action("rds", "ModifyDBInstance", checksum = "08b493a8")]
+#[tokio::test]
+async fn rds_modify_db_instance() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client).await;
+
+    let response = client
+        .modify_db_instance()
+        .db_instance_identifier("conf-rds-db")
+        .deletion_protection(true)
+        .apply_immediately(true)
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    assert_eq!(instance.db_instance_status(), Some("modifying"));
+    assert_eq!(instance.deletion_protection(), Some(true));
+}
+
+#[test_action("rds", "RebootDBInstance", checksum = "cd4d463b")]
+#[tokio::test]
+async fn rds_reboot_db_instance() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client).await;
+
+    let response = client
+        .reboot_db_instance()
+        .db_instance_identifier("conf-rds-db")
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    assert_eq!(instance.db_instance_identifier(), Some("conf-rds-db"));
+    assert_eq!(instance.db_instance_status(), Some("rebooting"));
+}
+
 #[tokio::test]
 async fn rds_delete_db_instance_rejects_deletion_protection() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -276,12 +276,12 @@ async fn rds_reboot_db_instance() {
     let endpoint = describe_after.db_instances()[0]
         .endpoint()
         .expect("endpoint after reboot");
+    let address = endpoint.address().expect("address after reboot");
     let port = endpoint.port().expect("port after reboot");
 
-    let (db_client, connection) =
-        connect_with_retry("127.0.0.1", port, "admin", "secret123", "appdb")
-            .await
-            .expect("reconnect after reboot");
+    let (db_client, connection) = connect_with_retry(address, port, "admin", "secret123", "appdb")
+        .await
+        .expect("reconnect after reboot");
     tokio::spawn(connection);
     let row = db_client
         .query_one("SELECT 1", &[])
@@ -289,6 +289,26 @@ async fn rds_reboot_db_instance() {
         .expect("select 1");
     let value: i32 = row.get(0);
     assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn rds_reboot_db_instance_rejects_force_failover() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client, "orders-force-failover-db").await;
+
+    let error = client
+        .reboot_db_instance()
+        .db_instance_identifier("orders-force-failover-db")
+        .force_failover(true)
+        .send()
+        .await
+        .expect_err("force failover should be rejected");
+    assert_eq!(
+        error.into_service_error().meta().code(),
+        Some("InvalidParameterCombination")
+    );
 }
 
 async fn create_instance(

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -212,6 +212,85 @@ async fn rds_delete_db_instance_respects_deletion_protection() {
     assert_eq!(response.db_instances().len(), 1);
 }
 
+#[tokio::test]
+async fn rds_modify_db_instance() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client, "orders-modify-db").await;
+
+    let response = client
+        .modify_db_instance()
+        .db_instance_identifier("orders-modify-db")
+        .deletion_protection(true)
+        .apply_immediately(true)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response
+            .db_instance()
+            .and_then(|instance| instance.deletion_protection()),
+        Some(true)
+    );
+
+    let delete_error = client
+        .delete_db_instance()
+        .db_instance_identifier("orders-modify-db")
+        .skip_final_snapshot(true)
+        .send()
+        .await
+        .expect_err("deletion protection should block deletion");
+    assert_eq!(
+        delete_error.into_service_error().meta().code(),
+        Some("InvalidDBInstanceState")
+    );
+}
+
+#[tokio::test]
+async fn rds_reboot_db_instance() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client, "orders-reboot-db").await;
+
+    let response = client
+        .reboot_db_instance()
+        .db_instance_identifier("orders-reboot-db")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response
+            .db_instance()
+            .and_then(|instance| instance.db_instance_status()),
+        Some("rebooting")
+    );
+
+    let describe_after = client
+        .describe_db_instances()
+        .db_instance_identifier("orders-reboot-db")
+        .send()
+        .await
+        .unwrap();
+    let endpoint = describe_after.db_instances()[0]
+        .endpoint()
+        .expect("endpoint after reboot");
+    let port = endpoint.port().expect("port after reboot");
+
+    let (db_client, connection) =
+        connect_with_retry("127.0.0.1", port, "admin", "secret123", "appdb")
+            .await
+            .expect("reconnect after reboot");
+    tokio::spawn(connection);
+    let row = db_client
+        .query_one("SELECT 1", &[])
+        .await
+        .expect("select 1");
+    let value: i32 = row.get(0);
+    assert_eq!(value, 1);
+}
+
 async fn create_instance(
     client: &aws_sdk_rds::Client,
     db_instance_identifier: &str,

--- a/crates/fakecloud-rds/Cargo.toml
+++ b/crates/fakecloud-rds/Cargo.toml
@@ -20,3 +20,4 @@ tokio = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
+tokio-postgres = { workspace = true }

--- a/crates/fakecloud-rds/src/runtime.rs
+++ b/crates/fakecloud-rds/src/runtime.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use parking_lot::RwLock;
+use tokio_postgres::NoTls;
 
 #[derive(Debug, Clone)]
 pub struct RunningDbContainer {
@@ -109,7 +110,7 @@ impl RdsRuntime {
             }
         };
         if let Err(error) = self
-            .wait_for_postgres(&container_id, username, db_name, host_port)
+            .wait_for_postgres(username, password, db_name, host_port)
             .await
         {
             self.remove_container(&container_id).await;
@@ -131,6 +132,46 @@ impl RdsRuntime {
         if let Some(container) = container {
             self.remove_container(&container.container_id).await;
         }
+    }
+
+    pub async fn restart_container(
+        &self,
+        db_instance_identifier: &str,
+        username: &str,
+        password: &str,
+        db_name: &str,
+    ) -> Result<RunningDbContainer, RuntimeError> {
+        let running = self
+            .containers
+            .read()
+            .get(db_instance_identifier)
+            .cloned()
+            .ok_or(RuntimeError::Unavailable)?;
+
+        let output = tokio::process::Command::new(&self.cli)
+            .args(["restart", &running.container_id])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+
+        if !output.status.success() {
+            return Err(RuntimeError::ContainerStartFailed(format!(
+                "container restart failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+
+        let host_port = self.lookup_port(&running.container_id).await?;
+        self.wait_for_postgres(username, password, db_name, host_port)
+            .await?;
+        let running = RunningDbContainer {
+            container_id: running.container_id,
+            host_port,
+        };
+        self.containers
+            .write()
+            .insert(db_instance_identifier.to_string(), running.clone());
+        Ok(running)
     }
 
     pub async fn stop_all(&self) {
@@ -169,35 +210,23 @@ impl RdsRuntime {
 
     async fn wait_for_postgres(
         &self,
-        container_id: &str,
         username: &str,
+        password: &str,
         db_name: &str,
         host_port: u16,
     ) -> Result<(), RuntimeError> {
         for _ in 0..40 {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            if tokio::net::TcpStream::connect(format!("127.0.0.1:{host_port}"))
-                .await
-                .is_err()
+            let connection_string = format!(
+                "host=127.0.0.1 port={host_port} user={username} password={password} dbname={db_name}"
+            );
+            if let Ok((client, connection)) =
+                tokio_postgres::connect(&connection_string, NoTls).await
             {
-                continue;
-            }
-
-            let output = tokio::process::Command::new(&self.cli)
-                .args([
-                    "exec",
-                    container_id,
-                    "pg_isready",
-                    "-U",
-                    username,
-                    "-d",
-                    db_name,
-                ])
-                .output()
-                .await
-                .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
-
-            if output.status.success() {
+                tokio::spawn(async move {
+                    let _ = connection.await;
+                });
+                let _ = client.simple_query("SELECT 1").await;
                 return Ok(());
             }
         }

--- a/crates/fakecloud-rds/src/runtime.rs
+++ b/crates/fakecloud-rds/src/runtime.rs
@@ -226,8 +226,9 @@ impl RdsRuntime {
                 tokio::spawn(async move {
                     let _ = connection.await;
                 });
-                let _ = client.simple_query("SELECT 1").await;
-                return Ok(());
+                if client.simple_query("SELECT 1").await.is_ok() {
+                    return Ok(());
+                }
             }
         }
 

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -304,8 +304,15 @@ impl RdsService {
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let db_instance_identifier = required_param(request, "DBInstanceIdentifier")?;
-        let _force_failover =
+        let force_failover =
             parse_optional_bool(optional_param(request, "ForceFailover").as_deref())?;
+        if force_failover == Some(true) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterCombination",
+                "ForceFailover is not supported for single-instance PostgreSQL DB instances.",
+            ));
+        }
 
         let instance = {
             let state = self.state.read();

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -22,6 +22,8 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "DescribeDBInstances",
     "DescribeOrderableDBInstanceOptions",
     "ListTagsForResource",
+    "ModifyDBInstance",
+    "RebootDBInstance",
     "RemoveTagsFromResource",
 ];
 
@@ -61,6 +63,8 @@ impl AwsService for RdsService {
                 self.describe_orderable_db_instance_options(&request)
             }
             "ListTagsForResource" => self.list_tags_for_resource(&request),
+            "ModifyDBInstance" => self.modify_db_instance(&request),
+            "RebootDBInstance" => self.reboot_db_instance(&request).await,
             "RemoveTagsFromResource" => self.remove_tags_from_resource(&request),
             _ => Err(AwsServiceError::action_not_implemented(
                 self.service_name(),
@@ -237,6 +241,117 @@ impl RdsService {
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, Some("deleting"))
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn modify_db_instance(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let db_instance_identifier = required_param(request, "DBInstanceIdentifier")?;
+        let db_instance_class = optional_param(request, "DBInstanceClass");
+        let deletion_protection =
+            parse_optional_bool(optional_param(request, "DeletionProtection").as_deref())?;
+        let apply_immediately =
+            parse_optional_bool(optional_param(request, "ApplyImmediately").as_deref())?;
+
+        if apply_immediately == Some(false) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                "ApplyImmediately=false is not yet supported for ModifyDBInstance.",
+            ));
+        }
+        if db_instance_class.is_none() && deletion_protection.is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterCombination",
+                "At least one supported mutable field must be provided.",
+            ));
+        }
+        if let Some(ref class) = db_instance_class {
+            validate_db_instance_class(class)?;
+        }
+
+        let mut state = self.state.write();
+        let instance = state
+            .instances
+            .get_mut(&db_instance_identifier)
+            .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
+
+        if let Some(class) = db_instance_class {
+            instance.db_instance_class = class;
+        }
+        if let Some(deletion_protection) = deletion_protection {
+            instance.deletion_protection = deletion_protection;
+        }
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "ModifyDBInstance",
+                &format!(
+                    "<DBInstance>{}</DBInstance>",
+                    db_instance_xml(instance, Some("modifying"))
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    async fn reboot_db_instance(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let db_instance_identifier = required_param(request, "DBInstanceIdentifier")?;
+        let _force_failover =
+            parse_optional_bool(optional_param(request, "ForceFailover").as_deref())?;
+
+        let instance = {
+            let state = self.state.read();
+            state
+                .instances
+                .get(&db_instance_identifier)
+                .cloned()
+                .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?
+        };
+
+        let runtime = self.runtime.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "InvalidParameterValue",
+                "Docker/Podman is required for RDS DB instances but is not available",
+            )
+        })?;
+
+        let running = runtime
+            .restart_container(
+                &db_instance_identifier,
+                &instance.master_username,
+                &instance.master_user_password,
+                instance.db_name.as_deref().unwrap_or("postgres"),
+            )
+            .await
+            .map_err(runtime_error_to_service_error)?;
+
+        let instance = {
+            let mut state = self.state.write();
+            let instance = state
+                .instances
+                .get_mut(&db_instance_identifier)
+                .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
+            instance.host_port = running.host_port;
+            instance.port = i32::from(running.host_port);
+            instance.clone()
+        };
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "RebootDBInstance",
+                &format!(
+                    "<DBInstance>{}</DBInstance>",
+                    db_instance_xml(&instance, Some("rebooting"))
                 ),
                 &request.request_id,
             ),
@@ -573,6 +688,11 @@ fn validate_create_request(
             format!("EngineVersion '{engine_version}' is not supported yet."),
         ));
     }
+    validate_db_instance_class(db_instance_class)?;
+    Ok(())
+}
+
+fn validate_db_instance_class(db_instance_class: &str) -> Result<(), AwsServiceError> {
     if db_instance_class != "db.t3.micro" {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,


### PR DESCRIPTION
## Summary
- add `ModifyDBInstance` support for the initial mutable RDS fields
- add `RebootDBInstance` support backed by restarting the real Postgres container
- add conformance and E2E coverage for modify/reboot flows

## Testing
- cargo fmt --all
- cargo test -p fakecloud-rds --lib
- cargo build
- cargo test -p fakecloud-conformance --test rds
- cargo test -p fakecloud-e2e --test rds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RDS `ModifyDBInstance` and `RebootDBInstance` with immediate apply, backed by container restart and readiness checks using `tokio-postgres`. Adds conformance and E2E tests and rejects unsupported options.

- **New Features**
  - ModifyDBInstance: supports `DBInstanceClass` and `DeletionProtection`; requires `ApplyImmediately=true`; returns "modifying"; validates class; errors if no mutable fields.
  - RebootDBInstance: restarts the Postgres container, waits until queries succeed, updates endpoint/port, and returns "rebooting".

- **Bug Fixes**
  - Rejects `ForceFailover=true` with `InvalidParameterCombination`.
  - Returns `InvalidParameterValue` when `ApplyImmediately=false` for modify.

<sup>Written for commit 78c1987261caf07465cfec2be85c3b7a0170a478. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

