### PR TITLE
feat(rds): implement DB parameter groups

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -639,3 +639,90 @@ async fn rds_delete_db_subnet_group() {
         Some("DBSubnetGroupNotFoundFault")
     );
 }
+
+#[test_action("rds", "CreateDBParameterGroup", checksum = "d0c5767f")]
+#[tokio::test]
+async fn rds_create_db_parameter_group() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let response = client
+        .create_db_parameter_group()
+        .db_parameter_group_name("conf-param-group")
+        .db_parameter_group_family("postgres16")
+        .description("Test parameter group")
+        .send()
+        .await
+        .unwrap();
+
+    let param_group = response.db_parameter_group().unwrap();
+    assert_eq!(
+        param_group.db_parameter_group_name(),
+        Some("conf-param-group")
+    );
+    assert_eq!(param_group.db_parameter_group_family(), Some("postgres16"));
+}
+
+#[test_action("rds", "DescribeDBParameterGroups", checksum = "4032d108")]
+#[tokio::test]
+async fn rds_describe_db_parameter_groups() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_parameter_group()
+        .db_parameter_group_name("conf-param-group")
+        .db_parameter_group_family("postgres16")
+        .description("Test parameter group")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .describe_db_parameter_groups()
+        .db_parameter_group_name("conf-param-group")
+        .send()
+        .await
+        .unwrap();
+
+    let param_groups = response.db_parameter_groups();
+    assert!(param_groups.len() >= 1);
+    let found = param_groups
+        .iter()
+        .find(|pg| pg.db_parameter_group_name() == Some("conf-param-group"));
+    assert!(found.is_some());
+}
+
+#[test_action("rds", "DeleteDBParameterGroup", checksum = "2fec5329")]
+#[tokio::test]
+async fn rds_delete_db_parameter_group() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_parameter_group()
+        .db_parameter_group_name("conf-param-group")
+        .db_parameter_group_family("postgres16")
+        .description("Test parameter group")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_db_parameter_group()
+        .db_parameter_group_name("conf-param-group")
+        .send()
+        .await
+        .unwrap();
+
+    let error = client
+        .describe_db_parameter_groups()
+        .db_parameter_group_name("conf-param-group")
+        .send()
+        .await
+        .expect_err("parameter group should be deleted");
+    assert_eq!(
+        error.into_service_error().meta().code(),
+        Some("DBParameterGroupNotFound")
+    );
+}

--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -686,7 +686,7 @@ async fn rds_describe_db_parameter_groups() {
         .unwrap();
 
     let param_groups = response.db_parameter_groups();
-    assert!(param_groups.len() >= 1);
+    assert!(!param_groups.is_empty());
     let found = param_groups
         .iter()
         .find(|pg| pg.db_parameter_group_name() == Some("conf-param-group"));

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -9,8 +9,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 
 use crate::runtime::{RdsRuntime, RuntimeError};
 use crate::state::{
-    default_engine_versions, default_orderable_options, DbInstance, DbSnapshot, DbSubnetGroup,
-    EngineVersionInfo, OrderableDbInstanceOption, RdsTag, SharedRdsState,
+    default_engine_versions, default_orderable_options, DbInstance, DbParameterGroup, DbSnapshot,
+    DbSubnetGroup, EngineVersionInfo, OrderableDbInstanceOption, RdsTag, SharedRdsState,
 };
 
 const RDS_NS: &str = "http://rds.amazonaws.com/doc/2014-10-31/";
@@ -18,18 +18,22 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "AddTagsToResource",
     "CreateDBInstance",
     "CreateDBInstanceReadReplica",
+    "CreateDBParameterGroup",
     "CreateDBSnapshot",
     "CreateDBSubnetGroup",
     "DeleteDBInstance",
+    "DeleteDBParameterGroup",
     "DeleteDBSnapshot",
     "DeleteDBSubnetGroup",
     "DescribeDBEngineVersions",
     "DescribeDBInstances",
+    "DescribeDBParameterGroups",
     "DescribeDBSnapshots",
     "DescribeDBSubnetGroups",
     "DescribeOrderableDBInstanceOptions",
     "ListTagsForResource",
     "ModifyDBInstance",
+    "ModifyDBParameterGroup",
     "ModifyDBSubnetGroup",
     "RebootDBInstance",
     "RemoveTagsFromResource",
@@ -66,13 +70,16 @@ impl AwsService for RdsService {
             "AddTagsToResource" => self.add_tags_to_resource(&request),
             "CreateDBInstance" => self.create_db_instance(&request).await,
             "CreateDBInstanceReadReplica" => self.create_db_instance_read_replica(&request).await,
+            "CreateDBParameterGroup" => self.create_db_parameter_group(&request),
             "CreateDBSnapshot" => self.create_db_snapshot(&request).await,
             "CreateDBSubnetGroup" => self.create_db_subnet_group(&request),
             "DeleteDBInstance" => self.delete_db_instance(&request).await,
+            "DeleteDBParameterGroup" => self.delete_db_parameter_group(&request),
             "DeleteDBSnapshot" => self.delete_db_snapshot(&request),
             "DeleteDBSubnetGroup" => self.delete_db_subnet_group(&request),
             "DescribeDBEngineVersions" => self.describe_db_engine_versions(&request),
             "DescribeDBInstances" => self.describe_db_instances(&request),
+            "DescribeDBParameterGroups" => self.describe_db_parameter_groups(&request),
             "DescribeDBSnapshots" => self.describe_db_snapshots(&request),
             "DescribeDBSubnetGroups" => self.describe_db_subnet_groups(&request),
             "DescribeOrderableDBInstanceOptions" => {
@@ -80,6 +87,7 @@ impl AwsService for RdsService {
             }
             "ListTagsForResource" => self.list_tags_for_resource(&request),
             "ModifyDBInstance" => self.modify_db_instance(&request),
+            "ModifyDBParameterGroup" => self.modify_db_parameter_group(&request),
             "ModifyDBSubnetGroup" => self.modify_db_subnet_group(&request),
             "RebootDBInstance" => self.reboot_db_instance(&request).await,
             "RemoveTagsFromResource" => self.remove_tags_from_resource(&request),
@@ -1198,6 +1206,168 @@ impl RdsService {
             ),
         ))
     }
