### PR TITLE
feat: add elasticache subnet group APIs

### DIFF
--- a/crates/fakecloud-conformance/tests/elasticache.rs
+++ b/crates/fakecloud-conformance/tests/elasticache.rs
@@ -3,6 +3,97 @@ mod helpers;
 use fakecloud_conformance_macros::test_action;
 use helpers::TestServer;
 
+#[test_action("elasticache", "CreateCacheSubnetGroup", checksum = "84cb3eb4")]
+#[tokio::test]
+async fn elasticache_create_cache_subnet_group() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("test-subnet-group")
+        .cache_subnet_group_description("Test subnet group")
+        .subnet_ids("subnet-abc123")
+        .send()
+        .await
+        .unwrap();
+
+    let group = response.cache_subnet_group().expect("cache subnet group");
+    assert_eq!(group.cache_subnet_group_name(), Some("test-subnet-group"));
+    assert_eq!(
+        group.cache_subnet_group_description(),
+        Some("Test subnet group")
+    );
+}
+
+#[test_action("elasticache", "DeleteCacheSubnetGroup", checksum = "9ffab4c4")]
+#[tokio::test]
+async fn elasticache_delete_cache_subnet_group() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("to-delete")
+        .cache_subnet_group_description("Will be deleted")
+        .subnet_ids("subnet-abc123")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_cache_subnet_group()
+        .cache_subnet_group_name("to-delete")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("elasticache", "DescribeCacheSubnetGroups", checksum = "0f6a2b15")]
+#[tokio::test]
+async fn elasticache_describe_cache_subnet_groups() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client.describe_cache_subnet_groups().send().await.unwrap();
+
+    let groups = response.cache_subnet_groups();
+    assert!(!groups.is_empty());
+    assert!(groups
+        .iter()
+        .any(|g| g.cache_subnet_group_name() == Some("default")));
+}
+
+#[test_action("elasticache", "ModifyCacheSubnetGroup", checksum = "ebab21f4")]
+#[tokio::test]
+async fn elasticache_modify_cache_subnet_group() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("to-modify")
+        .cache_subnet_group_description("Original description")
+        .subnet_ids("subnet-abc123")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .modify_cache_subnet_group()
+        .cache_subnet_group_name("to-modify")
+        .cache_subnet_group_description("Updated description")
+        .send()
+        .await
+        .unwrap();
+
+    let group = response.cache_subnet_group().expect("cache subnet group");
+    assert_eq!(
+        group.cache_subnet_group_description(),
+        Some("Updated description")
+    );
+}
+
 #[test_action("elasticache", "DescribeCacheEngineVersions", checksum = "a71c9f1a")]
 #[tokio::test]
 async fn elasticache_describe_cache_engine_versions() {

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -2,6 +2,189 @@ mod helpers;
 
 use helpers::TestServer;
 
+// ---------------------------------------------------------------------------
+// CacheSubnetGroup tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn elasticache_create_subnet_group_and_describe() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let create_resp = client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("my-subnet-group")
+        .cache_subnet_group_description("My test subnet group")
+        .subnet_ids("subnet-aaa111")
+        .subnet_ids("subnet-bbb222")
+        .send()
+        .await
+        .unwrap();
+
+    let group = create_resp
+        .cache_subnet_group()
+        .expect("cache subnet group");
+    assert_eq!(group.cache_subnet_group_name(), Some("my-subnet-group"));
+    assert_eq!(
+        group.cache_subnet_group_description(),
+        Some("My test subnet group")
+    );
+    assert!(group.vpc_id().is_some());
+    assert_eq!(group.subnets().len(), 2);
+
+    // Verify it appears in describe
+    let describe_resp = client.describe_cache_subnet_groups().send().await.unwrap();
+
+    let groups = describe_resp.cache_subnet_groups();
+    assert!(groups
+        .iter()
+        .any(|g| g.cache_subnet_group_name() == Some("my-subnet-group")));
+}
+
+#[tokio::test]
+async fn elasticache_describe_subnet_groups_with_name_filter() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("filtered-group")
+        .cache_subnet_group_description("For filtering test")
+        .subnet_ids("subnet-aaa111")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .describe_cache_subnet_groups()
+        .cache_subnet_group_name("filtered-group")
+        .send()
+        .await
+        .unwrap();
+
+    let groups = response.cache_subnet_groups();
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].cache_subnet_group_name(), Some("filtered-group"));
+}
+
+#[tokio::test]
+async fn elasticache_modify_subnet_group_description() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("mod-group")
+        .cache_subnet_group_description("Original")
+        .subnet_ids("subnet-aaa111")
+        .send()
+        .await
+        .unwrap();
+
+    let modify_resp = client
+        .modify_cache_subnet_group()
+        .cache_subnet_group_name("mod-group")
+        .cache_subnet_group_description("Updated description")
+        .send()
+        .await
+        .unwrap();
+
+    let group = modify_resp
+        .cache_subnet_group()
+        .expect("cache subnet group");
+    assert_eq!(
+        group.cache_subnet_group_description(),
+        Some("Updated description")
+    );
+
+    // Verify via describe
+    let describe_resp = client
+        .describe_cache_subnet_groups()
+        .cache_subnet_group_name("mod-group")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        describe_resp.cache_subnet_groups()[0].cache_subnet_group_description(),
+        Some("Updated description")
+    );
+}
+
+#[tokio::test]
+async fn elasticache_delete_subnet_group_and_verify_gone() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("del-group")
+        .cache_subnet_group_description("Will be deleted")
+        .subnet_ids("subnet-aaa111")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_cache_subnet_group()
+        .cache_subnet_group_name("del-group")
+        .send()
+        .await
+        .unwrap();
+
+    // Verify it's gone
+    let result = client
+        .describe_cache_subnet_groups()
+        .cache_subnet_group_name("del-group")
+        .send()
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn elasticache_create_duplicate_subnet_group_errors() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("dup-group")
+        .cache_subnet_group_description("First")
+        .subnet_ids("subnet-aaa111")
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("dup-group")
+        .cache_subnet_group_description("Second")
+        .subnet_ids("subnet-bbb222")
+        .send()
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn elasticache_delete_nonexistent_subnet_group_errors() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let result = client
+        .delete_cache_subnet_group()
+        .cache_subnet_group_name("nonexistent-group")
+        .send()
+        .await;
+
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Existing tests
+// ---------------------------------------------------------------------------
+
 #[tokio::test]
 async fn elasticache_describe_cache_engine_versions_all() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -6,14 +6,18 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 
 use crate::state::{
     default_engine_versions, default_parameters_for_family, CacheEngineVersion,
-    CacheParameterGroup, EngineDefaultParameter, SharedElastiCacheState,
+    CacheParameterGroup, CacheSubnetGroup, EngineDefaultParameter, SharedElastiCacheState,
 };
 
 const ELASTICACHE_NS: &str = "http://elasticache.amazonaws.com/doc/2015-02-02/";
 const SUPPORTED_ACTIONS: &[&str] = &[
+    "CreateCacheSubnetGroup",
+    "DeleteCacheSubnetGroup",
     "DescribeCacheEngineVersions",
     "DescribeCacheParameterGroups",
+    "DescribeCacheSubnetGroups",
     "DescribeEngineDefaultParameters",
+    "ModifyCacheSubnetGroup",
 ];
 
 pub struct ElastiCacheService {
@@ -34,9 +38,13 @@ impl AwsService for ElastiCacheService {
 
     async fn handle(&self, request: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         match request.action.as_str() {
+            "CreateCacheSubnetGroup" => self.create_cache_subnet_group(&request),
+            "DeleteCacheSubnetGroup" => self.delete_cache_subnet_group(&request),
             "DescribeCacheEngineVersions" => self.describe_cache_engine_versions(&request),
             "DescribeCacheParameterGroups" => self.describe_cache_parameter_groups(&request),
+            "DescribeCacheSubnetGroups" => self.describe_cache_subnet_groups(&request),
             "DescribeEngineDefaultParameters" => self.describe_engine_default_parameters(&request),
+            "ModifyCacheSubnetGroup" => self.modify_cache_subnet_group(&request),
             _ => Err(AwsServiceError::action_not_implemented(
                 self.service_name(),
                 &request.action,
@@ -170,6 +178,183 @@ impl ElastiCacheService {
             ),
         ))
     }
+
+    fn create_cache_subnet_group(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = required_param(request, "CacheSubnetGroupName")?;
+        let description = required_param(request, "CacheSubnetGroupDescription")?;
+        let subnet_ids = parse_member_list(&request.query_params, "SubnetIds", "SubnetIdentifier");
+
+        if subnet_ids.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                "At least one subnet ID must be specified.".to_string(),
+            ));
+        }
+
+        let mut state = self.state.write();
+
+        if state.subnet_groups.contains_key(&name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "CacheSubnetGroupAlreadyExists",
+                format!("Cache subnet group {name} already exists."),
+            ));
+        }
+
+        let arn = format!(
+            "arn:aws:elasticache:{}:{}:subnetgroup:{}",
+            state.region, state.account_id, name
+        );
+        let vpc_id = format!(
+            "vpc-{:08x}",
+            name.as_bytes()
+                .iter()
+                .fold(0u32, |acc, &b| acc.wrapping_add(b as u32))
+        );
+
+        let group = CacheSubnetGroup {
+            cache_subnet_group_name: name.clone(),
+            cache_subnet_group_description: description,
+            vpc_id,
+            subnet_ids,
+            arn,
+        };
+
+        let xml = cache_subnet_group_xml(&group);
+        state.subnet_groups.insert(name, group);
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "CreateCacheSubnetGroup",
+                &format!("<CacheSubnetGroup>{xml}</CacheSubnetGroup>"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn describe_cache_subnet_groups(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let group_name = optional_param(request, "CacheSubnetGroupName");
+        let max_records = optional_usize_param(request, "MaxRecords")?;
+        let marker = optional_param(request, "Marker");
+
+        let state = self.state.read();
+
+        let groups: Vec<&CacheSubnetGroup> = if let Some(ref name) = group_name {
+            match state.subnet_groups.get(name) {
+                Some(g) => vec![g],
+                None => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "CacheSubnetGroupNotFoundFault",
+                        format!("Cache subnet group {name} not found."),
+                    ));
+                }
+            }
+        } else {
+            let mut groups: Vec<&CacheSubnetGroup> = state.subnet_groups.values().collect();
+            groups.sort_by(|a, b| a.cache_subnet_group_name.cmp(&b.cache_subnet_group_name));
+            groups
+        };
+
+        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records);
+
+        let members_xml: String = page
+            .iter()
+            .map(|g| {
+                format!(
+                    "<CacheSubnetGroup>{}</CacheSubnetGroup>",
+                    cache_subnet_group_xml(g)
+                )
+            })
+            .collect();
+        let marker_xml = next_marker
+            .map(|m| format!("<Marker>{}</Marker>", xml_escape(&m)))
+            .unwrap_or_default();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DescribeCacheSubnetGroups",
+                &format!("<CacheSubnetGroups>{members_xml}</CacheSubnetGroups>{marker_xml}"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn delete_cache_subnet_group(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = required_param(request, "CacheSubnetGroupName")?;
+
+        let mut state = self.state.write();
+
+        if name == "default" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "CacheSubnetGroupInUse",
+                "Cannot delete default cache subnet group.".to_string(),
+            ));
+        }
+
+        if state.subnet_groups.remove(&name).is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "CacheSubnetGroupNotFoundFault",
+                format!("Cache subnet group {name} not found."),
+            ));
+        }
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap("DeleteCacheSubnetGroup", "", &request.request_id),
+        ))
+    }
+
+    fn modify_cache_subnet_group(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = required_param(request, "CacheSubnetGroupName")?;
+        let description = optional_param(request, "CacheSubnetGroupDescription");
+        let subnet_ids = parse_member_list(&request.query_params, "SubnetIds", "SubnetIdentifier");
+
+        let mut state = self.state.write();
+
+        let group = state.subnet_groups.get_mut(&name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "CacheSubnetGroupNotFoundFault",
+                format!("Cache subnet group {name} not found."),
+            )
+        })?;
+
+        if let Some(desc) = description {
+            group.cache_subnet_group_description = desc;
+        }
+        if !subnet_ids.is_empty() {
+            group.subnet_ids = subnet_ids;
+        }
+
+        let xml = cache_subnet_group_xml(group);
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "ModifyCacheSubnetGroup",
+                &format!("<CacheSubnetGroup>{xml}</CacheSubnetGroup>"),
+                &request.request_id,
+            ),
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -205,6 +390,30 @@ fn parse_optional_bool(value: Option<&str>) -> Result<Option<bool>, AwsServiceEr
             )),
         })
         .transpose()
