### PR TITLE
fix: stop orphaned replica container when source disappears before finalize

### DIFF
--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -952,8 +952,6 @@ impl RdsService {
             return Err(runtime_error_to_service_error(e));
         }
 
-        let mut state = self.state.write();
-
         let replica = DbInstance {
             db_instance_identifier: db_instance_identifier.clone(),
             db_instance_arn,
@@ -978,19 +976,29 @@ impl RdsService {
             read_replica_db_instance_identifiers: Vec::new(),
         };
 
-        match state.instances.get_mut(&source_db_instance_identifier) {
-            Some(source) => {
-                source
-                    .read_replica_db_instance_identifiers
-                    .push(db_instance_identifier.clone());
+        let source_missing = {
+            let mut state = self.state.write();
+            match state.instances.get_mut(&source_db_instance_identifier) {
+                Some(source) => {
+                    source
+                        .read_replica_db_instance_identifiers
+                        .push(db_instance_identifier.clone());
+                    state.finish_instance_creation(replica.clone());
+                    false
+                }
+                None => {
+                    state.cancel_instance_creation(&db_instance_identifier);
+                    true
+                }
             }
-            None => {
-                state.cancel_instance_creation(&db_instance_identifier);
-                return Err(db_instance_not_found(&source_db_instance_identifier));
-            }
-        }
+        };
 
-        state.finish_instance_creation(replica.clone());
+        if source_missing {
+            runtime
+                .stop_container(&db_instance_identifier)
+                .await;
+            return Err(db_instance_not_found(&source_db_instance_identifier));
+        }
 
         Ok(AwsResponse::xml(
             StatusCode::OK,

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -994,9 +994,7 @@ impl RdsService {
         };
 
         if source_missing {
-            runtime
-                .stop_container(&db_instance_identifier)
-                .await;
+            runtime.stop_container(&db_instance_identifier).await;
             return Err(db_instance_not_found(&source_db_instance_identifier));
         }
 


### PR DESCRIPTION
Addresses cubic finding on PR #210: when the source instance is deleted during async replica creation, the newly-created postgres container was left running with no reference to clean it up.

**Fix:** restructured the finalize block to acquire the state write-lock in its own scope, check for source presence, and if missing — call `runtime.stop_container()` before returning the error. This ensures the container is stopped and removed even in the race condition path.

**Root cause:** the error path added in #210 called `cancel_instance_creation` (removes the DB identifier from the reserved set) but did not stop the already-created container, leaving an orphaned Docker resource.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents orphaned replica containers by stopping the newly created Postgres container if the source instance disappears before finalize during read-replica creation. This fixes a race condition and ensures Docker resources are cleaned up.

- **Bug Fixes**
  - Finalize now runs within its own write-lock scope; we update the source and call `finish_instance_creation` there.
  - If the source is missing, we call `cancel_instance_creation`, await `runtime.stop_container()`, then return NotFound.
  - Changes in `crates/fakecloud-rds/src/service.rs`; applied `rustfmt`.

<sup>Written for commit 45fe67102c7aeb6b2d3781383d0cd1e9bbbe5825. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

