### PR TITLE
feat(rds): implement DB subnet groups

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -515,3 +515,127 @@ async fn create_instance_with_deletion_protection(
         .await
         .unwrap()
 }
+
+#[test_action("rds", "CreateDBSubnetGroup", checksum = "1b1b06a3")]
+#[tokio::test]
+async fn rds_create_db_subnet_group() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let response = client
+        .create_db_subnet_group()
+        .db_subnet_group_name("conf-subnet-group")
+        .db_subnet_group_description("Test subnet group")
+        .subnet_ids("subnet-12345")
+        .subnet_ids("subnet-67890")
+        .send()
+        .await
+        .unwrap();
+
+    let subnet_group = response.db_subnet_group().unwrap();
+    assert_eq!(
+        subnet_group.db_subnet_group_name(),
+        Some("conf-subnet-group")
+    );
+    assert_eq!(
+        subnet_group.db_subnet_group_description(),
+        Some("Test subnet group")
+    );
+    assert_eq!(subnet_group.subnets().len(), 2);
+}
+
+#[test_action("rds", "DescribeDBSubnetGroups", checksum = "97a0e63e")]
+#[tokio::test]
+async fn rds_describe_db_subnet_groups() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_subnet_group()
+        .db_subnet_group_name("conf-subnet-group")
+        .db_subnet_group_description("Test subnet group")
+        .subnet_ids("subnet-12345")
+        .subnet_ids("subnet-67890")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .describe_db_subnet_groups()
+        .db_subnet_group_name("conf-subnet-group")
+        .send()
+        .await
+        .unwrap();
+
+    let subnet_groups = response.db_subnet_groups();
+    assert_eq!(subnet_groups.len(), 1);
+    assert_eq!(
+        subnet_groups[0].db_subnet_group_name(),
+        Some("conf-subnet-group")
+    );
+}
+
+#[test_action("rds", "ModifyDBSubnetGroup", checksum = "390acd2d")]
+#[tokio::test]
+async fn rds_modify_db_subnet_group() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_subnet_group()
+        .db_subnet_group_name("conf-subnet-group")
+        .db_subnet_group_description("Test subnet group")
+        .subnet_ids("subnet-12345")
+        .subnet_ids("subnet-67890")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .modify_db_subnet_group()
+        .db_subnet_group_name("conf-subnet-group")
+        .subnet_ids("subnet-11111")
+        .subnet_ids("subnet-22222")
+        .subnet_ids("subnet-33333")
+        .send()
+        .await
+        .unwrap();
+
+    let subnet_group = response.db_subnet_group().unwrap();
+    assert_eq!(subnet_group.subnets().len(), 3);
+}
+
+#[test_action("rds", "DeleteDBSubnetGroup", checksum = "e1ea45a9")]
+#[tokio::test]
+async fn rds_delete_db_subnet_group() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_subnet_group()
+        .db_subnet_group_name("conf-subnet-group")
+        .db_subnet_group_description("Test subnet group")
+        .subnet_ids("subnet-12345")
+        .subnet_ids("subnet-67890")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_db_subnet_group()
+        .db_subnet_group_name("conf-subnet-group")
+        .send()
+        .await
+        .unwrap();
+
+    let error = client
+        .describe_db_subnet_groups()
+        .db_subnet_group_name("conf-subnet-group")
+        .send()
+        .await
+        .expect_err("subnet group should be deleted");
+    assert_eq!(
+        error.into_service_error().meta().code(),
+        Some("DBSubnetGroupNotFoundFault")
+    );
+}

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -9,8 +9,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 
 use crate::runtime::{RdsRuntime, RuntimeError};
 use crate::state::{
-    default_engine_versions, default_orderable_options, DbInstance, DbSnapshot, EngineVersionInfo,
-    OrderableDbInstanceOption, RdsTag, SharedRdsState,
+    default_engine_versions, default_orderable_options, DbInstance, DbSnapshot, DbSubnetGroup,
+    EngineVersionInfo, OrderableDbInstanceOption, RdsTag, SharedRdsState,
 };
 
 const RDS_NS: &str = "http://rds.amazonaws.com/doc/2014-10-31/";
@@ -19,14 +19,18 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "CreateDBInstance",
     "CreateDBInstanceReadReplica",
     "CreateDBSnapshot",
+    "CreateDBSubnetGroup",
     "DeleteDBInstance",
     "DeleteDBSnapshot",
+    "DeleteDBSubnetGroup",
     "DescribeDBEngineVersions",
     "DescribeDBInstances",
     "DescribeDBSnapshots",
+    "DescribeDBSubnetGroups",
     "DescribeOrderableDBInstanceOptions",
     "ListTagsForResource",
     "ModifyDBInstance",
