### PR TITLE
feat(rds): implement deferred changes with ApplyImmediately=false

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -183,6 +183,45 @@ async fn rds_reboot_db_instance() {
 }
 
 #[tokio::test]
+async fn rds_modify_db_instance_with_apply_immediately_false() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client).await;
+
+    // Modify with ApplyImmediately=false should stage changes
+    let response = client
+        .modify_db_instance()
+        .db_instance_identifier("conf-rds-db")
+        .db_instance_class("db.t3.small")
+        .apply_immediately(false)
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    // Instance class should still be the original
+    assert_eq!(instance.db_instance_class(), Some("db.t3.micro"));
+    // Pending changes should exist
+    let pending = instance.pending_modified_values().expect("pending values");
+    assert_eq!(pending.db_instance_class(), Some("db.t3.small"));
+
+    // Reboot should apply pending changes
+    let response = client
+        .reboot_db_instance()
+        .db_instance_identifier("conf-rds-db")
+        .send()
+        .await
+        .unwrap();
+
+    let instance = response.db_instance().expect("db instance");
+    // Instance class should now be updated
+    assert_eq!(instance.db_instance_class(), Some("db.t3.small"));
+    // Pending changes should be cleared
+    assert!(instance.pending_modified_values().is_none());
+}
+
+#[tokio::test]
 async fn rds_delete_db_instance_rejects_deletion_protection() {
     let server = TestServer::start().await;
     let client = server.rds_client().await;

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -254,6 +254,7 @@ impl RdsService {
             latest_restorable_time: created_at,
             option_group_name,
             multi_az,
+            pending_modified_values: None,
         };
         state.finish_instance_creation(instance.clone());
 
@@ -454,13 +455,6 @@ impl RdsService {
             }
         };
 
-        if apply_immediately == Some(false) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                "ApplyImmediately=false is not yet supported for ModifyDBInstance.",
-            ));
-        }
         if db_instance_class.is_none()
             && deletion_protection.is_none()
             && vpc_security_group_ids.is_none()
