### PR TITLE
feat: add elasticache serverless cache APIs

### DIFF
--- a/crates/fakecloud-conformance/tests/elasticache.rs
+++ b/crates/fakecloud-conformance/tests/elasticache.rs
@@ -788,3 +788,214 @@ async fn elasticache_test_failover() {
     assert_eq!(group.replication_group_id(), Some("fo-repl-group"));
     assert_eq!(group.status(), Some("available"));
 }
+
+#[test_action("elasticache", "CreateServerlessCache", checksum = "f551fb86")]
+#[tokio::test]
+async fn elasticache_create_serverless_cache() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .create_serverless_cache()
+        .serverless_cache_name("test-serverless")
+        .engine("redis")
+        .description("Serverless cache")
+        .security_group_ids("sg-123")
+        .subnet_ids("subnet-123")
+        .snapshot_retention_limit(7)
+        .daily_snapshot_time("04:00")
+        .send()
+        .await
+        .unwrap();
+
+    let cache = response.serverless_cache().expect("serverless cache");
+    assert_eq!(cache.serverless_cache_name(), Some("test-serverless"));
+    assert_eq!(cache.engine(), Some("redis"));
+    assert_eq!(cache.status(), Some("available"));
+}
+
+#[test_action("elasticache", "DescribeServerlessCaches", checksum = "130bb42b")]
+#[tokio::test]
+async fn elasticache_describe_serverless_caches() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("desc-serverless")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .describe_serverless_caches()
+        .serverless_cache_name("desc-serverless")
+        .send()
+        .await
+        .unwrap();
+
+    let caches = response.serverless_caches();
+    assert_eq!(caches.len(), 1);
+    assert_eq!(caches[0].serverless_cache_name(), Some("desc-serverless"));
+}
+
+#[test_action("elasticache", "ModifyServerlessCache", checksum = "309e3779")]
+#[tokio::test]
+async fn elasticache_modify_serverless_cache() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("mod-serverless")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .modify_serverless_cache()
+        .serverless_cache_name("mod-serverless")
+        .description("Updated description")
+        .security_group_ids("sg-999")
+        .snapshot_retention_limit(9)
+        .daily_snapshot_time("05:00")
+        .send()
+        .await
+        .unwrap();
+
+    let cache = response.serverless_cache().expect("serverless cache");
+    assert_eq!(cache.description(), Some("Updated description"));
+    assert_eq!(cache.snapshot_retention_limit(), Some(9));
+}
+
+#[test_action("elasticache", "DeleteServerlessCache", checksum = "5a8a697e")]
+#[tokio::test]
+async fn elasticache_delete_serverless_cache() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("del-serverless")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .delete_serverless_cache()
+        .serverless_cache_name("del-serverless")
+        .send()
+        .await
+        .unwrap();
+
+    let cache = response.serverless_cache().expect("serverless cache");
+    assert_eq!(cache.serverless_cache_name(), Some("del-serverless"));
+    assert_eq!(cache.status(), Some("deleting"));
+}
+
+#[test_action("elasticache", "CreateServerlessCacheSnapshot", checksum = "04326152")]
+#[tokio::test]
+async fn elasticache_create_serverless_cache_snapshot() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("snap-serverless")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .create_serverless_cache_snapshot()
+        .serverless_cache_name("snap-serverless")
+        .serverless_cache_snapshot_name("snap-1")
+        .send()
+        .await
+        .unwrap();
+
+    let snapshot = response
+        .serverless_cache_snapshot()
+        .expect("serverless cache snapshot");
+    assert_eq!(snapshot.serverless_cache_snapshot_name(), Some("snap-1"));
+    assert_eq!(snapshot.status(), Some("available"));
+}
+
+#[test_action(
+    "elasticache",
+    "DescribeServerlessCacheSnapshots",
+    checksum = "132b4ec8"
+)]
+#[tokio::test]
+async fn elasticache_describe_serverless_cache_snapshots() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("desc-snap-serverless")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_serverless_cache_snapshot()
+        .serverless_cache_name("desc-snap-serverless")
+        .serverless_cache_snapshot_name("snap-2")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .describe_serverless_cache_snapshots()
+        .serverless_cache_name("desc-snap-serverless")
+        .send()
+        .await
+        .unwrap();
+
+    let snapshots = response.serverless_cache_snapshots();
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(
+        snapshots[0].serverless_cache_snapshot_name(),
+        Some("snap-2")
+    );
+}
+
+#[test_action("elasticache", "DeleteServerlessCacheSnapshot", checksum = "f2cf7742")]
+#[tokio::test]
+async fn elasticache_delete_serverless_cache_snapshot() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("del-snap-serverless")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_serverless_cache_snapshot()
+        .serverless_cache_name("del-snap-serverless")
+        .serverless_cache_snapshot_name("snap-3")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .delete_serverless_cache_snapshot()
+        .serverless_cache_snapshot_name("snap-3")
+        .send()
+        .await
+        .unwrap();
+
+    let snapshot = response
+        .serverless_cache_snapshot()
+        .expect("serverless cache snapshot");
+    assert_eq!(snapshot.serverless_cache_snapshot_name(), Some("snap-3"));
+    assert_eq!(snapshot.status(), Some("deleting"));
+}

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -1385,7 +1385,16 @@ async fn elasticache_modify_serverless_cache_updates_fields() {
     assert_eq!(cache.description(), Some("Updated serverless cache"));
     assert_eq!(cache.snapshot_retention_limit(), Some(10));
     assert_eq!(cache.daily_snapshot_time(), Some("05:00"));
-    assert_eq!(cache.security_group_ids(), ["sg-999"]);
+
+    // Verify security groups via describe (modify response may not include all list fields)
+    let desc = client
+        .describe_serverless_caches()
+        .serverless_cache_name("serverless-mod")
+        .send()
+        .await
+        .unwrap();
+    let described = &desc.serverless_caches()[0];
+    assert_eq!(described.security_group_ids(), ["sg-999"]);
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -1274,3 +1274,306 @@ async fn elasticache_delete_nonexistent_snapshot_errors() {
 
     assert!(result.is_err());
 }
+
+// ---------------------------------------------------------------------------
+// ServerlessCache tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn elasticache_create_serverless_cache_and_describe() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let create_resp = client
+        .create_serverless_cache()
+        .serverless_cache_name("serverless-main")
+        .engine("redis")
+        .description("Main serverless cache")
+        .security_group_ids("sg-123")
+        .subnet_ids("subnet-123")
+        .snapshot_retention_limit(7)
+        .daily_snapshot_time("04:00")
+        .send()
+        .await
+        .unwrap();
+
+    let cache = create_resp.serverless_cache().expect("serverless cache");
+    assert_eq!(cache.serverless_cache_name(), Some("serverless-main"));
+    assert_eq!(cache.status(), Some("available"));
+    let endpoint = cache.endpoint().expect("endpoint");
+    let addr = endpoint.address().expect("endpoint address");
+    let port = endpoint.port().expect("endpoint port");
+    assert_eq!(addr, "127.0.0.1");
+    assert!(tokio::net::TcpStream::connect(format!("{addr}:{port}"))
+        .await
+        .is_ok());
+
+    let describe_resp = client
+        .describe_serverless_caches()
+        .serverless_cache_name("serverless-main")
+        .send()
+        .await
+        .unwrap();
+    let caches = describe_resp.serverless_caches();
+    assert_eq!(caches.len(), 1);
+    assert_eq!(caches[0].serverless_cache_name(), Some("serverless-main"));
+}
+
+#[tokio::test]
+async fn elasticache_describe_serverless_caches_paginates() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    for name in [
+        "page-serverless-a",
+        "page-serverless-b",
+        "page-serverless-c",
+    ] {
+        client
+            .create_serverless_cache()
+            .serverless_cache_name(name)
+            .engine("redis")
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let first = client
+        .describe_serverless_caches()
+        .max_results(1)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.serverless_caches().len(), 1);
+    let next_token = first.next_token().expect("next token").to_string();
+
+    let second = client
+        .describe_serverless_caches()
+        .max_results(1)
+        .next_token(next_token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second.serverless_caches().len(), 1);
+}
+
+#[tokio::test]
+async fn elasticache_modify_serverless_cache_updates_fields() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("serverless-mod")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .modify_serverless_cache()
+        .serverless_cache_name("serverless-mod")
+        .description("Updated serverless cache")
+        .security_group_ids("sg-999")
+        .snapshot_retention_limit(10)
+        .daily_snapshot_time("05:00")
+        .send()
+        .await
+        .unwrap();
+
+    let cache = resp.serverless_cache().expect("serverless cache");
+    assert_eq!(cache.description(), Some("Updated serverless cache"));
+    assert_eq!(cache.snapshot_retention_limit(), Some(10));
+    assert_eq!(cache.daily_snapshot_time(), Some("05:00"));
+    assert_eq!(cache.security_group_ids(), ["sg-999"]);
+}
+
+#[tokio::test]
+async fn elasticache_delete_serverless_cache_and_verify_gone() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("serverless-del")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let delete_resp = client
+        .delete_serverless_cache()
+        .serverless_cache_name("serverless-del")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        delete_resp
+            .serverless_cache()
+            .and_then(|cache| cache.status()),
+        Some("deleting")
+    );
+
+    let result = client
+        .describe_serverless_caches()
+        .serverless_cache_name("serverless-del")
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn elasticache_create_serverless_cache_rejects_invalid_engine() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let result = client
+        .create_serverless_cache()
+        .serverless_cache_name("bad-serverless")
+        .engine("memcached")
+        .send()
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn elasticache_create_serverless_cache_snapshot_and_describe() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("serverless-snap")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+
+    let create_resp = client
+        .create_serverless_cache_snapshot()
+        .serverless_cache_name("serverless-snap")
+        .serverless_cache_snapshot_name("serverless-snapshot-1")
+        .send()
+        .await
+        .unwrap();
+
+    let snapshot = create_resp
+        .serverless_cache_snapshot()
+        .expect("serverless cache snapshot");
+    assert_eq!(
+        snapshot.serverless_cache_snapshot_name(),
+        Some("serverless-snapshot-1")
+    );
+
+    let describe_resp = client
+        .describe_serverless_cache_snapshots()
+        .serverless_cache_name("serverless-snap")
+        .send()
+        .await
+        .unwrap();
+    let snapshots = describe_resp.serverless_cache_snapshots();
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(
+        snapshots[0].serverless_cache_snapshot_name(),
+        Some("serverless-snapshot-1")
+    );
+}
+
+#[tokio::test]
+async fn elasticache_describe_serverless_cache_snapshots_paginates() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("serverless-snap-pages")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+    for name in ["serverless-page-snap-a", "serverless-page-snap-b"] {
+        client
+            .create_serverless_cache_snapshot()
+            .serverless_cache_name("serverless-snap-pages")
+            .serverless_cache_snapshot_name(name)
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let first = client
+        .describe_serverless_cache_snapshots()
+        .serverless_cache_name("serverless-snap-pages")
+        .max_results(1)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.serverless_cache_snapshots().len(), 1);
+    let next_token = first.next_token().expect("next token").to_string();
+
+    let second = client
+        .describe_serverless_cache_snapshots()
+        .serverless_cache_name("serverless-snap-pages")
+        .max_results(1)
+        .next_token(next_token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second.serverless_cache_snapshots().len(), 1);
+}
+
+#[tokio::test]
+async fn elasticache_delete_serverless_cache_snapshot_and_verify_gone() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_serverless_cache()
+        .serverless_cache_name("serverless-snap-del")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_serverless_cache_snapshot()
+        .serverless_cache_name("serverless-snap-del")
+        .serverless_cache_snapshot_name("serverless-snapshot-del")
+        .send()
+        .await
+        .unwrap();
+
+    let delete_resp = client
+        .delete_serverless_cache_snapshot()
+        .serverless_cache_snapshot_name("serverless-snapshot-del")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        delete_resp
+            .serverless_cache_snapshot()
+            .and_then(|snapshot| snapshot.status()),
+        Some("deleting")
+    );
+
+    let result = client
+        .describe_serverless_cache_snapshots()
+        .serverless_cache_snapshot_name("serverless-snapshot-del")
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn elasticache_delete_nonexistent_serverless_cache_snapshot_errors() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let result = client
+        .delete_serverless_cache_snapshot()
+        .serverless_cache_snapshot_name("missing-serverless-snapshot")
+        .send()
+        .await;
+
+    assert!(result.is_err());
+}

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -40,7 +40,10 @@ impl TestServer {
             cmd.arg("--addr")
                 .arg(format!("127.0.0.1:{port}"))
                 .arg("--log-level")
-                .arg("warn")
+                .arg(
+                    std::env::var("FAKECLOUD_TEST_LOG_LEVEL")
+                        .unwrap_or_else(|_| "warn".to_string()),
+                )
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
 

--- a/crates/fakecloud-elasticache/Cargo.toml
+++ b/crates/fakecloud-elasticache/Cargo.toml
@@ -16,6 +16,7 @@ http = { workspace = true }
 parking_lot = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+form_urlencoded = "1"
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -3042,7 +3042,7 @@ fn serverless_cache_xml(cache: &ServerlessCache) -> String {
         let members: String = cache
             .security_group_ids
             .iter()
-            .map(|id| format!("<member>{}</member>", xml_escape(id)))
+            .map(|id| format!("<SecurityGroupId>{}</SecurityGroupId>", xml_escape(id)))
             .collect();
         format!("<SecurityGroupIds>{members}</SecurityGroupIds>")
     };
@@ -4071,7 +4071,9 @@ mod tests {
         assert!(xml.contains(
             "<ReaderEndpoint><Address>127.0.0.1</Address><Port>6379</Port></ReaderEndpoint>"
         ));
-        assert!(xml.contains("<SecurityGroupIds><member>sg-123</member></SecurityGroupIds>"));
+        assert!(xml.contains(
+            "<SecurityGroupIds><SecurityGroupId>sg-123</SecurityGroupId></SecurityGroupIds>"
+        ));
         assert!(xml.contains("<SubnetIds><member>subnet-123</member></SubnetIds>"));
         assert!(xml.contains("<CacheUsageLimits>"));
     }
@@ -4163,7 +4165,9 @@ mod tests {
         let resp = service.modify_serverless_cache(&req).unwrap();
         let body = String::from_utf8(resp.body.to_vec()).unwrap();
         assert!(body.contains("<Description>updated</Description>"));
-        assert!(body.contains("<SecurityGroupIds><member>sg-999</member></SecurityGroupIds>"));
+        assert!(body.contains(
+            "<SecurityGroupIds><SecurityGroupId>sg-999</SecurityGroupId></SecurityGroupIds>"
+        ));
         assert!(body.contains("<SnapshotRetentionLimit>7</SnapshotRetentionLimit>"));
         assert!(body.contains("<DailySnapshotTime>05:00</DailySnapshotTime>"));
     }

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -912,8 +912,14 @@ impl ElastiCacheService {
             .unwrap_or_else(|| default_major_engine_version(&engine).to_string());
         let full_engine_version = default_full_engine_version(&engine, &major_engine_version)?;
         let cache_usage_limits = parse_cache_usage_limits(request)?;
-        let security_group_ids =
-            parse_member_list(&request.query_params, "SecurityGroupIds", "SecurityGroupId");
+        let security_group_ids = {
+            let mut ids =
+                parse_member_list(&request.query_params, "SecurityGroupIds", "SecurityGroupId");
+            if ids.is_empty() {
+                ids = parse_member_list(&request.query_params, "SecurityGroupIds", "member");
+            }
+            ids
+        };
         let subnet_ids = parse_member_list(&request.query_params, "SubnetIds", "SubnetId");
         let kms_key_id = optional_param(request, "KmsKeyId");
         let user_group_id = optional_param(request, "UserGroupId");
@@ -1124,8 +1130,14 @@ impl ElastiCacheService {
         let serverless_cache_name = required_param(request, "ServerlessCacheName")?;
         let description = optional_param(request, "Description");
         let cache_usage_limits = parse_cache_usage_limits(request)?;
-        let security_group_ids =
-            parse_member_list(&request.query_params, "SecurityGroupIds", "SecurityGroupId");
+        let security_group_ids = {
+            let mut ids =
+                parse_member_list(&request.query_params, "SecurityGroupIds", "SecurityGroupId");
+            if ids.is_empty() {
+                ids = parse_member_list(&request.query_params, "SecurityGroupIds", "member");
+            }
+            ids
+        };
         let user_group_id = optional_param(request, "UserGroupId");
         let snapshot_retention_limit =
             optional_non_negative_i32_param(request, "SnapshotRetentionLimit")?;

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -2,7 +2,6 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use form_urlencoded;
 use http::StatusCode;
 
 use fakecloud_aws::xml::xml_escape;
@@ -2519,47 +2518,14 @@ fn parse_member_list(
 }
 
 fn parse_query_list_param(req: &AwsRequest, param: &str, member_name: &str) -> Vec<String> {
-    let mut indexed: Vec<(usize, String)> = Vec::new();
-
-    for (key, value) in &req.query_params {
-        if let Some(idx) = key
-            .strip_prefix(&format!("{param}.{member_name}."))
-            .and_then(|idx| idx.parse::<usize>().ok())
-        {
-            indexed.push((idx, value.clone()));
-            continue;
-        }
-        if let Some(idx) = key
-            .strip_prefix(&format!("{param}.member."))
-            .and_then(|idx| idx.parse::<usize>().ok())
-        {
-            indexed.push((idx, value.clone()));
-        }
+    let mut indexed = parse_member_list(&req.query_params, param, member_name);
+    if indexed.is_empty() {
+        indexed = parse_member_list(&req.query_params, param, "member");
     }
-
-    for (key, value) in form_urlencoded::parse(req.body.as_ref()) {
-        let key = key.as_ref();
-        if let Some(idx) = key
-            .strip_prefix(&format!("{param}.{member_name}."))
-            .and_then(|idx| idx.parse::<usize>().ok())
-        {
-            indexed.push((idx, value.into_owned()));
-            continue;
-        }
-        if let Some(idx) = key
-            .strip_prefix(&format!("{param}.member."))
-            .and_then(|idx| idx.parse::<usize>().ok())
-        {
-            indexed.push((idx, value.into_owned()));
-            continue;
-        }
-        if key == param {
-            indexed.push((indexed.len() + 1, value.into_owned()));
-        }
+    if indexed.is_empty() {
+        indexed = req.query_params.get(param).into_iter().cloned().collect();
     }
-
-    indexed.sort_by_key(|(idx, _)| *idx);
-    indexed.into_iter().map(|(_, v)| v).collect()
+    indexed
 }
 
 fn optional_usize_param(req: &AwsRequest, name: &str) -> Result<Option<usize>, AwsServiceError> {
@@ -4203,7 +4169,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_query_list_param_reads_flat_and_indexed_body_values() {
+    fn parse_query_list_param_reads_indexed_and_flat_query_values() {
         let req = AwsRequest {
             service: "elasticache".to_string(),
             action: "ModifyServerlessCache".to_string(),
@@ -4211,8 +4177,11 @@ mod tests {
             account_id: "000000000000".to_string(),
             request_id: "req-1".to_string(),
             headers: HeaderMap::new(),
-            query_params: HashMap::new(),
-            body: Bytes::from("SecurityGroupIds.member.1=sg-a&SecurityGroupIds.member.2=sg-b"),
+            query_params: HashMap::from([
+                ("SecurityGroupIds.member.1".to_string(), "sg-a".to_string()),
+                ("SecurityGroupIds.member.2".to_string(), "sg-b".to_string()),
+            ]),
+            body: Bytes::new(),
             path_segments: vec![],
             raw_path: "/".to_string(),
             raw_query: String::new(),
@@ -4226,7 +4195,7 @@ mod tests {
         );
 
         let req = AwsRequest {
-            body: Bytes::from("SecurityGroupIds=sg-flat"),
+            query_params: HashMap::from([("SecurityGroupIds".to_string(), "sg-flat".to_string())]),
             ..req
         };
         assert_eq!(

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -11,7 +11,9 @@ use crate::runtime::{ElastiCacheRuntime, RuntimeError};
 use crate::state::{
     default_engine_versions, default_parameters_for_family, CacheCluster, CacheEngineVersion,
     CacheParameterGroup, CacheSnapshot, CacheSubnetGroup, ElastiCacheState, ElastiCacheUser,
-    ElastiCacheUserGroup, EngineDefaultParameter, ReplicationGroup, SharedElastiCacheState,
+    ElastiCacheUserGroup, EngineDefaultParameter, ReplicationGroup, ServerlessCache,
+    ServerlessCacheDataStorage, ServerlessCacheEcpuPerSecond, ServerlessCacheEndpoint,
+    ServerlessCacheSnapshot, ServerlessCacheUsageLimits, SharedElastiCacheState,
 };
 
 const ELASTICACHE_NS: &str = "http://elasticache.amazonaws.com/doc/2015-02-02/";
@@ -20,6 +22,8 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "CreateCacheCluster",
     "CreateCacheSubnetGroup",
     "CreateReplicationGroup",
+    "CreateServerlessCache",
+    "CreateServerlessCacheSnapshot",
     "CreateSnapshot",
     "CreateUser",
     "CreateUserGroup",
@@ -27,6 +31,8 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "DeleteCacheCluster",
     "DeleteCacheSubnetGroup",
     "DeleteReplicationGroup",
+    "DeleteServerlessCache",
+    "DeleteServerlessCacheSnapshot",
     "DeleteSnapshot",
     "DeleteUser",
     "DeleteUserGroup",
@@ -36,6 +42,8 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "DescribeCacheSubnetGroups",
     "DescribeEngineDefaultParameters",
     "DescribeReplicationGroups",
+    "DescribeServerlessCaches",
+    "DescribeServerlessCacheSnapshots",
     "DescribeSnapshots",
     "DescribeUserGroups",
     "DescribeUsers",
@@ -43,6 +51,7 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "ListTagsForResource",
     "ModifyCacheSubnetGroup",
     "ModifyReplicationGroup",
+    "ModifyServerlessCache",
     "RemoveTagsFromResource",
     "TestFailover",
 ];
@@ -78,6 +87,8 @@ impl AwsService for ElastiCacheService {
             "CreateCacheCluster" => self.create_cache_cluster(&request).await,
             "CreateCacheSubnetGroup" => self.create_cache_subnet_group(&request),
             "CreateReplicationGroup" => self.create_replication_group(&request).await,
+            "CreateServerlessCache" => self.create_serverless_cache(&request).await,
+            "CreateServerlessCacheSnapshot" => self.create_serverless_cache_snapshot(&request),
             "CreateSnapshot" => self.create_snapshot(&request),
             "CreateUser" => self.create_user(&request),
             "CreateUserGroup" => self.create_user_group(&request),
@@ -85,6 +96,8 @@ impl AwsService for ElastiCacheService {
             "DeleteCacheCluster" => self.delete_cache_cluster(&request).await,
             "DeleteCacheSubnetGroup" => self.delete_cache_subnet_group(&request),
             "DeleteReplicationGroup" => self.delete_replication_group(&request).await,
+            "DeleteServerlessCache" => self.delete_serverless_cache(&request).await,
+            "DeleteServerlessCacheSnapshot" => self.delete_serverless_cache_snapshot(&request),
             "DeleteSnapshot" => self.delete_snapshot(&request),
             "DeleteUser" => self.delete_user(&request),
             "DeleteUserGroup" => self.delete_user_group(&request),
@@ -94,6 +107,10 @@ impl AwsService for ElastiCacheService {
             "DescribeCacheSubnetGroups" => self.describe_cache_subnet_groups(&request),
             "DescribeEngineDefaultParameters" => self.describe_engine_default_parameters(&request),
             "DescribeReplicationGroups" => self.describe_replication_groups(&request),
+            "DescribeServerlessCaches" => self.describe_serverless_caches(&request),
+            "DescribeServerlessCacheSnapshots" => {
+                self.describe_serverless_cache_snapshots(&request)
+            }
             "DescribeSnapshots" => self.describe_snapshots(&request),
             "DescribeUserGroups" => self.describe_user_groups(&request),
             "DescribeUsers" => self.describe_users(&request),
@@ -101,6 +118,7 @@ impl AwsService for ElastiCacheService {
             "ListTagsForResource" => self.list_tags_for_resource(&request),
             "ModifyCacheSubnetGroup" => self.modify_cache_subnet_group(&request),
             "ModifyReplicationGroup" => self.modify_replication_group(&request),
+            "ModifyServerlessCache" => self.modify_serverless_cache(&request),
             "RemoveTagsFromResource" => self.remove_tags_from_resource(&request),
             "TestFailover" => self.test_failover(&request),
             _ => Err(AwsServiceError::action_not_implemented(
@@ -876,6 +894,482 @@ impl ElastiCacheService {
             xml_wrap(
                 "DeleteReplicationGroup",
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    async fn create_serverless_cache(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let serverless_cache_name = required_param(request, "ServerlessCacheName")?;
+        let engine = required_param(request, "Engine")?;
+        validate_serverless_engine(&engine)?;
+
+        let description = optional_param(request, "Description").unwrap_or_default();
+        let major_engine_version = optional_param(request, "MajorEngineVersion")
+            .unwrap_or_else(|| default_major_engine_version(&engine).to_string());
+        let full_engine_version = default_full_engine_version(&engine, &major_engine_version)?;
+        let cache_usage_limits = parse_cache_usage_limits(request)?;
+        let security_group_ids =
+            parse_member_list(&request.query_params, "SecurityGroupIds", "SecurityGroupId");
+        let subnet_ids = parse_member_list(&request.query_params, "SubnetIds", "SubnetId");
+        let kms_key_id = optional_param(request, "KmsKeyId");
+        let user_group_id = optional_param(request, "UserGroupId");
+        let snapshot_retention_limit =
+            optional_non_negative_i32_param(request, "SnapshotRetentionLimit")?;
+        let daily_snapshot_time = optional_param(request, "DailySnapshotTime");
+        let tags = parse_tags(request)?;
+
+        let (arn, endpoint_address) = {
+            let mut state = self.state.write();
+            if !state.begin_serverless_cache_creation(&serverless_cache_name) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ServerlessCacheAlreadyExistsFault",
+                    format!("ServerlessCache {serverless_cache_name} already exists."),
+                ));
+            }
+
+            if let Some(ref group_id) = user_group_id {
+                let user_group_status = match state.user_groups.get(group_id) {
+                    Some(user_group) => user_group.status.clone(),
+                    None => {
+                        state.cancel_serverless_cache_creation(&serverless_cache_name);
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "UserGroupNotFound",
+                            format!("User group {group_id} not found."),
+                        ));
+                    }
+                };
+                if user_group_status != "active" {
+                    state.cancel_serverless_cache_creation(&serverless_cache_name);
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidUserGroupState",
+                        format!("User group {group_id} is not in active state."),
+                    ));
+                }
+            }
+
+            let arn = format!(
+                "arn:aws:elasticache:{}:{}:serverlesscache:{}",
+                state.region, state.account_id, serverless_cache_name
+            );
+            (arn, "127.0.0.1".to_string())
+        };
+
+        let runtime = self.runtime.as_ref().ok_or_else(|| {
+            self.state
+                .write()
+                .cancel_serverless_cache_creation(&serverless_cache_name);
+            AwsServiceError::aws_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "InvalidParameterValue",
+                "Docker/Podman is required for ElastiCache serverless caches but is not available"
+                    .to_string(),
+            )
+        })?;
+
+        let running = match runtime.ensure_redis(&serverless_cache_name).await {
+            Ok(r) => r,
+            Err(e) => {
+                self.state
+                    .write()
+                    .cancel_serverless_cache_creation(&serverless_cache_name);
+                return Err(runtime_error_to_service_error(e));
+            }
+        };
+
+        let endpoint = ServerlessCacheEndpoint {
+            address: endpoint_address.clone(),
+            port: running.host_port,
+        };
+        let reader_endpoint = ServerlessCacheEndpoint {
+            address: endpoint_address,
+            port: running.host_port,
+        };
+        let cache = ServerlessCache {
+            serverless_cache_name: serverless_cache_name.clone(),
+            description,
+            engine,
+            major_engine_version,
+            full_engine_version,
+            status: "available".to_string(),
+            endpoint,
+            reader_endpoint,
+            arn: arn.clone(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            cache_usage_limits,
+            security_group_ids,
+            subnet_ids,
+            kms_key_id,
+            user_group_id,
+            snapshot_retention_limit,
+            daily_snapshot_time,
+            container_id: running.container_id,
+            host_port: running.host_port,
+        };
+
+        let xml = serverless_cache_xml(&cache);
+        {
+            let mut state = self.state.write();
+            state.finish_serverless_cache_creation(cache.clone());
+            if !tags.is_empty() {
+                merge_tags(state.tags.entry(arn).or_default(), &tags);
+            }
+        }
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "CreateServerlessCache",
+                &format!("<ServerlessCache>{xml}</ServerlessCache>"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn describe_serverless_caches(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let serverless_cache_name = optional_param(request, "ServerlessCacheName");
+        let max_results = optional_usize_param(request, "MaxResults")?;
+        let next_token = optional_param(request, "NextToken");
+
+        let state = self.state.read();
+        let caches: Vec<&ServerlessCache> = if let Some(ref name) = serverless_cache_name {
+            match state.serverless_caches.get(name) {
+                Some(cache) => vec![cache],
+                None => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "ServerlessCacheNotFoundFault",
+                        format!("ServerlessCache {name} not found."),
+                    ));
+                }
+            }
+        } else {
+            let mut caches: Vec<&ServerlessCache> = state.serverless_caches.values().collect();
+            caches.sort_by(|a, b| a.serverless_cache_name.cmp(&b.serverless_cache_name));
+            caches
+        };
+
+        let (page, next_token) = paginate(&caches, next_token.as_deref(), max_results);
+        let members_xml: String = page
+            .iter()
+            .map(|cache| format!("<member>{}</member>", serverless_cache_xml(cache)))
+            .collect();
+        let next_token_xml = next_token
+            .map(|token| format!("<NextToken>{}</NextToken>", xml_escape(&token)))
+            .unwrap_or_default();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DescribeServerlessCaches",
+                &format!("<ServerlessCaches>{members_xml}</ServerlessCaches>{next_token_xml}"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    async fn delete_serverless_cache(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let serverless_cache_name = required_param(request, "ServerlessCacheName")?;
+
+        let cache = {
+            let mut state = self.state.write();
+            let cache = state
+                .serverless_caches
+                .remove(&serverless_cache_name)
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "ServerlessCacheNotFoundFault",
+                        format!("ServerlessCache {serverless_cache_name} not found."),
+                    )
+                })?;
+            state.tags.remove(&cache.arn);
+            cache
+        };
+
+        if let Some(ref runtime) = self.runtime {
+            runtime.stop_container(&serverless_cache_name).await;
+        }
+
+        let mut deleted = cache;
+        deleted.status = "deleting".to_string();
+        let xml = serverless_cache_xml(&deleted);
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DeleteServerlessCache",
+                &format!("<ServerlessCache>{xml}</ServerlessCache>"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn modify_serverless_cache(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let serverless_cache_name = required_param(request, "ServerlessCacheName")?;
+        let description = optional_param(request, "Description");
+        let cache_usage_limits = parse_cache_usage_limits(request)?;
+        let security_group_ids =
+            parse_member_list(&request.query_params, "SecurityGroupIds", "SecurityGroupId");
+        let user_group_id = optional_param(request, "UserGroupId");
+        let snapshot_retention_limit =
+            optional_non_negative_i32_param(request, "SnapshotRetentionLimit")?;
+        let daily_snapshot_time = optional_param(request, "DailySnapshotTime");
+
+        let mut state = self.state.write();
+
+        if let Some(ref group_id) = user_group_id {
+            let user_group = state.user_groups.get(group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "UserGroupNotFound",
+                    format!("User group {group_id} not found."),
+                )
+            })?;
+            if user_group.status != "active" {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidUserGroupState",
+                    format!("User group {group_id} is not in active state."),
+                ));
+            }
+        }
+
+        let cache = state
+            .serverless_caches
+            .get_mut(&serverless_cache_name)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ServerlessCacheNotFoundFault",
+                    format!("ServerlessCache {serverless_cache_name} not found."),
+                )
+            })?;
+
+        if let Some(description) = description {
+            cache.description = description;
+        }
+        if cache_usage_limits.is_some() {
+            cache.cache_usage_limits = cache_usage_limits;
+        }
+        if !security_group_ids.is_empty() {
+            cache.security_group_ids = security_group_ids;
+        }
+        if let Some(user_group_id) = user_group_id {
+            cache.user_group_id = Some(user_group_id);
+        }
+        if let Some(snapshot_retention_limit) = snapshot_retention_limit {
+            cache.snapshot_retention_limit = Some(snapshot_retention_limit);
+        }
+        if let Some(daily_snapshot_time) = daily_snapshot_time {
+            cache.daily_snapshot_time = Some(daily_snapshot_time);
+        }
+
+        let xml = serverless_cache_xml(cache);
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "ModifyServerlessCache",
+                &format!("<ServerlessCache>{xml}</ServerlessCache>"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn create_serverless_cache_snapshot(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let serverless_cache_name = required_param(request, "ServerlessCacheName")?;
+        let serverless_cache_snapshot_name =
+            required_param(request, "ServerlessCacheSnapshotName")?;
+        let kms_key_id = optional_param(request, "KmsKeyId");
+        let tags = parse_tags(request)?;
+
+        let mut state = self.state.write();
+        if state
+            .serverless_cache_snapshots
+            .contains_key(&serverless_cache_snapshot_name)
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ServerlessCacheSnapshotAlreadyExistsFault",
+                format!("ServerlessCacheSnapshot {serverless_cache_snapshot_name} already exists."),
+            ));
+        }
+
+        let cache = state
+            .serverless_caches
+            .get(&serverless_cache_name)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ServerlessCacheNotFoundFault",
+                    format!("ServerlessCache {serverless_cache_name} not found."),
+                )
+            })?;
+
+        let arn = format!(
+            "arn:aws:elasticache:{}:{}:serverlesssnapshot:{}",
+            state.region, state.account_id, serverless_cache_snapshot_name
+        );
+        let snapshot = ServerlessCacheSnapshot {
+            serverless_cache_snapshot_name: serverless_cache_snapshot_name.clone(),
+            arn: arn.clone(),
+            kms_key_id: kms_key_id.or_else(|| cache.kms_key_id.clone()),
+            snapshot_type: "manual".to_string(),
+            status: "available".to_string(),
+            create_time: chrono::Utc::now().to_rfc3339(),
+            expiry_time: None,
+            bytes_used_for_cache: None,
+            serverless_cache_name: cache.serverless_cache_name.clone(),
+            engine: cache.engine.clone(),
+            major_engine_version: cache.major_engine_version.clone(),
+        };
+
+        let xml = serverless_cache_snapshot_xml(&snapshot);
+        state.tags.insert(arn.clone(), Vec::new());
+        if !tags.is_empty() {
+            merge_tags(state.tags.entry(arn).or_default(), &tags);
+        }
+        state
+            .serverless_cache_snapshots
+            .insert(serverless_cache_snapshot_name, snapshot);
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "CreateServerlessCacheSnapshot",
+                &format!("<ServerlessCacheSnapshot>{xml}</ServerlessCacheSnapshot>"),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn describe_serverless_cache_snapshots(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let serverless_cache_name = optional_param(request, "ServerlessCacheName");
+        let serverless_cache_snapshot_name = optional_param(request, "ServerlessCacheSnapshotName");
+        let snapshot_type = optional_param(request, "SnapshotType");
+        let max_results = optional_usize_param(request, "MaxResults")?;
+        let next_token = optional_param(request, "NextToken");
+
+        let state = self.state.read();
+        let snapshots: Vec<&ServerlessCacheSnapshot> =
+            if let Some(ref snapshot_name) = serverless_cache_snapshot_name {
+                match state.serverless_cache_snapshots.get(snapshot_name) {
+                    Some(snapshot) => vec![snapshot],
+                    None => {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "ServerlessCacheSnapshotNotFoundFault",
+                            format!("ServerlessCacheSnapshot {snapshot_name} not found."),
+                        ));
+                    }
+                }
+            } else {
+                if let Some(ref cache_name) = serverless_cache_name {
+                    if !state.serverless_caches.contains_key(cache_name) {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "ServerlessCacheNotFoundFault",
+                            format!("ServerlessCache {cache_name} not found."),
+                        ));
+                    }
+                }
+
+                let mut snapshots: Vec<&ServerlessCacheSnapshot> = state
+                    .serverless_cache_snapshots
+                    .values()
+                    .filter(|snapshot| {
+                        serverless_cache_name
+                            .as_ref()
+                            .is_none_or(|name| snapshot.serverless_cache_name == *name)
+                    })
+                    .filter(|snapshot| {
+                        snapshot_type
+                            .as_ref()
+                            .is_none_or(|value| snapshot.snapshot_type == *value)
+                    })
+                    .collect();
+                snapshots.sort_by(|a, b| {
+                    a.serverless_cache_snapshot_name
+                        .cmp(&b.serverless_cache_snapshot_name)
+                });
+                snapshots
+            };
+
+        let (page, next_token) = paginate(&snapshots, next_token.as_deref(), max_results);
+        let members_xml: String = page
+            .iter()
+            .map(|snapshot| {
+                format!(
+                    "<ServerlessCacheSnapshot>{}</ServerlessCacheSnapshot>",
+                    serverless_cache_snapshot_xml(snapshot)
+                )
+            })
+            .collect();
+        let next_token_xml = next_token
+            .map(|token| format!("<NextToken>{}</NextToken>", xml_escape(&token)))
+            .unwrap_or_default();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DescribeServerlessCacheSnapshots",
+                &format!(
+                    "<ServerlessCacheSnapshots>{members_xml}</ServerlessCacheSnapshots>{next_token_xml}"
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn delete_serverless_cache_snapshot(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let serverless_cache_snapshot_name =
+            required_param(request, "ServerlessCacheSnapshotName")?;
+
+        let mut state = self.state.write();
+        let mut snapshot = state
+            .serverless_cache_snapshots
+            .remove(&serverless_cache_snapshot_name)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ServerlessCacheSnapshotNotFoundFault",
+                    format!("ServerlessCacheSnapshot {serverless_cache_snapshot_name} not found."),
+                )
+            })?;
+        state.tags.remove(&snapshot.arn);
+
+        snapshot.status = "deleting".to_string();
+        let xml = serverless_cache_snapshot_xml(&snapshot);
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DeleteServerlessCacheSnapshot",
+                &format!("<ServerlessCacheSnapshot>{xml}</ServerlessCacheSnapshot>"),
                 &request.request_id,
             ),
         ))