+
+    fn create_db_parameter_group(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let db_parameter_group_name = required_param(request, "DBParameterGroupName")?;
+        let db_parameter_group_family = required_param(request, "DBParameterGroupFamily")?;
+        let description = required_param(request, "Description")?;
+
+        if db_parameter_group_family != "postgres16" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!("DBParameterGroupFamily '{db_parameter_group_family}' is not supported yet."),
+            ));
+        }
+
+        let mut state = self.state.write();
+
+        if state.parameter_groups.contains_key(&db_parameter_group_name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::CONFLICT,
+                "DBParameterGroupAlreadyExists",
+                format!("DBParameterGroup {db_parameter_group_name} already exists."),
+            ));
+        }
+
+        let db_parameter_group_arn = state.db_parameter_group_arn(&db_parameter_group_name);
+        let tags = parse_tags(request)?;
+
+        let parameter_group = DbParameterGroup {
+            db_parameter_group_name: db_parameter_group_name.clone(),
+            db_parameter_group_arn,
+            db_parameter_group_family,
+            description,
+            parameters: std::collections::HashMap::new(),
+            tags,
+        };
+
+        state
+            .parameter_groups
+            .insert(db_parameter_group_name, parameter_group.clone());
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "CreateDBParameterGroup",
+                &format!(
+                    "<DBParameterGroup>{}</DBParameterGroup>",
+                    db_parameter_group_xml(&parameter_group)
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn describe_db_parameter_groups(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let db_parameter_group_name = optional_param(request, "DBParameterGroupName");
+
+        let state = self.state.read();
+
+        let parameter_groups: Vec<&DbParameterGroup> = if let Some(name) = &db_parameter_group_name {
+            state
+                .parameter_groups
+                .get(name)
+                .map(|pg| vec![pg])
+                .unwrap_or_else(Vec::new)
+        } else {
+            state.parameter_groups.values().collect()
+        };
+
+        if db_parameter_group_name.is_some() && parameter_groups.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "DBParameterGroupNotFound",
+                format!(
+                    "DBParameterGroup {} not found.",
+                    db_parameter_group_name.unwrap()
+                ),
+            ));
+        }
+
+        let body = parameter_groups
+            .iter()
+            .map(|pg| format!("<DBParameterGroup>{}</DBParameterGroup>", db_parameter_group_xml(pg)))
+            .collect::<Vec<_>>()
+            .join("");
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "DescribeDBParameterGroups",
+                &format!("<DBParameterGroups>{}</DBParameterGroups>", body),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    fn delete_db_parameter_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let db_parameter_group_name = required_param(request, "DBParameterGroupName")?;
+
+        let mut state = self.state.write();
+
+        if db_parameter_group_name.starts_with("default.") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                "Cannot delete default parameter groups.",
+            ));
+        }
+
+        if state.parameter_groups.remove(&db_parameter_group_name).is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "DBParameterGroupNotFound",
+                format!("DBParameterGroup {db_parameter_group_name} not found."),
+            ));
+        }
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap("DeleteDBParameterGroup", "", &request.request_id),
+        ))
+    }
+
+    fn modify_db_parameter_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let db_parameter_group_name = required_param(request, "DBParameterGroupName")?;
+
+        let mut state = self.state.write();
+
+        let parameter_group = state
+            .parameter_groups
+            .get_mut(&db_parameter_group_name)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "DBParameterGroupNotFound",
+                    format!("DBParameterGroup {db_parameter_group_name} not found."),
+                )
+            })?;
+
+        if let Some(new_description) = optional_param(request, "Description") {
+            parameter_group.description = new_description;
+        }
+
+        let parameter_group_clone = parameter_group.clone();
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            xml_wrap(
+                "ModifyDBParameterGroup",
+                &format!(
+                    "<DBParameterGroupName>{}</DBParameterGroupName>",
+                    xml_escape(&parameter_group_clone.db_parameter_group_name)
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
 }
 
 fn optional_param(req: &AwsRequest, name: &str) -> Option<String> {
@@ -1658,6 +1828,19 @@ fn db_subnet_group_xml(subnet_group: &DbSubnetGroup) -> String {
         xml_escape(&subnet_group.vpc_id),
         subnets_xml,
         xml_escape(&subnet_group.db_subnet_group_arn),
+    )
+}
+
+fn db_parameter_group_xml(parameter_group: &DbParameterGroup) -> String {
+    format!(
+        "<DBParameterGroupName>{}</DBParameterGroupName>\
+         <DBParameterGroupFamily>{}</DBParameterGroupFamily>\
+         <Description>{}</Description>\
+         <DBParameterGroupArn>{}</DBParameterGroupArn>",
+        xml_escape(&parameter_group.db_parameter_group_name),
+        xml_escape(&parameter_group.db_parameter_group_family),
+        xml_escape(&parameter_group.description),
+        xml_escape(&parameter_group.db_parameter_group_arn),
     )
 }
 

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -1219,13 +1219,18 @@ impl RdsService {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameterValue",
-                format!("DBParameterGroupFamily '{db_parameter_group_family}' is not supported yet."),
+                format!(
+                    "DBParameterGroupFamily '{db_parameter_group_family}' is not supported yet."
+                ),
             ));
         }
 
         let mut state = self.state.write();
 
