### PR TITLE
feat: add rds read replicas

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -451,6 +451,44 @@ async fn rds_restore_db_instance_from_db_snapshot() {
     assert_eq!(instance.db_name(), Some("appdb"));
 }
 
+#[test_action("rds", "CreateDBInstanceReadReplica", checksum = "23be1880")]
+#[tokio::test]
+async fn rds_create_db_instance_read_replica() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client).await;
+
+    let response = client
+        .create_db_instance_read_replica()
+        .db_instance_identifier("conf-read-replica")
+        .source_db_instance_identifier("conf-rds-db")
+        .send()
+        .await
+        .unwrap();
+
+    let replica = response.db_instance().unwrap();
+    assert_eq!(replica.db_instance_identifier(), Some("conf-read-replica"));
+    assert_eq!(replica.engine(), Some("postgres"));
+    assert_eq!(
+        replica.read_replica_source_db_instance_identifier(),
+        Some("conf-rds-db")
+    );
+
+    let describe = client
+        .describe_db_instances()
+        .db_instance_identifier("conf-rds-db")
+        .send()
+        .await
+        .unwrap();
+    let source = &describe.db_instances()[0];
+    assert_eq!(source.read_replica_db_instance_identifiers().len(), 1);
+    assert_eq!(
+        source.read_replica_db_instance_identifiers()[0],
+        "conf-read-replica"
+    );
+}
+
 async fn create_instance(
     client: &aws_sdk_rds::Client,
 ) -> aws_sdk_rds::operation::create_db_instance::CreateDbInstanceOutput {

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -479,6 +479,111 @@ async fn rds_restore_from_snapshot() {
     assert_eq!(name, "snapshot test data");
 }
 
+#[tokio::test]
+async fn rds_create_and_query_read_replica() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client, "orders-source-db").await;
+
+    let source_describe = client
+        .describe_db_instances()
+        .db_instance_identifier("orders-source-db")
+        .send()
+        .await
+        .unwrap();
+    let source_instance = &source_describe.db_instances()[0];
+    let source_endpoint = source_instance.endpoint().unwrap();
+
+    let (source_client, source_connection) = connect_with_retry(
+        source_endpoint.address().unwrap(),
+        source_endpoint.port().unwrap(),
+        "admin",
+        "secret123",
+        "appdb",
+    )
+    .await
+    .unwrap();
+    tokio::spawn(async move {
+        if let Err(e) = source_connection.await {
+            eprintln!("connection error: {}", e);
+        }
+    });
+
+    source_client
+        .execute("CREATE TABLE test_table (id INT, name TEXT)", &[])
+        .await
+        .unwrap();
+    source_client
+        .execute(
+            "INSERT INTO test_table (id, name) VALUES (1, 'primary data')",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let replica_response = client
+        .create_db_instance_read_replica()
+        .db_instance_identifier("orders-replica-db")
+        .source_db_instance_identifier("orders-source-db")
+        .send()
+        .await
+        .unwrap();
+
+    let replica_instance = replica_response.db_instance().unwrap();
+    assert_eq!(
+        replica_instance.db_instance_identifier(),
+        Some("orders-replica-db")
+    );
+    assert_eq!(
+        replica_instance.read_replica_source_db_instance_identifier(),
+        Some("orders-source-db")
+    );
+
+    let source_describe_after = client
+        .describe_db_instances()
+        .db_instance_identifier("orders-source-db")
+        .send()
+        .await
+        .unwrap();
+    let source_after = &source_describe_after.db_instances()[0];
+    assert_eq!(source_after.read_replica_db_instance_identifiers().len(), 1);
+    assert_eq!(
+        source_after.read_replica_db_instance_identifiers()[0],
+        "orders-replica-db"
+    );
+
+    let replica_describe = client
+        .describe_db_instances()
+        .db_instance_identifier("orders-replica-db")
+        .send()
+        .await
+        .unwrap();
+    let replica_endpoint = replica_describe.db_instances()[0].endpoint().unwrap();
+
+    let (replica_client, replica_connection) = connect_with_retry(
+        replica_endpoint.address().unwrap(),
+        replica_endpoint.port().unwrap(),
+        "admin",
+        "secret123",
+        "appdb",
+    )
+    .await
+    .unwrap();
+    tokio::spawn(async move {
+        if let Err(e) = replica_connection.await {
+            eprintln!("connection error: {}", e);
+        }
+    });
+
+    let row = replica_client
+        .query_one("SELECT name FROM test_table WHERE id = 1", &[])
+        .await
+        .unwrap();
+    let name: String = row.get(0);
+    assert_eq!(name, "primary data");
+}
+
 async fn create_instance_with_deletion_protection(
     client: &aws_sdk_rds::Client,
     db_instance_identifier: &str,

--- a/crates/fakecloud-rds/src/runtime.rs
+++ b/crates/fakecloud-rds/src/runtime.rs
@@ -307,6 +307,8 @@ impl RdsRuntime {
                 "-d",
                 db_name,
                 "--no-password",
+                "-v",
+                "ON_ERROR_STOP=1",
             ])
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -627,6 +627,14 @@ impl RdsService {
 
         let mut state = self.state.write();
 
+        if state.snapshots.contains_key(&db_snapshot_identifier) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::CONFLICT,
+                "DBSnapshotAlreadyExists",
+                format!("DBSnapshot {db_snapshot_identifier} already exists."),
+            ));
+        }
+
         let snapshot = DbSnapshot {
             db_snapshot_identifier: db_snapshot_identifier.clone(),
             db_snapshot_arn: state.db_snapshot_arn(&db_snapshot_identifier),
@@ -772,7 +780,7 @@ impl RdsService {
         };
 
         let db_name = snapshot.db_name.as_deref().unwrap_or("postgres");
-        let running = runtime
+        let running = match runtime
             .ensure_postgres(
                 &db_instance_identifier,
                 &snapshot.master_username,
@@ -780,9 +788,17 @@ impl RdsService {
                 db_name,
             )
             .await
-            .map_err(runtime_error_to_service_error)?;
+        {
+            Ok(running) => running,
+            Err(e) => {
+                self.state
+                    .write()
+                    .cancel_instance_creation(&db_instance_identifier);
+                return Err(runtime_error_to_service_error(e));
+            }
+        };
 
-        runtime
+        if let Err(e) = runtime
             .restore_database(
                 &db_instance_identifier,
                 &snapshot.master_username,
@@ -790,7 +806,12 @@ impl RdsService {
                 &snapshot.dump_data,
             )
             .await
-            .map_err(runtime_error_to_service_error)?;
+        {
+            self.state
+                .write()
+                .cancel_instance_creation(&db_instance_identifier);
+            return Err(runtime_error_to_service_error(e));
+        }
 
         let mut state = self.state.write();
 
@@ -890,7 +911,7 @@ impl RdsService {
         let db_instance_arn = self.state.read().db_instance_arn(&db_instance_identifier);
         let created_at = Utc::now();
 
-        let running = runtime
+        let running = match runtime
             .ensure_postgres(
                 &db_instance_identifier,
                 &source_instance.master_username,
@@ -898,9 +919,17 @@ impl RdsService {
                 &db_name,
             )
             .await
-            .map_err(runtime_error_to_service_error)?;
+        {
+            Ok(running) => running,
+            Err(e) => {
+                self.state
+                    .write()
+                    .cancel_instance_creation(&db_instance_identifier);
+                return Err(runtime_error_to_service_error(e));
+            }
+        };
 
-        runtime
+        if let Err(e) = runtime
             .restore_database(
                 &db_instance_identifier,
                 &source_instance.master_username,
@@ -908,7 +937,12 @@ impl RdsService {
                 &dump_data,
             )
             .await
-            .map_err(runtime_error_to_service_error)?;
+        {
+            self.state
+                .write()
+                .cancel_instance_creation(&db_instance_identifier);
+            return Err(runtime_error_to_service_error(e));
+        }
 
         let mut state = self.state.write();
 

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -898,14 +898,22 @@ impl RdsService {
             (source_instance, db_name)
         };
 
-        let dump_data = runtime
+        let dump_data = match runtime
             .dump_database(
                 &source_db_instance_identifier,
                 &source_instance.master_username,
                 &db_name,
             )
             .await
-            .map_err(runtime_error_to_service_error)?;
+        {
+            Ok(data) => data,
+            Err(e) => {
+                self.state
+                    .write()
+                    .cancel_instance_creation(&db_instance_identifier);
+                return Err(runtime_error_to_service_error(e));
+            }
+        };
 
         let dbi_resource_id = self.state.read().next_dbi_resource_id();
         let db_instance_arn = self.state.read().db_instance_arn(&db_instance_identifier);
@@ -970,10 +978,16 @@ impl RdsService {
             read_replica_db_instance_identifiers: Vec::new(),
         };
 
-        if let Some(source) = state.instances.get_mut(&source_db_instance_identifier) {
-            source
-                .read_replica_db_instance_identifiers
-                .push(db_instance_identifier.clone());
+        match state.instances.get_mut(&source_db_instance_identifier) {
+            Some(source) => {
+                source
+                    .read_replica_db_instance_identifiers
+                    .push(db_instance_identifier.clone());
+            }
+            None => {
+                state.cancel_instance_creation(&db_instance_identifier);
+                return Err(db_instance_not_found(&source_db_instance_identifier));
+            }
         }
 
         state.finish_instance_creation(replica.clone());

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -17,6 +17,7 @@ const RDS_NS: &str = "http://rds.amazonaws.com/doc/2014-10-31/";
 const SUPPORTED_ACTIONS: &[&str] = &[
     "AddTagsToResource",
     "CreateDBInstance",
+    "CreateDBInstanceReadReplica",
     "CreateDBSnapshot",
     "DeleteDBInstance",
     "DeleteDBSnapshot",
@@ -60,6 +61,7 @@ impl AwsService for RdsService {
         match request.action.as_str() {
             "AddTagsToResource" => self.add_tags_to_resource(&request),
             "CreateDBInstance" => self.create_db_instance(&request).await,
+            "CreateDBInstanceReadReplica" => self.create_db_instance_read_replica(&request).await,
             "CreateDBSnapshot" => self.create_db_snapshot(&request).await,
             "DeleteDBInstance" => self.delete_db_instance(&request).await,
             "DeleteDBSnapshot" => self.delete_db_snapshot(&request),
@@ -175,6 +177,8 @@ impl RdsService {
             container_id: running.container_id,
             host_port: running.host_port,
             tags: Vec::new(),
+            read_replica_source_db_instance_identifier: None,
+            read_replica_db_instance_identifiers: Vec::new(),
         };
         state.finish_instance_creation(instance.clone());
 
@@ -235,6 +239,20 @@ impl RdsService {
                         db_instance_identifier
                     ),
                 ));
+            }
+
+            if let Some(source_id) = &instance.read_replica_source_db_instance_identifier {
+                if let Some(source) = state.instances.get_mut(source_id) {
+                    source
+                        .read_replica_db_instance_identifiers
+                        .retain(|id| id != &db_instance_identifier);
+                }
+            }
+
+            for replica_id in &instance.read_replica_db_instance_identifiers {
+                if let Some(replica) = state.instances.get_mut(replica_id) {
+                    replica.read_replica_source_db_instance_identifier = None;
+                }
             }
 
             instance
@@ -796,6 +814,8 @@ impl RdsService {
             container_id: running.container_id,
             host_port: running.host_port,
             tags: Vec::new(),
+            read_replica_source_db_instance_identifier: None,
+            read_replica_db_instance_identifiers: Vec::new(),
         };
 
         state.finish_instance_creation(instance.clone());
@@ -807,6 +827,130 @@ impl RdsService {
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, None)
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    async fn create_db_instance_read_replica(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let db_instance_identifier = required_param(request, "DBInstanceIdentifier")?;
+        let source_db_instance_identifier = required_param(request, "SourceDBInstanceIdentifier")?;
+
+        let runtime = self.runtime.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "InvalidParameterValue",
+                "Docker/Podman is required for RDS read replicas but is not available",
+            )
+        })?;
+
+        let (source_instance, db_name) = {
+            let mut state = self.state.write();
+
+            if !state.begin_instance_creation(&db_instance_identifier) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::CONFLICT,
+                    "DBInstanceAlreadyExists",
+                    format!("DBInstance {db_instance_identifier} already exists."),
+                ));
+            }
+
+            let source_instance = match state.instances.get(&source_db_instance_identifier).cloned()
+            {
+                Some(inst) => inst,
+                None => {
+                    state.cancel_instance_creation(&db_instance_identifier);
+                    return Err(db_instance_not_found(&source_db_instance_identifier));
+                }
+            };
+
+            let db_name = source_instance
+                .db_name
+                .as_deref()
+                .unwrap_or("postgres")
+                .to_string();
+
+            (source_instance, db_name)
+        };
+
+        let dump_data = runtime
+            .dump_database(
+                &source_db_instance_identifier,
+                &source_instance.master_username,
+                &db_name,
+            )
+            .await
+            .map_err(runtime_error_to_service_error)?;
+
+        let dbi_resource_id = self.state.read().next_dbi_resource_id();
+        let db_instance_arn = self.state.read().db_instance_arn(&db_instance_identifier);
+        let created_at = Utc::now();
+
+        let running = runtime
+            .ensure_postgres(
+                &db_instance_identifier,
+                &source_instance.master_username,
+                &source_instance.master_user_password,
+                &db_name,
+            )
+            .await
+            .map_err(runtime_error_to_service_error)?;
+
+        runtime
+            .restore_database(
+                &db_instance_identifier,
+                &source_instance.master_username,
+                &db_name,
+                &dump_data,
+            )
+            .await
+            .map_err(runtime_error_to_service_error)?;
+
+        let mut state = self.state.write();
+
+        let replica = DbInstance {
+            db_instance_identifier: db_instance_identifier.clone(),
+            db_instance_arn,
+            db_instance_class: source_instance.db_instance_class.clone(),
+            engine: source_instance.engine.clone(),
+            engine_version: source_instance.engine_version.clone(),
+            db_instance_status: "available".to_string(),
+            master_username: source_instance.master_username.clone(),
+            db_name: source_instance.db_name.clone(),
+            endpoint_address: "127.0.0.1".to_string(),
+            port: i32::from(running.host_port),
+            allocated_storage: source_instance.allocated_storage,
+            publicly_accessible: source_instance.publicly_accessible,
+            deletion_protection: false,
+            created_at,
+            dbi_resource_id,
+            master_user_password: source_instance.master_user_password.clone(),
+            container_id: running.container_id,
+            host_port: running.host_port,
+            tags: Vec::new(),
+            read_replica_source_db_instance_identifier: Some(source_db_instance_identifier.clone()),
+            read_replica_db_instance_identifiers: Vec::new(),
+        };
+
+        if let Some(source) = state.instances.get_mut(&source_db_instance_identifier) {
+            source
+                .read_replica_db_instance_identifiers
+                .push(db_instance_identifier.clone());
+        }
+
+        state.finish_instance_creation(replica.clone());
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "CreateDBInstanceReadReplica",
+                &format!(
+                    "<DBInstance>{}</DBInstance>",
+                    db_instance_xml(&replica, None)
                 ),
                 &request.request_id,
             ),
@@ -1106,6 +1250,34 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
         .as_ref()
         .map(|db_name| format!("<DBName>{}</DBName>", xml_escape(db_name)))
         .unwrap_or_default();
+
+    let read_replica_source_xml = instance
+        .read_replica_source_db_instance_identifier
+        .as_ref()
+        .map(|source| {
+            format!(
+                "<ReadReplicaSourceDBInstanceIdentifier>{}</ReadReplicaSourceDBInstanceIdentifier>",
+                xml_escape(source)
+            )
+        })
+        .unwrap_or_default();
+
+    let read_replica_identifiers_xml = if instance.read_replica_db_instance_identifiers.is_empty() {
+        "<ReadReplicaDBInstanceIdentifiers/>".to_string()
+    } else {
+        format!(
+            "<ReadReplicaDBInstanceIdentifiers>{}</ReadReplicaDBInstanceIdentifiers>",
+            instance
+                .read_replica_db_instance_identifiers
+                .iter()
+                .map(|id| format!(
+                    "<ReadReplicaDBInstanceIdentifier>{}</ReadReplicaDBInstanceIdentifier>",
+                    xml_escape(id)
+                ))
+                .collect::<String>()
+        )
+    };
+
     format!(
         "<DBInstanceIdentifier>{}</DBInstanceIdentifier>\
          <DBInstanceClass>{}</DBInstanceClass>\
@@ -1126,7 +1298,8 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
          <MultiAZ>false</MultiAZ>\
          <EngineVersion>{}</EngineVersion>\
          <AutoMinorVersionUpgrade>true</AutoMinorVersionUpgrade>\
-         <ReadReplicaDBInstanceIdentifiers/>\
+         {}\
+         {}\
          <LicenseModel>postgresql-license</LicenseModel>\
          <OptionGroupMemberships/>\
          <PubliclyAccessible>{}</PubliclyAccessible>\
@@ -1147,6 +1320,8 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
         instance.allocated_storage,
         instance.created_at.to_rfc3339(),
         xml_escape(&instance.engine_version),
+        read_replica_identifiers_xml,
+        read_replica_source_xml,
         if instance.publicly_accessible {
             "true"
         } else {
@@ -1359,6 +1534,8 @@ mod tests {
             container_id: "container".to_string(),
             host_port: 15432,
             tags: Vec::new(),
+            read_replica_source_db_instance_identifier: None,
+            read_replica_db_instance_identifiers: Vec::new(),
         };
 
         let xml = db_instance_xml(&instance, Some("creating"));

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -30,6 +30,8 @@ pub struct DbInstance {
     pub container_id: String,
     pub host_port: u16,
     pub tags: Vec<RdsTag>,
+    pub read_replica_source_db_instance_identifier: Option<String>,
+    pub read_replica_db_instance_identifiers: Vec<String>,
 }
 
 impl fmt::Debug for DbInstance {
@@ -54,6 +56,14 @@ impl fmt::Debug for DbInstance {
             .field("container_id", &self.container_id)
             .field("host_port", &self.host_port)
             .field("tags", &self.tags)
+            .field(
+                "read_replica_source_db_instance_identifier",
+                &self.read_replica_source_db_instance_identifier,
+            )
+            .field(
+                "read_replica_db_instance_identifiers",
+                &self.read_replica_db_instance_identifiers,
+            )
             .finish()
     }
 }
@@ -268,6 +278,8 @@ mod tests {
                 container_id: "container-id".to_string(),
                 host_port: 15432,
                 tags: Vec::new(),
+                read_replica_source_db_instance_identifier: None,
+                read_replica_db_instance_identifiers: Vec::new(),
             },
         );
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1351,6 +1351,8 @@ mod tests {
                 container_id: "container-id".to_string(),
                 host_port: 15432,
                 tags: Vec::new(),
+                read_replica_source_db_instance_identifier: None,
+                read_replica_db_instance_identifiers: Vec::new(),
             },
         );
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1456,6 +1456,8 @@ mod tests {
                 key: "env".to_string(),
                 value: "test".to_string(),
             }],