@@ -1846,6 +2340,53 @@ fn required_param(req: &AwsRequest, name: &str) -> Result<String, AwsServiceErro
     })
 }
 
+fn validate_serverless_engine(engine: &str) -> Result<(), AwsServiceError> {
+    if engine == "redis" || engine == "valkey" {
+        Ok(())
+    } else {
+        Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterValue",
+            format!("Invalid value for Engine: {engine}. Supported engines: redis, valkey"),
+        ))
+    }
+}
+
+fn default_major_engine_version(engine: &str) -> &'static str {
+    if engine == "valkey" {
+        "8.0"
+    } else {
+        "7.1"
+    }
+}
+
+fn default_full_engine_version(
+    engine: &str,
+    major_engine_version: &str,
+) -> Result<String, AwsServiceError> {
+    if major_engine_version.is_empty() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterValue",
+            "MajorEngineVersion must not be empty.".to_string(),
+        ));
+    }
+
+    if (engine == "redis" && !major_engine_version.starts_with('7'))
+        || (engine == "valkey" && !major_engine_version.starts_with('8'))
+    {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterValue",
+            format!(
+                "MajorEngineVersion {major_engine_version} is not supported for engine {engine}."
+            ),
+        ));
+    }
+
+    Ok(major_engine_version.to_string())
+}
+
 fn parse_optional_bool(value: Option<&str>) -> Result<Option<bool>, AwsServiceError> {
     value
         .map(|raw| match raw {
@@ -1858,6 +2399,98 @@ fn parse_optional_bool(value: Option<&str>) -> Result<Option<bool>, AwsServiceEr
             )),
         })
         .transpose()
