### PR TITLE
fix(rds): redact passwords in debug output and logs

### DIFF
--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -42,7 +42,7 @@ pub struct DbInstance {
     pub pending_modified_values: Option<PendingModifiedValues>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct PendingModifiedValues {
     pub db_instance_class: Option<String>,
     pub allocated_storage: Option<i32>,
@@ -50,6 +50,22 @@ pub struct PendingModifiedValues {
     pub multi_az: Option<bool>,
     pub engine_version: Option<String>,
     pub master_user_password: Option<String>,
+}
+
+impl fmt::Debug for PendingModifiedValues {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PendingModifiedValues")
+            .field("db_instance_class", &self.db_instance_class)
+            .field("allocated_storage", &self.allocated_storage)
+            .field("backup_retention_period", &self.backup_retention_period)
+            .field("multi_az", &self.multi_az)
+            .field("engine_version", &self.engine_version)
+            .field(
+                "master_user_password",
+                &self.master_user_password.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 impl fmt::Debug for DbInstance {


### PR DESCRIPTION
## Summary
- Add custom Debug impl for `PendingModifiedValues` to redact `master_user_password`
- Add structured tracing to `wait_for_postgres` that omits password from logs
- Prevents password exposure in debug formatting and log output

## Test plan
- [x] All existing RDS E2E tests pass
- [x] cargo clippy passes with no warnings
- [x] Manual verification: passwords redacted in debug output

Addresses Cubic findings:
- PR #221 (P1): Password exposed in PendingModifiedValues debug output
- PR #190 (P2): Connection string logs plaintext password

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leaking passwords in RDS debug output and logs. Redacts `master_user_password` and logs Postgres readiness without credentials.

- **Bug Fixes**
  - Custom `Debug` for `PendingModifiedValues` redacts `master_user_password` as "<redacted>".
  - Structured `tracing::debug!` in `wait_for_postgres` logs host, port, user, and db only.
  - Addresses Cubic security findings in PR #221 (P1) and PR #190 (P2).

<sup>Written for commit c16bd9729f3cd4723e9913d628adf9d5a8ba6c7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

