### PR TITLE
feat(logs): implement CloudWatch Logs → Lambda/Kinesis subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -2144,6 +2145,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -15,6 +15,8 @@ pub struct DeliveryBus {
     eventbridge_sender: Option<Arc<dyn EventBridgeDelivery>>,
     /// Invoke a Lambda function by ARN.
     lambda_invoker: Option<Arc<dyn LambdaDelivery>>,
+    /// Put records to a Kinesis Data Stream by ARN.
+    kinesis_sender: Option<Arc<dyn KinesisDelivery>>,
 }
 
 /// Message attribute for SQS delivery from SNS.
@@ -72,6 +74,13 @@ pub trait LambdaDelivery: Send + Sync {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>, String>> + Send>>;
 }
 
+/// Trait for putting records to Kinesis Data Streams.
+pub trait KinesisDelivery: Send + Sync {
+    /// Put a record to a Kinesis stream identified by ARN.
+    /// The data should be base64-encoded. partition_key is used for shard distribution.
+    fn put_record(&self, stream_arn: &str, data: &str, partition_key: &str);
+}
+
 impl DeliveryBus {
     pub fn new() -> Self {
         Self {
@@ -79,6 +88,7 @@ impl DeliveryBus {
             sns_sender: None,
             eventbridge_sender: None,
             lambda_invoker: None,
+            kinesis_sender: None,
         }
     }
 
@@ -99,6 +109,11 @@ impl DeliveryBus {
 
     pub fn with_lambda(mut self, invoker: Arc<dyn LambdaDelivery>) -> Self {
         self.lambda_invoker = Some(invoker);
+        self
+    }
+
+    pub fn with_kinesis(mut self, sender: Arc<dyn KinesisDelivery>) -> Self {
+        self.kinesis_sender = Some(sender);
         self
     }
 
@@ -164,6 +179,13 @@ impl DeliveryBus {
             Some(invoker.invoke_lambda(function_arn, payload).await)
         } else {
             None
+        }
+    }
+
+    /// Put a record to a Kinesis stream identified by ARN.
+    pub fn send_to_kinesis(&self, stream_arn: &str, data: &str, partition_key: &str) {
+        if let Some(ref sender) = self.kinesis_sender {
+            sender.put_record(stream_arn, data, partition_key);
         }
     }
 }

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -315,3 +315,12 @@ async fn wait_for_port(child: &mut Child, port: u16) -> bool {
     }
     false
 }
+
+/// Decompress gzipped data
+pub fn gunzip(data: &[u8]) -> Vec<u8> {
+    use std::io::Read;
+    let mut decoder = flate2::read::GzDecoder::new(data);
+    let mut result = Vec::new();
+    decoder.read_to_end(&mut result).unwrap();
+    result
+}

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -317,6 +317,7 @@ async fn wait_for_port(child: &mut Child, port: u16) -> bool {
 }
 
 /// Decompress gzipped data
