### PR TITLE
feat: add elasticache user and user group APIs

### DIFF
--- a/crates/fakecloud-conformance/tests/elasticache.rs
+++ b/crates/fakecloud-conformance/tests/elasticache.rs
@@ -358,6 +358,137 @@ async fn elasticache_remove_tags_from_resource() {
     assert_eq!(tags[0].key(), Some("team"));
 }
 
+#[test_action("elasticache", "CreateUser", checksum = "eeb45fb0")]
+#[tokio::test]
+async fn elasticache_create_user() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .create_user()
+        .user_id("testuser")
+        .user_name("testuser")
+        .engine("redis")
+        .access_string("on ~* +@all")
+        .no_password_required(true)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.user_id(), Some("testuser"));
+    assert_eq!(response.user_name(), Some("testuser"));
+    assert_eq!(response.status(), Some("active"));
+}
+
+#[test_action("elasticache", "DescribeUsers", checksum = "e5c2e676")]
+#[tokio::test]
+async fn elasticache_describe_users() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client.describe_users().send().await.unwrap();
+
+    let users = response.users();
+    assert!(!users.is_empty());
+    assert!(users.iter().any(|u| u.user_id() == Some("default")));
+}
+
+#[test_action("elasticache", "DeleteUser", checksum = "98b86a69")]
+#[tokio::test]
+async fn elasticache_delete_user() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user()
+        .user_id("deluser")
+        .user_name("deluser")
+        .engine("redis")
+        .access_string("on ~* +@all")
+        .no_password_required(true)
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .delete_user()
+        .user_id("deluser")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.user_id(), Some("deluser"));
+}
+
+#[test_action("elasticache", "CreateUserGroup", checksum = "294a66f3")]
+#[tokio::test]
+async fn elasticache_create_user_group() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .create_user_group()
+        .user_group_id("test-group")
+        .engine("redis")
+        .user_ids("default")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.user_group_id(), Some("test-group"));
+    assert_eq!(response.status(), Some("active"));
+}
+
+#[test_action("elasticache", "DescribeUserGroups", checksum = "94732ab4")]
+#[tokio::test]
+async fn elasticache_describe_user_groups() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user_group()
+        .user_group_id("desc-group")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .describe_user_groups()
+        .user_group_id("desc-group")
+        .send()
+        .await
+        .unwrap();
+
+    let groups = response.user_groups();
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].user_group_id(), Some("desc-group"));
+}
+
+#[test_action("elasticache", "DeleteUserGroup", checksum = "39a6b59a")]
+#[tokio::test]
+async fn elasticache_delete_user_group() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user_group()
+        .user_group_id("del-group")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .delete_user_group()
+        .user_group_id("del-group")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.user_group_id(), Some("del-group"));
+}
+
 #[test_action("elasticache", "DescribeCacheParameterGroups", checksum = "f2d641d8")]
 #[tokio::test]
 async fn elasticache_describe_cache_parameter_groups() {

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -496,6 +496,180 @@ async fn elasticache_delete_nonexistent_replication_group_errors() {
 }
 
 // ---------------------------------------------------------------------------
+// User tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn elasticache_create_user_and_verify_in_describe() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let create_resp = client
+        .create_user()
+        .user_id("myuser")
+        .user_name("myuser")
+        .engine("redis")
+        .access_string("on ~* +@all")
+        .no_password_required(true)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(create_resp.user_id(), Some("myuser"));
+    assert_eq!(create_resp.user_name(), Some("myuser"));
+    assert_eq!(create_resp.status(), Some("active"));
+    assert_eq!(create_resp.engine(), Some("redis"));
+
+    // Verify it appears in describe
+    let describe_resp = client
+        .describe_users()
+        .user_id("myuser")
+        .send()
+        .await
+        .unwrap();
+
+    let users = describe_resp.users();
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0].user_id(), Some("myuser"));
+}
+
+#[tokio::test]
+async fn elasticache_delete_user_and_verify_gone() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user()
+        .user_id("deluser")
+        .user_name("deluser")
+        .engine("redis")
+        .access_string("on ~* +@all")
+        .no_password_required(true)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_user()
+        .user_id("deluser")
+        .send()
+        .await
+        .unwrap();
+
+    // Verify it's gone
+    let result = client.describe_users().user_id("deluser").send().await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn elasticache_cannot_delete_default_user() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let result = client.delete_user().user_id("default").send().await;
+
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// UserGroup tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn elasticache_create_user_group_with_user_references() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    // Create a user first
+    client
+        .create_user()
+        .user_id("groupuser")
+        .user_name("groupuser")
+        .engine("redis")
+        .access_string("on ~* +@all")
+        .no_password_required(true)
+        .send()
+        .await
+        .unwrap();
+
+    let create_resp = client
+        .create_user_group()
+        .user_group_id("mygroup")
+        .engine("redis")
+        .user_ids("default")
+        .user_ids("groupuser")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(create_resp.user_group_id(), Some("mygroup"));
+    assert_eq!(create_resp.status(), Some("active"));
+    assert_eq!(create_resp.engine(), Some("redis"));
+    let user_ids = create_resp.user_ids();
+    assert!(user_ids.contains(&"default".to_string()));
+    assert!(user_ids.contains(&"groupuser".to_string()));
+}
+
+#[tokio::test]
+async fn elasticache_describe_user_groups() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user_group()
+        .user_group_id("descgroup")
+        .engine("redis")
+        .user_ids("default")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .describe_user_groups()
+        .user_group_id("descgroup")
+        .send()
+        .await
+        .unwrap();
+
+    let groups = response.user_groups();
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].user_group_id(), Some("descgroup"));
+}
+
+#[tokio::test]
+async fn elasticache_delete_user_group() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user_group()
+        .user_group_id("delgroup")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .delete_user_group()
+        .user_group_id("delgroup")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.user_group_id(), Some("delgroup"));
+
+    // Verify it's gone
+    let result = client
+        .describe_user_groups()
+        .user_group_id("delgroup")
+        .send()
+        .await;
+
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
 // Existing tests
 // ---------------------------------------------------------------------------
 

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -639,7 +639,35 @@ impl ElastiCacheService {
                 "AuthenticationMode.Passwords",
                 "member",
             );