-        if state.parameter_groups.contains_key(&db_parameter_group_name) {
+        if state
+            .parameter_groups
+            .contains_key(&db_parameter_group_name)
+        {
             return Err(AwsServiceError::aws_error(
                 StatusCode::CONFLICT,
                 "DBParameterGroupAlreadyExists",
@@ -1270,30 +1275,35 @@ impl RdsService {
 
         let state = self.state.read();
 
-        let parameter_groups: Vec<&DbParameterGroup> = if let Some(name) = &db_parameter_group_name {
+        let parameter_groups: Vec<&DbParameterGroup> = if let Some(name) = &db_parameter_group_name
+        {
             state
                 .parameter_groups
                 .get(name)
                 .map(|pg| vec![pg])
-                .unwrap_or_else(Vec::new)
+                .unwrap_or_default()
         } else {
             state.parameter_groups.values().collect()
         };
 
-        if db_parameter_group_name.is_some() && parameter_groups.is_empty() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "DBParameterGroupNotFound",
-                format!(
-                    "DBParameterGroup {} not found.",
-                    db_parameter_group_name.unwrap()
-                ),
-            ));
+        if let Some(name) = &db_parameter_group_name {
+            if parameter_groups.is_empty() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "DBParameterGroupNotFound",
+                    format!("DBParameterGroup {} not found.", name),
+                ));
+            }
         }
 
         let body = parameter_groups
             .iter()
-            .map(|pg| format!("<DBParameterGroup>{}</DBParameterGroup>", db_parameter_group_xml(pg)))
+            .map(|pg| {
+                format!(
+                    "<DBParameterGroup>{}</DBParameterGroup>",
+                    db_parameter_group_xml(pg)
+                )
+            })
             .collect::<Vec<_>>()
             .join("");
 
@@ -1307,7 +1317,10 @@ impl RdsService {
         ))
     }
 
-    fn delete_db_parameter_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    fn delete_db_parameter_group(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
         let db_parameter_group_name = required_param(request, "DBParameterGroupName")?;
 
         let mut state = self.state.write();
@@ -1320,7 +1333,11 @@ impl RdsService {
             ));
         }
 
-        if state.parameter_groups.remove(&db_parameter_group_name).is_none() {
+        if state
+            .parameter_groups
+            .remove(&db_parameter_group_name)
+            .is_none()
+        {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "DBParameterGroupNotFound",
@@ -1334,7 +1351,10 @@ impl RdsService {
         ))
     }
 
