### PR TITLE
perf(ci): run integration binaries in release mode

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -21,27 +21,27 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build server
-        run: cargo build --bin fakecloud
+        run: cargo build --release --bin fakecloud
 
       - name: Run conformance integration tests
         run: cargo test -p fakecloud-conformance --tests
 
       - name: Build conformance tool
-        run: cargo build -p fakecloud-conformance
+        run: cargo build --release -p fakecloud-conformance
 
       - name: Check conformance (fails if coverage drops)
         id: check
         run: |
           set -o pipefail
-          cargo run -p fakecloud-conformance -- check 2>&1 | tee conformance-report.txt
+          ./target/release/fakecloud-conformance check 2>&1 | tee conformance-report.txt
 
       - name: Audit handwritten tests (fails if implemented action lacks a test)
         if: always() && steps.check.outcome != 'skipped'
-        run: cargo run -p fakecloud-conformance -- audit
+        run: ./target/release/fakecloud-conformance audit
 
       - name: Generate JSON report
         if: always()
-        run: cargo run -p fakecloud-conformance -- run --format json > conformance-report.json 2>/dev/null || true
+        run: ./target/release/fakecloud-conformance run --format json > conformance-report.json 2>/dev/null || true
 
       - name: Post summary
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Build server
-        run: cargo build --bin fakecloud
+        run: cargo build --release --bin fakecloud
 
       - name: Run nextest partition
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -18,11 +18,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build server
-        run: cargo build --bin fakecloud
+        run: cargo build --release --bin fakecloud
 
       - name: Start FakeCloud
         run: |
-          cargo run --bin fakecloud &
+          ./target/release/fakecloud &
           for i in $(seq 1 30); do
             curl -sf http://localhost:4566/_fakecloud/health && exit 0
             sleep 1


### PR DESCRIPTION
## Summary
- build the conformance CLI in release mode and invoke the release binary directly
- build fakecloud in release mode for conformance and e2e workflows
- build and start fakecloud from the release binary in examples

## Why
These CI lanes are integration-style workflows or helper-CLI invocations where debug binaries add avoidable startup and runtime cost. This keeps behavior the same while reducing wasted CI time.

## Validation
- parsed updated workflow YAML locally
- cargo build --release -p fakecloud-conformance
- cargo build --release --bin fakecloud
- ./target/release/fakecloud-conformance --help

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `fakecloud` and `fakecloud-conformance` in release mode in CI to reduce startup and runtime overhead in integration workflows. Applies to conformance, e2e, and examples; behavior stays the same, runs faster.

- **Refactors**
  - Build `fakecloud` with `--release` in conformance, e2e, and examples workflows.
  - Build `fakecloud-conformance` with `--release` and call `./target/release/fakecloud-conformance` for check, audit, and run.
  - Start `fakecloud` via `./target/release/fakecloud` in examples.

<sup>Written for commit d23caf5841eb04d25b88f2288747d5a60db8138e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

