### PR TITLE
feat(integrations): add EventBridge→Kinesis and CloudFormation→SNS

### DIFF
--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -128,6 +128,42 @@ impl CloudFormationService {
         result
     }
 
+    fn extract_notification_arns(params: &HashMap<String, String>) -> Vec<String> {
+        let mut arns = Vec::new();
+        for i in 1.. {
+            let key = format!("NotificationARNs.member.{i}");
+            match params.get(&key) {
+                Some(arn) => arns.push(arn.clone()),
+                None => break,
+            }
+        }
+        arns
+    }
+
+    fn send_stack_notification(
+        delivery: &DeliveryBus,
+        notification_arns: &[String],
+        stack_name: &str,
+        stack_id: &str,
+        status: &str,
+    ) {
+        if notification_arns.is_empty() {
+            return;
+        }
+        let message = format!(
+            "StackId='{}'\nTimestamp='{}'\nEventId='{}'\nLogicalResourceId='{}'\nResourceStatus='{}'\nResourceType='AWS::CloudFormation::Stack'\nStackName='{}'",
+            stack_id,
+            chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ"),
+            uuid::Uuid::new_v4(),
+            stack_name,
+            status,
+            stack_name,
+        );
+        for arn in notification_arns {
+            delivery.publish_to_sns(arn, &message, Some("AWS CloudFormation Notification"));
+        }
+    }
+
     fn create_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let params = Self::get_all_params(req);
 
