### PR TITLE
fix(rds): optimize pagination test performance

### DIFF
--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -838,10 +838,10 @@ async fn pagination_with_real_instances() {
     let server = TestServer::start().await;
     let client = server.rds_client().await;
 
-    // Create 150 instances to test pagination
+    // Create 15 instances to test pagination (adequate coverage, much faster)
     let mut instance_ids = Vec::new();
-    for i in 1..=150 {
-        let id = format!("e2e-paginate-{:03}", i);
+    for i in 1..=15 {
+        let id = format!("e2e-paginate-{:02}", i);
         instance_ids.push(id.clone());
 
         client
@@ -863,7 +863,7 @@ async fn pagination_with_real_instances() {
     let mut marker: Option<String> = None;
 
     loop {
-        let mut request = client.describe_db_instances().set_max_records(Some(100));
+        let mut request = client.describe_db_instances().set_max_records(Some(10));
         if let Some(m) = marker {
             request = request.marker(m);
         }
@@ -882,7 +882,7 @@ async fn pagination_with_real_instances() {
     }
 
     // Verify all instances were returned
-    assert_eq!(collected_ids.len(), 150);
+    assert_eq!(collected_ids.len(), 15);
 
     // Verify all our instance IDs are present
     for id in &instance_ids {


### PR DESCRIPTION
## Summary
- Reduced pagination test from 150 to 15 database instances
- Adjusted MaxRecords from 100 to 10 to maintain multi-page pagination coverage
- Test completes in ~1 minute instead of ~10 minutes
- Maintains adequate test coverage while being significantly faster

## Test plan
- ✅ `cargo nextest run -p fakecloud-e2e -E 'test(pagination_with_real_instances)'` passes in ~69s
- ✅ Still validates pagination logic with 2 pages (10 + 5 instances)
- ✅ All assertions preserved

Addresses Cubic P2 issue from PR #219.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize RDS pagination e2e test by creating 15 instances instead of 150 and setting MaxRecords to 10 to keep multi-page coverage. Runtime drops from ~10 minutes to ~1 minute while preserving all assertions (2 pages: 10 + 5).

<sup>Written for commit 6c8b389f80cafaa95da22ba67cf00ccdcb081613. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

