### PR TITLE
feat(stepfunctions): add execution lifecycle with Pass/Succeed/Fail interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,6 +2344,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/crates/fakecloud-conformance/tests/stepfunctions.rs
+++ b/crates/fakecloud-conformance/tests/stepfunctions.rs
@@ -3,6 +3,7 @@ mod helpers;
 use aws_sdk_sfn::types::Tag;
 use fakecloud_conformance_macros::test_action;
 use helpers::TestServer;
+use tokio::time::{sleep, Duration};
 
 fn simple_definition() -> String {
     serde_json::json!({
@@ -243,4 +244,220 @@ async fn sfn_list_tags_for_resource() {
         .await
         .unwrap();
     assert!(tags.tags().is_empty());
+}
+
+// ─── Execution Lifecycle Conformance Tests ──────────────────────────
+
+async fn wait_for_execution(client: &aws_sdk_sfn::Client, arn: &str) {
+    for _ in 0..50 {
+        sleep(Duration::from_millis(50)).await;
+        let desc = client
+            .describe_execution()
+            .execution_arn(arn)
+            .send()
+            .await
+            .unwrap();
+        if desc.status().as_str() != "RUNNING" {
+            return;
+        }
+    }
+    panic!("Execution did not complete in time");
+}
+
+#[test_action("sfn", "StartExecution", checksum = "6ec509e4")]
+#[tokio::test]
+async fn sfn_start_execution() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("conf-start-exec")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.execution_arn().contains("execution:"));
+}
+
+#[test_action("sfn", "DescribeExecution", checksum = "7574d620")]
+#[tokio::test]
+async fn sfn_describe_execution() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("conf-desc-exec")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    wait_for_execution(&client, start.execution_arn()).await;
+
+    let resp = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_str(), "SUCCEEDED");
+}
+
+#[test_action("sfn", "ListExecutions", checksum = "6e3c28ed")]
+#[tokio::test]
+async fn sfn_list_executions() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("conf-list-exec")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    sleep(Duration::from_millis(200)).await;
+
+    let resp = client
+        .list_executions()
+        .state_machine_arn(create.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.executions().is_empty());
+}
+
+#[test_action("sfn", "StopExecution", checksum = "96371e61")]
+#[tokio::test]
+async fn sfn_stop_execution() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("conf-stop-exec")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    // Try to stop; may already be complete due to fast execution
+    let _ = client
+        .stop_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await;
+
+    // Just verify describe works after stop attempt
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    // Status is either ABORTED or SUCCEEDED
+    let status = desc.status().as_str();
+    assert!(status == "ABORTED" || status == "SUCCEEDED");
+}
+
+#[test_action("sfn", "GetExecutionHistory", checksum = "447fb14a")]
+#[tokio::test]
+async fn sfn_get_execution_history() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("conf-history")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    wait_for_execution(&client, start.execution_arn()).await;
+
+    let resp = client
+        .get_execution_history()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.events().is_empty());
+}
+
+#[test_action("sfn", "DescribeStateMachineForExecution", checksum = "208431fb")]
+#[tokio::test]
+async fn sfn_describe_state_machine_for_execution() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("conf-sm-for-exec")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    wait_for_execution(&client, start.execution_arn()).await;
+
+    let resp = client
+        .describe_state_machine_for_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.name(), "conf-sm-for-exec");
 }

--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -2,6 +2,7 @@ mod helpers;
 
 use aws_sdk_sfn::types::Tag;
 use helpers::TestServer;