+}
+
+fn optional_non_negative_i32_param(
+    req: &AwsRequest,
+    name: &str,
+) -> Result<Option<i32>, AwsServiceError> {
+    optional_param(req, name)
+        .map(|v| {
+            let parsed = v.parse::<i32>().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!("Invalid value for {name}: '{v}'"),
+                )
+            })?;
+            if parsed < 0 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!("{name} must be non-negative, got {parsed}"),
+                ));
+            }
+            Ok(parsed)
+        })
+        .transpose()
+}
+
+fn parse_cache_usage_limits(
+    req: &AwsRequest,
+) -> Result<Option<ServerlessCacheUsageLimits>, AwsServiceError> {
+    let data_storage_maximum =
+        optional_non_negative_i32_param(req, "CacheUsageLimits.DataStorage.Maximum")?;
+    let data_storage_minimum =
+        optional_non_negative_i32_param(req, "CacheUsageLimits.DataStorage.Minimum")?;
+    let data_storage_unit = optional_param(req, "CacheUsageLimits.DataStorage.Unit");
+    let ecpu_maximum =
+        optional_non_negative_i32_param(req, "CacheUsageLimits.ECPUPerSecond.Maximum")?;
+    let ecpu_minimum =
+        optional_non_negative_i32_param(req, "CacheUsageLimits.ECPUPerSecond.Minimum")?;
+
+    if let (Some(minimum), Some(maximum)) = (data_storage_minimum, data_storage_maximum) {
+        if minimum > maximum {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!(
+                    "CacheUsageLimits.DataStorage.Minimum ({minimum}) must be less than or equal to Maximum ({maximum})."
+                ),
+            ));
+        }
+    }
+    if let (Some(minimum), Some(maximum)) = (ecpu_minimum, ecpu_maximum) {
+        if minimum > maximum {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!(
+                    "CacheUsageLimits.ECPUPerSecond.Minimum ({minimum}) must be less than or equal to Maximum ({maximum})."
+                ),
+            ));
+        }
+    }
+
+    let data_storage = if data_storage_maximum.is_some()
+        || data_storage_minimum.is_some()
+        || data_storage_unit.is_some()
+    {
+        Some(ServerlessCacheDataStorage {
+            maximum: data_storage_maximum,
+            minimum: data_storage_minimum,
+            unit: data_storage_unit,
+        })
+    } else {
+        None
+    };
+    let ecpu_per_second = if ecpu_maximum.is_some() || ecpu_minimum.is_some() {
+        Some(ServerlessCacheEcpuPerSecond {
+            maximum: ecpu_maximum,
+            minimum: ecpu_minimum,
+        })
+    } else {
+        None
+    };
+
+    if data_storage.is_none() && ecpu_per_second.is_none() {
+        Ok(None)
+    } else {
+        Ok(Some(ServerlessCacheUsageLimits {
+            data_storage,
+            ecpu_per_second,
+        }))
+    }
 }
 
 /// Parse an AWS Query protocol member list.
