### PR TITLE
test(s3): actually unignore multipart upload coverage

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -897,7 +897,6 @@ async fn s3_object_lock_prevents_overwrite() {
 // ---- S3 Multipart Upload Tests ----
 
 #[tokio::test]
-#[ignore] // Multipart completion has edge cases with part size validation
 async fn s3_multipart_upload_basic() {
     let server = TestServer::start().await;
     let client = server.s3_client().await;


### PR DESCRIPTION
## Summary\n- remove the lingering ignore from s3_multipart_upload_basic\n- keep the already-merged valid multipart test shape\n- make the ignored-test inventory actually decrease\n\n## Testing\n- cargo test -p fakecloud-e2e s3_multipart_upload_basic -- --exact --nocapture

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled the basic S3 multipart upload test in `fakecloud-e2e` by removing the `#[ignore]` attribute. This restores CI coverage for multipart completion and part-size validation and reduces the ignored test count.

<sup>Written for commit 594139df1fa9c12a0bbf663b460d5221a973392b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

