### PR TITLE
feat: add elasticache metadata APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "fakecloud-cognito",
  "fakecloud-core",
  "fakecloud-dynamodb",
+ "fakecloud-elasticache",
  "fakecloud-eventbridge",
  "fakecloud-iam",
  "fakecloud-kinesis",
@@ -1786,6 +1787,17 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "zip",
+]
+
+[[package]]
+name = "fakecloud-elasticache"
+version = "0.5.1"
+dependencies = [
+ "async-trait",
+ "fakecloud-aws",
+ "fakecloud-core",
+ "http 1.4.0",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/fakecloud-cognito",
     "crates/fakecloud-kinesis",
     "crates/fakecloud-rds",
+    "crates/fakecloud-elasticache",
     "crates/fakecloud-sdk",
     "crates/fakecloud-e2e",
     "crates/fakecloud-conformance",
@@ -87,4 +88,5 @@ fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.5.1" }
 fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.5.1" }
 fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.5.1" }
 fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.5.1" }
+fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.5.1" }
 fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.5.1" }

--- a/crates/fakecloud-conformance/tests/elasticache.rs
+++ b/crates/fakecloud-conformance/tests/elasticache.rs
@@ -1,9 +1,72 @@
 mod helpers;
 
+use fakecloud_conformance_macros::test_action;
 use helpers::TestServer;
 
+#[test_action("elasticache", "DescribeCacheEngineVersions", checksum = "a71c9f1a")]
 #[tokio::test]
-async fn elasticache_test_server_sdk_bootstrap_compiles() {
+async fn elasticache_describe_cache_engine_versions() {
     let server = TestServer::start().await;
-    let _client = server.elasticache_client().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_cache_engine_versions()
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let versions = response.cache_engine_versions();
+    assert_eq!(versions.len(), 1);
+    assert_eq!(versions[0].engine(), Some("redis"));
+    assert_eq!(versions[0].engine_version(), Some("7.1"));
+    assert_eq!(versions[0].cache_parameter_group_family(), Some("redis7"));
+}
+
+#[test_action(
+    "elasticache",
+    "DescribeEngineDefaultParameters",
+    checksum = "0b34416b"
+)]
+#[tokio::test]
+async fn elasticache_describe_engine_default_parameters() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_engine_default_parameters()
+        .cache_parameter_group_family("redis7")
+        .send()
+        .await
+        .unwrap();
+
+    let defaults = response.engine_defaults().expect("engine defaults");
+    assert_eq!(defaults.cache_parameter_group_family(), Some("redis7"));
+    let params = defaults.parameters();
+    assert!(!params.is_empty());
+    assert_eq!(params[0].parameter_name(), Some("maxmemory-policy"));
+}
+
+#[test_action("elasticache", "DescribeCacheParameterGroups", checksum = "f2d641d8")]
+#[tokio::test]
+async fn elasticache_describe_cache_parameter_groups() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_cache_parameter_groups()
+        .send()
+        .await
+        .unwrap();
+
+    let groups = response.cache_parameter_groups();
+    assert!(groups.len() >= 2);
+    assert_eq!(
+        groups[0].cache_parameter_group_name(),
+        Some("default.redis7")
+    );
+    assert_eq!(
+        groups[1].cache_parameter_group_name(),
+        Some("default.valkey8")
+    );
 }

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -3,7 +3,135 @@ mod helpers;
 use helpers::TestServer;
 
 #[tokio::test]
