### PR TITLE
fix(lambda): make e2e lambda execution tests CI-reachable

### DIFF
--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -32,6 +32,13 @@ impl TestServer {
             .map(|(_, v)| v.to_string())
             .unwrap_or_else(detect_container_cli);
 
+        let log_level = env
+            .iter()
+            .find(|(k, _)| *k == "FAKECLOUD_TEST_LOG_LEVEL")
+            .map(|(_, v)| v.to_string())
+            .or_else(|| std::env::var("FAKECLOUD_TEST_LOG_LEVEL").ok())
+            .unwrap_or_else(|| "warn".to_string());
+
         for _ in 0..3 {
             let port = find_available_port();
             let endpoint = format!("http://127.0.0.1:{port}");
@@ -41,10 +48,7 @@ impl TestServer {
                 // Bind to 0.0.0.0 so Lambda containers can reach the server via Docker bridge
                 .arg(format!("0.0.0.0:{port}"))
                 .arg("--log-level")
-                .arg(
-                    std::env::var("FAKECLOUD_TEST_LOG_LEVEL")
-                        .unwrap_or_else(|_| "warn".to_string()),
-                )
+                .arg(&log_level)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
 
@@ -303,9 +307,12 @@ fn cli_available(cli: &str) -> bool {
 }
 
 async fn wait_for_port(child: &mut Child, port: u16) -> bool {
-    let addr = format!("127.0.0.1:{port}");
+    let loopback = format!("127.0.0.1:{port}");
+    let wildcard = format!("0.0.0.0:{port}");
     for _ in 0..300 {
-        if std::net::TcpStream::connect(&addr).is_ok() {
+        if std::net::TcpStream::connect(&loopback).is_ok()
+            || std::net::TcpStream::connect(&wildcard).is_ok()
+        {
             return true;
         }
         if child.try_wait().ok().flatten().is_some() {

--- a/crates/fakecloud-e2e/tests/lambda_integration.rs
+++ b/crates/fakecloud-e2e/tests/lambda_integration.rs
@@ -14,7 +14,8 @@ fn dockerized_endpoint(server: &TestServer) -> String {
 fn dockerized_queue_url(server: &TestServer, queue_name: &str) -> String {
     format!(
         "http://host.docker.internal:{}/123456789012/{}",
-        server.port(), queue_name
+        server.port(),
+        queue_name
     )
 }
 
@@ -87,7 +88,6 @@ def lambda_handler(event, context):
     return {"statusCode": 200, "body": "marker sent"}
 "#
 }
-
 
 /// Helper: create the result SQS queue and a Lambda function that writes to it.
 /// Returns (result_queue_url, lambda_function_name).

--- a/crates/fakecloud-e2e/tests/lambda_integration.rs
+++ b/crates/fakecloud-e2e/tests/lambda_integration.rs
@@ -7,6 +7,17 @@ use aws_sdk_lambda::primitives::Blob;
 use aws_sdk_lambda::types::{Environment, FunctionCode, Runtime};
 use helpers::TestServer;
 
+fn dockerized_endpoint(server: &TestServer) -> String {
+    format!("http://host.docker.internal:{}", server.port())
+}
+
+fn dockerized_queue_url(server: &TestServer, queue_name: &str) -> String {
+    format!(
+        "http://host.docker.internal:{}/123456789012/{}",
+        server.port(), queue_name
+    )
+}
+
 /// Create a ZIP file in memory containing a single file.
 fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
     let buf = Vec::new();
@@ -77,6 +88,7 @@ def lambda_handler(event, context):
 "#
 }
 
+
 /// Helper: create the result SQS queue and a Lambda function that writes to it.
 /// Returns (result_queue_url, lambda_function_name).
 async fn create_marker_lambda(
@@ -94,6 +106,8 @@ async fn create_marker_lambda(
         .await
         .unwrap();
     let queue_url = queue.queue_url().unwrap().to_string();
+    let docker_endpoint = dockerized_endpoint(server);
+    let docker_queue_url = dockerized_queue_url(server, queue_name);
 
     // Create Lambda with Python code that writes to the result queue
     let zip = make_zip(&[("lambda_function.py", python_sqs_writer_code().as_bytes())]);
@@ -106,8 +120,8 @@ async fn create_marker_lambda(
         .handler("lambda_function.lambda_handler")
         .environment(
             Environment::builder()
-                .variables("FAKECLOUD_ENDPOINT", server.endpoint())
-                .variables("RESULT_QUEUE_URL", &queue_url)
+                .variables("FAKECLOUD_ENDPOINT", &docker_endpoint)
+                .variables("RESULT_QUEUE_URL", &docker_queue_url)
                 .build(),
         )
         .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
@@ -121,32 +135,32 @@ async fn create_marker_lambda(
 /// Check the result queue for the marker message written by the Lambda.
 /// Returns true if the Lambda actually executed and wrote its marker.
 async fn check_marker(sqs: &aws_sdk_sqs::Client, queue_url: &str) -> bool {
-    // Give the Lambda time to execute (cold start + processing)
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    for _ in 0..10 {
+        let msgs = sqs
+            .receive_message()
+            .queue_url(queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(2)
+            .send()
+            .await
+            .unwrap();
 
-    let msgs = sqs
-        .receive_message()
-        .queue_url(queue_url)
-        .max_number_of_messages(10)
-        .wait_time_seconds(3)
-        .send()
-        .await
-        .unwrap();
-
-    for msg in msgs.messages() {
-        if let Some(body) = msg.body() {
-            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
-                if parsed["marker"] == "lambda-executed" {
-                    return true;
+        for msg in msgs.messages() {
+            if let Some(body) = msg.body() {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+                    if parsed["marker"] == "lambda-executed" {
+                        return true;
+                    }
                 }
             }
         }
+
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
     false
 }
 
 #[tokio::test]
-#[ignore] // Works locally, fails in CI - needs investigation of CI Docker networking
 async fn sns_to_lambda_executes_code() {
     let server = TestServer::start().await;
     let sns = server.sns_client().await;
@@ -192,7 +206,6 @@ async fn sns_to_lambda_executes_code() {
 }
 
 #[tokio::test]
-#[ignore] // Works locally, fails in CI - needs investigation of CI Docker networking
 async fn eventbridge_to_lambda_executes_code() {
     let server = TestServer::start().await;
     let eb = server.eventbridge_client().await;
@@ -247,7 +260,6 @@ async fn eventbridge_to_lambda_executes_code() {
 }
 
 #[tokio::test]
-#[ignore] // Works locally, fails in CI - needs investigation of CI Docker networking
 async fn sqs_to_lambda_event_source_mapping_executes_code() {
     let server = TestServer::start().await;
     let sqs = server.sqs_client().await;
@@ -294,7 +306,6 @@ async fn sqs_to_lambda_event_source_mapping_executes_code() {
 }
 
 #[tokio::test]
-#[ignore] // Works locally, fails in CI - needs investigation of CI Docker networking
 async fn s3_to_lambda_notification_executes_code() {
     let server = TestServer::start().await;
     let s3 = server.s3_client().await;


### PR DESCRIPTION
## Summary
- make the lambda integration tests pass Docker-reachable fakecloud endpoint and SQS queue URLs into the Lambda runtime
- keep the fakecloud e2e test server bound so dockerized Lambda containers can reach it reliably
- validate the SNS, EventBridge, SQS event source mapping, and S3 Lambda execution paths locally

## Test plan
- cargo test -p fakecloud-e2e --test lambda_integration -- --nocapture sns_to_lambda_executes_code eventbridge_to_lambda_executes_code sqs_to_lambda_event_source_mapping_executes_code s3_to_lambda_notification_executes_code

Closes #231

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Lambda e2e tests run in CI by fixing Docker networking: bind the test server to 0.0.0.0 and route container traffic via `host.docker.internal`. This enables SNS, EventBridge, SQS, and S3-triggered executions to pass in CI and closes Linear #231.

- **Bug Fixes**
  - Use `host.docker.internal` for `FAKECLOUD_ENDPOINT` and SQS `RESULT_QUEUE_URL` inside Dockerized Lambdas.
  - Bind the `fakecloud-e2e` server to `0.0.0.0` and wait for both loopback and wildcard sockets.
  - Honor `FAKECLOUD_TEST_LOG_LEVEL` from the test env or process env when starting the server.
  - Switch from fixed sleep to short polling when reading the SQS marker.
  - Unignore Lambda integration tests so CI runs SNS, EventBridge, SQS ESM, and S3 notification paths.

<sup>Written for commit 91d0b8f553cc6691901da7a08e181ec989290bec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

