### PR TITLE
fix(rds): validate subnet groups span at least 2 unique AZs

### DIFF
--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -1343,8 +1343,18 @@ impl RdsService {
 
         let vpc_id = format!("vpc-{}", uuid::Uuid::new_v4().simple());
         let subnet_availability_zones: Vec<String> = (0..subnet_ids.len())
-            .map(|i| format!("{}{}", &state.region, char::from(b'a' + (i % 3) as u8)))
+            .map(|i| format!("{}{}", &state.region, char::from(b'a' + (i % 6) as u8)))
             .collect();
+
+        // Validate that subnets span at least 2 unique Availability Zones
+        let unique_azs: std::collections::HashSet<_> = subnet_availability_zones.iter().collect();
+        if unique_azs.len() < 2 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "DBSubnetGroupDoesNotCoverEnoughAZs",
+                "DB Subnet Group must contain at least 2 subnets in different Availability Zones.",
+            ));
+        }
 
         let db_subnet_group_arn = state.db_subnet_group_arn(&db_subnet_group_name);
         let tags = parse_tags(request)?;
@@ -1496,8 +1506,18 @@ impl RdsService {
             })?;
 
         let subnet_availability_zones: Vec<String> = (0..subnet_ids.len())
-            .map(|i| format!("{}{}", &region, char::from(b'a' + (i % 3) as u8)))
+            .map(|i| format!("{}{}", &region, char::from(b'a' + (i % 6) as u8)))
             .collect();
+
+        // Validate that subnets span at least 2 unique Availability Zones
+        let unique_azs: std::collections::HashSet<_> = subnet_availability_zones.iter().collect();
+        if unique_azs.len() < 2 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "DBSubnetGroupDoesNotCoverEnoughAZs",
+                "DB Subnet Group must contain at least 2 subnets in different Availability Zones.",
+            ));
+        }
 
         subnet_group.subnet_ids = subnet_ids;
         subnet_group.subnet_availability_zones = subnet_availability_zones;


### PR DESCRIPTION
## Summary
- Change AZ rotation from mod 3 to mod 6
- Add HashSet validation for at least 2 unique AZs  
- Apply to both Create and Modify operations

## Test plan
- [x] All RDS E2E tests pass
- [x] Validation prevents invalid subnet groups

Addresses Cubic finding from PR #212 (P2).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces that RDS DB subnet groups span at least two unique Availability Zones and expands AZ assignment to six letters to prevent invalid configurations.

- **Bug Fixes**
  - Validate on Create and Modify that subnet groups cover at least 2 unique AZs; return BAD_REQUEST with code DBSubnetGroupDoesNotCoverEnoughAZs when invalid.
  - Change AZ rotation from mod 3 to mod 6 (letters a–f).

<sup>Written for commit a19a14ded3225514c01f72b8e5a10b186fd5adce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

