### PR TITLE
test(cloudformation): diagnose custom resource lambda ignored test

### DIFF
--- a/crates/fakecloud-e2e/tests/cloudformation.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation.rs
@@ -475,8 +475,28 @@ fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
 ///    ResourceProperties to the SQS queue as proof of execution
 /// 3. Create a CF stack with a Custom::MyResource pointing ServiceToken at the Lambda
 /// 4. Receive from SQS and assert the Lambda was invoked with the right event
+fn dockerized_endpoint(server: &TestServer) -> String {
+    format!("http://host.docker.internal:{}", server.port())
+}
+
+fn dockerized_queue_url(server: &TestServer, queue_name: &str) -> String {
+    format!(
+        "http://host.docker.internal:{}/123456789012/{}",
+        server.port(), queue_name
+    )
+}
+
+async fn get_lambda_invocations(endpoint: &str) -> serde_json::Value {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{endpoint}/_fakecloud/lambda/invocations"))
+        .send()
+        .await
+        .unwrap();
+    resp.json::<serde_json::Value>().await.unwrap()
+}
+
 #[tokio::test]
-#[ignore] // requires Docker for Lambda execution
 async fn cloudformation_custom_resource_invokes_lambda() {
     use aws_sdk_lambda::primitives::Blob;
     use aws_sdk_lambda::types::{Environment, FunctionCode, Runtime};
@@ -494,6 +514,8 @@ async fn cloudformation_custom_resource_invokes_lambda() {
         .await
         .unwrap();
     let queue_url = queue.queue_url().unwrap().to_string();
+    let docker_endpoint = dockerized_endpoint(&server);
+    let docker_queue_url = dockerized_queue_url(&server, "cf-custom-result");
 
     // 2. Create Lambda that forwards the CF event's ResourceProperties to SQS
     let python_code = r#"
@@ -540,8 +562,8 @@ def lambda_handler(event, context):
         .handler("lambda_function.lambda_handler")
         .environment(
             Environment::builder()
-                .variables("FAKECLOUD_ENDPOINT", server.endpoint())
-                .variables("RESULT_QUEUE_URL", &queue_url)
+                .variables("FAKECLOUD_ENDPOINT", &docker_endpoint)
+                .variables("RESULT_QUEUE_URL", &docker_queue_url)
                 .build(),
         )
         .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
@@ -577,37 +599,75 @@ def lambda_handler(event, context):
         .unwrap();
     assert!(result.stack_id().is_some());
 
-    // 4. Wait and receive from SQS
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    // 4. First prove that CloudFormation actually routed the custom-resource event
+    // into the Lambda delivery path, then separately look for the Lambda's SQS side effect.
+    let mut invocation_payload = None;
+    for _ in 0..10 {
+        let invocations = get_lambda_invocations(server.endpoint()).await;
+        if let Some(inv_list) = invocations["invocations"].as_array() {
+            if let Some(inv) = inv_list.iter().find(|inv| {
+                inv["functionArn"] == lambda_arn && inv["source"] == "aws:lambda:delivery"
+            }) {
+                invocation_payload = Some(inv["payload"].clone());
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
 
-    let msgs = sqs_client
-        .receive_message()
-        .queue_url(&queue_url)
-        .max_number_of_messages(10)
-        .wait_time_seconds(5)
-        .send()
-        .await
-        .unwrap();
+    let invocation_payload = invocation_payload.expect(
+        "CloudFormation should have recorded a Lambda delivery invocation for the custom resource",
+    );
+
+    let invocation_event = if let Some(payload_str) = invocation_payload.as_str() {
+        serde_json::from_str::<serde_json::Value>(payload_str).unwrap()
+    } else {
+        invocation_payload
+    };
+
+    assert_eq!(invocation_event["RequestType"], "Create");
+    assert_eq!(invocation_event["ResourceType"], "Custom::MyResource");
+    assert_eq!(invocation_event["LogicalResourceId"], "MyCustom");
+    assert_eq!(invocation_event["ResourceProperties"]["Foo"], "bar");
+    assert_eq!(invocation_event["ResourceProperties"]["Count"], 42);
 
     let mut found = false;
-    for msg in msgs.messages() {
-        if let Some(body) = msg.body() {
-            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
-                if parsed["marker"] == "custom-resource-invoked" {
-                    assert_eq!(parsed["request_type"], "Create");
-                    assert_eq!(parsed["resource_type"], "Custom::MyResource");
-                    assert_eq!(parsed["logical_resource_id"], "MyCustom");
-                    assert_eq!(parsed["resource_properties"]["Foo"], "bar");
-                    assert_eq!(parsed["resource_properties"]["Count"], 42);
-                    found = true;
-                    break;
+    for _ in 0..10 {
+        let msgs = sqs_client
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(2)
+            .send()
+            .await
+            .unwrap();
+
+        for msg in msgs.messages() {
+            if let Some(body) = msg.body() {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+                    if parsed["marker"] == "custom-resource-invoked" {
+                        assert_eq!(parsed["request_type"], "Create");
+                        assert_eq!(parsed["resource_type"], "Custom::MyResource");
+                        assert_eq!(parsed["logical_resource_id"], "MyCustom");
+                        assert_eq!(parsed["resource_properties"]["Foo"], "bar");
+                        assert_eq!(parsed["resource_properties"]["Count"], 42);
+                        found = true;
+                        break;
+                    }
                 }
             }
         }
+
+        if found {
+            break;
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
+
     assert!(
         found,
-        "Lambda should have been invoked with the custom resource event"
+        "Lambda was invoked for the custom resource, but the Lambda runtime never produced the expected SQS proof message"
     );
 }
 

--- a/crates/fakecloud-e2e/tests/cloudformation.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation.rs
@@ -482,7 +482,8 @@ fn dockerized_endpoint(server: &TestServer) -> String {
 fn dockerized_queue_url(server: &TestServer, queue_name: &str) -> String {
     format!(
         "http://host.docker.internal:{}/123456789012/{}",
-        server.port(), queue_name
+        server.port(),
+        queue_name
     )
 }
 
@@ -517,36 +518,36 @@ async fn cloudformation_custom_resource_invokes_lambda() {
     let docker_endpoint = dockerized_endpoint(&server);
     let docker_queue_url = dockerized_queue_url(&server, "cf-custom-result");
 
-    // 2. Create Lambda that forwards the CF event's ResourceProperties to SQS
+    // 2. Create Lambda that forwards the CF event's ResourceProperties to SQS.
+    // Use boto3 here instead of raw urllib so this path matches the successful
+    // Lambda-runtime integration patterns already proven in CI.
     let python_code = r#"
 import json
 import os
-import urllib.request
-import urllib.parse
+import boto3
 
 def lambda_handler(event, context):
-    endpoint = os.environ["FAKECLOUD_ENDPOINT"]
     queue_url = os.environ["RESULT_QUEUE_URL"]
+    endpoint = os.environ["FAKECLOUD_ENDPOINT"]
 
-    params = urllib.parse.urlencode({
-        "Action": "SendMessage",
-        "QueueUrl": queue_url,
-        "MessageBody": json.dumps({
+    sqs = boto3.client(
+        "sqs",
+        endpoint_url=endpoint,
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+
+    sqs.send_message(
+        QueueUrl=queue_url,
+        MessageBody=json.dumps({
             "marker": "custom-resource-invoked",
             "request_type": event.get("RequestType", ""),
             "resource_type": event.get("ResourceType", ""),
             "logical_resource_id": event.get("LogicalResourceId", ""),
             "resource_properties": event.get("ResourceProperties", {}),
         }),
-    }).encode()
-
-    req = urllib.request.Request(endpoint, data=params, method="POST")
-    req.add_header("Content-Type", "application/x-www-form-urlencoded")
-    req.add_header("Authorization", (
-        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20200101/us-east-1/sqs/aws4_request, "
-        "SignedHeaders=host, Signature=fake"
-    ))
-    urllib.request.urlopen(req)
+    )
 
     return {"statusCode": 200, "body": "ok"}
 "#;


### PR DESCRIPTION
## Summary
- improve the ignored CloudFormation custom-resource Lambda test so it first checks recorded Lambda invocation delivery
- distinguish between CloudFormation not invoking Lambda and Lambda invocation failing to produce the expected SQS proof
- keep this PR scoped to the single ignored test batch

## Test plan
- rely on GitHub Actions CI for end-to-end signal on this ignored-test batch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the CloudFormation custom-resource Lambda e2e test to diagnose failures: first confirms CloudFormation delivered the event to Lambda, then checks the Lambda’s SQS side effect. Switches the inline Lambda to `boto3` and routes it to the test server via Docker-aware endpoints.

- **Refactors**
  - Route the runtime to Docker-aware `FAKECLOUD_ENDPOINT`/`RESULT_QUEUE_URL` using `host.docker.internal`, and use `boto3` to send SQS in the inline Lambda.
  - Query `/_fakecloud/lambda/invocations` to assert a recorded delivery for the function ARN and validate event fields.
  - Poll SQS with retries and a clearer failure message when the proof message is missing.

<sup>Written for commit e3428be72ca902ccb4b7eef4e70a2f681f32f5d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