-            (mode.clone(), mode_passwords.len() as i32)
+            match mode.as_str() {
+                "password" => {
+                    if mode_passwords.is_empty() {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidParameterValue",
+                            "At least one password is required when AuthenticationMode.Type is password.".to_string(),
+                        ));
+                    }
+                    ("password".to_string(), mode_passwords.len() as i32)
+                }
+                "no-password-required" | "iam" => {
+                    if !mode_passwords.is_empty() {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidParameterValue",
+                            format!("Passwords cannot be provided when AuthenticationMode.Type is {mode}."),
+                        ));
+                    }
+                    (mode.clone(), 0)
+                }
+                _ => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValue",
+                        format!("Invalid value for AuthenticationMode.Type: {mode}. Supported values: password, iam, no-password-required"),
+                    ));
+                }
+            }
         } else if !passwords.is_empty() {
             ("password".to_string(), passwords.len() as i32)
         } else {
@@ -802,14 +830,27 @@ impl ElastiCacheService {
             ));
         }
 
-        // Validate all referenced users exist
+        // Validate all referenced users exist and have a matching engine
         for uid in &user_ids {
-            if !state.users.contains_key(uid) {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
-                    "UserNotFoundFault",
-                    format!("User {uid} not found."),
-                ));
+            match state.users.get(uid) {
+                None => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "UserNotFoundFault",
+                        format!("User {uid} not found."),
+                    ));
+                }
+                Some(user) if user.engine != engine => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValue",
+                        format!(
+                            "User {uid} has engine {} which does not match the user group engine {engine}.",
+                            user.engine
+                        ),
+                    ));
+                }
+                _ => {}
             }
         }
 

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -632,6 +632,13 @@ impl ElastiCacheService {
         let auth_mode_type = optional_param(request, "AuthenticationMode.Type");
 
         let (authentication_type, password_count) = if no_password_required {
+            if !passwords.is_empty() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterCombination",
+                    "Passwords cannot be provided when NoPasswordRequired is true.".to_string(),
+                ));
+            }
             ("no-password".to_string(), 0)
         } else if let Some(ref mode) = auth_mode_type {
             let mode_passwords = parse_member_list(

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -9,8 +9,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 use crate::runtime::{ElastiCacheRuntime, RuntimeError};
 use crate::state::{
     default_engine_versions, default_parameters_for_family, CacheEngineVersion,
-    CacheParameterGroup, CacheSubnetGroup, EngineDefaultParameter, ReplicationGroup,
-    SharedElastiCacheState,
+    CacheParameterGroup, CacheSubnetGroup, ElastiCacheUser, ElastiCacheUserGroup,
+    EngineDefaultParameter, ReplicationGroup, SharedElastiCacheState,
 };
 
 const ELASTICACHE_NS: &str = "http://elasticache.amazonaws.com/doc/2015-02-02/";
@@ -18,13 +18,19 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "AddTagsToResource",
     "CreateCacheSubnetGroup",
     "CreateReplicationGroup",
+    "CreateUser",
+    "CreateUserGroup",
     "DeleteCacheSubnetGroup",
     "DeleteReplicationGroup",
+    "DeleteUser",
+    "DeleteUserGroup",
     "DescribeCacheEngineVersions",
     "DescribeCacheParameterGroups",
     "DescribeCacheSubnetGroups",
     "DescribeEngineDefaultParameters",
     "DescribeReplicationGroups",
+    "DescribeUserGroups",
+    "DescribeUsers",
     "ListTagsForResource",
     "ModifyCacheSubnetGroup",
     "RemoveTagsFromResource",
@@ -60,13 +66,19 @@ impl AwsService for ElastiCacheService {
             "AddTagsToResource" => self.add_tags_to_resource(&request),
             "CreateCacheSubnetGroup" => self.create_cache_subnet_group(&request),
             "CreateReplicationGroup" => self.create_replication_group(&request).await,
+            "CreateUser" => self.create_user(&request),
+            "CreateUserGroup" => self.create_user_group(&request),
             "DeleteCacheSubnetGroup" => self.delete_cache_subnet_group(&request),
             "DeleteReplicationGroup" => self.delete_replication_group(&request).await,
+            "DeleteUser" => self.delete_user(&request),
+            "DeleteUserGroup" => self.delete_user_group(&request),
             "DescribeCacheEngineVersions" => self.describe_cache_engine_versions(&request),
             "DescribeCacheParameterGroups" => self.describe_cache_parameter_groups(&request),
             "DescribeCacheSubnetGroups" => self.describe_cache_subnet_groups(&request),
             "DescribeEngineDefaultParameters" => self.describe_engine_default_parameters(&request),
             "DescribeReplicationGroups" => self.describe_replication_groups(&request),
+            "DescribeUserGroups" => self.describe_user_groups(&request),
+            "DescribeUsers" => self.describe_users(&request),
             "ListTagsForResource" => self.list_tags_for_resource(&request),
             "ModifyCacheSubnetGroup" => self.modify_cache_subnet_group(&request),
             "RemoveTagsFromResource" => self.remove_tags_from_resource(&request),
@@ -599,6 +611,317 @@ impl ElastiCacheService {
         ))
     }
 
+    fn create_user(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let user_id = required_param(request, "UserId")?;
+        let user_name = required_param(request, "UserName")?;
+        let engine = required_param(request, "Engine")?;
+        let access_string = required_param(request, "AccessString")?;
+
+        if engine != "redis" && engine != "valkey" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!("Invalid value for Engine: {engine}. Supported engines: redis, valkey"),
+            ));
+        }
+
+        let no_password_required =
+            parse_optional_bool(optional_param(request, "NoPasswordRequired").as_deref())?
+                .unwrap_or(false);
+        let passwords = parse_member_list(&request.query_params, "Passwords", "member");
+        let auth_mode_type = optional_param(request, "AuthenticationMode.Type");
+
+        let (authentication_type, password_count) = if no_password_required {
+            ("no-password".to_string(), 0)
+        } else if let Some(ref mode) = auth_mode_type {
+            let mode_passwords = parse_member_list(
+                &request.query_params,
+                "AuthenticationMode.Passwords",
+                "member",
+            );
+            (mode.clone(), mode_passwords.len() as i32)
+        } else if !passwords.is_empty() {
+            ("password".to_string(), passwords.len() as i32)
+        } else {
+            ("no-password".to_string(), 0)
+        };
+
+        let minimum_engine_version = if engine == "valkey" {
+            "8.0".to_string()
+        } else {
+            "6.0".to_string()
+        };
+
+        let mut state = self.state.write();
+
+        if state.users.contains_key(&user_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "UserAlreadyExistsFault",
+                format!("User {user_id} already exists."),
+            ));
+        }
+
+        let arn = format!(
+            "arn:aws:elasticache:{}:{}:user:{}",
+            state.region, state.account_id, user_id
+        );
+
+        let user = ElastiCacheUser {
+            user_id: user_id.clone(),
+            user_name,
+            engine,
+            access_string,
+            status: "active".to_string(),
+            authentication_type,
+            password_count,
+            arn,
+            minimum_engine_version,
+            user_group_ids: Vec::new(),
+        };
+
+        let xml = user_xml(&user);
+        state.register_arn(&user.arn);
+        state.users.insert(user_id, user);
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap("CreateUser", &xml, &request.request_id),
+        ))
+    }
+
+    fn describe_users(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let user_id = optional_param(request, "UserId");
+        let max_records = optional_usize_param(request, "MaxRecords")?;
+        let marker = optional_param(request, "Marker");
+
+        let state = self.state.read();
+
+        let users: Vec<&ElastiCacheUser> = if let Some(ref id) = user_id {
+            match state.users.get(id) {
+                Some(u) => vec![u],
+                None => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "UserNotFoundFault",
+                        format!("User {id} not found."),
+                    ));
+                }
+            }
+        } else {
+            let mut users: Vec<&ElastiCacheUser> = state.users.values().collect();
+            users.sort_by(|a, b| a.user_id.cmp(&b.user_id));
+            users
+        };
+
+        let (page, next_marker) = paginate(&users, marker.as_deref(), max_records);
+
+        let members_xml: String = page
+            .iter()
+            .map(|u| format!("<member>{}</member>", user_xml(u)))
+            .collect();
+        let marker_xml = next_marker
+            .map(|m| format!("<Marker>{}</Marker>", xml_escape(&m)))
+            .unwrap_or_default();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DescribeUsers",
+                &format!("<Users>{members_xml}</Users>{marker_xml}"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn delete_user(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let user_id = required_param(request, "UserId")?;
+
+        if user_id == "default" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                "Cannot delete the default user.".to_string(),
+            ));
+        }
+
+        let mut state = self.state.write();
+
+        let user = state.users.remove(&user_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "UserNotFoundFault",
+                format!("User {user_id} not found."),
+            )
+        })?;
+
+        state.tags.remove(&user.arn);
+
+        // Remove user from any user groups
+        for group in state.user_groups.values_mut() {
+            group.user_ids.retain(|id| id != &user_id);
+        }
+
+        let mut deleted_user = user;
+        deleted_user.status = "deleting".to_string();
+        let xml = user_xml(&deleted_user);
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap("DeleteUser", &xml, &request.request_id),
+        ))
+    }
+
+    fn create_user_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let user_group_id = required_param(request, "UserGroupId")?;
+        let engine = required_param(request, "Engine")?;
+
+        if engine != "redis" && engine != "valkey" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!("Invalid value for Engine: {engine}. Supported engines: redis, valkey"),
+            ));
+        }
+
+        let user_ids = parse_member_list(&request.query_params, "UserIds", "member");
+
+        let minimum_engine_version = if engine == "valkey" {
+            "8.0".to_string()
+        } else {
+            "6.0".to_string()
+        };
+
+        let mut state = self.state.write();
+
+        if state.user_groups.contains_key(&user_group_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "UserGroupAlreadyExistsFault",
+                format!("User Group {user_group_id} already exists."),
+            ));
+        }
+
+        // Validate all referenced users exist
+        for uid in &user_ids {
+            if !state.users.contains_key(uid) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "UserNotFoundFault",
+                    format!("User {uid} not found."),
+                ));
+            }
+        }
+
+        let arn = format!(
+            "arn:aws:elasticache:{}:{}:usergroup:{}",
+            state.region, state.account_id, user_group_id
+        );
+
+        let group = ElastiCacheUserGroup {
+            user_group_id: user_group_id.clone(),
+            engine,
+            status: "active".to_string(),
+            user_ids: user_ids.clone(),
+            arn,
+            minimum_engine_version,
+            pending_changes: None,
+            replication_groups: Vec::new(),
+        };
+
+        // Update user_group_ids on referenced users
+        for uid in &user_ids {
+            if let Some(user) = state.users.get_mut(uid) {
+                user.user_group_ids.push(user_group_id.clone());
+            }
+        }
+
+        let xml = user_group_xml(&group);
+        state.register_arn(&group.arn);
+        state.user_groups.insert(user_group_id, group);
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap("CreateUserGroup", &xml, &request.request_id),
+        ))
+    }
+
+    fn describe_user_groups(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let user_group_id = optional_param(request, "UserGroupId");
+        let max_records = optional_usize_param(request, "MaxRecords")?;
+        let marker = optional_param(request, "Marker");
+
+        let state = self.state.read();
+
+        let groups: Vec<&ElastiCacheUserGroup> = if let Some(ref id) = user_group_id {
+            match state.user_groups.get(id) {
+                Some(g) => vec![g],
+                None => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "UserGroupNotFoundFault",
+                        format!("User Group {id} not found."),
+                    ));
+                }
+            }
+        } else {
+            let mut groups: Vec<&ElastiCacheUserGroup> = state.user_groups.values().collect();
+            groups.sort_by(|a, b| a.user_group_id.cmp(&b.user_group_id));
+            groups
+        };
+
+        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records);
+
+        let members_xml: String = page
+            .iter()
+            .map(|g| format!("<member>{}</member>", user_group_xml(g)))
+            .collect();
+        let marker_xml = next_marker
+            .map(|m| format!("<Marker>{}</Marker>", xml_escape(&m)))
+            .unwrap_or_default();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DescribeUserGroups",
+                &format!("<UserGroups>{members_xml}</UserGroups>{marker_xml}"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn delete_user_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let user_group_id = required_param(request, "UserGroupId")?;
+
+        let mut state = self.state.write();
+
+        let group = state.user_groups.remove(&user_group_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "UserGroupNotFoundFault",
+                format!("User Group {user_group_id} not found."),
+            )
+        })?;
+
+        state.tags.remove(&group.arn);
+
+        // Remove this group from users' user_group_ids
+        for uid in &group.user_ids {
+            if let Some(user) = state.users.get_mut(uid) {
+                user.user_group_ids.retain(|gid| gid != &user_group_id);
+            }
+        }
+
+        let mut deleted_group = group;
+        deleted_group.status = "deleting".to_string();
+        let xml = user_group_xml(&deleted_group);
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap("DeleteUserGroup", &xml, &request.request_id),
+        ))
+    }
+
     fn add_tags_to_resource(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let resource_name = required_param(request, "ResourceName")?;
         let tags = parse_tags(request)?;
@@ -995,6 +1318,85 @@ fn replication_group_xml(g: &ReplicationGroup, region: &str) -> String {
     )
 }
 
