### PR TITLE
feat(integrations): add DynamoDB SSE, S3→EventBridge, DynamoDB→Kinesis streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,6 +1964,7 @@ name = "fakecloud-dynamodb"
 version = "0.6.1"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "fakecloud-aws",

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -662,6 +662,8 @@ impl ResourceProvisioner {
             stream_view_type: None,
             stream_arn: None,
             stream_records: Arc::new(RwLock::new(Vec::new())),
+            sse_type: None,
+            sse_kms_key_arn: None,
         };
 
         state.tables.insert(table_name.to_string(), table);

--- a/crates/fakecloud-dynamodb/Cargo.toml
+++ b/crates/fakecloud-dynamodb/Cargo.toml
@@ -12,6 +12,7 @@ fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-s3 = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -2,11 +2,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use base64::Engine;
 use chrono::Utc;
 use http::StatusCode;
 use parking_lot::RwLock;
 use serde_json::{json, Value};
 
+use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -22,6 +24,7 @@ use crate::state::{
 pub struct DynamoDbService {
     state: SharedDynamoDbState,
     s3_state: Option<SharedS3State>,
+    delivery: Option<Arc<DeliveryBus>>,
 }
 
 impl DynamoDbService {
@@ -29,12 +32,74 @@ impl DynamoDbService {
         Self {
             state,
             s3_state: None,
+            delivery: None,
         }
     }
 
     pub fn with_s3(mut self, s3_state: SharedS3State) -> Self {
         self.s3_state = Some(s3_state);
         self
+    }
+
+    pub fn with_delivery(mut self, delivery: Arc<DeliveryBus>) -> Self {
+        self.delivery = Some(delivery);
+        self
+    }
+
+    /// Deliver a change record to all active Kinesis streaming destinations for a table.
+    fn deliver_to_kinesis_destinations(
+        &self,
+        table: &DynamoTable,
+        event_name: &str,
+        keys: &HashMap<String, AttributeValue>,
+        old_image: Option<&HashMap<String, AttributeValue>>,
+        new_image: Option<&HashMap<String, AttributeValue>>,
+    ) {
+        let delivery = match &self.delivery {
+            Some(d) => d,
+            None => return,
+        };
+
+        let active_destinations: Vec<_> = table
+            .kinesis_destinations
+            .iter()
+            .filter(|d| d.destination_status == "ACTIVE")
+            .collect();
+
+        if active_destinations.is_empty() {
+            return;
+        }
+
+        let mut record = json!({
+            "eventID": uuid::Uuid::new_v4().to_string(),
+            "eventName": event_name,
+            "eventVersion": "1.1",
+            "eventSource": "aws:dynamodb",
+            "awsRegion": table.arn.split(':').nth(3).unwrap_or("us-east-1"),
+            "dynamodb": {
+                "Keys": keys,
+                "SequenceNumber": chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0).to_string(),
+                "SizeBytes": serde_json::to_string(keys).map(|s| s.len()).unwrap_or(0),
+                "StreamViewType": "NEW_AND_OLD_IMAGES",
+            },
+            "eventSourceARN": &table.arn,
+            "tableName": &table.name,
+        });
+
+        if let Some(old) = old_image {
+            record["dynamodb"]["OldImage"] = json!(old);
+        }
+        if let Some(new) = new_image {
+            record["dynamodb"]["NewImage"] = json!(new);
+        }
+
+        let record_str = serde_json::to_string(&record).unwrap_or_default();
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&record_str);
+        let partition_key = serde_json::to_string(keys).unwrap_or_default();
+
+        for dest in active_destinations {
+            delivery.send_to_kinesis(&dest.stream_arn, &encoded, &partition_key);
+        }
     }
 
     fn parse_body(req: &AwsRequest) -> Result<Value, AwsServiceError> {
@@ -132,6 +197,30 @@ impl DynamoDbService {
                 (false, None)
             };
 
+        // Parse SSESpecification
+        let (sse_type, sse_kms_key_arn) = if let Some(sse_spec) = body.get("SSESpecification") {
+            let enabled = sse_spec
+                .get("Enabled")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if enabled {
+                let sse_type = sse_spec
+                    .get("SSEType")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("KMS")
+                    .to_string();
+                let kms_key = sse_spec
+                    .get("KMSMasterKeyId")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                (Some(sse_type), kms_key)
+            } else {
+                (None, None)
+            }
+        } else {
+            (None, None)
+        };
+
         let mut state = self.state.write();
 
         if state.tables.contains_key(&table_name) {
@@ -185,6 +274,8 @@ impl DynamoDbService {
             stream_view_type,
             stream_arn,
             stream_records: Arc::new(RwLock::new(Vec::new())),
+            sse_type,
+            sse_kms_key_arn,
         };
 
         state.tables.insert(table_name, table);
@@ -317,6 +408,30 @@ impl DynamoDbService {
             table.billing_mode = bm.to_string();
         }
 
+        // Handle SSESpecification update
+        if let Some(sse_spec) = body.get("SSESpecification") {
+            let enabled = sse_spec
+                .get("Enabled")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if enabled {
+                table.sse_type = Some(
+                    sse_spec
+                        .get("SSEType")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("KMS")
+                        .to_string(),
+                );
+                table.sse_kms_key_arn = sse_spec
+                    .get("KMSMasterKeyId")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+            } else {
+                table.sse_type = None;
+                table.sse_kms_key_arn = None;
+            }
+        }
+
         let table_desc = build_table_description_json(
             &table.arn,
             &table.key_schema,
@@ -347,7 +462,8 @@ impl DynamoDbService {
         let return_values = body["ReturnValues"].as_str().unwrap_or("NONE").to_string();
 
         // --- Acquire write lock ONLY for validation + mutation ---
-        let old_item = {
+        // Capture kinesis delivery info alongside the return value
+        let (old_item, kinesis_info) = {
             let mut state = self.state.write();
             let table = get_table_mut(&mut state.tables, table_name)?;
 
@@ -367,8 +483,13 @@ impl DynamoDbService {
                 None
             };
 
-            // Capture old item for stream record if needed
-            let old_item_for_stream = if table.stream_enabled {
+            // Capture old item for stream/kinesis if needed
+            let needs_change_capture = table.stream_enabled
+                || table
+                    .kinesis_destinations
+                    .iter()
+                    .any(|d| d.destination_status == "ACTIVE");
+            let old_item_for_stream = if needs_change_capture {
                 existing_idx.map(|i| table.items[i].clone())
             } else {
                 None
@@ -385,24 +506,53 @@ impl DynamoDbService {
             table.record_item_access(&item);
             table.recalculate_stats();
 
+            let event_name = if is_modify { "MODIFY" } else { "INSERT" };
+            let key = extract_key(table, &item);
+
             // Generate stream record
             if table.stream_enabled {
-                let key = extract_key(table, &item);
-                let event_name = if is_modify { "MODIFY" } else { "INSERT" };
                 if let Some(record) = crate::streams::generate_stream_record(
                     table,
                     event_name,
-                    key,
-                    old_item_for_stream,
+                    key.clone(),
+                    old_item_for_stream.clone(),
                     Some(item.clone()),
                 ) {
                     crate::streams::add_stream_record(table, record);
                 }
             }
 
-            old_item_for_return
+            // Capture kinesis delivery info (delivered after lock release)
+            let kinesis_info = if table
+                .kinesis_destinations
+                .iter()
+                .any(|d| d.destination_status == "ACTIVE")
+            {
+                Some((
+                    table.clone(),
+                    event_name.to_string(),
+                    key,
+                    old_item_for_stream,
+                    Some(item.clone()),
+                ))
+            } else {
+                None
+            };
+
+            (old_item_for_return, kinesis_info)
         };
         // --- Write lock released, build response ---
+
+        // Deliver to Kinesis destinations outside the lock
+        if let Some((table, event_name, keys, old_image, new_image)) = kinesis_info {
+            self.deliver_to_kinesis_destinations(
+                &table,
+                &event_name,
+                &keys,
+                old_image.as_ref(),
+                new_image.as_ref(),
+            );
+        }
 
         let mut result = json!({});
         if let Some(old) = old_item {
@@ -479,61 +629,80 @@ impl DynamoDbService {
         let table_name = require_str(&body, "TableName")?;
         let key = require_object(&body, "Key")?;
 
-        let mut state = self.state.write();
-        let table = get_table_mut(&mut state.tables, table_name)?;
+        let (result, kinesis_info) = {
+            let mut state = self.state.write();
+            let table = get_table_mut(&mut state.tables, table_name)?;
 
-        let condition = body["ConditionExpression"].as_str();
-        let expr_attr_names = parse_expression_attribute_names(&body);
-        let expr_attr_values = parse_expression_attribute_values(&body);
+            let condition = body["ConditionExpression"].as_str();
+            let expr_attr_names = parse_expression_attribute_names(&body);
+            let expr_attr_values = parse_expression_attribute_values(&body);
 
-        let existing_idx = table.find_item_index(&key);
+            let existing_idx = table.find_item_index(&key);
 
-        if let Some(cond) = condition {
-            let existing = existing_idx.map(|i| &table.items[i]);
-            evaluate_condition(cond, existing, &expr_attr_names, &expr_attr_values)?;
-        }
-
-        let return_values = body["ReturnValues"].as_str().unwrap_or("NONE");
-
-        let return_consumed = body["ReturnConsumedCapacity"].as_str().unwrap_or("NONE");
-        let return_icm = body["ReturnItemCollectionMetrics"]
-            .as_str()
-            .unwrap_or("NONE");
-
-        let mut result = json!({});
-
-        if let Some(idx) = existing_idx {
-            let old_item = table.items[idx].clone();
-            if return_values == "ALL_OLD" {
-                result["Attributes"] = json!(old_item);
+            if let Some(cond) = condition {
+                let existing = existing_idx.map(|i| &table.items[i]);
+                evaluate_condition(cond, existing, &expr_attr_names, &expr_attr_values)?;
             }
 
-            // Generate stream record before removing
-            if table.stream_enabled {
-                if let Some(record) = crate::streams::generate_stream_record(
-                    table,
-                    "REMOVE",
-                    key.clone(),
-                    Some(old_item),
-                    None,
-                ) {
-                    crate::streams::add_stream_record(table, record);
+            let return_values = body["ReturnValues"].as_str().unwrap_or("NONE");
+
+            let mut result = json!({});
+            let mut kinesis_info = None;
+
+            if let Some(idx) = existing_idx {
+                let old_item = table.items[idx].clone();
+                if return_values == "ALL_OLD" {
+                    result["Attributes"] = json!(old_item.clone());
                 }
+
+                // Generate stream record before removing
+                if table.stream_enabled {
+                    if let Some(record) = crate::streams::generate_stream_record(
+                        table,
+                        "REMOVE",
+                        key.clone(),
+                        Some(old_item.clone()),
+                        None,
+                    ) {
+                        crate::streams::add_stream_record(table, record);
+                    }
+                }
+
+                // Capture kinesis delivery info
+                if table
+                    .kinesis_destinations
+                    .iter()
+                    .any(|d| d.destination_status == "ACTIVE")
+                {
+                    kinesis_info = Some((table.clone(), key.clone(), Some(old_item)));
+                }
+
+                table.items.remove(idx);
+                table.recalculate_stats();
             }
 
-            table.items.remove(idx);
-            table.recalculate_stats();
-        }
+            let return_consumed = body["ReturnConsumedCapacity"].as_str().unwrap_or("NONE");
+            let return_icm = body["ReturnItemCollectionMetrics"]
+                .as_str()
+                .unwrap_or("NONE");
 
-        if return_consumed == "TOTAL" || return_consumed == "INDEXES" {
-            result["ConsumedCapacity"] = json!({
-                "TableName": table_name,
-                "CapacityUnits": 1.0,
-            });
-        }
+            if return_consumed == "TOTAL" || return_consumed == "INDEXES" {
+                result["ConsumedCapacity"] = json!({
+                    "TableName": table_name,
+                    "CapacityUnits": 1.0,
+                });
+            }
 
-        if return_icm == "SIZE" {
-            result["ItemCollectionMetrics"] = json!({});
+            if return_icm == "SIZE" {
+                result["ItemCollectionMetrics"] = json!({});
+            }
+
+            (result, kinesis_info)
+        };
+
+        // Deliver to Kinesis destinations outside the lock
+        if let Some((table, keys, old_image)) = kinesis_info {
+            self.deliver_to_kinesis_destinations(&table, "REMOVE", &keys, old_image.as_ref(), None);
         }
 
         Self::ok_json(result)
@@ -576,8 +745,13 @@ impl DynamoDbService {
             }
         };
 
-        // Capture old item for stream (before update)
-        let old_item_for_stream = if table.stream_enabled {
+        // Capture old item for stream/kinesis (before update)
+        let needs_change_capture = table.stream_enabled
+            || table
+                .kinesis_destinations
+                .iter()
+                .any(|d| d.destination_status == "ACTIVE");
+        let old_item_for_stream = if needs_change_capture {
             Some(table.items[idx].clone())
         } else {
             None
@@ -604,22 +778,54 @@ impl DynamoDbService {
             None
         };
 
+        let event_name = if is_insert { "INSERT" } else { "MODIFY" };
+        let new_item_for_stream = table.items[idx].clone();
+
         // Generate stream record after update
         if table.stream_enabled {
-            let event_name = if is_insert { "INSERT" } else { "MODIFY" };
-            let new_item_for_stream = table.items[idx].clone();
             if let Some(record) = crate::streams::generate_stream_record(
                 table,
                 event_name,
                 key.clone(),
-                old_item_for_stream,
-                Some(new_item_for_stream),
+                old_item_for_stream.clone(),
+                Some(new_item_for_stream.clone()),
             ) {
                 crate::streams::add_stream_record(table, record);
             }
         }
 
+        // Capture kinesis delivery info
+        let kinesis_info = if table
+            .kinesis_destinations
+            .iter()
+            .any(|d| d.destination_status == "ACTIVE")
+        {
+            Some((
+                table.clone(),
+                event_name.to_string(),
+                key.clone(),
+                old_item_for_stream,
+                Some(new_item_for_stream),
+            ))
+        } else {
+            None
+        };
+
         table.recalculate_stats();
+
+        // Release the write lock (drop `state`)
+        drop(state);
+
+        // Deliver to Kinesis destinations outside the lock
+        if let Some((tbl, ev, keys, old_image, new_image)) = kinesis_info {
+            self.deliver_to_kinesis_destinations(
+                &tbl,
+                &ev,
+                &keys,
+                old_image.as_ref(),
+                new_image.as_ref(),
+            );
+        }
 
         let mut result = json!({});
         if let Some(old) = old_item {
@@ -1897,6 +2103,8 @@ impl DynamoDbService {
             stream_view_type: None,
             stream_arn: None,
             stream_records: Arc::new(RwLock::new(Vec::new())),
+            sse_type: None,
+            sse_kms_key_arn: None,
         };
         table.recalculate_stats();
 
@@ -1972,6 +2180,8 @@ impl DynamoDbService {
             stream_view_type: None,
             stream_arn: None,
             stream_records: Arc::new(RwLock::new(Vec::new())),
+            sse_type: None,
+            sse_kms_key_arn: None,
         };
         table.recalculate_stats();
 
@@ -2897,6 +3107,8 @@ impl DynamoDbService {
             stream_view_type: None,
             stream_arn: None,
             stream_records: Arc::new(RwLock::new(Vec::new())),
+            sse_type: None,
+            sse_kms_key_arn: None,
         };
         table.recalculate_stats();
         state.tables.insert(table_name.to_string(), table);
@@ -4541,6 +4753,24 @@ fn build_table_description(table: &DynamoTable) -> Value {
                 "StreamViewType": view_type,
             });
         }
+    }
+
+    // Add SSE description
+    if let Some(ref sse_type) = table.sse_type {
+        let mut sse_desc = json!({
+            "Status": "ENABLED",
+            "SSEType": sse_type,
+        });
+        if let Some(ref key_arn) = table.sse_kms_key_arn {
+            sse_desc["KMSMasterKeyArn"] = json!(key_arn);
+        }
+        desc["SSEDescription"] = sse_desc;
+    } else {
+        // Default: AWS owned key encryption (always enabled in real AWS)
+        desc["SSEDescription"] = json!({
+            "Status": "ENABLED",
+            "SSEType": "AES256",
+        });
     }
 
     desc

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -91,6 +91,10 @@ pub struct DynamoTable {
     pub stream_arn: Option<String>,
     /// Stream records (retained for 24 hours)
     pub stream_records: Arc<RwLock<Vec<StreamRecord>>>,
+    /// Server-side encryption type: AES256 (owned) or KMS
+    pub sse_type: Option<String>,
+    /// KMS key ARN for SSE (only when sse_type is KMS)
+    pub sse_kms_key_arn: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/fakecloud-dynamodb/src/ttl.rs
+++ b/crates/fakecloud-dynamodb/src/ttl.rs
@@ -106,6 +106,8 @@ mod tests {
             stream_view_type: None,
             stream_arn: None,
             stream_records: Arc::new(RwLock::new(Vec::new())),
+            sse_type: None,
+            sse_kms_key_arn: None,
         }
     }
 

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -4,8 +4,8 @@ use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, BillingMode, ContributorInsightsAction, Delete,
     DeleteRequest, Get, GlobalSecondaryIndex, KeySchemaElement, KeyType,
     PointInTimeRecoverySpecification, Projection, ProjectionType, ProvisionedThroughput, Put,
-    PutRequest, Replica, ScalarAttributeType, Tag, TimeToLiveSpecification, TransactGetItem,
-    TransactWriteItem, WriteRequest,
+    PutRequest, Replica, ScalarAttributeType, SseSpecification, SseType, Tag,
+    TimeToLiveSpecification, TransactGetItem, TransactWriteItem, WriteRequest,
 };
 use helpers::TestServer;
 use std::collections::HashMap;
@@ -2388,4 +2388,213 @@ async fn dynamodb_ttl_processor_tick() {
         .unwrap();
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["expiredItems"], 0, "no more items to expire");
+}
+
+#[tokio::test]
+async fn dynamodb_sse_specification_kms() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    let kms_key_id = "arn:aws:kms:us-east-1:123456789012:key/test-key-id";
+
+    // Create table with KMS SSE
+    client
+        .create_table()
+        .table_name("SseTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .sse_specification(
+            SseSpecification::builder()
+                .enabled(true)
+                .sse_type(SseType::Kms)
+                .kms_master_key_id(kms_key_id)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Describe table and verify SSEDescription
+    let desc = client
+        .describe_table()
+        .table_name("SseTable")
+        .send()
+        .await
+        .unwrap();
+    let table = desc.table().unwrap();
+    let sse = table.sse_description().unwrap();
+    assert_eq!(sse.status().unwrap().as_str(), "ENABLED");
+    assert_eq!(sse.sse_type().unwrap().as_str(), "KMS");
+    assert_eq!(sse.kms_master_key_arn().unwrap(), kms_key_id);
+}
+
+#[tokio::test]
+async fn dynamodb_sse_default_aes256() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    // Create table without SSE spec — should default to AES256
+    client
+        .create_table()
+        .table_name("DefaultSseTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_table()
+        .table_name("DefaultSseTable")
+        .send()
+        .await
+        .unwrap();
+    let table = desc.table().unwrap();
+    let sse = table.sse_description().unwrap();
+    assert_eq!(sse.status().unwrap().as_str(), "ENABLED");
+    assert_eq!(sse.sse_type().unwrap().as_str(), "AES256");
+}
+
+#[tokio::test]
+async fn dynamodb_kinesis_streaming_delivers_records() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let kinesis = server.kinesis_client().await;
+
+    // Create Kinesis stream
+    kinesis
+        .create_stream()
+        .stream_name("ddb-changes")
+        .shard_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    // Create DynamoDB table
+    ddb.create_table()
+        .table_name("StreamedTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Enable Kinesis streaming destination
+    let stream_arn = "arn:aws:kinesis:us-east-1:123456789012:stream/ddb-changes";
+    ddb.enable_kinesis_streaming_destination()
+        .table_name("StreamedTable")
+        .stream_arn(stream_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Get a shard iterator (TRIM_HORIZON to read from beginning)
+    let desc = kinesis
+        .describe_stream()
+        .stream_name("ddb-changes")
+        .send()
+        .await
+        .unwrap();
+    let shard_id = desc
+        .stream_description()
+        .unwrap()
+        .shards()
+        .first()
+        .unwrap()
+        .shard_id()
+        .to_string();
+
+    let iter_resp = kinesis
+        .get_shard_iterator()
+        .stream_name("ddb-changes")
+        .shard_id(&shard_id)
+        .shard_iterator_type(aws_sdk_kinesis::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let shard_iterator = iter_resp.shard_iterator().unwrap().to_string();
+
+    // Put an item into DynamoDB
+    ddb.put_item()
+        .table_name("StreamedTable")
+        .item("pk", AttributeValue::S("item1".to_string()))
+        .item("data", AttributeValue::S("hello".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    // Delete the item
+    ddb.delete_item()
+        .table_name("StreamedTable")
+        .key("pk", AttributeValue::S("item1".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    // Read records from Kinesis
+    let records_resp = kinesis
+        .get_records()
+        .shard_iterator(&shard_iterator)
+        .send()
+        .await
+        .unwrap();
+
+    let records = records_resp.records();
+    assert!(
+        records.len() >= 2,
+        "expected at least 2 Kinesis records (INSERT + REMOVE), got {}",
+        records.len()
+    );
+
+    // Parse first record (INSERT) — data is raw JSON bytes
+    let insert_event: serde_json::Value =
+        serde_json::from_slice(records[0].data().as_ref()).unwrap();
+    assert_eq!(insert_event["eventName"], "INSERT");
+    assert_eq!(insert_event["eventSource"], "aws:dynamodb");
+    assert!(insert_event["dynamodb"]["NewImage"].is_object());
+
+    // Parse second record (REMOVE)
+    let remove_event: serde_json::Value =
+        serde_json::from_slice(records[1].data().as_ref()).unwrap();
+    assert_eq!(remove_event["eventName"], "REMOVE");
+    assert!(remove_event["dynamodb"]["OldImage"].is_object());
 }

--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -1,6 +1,7 @@
 mod helpers;
 
 use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_sqs::types::QueueAttributeName;
 use helpers::TestServer;
 
 #[tokio::test]
@@ -4013,4 +4014,113 @@ async fn s3_simulation_lifecycle_tick_expires_objects() {
         .await
         .unwrap();
     assert_eq!(resp.key_count().unwrap_or(0), 0);
+}
+
+#[tokio::test]
+async fn s3_eventbridge_notification() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    let eb = server.eventbridge_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create S3 bucket
+    s3.create_bucket()
+        .bucket("eb-notif-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // Create SQS queue to receive events via EventBridge
+    let queue = sqs
+        .create_queue()
+        .queue_name("s3-eb-target")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = attrs
+        .attributes()
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+
+    // Create EventBridge rule matching S3 events
+    eb.put_rule()
+        .name("s3-eb-rule")
+        .event_pattern(r#"{"source": ["aws.s3"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    eb.put_targets()
+        .rule("s3-eb-rule")
+        .targets(
+            aws_sdk_eventbridge::types::Target::builder()
+                .id("sqs-target")
+                .arn(&queue_arn)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Enable EventBridge notifications on the bucket via CLI
+    let notif_config = r#"{"EventBridgeConfiguration":{}}"#;
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "put-bucket-notification-configuration",
+            "--bucket",
+            "eb-notif-bucket",
+            "--notification-configuration",
+            notif_config,
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "put notification config failed: {}",
+        output.stderr_text()
+    );
+
+    // Upload an object to trigger S3→EventBridge notification
+    s3.put_object()
+        .bucket("eb-notif-bucket")
+        .key("test-file.txt")
+        .body(ByteStream::from_static(b"hello eventbridge"))
+        .send()
+        .await
+        .unwrap();
+
+    // Read events from SQS (delivered via EventBridge rule)
+    let msgs = sqs
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(
+        !msgs.messages().is_empty(),
+        "expected at least one S3→EventBridge event in SQS"
+    );
+
+    let body: serde_json::Value = serde_json::from_str(msgs.messages()[0].body().unwrap()).unwrap();
+    assert_eq!(body["source"], "aws.s3");
+    assert!(
+        body["detail-type"].as_str().unwrap().contains("Object"),
+        "detail-type should mention Object, got: {}",
+        body["detail-type"]
+    );
+    assert_eq!(body["detail"]["bucket"]["name"], "eb-notif-bucket");
+    assert_eq!(body["detail"]["object"]["key"], "test-file.txt");
 }

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -282,6 +282,8 @@ impl S3Service {
             .buckets
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
+        // Check if EventBridgeConfiguration is present (any tag, even empty/self-closing)
+        b.eventbridge_enabled = body_str.contains("EventBridgeConfiguration");
         // Auto-generate Id for each configuration element if missing
         let normalized = normalize_notification_ids(&body_str);
         b.notification_config = Some(normalized);
@@ -297,13 +299,19 @@ impl S3Service {
             .buckets
             .get(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        let body = match &b.notification_config {
+        let mut body = match &b.notification_config {
             Some(config) => config.clone(),
             None => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
                      <NotificationConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
                      </NotificationConfiguration>"
                 .to_string(),
         };
+        // Ensure EventBridgeConfiguration is in response if enabled
+        if b.eventbridge_enabled && !body.contains("EventBridgeConfiguration") {
+            if let Some(pos) = body.find("</NotificationConfiguration>") {
+                body.insert_str(pos, "<EventBridgeConfiguration/>");
+            }
+        }
         Ok(s3_xml(StatusCode::OK, body))
     }
 

--- a/crates/fakecloud-s3/src/service/notifications.rs
+++ b/crates/fakecloud-s3/src/service/notifications.rs
@@ -515,6 +515,32 @@ pub(crate) fn deliver_notifications(
     let s3_event_name = format!("s3:{event_name}");
     let message = build_s3_event_notification(event_name, bucket_name, key, size, etag, region);
 
+    // Deliver to EventBridge if enabled for this bucket
+    let eventbridge_enabled = s3_state
+        .and_then(|st| {
+            let state = st.read();
+            state
+                .buckets
+                .get(bucket_name)
+                .map(|b| b.eventbridge_enabled)
+        })
+        .unwrap_or(false);
+    if eventbridge_enabled {
+        let detail = serde_json::json!({
+            "version": "0",
+            "bucket": { "name": bucket_name },
+            "object": { "key": key, "size": size, "etag": etag },
+            "request-id": uuid::Uuid::new_v4().to_string(),
+            "requester": "123456789012",
+        });
+        delivery.put_event_to_eventbridge(
+            "aws.s3",
+            &format!("Object {event_name}"),
+            &detail.to_string(),
+            "default",
+        );
+    }
+
     let mut delivered = false;
 
     for target in &targets {

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -117,6 +117,8 @@ pub struct S3Bucket {
     pub replication_config: Option<String>,
     pub ownership_controls: Option<String>,
     pub inventory_configs: HashMap<String, String>,
+    /// Whether EventBridge notifications are enabled for this bucket.
+    pub eventbridge_enabled: bool,
 }
 
 impl S3Bucket {
@@ -152,6 +154,7 @@ impl S3Bucket {
             replication_config: None,
             ownership_controls: None,
             inventory_configs: HashMap::new(),
+            eventbridge_enabled: false,
         }
     }
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -211,12 +211,19 @@ async fn main() {
             .with_sns(sns_delivery.clone()),
     );
 
-    // Step 3: S3 delivery (S3 notifications can push to SQS, SNS, and Lambda)
+    // Step 3: S3 delivery (S3 notifications can push to SQS, SNS, Lambda, and EventBridge)
     let sns_delivery_for_ses = sns_delivery.clone();
+    let eb_delivery_for_s3 = Arc::new(
+        fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
+            eb_state.clone(),
+            Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+        ),
+    );
     let delivery_for_s3 = {
         let mut bus = DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())
-            .with_sns(sns_delivery);
+            .with_sns(sns_delivery)
+            .with_eventbridge(eb_delivery_for_s3);
         if let Some(ref ld) = lambda_delivery {
             bus = bus.with_lambda(ld.clone());
         }
@@ -227,13 +234,19 @@ async fn main() {
     let sqs_delivery_for_ses = sqs_delivery.clone();
     let kinesis_delivery =
         fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
+    let kinesis_delivery_for_dynamodb =
+        fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
     let mut delivery_for_logs = DeliveryBus::new()
-        .with_sqs(sqs_delivery)
+        .with_sqs(sqs_delivery.clone())
         .with_kinesis(kinesis_delivery);
     if let Some(ref ld) = lambda_delivery {
         delivery_for_logs = delivery_for_logs.with_lambda(ld.clone());
     }
     let delivery_for_logs = Arc::new(delivery_for_logs);
+
+    // Step 4b: DynamoDB delivery (Kinesis streaming destinations)
+    let delivery_for_dynamodb =
+        Arc::new(DeliveryBus::new().with_kinesis(kinesis_delivery_for_dynamodb));
 
     // Clone state refs for internal endpoints
     let lambda_invocations_state = lambda_state.clone();
@@ -342,7 +355,9 @@ async fn main() {
         SsmService::new(ssm_state).with_secretsmanager(secretsmanager_state.clone()),
     ));
     registry.register(Arc::new(
-        DynamoDbService::new(dynamodb_state.clone()).with_s3(s3_state.clone()),
+        DynamoDbService::new(dynamodb_state.clone())
+            .with_s3(s3_state.clone())
+            .with_delivery(delivery_for_dynamodb),
     ));
     let mut lambda_service = LambdaService::new(lambda_state.clone());
     if let Some(ref rt) = container_runtime {


### PR DESCRIPTION
## Summary

- **DynamoDB SSESpecification**: CreateTable/UpdateTable accept SSESpecification with SSEType (AES256/KMS) and KMSMasterKeyId, returned as SSEDescription in DescribeTable. Default tables report AES256 encryption.
- **S3 → EventBridge**: PutBucketNotificationConfiguration with EventBridgeConfiguration enables all S3 events to flow to EventBridge rules with correct `aws.s3` source and detail payload.
- **DynamoDB → Kinesis**: EnableKinesisStreamingDestination now actually delivers base64-encoded change records (INSERT/MODIFY/REMOVE) to Kinesis streams on PutItem, DeleteItem, and UpdateItem mutations.
- Wire new deliveries in main.rs (EventBridge for S3, Kinesis for DynamoDB)

## Test plan

- [x] E2E: `dynamodb_sse_specification_kms` — create table with KMS SSE, verify SSEDescription
- [x] E2E: `dynamodb_sse_default_aes256` — create table without SSE, verify default AES256
- [x] E2E: `s3_eventbridge_notification` — enable EventBridge on bucket, put object, verify event delivered via EventBridge→SQS
- [x] E2E: `dynamodb_kinesis_streaming_delivers_records` — enable Kinesis destination, put/delete items, verify INSERT/REMOVE records in Kinesis stream
- [x] Clippy clean, fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DynamoDB SSE, S3→EventBridge notifications, and DynamoDB→Kinesis change streaming. This enables table encryption control and end-to-end eventing across services.

- **New Features**
  - DynamoDB SSE: `CreateTable`/`UpdateTable` accept `SSESpecification` with `SSEType` (`AES256`/`KMS`) and optional `KMSMasterKeyId`; `DescribeTable` returns `SSEDescription`. Tables without SSE default to `AES256`.
  - S3 → EventBridge: `PutBucketNotificationConfiguration` with `EventBridgeConfiguration` enables all bucket events to flow to EventBridge with `aws.s3` source and object details in `detail`.
  - DynamoDB → Kinesis: `EnableKinesisStreamingDestination` activates streaming; `PutItem`, `UpdateItem`, and `DeleteItem` emit `INSERT`/`MODIFY`/`REMOVE` change records to configured streams. Delivery is wired in server startup.

<sup>Written for commit 6c5c099eb127f434cfe096d80ae55b84d56af6c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

