### PR TITLE
feat(rds): implement final snapshots on deletion

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -812,3 +812,54 @@ async fn rds_modify_db_instance_vpc_security_groups() {
         Some("sg-modified3")
     );
 }
+
+#[test_action("rds", "DeleteDBInstance", checksum = "22909663")]
+#[tokio::test]
+async fn rds_delete_db_instance_with_final_snapshot() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // Create instance
+    client
+        .create_db_instance()
+        .db_instance_identifier("conf-rds-final")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .send()
+        .await
+        .unwrap();
+
+    // Delete with final snapshot
+    let response = client
+        .delete_db_instance()
+        .db_instance_identifier("conf-rds-final")
+        .final_db_snapshot_identifier("conf-final-snap")
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    assert_eq!(instance.db_instance_identifier(), Some("conf-rds-final"));
+
+    // Verify snapshot was created
+    let snapshots = client
+        .describe_db_snapshots()
+        .db_snapshot_identifier("conf-final-snap")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(snapshots.db_snapshots().len(), 1);
+    assert_eq!(
+        snapshots.db_snapshots()[0].db_snapshot_identifier(),
+        Some("conf-final-snap")
+    );
+    assert_eq!(
+        snapshots.db_snapshots()[0].db_instance_identifier(),
+        Some("conf-rds-final")
+    );
+}

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -722,3 +722,90 @@ async fn vpc_security_groups() {
         Some("sg-updated3")
     );
 }
+
+#[tokio::test]
+async fn final_snapshot_on_delete() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // Create instance
+    let response = client
+        .create_db_instance()
+        .db_instance_identifier("e2e-rds-final")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("testdb")
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    let port = instance.endpoint().unwrap().port().unwrap();
+
+    // Wait for instance and insert test data
+    let (postgres, connection) =
+        connect_with_retry("127.0.0.1", port, "admin", "secret123", "testdb")
+            .await
+            .expect("connect to db");
+
+    tokio::spawn(connection);
+
+    postgres
+        .execute("CREATE TABLE test_final (id INT, value TEXT)", &[])
+        .await
+        .expect("create table");
+    postgres
+        .execute("INSERT INTO test_final VALUES (1, 'preserved')", &[])
+        .await
+        .expect("insert data");
+
+    // Delete with final snapshot
+    client
+        .delete_db_instance()
+        .db_instance_identifier("e2e-rds-final")
+        .final_db_snapshot_identifier("e2e-final-snap")
+        .send()
+        .await
+        .unwrap();
+
+    // Verify snapshot exists
+    let snapshots = client
+        .describe_db_snapshots()
+        .db_snapshot_identifier("e2e-final-snap")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(snapshots.db_snapshots().len(), 1);
+
+    // Restore from snapshot and verify data
+    let response = client
+        .restore_db_instance_from_db_snapshot()
+        .db_instance_identifier("e2e-rds-restored")
+        .db_snapshot_identifier("e2e-final-snap")
+        .send()
+        .await
+        .unwrap();
+
+    let restored = response.db_instance().expect("db instance");
+    let restored_port = restored.endpoint().unwrap().port().unwrap();
+
+    let (postgres, connection) =
+        connect_with_retry("127.0.0.1", restored_port, "admin", "secret123", "testdb")
+            .await
+            .expect("connect to restored db");
+
+    tokio::spawn(connection);
+
+    let row = postgres
+        .query_one("SELECT value FROM test_final WHERE id = 1", &[])
+        .await
+        .expect("query restored data");
+
+    let value: &str = row.get(0);
+    assert_eq!(value, "preserved");
+}

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -233,12 +233,91 @@ impl RdsService {
                 "FinalDBSnapshotIdentifier cannot be specified when SkipFinalSnapshot is enabled.",
             ));
         }
-        if !skip_final_snapshot {
+        if !skip_final_snapshot && final_db_snapshot_identifier.is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameterCombination",
-                "SkipFinalSnapshot must be enabled until final snapshot support is implemented.",
+                "FinalDBSnapshotIdentifier is required when SkipFinalSnapshot is false or not specified.",
             ));