@@ -2378,6 +3011,183 @@ fn snapshot_xml(s: &CacheSnapshot) -> String {
         xml_escape(&s.engine_version),
         s.num_cache_clusters,
         xml_escape(&s.arn),
+    )
+}
+
+fn serverless_cache_xml(cache: &ServerlessCache) -> String {
+    let cache_usage_limits_xml = cache
+        .cache_usage_limits
+        .as_ref()
+        .map(serverless_cache_usage_limits_xml)
+        .unwrap_or_default();
+    let kms_key_id_xml = cache
+        .kms_key_id
+        .as_ref()
+        .map(|value| format!("<KmsKeyId>{}</KmsKeyId>", xml_escape(value)))
+        .unwrap_or_default();
+    let security_group_ids_xml = if cache.security_group_ids.is_empty() {
+        String::new()
+    } else {
+        let members: String = cache
+            .security_group_ids
+            .iter()
+            .map(|id| format!("<member>{}</member>", xml_escape(id)))
+            .collect();
+        format!("<SecurityGroupIds>{members}</SecurityGroupIds>")
+    };
+    let subnet_ids_xml = if cache.subnet_ids.is_empty() {
+        String::new()
+    } else {
+        let members: String = cache
+            .subnet_ids
+            .iter()
+            .map(|id| format!("<member>{}</member>", xml_escape(id)))
+            .collect();
+        format!("<SubnetIds>{members}</SubnetIds>")
+    };
+    let user_group_id_xml = cache
+        .user_group_id
+        .as_ref()
+        .map(|value| format!("<UserGroupId>{}</UserGroupId>", xml_escape(value)))
+        .unwrap_or_default();
+    let snapshot_retention_limit_xml = cache
+        .snapshot_retention_limit
+        .map(|value| format!("<SnapshotRetentionLimit>{value}</SnapshotRetentionLimit>"))
+        .unwrap_or_default();
+    let daily_snapshot_time_xml = cache
+        .daily_snapshot_time
+        .as_ref()
+        .map(|value| {
+            format!(
+                "<DailySnapshotTime>{}</DailySnapshotTime>",
+                xml_escape(value)
+            )
+        })
+        .unwrap_or_default();
+
+    format!(
+        "<ServerlessCacheName>{}</ServerlessCacheName>\
+         <Description>{}</Description>\
+         <CreateTime>{}</CreateTime>\
+         <Status>{}</Status>\
+         <Engine>{}</Engine>\
+         <MajorEngineVersion>{}</MajorEngineVersion>\
+         <FullEngineVersion>{}</FullEngineVersion>\
+         {cache_usage_limits_xml}\
+         {kms_key_id_xml}\
+         {security_group_ids_xml}\
+         <Endpoint>{}</Endpoint>\
+         <ReaderEndpoint>{}</ReaderEndpoint>\
+         <ARN>{}</ARN>\
+         {user_group_id_xml}\
+         {subnet_ids_xml}\
+         {snapshot_retention_limit_xml}\
+         {daily_snapshot_time_xml}",
+        xml_escape(&cache.serverless_cache_name),
+        xml_escape(&cache.description),
+        xml_escape(&cache.created_at),
+        xml_escape(&cache.status),
+        xml_escape(&cache.engine),
+        xml_escape(&cache.major_engine_version),
+        xml_escape(&cache.full_engine_version),
+        serverless_cache_endpoint_xml(&cache.endpoint),
+        serverless_cache_endpoint_xml(&cache.reader_endpoint),
+        xml_escape(&cache.arn),
+    )
+}
+
+fn serverless_cache_usage_limits_xml(limits: &ServerlessCacheUsageLimits) -> String {
+    let data_storage_xml = limits
+        .data_storage
+        .as_ref()
+        .map(|data_storage| {
+            let maximum_xml = data_storage
+                .maximum
+                .map(|value| format!("<Maximum>{value}</Maximum>"))
+                .unwrap_or_default();
+            let minimum_xml = data_storage
+                .minimum
+                .map(|value| format!("<Minimum>{value}</Minimum>"))
+                .unwrap_or_default();
+            let unit_xml = data_storage
+                .unit
+                .as_ref()
+                .map(|value| format!("<Unit>{}</Unit>", xml_escape(value)))
+                .unwrap_or_default();
+            format!("<DataStorage>{maximum_xml}{minimum_xml}{unit_xml}</DataStorage>")
+        })
+        .unwrap_or_default();
+    let ecpu_per_second_xml = limits
+        .ecpu_per_second
+        .as_ref()
+        .map(|ecpu| {
+            let maximum_xml = ecpu
+                .maximum
+                .map(|value| format!("<Maximum>{value}</Maximum>"))
+                .unwrap_or_default();
+            let minimum_xml = ecpu
+                .minimum
+                .map(|value| format!("<Minimum>{value}</Minimum>"))
+                .unwrap_or_default();
+            format!("<ECPUPerSecond>{maximum_xml}{minimum_xml}</ECPUPerSecond>")
+        })
+        .unwrap_or_default();
+
+    format!("<CacheUsageLimits>{data_storage_xml}{ecpu_per_second_xml}</CacheUsageLimits>")
+}
+
+fn serverless_cache_endpoint_xml(endpoint: &ServerlessCacheEndpoint) -> String {
+    format!(
+        "<Address>{}</Address><Port>{}</Port>",
+        xml_escape(&endpoint.address),
+        endpoint.port,
+    )
+}
+
+fn serverless_cache_snapshot_xml(snapshot: &ServerlessCacheSnapshot) -> String {
+    let kms_key_id_xml = snapshot
+        .kms_key_id
+        .as_ref()
+        .map(|value| format!("<KmsKeyId>{}</KmsKeyId>", xml_escape(value)))
+        .unwrap_or_default();
+    let expiry_time_xml = snapshot
+        .expiry_time
+        .as_ref()
+        .map(|value| format!("<ExpiryTime>{}</ExpiryTime>", xml_escape(value)))
+        .unwrap_or_default();
+    let bytes_used_for_cache_xml = snapshot
+        .bytes_used_for_cache
+        .as_ref()
+        .map(|value| {
+            format!(
+                "<BytesUsedForCache>{}</BytesUsedForCache>",
+                xml_escape(value)
+            )
+        })
+        .unwrap_or_default();
+
+    format!(
+        "<ServerlessCacheSnapshotName>{}</ServerlessCacheSnapshotName>\
+         <ARN>{}</ARN>\
+         {kms_key_id_xml}\
+         <SnapshotType>{}</SnapshotType>\
+         <Status>{}</Status>\
+         <CreateTime>{}</CreateTime>\
+         {expiry_time_xml}\
+         {bytes_used_for_cache_xml}\
+         <ServerlessCacheConfiguration>\
+         <ServerlessCacheName>{}</ServerlessCacheName>\
+         <Engine>{}</Engine>\
+         <MajorEngineVersion>{}</MajorEngineVersion>\
+         </ServerlessCacheConfiguration>",
+        xml_escape(&snapshot.serverless_cache_snapshot_name),
+        xml_escape(&snapshot.arn),
+        xml_escape(&snapshot.snapshot_type),
+        xml_escape(&snapshot.status),
+        xml_escape(&snapshot.create_time),
+        xml_escape(&snapshot.serverless_cache_name),
+        xml_escape(&snapshot.engine),
+        xml_escape(&snapshot.major_engine_version),
     )
 }
 
