### PR TITLE
fix(rds): stop containers on read replica and snapshot restore failures

### DIFF
--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -1091,6 +1091,7 @@ impl RdsService {
             self.state
                 .write()
                 .cancel_instance_creation(&db_instance_identifier);
+            runtime.stop_container(&db_instance_identifier).await;
             return Err(runtime_error_to_service_error(e));
         }
 
@@ -1240,6 +1241,7 @@ impl RdsService {
             self.state
                 .write()
                 .cancel_instance_creation(&db_instance_identifier);
+            runtime.stop_container(&db_instance_identifier).await;
             return Err(runtime_error_to_service_error(e));
         }
 


### PR DESCRIPTION
## Summary
- Added `stop_container()` call when `restore_database` fails in read replica creation
- Added `stop_container()` call when `restore_database` fails in snapshot restore
- Ensures no dangling containers remain when async operations fail after container creation

## Test plan
- ✅ Existing tests verify normal paths work correctly
- ✅ Error paths now properly clean up containers via `stop_container()`
- Pattern: `cancel_instance_creation()` + `stop_container()` on all post-container errors

## Issue
Previously, if `restore_database` failed after `ensure_postgres` succeeded:
1. Container was created and running
2. `cancel_instance_creation` was called (releasing the identifier)
3. Container was NOT stopped, creating a dangling container
4. Instance identifier could be reused, but old container still running

## Fix
Now both error paths call `runtime.stop_container()` to ensure proper cleanup.

Addresses Cubic P1 issue from PR #210.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop RDS containers when read replica creation or snapshot restore fails after the container is started. This prevents dangling containers and resource leaks.

- **Bug Fixes**
  - Read replica: on `restore_database` error, call `cancel_instance_creation()` then `runtime.stop_container(db_instance_identifier)`.
  - Snapshot restore: on `restore_database` error, call `cancel_instance_creation()` then `runtime.stop_container(db_instance_identifier)`.

<sup>Written for commit f252e0225208b4f091bed565aaa12020b914fb0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