+        }
+
+        // Create final snapshot if requested
+        if let Some(ref snapshot_id) = final_db_snapshot_identifier {
+            let runtime = self.runtime.as_ref().ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "InvalidParameterValue",
+                    "Docker/Podman is required for RDS snapshots but is not available",
+                )
+            })?;
+
+            let (instance_for_snapshot, db_name) = {
+                let state = self.state.read();
+
+                if state.snapshots.contains_key(snapshot_id) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::CONFLICT,
+                        "DBSnapshotAlreadyExists",
+                        format!("DBSnapshot {snapshot_id} already exists."),
+                    ));
+                }
+
+                let instance = state
+                    .instances
+                    .get(&db_instance_identifier)
+                    .cloned()
+                    .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
+
+                let db_name = instance
+                    .db_name
+                    .as_deref()
+                    .unwrap_or("postgres")
+                    .to_string();
+
+                (instance, db_name)
+            };
+
+            let dump_data = runtime
+                .dump_database(
+                    &db_instance_identifier,
+                    &instance_for_snapshot.master_username,
+                    &db_name,
+                )
+                .await
+                .map_err(runtime_error_to_service_error)?;
+
+            let mut state = self.state.write();
+
+            if state.snapshots.contains_key(snapshot_id) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::CONFLICT,
+                    "DBSnapshotAlreadyExists",
+                    format!("DBSnapshot {snapshot_id} already exists."),
+                ));
+            }
+
+            let snapshot_arn = state.db_snapshot_arn(snapshot_id);
+
+            let snapshot = DbSnapshot {
+                db_snapshot_identifier: snapshot_id.clone(),
+                db_snapshot_arn: snapshot_arn,
+                db_instance_identifier: db_instance_identifier.clone(),
+                snapshot_create_time: Utc::now(),
+                engine: instance_for_snapshot.engine.clone(),
+                engine_version: instance_for_snapshot.engine_version.clone(),
+                allocated_storage: instance_for_snapshot.allocated_storage,
+                status: "available".to_string(),
+                port: instance_for_snapshot.port,
+                master_username: instance_for_snapshot.master_username.clone(),
+                db_name: instance_for_snapshot.db_name.clone(),
+                dbi_resource_id: instance_for_snapshot.dbi_resource_id.clone(),
+                snapshot_type: "manual".to_string(),
+                master_user_password: instance_for_snapshot.master_user_password.clone(),
+                tags: Vec::new(),
+                dump_data,
+            };
+
+            state.snapshots.insert(snapshot_id.clone(), snapshot);
         }
 
         let instance = {


### PR DESCRIPTION
## Summary

Implements FinalDBSnapshotIdentifier parameter in DeleteDBInstance operation:
- Accepts FinalDBSnapshotIdentifier parameter when SkipFinalSnapshot is false
- Creates snapshot using pg_dump before deleting the instance
- Snapshot is marked as "manual" type
- Validates snapshot identifier doesn't already exist

## Test plan

- ✅ Conformance test: verifies snapshot creation on delete
- ✅ E2E test: creates instance with data, deletes with final snapshot, restores from snapshot, verifies data integrity
- ✅ All existing RDS tests pass
- ✅ Clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds final snapshot support when deleting RDS DB instances. When `SkipFinalSnapshot` is false or omitted, the service creates a manual snapshot via `pg_dump` before deleting the instance.

- **New Features**
  - Accepts `FinalDBSnapshotIdentifier` in `DeleteDBInstance`; required if `SkipFinalSnapshot` is false or not set.
  - Creates a "manual" snapshot using `pg_dump` before instance removal.
  - Validates snapshot ID uniqueness; returns `DBSnapshotAlreadyExists` on conflicts.
  - Returns a clear error if the runtime for snapshots (Docker/Podman) is unavailable.
  - Adds conformance and E2E tests, including restore and data integrity verification.

<sup>Written for commit d46b4e8bfbc57dae4669d9a48b8972d1852a6d31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