+#[allow(dead_code)]
 pub fn gunzip(data: &[u8]) -> Vec<u8> {
     use std::io::Read;
     let mut decoder = flate2::read::GzDecoder::new(data);

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -2167,3 +2167,293 @@ async fn logs_get_log_record() {
     // Returns a (possibly empty) map of fields
     let _ = resp.log_record();
 }
+
+// ---- Cross-service integrations: CloudWatch Logs → Lambda ----
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for Lambda execution"]
+async fn logs_subscription_filter_invokes_lambda() {
+    use std::io::Write;
+    use tokio::time::{sleep, Duration};
+
+    let server = TestServer::start().await;
+    let logs_client = server.logs_client().await;
+    let lambda_client = server.lambda_client().await;
+    let sqs_client = server.sqs_client().await;
+
+    // Create Lambda that echoes to SQS
+    let queue_resp = sqs_client
+        .create_queue()
+        .queue_name("logs-lambda-echo")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue_resp.queue_url().unwrap();
+
+    // Lambda code: logs the event to verify format
+    let lambda_code = format!(
+        r#"
+import json
+import urllib.request
+import urllib.parse
+import gzip
+import base64
+
+def lambda_handler(event, context):
+    # CloudWatch Logs sends data in event["awslogs"]["data"] as gzip+base64
+    data = event['awslogs']['data']
+    decoded = base64.b64decode(data)
+    decompressed = gzip.decompress(decoded).decode('utf-8')
+    payload = json.loads(decompressed)
+
+    # Echo subscription filter details to SQS using urllib
+    params = urllib.parse.urlencode({{
+        "Action": "SendMessage",
+        "QueueUrl": "{}",
+        "MessageBody": json.dumps({{
+            'logGroup': payload['logGroup'],
+            'logStream': payload['logStream'],
+            'logEvents': payload['logEvents']
+        }})
+    }}).encode()
+
+    req = urllib.request.Request("{}", data=params, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    req.add_header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20200101/us-east-1/sqs/aws4_request, SignedHeaders=host, Signature=fake")
+    urllib.request.urlopen(req)
+
+    return {{'statusCode': 200}}
+"#,
+        queue_url,
+        server.endpoint()
+    );
+
+    // Create ZIP with Lambda code
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    let options = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+    writer.start_file("lambda_function.py", options).unwrap();
+    writer.write_all(lambda_code.as_bytes()).unwrap();
+    let cursor = writer.finish().unwrap();
+    let zip_bytes = cursor.into_inner();
+
+    // Deploy Lambda
+    lambda_client
+        .create_function()
+        .function_name("logs-subscriber")
+        .runtime(aws_sdk_lambda::types::Runtime::Python313)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("lambda_function.lambda_handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(aws_sdk_lambda::primitives::Blob::new(zip_bytes))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let lambda_arn = "arn:aws:lambda:us-east-1:123456789012:function:logs-subscriber";
+
+    // Create log group and stream
+    logs_client
+        .create_log_group()
+        .log_group_name("/lambda-sub/test")
+        .send()
+        .await
+        .unwrap();
+    logs_client
+        .create_log_stream()
+        .log_group_name("/lambda-sub/test")
+        .log_stream_name("stream-1")
+        .send()
+        .await
+        .unwrap();
+
+    // Create subscription filter with Lambda destination
+    logs_client
+        .put_subscription_filter()
+        .log_group_name("/lambda-sub/test")
+        .filter_name("lambda-filter")
+        .filter_pattern("ERROR")
+        .destination_arn(lambda_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Put log events (some match, some don't)
+    let now = chrono::Utc::now().timestamp_millis();
+    logs_client
+        .put_log_events()
+        .log_group_name("/lambda-sub/test")
+        .log_stream_name("stream-1")
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now)
+                .message("ERROR: something broke")
+                .build()
+                .unwrap(),
+        )
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now + 1000)
+                .message("INFO: all good")
+                .build()
+                .unwrap(),
+        )
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now + 2000)
+                .message("ERROR: disk full")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Wait for async Lambda invocation via subscription filter
+    sleep(Duration::from_secs(3)).await;
+
+    // Verify Lambda was invoked with filtered log events
+    let messages = sqs_client
+        .receive_message()
+        .queue_url(queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+
+    let msgs = messages.messages();
+    assert_eq!(msgs.len(), 1, "Lambda should have echoed one message");
+
+    let body: Value = serde_json::from_str(msgs[0].body().unwrap()).unwrap();
+    assert_eq!(body["logGroup"], "/lambda-sub/test");
+    assert_eq!(body["logStream"], "stream-1");
+
+    let log_events = body["logEvents"].as_array().unwrap();
+    // Filter pattern "ERROR" should match only 2 events
+    assert_eq!(log_events.len(), 2, "Should have filtered 2 ERROR events");
+    assert!(log_events[0]["message"].as_str().unwrap().contains("ERROR"));
+    assert!(log_events[1]["message"].as_str().unwrap().contains("ERROR"));
+}
+
+// ---- Cross-service integrations: CloudWatch Logs → Kinesis ----
+
+#[tokio::test]
+async fn logs_subscription_filter_streams_to_kinesis() {
+    use tokio::time::{sleep, Duration};
+
+    let server = TestServer::start().await;
+    let logs_client = server.logs_client().await;
+    let kinesis_client = server.kinesis_client().await;
+
+    // Create Kinesis stream
+    kinesis_client
+        .create_stream()
+        .stream_name("logs-kinesis-test")
+        .shard_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    // Construct stream ARN (AWS format: arn:aws:kinesis:region:account:stream/StreamName)
+    let stream_arn = "arn:aws:kinesis:us-east-1:123456789012:stream/logs-kinesis-test";
+
+    // Create log group and stream
+    logs_client
+        .create_log_group()
+        .log_group_name("/kinesis-sub/test")
+        .send()
+        .await
+        .unwrap();
+    logs_client
+        .create_log_stream()
+        .log_group_name("/kinesis-sub/test")
+        .log_stream_name("stream-a")
+        .send()
+        .await
+        .unwrap();
+
+    // Create subscription filter with Kinesis destination
+    logs_client
+        .put_subscription_filter()
+        .log_group_name("/kinesis-sub/test")
+        .filter_name("kinesis-filter")
+        .filter_pattern("") // Empty pattern matches all events
+        .destination_arn(stream_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Put log events
+    let now = chrono::Utc::now().timestamp_millis();
+    logs_client
+        .put_log_events()
+        .log_group_name("/kinesis-sub/test")
+        .log_stream_name("stream-a")
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now)
+                .message("event one")
+                .build()
+                .unwrap(),
+        )
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now + 1000)
+                .message("event two")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Wait for async delivery
+    sleep(Duration::from_millis(500)).await;
+
+    // Get records from Kinesis stream
+    let shard_iterator_resp = kinesis_client
+        .get_shard_iterator()
+        .stream_name("logs-kinesis-test")
+        .shard_id("shardId-000000000000")
+        .shard_iterator_type(aws_sdk_kinesis::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let shard_iterator = shard_iterator_resp.shard_iterator().unwrap();
+
+    let records_resp = kinesis_client
+        .get_records()
+        .shard_iterator(shard_iterator)
+        .send()
+        .await
+        .unwrap();
+
+    let records = records_resp.records();
+    assert_eq!(
+        records.len(),
+        1,
+        "Should have one batched record in Kinesis"
+    );
+
+    // Decode the data - CloudWatch Logs sends gzipped+base64 data to Kinesis,
+    // but Kinesis stores it as raw bytes
+    let data_blob = records[0].data().as_ref();
+
+    // Data is already stored as raw bytes in Kinesis (the gzipped data)
+    // So we just need to decompress it
+    let decompressed = helpers::gunzip(data_blob);
+
+    let payload: Value = serde_json::from_slice(&decompressed).unwrap();
+
+    assert_eq!(payload["logGroup"], "/kinesis-sub/test");
+    assert_eq!(payload["logStream"], "stream-a");
+
+    let log_events = payload["logEvents"].as_array().unwrap();
+    assert_eq!(log_events.len(), 2);
+    assert_eq!(log_events[0]["message"], "event one");
+    assert_eq!(log_events[1]["message"], "event two");
+}