+    "ModifyDBSubnetGroup",
     "RebootDBInstance",
     "RemoveTagsFromResource",
     "RestoreDBInstanceFromDBSnapshot",
@@ -63,16 +67,20 @@ impl AwsService for RdsService {
             "CreateDBInstance" => self.create_db_instance(&request).await,
             "CreateDBInstanceReadReplica" => self.create_db_instance_read_replica(&request).await,
             "CreateDBSnapshot" => self.create_db_snapshot(&request).await,
+            "CreateDBSubnetGroup" => self.create_db_subnet_group(&request),
             "DeleteDBInstance" => self.delete_db_instance(&request).await,
             "DeleteDBSnapshot" => self.delete_db_snapshot(&request),
+            "DeleteDBSubnetGroup" => self.delete_db_subnet_group(&request),
             "DescribeDBEngineVersions" => self.describe_db_engine_versions(&request),
             "DescribeDBInstances" => self.describe_db_instances(&request),
             "DescribeDBSnapshots" => self.describe_db_snapshots(&request),
+            "DescribeDBSubnetGroups" => self.describe_db_subnet_groups(&request),
             "DescribeOrderableDBInstanceOptions" => {
                 self.describe_orderable_db_instance_options(&request)
             }
             "ListTagsForResource" => self.list_tags_for_resource(&request),
             "ModifyDBInstance" => self.modify_db_instance(&request),
+            "ModifyDBSubnetGroup" => self.modify_db_subnet_group(&request),
             "RebootDBInstance" => self.reboot_db_instance(&request).await,
             "RemoveTagsFromResource" => self.remove_tags_from_resource(&request),
             "RestoreDBInstanceFromDBSnapshot" => {
@@ -1004,6 +1012,193 @@ impl RdsService {
             ),
         ))
     }
