### PR TITLE
feat(rds): add VPC security group support

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -726,3 +726,89 @@ async fn rds_delete_db_parameter_group() {
         Some("DBParameterGroupNotFound")
     );
 }
+
+#[test_action("rds", "CreateDBInstance", checksum = "66cdd119")]
+#[tokio::test]
+async fn rds_create_db_instance_with_vpc_security_groups() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let response = client
+        .create_db_instance()
+        .db_instance_identifier("conf-rds-sg")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .vpc_security_group_ids("sg-12345678")
+        .vpc_security_group_ids("sg-87654321")
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    assert_eq!(instance.db_instance_identifier(), Some("conf-rds-sg"));
+
+    let sg_memberships = instance.vpc_security_groups();
+    assert_eq!(sg_memberships.len(), 2);
+    assert_eq!(
+        sg_memberships[0].vpc_security_group_id(),
+        Some("sg-12345678")
+    );
+    assert_eq!(sg_memberships[0].status(), Some("active"));
+    assert_eq!(
+        sg_memberships[1].vpc_security_group_id(),
+        Some("sg-87654321")
+    );
+    assert_eq!(sg_memberships[1].status(), Some("active"));
+}
+
+#[test_action("rds", "ModifyDBInstance", checksum = "08b493a8")]
+#[tokio::test]
+async fn rds_modify_db_instance_vpc_security_groups() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_instance()
+        .db_instance_identifier("conf-rds-sg-modify")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .vpc_security_group_ids("sg-original")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .modify_db_instance()
+        .db_instance_identifier("conf-rds-sg-modify")
+        .vpc_security_group_ids("sg-modified1")
+        .vpc_security_group_ids("sg-modified2")
+        .vpc_security_group_ids("sg-modified3")
+        .apply_immediately(true)
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    let sg_memberships = instance.vpc_security_groups();
+    assert_eq!(sg_memberships.len(), 3);
+    assert_eq!(
+        sg_memberships[0].vpc_security_group_id(),
+        Some("sg-modified1")
+    );
+    assert_eq!(
+        sg_memberships[1].vpc_security_group_id(),
+        Some("sg-modified2")
+    );
+    assert_eq!(
+        sg_memberships[2].vpc_security_group_id(),
+        Some("sg-modified3")
+    );
+}

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -634,3 +634,91 @@ async fn connect_with_retry(
 
     Err(last_error.expect("postgres connection error"))
 }