--- a/crates/fakecloud-kinesis/Cargo.toml
+++ b/crates/fakecloud-kinesis/Cargo.toml
@@ -17,6 +17,7 @@ md-5 = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/fakecloud-kinesis/src/delivery.rs
+++ b/crates/fakecloud-kinesis/src/delivery.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use fakecloud_core::delivery::KinesisDelivery;
+
+use crate::state::{KinesisRecord, SharedKinesisState};
+
+/// Kinesis delivery implementation for cross-service integrations.
+pub struct KinesisDeliveryImpl {
+    state: SharedKinesisState,
+}
+
+impl KinesisDeliveryImpl {
+    pub fn new(state: SharedKinesisState) -> Arc<Self> {
+        Arc::new(Self { state })
+    }
+}
+
+impl KinesisDelivery for KinesisDeliveryImpl {
+    fn put_record(&self, stream_arn: &str, data: &str, partition_key: &str) {
+        // Extract stream name from ARN: arn:aws:kinesis:region:account:stream/StreamName
+        let stream_name = if let Some(name_part) = stream_arn.split("/stream/").nth(1) {
+            name_part
+        } else if let Some(name_part) = stream_arn.split(':').next_back() {
+            // Fallback: take the last segment
+            name_part
+        } else {
+            // If it's not an ARN, assume it's the stream name
+            stream_arn
+        };
+
+        let mut state = self.state.write();
+        if let Some(stream) = state.streams.get_mut(stream_name) {
+            // Find the shard to write to based on partition key
+            // For simplicity, hash the partition key and mod by shard count
+            let shard_idx = if stream.shards.is_empty() {
+                0
+            } else {
+                partition_key
+                    .bytes()
+                    .fold(0u64, |acc, b| acc.wrapping_add(b as u64))
+                    % stream.shards.len() as u64
+            };
+
+            if let Some(shard) = stream.shards.get_mut(shard_idx as usize) {
+                let now = Utc::now();
+                let sequence_number = now.timestamp_nanos_opt().unwrap_or(0).to_string();
+
+                // Data is base64-encoded string, convert to bytes
+                let data_bytes = data.as_bytes().to_vec();
+
+                shard.records.push(KinesisRecord {
+                    sequence_number: sequence_number.clone(),
+                    partition_key: partition_key.to_string(),
+                    data: data_bytes,
+                    approximate_arrival_timestamp: now,
+                });
+
+                tracing::debug!(
+                    stream_name = %stream_name,
+                    partition_key = %partition_key,
+                    sequence_number = %sequence_number,
+                    "Delivered record to Kinesis stream"
+                );
+            }
+        } else {
+            tracing::warn!(
+                stream_arn = %stream_arn,
+                stream_name = %stream_name,
+                "Stream not found for Kinesis delivery"
+            );
+        }
+    }
+}

