### PR TITLE
feat(stepfunctions): add Parallel and Map states to ASL interpreter

### DIFF
--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -2273,3 +2273,621 @@ async fn sfn_choice_state_history_events() {
     assert!(event_types.contains(&"ChoiceStateExited".to_string()));
     assert!(event_types.contains(&"ExecutionSucceeded".to_string()));
 }
+
+// --- Parallel state tests ---
+
+#[tokio::test]
+async fn sfn_parallel_state_basic() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    // Three parallel branches, each doing a Pass with different results
+    let definition = serde_json::json!({
+        "StartAt": "ParallelWork",
+        "States": {
+            "ParallelWork": {
+                "Type": "Parallel",
+                "Branches": [
+                    {
+                        "StartAt": "Branch1",
+                        "States": {
+                            "Branch1": {
+                                "Type": "Pass",
+                                "Result": "result-1",
+                                "End": true
+                            }
+                        }
+                    },
+                    {
+                        "StartAt": "Branch2",
+                        "States": {
+                            "Branch2": {
+                                "Type": "Pass",
+                                "Result": "result-2",
+                                "End": true
+                            }
+                        }
+                    },
+                    {
+                        "StartAt": "Branch3",
+                        "States": {
+                            "Branch3": {
+                                "Type": "Pass",
+                                "Result": "result-3",
+                                "End": true
+                            }
+                        }
+                    }
+                ],
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("parallel-basic-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    // Output should be an array of branch results in order
+    assert_eq!(
+        output,
+        serde_json::json!(["result-1", "result-2", "result-3"])
+    );
+}
+
+#[tokio::test]
+async fn sfn_parallel_state_with_result_path() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "ParallelWork",
+        "States": {
+            "ParallelWork": {
+                "Type": "Parallel",
+                "ResultPath": "$.results",
+                "Branches": [
+                    {
+                        "StartAt": "A",
+                        "States": {
+                            "A": {
+                                "Type": "Pass",
+                                "Result": {"branch": "a"},
+                                "End": true
+                            }
+                        }
+                    },
+                    {
+                        "StartAt": "B",
+                        "States": {
+                            "B": {
+                                "Type": "Pass",
+                                "Result": {"branch": "b"},
+                                "End": true
+                            }
+                        }
+                    }
+                ],
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("parallel-resultpath-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"original": true}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output["original"], true);
+    assert_eq!(
+        output["results"],
+        serde_json::json!([{"branch": "a"}, {"branch": "b"}])
+    );
+}
+
+#[tokio::test]
+async fn sfn_parallel_state_branch_failure_with_catch() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    // One branch fails, Catch routes to error handler
+    let definition = serde_json::json!({
+        "StartAt": "ParallelWork",
+        "States": {
+            "ParallelWork": {
+                "Type": "Parallel",
+                "Branches": [
+                    {
+                        "StartAt": "Good",
+                        "States": {
+                            "Good": {
+                                "Type": "Pass",
+                                "Result": "ok",
+                                "End": true
+                            }
+                        }
+                    },
+                    {
+                        "StartAt": "Bad",
+                        "States": {
+                            "Bad": {
+                                "Type": "Fail",
+                                "Error": "BranchError",
+                                "Cause": "Branch 2 failed"
+                            }
+                        }
+                    }
+                ],
+                "Catch": [{
+                    "ErrorEquals": ["States.ALL"],
+                    "Next": "HandleError",
+                    "ResultPath": "$.error"
+                }],
+                "End": true
+            },
+            "HandleError": {
+                "Type": "Pass",
+                "Result": "handled",
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("parallel-catch-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, "handled");
+}
+
+#[tokio::test]
+async fn sfn_parallel_state_history_events() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "ParallelWork",
+        "States": {
+            "ParallelWork": {
+                "Type": "Parallel",
+                "Branches": [
+                    {
+                        "StartAt": "A",
+                        "States": {
+                            "A": { "Type": "Pass", "Result": "a", "End": true }
+                        }
+                    }
+                ],
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("parallel-history-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let history = client
+        .get_execution_history()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let event_types: Vec<String> = history
+        .events()
+        .iter()
+        .map(|e| e.r#type().as_str().to_string())
+        .collect();
+
+    assert!(event_types.contains(&"ParallelStateEntered".to_string()));
+    assert!(event_types.contains(&"ParallelStateExited".to_string()));
+}
+
+// --- Map state tests ---
+
+#[tokio::test]
+async fn sfn_map_state_basic() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    // Map over an array, each item gets a Pass that adds "processed" field
+    let definition = serde_json::json!({
+        "StartAt": "ProcessItems",
+        "States": {
+            "ProcessItems": {
+                "Type": "Map",
+                "ItemsPath": "$.items",
+                "ItemProcessor": {
+                    "StartAt": "Process",
+                    "States": {
+                        "Process": {
+                            "Type": "Pass",
+                            "Result": "done",
+                            "ResultPath": "$.status",
+                            "End": true
+                        }
+                    }
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("map-basic-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"items": [{"id": 1}, {"id": 2}, {"id": 3}]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    let arr = output.as_array().unwrap();
+    assert_eq!(arr.len(), 3);
+    assert_eq!(arr[0]["id"], 1);
+    assert_eq!(arr[0]["status"], "done");
+    assert_eq!(arr[2]["id"], 3);
+}
+
+#[tokio::test]
+async fn sfn_map_state_with_result_path() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "ProcessItems",
+        "States": {
+            "ProcessItems": {
+                "Type": "Map",
+                "ItemsPath": "$.items",
+                "ResultPath": "$.processed",
+                "ItemProcessor": {
+                    "StartAt": "Transform",
+                    "States": {
+                        "Transform": {
+                            "Type": "Pass",
+                            "End": true
+                        }
+                    }
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("map-resultpath-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"items": ["a", "b"], "keep": true}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output["keep"], true);
+    assert_eq!(output["processed"], serde_json::json!(["a", "b"]));
+}
+
+#[tokio::test]
+async fn sfn_map_state_empty_array() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "ProcessItems",
+        "States": {
+            "ProcessItems": {
+                "Type": "Map",
+                "ItemsPath": "$.items",
+                "ItemProcessor": {
+                    "StartAt": "Process",
+                    "States": {
+                        "Process": { "Type": "Pass", "End": true }
+                    }
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("map-empty-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"items": []}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output, serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn sfn_map_state_history_events() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "ProcessItems",
+        "States": {
+            "ProcessItems": {
+                "Type": "Map",
+                "ItemsPath": "$.items",
+                "ItemProcessor": {
+                    "StartAt": "Process",
+                    "States": {
+                        "Process": { "Type": "Pass", "End": true }
+                    }
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("map-history-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"items": [1, 2]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let history = client
+        .get_execution_history()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let event_types: Vec<String> = history
+        .events()
+        .iter()
+        .map(|e| e.r#type().as_str().to_string())
+        .collect();
+
+    assert!(event_types.contains(&"MapStateEntered".to_string()));
+    assert!(event_types.contains(&"MapIterationStarted".to_string()));
+    assert!(event_types.contains(&"MapIterationSucceeded".to_string()));
+    assert!(event_types.contains(&"MapStateExited".to_string()));
+}
+
+#[tokio::test]
+async fn sfn_parallel_then_map_workflow() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    // Parallel produces array, then Map processes each item
+    let definition = serde_json::json!({
+        "StartAt": "Gather",
+        "States": {
+            "Gather": {
+                "Type": "Parallel",
+                "ResultPath": "$.gathered",
+                "Branches": [
+                    {
+                        "StartAt": "Source1",
+                        "States": {
+                            "Source1": { "Type": "Pass", "Result": {"value": 10}, "End": true }
+                        }
+                    },
+                    {
+                        "StartAt": "Source2",
+                        "States": {
+                            "Source2": { "Type": "Pass", "Result": {"value": 20}, "End": true }
+                        }
+                    }
+                ],
+                "Next": "Process"
+            },
+            "Process": {
+                "Type": "Map",
+                "ItemsPath": "$.gathered",
+                "ItemProcessor": {
+                    "StartAt": "Transform",
+                    "States": {
+                        "Transform": {
+                            "Type": "Pass",
+                            "Result": "transformed",
+                            "ResultPath": "$.status",
+                            "End": true
+                        }
+                    }
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("parallel-map-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    let arr = output.as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+    assert_eq!(arr[0]["value"], 10);
+    assert_eq!(arr[0]["status"], "transformed");
+    assert_eq!(arr[1]["value"], 20);
+}

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -33,32 +33,6 @@ pub async fn execute_state_machine(
         }
     };
 
-    let start_at = match def["StartAt"].as_str() {
-        Some(s) => s.to_string(),
-        None => {
-            fail_execution(
-                &state,
-                &execution_arn,
-                "States.Runtime",
-                "Missing StartAt in definition",
-            );
-            return;
-        }
-    };
-
-    let states = match def.get("States") {
-        Some(s) => s,
-        None => {
-            fail_execution(
-                &state,
-                &execution_arn,
-                "States.Runtime",
-                "Missing States in definition",
-            );
-            return;
-        }
-    };
-
     let raw_input: Value = input
         .as_deref()
         .and_then(|s| serde_json::from_str(s).ok())
@@ -76,342 +50,479 @@ pub async fn execute_state_machine(
         }),
     );
 
-    let mut current_state = start_at;
-    let mut effective_input = raw_input;
-    let mut iteration = 0;
-    let max_iterations = 500; // safety limit
-
-    loop {
-        iteration += 1;
-        if iteration > max_iterations {
-            fail_execution(
-                &state,
-                &execution_arn,
-                "States.Runtime",
-                "Maximum number of state transitions exceeded",
-            );
-            return;
+    match run_states(&def, raw_input, &delivery, &state, &execution_arn).await {
+        Ok(output) => {
+            succeed_execution(&state, &execution_arn, &output);
         }
-
-        let state_def = match states.get(&current_state) {
-            Some(s) => s.clone(),
-            None => {
-                fail_execution(
-                    &state,
-                    &execution_arn,
-                    "States.Runtime",
-                    &format!("State '{current_state}' not found in definition"),
-                );
-                return;
-            }
-        };
-
-        let state_type = match state_def["Type"].as_str() {
-            Some(t) => t.to_string(),
-            None => {
-                fail_execution(
-                    &state,
-                    &execution_arn,
-                    "States.Runtime",
-                    &format!("State '{current_state}' missing Type field"),
-                );
-                return;
-            }
-        };
-
-        debug!(
-            execution_arn = %execution_arn,
-            state = %current_state,
-            state_type = %state_type,
-            "Executing state"
-        );
-
-        match state_type.as_str() {
-            "Pass" => {
-                let entered_event_id = add_event(
-                    &state,
-                    &execution_arn,
-                    "PassStateEntered",
-                    0,
-                    json!({
-                        "name": current_state,
-                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                    }),
-                );
-
-                let result = execute_pass_state(&state_def, &effective_input);
-
-                add_event(
-                    &state,
-                    &execution_arn,
-                    "PassStateExited",
-                    entered_event_id,
-                    json!({
-                        "name": current_state,
-                        "output": serde_json::to_string(&result).unwrap_or_default(),
-                    }),
-                );
-
-                effective_input = result;
-
-                match next_state(&state_def) {
-                    NextState::Name(next) => current_state = next,
-                    NextState::End => {
-                        succeed_execution(&state, &execution_arn, &effective_input);
-                        return;
-                    }
-                    NextState::Error(msg) => {
-                        fail_execution(&state, &execution_arn, "States.Runtime", &msg);
-                        return;
-                    }
-                }
-            }
-
-            "Succeed" => {
-                add_event(
-                    &state,
-                    &execution_arn,
-                    "SucceedStateEntered",
-                    0,
-                    json!({
-                        "name": current_state,
-                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                    }),
-                );
-
-                // Apply InputPath and OutputPath
-                let input_path = state_def["InputPath"].as_str();
-                let output_path = state_def["OutputPath"].as_str();
-
-                let processed = if input_path == Some("null") {
-                    json!({})
-                } else {
-                    apply_input_path(&effective_input, input_path)
-                };
-
-                let output = if output_path == Some("null") {
-                    json!({})
-                } else {
-                    apply_output_path(&processed, output_path)
-                };
-
-                add_event(
-                    &state,
-                    &execution_arn,
-                    "SucceedStateExited",
-                    0,
-                    json!({
-                        "name": current_state,
-                        "output": serde_json::to_string(&output).unwrap_or_default(),
-                    }),
-                );
-
-                succeed_execution(&state, &execution_arn, &output);
-                return;
-            }
-
-            "Fail" => {
-                let error = state_def["Error"]
-                    .as_str()
-                    .unwrap_or("States.Fail")
-                    .to_string();
-                let cause = state_def["Cause"].as_str().unwrap_or("").to_string();
-
-                add_event(
-                    &state,
-                    &execution_arn,
-                    "FailStateEntered",
-                    0,
-                    json!({
-                        "name": current_state,
-                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                    }),
-                );
-
-                fail_execution(&state, &execution_arn, &error, &cause);
-                return;
-            }
-
-            "Task" => {
-                let entered_event_id = add_event(
-                    &state,
-                    &execution_arn,
-                    "TaskStateEntered",
-                    0,
-                    json!({
-                        "name": current_state,
-                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                    }),
-                );
-
-                let result = execute_task_state(
-                    &state_def,
-                    &effective_input,
-                    &delivery,
-                    &state,
-                    &execution_arn,
-                    entered_event_id,
-                )
-                .await;
-
-                match result {
-                    Ok(output) => {
-                        add_event(
-                            &state,
-                            &execution_arn,
-                            "TaskStateExited",
-                            entered_event_id,
-                            json!({
-                                "name": current_state,
-                                "output": serde_json::to_string(&output).unwrap_or_default(),
-                            }),
-                        );
-
-                        effective_input = output;
-
-                        match next_state(&state_def) {
-                            NextState::Name(next) => current_state = next,
-                            NextState::End => {
-                                succeed_execution(&state, &execution_arn, &effective_input);
-                                return;
-                            }
-                            NextState::Error(msg) => {
-                                fail_execution(&state, &execution_arn, "States.Runtime", &msg);
-                                return;
-                            }
-                        }
-                    }
-                    Err((error, cause)) => {
-                        // Try Catch
-                        let catchers = state_def["Catch"].as_array().cloned().unwrap_or_default();
-
-                        if let Some((next, result_path)) = find_catcher(&catchers, &error) {
-                            let error_output = json!({
-                                "Error": error,
-                                "Cause": cause,
-                            });
-                            effective_input = apply_result_path(
-                                &effective_input,
-                                &error_output,
-                                result_path.as_deref(),
-                            );
-                            current_state = next;
-                        } else {
-                            fail_execution(&state, &execution_arn, &error, &cause);
-                            return;
-                        }
-                    }
-                }
-            }
-
-            "Choice" => {
-                let entered_event_id = add_event(
-                    &state,
-                    &execution_arn,
-                    "ChoiceStateEntered",
-                    0,
-                    json!({
-                        "name": current_state,
-                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                    }),
-                );
-
-                // Apply InputPath
-                let input_path = state_def["InputPath"].as_str();
-                let processed_input = if input_path == Some("null") {
-                    json!({})
-                } else {
-                    apply_input_path(&effective_input, input_path)
-                };
-
-                match evaluate_choice(&state_def, &processed_input) {
-                    Some(next) => {
-                        add_event(
-                            &state,
-                            &execution_arn,
-                            "ChoiceStateExited",
-                            entered_event_id,
-                            json!({
-                                "name": current_state,
-                                "output": serde_json::to_string(&effective_input).unwrap_or_default(),
-                            }),
-                        );
-                        current_state = next;
-                    }
-                    None => {
-                        fail_execution(
-                            &state,
-                            &execution_arn,
-                            "States.NoChoiceMatched",
-                            &format!(
-                                "No choice rule matched and no Default in state '{current_state}'"
-                            ),
-                        );
-                        return;
-                    }
-                }
-            }
-
-            "Wait" => {
-                let entered_event_id = add_event(
-                    &state,
-                    &execution_arn,
-                    "WaitStateEntered",
-                    0,
-                    json!({
-                        "name": current_state,
-                        "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                    }),
-                );
-
-                execute_wait_state(&state_def, &effective_input).await;
-
-                add_event(
-                    &state,
-                    &execution_arn,
-                    "WaitStateExited",
-                    entered_event_id,
-                    json!({
-                        "name": current_state,
-                        "output": serde_json::to_string(&effective_input).unwrap_or_default(),
-                    }),
-                );
-
-                match next_state(&state_def) {
-                    NextState::Name(next) => current_state = next,
-                    NextState::End => {
-                        succeed_execution(&state, &execution_arn, &effective_input);
-                        return;
-                    }
-                    NextState::Error(msg) => {
-                        fail_execution(&state, &execution_arn, "States.Runtime", &msg);
-                        return;
-                    }
-                }
-            }
-
-            other => {
-                fail_execution(
-                    &state,
-                    &execution_arn,
-                    "States.Runtime",
-                    &format!("Unsupported state type: '{other}'"),
-                );
-                return;
-            }
+        Err((error, cause)) => {
+            fail_execution(&state, &execution_arn, &error, &cause);
         }
     }
 }
 
+type StatesResult<'a> = std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<Value, (String, String)>> + Send + 'a>,
+>;
+
+/// Core execution loop: runs through states in a definition and returns the output.
+/// Used by the top-level executor, Parallel branches, and Map iterations.
+fn run_states<'a>(
+    def: &'a Value,
+    input: Value,
+    delivery: &'a Option<Arc<DeliveryBus>>,
+    shared_state: &'a SharedStepFunctionsState,
+    execution_arn: &'a str,
+) -> StatesResult<'a> {
+    Box::pin(async move {
+        let start_at = def["StartAt"]
+            .as_str()
+            .ok_or_else(|| {
+                (
+                    "States.Runtime".to_string(),
+                    "Missing StartAt in definition".to_string(),
+                )
+            })?
+            .to_string();
+
+        let states = def.get("States").ok_or_else(|| {
+            (
+                "States.Runtime".to_string(),
+                "Missing States in definition".to_string(),
+            )
+        })?;
+
+        let mut current_state = start_at;
+        let mut effective_input = input;
+        let mut iteration = 0;
+        let max_iterations = 500;
+
+        loop {
+            iteration += 1;
+            if iteration > max_iterations {
+                return Err((
+                    "States.Runtime".to_string(),
+                    "Maximum number of state transitions exceeded".to_string(),
+                ));
+            }
+
+            let state_def = states.get(&current_state).cloned().ok_or_else(|| {
+                (
+                    "States.Runtime".to_string(),
+                    format!("State '{current_state}' not found in definition"),
+                )
+            })?;
+
+            let state_type = state_def["Type"]
+                .as_str()
+                .ok_or_else(|| {
+                    (
+                        "States.Runtime".to_string(),
+                        format!("State '{current_state}' missing Type field"),
+                    )
+                })?
+                .to_string();
+
+            debug!(
+                execution_arn = %execution_arn,
+                state = %current_state,
+                state_type = %state_type,
+                "Executing state"
+            );
+
+            match state_type.as_str() {
+                "Pass" => {
+                    let entered_event_id = add_event(
+                        shared_state,
+                        execution_arn,
+                        "PassStateEntered",
+                        0,
+                        json!({
+                            "name": current_state,
+                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                        }),
+                    );
+
+                    let result = execute_pass_state(&state_def, &effective_input);
+
+                    add_event(
+                        shared_state,
+                        execution_arn,
+                        "PassStateExited",
+                        entered_event_id,
+                        json!({
+                            "name": current_state,
+                            "output": serde_json::to_string(&result).unwrap_or_default(),
+                        }),
+                    );
+
+                    effective_input = result;
+
+                    match next_state(&state_def) {
+                        NextState::Name(next) => current_state = next,
+                        NextState::End => return Ok(effective_input),
+                        NextState::Error(msg) => {
+                            return Err(("States.Runtime".to_string(), msg));
+                        }
+                    }
+                }
+
+                "Succeed" => {
+                    add_event(
+                        shared_state,
+                        execution_arn,
+                        "SucceedStateEntered",
+                        0,
+                        json!({
+                            "name": current_state,
+                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                        }),
+                    );
+
+                    let input_path = state_def["InputPath"].as_str();
+                    let output_path = state_def["OutputPath"].as_str();
+
+                    let processed = if input_path == Some("null") {
+                        json!({})
+                    } else {
+                        apply_input_path(&effective_input, input_path)
+                    };
+
+                    let output = if output_path == Some("null") {
+                        json!({})
+                    } else {
+                        apply_output_path(&processed, output_path)
+                    };
+
+                    add_event(
+                        shared_state,
+                        execution_arn,
+                        "SucceedStateExited",
+                        0,
+                        json!({
+                            "name": current_state,
+                            "output": serde_json::to_string(&output).unwrap_or_default(),
+                        }),
+                    );
+
+                    return Ok(output);
+                }
+
+                "Fail" => {
+                    let error = state_def["Error"]
+                        .as_str()
+                        .unwrap_or("States.Fail")
+                        .to_string();
+                    let cause = state_def["Cause"].as_str().unwrap_or("").to_string();
+
+                    add_event(
+                        shared_state,
+                        execution_arn,
+                        "FailStateEntered",
+                        0,
+                        json!({
+                            "name": current_state,
+                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                        }),
+                    );
+
+                    return Err((error, cause));
+                }
+
+                "Task" => {
+                    let entered_event_id = add_event(
+                        shared_state,
+                        execution_arn,
+                        "TaskStateEntered",
+                        0,
+                        json!({
+                            "name": current_state,
+                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                        }),
+                    );
+
+                    let result = execute_task_state(
+                        &state_def,
+                        &effective_input,
+                        delivery,
+                        shared_state,
+                        execution_arn,
+                        entered_event_id,
+                    )
+                    .await;
+
+                    match result {
+                        Ok(output) => {
+                            add_event(
+                                shared_state,
+                                execution_arn,
+                                "TaskStateExited",
+                                entered_event_id,
+                                json!({
+                                    "name": current_state,
+                                    "output": serde_json::to_string(&output).unwrap_or_default(),
+                                }),
+                            );
+
+                            effective_input = output;
+
+                            match next_state(&state_def) {
+                                NextState::Name(next) => current_state = next,
+                                NextState::End => return Ok(effective_input),
+                                NextState::Error(msg) => {
+                                    return Err(("States.Runtime".to_string(), msg));
+                                }
+                            }
+                        }
+                        Err((error, cause)) => {
+                            let catchers =
+                                state_def["Catch"].as_array().cloned().unwrap_or_default();
+
+                            if let Some((next, result_path)) = find_catcher(&catchers, &error) {
+                                let error_output = json!({
+                                    "Error": error,
+                                    "Cause": cause,
+                                });
+                                effective_input = apply_result_path(
+                                    &effective_input,
+                                    &error_output,
+                                    result_path.as_deref(),
+                                );
+                                current_state = next;
+                            } else {
+                                return Err((error, cause));
+                            }
+                        }
+                    }
+                }
+
+                "Choice" => {
+                    let entered_event_id = add_event(
+                        shared_state,
+                        execution_arn,
+                        "ChoiceStateEntered",
+                        0,
+                        json!({
+                            "name": current_state,
+                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                        }),
+                    );
+
+                    let input_path = state_def["InputPath"].as_str();
+                    let processed_input = if input_path == Some("null") {
+                        json!({})
+                    } else {
+                        apply_input_path(&effective_input, input_path)
+                    };
+
+                    match evaluate_choice(&state_def, &processed_input) {
+                        Some(next) => {
+                            add_event(
+                                shared_state,
+                                execution_arn,
+                                "ChoiceStateExited",
+                                entered_event_id,
+                                json!({
+                                    "name": current_state,
+                                    "output": serde_json::to_string(&effective_input).unwrap_or_default(),
+                                }),
+                            );
+                            current_state = next;
+                        }
+                        None => {
+                            return Err((
+                                "States.NoChoiceMatched".to_string(),
+                                format!(
+                                    "No choice rule matched and no Default in state '{current_state}'"
+                                ),
+                            ));
+                        }
+                    }
+                }
+
+                "Wait" => {
+                    let entered_event_id = add_event(
+                        shared_state,
+                        execution_arn,
+                        "WaitStateEntered",
+                        0,
+                        json!({
+                            "name": current_state,
+                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                        }),
+                    );
+
+                    execute_wait_state(&state_def, &effective_input).await;
+
+                    add_event(
+                        shared_state,
+                        execution_arn,
+                        "WaitStateExited",
+                        entered_event_id,
+                        json!({
+                            "name": current_state,
+                            "output": serde_json::to_string(&effective_input).unwrap_or_default(),
+                        }),
+                    );
+
+                    match next_state(&state_def) {
+                        NextState::Name(next) => current_state = next,
+                        NextState::End => return Ok(effective_input),
+                        NextState::Error(msg) => {
+                            return Err(("States.Runtime".to_string(), msg));
+                        }
+                    }
+                }
+
+                "Parallel" => {
+                    let entered_event_id = add_event(
+                        shared_state,
+                        execution_arn,
+                        "ParallelStateEntered",
+                        0,
+                        json!({
+                            "name": current_state,
+                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                        }),
+                    );
+
+                    let result = execute_parallel_state(
+                        &state_def,
+                        &effective_input,
+                        delivery,
+                        shared_state,
+                        execution_arn,
+                    )
+                    .await;
+
+                    match result {
+                        Ok(output) => {
+                            add_event(
+                                shared_state,
+                                execution_arn,
+                                "ParallelStateExited",
+                                entered_event_id,
+                                json!({
+                                    "name": current_state,
+                                    "output": serde_json::to_string(&output).unwrap_or_default(),
+                                }),
+                            );
+
+                            effective_input = output;
+
+                            match next_state(&state_def) {
+                                NextState::Name(next) => current_state = next,
+                                NextState::End => return Ok(effective_input),
+                                NextState::Error(msg) => {
+                                    return Err(("States.Runtime".to_string(), msg));
+                                }
+                            }
+                        }
+                        Err((error, cause)) => {
+                            let catchers =
+                                state_def["Catch"].as_array().cloned().unwrap_or_default();
+
+                            if let Some((next, result_path)) = find_catcher(&catchers, &error) {
+                                let error_output = json!({
+                                    "Error": error,
+                                    "Cause": cause,
+                                });
+                                effective_input = apply_result_path(
+                                    &effective_input,
+                                    &error_output,
+                                    result_path.as_deref(),
+                                );
+                                current_state = next;
+                            } else {
+                                return Err((error, cause));
+                            }
+                        }
+                    }
+                }
+
+                "Map" => {
+                    let entered_event_id = add_event(
+                        shared_state,
+                        execution_arn,
+                        "MapStateEntered",
+                        0,
+                        json!({
+                            "name": current_state,
+                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
+                        }),
+                    );
+
+                    let result = execute_map_state(
+                        &state_def,
+                        &effective_input,
+                        delivery,
+                        shared_state,
+                        execution_arn,
+                    )
+                    .await;
+
+                    match result {
+                        Ok(output) => {
+                            add_event(
+                                shared_state,
+                                execution_arn,
+                                "MapStateExited",
+                                entered_event_id,
+                                json!({
+                                    "name": current_state,
+                                    "output": serde_json::to_string(&output).unwrap_or_default(),
+                                }),
+                            );
+
+                            effective_input = output;
+
+                            match next_state(&state_def) {
+                                NextState::Name(next) => current_state = next,
+                                NextState::End => return Ok(effective_input),
+                                NextState::Error(msg) => {
+                                    return Err(("States.Runtime".to_string(), msg));
+                                }
+                            }
+                        }
+                        Err((error, cause)) => {
+                            let catchers =
+                                state_def["Catch"].as_array().cloned().unwrap_or_default();
+
+                            if let Some((next, result_path)) = find_catcher(&catchers, &error) {
+                                let error_output = json!({
+                                    "Error": error,
+                                    "Cause": cause,
+                                });
+                                effective_input = apply_result_path(
+                                    &effective_input,
+                                    &error_output,
+                                    result_path.as_deref(),
+                                );
+                                current_state = next;
+                            } else {
+                                return Err((error, cause));
+                            }
+                        }
+                    }
+                }
+
+                other => {
+                    return Err((
+                        "States.Runtime".to_string(),
+                        format!("Unsupported state type: '{other}'"),
+                    ));
+                }
+            }
+        }
+    })
+}
+
 /// Execute a Wait state: pause execution for a specified duration or until a timestamp.
 async fn execute_wait_state(state_def: &Value, input: &Value) {
-    // Seconds: fixed number of seconds
     if let Some(seconds) = state_def["Seconds"].as_u64() {
         tokio::time::sleep(tokio::time::Duration::from_secs(seconds)).await;
         return;
     }
 
-    // SecondsPath: JsonPath to a number of seconds in the input
     if let Some(path) = state_def["SecondsPath"].as_str() {
         let val = crate::io_processing::resolve_path(input, path);
         if let Some(seconds) = val.as_u64() {
@@ -420,7 +531,6 @@ async fn execute_wait_state(state_def: &Value, input: &Value) {
         return;
     }
 
-    // Timestamp: wait until a specific RFC3339 timestamp
     if let Some(ts_str) = state_def["Timestamp"].as_str() {
         if let Ok(target) = chrono::DateTime::parse_from_rfc3339(ts_str) {
             let now = Utc::now();
@@ -433,7 +543,6 @@ async fn execute_wait_state(state_def: &Value, input: &Value) {
         return;
     }
 
-    // TimestampPath: JsonPath to an RFC3339 timestamp in the input
     if let Some(path) = state_def["TimestampPath"].as_str() {
         let val = crate::io_processing::resolve_path(input, path);
         if let Some(ts_str) = val.as_str() {
@@ -455,28 +564,24 @@ fn execute_pass_state(state_def: &Value, input: &Value) -> Value {
     let result_path = state_def["ResultPath"].as_str();
     let output_path = state_def["OutputPath"].as_str();
 
-    // Step 1: Apply InputPath
     let effective_input = if input_path == Some("null") {
         json!({})
     } else {
         apply_input_path(input, input_path)
     };
 
-    // Step 2: Determine result (Pass can have a literal "Result" field)
     let result = if let Some(r) = state_def.get("Result") {
         r.clone()
     } else {
         effective_input.clone()
     };
 
-    // Step 3: Apply ResultPath (merge result into original input, not effective_input)
     let after_result = if result_path == Some("null") {
         input.clone()
     } else {
         apply_result_path(input, &result, result_path)
     };
 
-    // Step 4: Apply OutputPath
     if output_path == Some("null") {
         json!({})
     } else {
@@ -499,25 +604,20 @@ async fn execute_task_state(
     let result_path = state_def["ResultPath"].as_str();
     let output_path = state_def["OutputPath"].as_str();
 
-    // Step 1: Apply InputPath
     let effective_input = if input_path == Some("null") {
         json!({})
     } else {
         apply_input_path(input, input_path)
     };
 
-    // Step 2: Apply Parameters (template with .$ suffix for JsonPath extraction)
     let task_input = if let Some(params) = state_def.get("Parameters") {
         apply_parameters(params, &effective_input)
     } else {
         effective_input
     };
 
-    // Retry configuration
     let retriers = state_def["Retry"].as_array().cloned().unwrap_or_default();
-
     let timeout_seconds = state_def["TimeoutSeconds"].as_u64();
-
     let mut attempt = 0u32;
 
     loop {
@@ -557,21 +657,18 @@ async fn execute_task_state(
                     }),
                 );
 
-                // Apply ResultSelector if present
                 let selected = if let Some(selector) = state_def.get("ResultSelector") {
                     apply_parameters(selector, &result)
                 } else {
                     result
                 };
 
-                // Apply ResultPath
                 let after_result = if result_path == Some("null") {
                     input.clone()
                 } else {
                     apply_result_path(input, &selected, result_path)
                 };
 
-                // Apply OutputPath
                 let output = if output_path == Some("null") {
                     json!({})
                 } else {
@@ -589,10 +686,8 @@ async fn execute_task_state(
                     json!({ "error": error, "cause": cause }),
                 );
 
-                // Check Retry
                 if let Some(delay_ms) = should_retry(&retriers, &error, attempt) {
                     attempt += 1;
-                    // Cap the actual delay for testing (don't wait minutes)
                     let actual_delay = delay_ms.min(5000);
                     tokio::time::sleep(tokio::time::Duration::from_millis(actual_delay)).await;
                     continue;
@@ -604,6 +699,231 @@ async fn execute_task_state(
     }
 }
 
+/// Execute a Parallel state: run all branches concurrently, collect results into an array.
+async fn execute_parallel_state(
+    state_def: &Value,
+    input: &Value,
+    delivery: &Option<Arc<DeliveryBus>>,
+    shared_state: &SharedStepFunctionsState,
+    execution_arn: &str,
+) -> Result<Value, (String, String)> {
+    let input_path = state_def["InputPath"].as_str();
+    let result_path = state_def["ResultPath"].as_str();
+    let output_path = state_def["OutputPath"].as_str();
+
+    let effective_input = if input_path == Some("null") {
+        json!({})
+    } else {
+        apply_input_path(input, input_path)
+    };
+
+    let branches = state_def["Branches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+
+    if branches.is_empty() {
+        return Err((
+            "States.Runtime".to_string(),
+            "Parallel state has no Branches".to_string(),
+        ));
+    }
+
+    // Spawn all branches concurrently
+    let mut handles = Vec::new();
+    for branch_def in &branches {
+        let branch = branch_def.clone();
+        let branch_input = effective_input.clone();
+        let delivery = delivery.clone();
+        let state = shared_state.clone();
+        let arn = execution_arn.to_string();
+
+        handles.push(tokio::spawn(async move {
+            run_states(&branch, branch_input, &delivery, &state, &arn).await
+        }));
+    }
+
+    // Collect results in order
+    let mut results = Vec::with_capacity(handles.len());
+    for handle in handles {
+        let result = handle.await.map_err(|e| {
+            (
+                "States.Runtime".to_string(),
+                format!("Branch execution panicked: {e}"),
+            )
+        })??;
+        results.push(result);
+    }
+
+    let branch_output = Value::Array(results);
+
+    // Apply ResultSelector if present
+    let selected = if let Some(selector) = state_def.get("ResultSelector") {
+        apply_parameters(selector, &branch_output)
+    } else {
+        branch_output
+    };
+
+    // Apply ResultPath
+    let after_result = if result_path == Some("null") {
+        input.clone()
+    } else {
+        apply_result_path(input, &selected, result_path)
+    };
+
+    // Apply OutputPath
+    let output = if output_path == Some("null") {
+        json!({})
+    } else {
+        apply_output_path(&after_result, output_path)
+    };
+
+    Ok(output)
+}
+
+/// Execute a Map state: iterate over an array and run a sub-state machine per item.
+async fn execute_map_state(
+    state_def: &Value,
+    input: &Value,
+    delivery: &Option<Arc<DeliveryBus>>,
+    shared_state: &SharedStepFunctionsState,
+    execution_arn: &str,
+) -> Result<Value, (String, String)> {
+    let input_path = state_def["InputPath"].as_str();
+    let result_path = state_def["ResultPath"].as_str();
+    let output_path = state_def["OutputPath"].as_str();
+
+    let effective_input = if input_path == Some("null") {
+        json!({})
+    } else {
+        apply_input_path(input, input_path)
+    };
+
+    // Get the items to iterate over
+    let items_path = state_def["ItemsPath"].as_str().unwrap_or("$");
+    let items_value = crate::io_processing::resolve_path(&effective_input, items_path);
+    let items = items_value.as_array().cloned().unwrap_or_default();
+
+    // Get the iterator definition (ItemProcessor or Iterator for backwards compat)
+    let iterator_def = state_def
+        .get("ItemProcessor")
+        .or_else(|| state_def.get("Iterator"))
+        .cloned()
+        .ok_or_else(|| {
+            (
+                "States.Runtime".to_string(),
+                "Map state has no ItemProcessor or Iterator".to_string(),
+            )
+        })?;
+
+    let max_concurrency = state_def["MaxConcurrency"].as_u64().unwrap_or(0);
+    let effective_concurrency = if max_concurrency == 0 {
+        40
+    } else {
+        max_concurrency as usize
+    };
+
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(effective_concurrency));
+
+    // Process all items
+    let mut handles = Vec::new();
+    for (index, item) in items.into_iter().enumerate() {
+        let iter_def = iterator_def.clone();
+        let delivery = delivery.clone();
+        let state = shared_state.clone();
+        let arn = execution_arn.to_string();
+        let sem = semaphore.clone();
+
+        // Apply ItemSelector if present
+        let item_input = if let Some(selector) = state_def.get("ItemSelector") {
+            let mut ctx = serde_json::Map::new();
+            ctx.insert("value".to_string(), item.clone());
+            ctx.insert("index".to_string(), json!(index));
+            apply_parameters(selector, &Value::Object(ctx))
+        } else {
+            item
+        };
+
+        add_event(
+            shared_state,
+            execution_arn,
+            "MapIterationStarted",
+            0,
+            json!({ "index": index }),
+        );
+
+        handles.push(tokio::spawn(async move {
+            let _permit = sem
+                .acquire()
+                .await
+                .map_err(|_| ("States.Runtime".to_string(), "Semaphore closed".to_string()))?;
+            let result = run_states(&iter_def, item_input, &delivery, &state, &arn).await;
+            Ok::<(usize, Result<Value, (String, String)>), (String, String)>((index, result))
+        }));
+    }
+
+    // Collect results in order
+    let mut results: Vec<(usize, Value)> = Vec::with_capacity(handles.len());
+    for handle in handles {
+        let (index, result) = handle.await.map_err(|e| {
+            (
+                "States.Runtime".to_string(),
+                format!("Map iteration panicked: {e}"),
+            )
+        })??;
+
+        match result {
+            Ok(output) => {
+                add_event(
+                    shared_state,
+                    execution_arn,
+                    "MapIterationSucceeded",
+                    0,
+                    json!({ "index": index }),
+                );
+                results.push((index, output));
+            }
+            Err((error, cause)) => {
+                add_event(
+                    shared_state,
+                    execution_arn,
+                    "MapIterationFailed",
+                    0,
+                    json!({ "index": index, "error": error }),
+                );
+                return Err((error, cause));
+            }
+        }
+    }
+
+    // Sort by index to maintain order
+    results.sort_by_key(|(i, _)| *i);
+    let map_output = Value::Array(results.into_iter().map(|(_, v)| v).collect());
+
+    // Apply ResultSelector if present
+    let selected = if let Some(selector) = state_def.get("ResultSelector") {
+        apply_parameters(selector, &map_output)
+    } else {
+        map_output
+    };
+
+    // Apply ResultPath
+    let after_result = if result_path == Some("null") {
+        input.clone()
+    } else {
+        apply_result_path(input, &selected, result_path)
+    };
+
+    // Apply OutputPath
+    let output = if output_path == Some("null") {
+        json!({})
+    } else {
+        apply_output_path(&after_result, output_path)
+    };
+
+    Ok(output)
+}
+
 /// Invoke a resource (Lambda function or SDK integration).
 async fn invoke_resource(
     resource: &str,
@@ -611,12 +931,10 @@ async fn invoke_resource(
     delivery: &Option<Arc<DeliveryBus>>,
     timeout_seconds: Option<u64>,
 ) -> Result<Value, (String, String)> {
-    // Lambda direct invocation: arn:aws:lambda:...
     if resource.contains(":lambda:") && resource.contains(":function:") {
         return invoke_lambda_direct(resource, input, delivery, timeout_seconds).await;
     }
 
-    // SDK integration: arn:aws:states:::lambda:invoke
     if resource.starts_with("arn:aws:states:::lambda:invoke") {
         let function_name = input["FunctionName"]
             .as_str()
@@ -690,7 +1008,6 @@ fn apply_parameters(template: &Value, input: &Value) -> Value {
             let mut result = serde_json::Map::new();
             for (key, value) in map {
                 if let Some(stripped) = key.strip_suffix(".$") {
-                    // JsonPath reference
                     if let Some(path) = value.as_str() {
                         result.insert(
                             stripped.to_string(),


### PR DESCRIPTION
## Summary

- Refactors the ASL interpreter into a reusable `run_states()` function that enables recursive execution for Parallel branches and Map iterations
- Adds Parallel state with concurrent branch execution via `tokio::spawn`, ordered result collection into arrays, Catch support for branch failures, and ResultPath/OutputPath processing
- Adds Map state with array iteration from ItemsPath, MaxConcurrency limiting via `tokio::sync::Semaphore`, ItemSelector/ItemProcessor support, and ordered result collection
- All 8 ASL state types are now implemented: Pass, Succeed, Fail, Task, Choice, Wait, Parallel, Map

## Test plan

- [x] 9 new E2E tests: Parallel basic (3 branches), Parallel with ResultPath, Parallel branch failure + Catch, Parallel history events, Map basic, Map with ResultPath, Map empty array, Map history events, Parallel→Map combined workflow
- [x] All 52 E2E tests pass (including all prior batch tests)
- [x] 14 conformance tests pass
- [x] 39 unit tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Parallel and Map states to the ASL interpreter with ordered results, proper Catch/ResultPath/OutputPath handling, and execution history events. All 8 ASL state types are now supported.

- **New Features**
  - Parallel: runs branches concurrently via `tokio::spawn`; collects ordered array results; supports Catch; applies ResultPath/OutputPath; emits `ParallelStateEntered/Exited`.
  - Map: iterates arrays from `ItemsPath`; enforces `MaxConcurrency` with `tokio::sync::Semaphore` (default 40); supports `ItemSelector` and `ItemProcessor`/`Iterator`; ordered results; emits `MapStateEntered/Exited` and iteration events.

- **Refactors**
  - Introduced reusable `run_states()` for recursive execution, used by top-level flows, Parallel branches, and Map iterations.

<sup>Written for commit 375c003c146c82b6041d98e8c4c5adf57a5f85c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