-async fn elasticache_test_server_sdk_bootstrap_compiles() {
+async fn elasticache_describe_cache_engine_versions_all() {
     let server = TestServer::start().await;
-    let _client = server.elasticache_client().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_cache_engine_versions()
+        .send()
+        .await
+        .unwrap();
+
+    let versions = response.cache_engine_versions();
+    assert!(versions.len() >= 2);
+
+    let redis = versions.iter().find(|v| v.engine() == Some("redis"));
+    assert!(redis.is_some());
+    assert_eq!(redis.unwrap().engine_version(), Some("7.1"));
+
+    let valkey = versions.iter().find(|v| v.engine() == Some("valkey"));
+    assert!(valkey.is_some());
+    assert_eq!(valkey.unwrap().engine_version(), Some("8.0"));
+}
+
+#[tokio::test]
+async fn elasticache_describe_cache_engine_versions_filter_by_engine() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_cache_engine_versions()
+        .engine("valkey")
+        .send()
+        .await
+        .unwrap();
+
+    let versions = response.cache_engine_versions();
+    assert_eq!(versions.len(), 1);
+    assert_eq!(versions[0].engine(), Some("valkey"));
+    assert_eq!(versions[0].engine_version(), Some("8.0"));
+    assert_eq!(versions[0].cache_parameter_group_family(), Some("valkey8"));
+}
+
+#[tokio::test]
+async fn elasticache_describe_engine_default_parameters_redis7() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_engine_default_parameters()
+        .cache_parameter_group_family("redis7")
+        .send()
+        .await
+        .unwrap();
+
+    let defaults = response.engine_defaults().expect("engine defaults");
+    assert_eq!(defaults.cache_parameter_group_family(), Some("redis7"));
+    let params = defaults.parameters();
+    assert_eq!(params.len(), 3);
+
+    let maxmemory = params
+        .iter()
+        .find(|p| p.parameter_name() == Some("maxmemory-policy"))
+        .expect("maxmemory-policy parameter");
+    assert_eq!(maxmemory.parameter_value(), Some("volatile-lru"));
+    assert_eq!(maxmemory.is_modifiable(), Some(true));
+}
+
+#[tokio::test]
+async fn elasticache_describe_engine_default_parameters_valkey8() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_engine_default_parameters()
+        .cache_parameter_group_family("valkey8")
+        .send()
+        .await
+        .unwrap();
+
+    let defaults = response.engine_defaults().expect("engine defaults");
+    assert_eq!(defaults.cache_parameter_group_family(), Some("valkey8"));
+    let params = defaults.parameters();
+    assert_eq!(params.len(), 3);
+}
+
+#[tokio::test]
+async fn elasticache_describe_cache_parameter_groups_all() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_cache_parameter_groups()
+        .send()
+        .await
+        .unwrap();
+
+    let groups = response.cache_parameter_groups();
+    assert!(groups.len() >= 2);
+
+    let redis_group = groups
+        .iter()
+        .find(|g| g.cache_parameter_group_name() == Some("default.redis7"));
+    assert!(redis_group.is_some());
+    assert_eq!(
+        redis_group.unwrap().cache_parameter_group_family(),
+        Some("redis7")
+    );
+
+    let valkey_group = groups
+        .iter()
+        .find(|g| g.cache_parameter_group_name() == Some("default.valkey8"));
+    assert!(valkey_group.is_some());
+}
+
+#[tokio::test]
+async fn elasticache_describe_cache_parameter_groups_by_name() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_cache_parameter_groups()
+        .cache_parameter_group_name("default.redis7")
+        .send()
+        .await
+        .unwrap();
+
+    let groups = response.cache_parameter_groups();
+    assert_eq!(groups.len(), 1);
+    assert_eq!(
+        groups[0].cache_parameter_group_name(),
+        Some("default.redis7")
+    );
 }

--- a/crates/fakecloud-elasticache/Cargo.toml
+++ b/crates/fakecloud-elasticache/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fakecloud-elasticache"
+description = "Amazon ElastiCache implementation for FakeCloud"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+version.workspace = true
+
+[dependencies]
+fakecloud-aws = { workspace = true }
+fakecloud-core = { workspace = true }
+async-trait = { workspace = true }
+http = { workspace = true }
+parking_lot = { workspace = true }