+
+#[tokio::test]
+async fn vpc_security_groups() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // Create instance with VPC security groups
+    let response = client
+        .create_db_instance()
+        .db_instance_identifier("e2e-rds-sg")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("sgtest")
+        .vpc_security_group_ids("sg-initial1")
+        .vpc_security_group_ids("sg-initial2")
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    let sg_memberships = instance.vpc_security_groups();
+    assert_eq!(sg_memberships.len(), 2);
+    assert_eq!(
+        sg_memberships[0].vpc_security_group_id(),
+        Some("sg-initial1")
+    );
+    assert_eq!(
+        sg_memberships[1].vpc_security_group_id(),
+        Some("sg-initial2")
+    );
+
+    // Modify security groups
+    let response = client
+        .modify_db_instance()
+        .db_instance_identifier("e2e-rds-sg")
+        .vpc_security_group_ids("sg-updated1")
+        .vpc_security_group_ids("sg-updated2")
+        .vpc_security_group_ids("sg-updated3")
+        .apply_immediately(true)
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    let sg_memberships = instance.vpc_security_groups();
+    assert_eq!(sg_memberships.len(), 3);
+    assert_eq!(
+        sg_memberships[0].vpc_security_group_id(),
+        Some("sg-updated1")
+    );
+    assert_eq!(
+        sg_memberships[1].vpc_security_group_id(),
+        Some("sg-updated2")
+    );
+    assert_eq!(
+        sg_memberships[2].vpc_security_group_id(),
+        Some("sg-updated3")
+    );
+
+    // Verify persistence in describe
+    let response = client
+        .describe_db_instances()
+        .db_instance_identifier("e2e-rds-sg")
+        .send()
+        .await
+        .unwrap();
+
+    let instances = response.db_instances();
+    assert_eq!(instances.len(), 1);
+    let sg_memberships = instances[0].vpc_security_groups();
+    assert_eq!(sg_memberships.len(), 3);
+    assert_eq!(
+        sg_memberships[0].vpc_security_group_id(),
+        Some("sg-updated1")
+    );
+    assert_eq!(
+        sg_memberships[1].vpc_security_group_id(),
+        Some("sg-updated2")
+    );
+    assert_eq!(
+        sg_memberships[2].vpc_security_group_id(),
+        Some("sg-updated3")
+    );
+}

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -127,6 +127,7 @@ impl RdsService {
             parse_optional_bool(optional_param(request, "DeletionProtection").as_deref())?
                 .unwrap_or(false);
         let port = optional_i32_param(request, "Port")?.unwrap_or(5432);
+        let vpc_security_group_ids = parse_vpc_security_group_ids(request);
 
         validate_create_request(
             &db_instance_identifier,
@@ -195,6 +196,7 @@ impl RdsService {
             tags: Vec::new(),
             read_replica_source_db_instance_identifier: None,
             read_replica_db_instance_identifiers: Vec::new(),
+            vpc_security_group_ids,
         };
         state.finish_instance_creation(instance.clone());
 
@@ -299,6 +301,23 @@ impl RdsService {
         let apply_immediately =
             parse_optional_bool(optional_param(request, "ApplyImmediately").as_deref())?;
 
+        // Parse VPC security group IDs - only if at least one is provided
+        let vpc_security_group_ids = {
+            let mut ids = Vec::new();
+            for index in 1.. {
+                let sg_id_name = format!("VpcSecurityGroupIds.VpcSecurityGroupId.{index}");
+                match optional_param(request, &sg_id_name) {
+                    Some(sg_id) => ids.push(sg_id),
+                    None => break,
+                }
+            }
+            if ids.is_empty() {
+                None
+            } else {
+                Some(ids)
+            }
+        };
+
         if apply_immediately == Some(false) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -306,7 +325,10 @@ impl RdsService {
                 "ApplyImmediately=false is not yet supported for ModifyDBInstance.",
             ));
         }
-        if db_instance_class.is_none() && deletion_protection.is_none() {
+        if db_instance_class.is_none()
+            && deletion_protection.is_none()
+            && vpc_security_group_ids.is_none()
+        {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameterCombination",
@@ -328,6 +350,9 @@ impl RdsService {
         }
         if let Some(deletion_protection) = deletion_protection {
             instance.deletion_protection = deletion_protection;
+        }
+        if let Some(security_group_ids) = vpc_security_group_ids {
+            instance.vpc_security_group_ids = security_group_ids;
         }
 
         Ok(AwsResponse::xml(
@@ -760,6 +785,7 @@ impl RdsService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let db_instance_identifier = required_param(request, "DBInstanceIdentifier")?;
         let db_snapshot_identifier = required_param(request, "DBSnapshotIdentifier")?;
+        let vpc_security_group_ids = parse_vpc_security_group_ids(request);
 
         let runtime = self.runtime.as_ref().ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -853,6 +879,7 @@ impl RdsService {
             tags: Vec::new(),
             read_replica_source_db_instance_identifier: None,
             read_replica_db_instance_identifiers: Vec::new(),
+            vpc_security_group_ids,
         };
 
         state.finish_instance_creation(instance.clone());
@@ -990,6 +1017,7 @@ impl RdsService {
             tags: Vec::new(),
             read_replica_source_db_instance_identifier: Some(source_db_instance_identifier.clone()),
             read_replica_db_instance_identifiers: Vec::new(),
+            vpc_security_group_ids: source_instance.vpc_security_group_ids.clone(),
         };
 
         let source_missing = {
@@ -1488,6 +1516,24 @@ fn parse_subnet_ids(req: &AwsRequest) -> Result<Vec<String>, AwsServiceError> {
     Ok(subnet_ids)
 }
 
+fn parse_vpc_security_group_ids(req: &AwsRequest) -> Vec<String> {
+    let mut security_group_ids = Vec::new();
+    for index in 1.. {
+        let sg_id_name = format!("VpcSecurityGroupIds.VpcSecurityGroupId.{index}");
+        match optional_param(req, &sg_id_name) {
+            Some(sg_id) => security_group_ids.push(sg_id),
+            None => break,
+        }
+    }
+
+    // If no security groups provided, return a default one
+    if security_group_ids.is_empty() {
+        security_group_ids.push("sg-default".to_string());
+    }
+
+    security_group_ids
+}
+
 fn query_param_prefix_exists(req: &AwsRequest, prefix: &str) -> bool {
     req.query_params.keys().any(|key| key.starts_with(prefix))
 }
@@ -1729,6 +1775,25 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
         )
     };
 
+    let vpc_security_groups_xml = if instance.vpc_security_group_ids.is_empty() {
+        "<VpcSecurityGroups/>".to_string()
+    } else {
+        format!(
+            "<VpcSecurityGroups>{}</VpcSecurityGroups>",
+            instance
+                .vpc_security_group_ids
+                .iter()
+                .map(|sg_id| format!(
+                    "<VpcSecurityGroupMembership>\
+                     <VpcSecurityGroupId>{}</VpcSecurityGroupId>\
+                     <Status>active</Status>\
+                     </VpcSecurityGroupMembership>",
+                    xml_escape(sg_id)
+                ))
+                .collect::<String>()
+        )
+    };
+
     format!(
         "<DBInstanceIdentifier>{}</DBInstanceIdentifier>\
          <DBInstanceClass>{}</DBInstanceClass>\
@@ -1742,7 +1807,7 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
          <PreferredBackupWindow>00:00-00:30</PreferredBackupWindow>\
          <BackupRetentionPeriod>1</BackupRetentionPeriod>\
          <DBSecurityGroups/>\
-         <VpcSecurityGroups/>\
+         {}\
          <DBParameterGroups/>\
          <AvailabilityZone>us-east-1a</AvailabilityZone>\
          <PreferredMaintenanceWindow>sun:00:00-sun:00:30</PreferredMaintenanceWindow>\
@@ -1770,6 +1835,7 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
         instance.port,
         instance.allocated_storage,
         instance.created_at.to_rfc3339(),
+        vpc_security_groups_xml,
         xml_escape(&instance.engine_version),
         read_replica_identifiers_xml,
         read_replica_source_xml,
@@ -2033,6 +2099,7 @@ mod tests {
             tags: Vec::new(),
             read_replica_source_db_instance_identifier: None,
             read_replica_db_instance_identifiers: Vec::new(),
+            vpc_security_group_ids: vec!["sg-12345678".to_string()],
         };
 
         let xml = db_instance_xml(&instance, Some("creating"));

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -32,6 +32,7 @@ pub struct DbInstance {
     pub tags: Vec<RdsTag>,
     pub read_replica_source_db_instance_identifier: Option<String>,
     pub read_replica_db_instance_identifiers: Vec<String>,
+    pub vpc_security_group_ids: Vec<String>,
 }
 
 impl fmt::Debug for DbInstance {
@@ -64,6 +65,7 @@ impl fmt::Debug for DbInstance {
                 "read_replica_db_instance_identifiers",
                 &self.read_replica_db_instance_identifiers,
             )
+            .field("vpc_security_group_ids", &self.vpc_security_group_ids)
             .finish()
     }
 }
@@ -346,6 +348,7 @@ mod tests {
                 tags: Vec::new(),
                 read_replica_source_db_instance_identifier: None,
                 read_replica_db_instance_identifiers: Vec::new(),
+                vpc_security_group_ids: Vec::new(),
             },
         );
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1353,6 +1353,7 @@ mod tests {
                 tags: Vec::new(),
                 read_replica_source_db_instance_identifier: None,
                 read_replica_db_instance_identifiers: Vec::new(),
+                vpc_security_group_ids: Vec::new(),
             },
         );
 
@@ -1458,6 +1459,7 @@ mod tests {
             }],
             read_replica_source_db_instance_identifier: None,
             read_replica_db_instance_identifiers: Vec::new(),
+            vpc_security_group_ids: Vec::new(),
         };
 
         let response = rds_instance_response(&instance);


### PR DESCRIPTION
## Summary
- Add VPC security group support to RDS DB instances
- Store and render security group IDs with active status
- Support creation, modification, and persistence of security groups
- Default to sg-default when none specified

## Test plan
- ✅ Unit tests pass
- ✅ Conformance tests pass (create + modify)
- ✅ E2E test validates full lifecycle
- ✅ Clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds VPC security group support to RDS DB instances, including create, modify, restore, and read replicas. When none are provided, instances default to `sg-default`.

- **New Features**
  - Store `vpc_security_group_ids` on `DbInstance` and render `<VpcSecurityGroups>` with `active` status.
  - Parse `VpcSecurityGroupIds.VpcSecurityGroupId.N` on create and restore; default to `sg-default` if none.
  - Support updates via ModifyDBInstance when `ApplyImmediately=true`; propagate IDs to read replicas.
  - Add conformance and E2E tests for create/modify/describe lifecycle.

<sup>Written for commit a12cc721fdc345951a2783947a84845599ce1f4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