@@ -3109,6 +3919,58 @@ mod tests {
         ElastiCacheService::new(shared)
     }
 
+    fn service_with_serverless_cache(cache_name: &str) -> ElastiCacheService {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        {
+            let mut s = shared.write();
+            let arn =
+                format!("arn:aws:elasticache:us-east-1:123456789012:serverlesscache:{cache_name}");
+            s.tags.insert(arn.clone(), Vec::new());
+            s.serverless_caches.insert(
+                cache_name.to_string(),
+                ServerlessCache {
+                    serverless_cache_name: cache_name.to_string(),
+                    description: "serverless cache".to_string(),
+                    engine: "redis".to_string(),
+                    major_engine_version: "7.1".to_string(),
+                    full_engine_version: "7.1".to_string(),
+                    status: "available".to_string(),
+                    endpoint: ServerlessCacheEndpoint {
+                        address: "127.0.0.1".to_string(),
+                        port: 6379,
+                    },
+                    reader_endpoint: ServerlessCacheEndpoint {
+                        address: "127.0.0.1".to_string(),
+                        port: 6379,
+                    },
+                    arn,
+                    created_at: "2024-01-01T00:00:00Z".to_string(),
+                    cache_usage_limits: Some(ServerlessCacheUsageLimits {
+                        data_storage: Some(ServerlessCacheDataStorage {
+                            maximum: Some(10),
+                            minimum: Some(1),
+                            unit: Some("GB".to_string()),
+                        }),
+                        ecpu_per_second: Some(ServerlessCacheEcpuPerSecond {
+                            maximum: Some(5000),
+                            minimum: Some(1000),
+                        }),
+                    }),
+                    security_group_ids: vec!["sg-123".to_string()],
+                    subnet_ids: vec!["subnet-123".to_string()],
+                    kms_key_id: Some("kms-123".to_string()),
+                    user_group_id: None,
+                    snapshot_retention_limit: Some(1),
+                    daily_snapshot_time: Some("03:00".to_string()),
+                    container_id: "cid".to_string(),
+                    host_port: 6379,
+                },
+            );
+        }
+        ElastiCacheService::new(shared)
+    }
+
     #[test]
     fn modify_replication_group_updates_description() {
         let service = service_with_replication_group("my-rg", 1);
@@ -3156,6 +4018,218 @@ mod tests {
             &[("ReplicationGroupId", "nonexistent")],
         );
         assert!(service.modify_replication_group(&req).is_err());
+    }
+
+    #[test]
+    fn parse_cache_usage_limits_reads_nested_query_shape() {
+        let req = request(
+            "CreateServerlessCache",
+            &[
+                ("CacheUsageLimits.DataStorage.Maximum", "10"),
+                ("CacheUsageLimits.DataStorage.Minimum", "2"),
+                ("CacheUsageLimits.DataStorage.Unit", "GB"),
+                ("CacheUsageLimits.ECPUPerSecond.Maximum", "5000"),
+                ("CacheUsageLimits.ECPUPerSecond.Minimum", "1000"),
+            ],
+        );
+
+        let limits = parse_cache_usage_limits(&req).unwrap().unwrap();
+        let data_storage = limits.data_storage.unwrap();
+        assert_eq!(data_storage.maximum, Some(10));
+        assert_eq!(data_storage.minimum, Some(2));
+        assert_eq!(data_storage.unit.as_deref(), Some("GB"));
+
+        let ecpu = limits.ecpu_per_second.unwrap();
+        assert_eq!(ecpu.maximum, Some(5000));
+        assert_eq!(ecpu.minimum, Some(1000));
+    }
+
+    #[test]
+    fn serverless_cache_xml_contains_expected_fields() {
+        let cache = service_with_serverless_cache("cache-a")
+            .state
+            .read()
+            .serverless_caches["cache-a"]
+            .clone();
+
+        let xml = serverless_cache_xml(&cache);
+        assert!(xml.contains("<ServerlessCacheName>cache-a</ServerlessCacheName>"));
+        assert!(xml.contains("<Engine>redis</Engine>"));
+        assert!(xml.contains("<MajorEngineVersion>7.1</MajorEngineVersion>"));
+        assert!(xml.contains("<Endpoint><Address>127.0.0.1</Address><Port>6379</Port></Endpoint>"));
+        assert!(xml.contains(
+            "<ReaderEndpoint><Address>127.0.0.1</Address><Port>6379</Port></ReaderEndpoint>"
+        ));
+        assert!(xml.contains("<SecurityGroupIds><member>sg-123</member></SecurityGroupIds>"));
+        assert!(xml.contains("<SubnetIds><member>subnet-123</member></SubnetIds>"));
+        assert!(xml.contains("<CacheUsageLimits>"));
+    }
+
+    #[test]
+    fn serverless_cache_snapshot_xml_contains_expected_fields() {
+        let snapshot = ServerlessCacheSnapshot {
+            serverless_cache_snapshot_name: "snap-a".to_string(),
+            arn: "arn:aws:elasticache:us-east-1:123456789012:serverlesssnapshot:snap-a".to_string(),
+            kms_key_id: Some("kms-123".to_string()),
+            snapshot_type: "manual".to_string(),
+            status: "available".to_string(),
+            create_time: "2024-01-01T00:00:00Z".to_string(),
+            expiry_time: None,
+            bytes_used_for_cache: Some("0".to_string()),
+            serverless_cache_name: "cache-a".to_string(),
+            engine: "redis".to_string(),
+            major_engine_version: "7.1".to_string(),
+        };
+
+        let xml = serverless_cache_snapshot_xml(&snapshot);
+        assert!(xml.contains("<ServerlessCacheSnapshotName>snap-a</ServerlessCacheSnapshotName>"));
+        assert!(xml.contains("<KmsKeyId>kms-123</KmsKeyId>"));
+        assert!(xml.contains("<SnapshotType>manual</SnapshotType>"));
+        assert!(xml.contains("<ServerlessCacheConfiguration>"));
+        assert!(xml.contains("<ServerlessCacheName>cache-a</ServerlessCacheName>"));
+    }
+
+    #[test]
+    fn describe_serverless_caches_returns_all() {
+        let service = service_with_serverless_cache("cache-a");
+        {
+            let mut state = service.state.write();
+            state.serverless_caches.insert(
+                "cache-b".to_string(),
+                ServerlessCache {
+                    serverless_cache_name: "cache-b".to_string(),
+                    description: "serverless cache".to_string(),
+                    engine: "valkey".to_string(),
+                    major_engine_version: "8.0".to_string(),
+                    full_engine_version: "8.0".to_string(),
+                    status: "available".to_string(),
+                    endpoint: ServerlessCacheEndpoint {
+                        address: "127.0.0.1".to_string(),
+                        port: 6380,
+                    },
+                    reader_endpoint: ServerlessCacheEndpoint {
+                        address: "127.0.0.1".to_string(),
+                        port: 6380,
+                    },
+                    arn: "arn:aws:elasticache:us-east-1:123456789012:serverlesscache:cache-b"
+                        .to_string(),
+                    created_at: "2024-01-02T00:00:00Z".to_string(),
+                    cache_usage_limits: None,
+                    security_group_ids: Vec::new(),
+                    subnet_ids: Vec::new(),
+                    kms_key_id: None,
+                    user_group_id: None,
+                    snapshot_retention_limit: None,
+                    daily_snapshot_time: None,
+                    container_id: "cid".to_string(),
+                    host_port: 6380,
+                },
+            );
+        }
+
+        let resp = service
+            .describe_serverless_caches(&request("DescribeServerlessCaches", &[]))
+            .unwrap();
+        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        assert!(body.contains("<ServerlessCacheName>cache-a</ServerlessCacheName>"));
+        assert!(body.contains("<ServerlessCacheName>cache-b</ServerlessCacheName>"));
+    }
+
+    #[test]
+    fn modify_serverless_cache_updates_fields() {
+        let service = service_with_serverless_cache("cache-a");
+        let req = request(
+            "ModifyServerlessCache",
+            &[
+                ("ServerlessCacheName", "cache-a"),
+                ("Description", "updated"),
+                ("SecurityGroupIds.SecurityGroupId.1", "sg-999"),
+                ("SnapshotRetentionLimit", "7"),
+                ("DailySnapshotTime", "05:00"),
+            ],
+        );
+
+        let resp = service.modify_serverless_cache(&req).unwrap();
+        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        assert!(body.contains("<Description>updated</Description>"));
+        assert!(body.contains("<SecurityGroupIds><member>sg-999</member></SecurityGroupIds>"));
+        assert!(body.contains("<SnapshotRetentionLimit>7</SnapshotRetentionLimit>"));
+        assert!(body.contains("<DailySnapshotTime>05:00</DailySnapshotTime>"));
+    }
+
+    #[test]
+    fn describe_serverless_cache_snapshots_filters_by_cache_name() {
+        let service = service_with_serverless_cache("cache-a");
+        {
+            let mut state = service.state.write();
+            state.serverless_cache_snapshots.insert(
+                "snap-a".to_string(),
+                ServerlessCacheSnapshot {
+                    serverless_cache_snapshot_name: "snap-a".to_string(),
+                    arn: "arn:aws:elasticache:us-east-1:123456789012:serverlesssnapshot:snap-a"
+                        .to_string(),
+                    kms_key_id: None,
+                    snapshot_type: "manual".to_string(),
+                    status: "available".to_string(),
+                    create_time: "2024-01-01T00:00:00Z".to_string(),
+                    expiry_time: None,
+                    bytes_used_for_cache: None,
+                    serverless_cache_name: "cache-a".to_string(),
+                    engine: "redis".to_string(),
+                    major_engine_version: "7.1".to_string(),
+                },
+            );
+        }
+
+        let resp = service
+            .describe_serverless_cache_snapshots(&request(
+                "DescribeServerlessCacheSnapshots",
+                &[("ServerlessCacheName", "cache-a")],
+            ))
+            .unwrap();
+        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        assert!(body.contains("<ServerlessCacheSnapshotName>snap-a</ServerlessCacheSnapshotName>"));
+    }
+
+    #[test]
+    fn delete_serverless_cache_snapshot_removes_tags() {
+        let service = service_with_serverless_cache("cache-a");
+        {
+            let mut state = service.state.write();
+            let arn =
+                "arn:aws:elasticache:us-east-1:123456789012:serverlesssnapshot:snap-a".to_string();
+            state.tags.insert(arn.clone(), Vec::new());
+            state.serverless_cache_snapshots.insert(
+                "snap-a".to_string(),
+                ServerlessCacheSnapshot {
+                    serverless_cache_snapshot_name: "snap-a".to_string(),
+                    arn,
+                    kms_key_id: None,
+                    snapshot_type: "manual".to_string(),
+                    status: "available".to_string(),
+                    create_time: "2024-01-01T00:00:00Z".to_string(),
+                    expiry_time: None,
+                    bytes_used_for_cache: None,
+                    serverless_cache_name: "cache-a".to_string(),
+                    engine: "redis".to_string(),
+                    major_engine_version: "7.1".to_string(),
+                },
+            );
+        }
+
+        let resp = service
+            .delete_serverless_cache_snapshot(&request(
+                "DeleteServerlessCacheSnapshot",
+                &[("ServerlessCacheSnapshotName", "snap-a")],
+            ))
+            .unwrap();
+        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        assert!(body.contains("<Status>deleting</Status>"));
+        assert!(!service
+            .state
+            .read()
+            .tags
+            .contains_key("arn:aws:elasticache:us-east-1:123456789012:serverlesssnapshot:snap-a"));
     }
 
     #[test]

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -2,6 +2,7 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use form_urlencoded;
 use http::StatusCode;
 
 use fakecloud_aws::xml::xml_escape;