--- a/crates/fakecloud-elasticache/src/lib.rs
+++ b/crates/fakecloud-elasticache/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod service;
+pub mod state;

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -1,0 +1,407 @@
+use async_trait::async_trait;
+use http::StatusCode;
+
+use fakecloud_aws::xml::xml_escape;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+
+use crate::state::{
+    default_engine_versions, default_parameters_for_family, CacheEngineVersion,
+    CacheParameterGroup, EngineDefaultParameter, SharedElastiCacheState,
+};
+
+const ELASTICACHE_NS: &str = "http://elasticache.amazonaws.com/doc/2015-02-02/";
+const SUPPORTED_ACTIONS: &[&str] = &[
+    "DescribeCacheEngineVersions",
+    "DescribeCacheParameterGroups",
+    "DescribeEngineDefaultParameters",
+];
+
+pub struct ElastiCacheService {
+    state: SharedElastiCacheState,
+}
+
+impl ElastiCacheService {
+    pub fn new(state: SharedElastiCacheState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl AwsService for ElastiCacheService {
+    fn service_name(&self) -> &str {
+        "elasticache"
+    }
+
+    async fn handle(&self, request: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        match request.action.as_str() {
+            "DescribeCacheEngineVersions" => self.describe_cache_engine_versions(&request),
+            "DescribeCacheParameterGroups" => self.describe_cache_parameter_groups(&request),
+            "DescribeEngineDefaultParameters" => self.describe_engine_default_parameters(&request),
+            _ => Err(AwsServiceError::action_not_implemented(
+                self.service_name(),
+                &request.action,
+            )),
+        }
+    }
+
+    fn supported_actions(&self) -> &[&str] {
+        SUPPORTED_ACTIONS
+    }
+}
+
+impl ElastiCacheService {
+    fn describe_cache_engine_versions(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let engine = optional_param(request, "Engine");
+        let engine_version = optional_param(request, "EngineVersion");
+        let family = optional_param(request, "CacheParameterGroupFamily");
+        let default_only = parse_optional_bool(optional_param(request, "DefaultOnly").as_deref())?;
+        let max_records = optional_usize_param(request, "MaxRecords")?;
+        let marker = optional_param(request, "Marker");
+
+        let mut versions = filter_engine_versions(
+            &default_engine_versions(),
+            &engine,
+            &engine_version,
+            &family,
+        );
+
+        if default_only.unwrap_or(false) {
+            // Keep only one version per engine (the latest)
+            let mut seen_engines = std::collections::HashSet::new();
+            versions.retain(|v| seen_engines.insert(v.engine.clone()));
+        }
+
+        let (page, next_marker) = paginate(&versions, marker.as_deref(), max_records);
+
+        let members_xml: String = page.iter().map(engine_version_xml).collect();
+        let marker_xml = next_marker
+            .map(|m| format!("<Marker>{}</Marker>", xml_escape(&m)))
+            .unwrap_or_default();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DescribeCacheEngineVersions",
+                &format!("<CacheEngineVersions>{members_xml}</CacheEngineVersions>{marker_xml}"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn describe_cache_parameter_groups(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let group_name = optional_param(request, "CacheParameterGroupName");
+        let max_records = optional_usize_param(request, "MaxRecords")?;
+        let marker = optional_param(request, "Marker");
+
+        let state = self.state.read();
+
+        let groups: Vec<&CacheParameterGroup> = state
+            .parameter_groups
+            .iter()
+            .filter(|g| {
+                group_name
+                    .as_ref()
+                    .is_none_or(|name| g.cache_parameter_group_name == *name)
+            })
+            .collect();
+
+        if let Some(ref name) = group_name {
+            if groups.is_empty() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "CacheParameterGroupNotFound",
+                    format!("CacheParameterGroup {name} not found."),
+                ));
+            }
+        }
+
+        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records);
+
+        let members_xml: String = page.iter().map(|g| cache_parameter_group_xml(g)).collect();
+        let marker_xml = next_marker
+            .map(|m| format!("<Marker>{}</Marker>", xml_escape(&m)))
+            .unwrap_or_default();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DescribeCacheParameterGroups",
+                &format!("<CacheParameterGroups>{members_xml}</CacheParameterGroups>{marker_xml}"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn describe_engine_default_parameters(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let family = required_param(request, "CacheParameterGroupFamily")?;
+        let max_records = optional_usize_param(request, "MaxRecords")?;
+        let marker = optional_param(request, "Marker");
+
+        let params = default_parameters_for_family(&family);
+        let (page, next_marker) = paginate(&params, marker.as_deref(), max_records);
+
+        let params_xml: String = page.iter().map(parameter_xml).collect();
+        let marker_xml = next_marker
+            .map(|m| format!("<Marker>{}</Marker>", xml_escape(&m)))
+            .unwrap_or_default();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DescribeEngineDefaultParameters",
+                &format!(
+                    "<EngineDefaults>\
+                     <CacheParameterGroupFamily>{}</CacheParameterGroupFamily>\
+                     <Parameters>{params_xml}</Parameters>\
+                     {marker_xml}\
+                     </EngineDefaults>",
+                    xml_escape(&family),
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn optional_param(req: &AwsRequest, name: &str) -> Option<String> {
+    req.query_params
+        .get(name)
+        .cloned()
+        .filter(|value| !value.is_empty())
+}
+
+fn required_param(req: &AwsRequest, name: &str) -> Result<String, AwsServiceError> {
+    optional_param(req, name).ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "MissingParameter",
+            format!("The request must contain the parameter {name}."),
+        )
+    })
+}
+
+fn parse_optional_bool(value: Option<&str>) -> Result<Option<bool>, AwsServiceError> {
+    value
+        .map(|raw| match raw {
+            "true" | "True" | "TRUE" => Ok(true),
+            "false" | "False" | "FALSE" => Ok(false),
+            _ => Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!("Boolean parameter value '{raw}' is invalid."),
+            )),
+        })
+        .transpose()
+}
+
+fn optional_usize_param(req: &AwsRequest, name: &str) -> Result<Option<usize>, AwsServiceError> {
+    optional_param(req, name)
+        .map(|v| {
+            v.parse::<usize>().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!("Value '{v}' for parameter {name} is not a valid integer."),
+                )
+            })
+        })
+        .transpose()
+}
+
+/// Simple index-based pagination. Returns the current page and an optional next marker.
+fn paginate<T: Clone>(
+    items: &[T],
+    marker: Option<&str>,
+    max_records: Option<usize>,
+) -> (Vec<T>, Option<String>) {
+    let start = marker.and_then(|m| m.parse::<usize>().ok()).unwrap_or(0);
+    let limit = max_records.unwrap_or(100).min(100);
+
+    if start >= items.len() {
+        return (Vec::new(), None);
+    }
+
+    let end = (start + limit).min(items.len());
+    let page = items[start..end].to_vec();
+    let next_marker = if end < items.len() {
+        Some(end.to_string())
+    } else {
+        None
+    };
+    (page, next_marker)
+}
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+fn filter_engine_versions(
+    versions: &[CacheEngineVersion],
+    engine: &Option<String>,
+    engine_version: &Option<String>,
+    family: &Option<String>,
+) -> Vec<CacheEngineVersion> {
+    versions
+        .iter()
+        .filter(|v| engine.as_ref().is_none_or(|expected| v.engine == *expected))
+        .filter(|v| {
+            engine_version
+                .as_ref()
+                .is_none_or(|expected| v.engine_version == *expected)
+        })
+        .filter(|v| {
+            family
+                .as_ref()
+                .is_none_or(|expected| v.cache_parameter_group_family == *expected)
+        })
+        .cloned()
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// XML formatting
+// ---------------------------------------------------------------------------
+
+fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+         <{action}Response xmlns=\"{ELASTICACHE_NS}\">\
+         <{action}Result>{inner}</{action}Result>\
+         <ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata>\
+         </{action}Response>"
+    )
+}
+
+fn engine_version_xml(v: &CacheEngineVersion) -> String {
+    format!(
+        "<CacheEngineVersion>\
+         <Engine>{}</Engine>\
+         <EngineVersion>{}</EngineVersion>\
+         <CacheParameterGroupFamily>{}</CacheParameterGroupFamily>\
+         <CacheEngineDescription>{}</CacheEngineDescription>\
+         <CacheEngineVersionDescription>{}</CacheEngineVersionDescription>\
+         </CacheEngineVersion>",
+        xml_escape(&v.engine),
+        xml_escape(&v.engine_version),
+        xml_escape(&v.cache_parameter_group_family),
+        xml_escape(&v.cache_engine_description),
+        xml_escape(&v.cache_engine_version_description),
+    )
+}
+
+fn cache_parameter_group_xml(g: &CacheParameterGroup) -> String {
+    format!(
+        "<CacheParameterGroup>\
+         <CacheParameterGroupName>{}</CacheParameterGroupName>\
+         <CacheParameterGroupFamily>{}</CacheParameterGroupFamily>\
+         <Description>{}</Description>\
+         <IsGlobal>{}</IsGlobal>\
+         <ARN>{}</ARN>\
+         </CacheParameterGroup>",
+        xml_escape(&g.cache_parameter_group_name),
+        xml_escape(&g.cache_parameter_group_family),
+        xml_escape(&g.description),
+        g.is_global,
+        xml_escape(&g.arn),
+    )
+}
+
+fn parameter_xml(p: &EngineDefaultParameter) -> String {
+    format!(
+        "<Parameter>\
+         <ParameterName>{}</ParameterName>\
+         <ParameterValue>{}</ParameterValue>\
+         <Description>{}</Description>\
+         <Source>{}</Source>\
+         <DataType>{}</DataType>\
+         <AllowedValues>{}</AllowedValues>\
+         <IsModifiable>{}</IsModifiable>\
+         <MinimumEngineVersion>{}</MinimumEngineVersion>\
+         </Parameter>",
+        xml_escape(&p.parameter_name),
+        xml_escape(&p.parameter_value),
+        xml_escape(&p.description),
+        xml_escape(&p.source),
+        xml_escape(&p.data_type),
+        xml_escape(&p.allowed_values),
+        p.is_modifiable,
+        xml_escape(&p.minimum_engine_version),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::default_engine_versions;
+
+    #[test]
+    fn filter_engine_versions_by_engine() {
+        let versions = default_engine_versions();
+        let filtered = filter_engine_versions(&versions, &Some("redis".to_string()), &None, &None);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].engine, "redis");
+    }
+
+    #[test]
+    fn filter_engine_versions_by_family() {
+        let versions = default_engine_versions();
+        let filtered =
+            filter_engine_versions(&versions, &None, &None, &Some("valkey8".to_string()));
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].engine, "valkey");
+    }
+
+    #[test]
+    fn filter_engine_versions_no_match() {
+        let versions = default_engine_versions();
+        let filtered =
+            filter_engine_versions(&versions, &Some("memcached".to_string()), &None, &None);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn paginate_returns_all_when_within_limit() {
+        let items = vec![1, 2, 3];
+        let (page, marker) = paginate(&items, None, None);
+        assert_eq!(page, vec![1, 2, 3]);
+        assert!(marker.is_none());
+    }
+
+    #[test]
+    fn paginate_respects_max_records() {
+        let items = vec![1, 2, 3, 4, 5];
+        let (page, marker) = paginate(&items, None, Some(2));
+        assert_eq!(page, vec![1, 2]);
+        assert_eq!(marker, Some("2".to_string()));
+
+        let (page2, marker2) = paginate(&items, Some("2"), Some(2));
+        assert_eq!(page2, vec![3, 4]);
+        assert_eq!(marker2, Some("4".to_string()));
+
+        let (page3, marker3) = paginate(&items, Some("4"), Some(2));
+        assert_eq!(page3, vec![5]);
+        assert!(marker3.is_none());
+    }
+
+    #[test]
+    fn xml_wrap_produces_valid_response() {
+        let xml = xml_wrap("TestAction", "<Data>ok</Data>", "req-123");
+        assert!(xml.contains("<TestActionResponse"));
+        assert!(xml.contains("<TestActionResult>"));
+        assert!(xml.contains("<RequestId>req-123</RequestId>"));
+        assert!(xml.contains(ELASTICACHE_NS));
+    }
+}

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -1,0 +1,218 @@
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+pub type SharedElastiCacheState = Arc<RwLock<ElastiCacheState>>;
+
+#[derive(Debug, Clone)]
+pub struct CacheEngineVersion {
+    pub engine: String,
+    pub engine_version: String,
+    pub cache_parameter_group_family: String,
+    pub cache_engine_description: String,
+    pub cache_engine_version_description: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CacheParameterGroup {
+    pub cache_parameter_group_name: String,
+    pub cache_parameter_group_family: String,
+    pub description: String,
+    pub is_global: bool,
+    pub arn: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EngineDefaultParameter {
+    pub parameter_name: String,
+    pub parameter_value: String,
+    pub description: String,
+    pub source: String,
+    pub data_type: String,
+    pub allowed_values: String,
+    pub is_modifiable: bool,
+    pub minimum_engine_version: String,
+}
+
+#[derive(Debug)]
+pub struct ElastiCacheState {
+    pub account_id: String,
+    pub region: String,
+    pub parameter_groups: Vec<CacheParameterGroup>,
+}
+
+impl ElastiCacheState {
+    pub fn new(account_id: &str, region: &str) -> Self {
+        let parameter_groups = default_parameter_groups(account_id, region);
+        Self {
+            account_id: account_id.to_string(),
+            region: region.to_string(),
+            parameter_groups,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.parameter_groups = default_parameter_groups(&self.account_id, &self.region);
+    }
+}
+
+pub fn default_engine_versions() -> Vec<CacheEngineVersion> {
+    vec![
+        CacheEngineVersion {
+            engine: "redis".to_string(),
+            engine_version: "7.1".to_string(),
+            cache_parameter_group_family: "redis7".to_string(),
+            cache_engine_description: "Redis".to_string(),
+            cache_engine_version_description: "Redis 7.1".to_string(),
+        },
+        CacheEngineVersion {
+            engine: "valkey".to_string(),
+            engine_version: "8.0".to_string(),
+            cache_parameter_group_family: "valkey8".to_string(),
+            cache_engine_description: "Valkey".to_string(),
+            cache_engine_version_description: "Valkey 8.0".to_string(),
+        },
+    ]
+}
+
+fn default_parameter_groups(account_id: &str, region: &str) -> Vec<CacheParameterGroup> {
+    vec![
+        CacheParameterGroup {
+            cache_parameter_group_name: "default.redis7".to_string(),
+            cache_parameter_group_family: "redis7".to_string(),
+            description: "Default parameter group for redis7".to_string(),
+            is_global: false,
+            arn: format!("arn:aws:elasticache:{region}:{account_id}:parametergroup:default.redis7"),
+        },
+        CacheParameterGroup {
+            cache_parameter_group_name: "default.valkey8".to_string(),
+            cache_parameter_group_family: "valkey8".to_string(),
+            description: "Default parameter group for valkey8".to_string(),
+            is_global: false,
+            arn: format!(
+                "arn:aws:elasticache:{region}:{account_id}:parametergroup:default.valkey8"
+            ),
+        },
+    ]
+}
+
+pub fn default_parameters_for_family(family: &str) -> Vec<EngineDefaultParameter> {
+    match family {
+        "redis7" => vec![
+            EngineDefaultParameter {
+                parameter_name: "maxmemory-policy".to_string(),
+                parameter_value: "volatile-lru".to_string(),
+                description: "Max memory policy".to_string(),
+                source: "system".to_string(),
+                data_type: "string".to_string(),
+                allowed_values: "volatile-lru,allkeys-lru,volatile-lfu,allkeys-lfu,volatile-random,allkeys-random,volatile-ttl,noeviction".to_string(),
+                is_modifiable: true,
+                minimum_engine_version: "7.0.0".to_string(),
+            },
+            EngineDefaultParameter {
+                parameter_name: "cluster-enabled".to_string(),
+                parameter_value: "no".to_string(),
+                description: "Enable or disable Redis Cluster mode".to_string(),
+                source: "system".to_string(),
+                data_type: "string".to_string(),
+                allowed_values: "yes,no".to_string(),
+                is_modifiable: false,
+                minimum_engine_version: "7.0.0".to_string(),
+            },
+            EngineDefaultParameter {
+                parameter_name: "activedefrag".to_string(),
+                parameter_value: "no".to_string(),
+                description: "Enable active defragmentation".to_string(),
+                source: "system".to_string(),
+                data_type: "string".to_string(),
+                allowed_values: "yes,no".to_string(),
+                is_modifiable: true,
+                minimum_engine_version: "7.0.0".to_string(),
+            },
+        ],
+        "valkey8" => vec![
+            EngineDefaultParameter {
+                parameter_name: "maxmemory-policy".to_string(),
+                parameter_value: "volatile-lru".to_string(),
+                description: "Max memory policy".to_string(),
+                source: "system".to_string(),
+                data_type: "string".to_string(),
+                allowed_values: "volatile-lru,allkeys-lru,volatile-lfu,allkeys-lfu,volatile-random,allkeys-random,volatile-ttl,noeviction".to_string(),
+                is_modifiable: true,
+                minimum_engine_version: "8.0.0".to_string(),
+            },
+            EngineDefaultParameter {
+                parameter_name: "cluster-enabled".to_string(),
+                parameter_value: "no".to_string(),
+                description: "Enable or disable cluster mode".to_string(),
+                source: "system".to_string(),
+                data_type: "string".to_string(),
+                allowed_values: "yes,no".to_string(),
+                is_modifiable: false,
+                minimum_engine_version: "8.0.0".to_string(),
+            },
+            EngineDefaultParameter {
+                parameter_name: "activedefrag".to_string(),
+                parameter_value: "no".to_string(),
+                description: "Enable active defragmentation".to_string(),
+                source: "system".to_string(),
+                data_type: "string".to_string(),
+                allowed_values: "yes,no".to_string(),
+                is_modifiable: true,
+                minimum_engine_version: "8.0.0".to_string(),
+            },
+        ],
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_engine_versions_contains_redis_and_valkey() {
+        let versions = default_engine_versions();
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].engine, "redis");
+        assert_eq!(versions[0].engine_version, "7.1");
+        assert_eq!(versions[1].engine, "valkey");
+        assert_eq!(versions[1].engine_version, "8.0");
+    }
+
+    #[test]
+    fn state_new_creates_default_parameter_groups() {
+        let state = ElastiCacheState::new("123456789012", "us-east-1");
+        assert_eq!(state.parameter_groups.len(), 2);
+        assert_eq!(
+            state.parameter_groups[0].cache_parameter_group_name,
+            "default.redis7"
+        );
+        assert_eq!(
+            state.parameter_groups[1].cache_parameter_group_name,
+            "default.valkey8"
+        );
+    }
+
+    #[test]
+    fn reset_restores_default_parameter_groups() {
+        let mut state = ElastiCacheState::new("123456789012", "us-east-1");
+        state.parameter_groups.clear();
+        assert!(state.parameter_groups.is_empty());
+        state.reset();
+        assert_eq!(state.parameter_groups.len(), 2);
+    }
+
+    #[test]
+    fn default_parameters_for_redis7_returns_parameters() {
+        let params = default_parameters_for_family("redis7");
+        assert_eq!(params.len(), 3);
+        assert_eq!(params[0].parameter_name, "maxmemory-policy");
+    }
+
+    #[test]
+    fn default_parameters_for_unknown_family_returns_empty() {
+        let params = default_parameters_for_family("unknown");
+        assert!(params.is_empty());
+    }
+}

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -32,6 +32,7 @@ fakecloud-ses = { workspace = true }
 fakecloud-cognito = { workspace = true }
 fakecloud-kinesis = { workspace = true }
 fakecloud-rds = { workspace = true }
+fakecloud-elasticache = { workspace = true }
 fakecloud-sdk = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -20,6 +20,7 @@ use sqs_lambda_poller::SqsLambdaPoller;
 use fakecloud_cloudformation::service::CloudFormationService;
 use fakecloud_cognito::service::CognitoService;
 use fakecloud_dynamodb::service::DynamoDbService;
+use fakecloud_elasticache::service::ElastiCacheService;
 use fakecloud_eventbridge::service::EventBridgeService;
 use fakecloud_iam::iam_service::IamService;
 use fakecloud_iam::sts_service::StsService;
@@ -147,6 +148,10 @@ async fn main() {
     let rds_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_rds::state::RdsState::new(&cli.account_id, &cli.region),
     ));
+    let elasticache_state = Arc::new(parking_lot::RwLock::new(
+        fakecloud_elasticache::state::ElastiCacheState::new(&cli.account_id, &cli.region),
+    ));
+
     let rds_runtime = fakecloud_rds::runtime::RdsRuntime::new().map(Arc::new);
     if let Some(ref rt) = rds_runtime {
         tracing::info!(
@@ -258,6 +263,7 @@ async fn main() {
         cognito: cognito_state.clone(),
         kinesis: kinesis_state.clone(),
         rds: rds_state.clone(),
+        elasticache: elasticache_state.clone(),
         container_runtime: container_runtime.clone(),
         rds_runtime: rds_runtime.clone(),
     };
@@ -373,6 +379,7 @@ async fn main() {
         rds_service = rds_service.with_runtime(rt.clone());
     }
     registry.register(Arc::new(rds_service));
+    registry.register(Arc::new(ElastiCacheService::new(elasticache_state)));
 
     // Spawn background tasks
     let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state);
@@ -1081,6 +1088,7 @@ struct ResetState {
     cognito: fakecloud_cognito::state::SharedCognitoState,
     kinesis: fakecloud_kinesis::state::SharedKinesisState,
     rds: fakecloud_rds::state::SharedRdsState,
+    elasticache: fakecloud_elasticache::state::SharedElastiCacheState,
     container_runtime: Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
     rds_runtime: Option<Arc<fakecloud_rds::runtime::RdsRuntime>>,
 }
@@ -1158,6 +1166,9 @@ impl ResetState {
                     tokio::spawn(async move { rt.stop_all().await });
                 }
             }
+            "elasticache" => {
+                self.elasticache.write().reset();
+            }
             _ => {
                 return Err(format!("Unknown service: {service}"));
             }
@@ -1209,6 +1220,7 @@ impl ResetState {
             let rt = rt.clone();
             tokio::spawn(async move { rt.stop_all().await });
         }
+        self.elasticache.write().reset();
         tracing::info!("state reset via reset API");
         axum::Json(types::ResetResponse {
             status: "ok".to_string(),
@@ -1322,6 +1334,9 @@ mod tests {
                 fakecloud_kinesis::state::KinesisState::new("123456789012", "us-east-1"),
             )),
             rds: Arc::new(parking_lot::RwLock::new(rds)),
+            elasticache: Arc::new(parking_lot::RwLock::new(
+                fakecloud_elasticache::state::ElastiCacheState::new("123456789012", "us-east-1"),
+            )),
             container_runtime: None,
             rds_runtime: None,
         };


### PR DESCRIPTION
## Summary
- add new fakecloud-elasticache crate with 3 metadata-only actions
- implement DescribeCacheEngineVersions with filtering by Engine, EngineVersion, CacheParameterGroupFamily, and DefaultOnly
- implement DescribeEngineDefaultParameters with per-family parameter sets
- implement DescribeCacheParameterGroups with name filtering
- seed Redis 7.1 and Valkey 8.0 engine data with realistic parameter groups and parameters
- wire into server with state creation, service registration, and per-service/global reset
- add handwritten conformance tests with test_action macro coverage for all 3 actions
- add 6 e2e tests covering filtering and parameter retrieval via aws-sdk-elasticache
- add 11 unit tests for filtering, pagination, XML output, and state management

## Validation
- cargo fmt --all
- cargo build --bin fakecloud
- cargo clippy --workspace -- -D warnings
- cargo test -p fakecloud-elasticache --lib (11 passed)
- cargo test -p fakecloud-conformance --test elasticache (3 passed)
- cargo test -p fakecloud-e2e --test elasticache (6 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ElastiCache metadata APIs with three read-only actions and AWS-compatible XML, backed by seeded Redis 7.1 and Valkey 8.0 data. Introduces the `fakecloud-elasticache` crate and wires it into the server with state, filtering, and pagination.

- **New Features**
  - New `fakecloud-elasticache` crate with DescribeCacheEngineVersions, DescribeEngineDefaultParameters, and DescribeCacheParameterGroups (metadata-only).
  - Filtering support: Engine, EngineVersion, CacheParameterGroupFamily, DefaultOnly, and group name.
  - Pagination via Marker and MaxRecords; stable, AWS-style XML responses.
  - Seeded engines: Redis 7.1 (`redis7`) and Valkey 8.0 (`valkey8`) with realistic parameter groups/defaults.
  - Server integration: state creation, service registration, and per-service/global reset.
  - Tests: conformance coverage for all actions, 6 e2e cases using `aws-sdk-elasticache`, and unit tests for filtering, pagination, XML, and state.

<sup>Written for commit bfd1a82fa5767af21fa90156d653cfee534d5d26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