+use tokio::time::{sleep, Duration};
 
 fn simple_definition() -> String {
     serde_json::json!({
@@ -457,4 +458,542 @@ async fn sfn_reset_clears_state() {
     // Verify cleared
     let list = client.list_state_machines().send().await.unwrap();
     assert_eq!(list.state_machines().len(), 0);
+}
+
+// ─── Execution Lifecycle Tests ──────────────────────────────────────────
+
+fn pass_with_result_definition() -> String {
+    serde_json::json!({
+        "StartAt": "PassState",
+        "States": {
+            "PassState": {
+                "Type": "Pass",
+                "Result": {"processed": true, "value": 42},
+                "End": true
+            }
+        }
+    })
+    .to_string()
+}
+
+fn pass_chain_with_result_path() -> String {
+    serde_json::json!({
+        "StartAt": "First",
+        "States": {
+            "First": {
+                "Type": "Pass",
+                "Result": "step1-done",
+                "ResultPath": "$.firstResult",
+                "Next": "Second"
+            },
+            "Second": {
+                "Type": "Pass",
+                "Result": "step2-done",
+                "ResultPath": "$.secondResult",
+                "End": true
+            }
+        }
+    })
+    .to_string()
+}
+
+fn succeed_definition() -> String {
+    serde_json::json!({
+        "StartAt": "Done",
+        "States": {
+            "Done": {
+                "Type": "Succeed"
+            }
+        }
+    })
+    .to_string()
+}
+
+fn fail_definition() -> String {
+    serde_json::json!({
+        "StartAt": "FailState",
+        "States": {
+            "FailState": {
+                "Type": "Fail",
+                "Error": "CustomError",
+                "Cause": "Something went wrong"
+            }
+        }
+    })
+    .to_string()
+}
+
+/// Helper to wait for an execution to finish (not RUNNING).
+async fn wait_for_execution(client: &aws_sdk_sfn::Client, arn: &str) -> String {
+    for _ in 0..50 {
+        sleep(Duration::from_millis(50)).await;
+        let desc = client
+            .describe_execution()
+            .execution_arn(arn)
+            .send()
+            .await
+            .unwrap();
+        let status = desc.status().as_str().to_string();
+        if status != "RUNNING" {
+            return status;
+        }
+    }
+    panic!("Execution did not complete in time: {arn}");
+}
+
+#[tokio::test]
+async fn sfn_start_and_describe_execution() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("exec-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"key": "value"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let exec_arn = start.execution_arn();
+    assert!(exec_arn.contains("execution:exec-sm:"));
+
+    let status = wait_for_execution(&client, exec_arn).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    // Describe the completed execution
+    let desc = client
+        .describe_execution()
+        .execution_arn(exec_arn)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(desc.status().as_str(), "SUCCEEDED");
+    assert!(desc.output().is_some());
+    assert!(desc.stop_date().is_some());
+}
+
+#[tokio::test]
+async fn sfn_execution_with_pass_result() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("pass-result-sm")
+        .definition(pass_with_result_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"original": true}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap()).unwrap();
+    assert_eq!(output["processed"], true);
+    assert_eq!(output["value"], 42);
+}
+
+#[tokio::test]
+async fn sfn_execution_pass_chain_with_result_path() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("chain-sm")
+        .definition(pass_chain_with_result_path())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"initial": "data"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap()).unwrap();
+    assert_eq!(output["initial"], "data");
+    assert_eq!(output["firstResult"], "step1-done");
+    assert_eq!(output["secondResult"], "step2-done");
+}
+
+#[tokio::test]
+async fn sfn_execution_succeed_state() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("succeed-sm")
+        .definition(succeed_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"data": "test"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+}
+
+#[tokio::test]
+async fn sfn_execution_fail_state() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("fail-sm")
+        .definition(fail_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "FAILED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(desc.error().unwrap(), "CustomError");
+    assert_eq!(desc.cause().unwrap(), "Something went wrong");
+}
+
+#[tokio::test]
+async fn sfn_list_executions() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("list-exec-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+    let sm_arn = create.state_machine_arn();
+
+    // Start 3 executions
+    for _ in 0..3 {
+        client
+            .start_execution()
+            .state_machine_arn(sm_arn)
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // Wait for them to complete
+    sleep(Duration::from_millis(200)).await;
+
+    let list = client
+        .list_executions()
+        .state_machine_arn(sm_arn)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(list.executions().len(), 3);
+}
+
+#[tokio::test]
+async fn sfn_list_executions_with_status_filter() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    // Create one that succeeds
+    let sm1 = client
+        .create_state_machine()
+        .name("filter-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start1 = client
+        .start_execution()
+        .state_machine_arn(sm1.state_machine_arn())
+        .name("succeed-exec")
+        .send()
+        .await
+        .unwrap();
+
+    wait_for_execution(&client, start1.execution_arn()).await;
+
+    // Start one that fails (using a fail state machine)
+    client
+        .update_state_machine()
+        .state_machine_arn(sm1.state_machine_arn())
+        .definition(fail_definition())
+        .send()
+        .await
+        .unwrap();
+
+    let start2 = client
+        .start_execution()
+        .state_machine_arn(sm1.state_machine_arn())
+        .name("fail-exec")
+        .send()
+        .await
+        .unwrap();
+
+    wait_for_execution(&client, start2.execution_arn()).await;
+
+    // Filter by SUCCEEDED
+    let succeeded = client
+        .list_executions()
+        .state_machine_arn(sm1.state_machine_arn())
+        .status_filter(aws_sdk_sfn::types::ExecutionStatus::Succeeded)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(succeeded.executions().len(), 1);
+
+    // Filter by FAILED
+    let failed = client
+        .list_executions()
+        .state_machine_arn(sm1.state_machine_arn())
+        .status_filter(aws_sdk_sfn::types::ExecutionStatus::Failed)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(failed.executions().len(), 1);
+}
+
+#[tokio::test]
+async fn sfn_get_execution_history() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("history-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    wait_for_execution(&client, start.execution_arn()).await;
+
+    let history = client
+        .get_execution_history()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let events = history.events();
+    assert!(events.len() >= 4); // ExecutionStarted, PassStateEntered, PassStateExited, ExecutionSucceeded
+
+    // First event should be ExecutionStarted
+    assert_eq!(events[0].r#type().as_str(), "ExecutionStarted");
+}
+
+#[tokio::test]
+async fn sfn_stop_execution() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    // Use a Succeed state which is still fast but gives us a valid execution
+    let create = client
+        .create_state_machine()
+        .name("stop-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("stop-exec")
+        .send()
+        .await
+        .unwrap();
+
+    // Try to stop it immediately (it may already be done given fast execution)
+    let stop_result = client
+        .stop_execution()
+        .execution_arn(start.execution_arn())
+        .error("UserCancelled")
+        .cause("Test cancellation")
+        .send()
+        .await;
+
+    // Either it stops successfully or it already finished
+    if stop_result.is_ok() {
+        let desc = client
+            .describe_execution()
+            .execution_arn(start.execution_arn())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(desc.status().as_str(), "ABORTED");
+    }
+}
+
+#[tokio::test]
+async fn sfn_start_execution_with_name() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("named-exec-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("my-execution")
+        .send()
+        .await
+        .unwrap();
+
+    assert!(start.execution_arn().contains("my-execution"));
+
+    wait_for_execution(&client, start.execution_arn()).await;
+
+    // Duplicate execution name should fail
+    let err = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("my-execution")
+        .send()
+        .await;
+    assert!(err.is_err());
+}
+
+#[tokio::test]
+async fn sfn_describe_state_machine_for_execution() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("for-exec-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    wait_for_execution(&client, start.execution_arn()).await;
+
+    let sm = client
+        .describe_state_machine_for_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(sm.name(), "for-exec-sm");
+    assert_eq!(sm.state_machine_arn(), create.state_machine_arn());
+}
+
+#[tokio::test]
+async fn sfn_start_execution_no_input() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("no-input-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
 }

--- a/crates/fakecloud-stepfunctions/Cargo.toml
+++ b/crates/fakecloud-stepfunctions/Cargo.toml
@@ -15,5 +15,6 @@ http = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1,0 +1,561 @@
+use chrono::Utc;
+use serde_json::{json, Value};
+use tracing::debug;
+
+use crate::io_processing::{apply_input_path, apply_output_path, apply_result_path};
+use crate::state::{ExecutionStatus, HistoryEvent, SharedStepFunctionsState};
+
+/// Execute a state machine definition with the given input.
+/// Updates the execution record in shared state as it progresses.
+pub async fn execute_state_machine(
+    state: SharedStepFunctionsState,
+    execution_arn: String,
+    definition: String,
+    input: Option<String>,
+) {
+    let def: Value = match serde_json::from_str(&definition) {
+        Ok(v) => v,
+        Err(e) => {
+            fail_execution(
+                &state,
+                &execution_arn,
+                "States.Runtime",
+                &format!("Failed to parse definition: {e}"),
+            );
+            return;
+        }
+    };
+
+    let start_at = match def["StartAt"].as_str() {
+        Some(s) => s.to_string(),
+        None => {
+            fail_execution(
+                &state,
+                &execution_arn,
+                "States.Runtime",
+                "Missing StartAt in definition",
+            );
+            return;
+        }
+    };
+
+    let states = match def.get("States") {
+        Some(s) => s,
+        None => {
+            fail_execution(
+                &state,
+                &execution_arn,
+                "States.Runtime",
+                "Missing States in definition",
+            );
+            return;
+        }
+    };
+
+    let raw_input: Value = input
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or(json!({}));
+
+    // Record ExecutionStarted event
+    add_event(
+        &state,
+        &execution_arn,
+        "ExecutionStarted",
+        0,
+        json!({
+            "input": serde_json::to_string(&raw_input).unwrap_or_default(),
+            "roleArn": "arn:aws:iam::123456789012:role/execution-role"
+        }),
+    );
+
+    let mut current_state = start_at;
+    let mut effective_input = raw_input;
+    let mut iteration = 0;
+    let max_iterations = 500; // safety limit
+
+    loop {
+        iteration += 1;
+        if iteration > max_iterations {
+            fail_execution(
+                &state,
+                &execution_arn,
+                "States.Runtime",
+                "Maximum number of state transitions exceeded",
+            );
+            return;
+        }
+
+        let state_def = match states.get(&current_state) {
+            Some(s) => s.clone(),
+            None => {
+                fail_execution(
+                    &state,
+                    &execution_arn,
+                    "States.Runtime",
+                    &format!("State '{current_state}' not found in definition"),
+                );
+                return;
+            }
+        };
+
+        let state_type = match state_def["Type"].as_str() {
+            Some(t) => t.to_string(),
+            None => {
+                fail_execution(
+                    &state,
+                    &execution_arn,
+                    "States.Runtime",
+                    &format!("State '{current_state}' missing Type field"),
+                );
+                return;
+            }
+        };
+
+        debug!(
+            execution_arn = %execution_arn,
+            state = %current_state,
+            state_type = %state_type,
+            "Executing state"
+        );
+
+        match state_type.as_str() {
+            "Pass" => {
+                let entered_event_id = add_event(
+                    &state,
+                    &execution_arn,
+                    "PassStateEntered",
+                    0,
+                    json!({
+                        "name": current_state,
+                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                    }),
+                );
+
+                let result = execute_pass_state(&state_def, &effective_input);
+
+                add_event(
+                    &state,
+                    &execution_arn,
+                    "PassStateExited",
+                    entered_event_id,
+                    json!({
+                        "name": current_state,
+                        "output": serde_json::to_string(&result).unwrap_or_default(),
+                    }),
+                );
+
+                effective_input = result;
+
+                match next_state(&state_def) {
+                    NextState::Name(next) => current_state = next,
+                    NextState::End => {
+                        succeed_execution(&state, &execution_arn, &effective_input);
+                        return;
+                    }
+                    NextState::Error(msg) => {
+                        fail_execution(&state, &execution_arn, "States.Runtime", &msg);
+                        return;
+                    }
+                }
+            }
+
+            "Succeed" => {
+                add_event(
+                    &state,
+                    &execution_arn,
+                    "SucceedStateEntered",
+                    0,
+                    json!({
+                        "name": current_state,
+                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                    }),
+                );
+
+                // Apply InputPath and OutputPath
+                let input_path = state_def["InputPath"].as_str();
+                let output_path = state_def["OutputPath"].as_str();
+
+                let processed = if input_path == Some("null") {
+                    json!({})
+                } else {
+                    apply_input_path(&effective_input, input_path)
+                };
+
+                let output = if output_path == Some("null") {
+                    json!({})
+                } else {
+                    apply_output_path(&processed, output_path)
+                };
+
+                add_event(
+                    &state,
+                    &execution_arn,
+                    "SucceedStateExited",
+                    0,
+                    json!({
+                        "name": current_state,
+                        "output": serde_json::to_string(&output).unwrap_or_default(),
+                    }),
+                );
+
+                succeed_execution(&state, &execution_arn, &output);
+                return;
+            }
+
+            "Fail" => {
+                let error = state_def["Error"]
+                    .as_str()
+                    .unwrap_or("States.Fail")
+                    .to_string();
+                let cause = state_def["Cause"].as_str().unwrap_or("").to_string();
+
+                add_event(
+                    &state,
+                    &execution_arn,
+                    "FailStateEntered",
+                    0,
+                    json!({
+                        "name": current_state,
+                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                    }),
+                );
+
+                fail_execution(&state, &execution_arn, &error, &cause);
+                return;
+            }
+
+            other => {
+                fail_execution(
+                    &state,
+                    &execution_arn,
+                    "States.Runtime",
+                    &format!("Unsupported state type: '{other}'"),
+                );
+                return;
+            }
+        }
+    }
+}
+
+/// Execute a Pass state: apply InputPath, use Result if present, apply ResultPath and OutputPath.
+fn execute_pass_state(state_def: &Value, input: &Value) -> Value {
+    let input_path = state_def["InputPath"].as_str();
+    let result_path = state_def["ResultPath"].as_str();
+    let output_path = state_def["OutputPath"].as_str();
+
+    // Step 1: Apply InputPath
+    let effective_input = if input_path == Some("null") {
+        json!({})
+    } else {
+        apply_input_path(input, input_path)
+    };
+
+    // Step 2: Determine result (Pass can have a literal "Result" field)
+    let result = if let Some(r) = state_def.get("Result") {
+        r.clone()
+    } else {
+        effective_input.clone()
+    };
+
+    // Step 3: Apply ResultPath (merge result into original input, not effective_input)
+    let after_result = if result_path == Some("null") {
+        input.clone()
+    } else {
+        apply_result_path(input, &result, result_path)
+    };
+
+    // Step 4: Apply OutputPath
+    if output_path == Some("null") {
+        json!({})
+    } else {
+        apply_output_path(&after_result, output_path)
+    }
+}
+
+enum NextState {
+    Name(String),
+    End,
+    Error(String),
+}
+
+fn next_state(state_def: &Value) -> NextState {
+    if state_def["End"].as_bool() == Some(true) {
+        return NextState::End;
+    }
+    match state_def["Next"].as_str() {
+        Some(next) => NextState::Name(next.to_string()),
+        None => NextState::Error("State has neither 'End' nor 'Next' field".to_string()),
+    }
+}
+
+fn add_event(
+    state: &SharedStepFunctionsState,
+    execution_arn: &str,
+    event_type: &str,
+    previous_event_id: i64,
+    details: Value,
+) -> i64 {
+    let mut s = state.write();
+    if let Some(exec) = s.executions.get_mut(execution_arn) {
+        let id = exec.history_events.len() as i64 + 1;
+        exec.history_events.push(HistoryEvent {
+            id,
+            event_type: event_type.to_string(),
+            timestamp: Utc::now(),
+            previous_event_id,
+            details,
+        });
+        id
+    } else {
+        0
+    }
+}
+
+fn succeed_execution(state: &SharedStepFunctionsState, execution_arn: &str, output: &Value) {
+    let output_str = serde_json::to_string(output).unwrap_or_default();
+
+    add_event(
+        state,
+        execution_arn,
+        "ExecutionSucceeded",
+        0,
+        json!({ "output": output_str }),
+    );
+
+    let mut s = state.write();
+    if let Some(exec) = s.executions.get_mut(execution_arn) {
+        exec.status = ExecutionStatus::Succeeded;
+        exec.output = Some(output_str);
+        exec.stop_date = Some(Utc::now());
+    }
+}
+
+fn fail_execution(state: &SharedStepFunctionsState, execution_arn: &str, error: &str, cause: &str) {
+    add_event(
+        state,
+        execution_arn,
+        "ExecutionFailed",
+        0,
+        json!({ "error": error, "cause": cause }),
+    );
+
+    let mut s = state.write();
+    if let Some(exec) = s.executions.get_mut(execution_arn) {
+        exec.status = ExecutionStatus::Failed;
+        exec.error = Some(error.to_string());
+        exec.cause = Some(cause.to_string());
+        exec.stop_date = Some(Utc::now());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{Execution, StepFunctionsState};
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn make_state() -> SharedStepFunctionsState {
+        Arc::new(RwLock::new(StepFunctionsState::new(
+            "123456789012",
+            "us-east-1",
+        )))
+    }
+
+    fn create_execution(state: &SharedStepFunctionsState, arn: &str, input: Option<String>) {
+        let mut s = state.write();
+        s.executions.insert(
+            arn.to_string(),
+            Execution {
+                execution_arn: arn.to_string(),
+                state_machine_arn: "arn:aws:states:us-east-1:123456789012:stateMachine:test"
+                    .to_string(),
+                state_machine_name: "test".to_string(),
+                name: "exec-1".to_string(),
+                status: ExecutionStatus::Running,
+                input,
+                output: None,
+                start_date: Utc::now(),
+                stop_date: None,
+                error: None,
+                cause: None,
+                history_events: vec![],
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn test_simple_pass_state() {
+        let state = make_state();
+        let arn = "arn:aws:states:us-east-1:123456789012:execution:test:exec-1";
+        create_execution(&state, arn, Some(r#"{"hello":"world"}"#.to_string()));
+
+        let definition = json!({
+            "StartAt": "PassState",
+            "States": {
+                "PassState": {
+                    "Type": "Pass",
+                    "Result": {"processed": true},
+                    "End": true
+                }
+            }
+        })
+        .to_string();
+
+        execute_state_machine(
+            state.clone(),
+            arn.to_string(),
+            definition,
+            Some(r#"{"hello":"world"}"#.to_string()),
+        )
+        .await;
+
+        let s = state.read();
+        let exec = s.executions.get(arn).unwrap();
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        assert!(exec.output.is_some());
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        assert_eq!(output, json!({"processed": true}));
+    }
+
+    #[tokio::test]
+    async fn test_pass_chain() {
+        let state = make_state();
+        let arn = "arn:aws:states:us-east-1:123456789012:execution:test:exec-1";
+        create_execution(&state, arn, Some(r#"{}"#.to_string()));
+
+        let definition = json!({
+            "StartAt": "First",
+            "States": {
+                "First": {
+                    "Type": "Pass",
+                    "Result": "step1",
+                    "ResultPath": "$.first",
+                    "Next": "Second"
+                },
+                "Second": {
+                    "Type": "Pass",
+                    "Result": "step2",
+                    "ResultPath": "$.second",
+                    "End": true
+                }
+            }
+        })
+        .to_string();
+
+        execute_state_machine(
+            state.clone(),
+            arn.to_string(),
+            definition,
+            Some("{}".to_string()),
+        )
+        .await;
+
+        let s = state.read();
+        let exec = s.executions.get(arn).unwrap();
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        assert_eq!(output["first"], json!("step1"));
+        assert_eq!(output["second"], json!("step2"));
+    }
+
+    #[tokio::test]
+    async fn test_succeed_state() {
+        let state = make_state();
+        let arn = "arn:aws:states:us-east-1:123456789012:execution:test:exec-1";
+        create_execution(&state, arn, Some(r#"{"data": "value"}"#.to_string()));
+
+        let definition = json!({
+            "StartAt": "Done",
+            "States": {
+                "Done": {
+                    "Type": "Succeed"
+                }
+            }
+        })
+        .to_string();
+
+        execute_state_machine(
+            state.clone(),
+            arn.to_string(),
+            definition,
+            Some(r#"{"data": "value"}"#.to_string()),
+        )
+        .await;
+
+        let s = state.read();
+        let exec = s.executions.get(arn).unwrap();
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+    }
+
+    #[tokio::test]
+    async fn test_fail_state() {
+        let state = make_state();
+        let arn = "arn:aws:states:us-east-1:123456789012:execution:test:exec-1";
+        create_execution(&state, arn, None);
+
+        let definition = json!({
+            "StartAt": "FailState",
+            "States": {
+                "FailState": {
+                    "Type": "Fail",
+                    "Error": "CustomError",
+                    "Cause": "Something went wrong"
+                }
+            }
+        })
+        .to_string();
+
+        execute_state_machine(state.clone(), arn.to_string(), definition, None).await;
+
+        let s = state.read();
+        let exec = s.executions.get(arn).unwrap();
+        assert_eq!(exec.status, ExecutionStatus::Failed);
+        assert_eq!(exec.error.as_deref(), Some("CustomError"));
+        assert_eq!(exec.cause.as_deref(), Some("Something went wrong"));
+    }
+
+    #[tokio::test]
+    async fn test_history_events_recorded() {
+        let state = make_state();
+        let arn = "arn:aws:states:us-east-1:123456789012:execution:test:exec-1";
+        create_execution(&state, arn, Some("{}".to_string()));
+
+        let definition = json!({
+            "StartAt": "PassState",
+            "States": {
+                "PassState": {
+                    "Type": "Pass",
+                    "End": true
+                }
+            }
+        })
+        .to_string();
+
+        execute_state_machine(
+            state.clone(),
+            arn.to_string(),
+            definition,
+            Some("{}".to_string()),
+        )
+        .await;
+
+        let s = state.read();
+        let exec = s.executions.get(arn).unwrap();
+        let event_types: Vec<&str> = exec
+            .history_events
+            .iter()
+            .map(|e| e.event_type.as_str())
+            .collect();
+        assert_eq!(
+            event_types,
+            vec![
+                "ExecutionStarted",
+                "PassStateEntered",
+                "PassStateExited",
+                "ExecutionSucceeded"
+            ]
+        );
+    }
+}

--- a/crates/fakecloud-stepfunctions/src/io_processing.rs
+++ b/crates/fakecloud-stepfunctions/src/io_processing.rs
@@ -1,0 +1,193 @@
+use serde_json::Value;
+
+/// Apply InputPath to extract a subset of the raw input.
+/// - `None` or `Some("$")` → return input unchanged
+/// - `Some("null")` handled at call site (pass `{}`)
+/// - `Some("$.foo.bar")` → extract nested field
+pub fn apply_input_path(input: &Value, path: Option<&str>) -> Value {
+    match path {
+        None | Some("$") => input.clone(),
+        Some(p) => resolve_path(input, p),
+    }
+}
+
+/// Apply OutputPath to extract a subset of the effective output.
+/// Same semantics as InputPath.
+pub fn apply_output_path(output: &Value, path: Option<&str>) -> Value {
+    match path {
+        None | Some("$") => output.clone(),
+        Some(p) => resolve_path(output, p),
+    }
+}
+
+/// Apply ResultPath to merge a state's result into the input.
+/// - `None` or `Some("$")` → result replaces input entirely
+/// - `Some("null")` → discard result, return original input
+/// - `Some("$.foo")` → set result at that path within input
+pub fn apply_result_path(input: &Value, result: &Value, path: Option<&str>) -> Value {
+    match path {
+        None | Some("$") => result.clone(),
+        Some("null") => input.clone(),
+        Some(p) => set_at_path(input, p, result),
+    }
+}
+
+/// Resolve a simple JsonPath expression against a JSON value.
+/// Supports: `$`, `$.field`, `$.field.nested`, `$.arr[0]`
+pub fn resolve_path(root: &Value, path: &str) -> Value {
+    if path == "$" {
+        return root.clone();
+    }
+
+    let path = path.strip_prefix("$.").unwrap_or(path);
+    let mut current = root;
+
+    for segment in split_path_segments(path) {
+        match segment {
+            PathSegment::Field(name) => {
+                current = match current.get(name) {
+                    Some(v) => v,
+                    None => return Value::Null,
+                };
+            }
+            PathSegment::Index(name, idx) => {
+                current = match current.get(name) {
+                    Some(v) => match v.get(idx) {
+                        Some(v) => v,
+                        None => return Value::Null,
+                    },
+                    None => return Value::Null,
+                };
+            }
+        }
+    }
+
+    current.clone()
+}
+
+/// Set a value at a simple JsonPath within a JSON structure.
+fn set_at_path(root: &Value, path: &str, value: &Value) -> Value {
+    let mut result = root.clone();
+    let path = path.strip_prefix("$.").unwrap_or(path);
+    let segments: Vec<&str> = path.split('.').collect();
+
+    let mut current = &mut result;
+    for (i, segment) in segments.iter().enumerate() {
+        if i == segments.len() - 1 {
+            // Last segment — set the value
+            if let Some(obj) = current.as_object_mut() {
+                obj.insert(segment.to_string(), value.clone());
+            }
+        } else {
+            // Intermediate — ensure object exists
+            if current.get(*segment).is_none() {
+                if let Some(obj) = current.as_object_mut() {
+                    obj.insert(segment.to_string(), serde_json::json!({}));
+                }
+            }
+            current = current.get_mut(*segment).unwrap();
+        }
+    }
+
+    result
+}
+
+enum PathSegment<'a> {
+    Field(&'a str),
+    Index(&'a str, usize),
+}
+
+fn split_path_segments(path: &str) -> Vec<PathSegment<'_>> {
+    let mut segments = Vec::new();
+    for part in path.split('.') {
+        if let Some(bracket_pos) = part.find('[') {
+            let name = &part[..bracket_pos];
+            let idx_str = &part[bracket_pos + 1..part.len() - 1];
+            if let Ok(idx) = idx_str.parse::<usize>() {
+                segments.push(PathSegment::Index(name, idx));
+            } else {
+                segments.push(PathSegment::Field(part));
+            }
+        } else {
+            segments.push(PathSegment::Field(part));
+        }
+    }
+    segments
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_resolve_path_root() {
+        let input = json!({"a": 1});
+        assert_eq!(resolve_path(&input, "$"), input);
+    }
+
+    #[test]
+    fn test_resolve_path_simple_field() {
+        let input = json!({"name": "hello", "value": 42});
+        assert_eq!(resolve_path(&input, "$.name"), json!("hello"));
+        assert_eq!(resolve_path(&input, "$.value"), json!(42));
+    }
+
+    #[test]
+    fn test_resolve_path_nested() {
+        let input = json!({"a": {"b": {"c": 99}}});
+        assert_eq!(resolve_path(&input, "$.a.b.c"), json!(99));
+    }
+
+    #[test]
+    fn test_resolve_path_missing() {
+        let input = json!({"a": 1});
+        assert_eq!(resolve_path(&input, "$.missing"), Value::Null);
+    }
+
+    #[test]
+    fn test_resolve_path_array_index() {
+        let input = json!({"items": [10, 20, 30]});
+        assert_eq!(resolve_path(&input, "$.items[0]"), json!(10));
+        assert_eq!(resolve_path(&input, "$.items[2]"), json!(30));
+    }
+
+    #[test]
+    fn test_apply_input_path_default() {
+        let input = json!({"x": 1});
+        assert_eq!(apply_input_path(&input, None), input);
+        assert_eq!(apply_input_path(&input, Some("$")), input);
+    }
+
+    #[test]
+    fn test_apply_result_path_default() {
+        let input = json!({"x": 1});
+        let result = json!({"y": 2});
+        // Default: result replaces input
+        assert_eq!(apply_result_path(&input, &result, None), result);
+        assert_eq!(apply_result_path(&input, &result, Some("$")), result);
+    }
+
+    #[test]
+    fn test_apply_result_path_null() {
+        let input = json!({"x": 1});
+        let result = json!({"y": 2});
+        // null: discard result, keep input
+        assert_eq!(apply_result_path(&input, &result, Some("null")), input);
+    }
+
+    #[test]
+    fn test_apply_result_path_nested() {
+        let input = json!({"x": 1});
+        let result = json!("hello");
+        let output = apply_result_path(&input, &result, Some("$.result"));
+        assert_eq!(output, json!({"x": 1, "result": "hello"}));
+    }
+
+    #[test]
+    fn test_apply_output_path() {
+        let output = json!({"a": 1, "b": 2});
+        assert_eq!(apply_output_path(&output, Some("$.a")), json!(1));
+        assert_eq!(apply_output_path(&output, None), output);
+    }
+}

--- a/crates/fakecloud-stepfunctions/src/lib.rs
+++ b/crates/fakecloud-stepfunctions/src/lib.rs
@@ -1,2 +1,4 @@
+pub mod interpreter;
+pub mod io_processing;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -9,7 +9,11 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{SharedStepFunctionsState, StateMachine, StateMachineStatus, StateMachineType};
+use crate::interpreter;
+use crate::state::{
+    Execution, ExecutionStatus, SharedStepFunctionsState, StateMachine, StateMachineStatus,
+    StateMachineType,
+};
 
 const SUPPORTED: &[&str] = &[
     "CreateStateMachine",
@@ -20,6 +24,12 @@ const SUPPORTED: &[&str] = &[
     "TagResource",
     "UntagResource",
     "ListTagsForResource",
+    "StartExecution",
+    "StopExecution",
+    "DescribeExecution",
+    "ListExecutions",
+    "GetExecutionHistory",
+    "DescribeStateMachineForExecution",
 ];
 
 pub struct StepFunctionsService {
@@ -48,6 +58,12 @@ impl AwsService for StepFunctionsService {
             "TagResource" => self.tag_resource(&req),
             "UntagResource" => self.untag_resource(&req),
             "ListTagsForResource" => self.list_tags_for_resource(&req),
+            "StartExecution" => self.start_execution(&req),
+            "StopExecution" => self.stop_execution(&req),
+            "DescribeExecution" => self.describe_execution(&req),
+            "ListExecutions" => self.list_executions(&req),
+            "GetExecutionHistory" => self.get_execution_history(&req),
+            "DescribeStateMachineForExecution" => self.describe_state_machine_for_execution(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "states",
                 &req.action,
@@ -261,6 +277,276 @@ impl StepFunctionsService {
         })))
     }
 
+    // ─── Execution Lifecycle ──────────────────────────────────────────
+
+    fn start_execution(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        validate_required("stateMachineArn", &body["stateMachineArn"])?;
+        let sm_arn = body["stateMachineArn"]
+            .as_str()
+            .ok_or_else(|| missing("stateMachineArn"))?;
+        validate_arn(sm_arn)?;
+
+        let input = body["input"].as_str().map(|s| s.to_string());
+
+        // Validate input is valid JSON if provided
+        if let Some(ref input_str) = input {
+            let _: serde_json::Value = serde_json::from_str(input_str).map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidExecutionInput",
+                    "Invalid execution input: must be valid JSON".to_string(),
+                )
+            })?;
+        }
+
+        let execution_name = body["name"]
+            .as_str()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+        if let Some(name) = body["name"].as_str() {
+            validate_name(name)?;
+        }
+
+        let mut state = self.state.write();
+        let sm = state
+            .state_machines
+            .get(sm_arn)
+            .ok_or_else(|| state_machine_not_found(sm_arn))?;
+
+        let sm_name = sm.name.clone();
+        let definition = sm.definition.clone();
+        let exec_arn = state.execution_arn(&sm_name, &execution_name);
+
+        // Check for duplicate execution name
+        if state.executions.contains_key(&exec_arn) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::CONFLICT,
+                "ExecutionAlreadyExists",
+                format!("Execution Already Exists: '{exec_arn}'"),
+            ));
+        }
+
+        let now = Utc::now();
+        let execution = Execution {
+            execution_arn: exec_arn.clone(),
+            state_machine_arn: sm_arn.to_string(),
+            state_machine_name: sm_name,
+            name: execution_name,
+            status: ExecutionStatus::Running,
+            input: input.clone(),
+            output: None,
+            start_date: now,
+            stop_date: None,
+            error: None,
+            cause: None,
+            history_events: vec![],
+        };
+
+        state.executions.insert(exec_arn.clone(), execution);
+        drop(state);
+
+        // Spawn async execution
+        let shared_state = self.state.clone();
+        let exec_arn_clone = exec_arn.clone();
+        let input_clone = input;
+        tokio::spawn(async move {
+            interpreter::execute_state_machine(
+                shared_state,
+                exec_arn_clone,
+                definition,
+                input_clone,
+            )
+            .await;
+        });
+
+        Ok(AwsResponse::ok_json(json!({
+            "executionArn": exec_arn,
+            "startDate": now.timestamp() as f64,
+        })))
+    }
+
+    fn stop_execution(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        validate_required("executionArn", &body["executionArn"])?;
+        let exec_arn = body["executionArn"]
+            .as_str()
+            .ok_or_else(|| missing("executionArn"))?;
+
+        let error = body["error"].as_str().map(|s| s.to_string());
+        let cause = body["cause"].as_str().map(|s| s.to_string());
+
+        let mut state = self.state.write();
+        let exec = state
+            .executions
+            .get_mut(exec_arn)
+            .ok_or_else(|| execution_not_found(exec_arn))?;
+
+        if exec.status != ExecutionStatus::Running {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ExecutionNotRunning",
+                format!("Execution is not running: '{exec_arn}'"),
+            ));
+        }
+
+        let now = Utc::now();
+        exec.status = ExecutionStatus::Aborted;
+        exec.stop_date = Some(now);
+        exec.error = error;
+        exec.cause = cause;
+
+        Ok(AwsResponse::ok_json(json!({
+            "stopDate": now.timestamp() as f64,
+        })))
+    }
+
+    fn describe_execution(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        validate_required("executionArn", &body["executionArn"])?;
+        let exec_arn = body["executionArn"]
+            .as_str()
+            .ok_or_else(|| missing("executionArn"))?;
+
+        let state = self.state.read();
+        let exec = state
+            .executions
+            .get(exec_arn)
+            .ok_or_else(|| execution_not_found(exec_arn))?;
+
+        Ok(AwsResponse::ok_json(execution_to_json(exec)))
+    }
+
+    fn list_executions(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        validate_required("stateMachineArn", &body["stateMachineArn"])?;
+        let sm_arn = body["stateMachineArn"]
+            .as_str()
+            .ok_or_else(|| missing("stateMachineArn"))?;
+        validate_arn(sm_arn)?;
+
+        let max_results = body["maxResults"].as_i64().unwrap_or(100) as usize;
+        validate_range_i64("maxResults", max_results as i64, 1, 1000)?;
+        let next_token = body["nextToken"].as_str();
+        let status_filter = body["statusFilter"].as_str();
+
+        let state = self.state.read();
+
+        // Verify state machine exists
+        if !state.state_machines.contains_key(sm_arn) {
+            return Err(state_machine_not_found(sm_arn));
+        }
+
+        let mut executions: Vec<&Execution> = state
+            .executions
+            .values()
+            .filter(|e| e.state_machine_arn == sm_arn)
+            .filter(|e| {
+                status_filter
+                    .map(|sf| e.status.as_str() == sf)
+                    .unwrap_or(true)
+            })
+            .collect();
+
+        // Sort by start date descending (most recent first)
+        executions.sort_by(|a, b| b.start_date.cmp(&a.start_date));
+
+        let items: Vec<Value> = executions
+            .iter()
+            .map(|e| {
+                let mut item = json!({
+                    "executionArn": e.execution_arn,
+                    "stateMachineArn": e.state_machine_arn,
+                    "name": e.name,
+                    "status": e.status.as_str(),
+                    "startDate": e.start_date.timestamp() as f64,
+                });
+                if let Some(stop) = e.stop_date {
+                    item["stopDate"] = json!(stop.timestamp() as f64);
+                }
+                item
+            })
+            .collect();
+
+        let (page, token) = paginate(&items, next_token, max_results);
+
+        let mut resp = json!({ "executions": page });
+        if let Some(t) = token {
+            resp["nextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
+    }
+
+    fn get_execution_history(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        validate_required("executionArn", &body["executionArn"])?;
+        let exec_arn = body["executionArn"]
+            .as_str()
+            .ok_or_else(|| missing("executionArn"))?;
+
+        let max_results = body["maxResults"].as_i64().unwrap_or(100) as usize;
+        validate_range_i64("maxResults", max_results as i64, 1, 1000)?;
+        let next_token = body["nextToken"].as_str();
+        let reverse_order = body["reverseOrder"].as_bool().unwrap_or(false);
+
+        let state = self.state.read();
+        let exec = state
+            .executions
+            .get(exec_arn)
+            .ok_or_else(|| execution_not_found(exec_arn))?;
+
+        let mut events: Vec<Value> = exec
+            .history_events
+            .iter()
+            .map(|e| {
+                json!({
+                    "id": e.id,
+                    "type": e.event_type,
+                    "timestamp": e.timestamp.timestamp() as f64,
+                    "previousEventId": e.previous_event_id,
+                    format!("{}EventDetails", camel_to_details_key(&e.event_type)): e.details,
+                })
+            })
+            .collect();
+
+        if reverse_order {
+            events.reverse();
+        }
+
+        let (page, token) = paginate(&events, next_token, max_results);
+
+        let mut resp = json!({ "events": page });
+        if let Some(t) = token {
+            resp["nextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
+    }
+
+    fn describe_state_machine_for_execution(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        validate_required("executionArn", &body["executionArn"])?;
+        let exec_arn = body["executionArn"]
+            .as_str()
+            .ok_or_else(|| missing("executionArn"))?;
+
+        let state = self.state.read();
+        let exec = state
+            .executions
+            .get(exec_arn)
+            .ok_or_else(|| execution_not_found(exec_arn))?;
+
+        let sm = state
+            .state_machines
+            .get(&exec.state_machine_arn)
+            .ok_or_else(|| state_machine_not_found(&exec.state_machine_arn))?;
+
+        Ok(AwsResponse::ok_json(state_machine_to_json(sm)))
+    }
+
     // ─── Tagging ────────────────────────────────────────────────────────
 
     fn tag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -468,6 +754,51 @@ fn validate_definition(definition: &str) -> Result<(), AwsServiceError> {
     }
 
     Ok(())
+}
+
+fn execution_not_found(arn: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ExecutionDoesNotExist",
+        format!("Execution Does Not Exist: '{arn}'"),
+    )
+}
+
+fn execution_to_json(exec: &Execution) -> Value {
+    let mut resp = json!({
+        "executionArn": exec.execution_arn,
+        "stateMachineArn": exec.state_machine_arn,
+        "name": exec.name,
+        "status": exec.status.as_str(),
+        "startDate": exec.start_date.timestamp() as f64,
+    });
+
+    if let Some(ref input) = exec.input {
+        resp["input"] = json!(input);
+    }
+    if let Some(ref output) = exec.output {
+        resp["output"] = json!(output);
+    }
+    if let Some(stop) = exec.stop_date {
+        resp["stopDate"] = json!(stop.timestamp() as f64);
+    }
+    if let Some(ref error) = exec.error {
+        resp["error"] = json!(error);
+    }
+    if let Some(ref cause) = exec.cause {
+        resp["cause"] = json!(cause);
+    }
+
+    resp
+}
+
+/// Convert event type like "PassStateEntered" to the details key format "passStateEntered".
+fn camel_to_details_key(event_type: &str) -> String {
+    let mut chars = event_type.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_lowercase().to_string() + chars.as_str(),
+    }
 }
 
 fn validate_arn(arn: &str) -> Result<(), AwsServiceError> {


### PR DESCRIPTION
## Summary

- 6 new operations: StartExecution, StopExecution, DescribeExecution, ListExecutions, GetExecutionHistory, DescribeStateMachineForExecution
- ASL interpreter executing Pass, Succeed, and Fail state types with InputPath/ResultPath/OutputPath processing
- Async execution via `tokio::spawn` — StartExecution returns immediately, interpreter runs in background
- Execution history events recorded for each state transition

## Test plan

- [x] 25 E2E tests (12 new) covering execution lifecycle, Pass chains, ResultPath, Succeed/Fail states
- [x] 14 conformance tests (6 new) with Smithy model checksums
- [x] 15 unit tests for interpreter and I/O processing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Step Functions execution lifecycle with an async interpreter for Pass, Succeed, and Fail states, including path processing and execution history. Exposes execution APIs so state machines can run end to end.

- **New Features**
  - New APIs: StartExecution, StopExecution, DescribeExecution, ListExecutions, GetExecutionHistory, DescribeStateMachineForExecution
  - Async execution via `tokio::spawn`; StartExecution returns immediately
  - ASL interpreter for Pass/Succeed/Fail with InputPath/ResultPath/OutputPath (simple JSONPath)
  - Execution history recorded with event details; ListExecutions supports status filtering and pagination

- **Dependencies**
  - Add `tokio` to `crates/fakecloud-stepfunctions`

<sup>Written for commit f9982f1c62a52a6b1612dae493dc1749bc474e4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

