### PR TITLE
feat(rds): add multi-engine support (PostgreSQL, MySQL, MariaDB)

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -37,7 +37,7 @@ async fn rds_describe_orderable_db_instance_options() {
         .unwrap();
 
     let options = response.orderable_db_instance_options();
-    assert_eq!(options.len(), 1);
+    assert_eq!(options.len(), 7); // 7 instance classes per engine/version
     assert_eq!(options[0].engine(), Some("postgres"));
     assert_eq!(options[0].engine_version(), Some("16.3"));
     assert_eq!(options[0].db_instance_class(), Some("db.t3.micro"));

--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -17,10 +17,9 @@ async fn rds_describe_db_engine_versions() {
         .unwrap();
 
     let versions = response.db_engine_versions();
-    assert_eq!(versions.len(), 1);
-    assert_eq!(versions[0].engine(), Some("postgres"));
-    assert_eq!(versions[0].engine_version(), Some("16.3"));
-    assert_eq!(versions[0].db_parameter_group_family(), Some("postgres16"));
+    // Returns all postgres versions
+    assert!(versions.len() >= 4);
+    assert!(versions.iter().any(|v| v.engine_version() == Some("16.3")));
 }
 
 #[test_action("rds", "DescribeOrderableDBInstanceOptions", checksum = "cc28ac3c")]

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -18,9 +18,7 @@ async fn rds_describe_db_engine_versions() {
     let versions = response.db_engine_versions();
     assert_eq!(versions.len(), 4); // All postgres versions
     assert!(versions.iter().all(|v| v.engine() == Some("postgres")));
-    assert!(versions
-        .iter()
-        .any(|v| v.engine_version() == Some("16.3")));
+    assert!(versions.iter().any(|v| v.engine_version() == Some("16.3")));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -16,12 +16,11 @@ async fn rds_describe_db_engine_versions() {
         .unwrap();
 
     let versions = response.db_engine_versions();
-    assert_eq!(versions.len(), 1);
-    assert_eq!(versions[0].engine(), Some("postgres"));
-    assert_eq!(
-        versions[0].db_engine_version_description(),
-        Some("PostgreSQL 16.3")
-    );
+    assert_eq!(versions.len(), 4); // All postgres versions
+    assert!(versions.iter().all(|v| v.engine() == Some("postgres")));
+    assert!(versions
+        .iter()
+        .any(|v| v.engine_version() == Some("16.3")));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-rds/src/runtime.rs
+++ b/crates/fakecloud-rds/src/runtime.rs
@@ -54,29 +54,84 @@ impl RdsRuntime {
     pub async fn ensure_postgres(
         &self,
         db_instance_identifier: &str,
+        engine: &str,
+        engine_version: &str,
         username: &str,
         password: &str,
         db_name: &str,
     ) -> Result<RunningDbContainer, RuntimeError> {
         self.stop_container(db_instance_identifier).await;
 
+        // Determine Docker image and port based on engine
+        let (image, port, env_vars) = match engine {
+            "postgres" => {
+                let major_version = engine_version.split('.').next().unwrap_or("16");
+                let image = format!("postgres:{}-alpine", major_version);
+                let env_vars = vec![
+                    format!("POSTGRES_USER={username}"),
+                    format!("POSTGRES_PASSWORD={password}"),
+                    format!("POSTGRES_DB={db_name}"),
+                ];
+                (image, "5432", env_vars)
+            }
+            "mysql" => {
+                let major_version = if engine_version.starts_with("5.7") {
+                    "5.7"
+                } else {
+                    "8.0"
+                };
+                let image = format!("mysql:{}", major_version);
+                let env_vars = vec![
+                    format!("MYSQL_ROOT_PASSWORD={password}"),
+                    format!("MYSQL_USER={username}"),
+                    format!("MYSQL_PASSWORD={password}"),
+                    format!("MYSQL_DATABASE={db_name}"),
+                ];
+                (image, "3306", env_vars)
+            }
+            "mariadb" => {
+                let major_version = if engine_version.starts_with("10.11") {
+                    "10.11"
+                } else {
+                    "10.6"
+                };
+                let image = format!("mariadb:{}", major_version);
+                let env_vars = vec![
+                    format!("MARIADB_ROOT_PASSWORD={password}"),
+                    format!("MARIADB_USER={username}"),
+                    format!("MARIADB_PASSWORD={password}"),
+                    format!("MARIADB_DATABASE={db_name}"),
+                ];
+                (image, "3306", env_vars)
+            }
+            _ => {
+                return Err(RuntimeError::ContainerStartFailed(format!(
+                    "Unsupported engine: {}",
+                    engine
+                )))
+            }
+        };
+
+        // Build container create args
+        let mut args = vec![
+            "create".to_string(),
+            "-p".to_string(),
+            format!(":{}", port),
+            "--label".to_string(),
+            format!("fakecloud-rds={db_instance_identifier}"),
+            "--label".to_string(),
+            format!("fakecloud-instance={}", self.instance_id),
+        ];
+
+        for env_var in env_vars {
+            args.push("-e".to_string());
+            args.push(env_var);
+        }
+
+        args.push(image);
+
         let output = tokio::process::Command::new(&self.cli)
-            .args([
-                "create",
-                "-p",
-                ":5432",
-                "--label",
-                &format!("fakecloud-rds={db_instance_identifier}"),
-                "--label",
-                &format!("fakecloud-instance={}", self.instance_id),
-                "-e",
-                &format!("POSTGRES_USER={username}"),
-                "-e",
-                &format!("POSTGRES_PASSWORD={password}"),
-                "-e",
-                &format!("POSTGRES_DB={db_name}"),
-                "postgres:16-alpine",
-            ])
+            .args(&args)
             .output()
             .await
             .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
@@ -109,12 +164,19 @@ impl RdsRuntime {
                 return Err(error);
             }
         };
-        if let Err(error) = self
-            .wait_for_postgres(username, password, db_name, host_port)
-            .await
-        {
-            self.remove_container(&container_id).await;
-            return Err(error);
+
+        // Wait for database to be ready (currently only supports postgres check)
+        if engine == "postgres" {
+            if let Err(error) = self
+                .wait_for_postgres(username, password, db_name, host_port)
+                .await
+            {
+                self.remove_container(&container_id).await;
+                return Err(error);
+            }
+        } else {
+            // For MySQL/MariaDB, give it a moment to start
+            tokio::time::sleep(Duration::from_secs(5)).await;
         }
 
         let running = RunningDbContainer {

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -1934,11 +1934,20 @@ fn validate_create_request(
 }
 
 fn validate_db_instance_class(db_instance_class: &str) -> Result<(), AwsServiceError> {
-    if db_instance_class != "db.t3.micro" {
+    let supported_classes = [
+        "db.t3.micro",
+        "db.t3.small",
+        "db.t3.medium",
+        "db.t3.large",
+        "db.t4g.micro",
+        "db.t4g.small",
+        "db.m5.large",
+    ];
+    if !supported_classes.contains(&db_instance_class) {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "InvalidParameterValue",
-            format!("DBInstanceClass '{db_instance_class}' is not supported yet."),
+            format!("DBInstanceClass '{}' is not supported.", db_instance_class),
         ));
     }
     Ok(())

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -164,6 +164,14 @@ impl RdsService {
         let db_parameter_group_name =
             optional_param(request, "DBParameterGroupName").or(Some(default_param_group));
 
+        let backup_retention_period =
+            optional_i32_param(request, "BackupRetentionPeriod")?.unwrap_or(1);
+        let preferred_backup_window = optional_param(request, "PreferredBackupWindow")
+            .unwrap_or_else(|| "03:00-04:00".to_string());
+        let option_group_name = optional_param(request, "OptionGroupName");
+        let multi_az =
+            parse_optional_bool(optional_param(request, "MultiAZ").as_deref())?.unwrap_or(false);
+
         validate_create_request(
             &db_instance_identifier,
             allocated_storage,
@@ -216,6 +224,7 @@ impl RdsService {
             })?;
 
         let mut state = self.state.write();
+        let created_at = Utc::now();
         let instance = DbInstance {
             db_instance_identifier: db_instance_identifier.clone(),
             db_instance_arn: state.db_instance_arn(&db_instance_identifier),
@@ -230,7 +239,7 @@ impl RdsService {
             allocated_storage,
             publicly_accessible,
             deletion_protection,
-            created_at: Utc::now(),
+            created_at,
             dbi_resource_id: state.next_dbi_resource_id(),
             master_user_password,
             container_id: running.container_id,
@@ -240,6 +249,11 @@ impl RdsService {
             read_replica_db_instance_identifiers: Vec::new(),
             vpc_security_group_ids,
             db_parameter_group_name,
+            backup_retention_period,
+            preferred_backup_window,
+            latest_restorable_time: created_at,
+            option_group_name,
+            multi_az,
         };
         state.finish_instance_creation(instance.clone());
 
@@ -1065,6 +1079,11 @@ impl RdsService {
             read_replica_db_instance_identifiers: Vec::new(),
             vpc_security_group_ids,
             db_parameter_group_name: None,
+            backup_retention_period: 1,
+            preferred_backup_window: "03:00-04:00".to_string(),
+            latest_restorable_time: created_at,
+            option_group_name: None,
+            multi_az: false,
         };
 
         state.finish_instance_creation(instance.clone());
@@ -1206,6 +1225,11 @@ impl RdsService {
             read_replica_db_instance_identifiers: Vec::new(),
             vpc_security_group_ids: source_instance.vpc_security_group_ids.clone(),
             db_parameter_group_name: source_instance.db_parameter_group_name.clone(),
+            backup_retention_period: source_instance.backup_retention_period,
+            preferred_backup_window: source_instance.preferred_backup_window.clone(),
+            latest_restorable_time: created_at,
+            option_group_name: source_instance.option_group_name.clone(),
+            multi_az: source_instance.multi_az,
         };
 
         let source_missing = {
@@ -2147,6 +2171,19 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
         None => "<DBParameterGroups/>".to_string(),
     };
 
+    let option_group_memberships_xml = match &instance.option_group_name {
+        Some(og_name) => format!(
+            "<OptionGroupMemberships>\
+             <OptionGroupMembership>\
+             <OptionGroupName>{}</OptionGroupName>\
+             <Status>in-sync</Status>\
+             </OptionGroupMembership>\
+             </OptionGroupMemberships>",
+            xml_escape(og_name)
+        ),
+        None => "<OptionGroupMemberships/>".to_string(),
+    };
+
     format!(
         "<DBInstanceIdentifier>{}</DBInstanceIdentifier>\
          <DBInstanceClass>{}</DBInstanceClass>\
@@ -2157,20 +2194,21 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
          <Endpoint><Address>{}</Address><Port>{}</Port></Endpoint>\
          <AllocatedStorage>{}</AllocatedStorage>\
          <InstanceCreateTime>{}</InstanceCreateTime>\
-         <PreferredBackupWindow>00:00-00:30</PreferredBackupWindow>\
-         <BackupRetentionPeriod>1</BackupRetentionPeriod>\
+         <PreferredBackupWindow>{}</PreferredBackupWindow>\
+         <BackupRetentionPeriod>{}</BackupRetentionPeriod>\
          <DBSecurityGroups/>\
          {}\
          {}\
          <AvailabilityZone>us-east-1a</AvailabilityZone>\
+         <LatestRestorableTime>{}</LatestRestorableTime>\
          <PreferredMaintenanceWindow>sun:00:00-sun:00:30</PreferredMaintenanceWindow>\
-         <MultiAZ>false</MultiAZ>\
+         <MultiAZ>{}</MultiAZ>\
          <EngineVersion>{}</EngineVersion>\
          <AutoMinorVersionUpgrade>true</AutoMinorVersionUpgrade>\
          {}\
          {}\
          <LicenseModel>postgresql-license</LicenseModel>\
-         <OptionGroupMemberships/>\
+         {}\
          <PubliclyAccessible>{}</PubliclyAccessible>\
          <StorageType>gp2</StorageType>\
          <DbInstancePort>{}</DbInstancePort>\
@@ -2188,11 +2226,16 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
         instance.port,
         instance.allocated_storage,
         instance.created_at.to_rfc3339(),
+        xml_escape(&instance.preferred_backup_window),
+        instance.backup_retention_period,
         vpc_security_groups_xml,
         db_parameter_groups_xml,
+        instance.latest_restorable_time.to_rfc3339(),
+        if instance.multi_az { "true" } else { "false" },
         xml_escape(&instance.engine_version),
         read_replica_identifiers_xml,
         read_replica_source_xml,
+        option_group_memberships_xml,
         if instance.publicly_accessible {
             "true"
         } else {
@@ -2431,6 +2474,7 @@ mod tests {
 
     #[test]
     fn db_instance_xml_renders_endpoint_and_status() {
+        let created_at = Utc::now();
         let instance = DbInstance {
             db_instance_identifier: "test-db".to_string(),
             db_instance_arn: "arn:aws:rds:us-east-1:123456789012:db:test-db".to_string(),
@@ -2445,7 +2489,7 @@ mod tests {
             allocated_storage: 20,
             publicly_accessible: true,
             deletion_protection: false,
-            created_at: Utc::now(),
+            created_at,
             dbi_resource_id: format!("db-{}", Uuid::new_v4().simple()),
             master_user_password: "secret123".to_string(),
             container_id: "container".to_string(),
@@ -2455,6 +2499,11 @@ mod tests {
             read_replica_db_instance_identifiers: Vec::new(),
             vpc_security_group_ids: vec!["sg-12345678".to_string()],
             db_parameter_group_name: Some("default.postgres16".to_string()),
+            backup_retention_period: 1,
+            preferred_backup_window: "03:00-04:00".to_string(),
+            latest_restorable_time: created_at,
+            option_group_name: None,
+            multi_az: false,
         };
 
         let xml = db_instance_xml(&instance, Some("creating"));

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -128,10 +128,41 @@ impl RdsService {
         let deletion_protection =
             parse_optional_bool(optional_param(request, "DeletionProtection").as_deref())?
                 .unwrap_or(false);
-        let port = optional_i32_param(request, "Port")?.unwrap_or(5432);
+        // Default port based on engine
+        let default_port = match engine.as_str() {
+            "postgres" => 5432,
+            "mysql" | "mariadb" => 3306,
+            _ => 5432,
+        };
+        let port = optional_i32_param(request, "Port")?.unwrap_or(default_port);
         let vpc_security_group_ids = parse_vpc_security_group_ids(request);
-        let db_parameter_group_name = optional_param(request, "DBParameterGroupName")
-            .or_else(|| Some("default.postgres16".to_string()));
+
+        // Default parameter group based on engine and version
+        let default_param_group = match engine.as_str() {
+            "postgres" => {
+                let major = engine_version.split('.').next().unwrap_or("16");
+                format!("default.postgres{}", major)
+            }
+            "mysql" => {
+                let major = if engine_version.starts_with("5.7") {
+                    "5.7"
+                } else {
+                    "8.0"
+                };
+                format!("default.mysql{}", major)
+            }
+            "mariadb" => {
+                let major = if engine_version.starts_with("10.11") {
+                    "10.11"
+                } else {
+                    "10.6"
+                };
+                format!("default.mariadb{}", major)
+            }
+            _ => "default.postgres16".to_string(),
+        };
+        let db_parameter_group_name =
+            optional_param(request, "DBParameterGroupName").or(Some(default_param_group));
 
         validate_create_request(
             &db_instance_identifier,
@@ -161,10 +192,17 @@ impl RdsService {
             )
         })?;
 
-        let logical_db_name = db_name.clone().unwrap_or_else(|| "postgres".to_string());
+        // Default database name based on engine
+        let logical_db_name = db_name.clone().unwrap_or_else(|| match engine.as_str() {
+            "postgres" => "postgres".to_string(),
+            "mysql" | "mariadb" => "mysql".to_string(),
+            _ => "postgres".to_string(),
+        });
         let running = runtime
             .ensure_postgres(
                 &db_instance_identifier,
+                &engine,
+                &engine_version,
                 &master_username,
                 &master_user_password,
                 &logical_db_name,
@@ -969,6 +1007,8 @@ impl RdsService {
         let running = match runtime
             .ensure_postgres(
                 &db_instance_identifier,
+                &snapshot.engine,
+                &snapshot.engine_version,
                 &snapshot.master_username,
                 &snapshot.master_user_password,
                 db_name,
@@ -1110,6 +1150,8 @@ impl RdsService {
         let running = match runtime
             .ensure_postgres(
                 &db_instance_identifier,
+                &source_instance.engine,
+                &source_instance.engine_version,
                 &source_instance.master_username,
                 &source_instance.master_user_password,
                 &db_name,
@@ -1862,14 +1904,25 @@ fn validate_create_request(
             "DBInstanceIdentifier must contain only alphanumeric characters or hyphens.",
         ));
     }
-    if engine != "postgres" {
+    // Validate engine
+    let supported_engines = ["postgres", "mysql", "mariadb"];
+    if !supported_engines.contains(&engine) {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "InvalidParameterValue",
-            format!("Engine '{engine}' is not supported yet."),
+            format!("Engine '{}' is not supported.", engine),
         ));
     }
-    if engine_version != "16.3" {
+
+    // Validate engine version
+    let supported_versions = match engine {
+        "postgres" => vec!["16.3", "15.5", "14.10", "13.13"],
+        "mysql" => vec!["8.0.35", "8.0.28", "5.7.44"],
+        "mariadb" => vec!["10.11.6", "10.6.16"],
+        _ => vec![],
+    };
+
+    if !supported_versions.contains(&engine_version) {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "InvalidParameterValue",
@@ -2329,8 +2382,8 @@ mod tests {
         let filtered =
             filter_engine_versions(&versions, &Some("postgres".to_string()), &None, &None);
 
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].engine, "postgres");
+        assert_eq!(filtered.len(), 4); // All postgres versions
+        assert!(filtered.iter().all(|v| v.engine == "postgres"));
     }
 
     #[test]

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -359,16 +359,28 @@ pub fn default_orderable_options() -> Vec<OrderableDbInstanceOption> {
         ("mariadb", "10.6.16", "general-public-license"),
     ];
 
+    let instance_classes = vec![
+        "db.t3.micro",
+        "db.t3.small",
+        "db.t3.medium",
+        "db.t3.large",
+        "db.t4g.micro",
+        "db.t4g.small",
+        "db.m5.large",
+    ];
+
     for (engine, version, license) in engines_and_versions {
-        options.push(OrderableDbInstanceOption {
-            engine: engine.to_string(),
-            engine_version: version.to_string(),
-            db_instance_class: "db.t3.micro".to_string(),
-            license_model: license.to_string(),
-            storage_type: "gp2".to_string(),
-            min_storage_size: 20,
-            max_storage_size: 16384,
-        });
+        for class in &instance_classes {
+            options.push(OrderableDbInstanceOption {
+                engine: engine.to_string(),
+                engine_version: version.to_string(),
+                db_instance_class: class.to_string(),
+                license_model: license.to_string(),
+                storage_type: "gp2".to_string(),
+                min_storage_size: 20,
+                max_storage_size: 16384,
+            });
+        }
     }
 
     options
@@ -477,8 +489,8 @@ mod tests {
         let versions = default_engine_versions();
         let options = default_orderable_options();
 
-        assert_eq!(options.len(), 9); // One per engine version
-                                      // Verify all engines and versions have orderable options
+        assert_eq!(options.len(), 63); // 9 versions * 7 instance classes
+                                       // Verify all engines and versions have orderable options
         for version in &versions {
             assert!(options.iter().any(|opt| {
                 opt.engine == version.engine && opt.engine_version == version.engine_version

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -266,26 +266,112 @@ impl RdsState {
 }
 
 pub fn default_engine_versions() -> Vec<EngineVersionInfo> {
-    vec![EngineVersionInfo {
-        engine: "postgres".to_string(),
-        engine_version: "16.3".to_string(),
-        db_parameter_group_family: "postgres16".to_string(),
-        db_engine_description: "PostgreSQL".to_string(),
-        db_engine_version_description: "PostgreSQL 16.3".to_string(),
-        status: "available".to_string(),
-    }]
+    vec![
+        // PostgreSQL versions
+        EngineVersionInfo {
+            engine: "postgres".to_string(),
+            engine_version: "16.3".to_string(),
+            db_parameter_group_family: "postgres16".to_string(),
+            db_engine_description: "PostgreSQL".to_string(),
+            db_engine_version_description: "PostgreSQL 16.3".to_string(),
+            status: "available".to_string(),
+        },
+        EngineVersionInfo {
+            engine: "postgres".to_string(),
+            engine_version: "15.5".to_string(),
+            db_parameter_group_family: "postgres15".to_string(),
+            db_engine_description: "PostgreSQL".to_string(),
+            db_engine_version_description: "PostgreSQL 15.5".to_string(),
+            status: "available".to_string(),
+        },
+        EngineVersionInfo {
+            engine: "postgres".to_string(),
+            engine_version: "14.10".to_string(),
+            db_parameter_group_family: "postgres14".to_string(),
+            db_engine_description: "PostgreSQL".to_string(),
+            db_engine_version_description: "PostgreSQL 14.10".to_string(),
+            status: "available".to_string(),
+        },
+        EngineVersionInfo {
+            engine: "postgres".to_string(),
+            engine_version: "13.13".to_string(),
+            db_parameter_group_family: "postgres13".to_string(),
+            db_engine_description: "PostgreSQL".to_string(),
+            db_engine_version_description: "PostgreSQL 13.13".to_string(),
+            status: "available".to_string(),
+        },
+        // MySQL versions
+        EngineVersionInfo {
+            engine: "mysql".to_string(),
+            engine_version: "8.0.35".to_string(),
+            db_parameter_group_family: "mysql8.0".to_string(),
+            db_engine_description: "MySQL Community Edition".to_string(),
+            db_engine_version_description: "MySQL 8.0.35".to_string(),
+            status: "available".to_string(),
+        },
+        EngineVersionInfo {
+            engine: "mysql".to_string(),
+            engine_version: "8.0.28".to_string(),
+            db_parameter_group_family: "mysql8.0".to_string(),
+            db_engine_description: "MySQL Community Edition".to_string(),
+            db_engine_version_description: "MySQL 8.0.28".to_string(),
+            status: "available".to_string(),
+        },
+        EngineVersionInfo {
+            engine: "mysql".to_string(),
+            engine_version: "5.7.44".to_string(),
+            db_parameter_group_family: "mysql5.7".to_string(),
+            db_engine_description: "MySQL Community Edition".to_string(),
+            db_engine_version_description: "MySQL 5.7.44".to_string(),
+            status: "available".to_string(),
+        },
+        // MariaDB versions
+        EngineVersionInfo {
+            engine: "mariadb".to_string(),
+            engine_version: "10.11.6".to_string(),
+            db_parameter_group_family: "mariadb10.11".to_string(),
+            db_engine_description: "MariaDB Community Edition".to_string(),
+            db_engine_version_description: "MariaDB 10.11.6".to_string(),
+            status: "available".to_string(),
+        },
+        EngineVersionInfo {
+            engine: "mariadb".to_string(),
+            engine_version: "10.6.16".to_string(),
+            db_parameter_group_family: "mariadb10.6".to_string(),
+            db_engine_description: "MariaDB Community Edition".to_string(),
+            db_engine_version_description: "MariaDB 10.6.16".to_string(),
+            status: "available".to_string(),
+        },
+    ]
 }
 
 pub fn default_orderable_options() -> Vec<OrderableDbInstanceOption> {
-    vec![OrderableDbInstanceOption {
-        engine: "postgres".to_string(),
-        engine_version: "16.3".to_string(),
-        db_instance_class: "db.t3.micro".to_string(),
-        license_model: "postgresql-license".to_string(),
-        storage_type: "gp2".to_string(),
-        min_storage_size: 20,
-        max_storage_size: 16384,
-    }]
+    let mut options = Vec::new();
+    let engines_and_versions = vec![
+        ("postgres", "16.3", "postgresql-license"),
+        ("postgres", "15.5", "postgresql-license"),
+        ("postgres", "14.10", "postgresql-license"),
+        ("postgres", "13.13", "postgresql-license"),
+        ("mysql", "8.0.35", "general-public-license"),
+        ("mysql", "8.0.28", "general-public-license"),
+        ("mysql", "5.7.44", "general-public-license"),
+        ("mariadb", "10.11.6", "general-public-license"),
+        ("mariadb", "10.6.16", "general-public-license"),
+    ];
+
+    for (engine, version, license) in engines_and_versions {
+        options.push(OrderableDbInstanceOption {
+            engine: engine.to_string(),
+            engine_version: version.to_string(),
+            db_instance_class: "db.t3.micro".to_string(),
+            license_model: license.to_string(),
+            storage_type: "gp2".to_string(),
+            min_storage_size: 20,
+            max_storage_size: 16384,
+        });
+    }
+
+    options
 }
 
 pub fn default_parameter_groups(
@@ -294,16 +380,30 @@ pub fn default_parameter_groups(
 ) -> HashMap<String, DbParameterGroup> {
     let mut groups = HashMap::new();
 
-    let default_group = DbParameterGroup {
-        db_parameter_group_name: "default.postgres16".to_string(),
-        db_parameter_group_arn: format!("arn:aws:rds:{region}:{account_id}:pg:default.postgres16"),
-        db_parameter_group_family: "postgres16".to_string(),
-        description: "Default parameter group for postgres16".to_string(),
-        parameters: HashMap::new(),
-        tags: Vec::new(),
-    };
+    let families = vec![
+        ("postgres16", "Default parameter group for postgres16"),
+        ("postgres15", "Default parameter group for postgres15"),
+        ("postgres14", "Default parameter group for postgres14"),
+        ("postgres13", "Default parameter group for postgres13"),
+        ("mysql8.0", "Default parameter group for mysql8.0"),
+        ("mysql5.7", "Default parameter group for mysql5.7"),
+        ("mariadb10.11", "Default parameter group for mariadb10.11"),
+        ("mariadb10.6", "Default parameter group for mariadb10.6"),
+    ];
 
-    groups.insert("default.postgres16".to_string(), default_group);
+    for (family, description) in families {
+        let group_name = format!("default.{}", family);
+        let group = DbParameterGroup {
+            db_parameter_group_name: group_name.clone(),
+            db_parameter_group_arn: format!("arn:aws:rds:{region}:{account_id}:pg:{group_name}"),
+            db_parameter_group_family: family.to_string(),
+            description: description.to_string(),
+            parameters: HashMap::new(),
+            tags: Vec::new(),
+        };
+        groups.insert(group_name, group);
+    }
+
     groups
 }
 
@@ -365,7 +465,8 @@ mod tests {
     fn default_engine_versions_are_postgres_metadata() {
         let versions = default_engine_versions();
 
-        assert_eq!(versions.len(), 1);
+        assert_eq!(versions.len(), 9); // 4 postgres + 3 mysql + 2 mariadb
+                                       // Check first postgres version
         assert_eq!(versions[0].engine, "postgres");
         assert_eq!(versions[0].engine_version, "16.3");
         assert_eq!(versions[0].db_parameter_group_family, "postgres16");
@@ -376,10 +477,13 @@ mod tests {
         let versions = default_engine_versions();
         let options = default_orderable_options();
 
-        assert_eq!(options.len(), 1);
-        assert_eq!(options[0].engine, versions[0].engine);
-        assert_eq!(options[0].engine_version, versions[0].engine_version);
-        assert_eq!(options[0].db_instance_class, "db.t3.micro");
+        assert_eq!(options.len(), 9); // One per engine version
+                                      // Verify all engines and versions have orderable options
+        for version in &versions {
+            assert!(options.iter().any(|opt| {
+                opt.engine == version.engine && opt.engine_version == version.engine_version
+            }));
+        }
     }
 
     #[test]

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -34,6 +34,11 @@ pub struct DbInstance {
     pub read_replica_db_instance_identifiers: Vec<String>,
     pub vpc_security_group_ids: Vec<String>,
     pub db_parameter_group_name: Option<String>,
+    pub backup_retention_period: i32,
+    pub preferred_backup_window: String,
+    pub latest_restorable_time: DateTime<Utc>,
+    pub option_group_name: Option<String>,
+    pub multi_az: bool,
 }
 
 impl fmt::Debug for DbInstance {
@@ -68,6 +73,11 @@ impl fmt::Debug for DbInstance {
             )
             .field("vpc_security_group_ids", &self.vpc_security_group_ids)
             .field("db_parameter_group_name", &self.db_parameter_group_name)
+            .field("backup_retention_period", &self.backup_retention_period)
+            .field("preferred_backup_window", &self.preferred_backup_window)
+            .field("latest_restorable_time", &self.latest_restorable_time)
+            .field("option_group_name", &self.option_group_name)
+            .field("multi_az", &self.multi_az)
             .finish()
     }
 }
@@ -438,6 +448,7 @@ mod tests {
     #[test]
     fn reset_clears_instances() {
         let mut state = RdsState::new("123456789012", "us-east-1");
+        let created_at = Utc::now();
         state.instances.insert(
             "db-1".to_string(),
             DbInstance {
@@ -454,7 +465,7 @@ mod tests {
                 allocated_storage: 20,
                 publicly_accessible: true,
                 deletion_protection: false,
-                created_at: Utc::now(),
+                created_at,
                 dbi_resource_id: "db-test".to_string(),
                 master_user_password: "secret123".to_string(),
                 container_id: "container-id".to_string(),
@@ -464,6 +475,11 @@ mod tests {
                 read_replica_db_instance_identifiers: Vec::new(),
                 vpc_security_group_ids: Vec::new(),
                 db_parameter_group_name: None,
+                backup_retention_period: 1,
+                preferred_backup_window: "03:00-04:00".to_string(),
+                latest_restorable_time: created_at,
+                option_group_name: None,
+                multi_az: false,
             },
         );
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1441,6 +1441,7 @@ mod tests {
     #[test]
     fn reset_service_clears_rds_state() {
         let mut rds = RdsState::new("123456789012", "us-east-1");
+        let created_at = Utc::now();
         rds.instances.insert(
             "db-1".to_string(),
             DbInstance {
@@ -1457,7 +1458,7 @@ mod tests {
                 allocated_storage: 20,
                 publicly_accessible: true,
                 deletion_protection: false,
-                created_at: Utc::now(),
+                created_at,
                 dbi_resource_id: "db-test".to_string(),
                 master_user_password: "secret123".to_string(),
                 container_id: "container-id".to_string(),
@@ -1467,6 +1468,11 @@ mod tests {
                 read_replica_db_instance_identifiers: Vec::new(),
                 vpc_security_group_ids: Vec::new(),
                 db_parameter_group_name: None,
+                backup_retention_period: 1,
+                preferred_backup_window: "03:00-04:00".to_string(),
+                latest_restorable_time: created_at,
+                option_group_name: None,
+                multi_az: false,
             },
         );
 
@@ -1547,6 +1553,7 @@ mod tests {
 
     #[test]
     fn rds_instance_response_omits_password_but_keeps_runtime_metadata() {
+        let created_at = Utc::now();
         let instance = DbInstance {
             db_instance_identifier: "db-1".to_string(),
             db_instance_arn: "arn:aws:rds:us-east-1:123456789012:db:db-1".to_string(),
@@ -1561,7 +1568,7 @@ mod tests {
             allocated_storage: 20,
             publicly_accessible: true,
             deletion_protection: false,
-            created_at: Utc::now(),
+            created_at,
             dbi_resource_id: "db-test".to_string(),
             master_user_password: "secret123".to_string(),
             container_id: "container-id".to_string(),
@@ -1574,6 +1581,11 @@ mod tests {
             read_replica_db_instance_identifiers: Vec::new(),
             vpc_security_group_ids: Vec::new(),
             db_parameter_group_name: None,
+            backup_retention_period: 1,
+            preferred_backup_window: "03:00-04:00".to_string(),
+            latest_restorable_time: created_at,
+            option_group_name: None,
+            multi_az: false,
         };
 
         let response = rds_instance_response(&instance);


### PR DESCRIPTION
## Summary

Adds support for multiple database engines and versions in RDS:

**PostgreSQL** (4 versions):
- 16.3, 15.5, 14.10, 13.13

**MySQL** (3 versions):
- 8.0.35, 8.0.28, 5.7.44

**MariaDB** (2 versions):
- 10.11.6, 10.6.16

Implementation:
- Runtime selects Docker images based on engine/version
- Engine-specific environment variables (POSTGRES_*, MYSQL_*, MARIADB_*)
- Default ports: 5432 (postgres), 3306 (mysql/mariadb)
- Default parameter groups for all engine families
- Validation updated for all engines

## Test plan

- ✅ All existing RDS tests pass with updated assertions
- ✅ Unit tests verify all 9 engine versions
- ✅ Clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-engine RDS support (PostgreSQL, MySQL, MariaDB) across 9 versions and 7 instance classes, plus backup and Multi-AZ metadata on instances. The runtime picks engine-aware Docker images, ports, defaults, and validation, with 63 orderable options exposed by the API.

- **New Features**
  - Engines/versions: PostgreSQL 16.3, 15.5, 14.10, 13.13; MySQL 8.0.35, 8.0.28, 5.7.44; MariaDB 10.11.6, 10.6.16.
  - Instance classes: `db.t3.micro`, `db.t3.small`, `db.t3.medium`, `db.t3.large`, `db.t4g.micro`, `db.t4g.small`, `db.m5.large`.
  - Engine-aware runtime: selects image and port (5432 for postgres; 3306 for mysql/mariadb), sets `POSTGRES_*`, `MYSQL_*`, `MARIADB_*` env vars; postgres readiness check; short startup wait for MySQL/MariaDB.
  - Defaults: parameter groups per family (e.g., `default.postgres16`, `default.mysql8.0`, `default.mariadb10.11`), engine-based default DB name (`postgres` or `mysql`), and port.
  - Metadata fields: `BackupRetentionPeriod` (default 1), `PreferredBackupWindow` (default 03:00-04:00), `LatestRestorableTime` (set to created_at), `OptionGroupName` (optional), `MultiAZ` (boolean). Parsed on create, stored, rendered in responses, and copied to read replicas.
  - Validation enforces supported engines/versions and instance classes; describe/orderable APIs list all versions and classes.

- **Tests**
  - Conformance updated to expect 7 instance classes per engine/version and multiple postgres versions.
  - E2E expects 4 postgres versions.
  - Orderable options tests cover 9 versions × 7 classes (63 combos).

<sup>Written for commit c50629065b1bc526ed2077d0df92cb1d79a1db60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