@@ -481,14 +475,33 @@ impl RdsService {
             .get_mut(&db_instance_identifier)
             .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
 
-        if let Some(class) = db_instance_class {
-            instance.db_instance_class = class;
-        }
-        if let Some(deletion_protection) = deletion_protection {
-            instance.deletion_protection = deletion_protection;
-        }
-        if let Some(security_group_ids) = vpc_security_group_ids {
-            instance.vpc_security_group_ids = security_group_ids;
+        // If ApplyImmediately is false, stage changes as pending
+        if apply_immediately == Some(false) {
+            let pending = instance
+                .pending_modified_values
+                .get_or_insert(Default::default());
+            if let Some(class) = db_instance_class {
+                pending.db_instance_class = Some(class);
+            }
+            // Note: deletion_protection and vpc_security_group_ids are applied immediately
+            // regardless of ApplyImmediately flag (per AWS behavior)
+            if let Some(deletion_protection) = deletion_protection {
+                instance.deletion_protection = deletion_protection;
+            }
+            if let Some(security_group_ids) = vpc_security_group_ids {
+                instance.vpc_security_group_ids = security_group_ids;
+            }
+        } else {
+            // Apply immediately (default behavior)
+            if let Some(class) = db_instance_class {
+                instance.db_instance_class = class;
+            }
+            if let Some(deletion_protection) = deletion_protection {
+                instance.deletion_protection = deletion_protection;
+            }
+            if let Some(security_group_ids) = vpc_security_group_ids {
+                instance.vpc_security_group_ids = security_group_ids;
+            }
         }
 
         Ok(AwsResponse::xml(
@@ -554,6 +567,29 @@ impl RdsService {
                 .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
             instance.host_port = running.host_port;
             instance.port = i32::from(running.host_port);
+
+            // Apply any pending modifications
+            if let Some(pending) = instance.pending_modified_values.take() {
+                if let Some(class) = pending.db_instance_class {
+                    instance.db_instance_class = class;
+                }
+                if let Some(allocated_storage) = pending.allocated_storage {
+                    instance.allocated_storage = allocated_storage;
+                }
+                if let Some(backup_retention_period) = pending.backup_retention_period {
+                    instance.backup_retention_period = backup_retention_period;
+                }
+                if let Some(multi_az) = pending.multi_az {
+                    instance.multi_az = multi_az;
+                }
+                if let Some(engine_version) = pending.engine_version {
+                    instance.engine_version = engine_version;
+                }
+                if let Some(master_user_password) = pending.master_user_password {
+                    instance.master_user_password = master_user_password;
+                }
+            }
+
             instance.clone()
         };
 
@@ -1084,6 +1120,7 @@ impl RdsService {
             latest_restorable_time: created_at,
             option_group_name: None,
             multi_az: false,
+            pending_modified_values: None,
         };
 
         state.finish_instance_creation(instance.clone());
@@ -1230,6 +1267,7 @@ impl RdsService {
             latest_restorable_time: created_at,
             option_group_name: source_instance.option_group_name.clone(),
             multi_az: source_instance.multi_az,
+            pending_modified_values: None,
         };
 
         let source_missing = {
@@ -2184,6 +2222,53 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
         None => "<OptionGroupMemberships/>".to_string(),
     };
 
+    let pending_modified_values_xml = if let Some(ref pending) = instance.pending_modified_values {
+        let mut fields = Vec::new();
+        if let Some(ref class) = pending.db_instance_class {
+            fields.push(format!(
+                "<DBInstanceClass>{}</DBInstanceClass>",
+                xml_escape(class)
+            ));
+        }
+        if let Some(allocated_storage) = pending.allocated_storage {
+            fields.push(format!(
+                "<AllocatedStorage>{}</AllocatedStorage>",
+                allocated_storage
+            ));
+        }
+        if let Some(backup_retention_period) = pending.backup_retention_period {
+            fields.push(format!(
+                "<BackupRetentionPeriod>{}</BackupRetentionPeriod>",
+                backup_retention_period
+            ));
+        }
+        if let Some(multi_az) = pending.multi_az {
+            fields.push(format!(
+                "<MultiAZ>{}</MultiAZ>",
+                if multi_az { "true" } else { "false" }
+            ));
+        }
+        if let Some(ref engine_version) = pending.engine_version {
+            fields.push(format!(
+                "<EngineVersion>{}</EngineVersion>",
+                xml_escape(engine_version)
+            ));
+        }
+        if pending.master_user_password.is_some() {
+            fields.push("<MasterUserPassword>****</MasterUserPassword>".to_string());
+        }
+        if !fields.is_empty() {
+            format!(
+                "<PendingModifiedValues>{}</PendingModifiedValues>",
+                fields.join("")
+            )
+        } else {
+            String::new()
+        }
+    } else {
+        String::new()
+    };
+
     format!(
         "<DBInstanceIdentifier>{}</DBInstanceIdentifier>\
          <DBInstanceClass>{}</DBInstanceClass>\
@@ -2215,6 +2300,7 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
          <StorageEncrypted>false</StorageEncrypted>\
          <DbiResourceId>{}</DbiResourceId>\
          <DeletionProtection>{}</DeletionProtection>\
+         {}\
          <DBInstanceArn>{}</DBInstanceArn>",
         xml_escape(&instance.db_instance_identifier),
         xml_escape(&instance.db_instance_class),
@@ -2248,6 +2334,7 @@ fn db_instance_xml(instance: &DbInstance, status_override: Option<&str>) -> Stri
         } else {
             "false"
         },
+        pending_modified_values_xml,
         xml_escape(&instance.db_instance_arn),
     )
 }
@@ -2504,6 +2591,7 @@ mod tests {
             latest_restorable_time: created_at,
             option_group_name: None,
             multi_az: false,
+            pending_modified_values: None,
         };
 
         let xml = db_instance_xml(&instance, Some("creating"));

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -39,6 +39,17 @@ pub struct DbInstance {
     pub latest_restorable_time: DateTime<Utc>,
     pub option_group_name: Option<String>,
     pub multi_az: bool,
+    pub pending_modified_values: Option<PendingModifiedValues>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PendingModifiedValues {
+    pub db_instance_class: Option<String>,
+    pub allocated_storage: Option<i32>,
+    pub backup_retention_period: Option<i32>,
+    pub multi_az: Option<bool>,
+    pub engine_version: Option<String>,
+    pub master_user_password: Option<String>,
 }
 
 impl fmt::Debug for DbInstance {
@@ -78,6 +89,7 @@ impl fmt::Debug for DbInstance {
             .field("latest_restorable_time", &self.latest_restorable_time)
             .field("option_group_name", &self.option_group_name)
             .field("multi_az", &self.multi_az)
+            .field("pending_modified_values", &self.pending_modified_values)
             .finish()
     }
 }
@@ -480,6 +492,7 @@ mod tests {
                 latest_restorable_time: created_at,
                 option_group_name: None,
                 multi_az: false,
+                pending_modified_values: None,
             },
         );
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1473,6 +1473,7 @@ mod tests {
                 latest_restorable_time: created_at,
                 option_group_name: None,
                 multi_az: false,
+                pending_modified_values: None,
             },
         );
 
@@ -1586,6 +1587,7 @@ mod tests {
             latest_restorable_time: created_at,
             option_group_name: None,
             multi_az: false,
+            pending_modified_values: None,
         };
 
         let response = rds_instance_response(&instance);


### PR DESCRIPTION
## Summary
- Add PendingModifiedValues support for ModifyDBInstance with ApplyImmediately=false
- Changes are staged and applied on next RebootDBInstance
- Completes Batch 9 of the 10-batch RDS implementation plan

## Changes
- Add `PendingModifiedValues` struct to track staged modifications
- Add `pending_modified_values` field to `DbInstance`
- Update ModifyDBInstance to stage changes when ApplyImmediately=false
- Update RebootDBInstance to apply all pending modifications
- Render PendingModifiedValues in XML responses
- Note: deletion_protection and vpc_security_group_ids apply immediately (per AWS behavior)

## Test plan
- [x] New conformance test: rds_modify_db_instance_with_apply_immediately_false
- [x] All existing RDS conformance tests pass (31/31)
- [x] Unit tests pass
- [x] Clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deferred RDS instance changes when ApplyImmediately=false by staging updates and applying them on reboot. XML responses now include pending values to mirror AWS behavior.

- **New Features**
  - Added PendingModifiedValues to track staged updates (class, storage, backup retention, MultiAZ, engine version, master password).
  - ModifyDBInstance with ApplyImmediately=false stages changes; RebootDBInstance applies and clears them.
  - XML responses render PendingModifiedValues; deletion_protection and vpc_security_group_ids still apply immediately to match AWS.

<sup>Written for commit 5491549fa95c97360941cbade8ff629cb520d501. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