-    fn modify_db_parameter_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    fn modify_db_parameter_group(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
         let db_parameter_group_name = required_param(request, "DBParameterGroupName")?;
 
         let mut state = self.state.write();

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -125,6 +125,7 @@ pub struct RdsState {
     pub in_progress_instance_ids: HashSet<String>,
     pub snapshots: HashMap<String, DbSnapshot>,
     pub subnet_groups: HashMap<String, DbSubnetGroup>,
+    pub parameter_groups: HashMap<String, DbParameterGroup>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -159,6 +160,16 @@ pub struct DbSubnetGroup {
     pub tags: Vec<RdsTag>,
 }
 
+#[derive(Debug, Clone)]
+pub struct DbParameterGroup {
+    pub db_parameter_group_name: String,
+    pub db_parameter_group_arn: String,
+    pub db_parameter_group_family: String,
+    pub description: String,
+    pub parameters: HashMap<String, String>,
+    pub tags: Vec<RdsTag>,
+}
+
 impl RdsState {
     pub fn new(account_id: &str, region: &str) -> Self {
         Self {
@@ -168,6 +179,7 @@ impl RdsState {
             in_progress_instance_ids: HashSet::new(),
             snapshots: HashMap::new(),
             subnet_groups: HashMap::new(),
+            parameter_groups: default_parameter_groups(account_id, region),
         }
     }
 
@@ -176,6 +188,7 @@ impl RdsState {
         self.in_progress_instance_ids.clear();
         self.snapshots.clear();
         self.subnet_groups.clear();
+        self.parameter_groups = default_parameter_groups(&self.account_id, &self.region);
     }
 
     pub fn db_instance_arn(&self, db_instance_identifier: &str) -> String {
@@ -204,6 +217,16 @@ impl RdsState {
             &self.region,
             &self.account_id,
             &format!("subgrp:{db_subnet_group_name}"),
+        )
+        .to_string()
+    }
+
+    pub fn db_parameter_group_arn(&self, db_parameter_group_name: &str) -> String {
+        Arn::new(
+            "rds",
+            &self.region,
+            &self.account_id,
+            &format!("pg:{db_parameter_group_name}"),
         )
         .to_string()
     }
@@ -259,6 +282,24 @@ pub fn default_orderable_options() -> Vec<OrderableDbInstanceOption> {
         min_storage_size: 20,
         max_storage_size: 16384,
     }]
+}
+
+pub fn default_parameter_groups(account_id: &str, region: &str) -> HashMap<String, DbParameterGroup> {
+    let mut groups = HashMap::new();
+
+    let default_group = DbParameterGroup {
+        db_parameter_group_name: "default.postgres16".to_string(),
+        db_parameter_group_arn: format!(
+            "arn:aws:rds:{region}:{account_id}:pg:default.postgres16"
+        ),
+        db_parameter_group_family: "postgres16".to_string(),
+        description: "Default parameter group for postgres16".to_string(),
+        parameters: HashMap::new(),
+        tags: Vec::new(),
+    };
+
+    groups.insert("default.postgres16".to_string(), default_group);
+    groups
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -284,14 +284,15 @@ pub fn default_orderable_options() -> Vec<OrderableDbInstanceOption> {
     }]
 }
 
-pub fn default_parameter_groups(account_id: &str, region: &str) -> HashMap<String, DbParameterGroup> {
+pub fn default_parameter_groups(
+    account_id: &str,
+    region: &str,
+) -> HashMap<String, DbParameterGroup> {
     let mut groups = HashMap::new();
 
     let default_group = DbParameterGroup {
         db_parameter_group_name: "default.postgres16".to_string(),
-        db_parameter_group_arn: format!(
-            "arn:aws:rds:{region}:{account_id}:pg:default.postgres16"
-        ),
+        db_parameter_group_arn: format!("arn:aws:rds:{region}:{account_id}:pg:default.postgres16"),
         db_parameter_group_family: "postgres16".to_string(),
         description: "Default parameter group for postgres16".to_string(),
         parameters: HashMap::new(),


### PR DESCRIPTION
## Summary
- CreateDBParameterGroup: create with family postgres16
- DescribeDBParameterGroups: list all or filter by name  
- ModifyDBParameterGroup: update description
- DeleteDBParameterGroup: remove parameter group (blocks deleting defaults)

## Test plan
- ✅ All 23 RDS conformance tests passing (20 existing + 3 new)
- ✅ Default parameter group (default.postgres16) created automatically
- ✅ Prevents deletion of default parameter groups

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RDS DB parameter groups with create, describe, modify, and delete. Auto-creates `default.postgres16` and blocks deleting defaults; all 23 RDS conformance tests pass.

- **New Features**
  - DB Parameter Groups (family `postgres16`): create, describe (all/by name), modify description, delete non-default groups.

- **Refactors**
  - Fix clippy warnings in parameter group code and tests.

<sup>Written for commit 3e611ccfc0f88225f574830d57a0f63c9d86de84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