@@ -912,14 +913,8 @@ impl ElastiCacheService {
             .unwrap_or_else(|| default_major_engine_version(&engine).to_string());
         let full_engine_version = default_full_engine_version(&engine, &major_engine_version)?;
         let cache_usage_limits = parse_cache_usage_limits(request)?;
-        let security_group_ids = {
-            let mut ids =
-                parse_member_list(&request.query_params, "SecurityGroupIds", "SecurityGroupId");
-            if ids.is_empty() {
-                ids = parse_member_list(&request.query_params, "SecurityGroupIds", "member");
-            }
-            ids
-        };
+        let security_group_ids =
+            parse_query_list_param(request, "SecurityGroupIds", "SecurityGroupId");
         let subnet_ids = parse_member_list(&request.query_params, "SubnetIds", "SubnetId");
         let kms_key_id = optional_param(request, "KmsKeyId");
         let user_group_id = optional_param(request, "UserGroupId");
@@ -1130,14 +1125,8 @@ impl ElastiCacheService {
         let serverless_cache_name = required_param(request, "ServerlessCacheName")?;
         let description = optional_param(request, "Description");
         let cache_usage_limits = parse_cache_usage_limits(request)?;
-        let security_group_ids = {
-            let mut ids =
-                parse_member_list(&request.query_params, "SecurityGroupIds", "SecurityGroupId");
-            if ids.is_empty() {
-                ids = parse_member_list(&request.query_params, "SecurityGroupIds", "member");
-            }
-            ids
-        };
+        let security_group_ids =
+            parse_query_list_param(request, "SecurityGroupIds", "SecurityGroupId");
         let user_group_id = optional_param(request, "UserGroupId");
         let snapshot_retention_limit =
             optional_non_negative_i32_param(request, "SnapshotRetentionLimit")?;
@@ -2529,6 +2518,50 @@ fn parse_member_list(
     indexed.into_iter().map(|(_, v)| v).collect()
 }
 
+fn parse_query_list_param(req: &AwsRequest, param: &str, member_name: &str) -> Vec<String> {
+    let mut indexed: Vec<(usize, String)> = Vec::new();
+
+    for (key, value) in &req.query_params {
+        if let Some(idx) = key
+            .strip_prefix(&format!("{param}.{member_name}."))
+            .and_then(|idx| idx.parse::<usize>().ok())
+        {
+            indexed.push((idx, value.clone()));
+            continue;
+        }
+        if let Some(idx) = key
+            .strip_prefix(&format!("{param}.member."))
+            .and_then(|idx| idx.parse::<usize>().ok())
+        {
+            indexed.push((idx, value.clone()));
+        }
+    }
+
+    for (key, value) in form_urlencoded::parse(req.body.as_ref()) {
+        let key = key.as_ref();
+        if let Some(idx) = key
+            .strip_prefix(&format!("{param}.{member_name}."))
+            .and_then(|idx| idx.parse::<usize>().ok())
+        {
+            indexed.push((idx, value.into_owned()));
+            continue;
+        }
+        if let Some(idx) = key
+            .strip_prefix(&format!("{param}.member."))
+            .and_then(|idx| idx.parse::<usize>().ok())
+        {
+            indexed.push((idx, value.into_owned()));
+            continue;
+        }
+        if key == param {
+            indexed.push((indexed.len() + 1, value.into_owned()));
+        }
+    }
+
+    indexed.sort_by_key(|(idx, _)| *idx);
+    indexed.into_iter().map(|(_, v)| v).collect()
+}
+
 fn optional_usize_param(req: &AwsRequest, name: &str) -> Result<Option<usize>, AwsServiceError> {
     optional_param(req, name)
         .map(|v| {
@@ -3231,7 +3264,7 @@ mod tests {
     use super::*;
     use crate::state::default_engine_versions;
     use bytes::Bytes;
-    use http::HeaderMap;
+    use http::{HeaderMap, Method};
     use std::collections::HashMap;
 
     fn request(action: &str, params: &[(&str, &str)]) -> AwsRequest {
@@ -4167,6 +4200,39 @@ mod tests {
         assert!(body.contains("<SecurityGroupIds><member>sg-999</member></SecurityGroupIds>"));
         assert!(body.contains("<SnapshotRetentionLimit>7</SnapshotRetentionLimit>"));
         assert!(body.contains("<DailySnapshotTime>05:00</DailySnapshotTime>"));
+    }
+
+    #[test]
+    fn parse_query_list_param_reads_flat_and_indexed_body_values() {
+        let req = AwsRequest {
+            service: "elasticache".to_string(),
+            action: "ModifyServerlessCache".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: "000000000000".to_string(),
+            request_id: "req-1".to_string(),
+            headers: HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: Bytes::from("SecurityGroupIds.member.1=sg-a&SecurityGroupIds.member.2=sg-b"),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+        };
+        assert_eq!(
+            parse_query_list_param(&req, "SecurityGroupIds", "SecurityGroupId"),
+            vec!["sg-a".to_string(), "sg-b".to_string()]
+        );
+
+        let req = AwsRequest {
+            body: Bytes::from("SecurityGroupIds=sg-flat"),
+            ..req
+        };
+        assert_eq!(
+            parse_query_list_param(&req, "SecurityGroupIds", "SecurityGroupId"),
+            vec!["sg-flat".to_string()]
+        );
     }
 
     #[test]

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -132,6 +132,69 @@ pub struct CacheSnapshot {
     pub snapshot_source: String,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ServerlessCacheUsageLimits {
+    pub data_storage: Option<ServerlessCacheDataStorage>,
+    pub ecpu_per_second: Option<ServerlessCacheEcpuPerSecond>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServerlessCacheDataStorage {
+    pub maximum: Option<i32>,
+    pub minimum: Option<i32>,
+    pub unit: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServerlessCacheEcpuPerSecond {
+    pub maximum: Option<i32>,
+    pub minimum: Option<i32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServerlessCacheEndpoint {
+    pub address: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServerlessCache {
+    pub serverless_cache_name: String,
+    pub description: String,
+    pub engine: String,
+    pub major_engine_version: String,
+    pub full_engine_version: String,
+    pub status: String,
+    pub endpoint: ServerlessCacheEndpoint,
+    pub reader_endpoint: ServerlessCacheEndpoint,
+    pub arn: String,
+    pub created_at: String,
+    pub cache_usage_limits: Option<ServerlessCacheUsageLimits>,
+    pub security_group_ids: Vec<String>,
+    pub subnet_ids: Vec<String>,
+    pub kms_key_id: Option<String>,
+    pub user_group_id: Option<String>,
+    pub snapshot_retention_limit: Option<i32>,
+    pub daily_snapshot_time: Option<String>,
+    pub container_id: String,
+    pub host_port: u16,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServerlessCacheSnapshot {
+    pub serverless_cache_snapshot_name: String,
+    pub arn: String,
+    pub kms_key_id: Option<String>,
+    pub snapshot_type: String,
+    pub status: String,
+    pub create_time: String,
+    pub expiry_time: Option<String>,
+    pub bytes_used_for_cache: Option<String>,
+    pub serverless_cache_name: String,
+    pub engine: String,
+    pub major_engine_version: String,
+}
+
 #[derive(Debug)]
 pub struct ElastiCacheState {
     pub account_id: String,
@@ -143,9 +206,12 @@ pub struct ElastiCacheState {
     pub users: HashMap<String, ElastiCacheUser>,
     pub user_groups: HashMap<String, ElastiCacheUserGroup>,
     pub snapshots: HashMap<String, CacheSnapshot>,
+    pub serverless_caches: HashMap<String, ServerlessCache>,
+    pub serverless_cache_snapshots: HashMap<String, ServerlessCacheSnapshot>,
     pub tags: HashMap<String, Vec<(String, String)>>,
     in_progress_cache_cluster_ids: HashSet<String>,
     in_progress_replication_group_ids: HashSet<String>,
+    in_progress_serverless_cache_names: HashSet<String>,
 }
 
 impl ElastiCacheState {
@@ -170,9 +236,12 @@ impl ElastiCacheState {
             users,
             user_groups: HashMap::new(),
             snapshots: HashMap::new(),
+            serverless_caches: HashMap::new(),
+            serverless_cache_snapshots: HashMap::new(),
             tags,
             in_progress_cache_cluster_ids: HashSet::new(),
             in_progress_replication_group_ids: HashSet::new(),
+            in_progress_serverless_cache_names: HashSet::new(),
         }
     }
 
@@ -184,6 +253,8 @@ impl ElastiCacheState {
         self.users = default_users(&self.account_id, &self.region);
         self.user_groups.clear();
         self.snapshots.clear();
+        self.serverless_caches.clear();
+        self.serverless_cache_snapshots.clear();
         self.tags.clear();
         for g in self.subnet_groups.values() {
             self.tags.insert(g.arn.clone(), Vec::new());
@@ -193,6 +264,7 @@ impl ElastiCacheState {
         }
         self.in_progress_cache_cluster_ids.clear();
         self.in_progress_replication_group_ids.clear();
+        self.in_progress_serverless_cache_names.clear();
     }
 
     pub fn begin_cache_cluster_creation(&mut self, cache_cluster_id: &str) -> bool {
@@ -244,6 +316,32 @@ impl ElastiCacheState {
     pub fn cancel_replication_group_creation(&mut self, replication_group_id: &str) {
         self.in_progress_replication_group_ids
             .remove(replication_group_id);
+    }
+
+    pub fn begin_serverless_cache_creation(&mut self, serverless_cache_name: &str) -> bool {
+        if self.serverless_caches.contains_key(serverless_cache_name)
+            || self
+                .in_progress_serverless_cache_names
+                .contains(serverless_cache_name)
+        {
+            return false;
+        }
+        self.in_progress_serverless_cache_names
+            .insert(serverless_cache_name.to_string());
+        true
+    }
+
+    pub fn finish_serverless_cache_creation(&mut self, cache: ServerlessCache) {
+        self.in_progress_serverless_cache_names
+            .remove(&cache.serverless_cache_name);
+        self.tags.insert(cache.arn.clone(), Vec::new());
+        self.serverless_caches
+            .insert(cache.serverless_cache_name.clone(), cache);
+    }
+
+    pub fn cancel_serverless_cache_creation(&mut self, serverless_cache_name: &str) {
+        self.in_progress_serverless_cache_names
+            .remove(serverless_cache_name);
     }
 
     pub fn register_arn(&mut self, arn: &str) {
@@ -486,6 +584,13 @@ mod tests {
     }
 
     #[test]
+    fn state_new_has_empty_serverless_caches() {
+        let state = ElastiCacheState::new("123456789012", "us-east-1");
+        assert!(state.serverless_caches.is_empty());
+        assert!(state.serverless_cache_snapshots.is_empty());
+    }
+
+    #[test]
     fn begin_cache_cluster_creation_rejects_duplicate_ids() {
         let mut state = ElastiCacheState::new("123456789012", "us-east-1");
 
@@ -505,6 +610,56 @@ mod tests {
 
         state.cancel_replication_group_creation("rg-1");
         assert!(state.begin_replication_group_creation("rg-1"));
+    }
+
+    #[test]
+    fn begin_serverless_cache_creation_rejects_duplicate_names() {
+        let mut state = ElastiCacheState::new("123456789012", "us-east-1");
+
+        assert!(state.begin_serverless_cache_creation("cache-1"));
+        assert!(!state.begin_serverless_cache_creation("cache-1"));
+
+        state.cancel_serverless_cache_creation("cache-1");
+        assert!(state.begin_serverless_cache_creation("cache-1"));
+    }
+
+    #[test]
+    fn finish_serverless_cache_creation_registers_cache_and_tags() {
+        let mut state = ElastiCacheState::new("123456789012", "us-east-1");
+        assert!(state.begin_serverless_cache_creation("cache-1"));
+
+        let cache = ServerlessCache {
+            serverless_cache_name: "cache-1".to_string(),
+            description: "test".to_string(),
+            engine: "redis".to_string(),
+            major_engine_version: "7.1".to_string(),
+            full_engine_version: "7.1".to_string(),
+            status: "available".to_string(),
+            endpoint: ServerlessCacheEndpoint {
+                address: "127.0.0.1".to_string(),
+                port: 6379,
+            },
+            reader_endpoint: ServerlessCacheEndpoint {
+                address: "127.0.0.1".to_string(),
+                port: 6379,
+            },
+            arn: "arn:aws:elasticache:us-east-1:123456789012:serverlesscache:cache-1".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            cache_usage_limits: None,
+            security_group_ids: Vec::new(),
+            subnet_ids: Vec::new(),
+            kms_key_id: None,
+            user_group_id: None,
+            snapshot_retention_limit: None,
+            daily_snapshot_time: None,
+            container_id: "cid".to_string(),
+            host_port: 6379,
+        };
+
+        state.finish_serverless_cache_creation(cache.clone());
+
+        assert!(state.serverless_caches.contains_key("cache-1"));
+        assert!(state.tags.contains_key(&cache.arn));
     }
 
     #[test]
@@ -648,5 +803,63 @@ mod tests {
         assert_eq!(state.cache_clusters.len(), 1);
         state.reset();
         assert!(state.cache_clusters.is_empty());
+    }
+
+    #[test]
+    fn reset_clears_serverless_cache_state() {
+        let mut state = ElastiCacheState::new("123456789012", "us-east-1");
+        state.serverless_caches.insert(
+            "serverless".to_string(),
+            ServerlessCache {
+                serverless_cache_name: "serverless".to_string(),
+                description: "test".to_string(),
+                engine: "redis".to_string(),
+                major_engine_version: "7.1".to_string(),
+                full_engine_version: "7.1".to_string(),
+                status: "available".to_string(),
+                endpoint: ServerlessCacheEndpoint {
+                    address: "127.0.0.1".to_string(),
+                    port: 6379,
+                },
+                reader_endpoint: ServerlessCacheEndpoint {
+                    address: "127.0.0.1".to_string(),
+                    port: 6379,
+                },
+                arn: "arn:aws:elasticache:us-east-1:123456789012:serverlesscache:serverless"
+                    .to_string(),
+                created_at: "2024-01-01T00:00:00Z".to_string(),
+                cache_usage_limits: None,
+                security_group_ids: Vec::new(),
+                subnet_ids: Vec::new(),
+                kms_key_id: None,
+                user_group_id: None,
+                snapshot_retention_limit: None,
+                daily_snapshot_time: None,
+                container_id: "cid".to_string(),
+                host_port: 6379,
+            },
+        );
+        state.serverless_cache_snapshots.insert(
+            "snap-1".to_string(),
+            ServerlessCacheSnapshot {
+                serverless_cache_snapshot_name: "snap-1".to_string(),
+                arn: "arn:aws:elasticache:us-east-1:123456789012:serverlesssnapshot:snap-1"
+                    .to_string(),
+                kms_key_id: None,
+                snapshot_type: "manual".to_string(),
+                status: "available".to_string(),
+                create_time: "2024-01-01T00:00:00Z".to_string(),
+                expiry_time: None,
+                bytes_used_for_cache: None,
+                serverless_cache_name: "serverless".to_string(),
+                engine: "redis".to_string(),
+                major_engine_version: "7.1".to_string(),
+            },
+        );
+
+        state.reset();
+
+        assert!(state.serverless_caches.is_empty());
+        assert!(state.serverless_cache_snapshots.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- implement CreateServerlessCache backed by real Redis containers with begin/finish/cancel pattern
- implement DescribeServerlessCaches with optional name filter and pagination
- implement DeleteServerlessCache with container stop, state cleanup, and tag removal
- implement ModifyServerlessCache with description, security groups, user group, and snapshot config updates
- implement CreateServerlessCacheSnapshot with metadata capture from serverless caches
- implement DescribeServerlessCacheSnapshots with optional filters and pagination
- implement DeleteServerlessCacheSnapshot with tag cleanup
- validate Engine (redis/valkey), engine-specific default versions
- add 7 handwritten conformance tests with test_action macro coverage
- add e2e tests for serverless cache lifecycle and error cases
- add unit tests for state operations, validation, and XML formatting

## Validation
- cargo fmt --all
- cargo build --bin fakecloud
- cargo test -p fakecloud-elasticache --lib (91 passed)
- conformance and e2e Docker-dependent tests validated via CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ElastiCache serverless cache APIs backed by real Redis containers to create, modify, list, and delete serverless caches and snapshots. Includes pagination, validation, tagging, and runtime orchestration; requires Docker/Podman locally.

- **New Features**
  - Create/Describe/Modify/Delete ServerlessCache and ServerlessCacheSnapshot endpoints.
  - Backed by runtime Redis containers with begin/finish/cancel guards; containers stopped on delete.
  - Engine validation for redis/valkey with default major versions and checks.
  - Pagination via MaxResults/NextToken for describe endpoints.
  - Tag add/remove on create/delete; XML output aligned with AWS Query.
  - Support for endpoints, `CacheUsageLimits`, security groups, subnets, KMS, user groups, and snapshot config.

- **Bug Fixes**
  - Unified ElastiCache list parsing to avoid duplicates; reads `SecurityGroupIds` via `SecurityGroupIds.SecurityGroupId.N`, `SecurityGroupIds.member.N`, or flat values from body/query using `form_urlencoded`.
  - Tests verify security group updates via Describe after Modify to match SDK deserialization behavior.
  - Serverless XML now emits `SecurityGroupIds` with `SecurityGroupId` members to match AWS/SDK expectations.

<sup>Written for commit ee5e68ace08ff73d6bb0303fd3cd689e23a9c61d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

