### PR TITLE
fix(rds): check deletion protection before creating snapshots

### DIFF
--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -188,6 +188,7 @@ async fn rds_delete_db_instance_respects_deletion_protection() {
 
     create_instance_with_deletion_protection(&client, "orders-protected-db", true).await;
 
+    // Test with skip_final_snapshot=true
     let error = client
         .delete_db_instance()
         .db_instance_identifier("orders-protected-db")
@@ -200,6 +201,20 @@ async fn rds_delete_db_instance_respects_deletion_protection() {
         Some("InvalidDBInstanceState")
     );
 
+    // Test with final snapshot - should fail BEFORE creating snapshot
+    let error = client
+        .delete_db_instance()
+        .db_instance_identifier("orders-protected-db")
+        .final_db_snapshot_identifier("protected-snapshot")
+        .send()
+        .await
+        .expect_err("deletion protection should block deletion before snapshot creation");
+    assert_eq!(
+        error.into_service_error().meta().code(),
+        Some("InvalidDBInstanceState")
+    );
+
+    // Verify instance still exists
     let response = client
         .describe_db_instances()
         .db_instance_identifier("orders-protected-db")
@@ -207,6 +222,17 @@ async fn rds_delete_db_instance_respects_deletion_protection() {
         .await
         .unwrap();
     assert_eq!(response.db_instances().len(), 1);
+
+    // Verify NO snapshot was created (critical: proves deletion protection checked BEFORE snapshot)
+    let snapshots_response = client.describe_db_snapshots().send().await.unwrap();
+    let protected_snapshot = snapshots_response
+        .db_snapshots()
+        .iter()
+        .find(|s| s.db_snapshot_identifier() == Some("protected-snapshot"));
+    assert!(
+        protected_snapshot.is_none(),
+        "Snapshot should NOT be created when deletion protection blocks deletion"
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -296,6 +296,25 @@ impl RdsService {
             ));
         }
 
+        // Check deletion protection BEFORE creating snapshot or making any changes
+        {
+            let state = self.state.read();
+            if let Some(instance) = state.instances.get(&db_instance_identifier) {
+                if instance.deletion_protection {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidDBInstanceState",
+                        format!(
+                            "DBInstance {} cannot be deleted because deletion protection is enabled.",
+                            db_instance_identifier
+                        ),
+                    ));
+                }
+            } else {
+                return Err(db_instance_not_found(&db_instance_identifier));
+            }
+        }
+
         // Create final snapshot if requested
         if let Some(ref snapshot_id) = final_db_snapshot_identifier {
             let runtime = self.runtime.as_ref().ok_or_else(|| {
@@ -381,20 +400,6 @@ impl RdsService {
                 .instances
                 .remove(&db_instance_identifier)
                 .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
-
-            if instance.deletion_protection {
-                state
-                    .instances
-                    .insert(db_instance_identifier.clone(), instance.clone());
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidDBInstanceState",
-                    format!(
-                        "DBInstance {} cannot be deleted because deletion protection is enabled.",
-                        db_instance_identifier
-                    ),
-                ));
-            }
 
             if let Some(source_id) = &instance.read_replica_source_db_instance_identifier {
                 if let Some(source) = state.instances.get_mut(source_id) {


### PR DESCRIPTION
## Summary
- Move deletion protection validation to the beginning of `delete_db_instance`
- Check protection before any side effects (snapshot creation)
- Remove duplicate deletion protection check after instance removal
- Add test assertion verifying no snapshot is created when deletion is blocked

## Test plan
- [x] All RDS E2E tests pass (17/17)
- [x] Enhanced deletion protection test now verifies:
  - Deletion fails with InvalidDBInstanceState error
  - Instance still exists after failed deletion
  - **Critical**: NO snapshot created when deletion protection blocks deletion
- [x] cargo clippy passes with no warnings

Addresses Cubic finding from PR #218 (P1): Final snapshot was created BEFORE deletion protection validation, allowing protected instances to produce snapshots even when deletion fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate deletion protection at the start of `delete_db_instance` to prevent creating final snapshots for protected instances. This ensures protected DBs aren't altered and returns `InvalidDBInstanceState` early.

- **Bug Fixes**
  - Check deletion protection before any side effects (snapshot or state changes).
  - Remove duplicate protection check after instance removal.
  - Update E2E test to assert no snapshot is created and the instance remains.

<sup>Written for commit 80ed59aa50637c8322286e04d36ed5c35c972607. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

