### PR TITLE
feat(stepfunctions): add Choice and Wait states to ASL interpreter

### DIFF
--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -1474,3 +1474,802 @@ async fn sfn_task_chain_with_pass() {
     assert_eq!(output["original"], true);
     assert_eq!(output["enrichment"], "enriched");
 }
+
+// --- Choice state tests ---
+
+#[tokio::test]
+async fn sfn_choice_state_string_equals() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "Route",
+        "States": {
+            "Route": {
+                "Type": "Choice",
+                "Choices": [
+                    {
+                        "Variable": "$.status",
+                        "StringEquals": "active",
+                        "Next": "ActivePath"
+                    },
+                    {
+                        "Variable": "$.status",
+                        "StringEquals": "inactive",
+                        "Next": "InactivePath"
+                    }
+                ],
+                "Default": "DefaultPath"
+            },
+            "ActivePath": {
+                "Type": "Pass",
+                "Result": "went-active",
+                "End": true
+            },
+            "InactivePath": {
+                "Type": "Pass",
+                "Result": "went-inactive",
+                "End": true
+            },
+            "DefaultPath": {
+                "Type": "Pass",
+                "Result": "went-default",
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("choice-string-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    // Test active path
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-active")
+        .input(r#"{"status": "active"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "went-active");
+
+    // Test inactive path
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-inactive")
+        .input(r#"{"status": "inactive"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "went-inactive");
+
+    // Test default path
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-default")
+        .input(r#"{"status": "unknown"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "went-default");
+}
+
+#[tokio::test]
+async fn sfn_choice_state_numeric_comparison() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "CheckScore",
+        "States": {
+            "CheckScore": {
+                "Type": "Choice",
+                "Choices": [
+                    {
+                        "Variable": "$.score",
+                        "NumericGreaterThanEquals": 90,
+                        "Next": "Grade_A"
+                    },
+                    {
+                        "Variable": "$.score",
+                        "NumericGreaterThanEquals": 80,
+                        "Next": "Grade_B"
+                    }
+                ],
+                "Default": "Grade_C"
+            },
+            "Grade_A": {
+                "Type": "Pass",
+                "Result": "A",
+                "End": true
+            },
+            "Grade_B": {
+                "Type": "Pass",
+                "Result": "B",
+                "End": true
+            },
+            "Grade_C": {
+                "Type": "Pass",
+                "Result": "C",
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("choice-numeric-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("score-95")
+        .input(r#"{"score": 95}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "A");
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("score-85")
+        .input(r#"{"score": 85}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "B");
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("score-50")
+        .input(r#"{"score": 50}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "C");
+}
+
+#[tokio::test]
+async fn sfn_choice_state_boolean_and_compound() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "Check",
+        "States": {
+            "Check": {
+                "Type": "Choice",
+                "Choices": [
+                    {
+                        "And": [
+                            {"Variable": "$.enabled", "BooleanEquals": true},
+                            {"Variable": "$.count", "NumericGreaterThan": 0}
+                        ],
+                        "Next": "Process"
+                    }
+                ],
+                "Default": "Skip"
+            },
+            "Process": {
+                "Type": "Pass",
+                "Result": "processed",
+                "End": true
+            },
+            "Skip": {
+                "Type": "Pass",
+                "Result": "skipped",
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("choice-compound-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    // Both conditions true
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-both-true")
+        .input(r#"{"enabled": true, "count": 5}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "processed");
+
+    // One condition false — should go to Skip
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-disabled")
+        .input(r#"{"enabled": false, "count": 5}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "skipped");
+}
+
+#[tokio::test]
+async fn sfn_choice_state_not_operator() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "Check",
+        "States": {
+            "Check": {
+                "Type": "Choice",
+                "Choices": [
+                    {
+                        "Not": {
+                            "Variable": "$.type",
+                            "StringEquals": "admin"
+                        },
+                        "Next": "RegularUser"
+                    }
+                ],
+                "Default": "AdminUser"
+            },
+            "RegularUser": {
+                "Type": "Pass",
+                "Result": "regular",
+                "End": true
+            },
+            "AdminUser": {
+                "Type": "Pass",
+                "Result": "admin",
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("choice-not-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-user")
+        .input(r#"{"type": "user"}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "regular");
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-admin")
+        .input(r#"{"type": "admin"}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "admin");
+}
+
+#[tokio::test]
+async fn sfn_choice_state_no_match_no_default() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "Route",
+        "States": {
+            "Route": {
+                "Type": "Choice",
+                "Choices": [
+                    {
+                        "Variable": "$.status",
+                        "StringEquals": "active",
+                        "Next": "Active"
+                    }
+                ]
+            },
+            "Active": {
+                "Type": "Succeed"
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("choice-no-default-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"status": "unknown"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "FAILED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desc.error().unwrap_or(""), "States.NoChoiceMatched");
+}
+
+#[tokio::test]
+async fn sfn_choice_state_is_present() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "Check",
+        "States": {
+            "Check": {
+                "Type": "Choice",
+                "Choices": [
+                    {
+                        "Variable": "$.optional",
+                        "IsPresent": true,
+                        "Next": "HasField"
+                    }
+                ],
+                "Default": "NoField"
+            },
+            "HasField": {
+                "Type": "Pass",
+                "Result": "present",
+                "End": true
+            },
+            "NoField": {
+                "Type": "Pass",
+                "Result": "absent",
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("choice-ispresent-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-with-field")
+        .input(r#"{"optional": "value"}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "present");
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-without-field")
+        .input(r#"{"other": "value"}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "absent");
+}
+
+// --- Wait state tests ---
+
+#[tokio::test]
+async fn sfn_wait_state_seconds() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "WaitBriefly",
+        "States": {
+            "WaitBriefly": {
+                "Type": "Wait",
+                "Seconds": 1,
+                "Next": "Done"
+            },
+            "Done": {
+                "Type": "Pass",
+                "Result": "waited",
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("wait-seconds-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Execution should be running during wait
+    sleep(Duration::from_millis(200)).await;
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desc.status().as_str(), "RUNNING");
+
+    // Wait for completion
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "waited");
+}
+
+#[tokio::test]
+async fn sfn_wait_state_seconds_path() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "WaitDynamic",
+        "States": {
+            "WaitDynamic": {
+                "Type": "Wait",
+                "SecondsPath": "$.delay",
+                "Next": "Done"
+            },
+            "Done": {
+                "Type": "Pass",
+                "Result": "dynamic-wait-done",
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("wait-seconds-path-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"delay": 1}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "dynamic-wait-done");
+}
+
+#[tokio::test]
+async fn sfn_choice_then_wait_workflow() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    // Combined workflow: Choice routes to either a fast or slow path with Wait
+    let definition = serde_json::json!({
+        "StartAt": "Route",
+        "States": {
+            "Route": {
+                "Type": "Choice",
+                "Choices": [
+                    {
+                        "Variable": "$.priority",
+                        "StringEquals": "high",
+                        "Next": "FastTrack"
+                    }
+                ],
+                "Default": "SlowTrack"
+            },
+            "FastTrack": {
+                "Type": "Pass",
+                "Result": "fast",
+                "End": true
+            },
+            "SlowTrack": {
+                "Type": "Wait",
+                "Seconds": 1,
+                "Next": "Done"
+            },
+            "Done": {
+                "Type": "Pass",
+                "Result": "slow",
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("choice-wait-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-high")
+        .input(r#"{"priority": "high"}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "fast");
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-low")
+        .input(r#"{"priority": "low"}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "slow");
+}
+
+#[tokio::test]
+async fn sfn_choice_state_history_events() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "Route",
+        "States": {
+            "Route": {
+                "Type": "Choice",
+                "Choices": [
+                    {
+                        "Variable": "$.go",
+                        "BooleanEquals": true,
+                        "Next": "Done"
+                    }
+                ],
+                "Default": "Done"
+            },
+            "Done": {
+                "Type": "Succeed"
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("choice-history-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"go": true}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let history = client
+        .get_execution_history()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let event_types: Vec<String> = history
+        .events()
+        .iter()
+        .map(|e| e.r#type().as_str().to_string())
+        .collect();
+
+    assert!(event_types.contains(&"ChoiceStateEntered".to_string()));
+    assert!(event_types.contains(&"ChoiceStateExited".to_string()));
+    assert!(event_types.contains(&"ExecutionSucceeded".to_string()));
+}

--- a/crates/fakecloud-stepfunctions/src/choice.rs
+++ b/crates/fakecloud-stepfunctions/src/choice.rs
@@ -1,0 +1,491 @@
+use serde_json::Value;
+
+use crate::io_processing::resolve_path;
+
+/// Evaluate a Choice state's rules against the input and return the Next state name.
+/// Returns None if no rule matches and there's no Default.
+pub fn evaluate_choice(state_def: &Value, input: &Value) -> Option<String> {
+    if let Some(choices) = state_def["Choices"].as_array() {
+        for choice in choices {
+            if evaluate_rule(choice, input) {
+                return choice["Next"].as_str().map(|s| s.to_string());
+            }
+        }
+    }
+
+    // Fall through to Default
+    state_def["Default"].as_str().map(|s| s.to_string())
+}
+
+/// Evaluate a single choice rule (may be compound via And/Or/Not).
+fn evaluate_rule(rule: &Value, input: &Value) -> bool {
+    // Logical operators
+    if let Some(and_rules) = rule["And"].as_array() {
+        return and_rules.iter().all(|r| evaluate_rule(r, input));
+    }
+    if let Some(or_rules) = rule["Or"].as_array() {
+        return or_rules.iter().any(|r| evaluate_rule(r, input));
+    }
+    if rule.get("Not").is_some() {
+        return !evaluate_rule(&rule["Not"], input);
+    }
+
+    // Get the variable value
+    let variable = match rule["Variable"].as_str() {
+        Some(v) => v,
+        None => return false,
+    };
+    let value = resolve_path(input, variable);
+
+    // Presence/type checks
+    if let Some(expected) = rule.get("IsPresent") {
+        let is_present = !value.is_null();
+        return expected.as_bool().unwrap_or(false) == is_present;
+    }
+    if let Some(expected) = rule.get("IsNull") {
+        let is_null = value.is_null();
+        return expected.as_bool().unwrap_or(false) == is_null;
+    }
+    if let Some(expected) = rule.get("IsNumeric") {
+        let is_numeric = value.is_number();
+        return expected.as_bool().unwrap_or(false) == is_numeric;
+    }
+    if let Some(expected) = rule.get("IsString") {
+        let is_string = value.is_string();
+        return expected.as_bool().unwrap_or(false) == is_string;
+    }
+    if let Some(expected) = rule.get("IsBoolean") {
+        let is_boolean = value.is_boolean();
+        return expected.as_bool().unwrap_or(false) == is_boolean;
+    }
+    if let Some(expected) = rule.get("IsTimestamp") {
+        let is_ts = value
+            .as_str()
+            .map(|s| chrono::DateTime::parse_from_rfc3339(s).is_ok())
+            .unwrap_or(false);
+        return expected.as_bool().unwrap_or(false) == is_ts;
+    }
+
+    // String comparisons
+    if let Some(expected) = rule["StringEquals"].as_str() {
+        return value.as_str() == Some(expected);
+    }
+    if let Some(path) = rule["StringEqualsPath"].as_str() {
+        let other = resolve_path(input, path);
+        return value.as_str().is_some() && value.as_str() == other.as_str();
+    }
+    if let Some(expected) = rule["StringLessThan"].as_str() {
+        return value.as_str().is_some_and(|v| v < expected);
+    }
+    if let Some(expected) = rule["StringGreaterThan"].as_str() {
+        return value.as_str().is_some_and(|v| v > expected);
+    }
+    if let Some(expected) = rule["StringLessThanEquals"].as_str() {
+        return value.as_str().is_some_and(|v| v <= expected);
+    }
+    if let Some(expected) = rule["StringGreaterThanEquals"].as_str() {
+        return value.as_str().is_some_and(|v| v >= expected);
+    }
+    if let Some(pattern) = rule["StringMatches"].as_str() {
+        return value.as_str().is_some_and(|v| string_matches(v, pattern));
+    }
+
+    // Numeric comparisons
+    if let Some(expected) = rule["NumericEquals"].as_f64() {
+        return value.as_f64() == Some(expected);
+    }
+    if let Some(path) = rule["NumericEqualsPath"].as_str() {
+        let other = resolve_path(input, path);
+        return value.as_f64().is_some() && value.as_f64() == other.as_f64();
+    }
+    if let Some(expected) = rule["NumericLessThan"].as_f64() {
+        return value.as_f64().is_some_and(|v| v < expected);
+    }
+    if let Some(expected) = rule["NumericGreaterThan"].as_f64() {
+        return value.as_f64().is_some_and(|v| v > expected);
+    }
+    if let Some(expected) = rule["NumericLessThanEquals"].as_f64() {
+        return value.as_f64().is_some_and(|v| v <= expected);
+    }
+    if let Some(expected) = rule["NumericGreaterThanEquals"].as_f64() {
+        return value.as_f64().is_some_and(|v| v >= expected);
+    }
+
+    // Boolean comparisons
+    if let Some(expected) = rule["BooleanEquals"].as_bool() {
+        return value.as_bool() == Some(expected);
+    }
+    if let Some(path) = rule["BooleanEqualsPath"].as_str() {
+        let other = resolve_path(input, path);
+        return value.as_bool().is_some() && value.as_bool() == other.as_bool();
+    }
+
+    // Timestamp comparisons
+    if let Some(expected) = rule["TimestampEquals"].as_str() {
+        return compare_timestamps(&value, expected, |a, b| a == b);
+    }
+    if let Some(expected) = rule["TimestampLessThan"].as_str() {
+        return compare_timestamps(&value, expected, |a, b| a < b);
+    }
+    if let Some(expected) = rule["TimestampGreaterThan"].as_str() {
+        return compare_timestamps(&value, expected, |a, b| a > b);
+    }
+    if let Some(expected) = rule["TimestampLessThanEquals"].as_str() {
+        return compare_timestamps(&value, expected, |a, b| a <= b);
+    }
+    if let Some(expected) = rule["TimestampGreaterThanEquals"].as_str() {
+        return compare_timestamps(&value, expected, |a, b| a >= b);
+    }
+
+    false
+}
+
+/// Compare two RFC3339 timestamps using the provided comparison function.
+fn compare_timestamps<F>(value: &Value, expected: &str, cmp: F) -> bool
+where
+    F: Fn(chrono::DateTime<chrono::FixedOffset>, chrono::DateTime<chrono::FixedOffset>) -> bool,
+{
+    let val_str = match value.as_str() {
+        Some(s) => s,
+        None => return false,
+    };
+    let val_ts = match chrono::DateTime::parse_from_rfc3339(val_str) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    let exp_ts = match chrono::DateTime::parse_from_rfc3339(expected) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    cmp(val_ts, exp_ts)
+}
+
+/// Glob-style pattern matching for StringMatches.
+/// Supports `*` (matches any sequence) and `\*` (literal asterisk).
+fn string_matches(value: &str, pattern: &str) -> bool {
+    let mut pattern_chars: Vec<char> = pattern.chars().collect();
+    let value_chars: Vec<char> = value.chars().collect();
+
+    // Preprocess: handle escaped asterisks
+    let mut segments: Vec<PatternSegment> = Vec::new();
+    let mut current = String::new();
+    let mut i = 0;
+    while i < pattern_chars.len() {
+        if pattern_chars[i] == '\\' && i + 1 < pattern_chars.len() && pattern_chars[i + 1] == '*' {
+            current.push('*');
+            i += 2;
+        } else if pattern_chars[i] == '*' {
+            if !current.is_empty() {
+                segments.push(PatternSegment::Literal(current.clone()));
+                current.clear();
+            }
+            segments.push(PatternSegment::Wildcard);
+            i += 1;
+        } else {
+            current.push(pattern_chars[i]);
+            i += 1;
+        }
+    }
+    if !current.is_empty() {
+        segments.push(PatternSegment::Literal(current));
+    }
+
+    // Use cleaned-up pattern_chars for matching
+    pattern_chars = Vec::new();
+    for seg in &segments {
+        match seg {
+            PatternSegment::Literal(s) => {
+                for c in s.chars() {
+                    pattern_chars.push(c);
+                }
+            }
+            PatternSegment::Wildcard => {
+                pattern_chars.push('\0'); // sentinel for wildcard
+            }
+        }
+    }
+
+    // DP matching
+    let m = value_chars.len();
+    let n = pattern_chars.len();
+    let mut dp = vec![vec![false; n + 1]; m + 1];
+    dp[0][0] = true;
+
+    // Handle leading wildcards
+    for j in 1..=n {
+        if pattern_chars[j - 1] == '\0' {
+            dp[0][j] = dp[0][j - 1];
+        }
+    }
+
+    for i in 1..=m {
+        for j in 1..=n {
+            if pattern_chars[j - 1] == '\0' {
+                dp[i][j] = dp[i][j - 1] || dp[i - 1][j];
+            } else if pattern_chars[j - 1] == value_chars[i - 1] {
+                dp[i][j] = dp[i - 1][j - 1];
+            }
+        }
+    }
+
+    dp[m][n]
+}
+
+enum PatternSegment {
+    Literal(String),
+    Wildcard,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_string_equals() {
+        let rule = json!({
+            "Variable": "$.status",
+            "StringEquals": "active",
+            "Next": "Active"
+        });
+        let input = json!({"status": "active"});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"status": "inactive"});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_numeric_greater_than() {
+        let rule = json!({
+            "Variable": "$.count",
+            "NumericGreaterThan": 10,
+            "Next": "High"
+        });
+        let input = json!({"count": 15});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"count": 5});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_boolean_equals() {
+        let rule = json!({
+            "Variable": "$.enabled",
+            "BooleanEquals": true,
+            "Next": "Enabled"
+        });
+        let input = json!({"enabled": true});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"enabled": false});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_and_operator() {
+        let rule = json!({
+            "And": [
+                {"Variable": "$.a", "NumericGreaterThan": 0},
+                {"Variable": "$.b", "NumericLessThan": 100}
+            ],
+            "Next": "Both"
+        });
+        let input = json!({"a": 5, "b": 50});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"a": -1, "b": 50});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_or_operator() {
+        let rule = json!({
+            "Or": [
+                {"Variable": "$.status", "StringEquals": "active"},
+                {"Variable": "$.status", "StringEquals": "pending"}
+            ],
+            "Next": "Valid"
+        });
+        let input = json!({"status": "active"});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"status": "closed"});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_not_operator() {
+        let rule = json!({
+            "Not": {
+                "Variable": "$.status",
+                "StringEquals": "closed"
+            },
+            "Next": "Open"
+        });
+        let input = json!({"status": "active"});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"status": "closed"});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_is_present() {
+        let rule = json!({
+            "Variable": "$.optional",
+            "IsPresent": true,
+            "Next": "HasField"
+        });
+        let input = json!({"optional": "value"});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"other": "value"});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_is_null() {
+        let rule = json!({
+            "Variable": "$.field",
+            "IsNull": true,
+            "Next": "Null"
+        });
+        let input = json!({"field": null});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"field": "value"});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_is_numeric() {
+        let rule = json!({
+            "Variable": "$.value",
+            "IsNumeric": true,
+            "Next": "Number"
+        });
+        let input = json!({"value": 42});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"value": "not a number"});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_string_matches() {
+        assert!(string_matches("hello world", "hello*"));
+        assert!(string_matches("hello world", "*world"));
+        assert!(string_matches("hello world", "hello*world"));
+        assert!(string_matches("hello world", "*"));
+        assert!(!string_matches("hello world", "goodbye*"));
+        assert!(string_matches("log-2024-01-15.txt", "log-*.txt"));
+    }
+
+    #[test]
+    fn test_evaluate_choice_with_default() {
+        let state_def = json!({
+            "Type": "Choice",
+            "Choices": [
+                {
+                    "Variable": "$.status",
+                    "StringEquals": "active",
+                    "Next": "ActivePath"
+                }
+            ],
+            "Default": "DefaultPath"
+        });
+        let input = json!({"status": "unknown"});
+        assert_eq!(
+            evaluate_choice(&state_def, &input),
+            Some("DefaultPath".to_string())
+        );
+    }
+
+    #[test]
+    fn test_evaluate_choice_matching() {
+        let state_def = json!({
+            "Type": "Choice",
+            "Choices": [
+                {
+                    "Variable": "$.value",
+                    "NumericGreaterThan": 100,
+                    "Next": "High"
+                },
+                {
+                    "Variable": "$.value",
+                    "NumericLessThanEquals": 100,
+                    "Next": "Low"
+                }
+            ],
+            "Default": "Unknown"
+        });
+        let input = json!({"value": 150});
+        assert_eq!(
+            evaluate_choice(&state_def, &input),
+            Some("High".to_string())
+        );
+
+        let input = json!({"value": 50});
+        assert_eq!(evaluate_choice(&state_def, &input), Some("Low".to_string()));
+    }
+
+    #[test]
+    fn test_evaluate_choice_no_match_no_default() {
+        let state_def = json!({
+            "Type": "Choice",
+            "Choices": [
+                {
+                    "Variable": "$.status",
+                    "StringEquals": "active",
+                    "Next": "Active"
+                }
+            ]
+        });
+        let input = json!({"status": "closed"});
+        assert_eq!(evaluate_choice(&state_def, &input), None);
+    }
+
+    #[test]
+    fn test_numeric_equals_path() {
+        let rule = json!({
+            "Variable": "$.a",
+            "NumericEqualsPath": "$.b",
+            "Next": "Equal"
+        });
+        let input = json!({"a": 42, "b": 42});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"a": 42, "b": 99});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_timestamp_comparisons() {
+        let rule = json!({
+            "Variable": "$.ts",
+            "TimestampLessThan": "2024-06-01T00:00:00Z",
+            "Next": "Before"
+        });
+        let input = json!({"ts": "2024-01-15T12:00:00Z"});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"ts": "2024-12-01T00:00:00Z"});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_string_less_than() {
+        let rule = json!({
+            "Variable": "$.name",
+            "StringLessThan": "beta",
+            "Next": "Before"
+        });
+        let input = json!({"name": "alpha"});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"name": "gamma"});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+}

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -6,6 +6,7 @@ use tracing::debug;
 
 use fakecloud_core::delivery::DeliveryBus;
 
+use crate::choice::evaluate_choice;
 use crate::error_handling::{find_catcher, should_retry};
 use crate::io_processing::{apply_input_path, apply_output_path, apply_result_path};
 use crate::state::{ExecutionStatus, HistoryEvent, SharedStepFunctionsState};
@@ -303,6 +304,92 @@ pub async fn execute_state_machine(
                 }
             }
 
+            "Choice" => {
+                let entered_event_id = add_event(
+                    &state,
+                    &execution_arn,
+                    "ChoiceStateEntered",
+                    0,
+                    json!({
+                        "name": current_state,
+                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                    }),
+                );
+
+                // Apply InputPath
+                let input_path = state_def["InputPath"].as_str();
+                let processed_input = if input_path == Some("null") {
+                    json!({})
+                } else {
+                    apply_input_path(&effective_input, input_path)
+                };
+
+                match evaluate_choice(&state_def, &processed_input) {
+                    Some(next) => {
+                        add_event(
+                            &state,
+                            &execution_arn,
+                            "ChoiceStateExited",
+                            entered_event_id,
+                            json!({
+                                "name": current_state,
+                                "output": serde_json::to_string(&effective_input).unwrap_or_default(),
+                            }),
+                        );
+                        current_state = next;
+                    }
+                    None => {
+                        fail_execution(
+                            &state,
+                            &execution_arn,
+                            "States.NoChoiceMatched",
+                            &format!(
+                                "No choice rule matched and no Default in state '{current_state}'"
+                            ),
+                        );
+                        return;
+                    }
+                }
+            }
+
+            "Wait" => {
+                let entered_event_id = add_event(
+                    &state,
+                    &execution_arn,
+                    "WaitStateEntered",
+                    0,
+                    json!({
+                        "name": current_state,
+                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                    }),
+                );
+
+                execute_wait_state(&state_def, &effective_input).await;
+
+                add_event(
+                    &state,
+                    &execution_arn,
+                    "WaitStateExited",
+                    entered_event_id,
+                    json!({
+                        "name": current_state,
+                        "output": serde_json::to_string(&effective_input).unwrap_or_default(),
+                    }),
+                );
+
+                match next_state(&state_def) {
+                    NextState::Name(next) => current_state = next,
+                    NextState::End => {
+                        succeed_execution(&state, &execution_arn, &effective_input);
+                        return;
+                    }
+                    NextState::Error(msg) => {
+                        fail_execution(&state, &execution_arn, "States.Runtime", &msg);
+                        return;
+                    }
+                }
+            }
+
             other => {
                 fail_execution(
                     &state,
@@ -311,6 +398,52 @@ pub async fn execute_state_machine(
                     &format!("Unsupported state type: '{other}'"),
                 );
                 return;
+            }
+        }
+    }
+}
+
+/// Execute a Wait state: pause execution for a specified duration or until a timestamp.
+async fn execute_wait_state(state_def: &Value, input: &Value) {
+    // Seconds: fixed number of seconds
+    if let Some(seconds) = state_def["Seconds"].as_u64() {
+        tokio::time::sleep(tokio::time::Duration::from_secs(seconds)).await;
+        return;
+    }
+
+    // SecondsPath: JsonPath to a number of seconds in the input
+    if let Some(path) = state_def["SecondsPath"].as_str() {
+        let val = crate::io_processing::resolve_path(input, path);
+        if let Some(seconds) = val.as_u64() {
+            tokio::time::sleep(tokio::time::Duration::from_secs(seconds)).await;
+        }
+        return;
+    }
+
+    // Timestamp: wait until a specific RFC3339 timestamp
+    if let Some(ts_str) = state_def["Timestamp"].as_str() {
+        if let Ok(target) = chrono::DateTime::parse_from_rfc3339(ts_str) {
+            let now = Utc::now();
+            let target_utc = target.with_timezone(&chrono::Utc);
+            if target_utc > now {
+                let duration = (target_utc - now).to_std().unwrap_or_default();
+                tokio::time::sleep(duration).await;
+            }
+        }
+        return;
+    }
+
+    // TimestampPath: JsonPath to an RFC3339 timestamp in the input
+    if let Some(path) = state_def["TimestampPath"].as_str() {
+        let val = crate::io_processing::resolve_path(input, path);
+        if let Some(ts_str) = val.as_str() {
+            if let Ok(target) = chrono::DateTime::parse_from_rfc3339(ts_str) {
+                let now = Utc::now();
+                let target_utc = target.with_timezone(&chrono::Utc);
+                if target_utc > now {
+                    let duration = (target_utc - now).to_std().unwrap_or_default();
+                    tokio::time::sleep(duration).await;
+                }
             }
         }
     }

--- a/crates/fakecloud-stepfunctions/src/lib.rs
+++ b/crates/fakecloud-stepfunctions/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod choice;
 pub mod error_handling;
 pub mod interpreter;
 pub mod io_processing;


### PR DESCRIPTION
## Summary

- Adds Choice state with comprehensive comparison operators: string (7 ops), numeric (6 ops), boolean (2 ops), timestamp (5 ops), presence/type checks (6 ops), logical operators (And/Or/Not), Default fallback, and States.NoChoiceMatched error
- Adds Wait state with Seconds, SecondsPath, Timestamp, and TimestampPath support
- Includes history events: ChoiceStateEntered/Exited, WaitStateEntered/Exited

## Test plan

- [x] 16 unit tests for choice evaluation (string, numeric, boolean, And/Or/Not, IsPresent/IsNull/IsNumeric, timestamps, path comparisons, StringMatches, evaluate_choice with default/matching/no-match)
- [x] 10 new E2E tests: Choice string routing, numeric grading, boolean+compound And, Not operator, NoChoiceMatched error, IsPresent, Wait Seconds, Wait SecondsPath, Choice+Wait workflow, Choice history events
- [x] 14 conformance tests pass
- [x] All 43 E2E tests pass (including all Batch 2-3 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Choice and Wait states to the ASL interpreter, enabling branching and time-based delays with full operator support and execution history events.

- **New Features**
  - Choice: string (equals/path/</>/<=/>=/matches), numeric (equals/path/</>/<=/>=), boolean (equals/path), timestamp (equals/</>/<=/>=), presence/type checks, And/Or/Not, Default fallback, and States.NoChoiceMatched.
  - Wait: supports Seconds, SecondsPath, Timestamp, and TimestampPath.
  - History: emits ChoiceStateEntered/Exited and WaitStateEntered/Exited.

<sup>Written for commit 1e2d957bfe9b47b11a41908e431e8213c07141f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