+fn user_xml(u: &ElastiCacheUser) -> String {
+    let user_group_ids_xml: String = u
+        .user_group_ids
+        .iter()
+        .map(|id| format!("<member>{}</member>", xml_escape(id)))
+        .collect();
+    format!(
+        "<UserId>{}</UserId>\
+         <UserName>{}</UserName>\
+         <Status>{}</Status>\
+         <Engine>{}</Engine>\
+         <MinimumEngineVersion>{}</MinimumEngineVersion>\
+         <AccessString>{}</AccessString>\
+         <UserGroupIds>{user_group_ids_xml}</UserGroupIds>\
+         <Authentication>\
+         <Type>{}</Type>\
+         <PasswordCount>{}</PasswordCount>\
+         </Authentication>\
+         <ARN>{}</ARN>",
+        xml_escape(&u.user_id),
+        xml_escape(&u.user_name),
+        xml_escape(&u.status),
+        xml_escape(&u.engine),
+        xml_escape(&u.minimum_engine_version),
+        xml_escape(&u.access_string),
+        xml_escape(&u.authentication_type),
+        u.password_count,
+        xml_escape(&u.arn),
+    )
+}
+
+fn user_group_xml(g: &ElastiCacheUserGroup) -> String {
+    let user_ids_xml: String = g
+        .user_ids
+        .iter()
+        .map(|id| format!("<member>{}</member>", xml_escape(id)))
+        .collect();
+    let replication_groups_xml: String = g
+        .replication_groups
+        .iter()
+        .map(|id| format!("<member>{}</member>", xml_escape(id)))
+        .collect();
+    let pending_xml = if let Some(ref pc) = g.pending_changes {
+        let to_add: String = pc
+            .user_ids_to_add
+            .iter()
+            .map(|id| format!("<member>{}</member>", xml_escape(id)))
+            .collect();
+        let to_remove: String = pc
+            .user_ids_to_remove
+            .iter()
+            .map(|id| format!("<member>{}</member>", xml_escape(id)))
+            .collect();
+        format!(
+            "<PendingChanges>\
+             <UserIdsToAdd>{to_add}</UserIdsToAdd>\
+             <UserIdsToRemove>{to_remove}</UserIdsToRemove>\
+             </PendingChanges>"
+        )
+    } else {
+        String::new()
+    };
+    format!(
+        "<UserGroupId>{}</UserGroupId>\
+         <Status>{}</Status>\
+         <Engine>{}</Engine>\
+         <MinimumEngineVersion>{}</MinimumEngineVersion>\
+         <UserIds>{user_ids_xml}</UserIds>\
+         <ReplicationGroups>{replication_groups_xml}</ReplicationGroups>\
+         {pending_xml}\
+         <ARN>{}</ARN>",
+        xml_escape(&g.user_group_id),
+        xml_escape(&g.status),
+        xml_escape(&g.engine),
+        xml_escape(&g.minimum_engine_version),
+        xml_escape(&g.arn),
+    )
+}
+
 fn runtime_error_to_service_error(error: RuntimeError) -> AwsServiceError {
     match error {
         RuntimeError::Unavailable => AwsServiceError::aws_error(
@@ -1254,5 +1656,177 @@ mod tests {
     fn tag_xml_produces_valid_element() {
         let xml = tag_xml(&("env".to_string(), "prod".to_string()));
         assert_eq!(xml, "<Tag><Key>env</Key><Value>prod</Value></Tag>");
+    }
+
+    #[test]
+    fn user_xml_contains_all_fields() {
+        let user = ElastiCacheUser {
+            user_id: "myuser".to_string(),
+            user_name: "myuser".to_string(),
+            engine: "redis".to_string(),
+            access_string: "on ~* +@all".to_string(),
+            status: "active".to_string(),
+            authentication_type: "password".to_string(),
+            password_count: 1,
+            arn: "arn:aws:elasticache:us-east-1:123:user:myuser".to_string(),
+            minimum_engine_version: "6.0".to_string(),
+            user_group_ids: vec!["group1".to_string()],
+        };
+        let xml = user_xml(&user);
+        assert!(xml.contains("<UserId>myuser</UserId>"));
+        assert!(xml.contains("<UserName>myuser</UserName>"));
+        assert!(xml.contains("<Engine>redis</Engine>"));
+        assert!(xml.contains("<AccessString>on ~* +@all</AccessString>"));
+        assert!(xml.contains("<Status>active</Status>"));
+        assert!(xml.contains("<Type>password</Type>"));
+        assert!(xml.contains("<PasswordCount>1</PasswordCount>"));
+        assert!(xml.contains("<member>group1</member>"));
+        assert!(xml.contains("<ARN>arn:aws:elasticache:us-east-1:123:user:myuser</ARN>"));
+    }
+
+    #[test]
+    fn user_group_xml_contains_all_fields() {
+        let group = ElastiCacheUserGroup {
+            user_group_id: "mygroup".to_string(),
+            engine: "redis".to_string(),
+            status: "active".to_string(),
+            user_ids: vec!["default".to_string(), "myuser".to_string()],
+            arn: "arn:aws:elasticache:us-east-1:123:usergroup:mygroup".to_string(),
+            minimum_engine_version: "6.0".to_string(),
+            pending_changes: None,
+            replication_groups: Vec::new(),
+        };
+        let xml = user_group_xml(&group);
+        assert!(xml.contains("<UserGroupId>mygroup</UserGroupId>"));
+        assert!(xml.contains("<Engine>redis</Engine>"));
+        assert!(xml.contains("<Status>active</Status>"));
+        assert!(xml.contains("<member>default</member>"));
+        assert!(xml.contains("<member>myuser</member>"));
+        assert!(xml.contains("<ARN>arn:aws:elasticache:us-east-1:123:usergroup:mygroup</ARN>"));
+    }
+
+    #[test]
+    fn create_user_returns_user_xml() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let service = ElastiCacheService::new(shared);
+
+        let req = request(
+            "CreateUser",
+            &[
+                ("UserId", "testuser"),
+                ("UserName", "testuser"),
+                ("Engine", "redis"),
+                ("AccessString", "on ~* +@all"),
+            ],
+        );
+        let resp = service.create_user(&req).unwrap();
+        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        assert!(body.contains("<UserId>testuser</UserId>"));
+        assert!(body.contains("<Status>active</Status>"));
+        assert!(body.contains("<CreateUserResponse"));
+    }
+
+    #[test]
+    fn create_user_rejects_duplicate() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let service = ElastiCacheService::new(shared);
+
+        let req = request(
+            "CreateUser",
+            &[
+                ("UserId", "default"),
+                ("UserName", "default"),
+                ("Engine", "redis"),
+                ("AccessString", "on ~* +@all"),
+            ],
+        );
+        assert!(service.create_user(&req).is_err());
+    }
+
+    #[test]
+    fn delete_user_rejects_default() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let service = ElastiCacheService::new(shared);
+
+        let req = request("DeleteUser", &[("UserId", "default")]);
+        assert!(service.delete_user(&req).is_err());
+    }
+
+    #[test]
+    fn describe_users_returns_default_user() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let service = ElastiCacheService::new(shared);
+
+        let req = request("DescribeUsers", &[]);
+        let resp = service.describe_users(&req).unwrap();
+        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        assert!(body.contains("<UserId>default</UserId>"));
+    }
+
+    #[test]
+    fn create_and_describe_user_group() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let service = ElastiCacheService::new(shared);
+
+        let req = request(
+            "CreateUserGroup",
+            &[
+                ("UserGroupId", "mygroup"),
+                ("Engine", "redis"),
+                ("UserIds.member.1", "default"),
+            ],
+        );
+        let resp = service.create_user_group(&req).unwrap();
+        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        assert!(body.contains("<UserGroupId>mygroup</UserGroupId>"));
+        assert!(body.contains("<member>default</member>"));
+
+        let req = request("DescribeUserGroups", &[]);
+        let resp = service.describe_user_groups(&req).unwrap();
+        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        assert!(body.contains("<UserGroupId>mygroup</UserGroupId>"));
+    }
+
+    #[test]
+    fn create_user_group_rejects_unknown_user() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let service = ElastiCacheService::new(shared);
+
+        let req = request(
+            "CreateUserGroup",
+            &[
+                ("UserGroupId", "mygroup"),
+                ("Engine", "redis"),
+                ("UserIds.member.1", "nonexistent"),
+            ],
+        );
+        assert!(service.create_user_group(&req).is_err());
+    }
+
+    #[test]
+    fn delete_user_group_removes_from_state() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let service = ElastiCacheService::new(shared);
+
+        let req = request(
+            "CreateUserGroup",
+            &[("UserGroupId", "delgroup"), ("Engine", "redis")],
+        );
+        service.create_user_group(&req).unwrap();
+
+        let req = request("DeleteUserGroup", &[("UserGroupId", "delgroup")]);
+        let resp = service.delete_user_group(&req).unwrap();
+        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        assert!(body.contains("<Status>deleting</Status>"));
+
+        let req = request("DescribeUserGroups", &[("UserGroupId", "delgroup")]);
+        assert!(service.describe_user_groups(&req).is_err());
     }
 }

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -113,10 +113,13 @@ impl ElastiCacheState {
         let parameter_groups = default_parameter_groups(account_id, region);
         let subnet_groups = default_subnet_groups(account_id, region);
         let users = default_users(account_id, region);
-        let tags: HashMap<String, Vec<(String, String)>> = subnet_groups
+        let mut tags: HashMap<String, Vec<(String, String)>> = subnet_groups
             .values()
             .map(|g| (g.arn.clone(), Vec::new()))
             .collect();
+        for user in users.values() {
+            tags.insert(user.arn.clone(), Vec::new());
+        }
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -139,6 +142,9 @@ impl ElastiCacheState {
         self.tags.clear();
         for g in self.subnet_groups.values() {
             self.tags.insert(g.arn.clone(), Vec::new());
+        }
+        for user in self.users.values() {
+            self.tags.insert(user.arn.clone(), Vec::new());
         }
         self.in_progress_replication_group_ids.clear();
     }

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -63,6 +63,38 @@ pub struct ReplicationGroup {
     pub member_clusters: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ElastiCacheUser {
+    pub user_id: String,
+    pub user_name: String,
+    pub engine: String,
+    pub access_string: String,
+    pub status: String,
+    pub authentication_type: String,
+    pub password_count: i32,
+    pub arn: String,
+    pub minimum_engine_version: String,
+    pub user_group_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ElastiCacheUserGroup {
+    pub user_group_id: String,
+    pub engine: String,
+    pub status: String,
+    pub user_ids: Vec<String>,
+    pub arn: String,
+    pub minimum_engine_version: String,
+    pub pending_changes: Option<UserGroupPendingChanges>,
+    pub replication_groups: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UserGroupPendingChanges {
+    pub user_ids_to_add: Vec<String>,
+    pub user_ids_to_remove: Vec<String>,
+}
+
 #[derive(Debug)]
 pub struct ElastiCacheState {
     pub account_id: String,
@@ -70,6 +102,8 @@ pub struct ElastiCacheState {
     pub parameter_groups: Vec<CacheParameterGroup>,
     pub subnet_groups: HashMap<String, CacheSubnetGroup>,
     pub replication_groups: HashMap<String, ReplicationGroup>,
+    pub users: HashMap<String, ElastiCacheUser>,
+    pub user_groups: HashMap<String, ElastiCacheUserGroup>,
     pub tags: HashMap<String, Vec<(String, String)>>,
     in_progress_replication_group_ids: HashSet<String>,
 }
@@ -78,6 +112,7 @@ impl ElastiCacheState {
     pub fn new(account_id: &str, region: &str) -> Self {
         let parameter_groups = default_parameter_groups(account_id, region);
         let subnet_groups = default_subnet_groups(account_id, region);
+        let users = default_users(account_id, region);
         let tags: HashMap<String, Vec<(String, String)>> = subnet_groups
             .values()
             .map(|g| (g.arn.clone(), Vec::new()))
@@ -88,6 +123,8 @@ impl ElastiCacheState {
             parameter_groups,
             subnet_groups,
             replication_groups: HashMap::new(),
+            users,
+            user_groups: HashMap::new(),
             tags,
             in_progress_replication_group_ids: HashSet::new(),
         }
@@ -97,6 +134,8 @@ impl ElastiCacheState {
         self.parameter_groups = default_parameter_groups(&self.account_id, &self.region);
         self.subnet_groups = default_subnet_groups(&self.account_id, &self.region);
         self.replication_groups.clear();
+        self.users = default_users(&self.account_id, &self.region);
+        self.user_groups.clear();
         self.tags.clear();
         for g in self.subnet_groups.values() {
             self.tags.insert(g.arn.clone(), Vec::new());
@@ -262,6 +301,26 @@ pub fn default_parameters_for_family(family: &str) -> Vec<EngineDefaultParameter
     }
 }
 
+fn default_users(account_id: &str, region: &str) -> HashMap<String, ElastiCacheUser> {
+    let mut map = HashMap::new();
+    map.insert(
+        "default".to_string(),
+        ElastiCacheUser {
+            user_id: "default".to_string(),
+            user_name: "default".to_string(),
+            engine: "redis".to_string(),
+            access_string: "on ~* +@all".to_string(),
+            status: "active".to_string(),
+            authentication_type: "no-password".to_string(),
+            password_count: 0,
+            arn: format!("arn:aws:elasticache:{region}:{account_id}:user:default"),
+            minimum_engine_version: "6.0".to_string(),
+            user_group_ids: Vec::new(),
+        },
+    );
+    map
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -352,6 +411,58 @@ mod tests {
 
         state.cancel_replication_group_creation("rg-1");
         assert!(state.begin_replication_group_creation("rg-1"));
+    }
+
+    #[test]
+    fn state_new_creates_default_user() {
+        let state = ElastiCacheState::new("123456789012", "us-east-1");
+        assert_eq!(state.users.len(), 1);
+        let default = state.users.get("default").unwrap();
+        assert_eq!(default.user_id, "default");
+        assert_eq!(default.user_name, "default");
+        assert_eq!(default.engine, "redis");
+        assert_eq!(default.access_string, "on ~* +@all");
+        assert_eq!(default.status, "active");
+        assert_eq!(default.authentication_type, "no-password");
+        assert_eq!(default.password_count, 0);
+        assert!(default.arn.contains("user:default"));
+    }
+
+    #[test]
+    fn state_new_has_empty_user_groups() {
+        let state = ElastiCacheState::new("123456789012", "us-east-1");
+        assert!(state.user_groups.is_empty());
+    }
+
+    #[test]
+    fn reset_restores_default_user() {
+        let mut state = ElastiCacheState::new("123456789012", "us-east-1");
+        state.users.clear();
+        assert!(state.users.is_empty());
+        state.reset();
+        assert_eq!(state.users.len(), 1);
+        assert!(state.users.contains_key("default"));
+    }
+
+    #[test]
+    fn reset_clears_user_groups() {
+        let mut state = ElastiCacheState::new("123456789012", "us-east-1");
+        state.user_groups.insert(
+            "my-group".to_string(),
+            ElastiCacheUserGroup {
+                user_group_id: "my-group".to_string(),
+                engine: "redis".to_string(),
+                status: "active".to_string(),
+                user_ids: vec!["default".to_string()],
+                arn: "arn:aws:elasticache:us-east-1:123456789012:usergroup:my-group".to_string(),
+                minimum_engine_version: "6.0".to_string(),
+                pending_changes: None,
+                replication_groups: Vec::new(),
+            },
+        );
+        assert_eq!(state.user_groups.len(), 1);
+        state.reset();
+        assert!(state.user_groups.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- implement CreateUser with engine validation, password/no-password auth modes, and duplicate detection
- implement DescribeUsers with optional UserId filter and pagination
- implement DeleteUser with protection against deleting the default user and user-group cleanup
- implement CreateUserGroup with user reference validation and cross-reference updates
- implement DescribeUserGroups with optional filter and pagination
- implement DeleteUserGroup with user cross-reference cleanup
- seed a default user (user_id=default, engine=redis, access_string=on ~* +@all)
- add 6 handwritten conformance tests with test_action macro coverage
- add 6 e2e tests covering create, describe, delete for both users and user groups
- add 13 unit tests for XML formatting, state operations, and validation

## Validation
- cargo fmt --all
- cargo build --bin fakecloud
- cargo test -p fakecloud-elasticache --lib (38 passed)
- cargo test -p fakecloud-conformance --test elasticache (16 passed, 3 skipped for Docker)
- cargo test -p fakecloud-e2e --test elasticache (tag/subnet/metadata e2e passed, replication group tests require Docker)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ElastiCache Users and User Groups to `fakecloud-elasticache`, with Create/Describe/Delete APIs, correct XML responses, validation, and pagination. Seeds a `default` user and keeps user/group references in sync.

- New Features
  - CRUD: Users and User Groups with filter + pagination; protect `default`; cross-reference cleanup.
  - Validation: engine (`redis`/`valkey`) + minimum versions; AuthenticationMode.Type rules and password requirements; enforce user/group engine match.

- Bug Fixes
  - XML: User and UserGroup fields are returned directly in the result; list responses wrap items in <member>.
  - Tags: register the default user ARN in `tags` on state creation and reset.
  - CreateUser: reject passwords when `NoPasswordRequired=true` (InvalidParameterCombination).

<sup>Written for commit f4a84e8e272570a655d9c5ff4b161f490e93e13f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