--- a/crates/fakecloud-kinesis/src/delivery.rs
+++ b/crates/fakecloud-kinesis/src/delivery.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use base64::Engine;
 use chrono::Utc;
 use fakecloud_core::delivery::KinesisDelivery;
 
@@ -19,13 +20,10 @@ impl KinesisDeliveryImpl {
 impl KinesisDelivery for KinesisDeliveryImpl {
     fn put_record(&self, stream_arn: &str, data: &str, partition_key: &str) {
         // Extract stream name from ARN: arn:aws:kinesis:region:account:stream/StreamName
-        let stream_name = if let Some(name_part) = stream_arn.split("/stream/").nth(1) {
-            name_part
-        } else if let Some(name_part) = stream_arn.split(':').next_back() {
-            // Fallback: take the last segment
+        let stream_name = if let Some(name_part) = stream_arn.rsplit('/').next() {
+            // Handles both arn:aws:kinesis:region:account:stream/Name and plain name
             name_part
         } else {
-            // If it's not an ARN, assume it's the stream name
             stream_arn
         };
 
@@ -46,8 +44,11 @@ impl KinesisDelivery for KinesisDeliveryImpl {
                 let now = Utc::now();
                 let sequence_number = now.timestamp_nanos_opt().unwrap_or(0).to_string();
 
-                // Data is base64-encoded string, convert to bytes
-                let data_bytes = data.as_bytes().to_vec();
+                // Data is base64-encoded; decode to raw bytes for storage.
+                // GetRecords will base64-encode when returning, matching AWS behavior.
+                let data_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(data)
+                    .unwrap_or_else(|_| data.as_bytes().to_vec());
 
                 shard.records.push(KinesisRecord {
                     sequence_number: sequence_number.clone(),

--- a/crates/fakecloud-kinesis/src/lib.rs
+++ b/crates/fakecloud-kinesis/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod delivery;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-logs/Cargo.toml
+++ b/crates/fakecloud-logs/Cargo.toml
@@ -20,6 +20,8 @@ uuid = { workspace = true }
 base64 = { workspace = true }
 flate2 = { workspace = true }
 regex = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -530,8 +530,47 @@ impl LogsService {
                 let compressed = encoder.finish().unwrap();
                 let encoded = base64::engine::general_purpose::STANDARD.encode(&compressed);
 
-                self.delivery_bus
-                    .send_to_sqs(destination_arn, &encoded, &HashMap::new());
+                // Route to the appropriate destination based on ARN
+                if destination_arn.contains(":sqs:") {
+                    self.delivery_bus
+                        .send_to_sqs(destination_arn, &encoded, &HashMap::new());
+                } else if destination_arn.contains(":lambda:") {
+                    // Lambda subscriptions receive the gzipped+base64 data in a special event format
+                    let lambda_event = json!({
+                        "awslogs": {
+                            "data": encoded,
+                        }
+                    });
+                    let lambda_payload = serde_json::to_string(&lambda_event).unwrap();
+                    tokio::spawn({
+                        let bus = self.delivery_bus.clone();
+                        let arn = destination_arn.clone();
+                        async move {
+                            if let Some(result) = bus.invoke_lambda(&arn, &lambda_payload).await {
+                                match result {
+                                    Ok(_) => {
+                                        tracing::debug!(
+                                            function_arn = %arn,
+                                            "CloudWatch Logs -> Lambda subscription delivered"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            function_arn = %arn,
+                                            error = %e,
+                                            "CloudWatch Logs -> Lambda subscription failed"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    });
+                } else if destination_arn.contains(":kinesis:") {
+                    // Kinesis subscriptions receive the gzipped+base64 data as the record data
+                    let partition_key = format!("{}-{}", group_name_owned, stream_name_owned);
+                    self.delivery_bus
+                        .send_to_kinesis(destination_arn, &encoded, &partition_key);
+                }
             }
         }
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -223,9 +223,18 @@ async fn main() {
         Arc::new(bus)
     };
 
-    // Step 4: Logs delivery (subscription filters can push to SQS)
+    // Step 4: Logs delivery (subscription filters can push to SQS, Lambda, and Kinesis)
     let sqs_delivery_for_ses = sqs_delivery.clone();
-    let delivery_for_logs = Arc::new(DeliveryBus::new().with_sqs(sqs_delivery));
+    let kinesis_delivery = fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(
+        kinesis_state.clone(),
+    );
+    let mut delivery_for_logs = DeliveryBus::new()
+        .with_sqs(sqs_delivery)
+        .with_kinesis(kinesis_delivery);
+    if let Some(ref ld) = lambda_delivery {
+        delivery_for_logs = delivery_for_logs.with_lambda(ld.clone());
+    }
+    let delivery_for_logs = Arc::new(delivery_for_logs);
 
     // Clone state refs for internal endpoints
     let lambda_invocations_state = lambda_state.clone();

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -225,9 +225,8 @@ async fn main() {
 
     // Step 4: Logs delivery (subscription filters can push to SQS, Lambda, and Kinesis)
     let sqs_delivery_for_ses = sqs_delivery.clone();
-    let kinesis_delivery = fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(
-        kinesis_state.clone(),
-    );
+    let kinesis_delivery =
+        fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
     let mut delivery_for_logs = DeliveryBus::new()
         .with_sqs(sqs_delivery)
         .with_kinesis(kinesis_delivery);


### PR DESCRIPTION
## Summary

Implements CloudWatch Logs subscription filters delivering log events to Lambda functions and Kinesis Data Streams.

- Add KinesisDelivery trait to DeliveryBus for cross-service Kinesis integration
- Implement KinesisDeliveryImpl with shard distribution via partition key hashing  
- Wire KinesisDeliveryImpl and Lambda delivery into CloudWatch Logs service
- Extend logs subscription filter routing to support Lambda and Kinesis destinations
- Add E2E tests for CloudWatch Logs → Lambda and → Kinesis subscription filters

The subscription filter delivery now routes based on destination ARN type:
- SQS: delivers gzipped+base64 log events directly
- Lambda: wraps in `{"awslogs": {"data": "<base64>"}}` format and invokes async
- Kinesis: sends gzipped+base64 data with partition key `{logGroup}-{logStream}`

All log event data is gzip-compressed and base64-encoded before delivery to match AWS CloudWatch Logs behavior.

## Test plan

- [x] Unit tests pass
- [x] Clippy passes for logs, kinesis, and server packages
- [x] E2E tests added for CloudWatch Logs → Lambda and → Kinesis
- [ ] CI checks pass
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudWatch Logs subscription filters that deliver to Lambda and Kinesis, alongside existing SQS support. Fixes Kinesis ARN parsing and data encoding to match AWS behavior.

- **New Features**
  - Added `KinesisDelivery` to `DeliveryBus` and `KinesisDeliveryImpl` with partition-key hashing.
  - Routed by destination ARN (`:sqs:`, `:lambda:`, `:kinesis:`) in `fakecloud-logs`; formats:
    - SQS: gzipped+base64 batch.
    - Lambda: async invoke with `{"awslogs":{"data":"<base64>"}}`.
    - Kinesis: gzipped+base64 record, partition key `{logGroup}-{logStream}`.
  - E2E tests for Logs → Lambda and Logs → Kinesis; added `gunzip` test helper.

- **Bug Fixes**
  - Fixed Kinesis stream name extraction from ARN using `rsplit('/')` for `...:stream/<name>`.
  - Base64-decode before storing Kinesis record data to avoid double-encoding; `GetRecords` returns base64 as expected.

<sup>Written for commit f3774020bb31e2b1147d5b2c71b4b9a52473e770. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