+            read_replica_source_db_instance_identifier: None,
+            read_replica_db_instance_identifiers: Vec::new(),
         };
 
         let response = rds_instance_response(&instance);


### PR DESCRIPTION
## Summary

Implements RDS read replicas for read scaling:
- `CreateDBInstanceReadReplica` - create a read replica from a source instance

## Implementation

Read replica creation:
1. Takes a pg_dump snapshot of the source database
2. Creates a new container with the source's credentials  
3. Restores the dump to the replica
4. Establishes metadata relationship (source tracks replicas, replicas track source)

**Note**: This implements point-in-time snapshot replication rather than streaming replication. Suitable for local development/testing where you want multiple read endpoints with the same initial data.

Relationship management:
- Source instances track their replicas in `read_replica_db_instance_identifiers`
- Replica instances reference their source in `read_replica_source_db_instance_identifier`
- `DeleteDBInstance` properly cleans up relationships in both directions

## Test Coverage

- **Conformance test**: `rds_create_db_instance_read_replica` (checksum: `23be1880`)
  - Verifies replica creation
  - Checks metadata relationship in both directions

- **E2E test**: `rds_create_and_query_read_replica`
  - Creates source with test table/data
  - Creates read replica
  - Verifies data was copied to replica
  - Tests actual connectivity to both instances

All 16 conformance and 12 E2E tests pass locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RDS read replicas via `CreateDBInstanceReadReplica` to scale reads. Replicas are snapshot-cloned, inherit engine/version/credentials/DB name, expose source ↔ replica links in `DescribeDBInstances`, and links are cleaned up on `DeleteDBInstance`.

- **Bug Fixes**
  - Stop `psql` restore on first error (`ON_ERROR_STOP=1`) to prevent partial restores.
  - Re-check snapshot ID uniqueness during create to avoid race conditions.
  - Cancel in-progress markers on dump/container/restore failures and when the source is missing during replica finalize to prevent stuck identifiers.
  - Ensure test `DbInstance` fixtures include read replica fields.

<sup>Written for commit 4297a6ef504554491196665b385cb59e27395b50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

