### PR TITLE
docs: update ROADMAP to reflect shipped DynamoDB Streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Part of the [faisca project family](https://faisca.dev).
 - Run your app against normal AWS SDKs, CLI tools, and IaC
 - Stay fully local with no AWS account, no auth token, and no paid tier
 - Assert what happened with first-party fakecloud SDKs for TypeScript, Python, Go, and Rust
-- Test cross-service behavior like SES -> SNS/EventBridge, S3 -> SQS/SNS/Lambda, and SQS -> Lambda
+- Test cross-service behavior like SES -> SNS/EventBridge, S3 -> SQS/SNS/Lambda/EventBridge, SQS -> Lambda, and DynamoDB Streams -> Lambda
 - Use a fast single binary or Docker image, depending on your setup
 
 ## Why fakecloud?
@@ -185,13 +185,18 @@ Services talk to each other — this is the kind of behavior that matters in
 integration tests:
 
 - **SNS -> SQS/Lambda/HTTP**: Fan-out delivery to all subscription types
-- **EventBridge -> SNS/SQS/Lambda/Logs**: Rules deliver to targets on schedule or event match
-- **S3 -> SNS/SQS/Lambda**: Bucket notifications on object create/delete
+- **S3 -> SNS/SQS/Lambda/EventBridge**: Bucket notifications on object create/delete
+- **EventBridge -> SNS/SQS/Lambda/Logs/Kinesis/HTTP**: Rules deliver to targets on schedule or event match, including API Destinations
 - **SQS -> Lambda**: Event source mapping polls and invokes
-- **SecretsManager -> Lambda**: Rotation invokes Lambda for all 4 steps
+- **Kinesis -> Lambda**: Event source mapping polls shards and invokes
+- **DynamoDB Streams -> Lambda**: Event source mapping polls stream records and invokes
+- **DynamoDB -> Kinesis**: Table changes stream to Kinesis Data Streams
+- **CloudWatch Logs -> Lambda/Kinesis/SQS**: Subscription filters deliver log events
+- **Cognito -> Lambda**: Pre-signup, post-confirmation, pre/post-auth, custom message, token generation, migration, and custom auth challenge triggers
 - **SES -> SNS/EventBridge**: Email event fanout (send, delivery, bounce, complaint) via configured event destinations
 - **SES Inbound -> S3/SNS/Lambda**: Receipt rules evaluate inbound email and execute S3, SNS, and Lambda actions
-- **CloudFormation -> Lambda**: Custom resources invoke via ServiceToken
+- **CloudFormation -> Lambda/SNS**: Custom resources invoke via ServiceToken, stack events notify via NotificationARNs
+- **SecretsManager -> Lambda**: Rotation invokes Lambda for all 4 steps
 - **S3 Lifecycle**: Background expiration and storage class transitions
 - **EventBridge Scheduler**: Cron and rate-based rules fire on schedule
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ For every service we implement, the standard is the same: full API coverage, rea
 
 ### Kinesis
 
-Kinesis Data Streams with full streaming API support. Put records, consume via shard iterators, manage stream retention and scaling. This also unlocks future DynamoDB Streams support.
+Kinesis Data Streams with full streaming API support. Put records, consume via shard iterators, manage stream retention and scaling. DynamoDB Streams → Lambda event source mappings and DynamoDB → Kinesis streaming are also shipped.
 
 ### RDS
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9,7 +9,7 @@ fakecloud emulates 18 AWS services locally for integration testing and developme
 Key design principles:
 - **Correctness over coverage**: Every implemented service targets 100% behavioral parity with real AWS, verified by automated conformance tests against AWS Smithy models
 - **Zero friction**: No auth tokens, no accounts, no config files needed
-- **Cross-service integration**: Services talk to each other (S3 notifications deliver to SNS/SQS, SNS fans out to SQS, EventBridge rules fire on schedule and deliver to targets)
+- **Cross-service integration**: 28 service-to-service integrations — S3 notifications, SNS fanout, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, and more
 
 fakecloud is NOT a production-ready cloud replacement. It is for integration testing and local development.
 
@@ -311,13 +311,20 @@ Protocol: Query (form-encoded body, `Action` parameter, XML responses)
 
 fakecloud implements real cross-service message delivery:
 
-- **S3 -> SNS/SQS**: Bucket notification configurations deliver to SNS topics and SQS queues on object create/delete
-- **SNS -> SQS**: Publishing to an SNS topic delivers to all SQS subscriptions
-- **SNS -> HTTP/HTTPS**: Publishing to an SNS topic delivers to HTTP endpoints
-- **EventBridge -> SNS/SQS**: PutEvents and scheduled rules deliver to SNS and SQS targets
-- **S3 Lifecycle**: Background processor expires objects and transitions storage classes based on lifecycle rules
+- **SNS -> SQS/Lambda/HTTP**: Fan-out delivery to all subscription types
+- **S3 -> SNS/SQS/Lambda/EventBridge**: Bucket notifications on object create/delete
+- **EventBridge -> SNS/SQS/Lambda/Logs/Kinesis/HTTP**: Rules deliver to targets on schedule or event match, including API Destinations
+- **SQS -> Lambda**: Event source mapping polls and invokes
+- **Kinesis -> Lambda**: Event source mapping polls shards and invokes
+- **DynamoDB Streams -> Lambda**: Event source mapping polls stream records and invokes
+- **DynamoDB -> Kinesis**: Table changes stream to Kinesis Data Streams
+- **CloudWatch Logs -> Lambda/Kinesis/SQS**: Subscription filters deliver log events
+- **Cognito -> Lambda**: Pre-signup, post-confirmation, pre/post-auth, custom message, token generation, migration, and custom auth challenge triggers
 - **SES -> SNS/EventBridge**: Email event fanout (send, delivery, bounce, complaint) via configured event destinations
 - **SES Inbound -> S3/SNS/Lambda**: Receipt rules evaluate inbound email and execute S3, SNS, and Lambda actions
+- **CloudFormation -> Lambda/SNS**: Custom resources invoke via ServiceToken, stack events notify via NotificationARNs
+- **SecretsManager -> Lambda**: Rotation invokes Lambda for all 4 steps
+- **S3 Lifecycle**: Background expiration and storage class transitions
 - **EventBridge Scheduler**: Cron and rate-based rules fire on schedule
 
 ## Protocol Notes

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -4,7 +4,7 @@
 
 - Single binary, no Docker required, starts in under 100ms
 - 18 AWS services (1002 operations): S3, SQS, SNS, EventBridge, IAM/STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES, Cognito User Pools, Kinesis, RDS, ElastiCache
-- Cross-service delivery: S3 notifications to SNS/SQS, SNS fan-out to SQS, EventBridge rules to SNS/SQS
+- 28 cross-service integrations: S3 notifications, SNS fanout, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, and more
 - Scheduled EventBridge rules (cron and rate) that actually fire
 - Conformance tested against real AWS behavior
 - AGPL-3.0 licensed, free for commercial use

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -58,7 +58,7 @@
       <div class="feature">
         <div class="label">Real behavior</div>
         <h3>Cross-service flows are wired up</h3>
-        <p>SES fanout, inbound email actions, S3 notifications, SQS to Lambda, EventBridge targets, and CloudFormation custom resources all exercise real service interactions.</p>
+        <p>28 service-to-service integrations: S3 notifications, SNS fanout, EventBridge targets, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, and more — all exercise real service interactions.</p>
       </div>
       <div class="feature">
         <div class="label">Simple</div>


### PR DESCRIPTION
## Summary

- Update ROADMAP.md to note that DynamoDB Streams → Lambda and DynamoDB → Kinesis streaming are now shipped (previously said "unlocks future DynamoDB Streams support")

## Test plan

- [ ] Docs-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to reflect shipped streaming features: DynamoDB Streams → Lambda and DynamoDB → Kinesis. Refresh README, ROADMAP, and website copy to list 28 cross-service integrations and specify new flows (EventBridge → Logs/Kinesis/HTTP, Kinesis → Lambda, CloudWatch Logs subscriptions, Cognito triggers, CloudFormation → SNS).

<sup>Written for commit 9ea93012d8b99410ee592e2951a0fb79c50be85c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

