### PR TITLE
test(s3): unignore valid multipart upload coverage

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -920,26 +920,28 @@ async fn s3_multipart_upload_basic() {
         .unwrap();
     let upload_id = create.upload_id().unwrap().to_string();
 
-    // Upload two parts
+    // Upload two parts. Non-last parts must be at least 5 MiB.
+    let part1_data = vec![b'a'; 5 * 1024 * 1024];
     let part1 = client
         .upload_part()
         .bucket("mp-bucket")
         .key("big-file.bin")
         .upload_id(&upload_id)
         .part_number(1)
-        .body(ByteStream::from_static(b"part-one-data-"))
+        .body(ByteStream::from(part1_data.clone()))
         .send()
         .await
         .unwrap();
     let etag1 = part1.e_tag().unwrap().to_string();
 
+    let part2_data = b"part-two-data".to_vec();
     let part2 = client
         .upload_part()
         .bucket("mp-bucket")
         .key("big-file.bin")
         .upload_id(&upload_id)
         .part_number(2)
-        .body(ByteStream::from_static(b"part-two-data"))
+        .body(ByteStream::from(part2_data.clone()))
         .send()
         .await
         .unwrap();
@@ -981,7 +983,9 @@ async fn s3_multipart_upload_basic() {
         .await
         .unwrap();
     let body = get.body.collect().await.unwrap().into_bytes();
-    assert_eq!(body.as_ref(), b"part-one-data-part-two-data");
+    let mut expected = part1_data;
+    expected.extend_from_slice(&part2_data);
+    assert_eq!(body.as_ref(), expected.as_slice());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary\n- unignore s3_multipart_upload_basic\n- make the multipart upload shape valid by using a 5 MiB non-last part\n- assert the assembled object bytes from the dynamic part payloads\n\n## Testing\n- cargo test -p fakecloud-e2e s3_multipart_upload_basic -- --ignored --exact --nocapture

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unignored the S3 multipart upload test and made it valid by using a 5 MiB non-last part. The test now asserts the downloaded object equals the concatenated bytes of both uploaded parts.

<sup>Written for commit dc8e8273b3e0976d4b9d99a0ebeda11adfc22b10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

