### PR TITLE
fix: add cognito and kinesis to conformance probe protocol map

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,66 +1,78 @@
 {
-  "variants_passed": 42164,
-  "total_variants": 42193,
+  "variants_passed": 49039,
+  "total_variants": 51399,
   "per_service": {
-    "s3": {
-      "passed": 3620,
-      "total": 3620
-    },
     "secretsmanager": {
       "passed": 852,
       "total": 852
     },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
     "cognito-idp": {
-      "passed": 4450,
+      "passed": 3115,
       "total": 4479
     },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
-    },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
-    },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "sts": {
-      "passed": 438,
-      "total": 438
-    },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
+    "elasticache": {
+      "passed": 2219,
+      "total": 2219
     },
     "ssm": {
       "passed": 5303,
       "total": 5303
     },
+    "rds": {
+      "passed": 5376,
+      "total": 5376
+    },
     "ses": {
       "passed": 2858,
       "total": 2858
+    },
+    "kms": {
+      "passed": 2196,
+      "total": 2196
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "sts": {
+      "passed": 438,
+      "total": 438
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "events": {
+      "passed": 2108,
+      "total": 2108
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "s3": {
+      "passed": 3620,
+      "total": 3620
+    },
+    "kinesis": {
+      "passed": 615,
+      "total": 1611
+    },
+    "logs": {
+      "passed": 3911,
+      "total": 3911
     }
   }
 }

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -82,6 +82,12 @@ pub fn service_protocol(service_name: &str) -> Protocol {
         "kms" => Protocol::Json {
             target_prefix: "TrentService",
         },
+        "cognito-idp" => Protocol::Json {
+            target_prefix: "AWSCognitoIdentityProviderService",
+        },
+        "kinesis" => Protocol::Json {
+            target_prefix: "Kinesis_20131202",
+        },
         "s3" => Protocol::Rest,
         "lambda" => Protocol::Rest,
         _ => Protocol::Query,


### PR DESCRIPTION
## Summary
- add cognito-idp with JSON protocol and AWSCognitoIdentityProviderService target prefix to conformance probe routing
- add kinesis with Kinesis_20131202 target prefix

The conformance probes were sending Cognito requests as Query protocol (the default fallback), which caused ListUsers and GetUser to be routed to IAM instead of Cognito. This made all GetUser probes fail (wrong response shape) and ListUsers negative probes pass incorrectly (IAM accepts them differently).

With this fix, Cognito probes will use the correct JSON protocol with X-Amz-Target header, routing to the actual Cognito service.

## Validation
- cargo fmt --all
- cargo build -p fakecloud-conformance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Cognito and Kinesis conformance probes using the correct JSON protocol and target prefixes so requests hit the right services. Update the conformance baseline to reflect real numbers after fixing Cognito misrouting (49039/51399, 95.4%).

- **Bug Fixes**
  - Map `cognito-idp` to JSON with target prefix `AWSCognitoIdentityProviderService`.
  - Map `kinesis` to JSON with target prefix `Kinesis_20131202`.

<sup>Written for commit 4bcda0906fd0aaee262590713dbaa078616be7e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