@@ -163,6 +199,7 @@ impl CloudFormationService {
 
         let tags = Self::extract_tags(&params);
         let parameters = Self::extract_parameters(&params);
+        let notification_arns = Self::extract_notification_arns(&params);
 
         // First pass: parse to get resource definitions (without physical ID resolution)
         let parsed = template::parse_template(template_body, &parameters).map_err(|e| {
@@ -260,12 +297,21 @@ impl CloudFormationService {
             created_at: Utc::now(),
             updated_at: None,
             description: parsed.description,
+            notification_arns: notification_arns.clone(),
         };
 
         {
             let mut state = self.state.write();
             state.stacks.insert(stack_name.clone(), stack);
         }
+
+        Self::send_stack_notification(
+            &self.delivery,
+            &notification_arns,
+            stack_name,
+            &stack_id,
+            "CREATE_COMPLETE",
+        );
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -291,6 +337,8 @@ impl CloudFormationService {
 
         if let Some(stack) = stack {
             let stack_id = stack.stack_id.clone();
+            let stack_name_for_notif = stack.name.clone();
+            let notification_arns = stack.notification_arns.clone();
             let resources: Vec<_> = stack.resources.clone();
 
             // Build the provisioner while we still have the stack_id
@@ -309,6 +357,15 @@ impl CloudFormationService {
                 stack.status = "DELETE_COMPLETE".to_string();
                 stack.resources.clear();
             }
+            drop(state);
+
+            Self::send_stack_notification(
+                &self.delivery,
+                &notification_arns,
+                &stack_name_for_notif,
+                &stack_id,
+                "DELETE_COMPLETE",
+            );
         }
 
         Ok(AwsResponse::xml(
@@ -450,6 +507,7 @@ impl CloudFormationService {
 
         let new_parameters = Self::extract_parameters(&params);
         let new_tags = Self::extract_tags(&params);
+        let new_notification_arns = Self::extract_notification_arns(&params);
 
         let parsed = template::parse_template(template_body, &new_parameters).map_err(|e| {
             AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
@@ -575,14 +633,36 @@ impl CloudFormationService {
         }
         stack.updated_at = Some(Utc::now());
         stack.description = parsed.description;
+        if !new_notification_arns.is_empty() {
+            stack.notification_arns = new_notification_arns;
+        }
+        let notification_arns = stack.notification_arns.clone();
+        let stack_name_for_notif = stack.name.clone();
 
         if update_failed {
+            drop(state);
+            Self::send_stack_notification(
+                &self.delivery,
+                &notification_arns,
+                &stack_name_for_notif,
+                &stack_id,
+                "UPDATE_FAILED",
+            );
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationError",
                 update_error_msg,
             ));
         }
+
+        drop(state);
+        Self::send_stack_notification(
+            &self.delivery,
+            &notification_arns,
+            &stack_name_for_notif,
+            &stack_id,
+            "UPDATE_COMPLETE",
+        );
 
         Ok(AwsResponse::xml(
             StatusCode::OK,

--- a/crates/fakecloud-cloudformation/src/state.rs
+++ b/crates/fakecloud-cloudformation/src/state.rs
@@ -25,6 +25,7 @@ pub struct Stack {
     pub created_at: DateTime<Utc>,
     pub updated_at: Option<DateTime<Utc>>,
     pub description: Option<String>,
+    pub notification_arns: Vec<String>,
 }
 
 pub struct CloudFormationState {

--- a/crates/fakecloud-cloudformation/src/xml_responses.rs
+++ b/crates/fakecloud-cloudformation/src/xml_responses.rs
@@ -108,12 +108,24 @@ fn stack_member_xml(stack: &Stack) -> String {
         .map(|d| format!("\n        <Description>{}</Description>", xml_escape(d)))
         .unwrap_or_default();
 
+    let notification_arns_xml = if stack.notification_arns.is_empty() {
+        String::new()
+    } else {
+        let members: String = stack
+            .notification_arns
+            .iter()
+            .map(|arn| format!("          <member>{}</member>", xml_escape(arn)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("\n        <NotificationARNs>\n{members}\n        </NotificationARNs>")
+    };
+
     format!(
         r#"      <member>
         <StackName>{name}</StackName>
         <StackId>{id}</StackId>
         <StackStatus>{status}</StackStatus>
-        <CreationTime>{created}</CreationTime>{description_xml}{tags_xml}{params_xml}
+        <CreationTime>{created}</CreationTime>{description_xml}{tags_xml}{params_xml}{notification_arns_xml}
       </member>"#,
         name = xml_escape(&stack.name),
         id = xml_escape(&stack.stack_id),

--- a/crates/fakecloud-e2e/tests/cloudformation.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation.rs
@@ -610,3 +610,101 @@ def lambda_handler(event, context):
         "Lambda should have been invoked with the custom resource event"
     );
 }
+
+#[tokio::test]
+async fn cloudformation_stack_sends_sns_notification() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+    let sns_client = server.sns_client().await;
+    let sqs_client = server.sqs_client().await;
+
+    // Create an SNS topic for stack notifications
+    let topic = sns_client
+        .create_topic()
+        .name("cf-notifications")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    // Create an SQS queue to receive SNS messages
+    let queue = sqs_client
+        .create_queue()
+        .queue_name("cf-notif-receiver")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let queue_attrs = sqs_client
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = queue_attrs
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+
+    // Subscribe SQS to SNS
+    sns_client
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&queue_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Create a stack with NotificationARNs
+    let template = r#"{
+        "Resources": {
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {
+                    "QueueName": "cf-notif-test-queue"
+                }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("notif-stack")
+        .template_body(template)
+        .notification_arns(&topic_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Check SQS for the notification
+    let msgs = sqs_client
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(
+        !msgs.messages().is_empty(),
+        "expected at least one CloudFormation notification in SQS"
+    );
+
+    let body = msgs.messages()[0].body().unwrap();
+    // SNS wraps the message in a JSON envelope
+    let envelope: serde_json::Value = serde_json::from_str(body).unwrap();
+    let message = envelope["Message"].as_str().unwrap_or(body);
+    assert!(
+        message.contains("CREATE_COMPLETE"),
+        "notification should contain CREATE_COMPLETE, got: {}",
+        message
+    );
+    assert!(
+        message.contains("notif-stack"),
+        "notification should contain stack name"
+    );
+}

--- a/crates/fakecloud-e2e/tests/eventbridge.rs
+++ b/crates/fakecloud-e2e/tests/eventbridge.rs
@@ -1179,3 +1179,99 @@ async fn eb_simulation_fire_rule_to_sqs() {
     let events = history["events"].as_array().unwrap();
     assert!(events.iter().any(|e| e["source"] == "aws.events"));
 }
+
+#[tokio::test]
+async fn eb_put_events_delivers_to_kinesis_target() {
+    let server = TestServer::start().await;
+    let eb = server.eventbridge_client().await;
+    let kinesis = server.kinesis_client().await;
+
+    // Create Kinesis stream
+    kinesis
+        .create_stream()
+        .stream_name("eb-kinesis-target")
+        .shard_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    // Create rule matching our source
+    eb.put_rule()
+        .name("kinesis-rule")
+        .event_pattern(r#"{"source": ["app.kinesis"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Add Kinesis stream as target
+    eb.put_targets()
+        .rule("kinesis-rule")
+        .targets(
+            Target::builder()
+                .id("kinesis-target")
+                .arn("arn:aws:kinesis:us-east-1:123456789012:stream/eb-kinesis-target")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Get shard iterator before putting events
+    let desc = kinesis
+        .describe_stream()
+        .stream_name("eb-kinesis-target")
+        .send()
+        .await
+        .unwrap();
+    let shard_id = desc
+        .stream_description()
+        .unwrap()
+        .shards()
+        .first()
+        .unwrap()
+        .shard_id()
+        .to_string();
+
+    let iter_resp = kinesis
+        .get_shard_iterator()
+        .stream_name("eb-kinesis-target")
+        .shard_id(&shard_id)
+        .shard_iterator_type(aws_sdk_kinesis::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let shard_iterator = iter_resp.shard_iterator().unwrap().to_string();
+
+    // Put a matching event
+    let resp = eb
+        .put_events()
+        .entries(
+            PutEventsRequestEntry::builder()
+                .source("app.kinesis")
+                .detail_type("TestEvent")
+                .detail(r#"{"key": "value"}"#)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.failed_entry_count(), 0);
+
+    // Read the Kinesis record
+    let records_resp = kinesis
+        .get_records()
+        .shard_iterator(&shard_iterator)
+        .send()
+        .await
+        .unwrap();
+
+    let records = records_resp.records();
+    assert_eq!(records.len(), 1, "expected 1 event in Kinesis stream");
+
+    // The data should be the EventBridge event JSON
+    let event: serde_json::Value = serde_json::from_slice(records[0].data().as_ref()).unwrap();
+    assert_eq!(event["source"], "app.kinesis");
+    assert_eq!(event["detail-type"], "TestEvent");
+    assert_eq!(event["detail"]["key"], "value");
+}

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -1978,6 +1978,13 @@ impl EventBridgeService {
                     if let Some(ref log_state) = self.logs_state {
                         deliver_to_logs(log_state, arn, &body_str, now);
                     }
+                } else if arn.contains(":kinesis:") {
+                    tracing::info!(
+                        stream_arn = %arn,
+                        "EventBridge delivering to Kinesis stream"
+                    );
+                    // Use event ID as partition key for even distribution
+                    self.delivery.send_to_kinesis(arn, &body_str, &event_id);
                 } else if arn.contains(":states:") {
                     tracing::info!(
                         state_machine_arn = %arn,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -205,14 +205,18 @@ async fn main() {
         sns_state.clone(),
         delivery_for_sns.clone(),
     ));
+    let kinesis_delivery_for_eb =
+        fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
     let delivery_for_eb = Arc::new(
         DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())
-            .with_sns(sns_delivery.clone()),
+            .with_sns(sns_delivery.clone())
+            .with_kinesis(kinesis_delivery_for_eb),
     );
 
     // Step 3: S3 delivery (S3 notifications can push to SQS, SNS, Lambda, and EventBridge)
     let sns_delivery_for_ses = sns_delivery.clone();
+    let sns_delivery_for_cf = sns_delivery.clone();
     let eb_delivery_for_s3 = Arc::new(
         fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
             eb_state.clone(),
@@ -309,7 +313,7 @@ async fn main() {
 
     // Step 5: CloudFormation delivery (custom resources can invoke Lambda)
     let delivery_for_cf = {
-        let mut bus = DeliveryBus::new();
+        let mut bus = DeliveryBus::new().with_sns(sns_delivery_for_cf);
         if let Some(ref ld) = lambda_delivery {
             bus = bus.with_lambda(ld.clone());
         }


### PR DESCRIPTION
## Summary

- **EventBridge → Kinesis**: Events matching rules with Kinesis stream targets (`:kinesis:` ARN) are now delivered as records to the stream, using event ID as partition key.
- **CloudFormation → SNS**: Stack operations (create/update/delete) send notification messages to SNS topics specified in `NotificationARNs`. Notifications include stack name, ID, status, and timestamp in AWS format.
- Wire Kinesis delivery into EventBridge's delivery bus and SNS delivery into CloudFormation's delivery bus.

## Test plan

- [x] E2E: `eb_put_events_delivers_to_kinesis_target` — create rule with Kinesis target, put matching event, verify record appears in Kinesis stream with correct payload
- [x] E2E: `cloudformation_stack_sends_sns_notification` — create SNS topic + SQS subscriber, create stack with NotificationARNs, verify CREATE_COMPLETE notification arrives in SQS
- [x] Clippy clean, fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds EventBridge→Kinesis delivery and CloudFormation→SNS notifications, so events reach Kinesis streams and stack changes reach SNS topics.

- **New Features**
  - EventBridge → Kinesis: deliver matching events as Kinesis records; uses event ID as the partition key.
  - CloudFormation → SNS: send create/update/delete notifications to `NotificationARNs`; message includes stack name, ID, status, and timestamp.
  - CloudFormation state: track `notification_arns`; include `NotificationARNs` in DescribeStacks XML.
  - Server wiring: add Kinesis to the EventBridge delivery bus and SNS to the CloudFormation delivery bus.

<sup>Written for commit daa5196f1c64bca0b7e23297151a38058e08f5a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