+
+    fn create_db_subnet_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let db_subnet_group_name = required_param(request, "DBSubnetGroupName")?;
+        let db_subnet_group_description = required_param(request, "DBSubnetGroupDescription")?;
+        let subnet_ids = parse_subnet_ids(request)?;
+
+        if subnet_ids.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                "At least one subnet must be specified.",
+            ));
+        }
+
+        if subnet_ids.len() < 2 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "DBSubnetGroupDoesNotCoverEnoughAZs",
+                "DB Subnet Group must contain at least 2 subnets in different Availability Zones.",
+            ));
+        }
+
+        let mut state = self.state.write();
+
+        if state.subnet_groups.contains_key(&db_subnet_group_name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::CONFLICT,
+                "DBSubnetGroupAlreadyExists",
+                format!("DBSubnetGroup {db_subnet_group_name} already exists."),
+            ));
+        }
+
+        let vpc_id = format!("vpc-{}", uuid::Uuid::new_v4().simple());
+        let subnet_availability_zones: Vec<String> = (0..subnet_ids.len())
+            .map(|i| format!("{}{}",  &state.region, char::from(b'a' + (i % 3) as u8)))
+            .collect();
+
+        let db_subnet_group_arn = state.db_subnet_group_arn(&db_subnet_group_name);
+        let tags = parse_tags(request)?;
+
+        let subnet_group = DbSubnetGroup {
+            db_subnet_group_name: db_subnet_group_name.clone(),
+            db_subnet_group_arn,
+            db_subnet_group_description,
+            vpc_id,
+            subnet_ids,
+            subnet_availability_zones,
+            tags,
+        };
+
+        state
+            .subnet_groups
+            .insert(db_subnet_group_name, subnet_group.clone());
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "CreateDBSubnetGroup",
+                &format!(
+                    "<DBSubnetGroup>{}</DBSubnetGroup>",
+                    db_subnet_group_xml(&subnet_group)
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn describe_db_subnet_groups(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let db_subnet_group_name = optional_param(request, "DBSubnetGroupName");
+
+        let state = self.state.read();
+
+        let subnet_groups: Vec<&DbSubnetGroup> = if let Some(name) = &db_subnet_group_name {
+            state
+                .subnet_groups
+                .get(name)
+                .map(|sg| vec![sg])
+                .unwrap_or_else(Vec::new)
+        } else {
+            state.subnet_groups.values().collect()
+        };
+
+        if db_subnet_group_name.is_some() && subnet_groups.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "DBSubnetGroupNotFoundFault",
+                format!(
+                    "DBSubnetGroup {} not found.",
+                    db_subnet_group_name.unwrap()
+                ),
+            ));
+        }
+
+        let body = subnet_groups
+            .iter()
+            .map(|sg| format!("<DBSubnetGroup>{}</DBSubnetGroup>", db_subnet_group_xml(sg)))
+            .collect::<Vec<_>>()
+            .join("");
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DescribeDBSubnetGroups",
+                &format!("<DBSubnetGroups>{}</DBSubnetGroups>", body),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn delete_db_subnet_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let db_subnet_group_name = required_param(request, "DBSubnetGroupName")?;
+
+        let mut state = self.state.write();
+
+        if state.subnet_groups.remove(&db_subnet_group_name).is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "DBSubnetGroupNotFoundFault",
+                format!("DBSubnetGroup {db_subnet_group_name} not found."),
+            ));
+        }
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap("DeleteDBSubnetGroup", "", &request.request_id),
+        ))
+    }
+
+    fn modify_db_subnet_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let db_subnet_group_name = required_param(request, "DBSubnetGroupName")?;
+        let subnet_ids = parse_subnet_ids(request)?;
+
+        if subnet_ids.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                "At least one subnet must be specified.",
+            ));
+        }
+
+        if subnet_ids.len() < 2 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "DBSubnetGroupDoesNotCoverEnoughAZs",
+                "DB Subnet Group must contain at least 2 subnets in different Availability Zones.",
+            ));
+        }
+
+        let mut state = self.state.write();
+
+        let region = state.region.clone();
+
+        let subnet_group = state
+            .subnet_groups
+            .get_mut(&db_subnet_group_name)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "DBSubnetGroupNotFoundFault",
+                    format!("DBSubnetGroup {db_subnet_group_name} not found."),
+                )
+            })?;
+
+        let subnet_availability_zones: Vec<String> = (0..subnet_ids.len())
+            .map(|i| format!("{}{}", &region, char::from(b'a' + (i % 3) as u8)))
+            .collect();
+
+        subnet_group.subnet_ids = subnet_ids;
+        subnet_group.subnet_availability_zones = subnet_availability_zones;
+
+        let subnet_group_clone = subnet_group.clone();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "ModifyDBSubnetGroup",
+                &format!(
+                    "<DBSubnetGroup>{}</DBSubnetGroup>",
+                    db_subnet_group_xml(&subnet_group_clone)
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
 }
 
 fn optional_param(req: &AwsRequest, name: &str) -> Option<String> {
@@ -1083,6 +1278,19 @@ fn parse_tag_keys(req: &AwsRequest) -> Result<Vec<String>, AwsServiceError> {
     }
 
     Ok(keys)
+}
+
+fn parse_subnet_ids(req: &AwsRequest) -> Result<Vec<String>, AwsServiceError> {
+    let mut subnet_ids = Vec::new();
+    for index in 1.. {
+        let subnet_id_name = format!("SubnetIds.SubnetIdentifier.{index}");
+        match optional_param(req, &subnet_id_name) {
+            Some(subnet_id) => subnet_ids.push(subnet_id),
+            None => break,
+        }
+    }
+
+    Ok(subnet_ids)
 }
 
 fn query_param_prefix_exists(req: &AwsRequest, prefix: &str) -> bool {
@@ -1418,6 +1626,39 @@ fn db_snapshot_xml(snapshot: &DbSnapshot) -> String {
         xml_escape(&snapshot.dbi_resource_id),
         xml_escape(&snapshot.snapshot_type),
         xml_escape(&snapshot.db_snapshot_arn),
+    )
+}
+
+fn db_subnet_group_xml(subnet_group: &DbSubnetGroup) -> String {
+    let subnets_xml = subnet_group
+        .subnet_ids
+        .iter()
+        .zip(&subnet_group.subnet_availability_zones)
+        .map(|(subnet_id, az)| {
+            format!(
+                "<Subnet>\
+                 <SubnetIdentifier>{}</SubnetIdentifier>\
+                 <SubnetAvailabilityZone><Name>{}</Name></SubnetAvailabilityZone>\
+                 <SubnetStatus>Active</SubnetStatus>\
+                 </Subnet>",
+                xml_escape(subnet_id),
+                xml_escape(az)
+            )
+        })
+        .collect::<String>();
+
+    format!(
+        "<DBSubnetGroupName>{}</DBSubnetGroupName>\
+         <DBSubnetGroupDescription>{}</DBSubnetGroupDescription>\
+         <VpcId>{}</VpcId>\
+         <SubnetGroupStatus>Complete</SubnetGroupStatus>\
+         <Subnets>{}</Subnets>\
+         <DBSubnetGroupArn>{}</DBSubnetGroupArn>",
+        xml_escape(&subnet_group.db_subnet_group_name),
+        xml_escape(&subnet_group.db_subnet_group_description),
+        xml_escape(&subnet_group.vpc_id),
+        subnets_xml,
+        xml_escape(&subnet_group.db_subnet_group_arn),
     )
 }
 

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -1046,7 +1046,7 @@ impl RdsService {
 
         let vpc_id = format!("vpc-{}", uuid::Uuid::new_v4().simple());
         let subnet_availability_zones: Vec<String> = (0..subnet_ids.len())
-            .map(|i| format!("{}{}",  &state.region, char::from(b'a' + (i % 3) as u8)))
+            .map(|i| format!("{}{}", &state.region, char::from(b'a' + (i % 3) as u8)))
             .collect();
 
         let db_subnet_group_arn = state.db_subnet_group_arn(&db_subnet_group_name);
@@ -1092,20 +1092,19 @@ impl RdsService {
                 .subnet_groups
                 .get(name)
                 .map(|sg| vec![sg])
-                .unwrap_or_else(Vec::new)
+                .unwrap_or_default()
         } else {
             state.subnet_groups.values().collect()
         };
 
-        if db_subnet_group_name.is_some() && subnet_groups.is_empty() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "DBSubnetGroupNotFoundFault",
-                format!(
-                    "DBSubnetGroup {} not found.",
-                    db_subnet_group_name.unwrap()
-                ),
-            ));
+        if let Some(name) = &db_subnet_group_name {
+            if subnet_groups.is_empty() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "DBSubnetGroupNotFoundFault",
+                    format!("DBSubnetGroup {} not found.", name),
+                ));
+            }
         }
 
         let body = subnet_groups

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -124,6 +124,7 @@ pub struct RdsState {
     pub instances: HashMap<String, DbInstance>,
     pub in_progress_instance_ids: HashSet<String>,
     pub snapshots: HashMap<String, DbSnapshot>,
+    pub subnet_groups: HashMap<String, DbSubnetGroup>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -147,6 +148,17 @@ pub struct OrderableDbInstanceOption {
     pub max_storage_size: i32,
 }
 
+#[derive(Debug, Clone)]
+pub struct DbSubnetGroup {
+    pub db_subnet_group_name: String,
+    pub db_subnet_group_arn: String,
+    pub db_subnet_group_description: String,
+    pub vpc_id: String,
+    pub subnet_ids: Vec<String>,
+    pub subnet_availability_zones: Vec<String>,
+    pub tags: Vec<RdsTag>,
+}
+
 impl RdsState {
     pub fn new(account_id: &str, region: &str) -> Self {
         Self {
@@ -155,6 +167,7 @@ impl RdsState {
             instances: HashMap::new(),
             in_progress_instance_ids: HashSet::new(),
             snapshots: HashMap::new(),
+            subnet_groups: HashMap::new(),
         }
     }
 
@@ -162,6 +175,7 @@ impl RdsState {
         self.instances.clear();
         self.in_progress_instance_ids.clear();
         self.snapshots.clear();
+        self.subnet_groups.clear();
     }
 
     pub fn db_instance_arn(&self, db_instance_identifier: &str) -> String {
@@ -180,6 +194,16 @@ impl RdsState {
             &self.region,
             &self.account_id,
             &format!("snapshot:{db_snapshot_identifier}"),
+        )
+        .to_string()
+    }
+
+    pub fn db_subnet_group_arn(&self, db_subnet_group_name: &str) -> String {
+        Arn::new(
+            "rds",
+            &self.region,
+            &self.account_id,
+            &format!("subgrp:{db_subnet_group_name}"),
         )
         .to_string()
     }


### PR DESCRIPTION
## Summary
- CreateDBSubnetGroup: create with 2+ subnets, validates AZ coverage  
- DescribeDBSubnetGroups: list all or filter by name
- ModifyDBSubnetGroup: update subnet membership
- DeleteDBSubnetGroup: remove subnet group

## Test plan
- ✅ All 20 RDS conformance tests passing (16 existing + 4 new)
- ✅ Validates minimum 2 subnets for AZ coverage
- ✅ Proper error handling for not found / already exists

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add RDS DB Subnet Groups with create/describe/modify/delete APIs and AZ coverage checks. Also adds snapshot-based read replicas and hardens snapshot restores; all 20 RDS conformance tests pass.

- **New Features**
  - DB Subnet Groups: `CreateDBSubnetGroup`, `DescribeDBSubnetGroups`, `ModifyDBSubnetGroup`, `DeleteDBSubnetGroup`; require 2+ subnets in different AZs; supports ARNs and tags.
  - Read replicas: `CreateDBInstanceReadReplica` via `pg_dump`/restore; tracks source/replica links; delete cleans them up.

- **Bug Fixes**
  - Stop on restore errors (`psql` with `ON_ERROR_STOP=1`) to avoid partial restores.
  - Prevent snapshot ID races by verifying existence before/after dump.
  - Clear in-progress markers on startup/restore failures.
  - Fix clippy warnings in subnet groups (use `unwrap_or_default`; remove unnecessary unwraps).

<sup>Written for commit 62a12d2051db5efe56a86a37538bdf8bd8570ad8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

