### PR TITLE
fix(sdk): normalize keys in Python SDK response classes

### DIFF
--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -113,9 +113,7 @@ class RdsInstancesResponse:
     def from_dict(cls, data: Dict[str, Any]) -> RdsInstancesResponse:
         d = _convert_keys(data)
         return cls(
-            instances=[
-                RdsInstance.from_dict(item) for item in d.get("instances", [])
-            ],
+            instances=[RdsInstance.from_dict(item) for item in d.get("instances", [])],
         )
 
 

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -111,9 +111,10 @@ class RdsInstancesResponse:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> RdsInstancesResponse:
+        d = _convert_keys(data)
         return cls(
             instances=[
-                RdsInstance.from_dict(item) for item in data.get("instances", [])
+                RdsInstance.from_dict(item) for item in d.get("instances", [])
             ],
         )
 
@@ -146,9 +147,10 @@ class ElastiCacheClustersResponse:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> ElastiCacheClustersResponse:
+        d = _convert_keys(data)
         return cls(
             clusters=[
-                ElastiCacheCluster.from_dict(item) for item in data.get("clusters", [])
+                ElastiCacheCluster.from_dict(item) for item in d.get("clusters", [])
             ],
         )
 
@@ -180,10 +182,11 @@ class ElastiCacheReplicationGroupsResponse:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> ElastiCacheReplicationGroupsResponse:
+        d = _convert_keys(data)
         return cls(
             replication_groups=[
                 ElastiCacheReplicationGroupIntrospection.from_dict(item)
-                for item in data.get("replicationGroups", [])
+                for item in d.get("replication_groups", [])
             ],
         )
 
@@ -208,10 +211,11 @@ class ElastiCacheServerlessCachesResponse:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> ElastiCacheServerlessCachesResponse:
+        d = _convert_keys(data)
         return cls(
             serverless_caches=[
                 ElastiCacheServerlessCacheIntrospection.from_dict(item)
-                for item in data.get("serverlessCaches", [])
+                for item in d.get("serverless_caches", [])
             ],
         )
 


### PR DESCRIPTION
## Summary
- Added `_convert_keys(data)` call to all response class `from_dict` methods
- Fixed: `RdsInstancesResponse`, `ElastiCacheClustersResponse`, `ElastiCacheReplicationGroupsResponse`, `ElastiCacheServerlessCachesResponse`
- Ensures consistent key normalization (camelCase → snake_case) across all response types

## Test plan
- ✅ Existing E2E tests verify these response classes work correctly
- ✅ Tests already exercise RDS and ElastiCache introspection endpoints
- Changes align with existing pattern used in individual entity classes

Addresses Cubic P2 issue from PR #192.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize keys in Python SDK response classes by applying `_convert_keys` in each `from_dict`. RDS and ElastiCache responses now accept both camelCase and snake_case, preventing missing data for `instances`, `clusters`, `replication_groups`, and `serverless_caches`.

- **Refactors**
  - Applied Ruff formatting to `sdks/python/src/fakecloud/types.py`.

<sup>Written for commit 78b30b0d3e55a0299bbcb4adc2a9429ed212b6ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