+}
+
+/// Parse an AWS Query protocol member list.
+///
+/// AWS encodes lists in the query string as:
+///   `{param}.{member_name}.1=val1&{param}.{member_name}.2=val2`
+///
+/// Returns the values sorted by index.
+fn parse_member_list(
+    params: &std::collections::HashMap<String, String>,
+    param: &str,
+    member_name: &str,
+) -> Vec<String> {
+    let prefix = format!("{param}.{member_name}.");
+    let mut indexed: Vec<(usize, String)> = params
+        .iter()
+        .filter_map(|(k, v)| {
+            k.strip_prefix(&prefix)
+                .and_then(|idx| idx.parse::<usize>().ok())
+                .map(|idx| (idx, v.clone()))
+        })
+        .collect();
+    indexed.sort_by_key(|(idx, _)| *idx);
+    indexed.into_iter().map(|(_, v)| v).collect()
 }
 
 fn optional_usize_param(req: &AwsRequest, name: &str) -> Result<Option<usize>, AwsServiceError> {
@@ -319,6 +528,33 @@ fn cache_parameter_group_xml(g: &CacheParameterGroup) -> String {
     )
 }
 
+fn cache_subnet_group_xml(g: &CacheSubnetGroup) -> String {
+    let subnets_xml: String = g
+        .subnet_ids
+        .iter()
+        .map(|id| {
+            format!(
+                "<Subnet>\
+                 <SubnetIdentifier>{}</SubnetIdentifier>\
+                 <SubnetAvailabilityZone><Name>us-east-1a</Name></SubnetAvailabilityZone>\
+                 </Subnet>",
+                xml_escape(id),
+            )
+        })
+        .collect();
+    format!(
+        "<CacheSubnetGroupName>{}</CacheSubnetGroupName>\
+         <CacheSubnetGroupDescription>{}</CacheSubnetGroupDescription>\
+         <VpcId>{}</VpcId>\
+         <Subnets>{subnets_xml}</Subnets>\
+         <ARN>{}</ARN>",
+        xml_escape(&g.cache_subnet_group_name),
+        xml_escape(&g.cache_subnet_group_description),
+        xml_escape(&g.vpc_id),
+        xml_escape(&g.arn),
+    )
+}
+
 fn parameter_xml(p: &EngineDefaultParameter) -> String {
     format!(
         "<Parameter>\
@@ -346,6 +582,70 @@ fn parameter_xml(p: &EngineDefaultParameter) -> String {
 mod tests {
     use super::*;
     use crate::state::default_engine_versions;
+    use std::collections::HashMap;
+
+    #[test]
+    fn parse_member_list_extracts_indexed_values() {
+        let mut params = HashMap::new();
+        params.insert(
+            "SubnetIds.SubnetIdentifier.1".to_string(),
+            "subnet-aaa".to_string(),
+        );
+        params.insert(
+            "SubnetIds.SubnetIdentifier.2".to_string(),
+            "subnet-bbb".to_string(),
+        );
+        params.insert(
+            "SubnetIds.SubnetIdentifier.3".to_string(),
+            "subnet-ccc".to_string(),
+        );
+        params.insert("OtherParam".to_string(), "ignored".to_string());
+
+        let result = parse_member_list(&params, "SubnetIds", "SubnetIdentifier");
+        assert_eq!(result, vec!["subnet-aaa", "subnet-bbb", "subnet-ccc"]);
+    }
+
+    #[test]
+    fn parse_member_list_returns_sorted_by_index() {
+        let mut params = HashMap::new();
+        params.insert(
+            "SubnetIds.SubnetIdentifier.3".to_string(),
+            "subnet-ccc".to_string(),
+        );
+        params.insert(
+            "SubnetIds.SubnetIdentifier.1".to_string(),
+            "subnet-aaa".to_string(),
+        );
+
+        let result = parse_member_list(&params, "SubnetIds", "SubnetIdentifier");
+        assert_eq!(result, vec!["subnet-aaa", "subnet-ccc"]);
+    }
+
+    #[test]
+    fn parse_member_list_returns_empty_for_no_matches() {
+        let params = HashMap::new();
+        let result = parse_member_list(&params, "SubnetIds", "SubnetIdentifier");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn cache_subnet_group_xml_contains_all_fields() {
+        let group = CacheSubnetGroup {
+            cache_subnet_group_name: "my-group".to_string(),
+            cache_subnet_group_description: "My description".to_string(),
+            vpc_id: "vpc-123".to_string(),
+            subnet_ids: vec!["subnet-aaa".to_string(), "subnet-bbb".to_string()],
+            arn: "arn:aws:elasticache:us-east-1:123:subnetgroup:my-group".to_string(),
+        };
+        let xml = cache_subnet_group_xml(&group);
+        assert!(xml.contains("<CacheSubnetGroupName>my-group</CacheSubnetGroupName>"));
+        assert!(xml
+            .contains("<CacheSubnetGroupDescription>My description</CacheSubnetGroupDescription>"));
+        assert!(xml.contains("<VpcId>vpc-123</VpcId>"));
+        assert!(xml.contains("<SubnetIdentifier>subnet-aaa</SubnetIdentifier>"));
+        assert!(xml.contains("<SubnetIdentifier>subnet-bbb</SubnetIdentifier>"));
+        assert!(xml.contains("<ARN>arn:aws:elasticache:us-east-1:123:subnetgroup:my-group</ARN>"));
+    }
 
     #[test]
     fn filter_engine_versions_by_engine() {

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -535,7 +535,7 @@ fn cache_subnet_group_xml(g: &CacheSubnetGroup, region: &str) -> String {
         .iter()
         .enumerate()
         .map(|(i, id)| {
-            let az = format!("{}{}", region, (b'a' + (i as u8 % 6)) as char);
+            let az = format!("{}{}", region, (b'a' + (i % 6) as u8) as char);
             format!(
                 "<Subnet>\
                  <SubnetIdentifier>{}</SubnetIdentifier>\

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -224,7 +224,7 @@ impl ElastiCacheService {
             arn,
         };
 
-        let xml = cache_subnet_group_xml(&group);
+        let xml = cache_subnet_group_xml(&group, &state.region);
         state.subnet_groups.insert(name, group);
 
         Ok(AwsResponse::xml(
@@ -271,7 +271,7 @@ impl ElastiCacheService {
             .map(|g| {
                 format!(
                     "<CacheSubnetGroup>{}</CacheSubnetGroup>",
-                    cache_subnet_group_xml(g)
+                    cache_subnet_group_xml(g, &state.region)
                 )
             })
             .collect();
@@ -328,6 +328,7 @@ impl ElastiCacheService {
         let subnet_ids = parse_member_list(&request.query_params, "SubnetIds", "SubnetIdentifier");
 
         let mut state = self.state.write();
+        let region = state.region.clone();
 
         let group = state.subnet_groups.get_mut(&name).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -344,7 +345,7 @@ impl ElastiCacheService {
             group.subnet_ids = subnet_ids;
         }
 
-        let xml = cache_subnet_group_xml(group);
+        let xml = cache_subnet_group_xml(group, &region);
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -528,17 +529,20 @@ fn cache_parameter_group_xml(g: &CacheParameterGroup) -> String {
     )
 }
 
-fn cache_subnet_group_xml(g: &CacheSubnetGroup) -> String {
+fn cache_subnet_group_xml(g: &CacheSubnetGroup, region: &str) -> String {
     let subnets_xml: String = g
         .subnet_ids
         .iter()
-        .map(|id| {
+        .enumerate()
+        .map(|(i, id)| {
+            let az = format!("{}{}", region, (b'a' + (i as u8 % 6)) as char);
             format!(
                 "<Subnet>\
                  <SubnetIdentifier>{}</SubnetIdentifier>\
-                 <SubnetAvailabilityZone><Name>us-east-1a</Name></SubnetAvailabilityZone>\
+                 <SubnetAvailabilityZone><Name>{}</Name></SubnetAvailabilityZone>\
                  </Subnet>",
                 xml_escape(id),
+                xml_escape(&az),
             )
         })
         .collect();
@@ -637,13 +641,15 @@ mod tests {
             subnet_ids: vec!["subnet-aaa".to_string(), "subnet-bbb".to_string()],
             arn: "arn:aws:elasticache:us-east-1:123:subnetgroup:my-group".to_string(),
         };
-        let xml = cache_subnet_group_xml(&group);
+        let xml = cache_subnet_group_xml(&group, "us-east-1");
         assert!(xml.contains("<CacheSubnetGroupName>my-group</CacheSubnetGroupName>"));
         assert!(xml
             .contains("<CacheSubnetGroupDescription>My description</CacheSubnetGroupDescription>"));
         assert!(xml.contains("<VpcId>vpc-123</VpcId>"));
         assert!(xml.contains("<SubnetIdentifier>subnet-aaa</SubnetIdentifier>"));
         assert!(xml.contains("<SubnetIdentifier>subnet-bbb</SubnetIdentifier>"));
+        assert!(xml.contains("<Name>us-east-1a</Name>"));
+        assert!(xml.contains("<Name>us-east-1b</Name>"));
         assert!(xml.contains("<ARN>arn:aws:elasticache:us-east-1:123:subnetgroup:my-group</ARN>"));
     }
 

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -34,25 +35,38 @@ pub struct EngineDefaultParameter {
     pub minimum_engine_version: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct CacheSubnetGroup {
+    pub cache_subnet_group_name: String,
+    pub cache_subnet_group_description: String,
+    pub vpc_id: String,
+    pub subnet_ids: Vec<String>,
+    pub arn: String,
+}
+
 #[derive(Debug)]
 pub struct ElastiCacheState {
     pub account_id: String,
     pub region: String,
     pub parameter_groups: Vec<CacheParameterGroup>,
+    pub subnet_groups: HashMap<String, CacheSubnetGroup>,
 }
 
 impl ElastiCacheState {
     pub fn new(account_id: &str, region: &str) -> Self {
         let parameter_groups = default_parameter_groups(account_id, region);
+        let subnet_groups = default_subnet_groups(account_id, region);
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
             parameter_groups,
+            subnet_groups,
         }
     }
 
     pub fn reset(&mut self) {
         self.parameter_groups = default_parameter_groups(&self.account_id, &self.region);
+        self.subnet_groups = default_subnet_groups(&self.account_id, &self.region);
     }
 }
 
@@ -94,6 +108,19 @@ fn default_parameter_groups(account_id: &str, region: &str) -> Vec<CacheParamete
             ),
         },
     ]
+}
+
+fn default_subnet_groups(account_id: &str, region: &str) -> HashMap<String, CacheSubnetGroup> {
+    let default_group = CacheSubnetGroup {
+        cache_subnet_group_name: "default".to_string(),
+        cache_subnet_group_description: "Default CacheSubnetGroup".to_string(),
+        vpc_id: "vpc-00000000".to_string(),
+        subnet_ids: vec!["subnet-00000000".to_string()],
+        arn: format!("arn:aws:elasticache:{region}:{account_id}:subnetgroup:default"),
+    };
+    let mut map = HashMap::new();
+    map.insert("default".to_string(), default_group);
+    map
 }
 
 pub fn default_parameters_for_family(family: &str) -> Vec<EngineDefaultParameter> {
@@ -195,12 +222,37 @@ mod tests {
     }
 
     #[test]
+    fn state_new_creates_default_subnet_group() {
+        let state = ElastiCacheState::new("123456789012", "us-east-1");
+        assert_eq!(state.subnet_groups.len(), 1);
+        let default = state.subnet_groups.get("default").unwrap();
+        assert_eq!(default.cache_subnet_group_name, "default");
+        assert_eq!(
+            default.cache_subnet_group_description,
+            "Default CacheSubnetGroup"
+        );
+        assert_eq!(default.vpc_id, "vpc-00000000");
+        assert!(!default.subnet_ids.is_empty());
+        assert!(default.arn.contains("subnetgroup:default"));
+    }
+
+    #[test]
     fn reset_restores_default_parameter_groups() {
         let mut state = ElastiCacheState::new("123456789012", "us-east-1");
         state.parameter_groups.clear();
         assert!(state.parameter_groups.is_empty());
         state.reset();
         assert_eq!(state.parameter_groups.len(), 2);
+    }
+
+    #[test]
+    fn reset_restores_default_subnet_groups() {
+        let mut state = ElastiCacheState::new("123456789012", "us-east-1");
+        state.subnet_groups.clear();
+        assert!(state.subnet_groups.is_empty());
+        state.reset();
+        assert_eq!(state.subnet_groups.len(), 1);
+        assert!(state.subnet_groups.contains_key("default"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- implement CreateCacheSubnetGroup with duplicate detection and required param validation
- implement DescribeCacheSubnetGroups with optional name filter and Marker/MaxRecords pagination
- implement DeleteCacheSubnetGroup with protection against deleting the default group
- implement ModifyCacheSubnetGroup with description and subnet ID updates
- add parse_member_list() helper for AWS Query protocol member list encoding
- seed a default subnet group on state creation
- add 4 handwritten conformance tests with test_action macro coverage
- add 6 e2e tests covering create, describe, filter, modify, delete, and error cases
- add 6 unit tests for member list parsing, XML output, and state management

## Validation
- cargo fmt --all
- cargo build --bin fakecloud
- cargo clippy --workspace -- -D warnings
- cargo test -p fakecloud-elasticache --lib (17 passed)
- cargo test -p fakecloud-conformance --test elasticache (7 passed)
- cargo test -p fakecloud-e2e --test elasticache (12 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full ElastiCache CacheSubnetGroup support to `fakecloud-elasticache` with create, describe, modify, and delete APIs. Also fixes subnet AZ rendering to use the configured region and correct AZ suffixes for long subnet lists.

- **New Features**
  - Implemented CreateCacheSubnetGroup, DescribeCacheSubnetGroups, ModifyCacheSubnetGroup, and DeleteCacheSubnetGroup with input validation and duplicate detection.
  - Added `parse_member_list` for AWS Query list encoding of `SubnetIds`.
  - Supported `CacheSubnetGroupName` filter and `Marker`/`MaxRecords` pagination in Describe.
  - Seeded a `default` subnet group and blocked its deletion.
  - Returned full XML responses with VPC ID, Subnets, and ARN.

- **Bug Fixes**
  - Subnet AvailabilityZone names now use the configured region.
  - Fixed AZ suffix calculation by applying modulo before the cast to avoid wrong letters with large subnet lists.

<sup>Written for commit c240e876563b5521fa42f9d176988b01f3a92804. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

