### PR TITLE
feat(integrations): add Step Functions cross-service task integrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,6 +2340,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "fakecloud-core",
+ "fakecloud-dynamodb",
  "http 1.4.0",
  "parking_lot",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,6 +2342,7 @@ dependencies = [
  "fakecloud-core",
  "fakecloud-dynamodb",
  "http 1.4.0",
+ "md-5 0.10.6",
  "parking_lot",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ tests; they are an extra layer, not the whole story.
 | Startup time        | ~500ms                                             | ~3s                                                                            |
 | Idle memory         | ~10 MiB                                            | ~150 MiB                                                                       |
 | Install size        | ~19 MB binary                                      | ~1 GB Docker image                                                             |
-| AWS services        | 18                                                 | 30+                                                                            |
+| AWS services        | 19                                                 | 30+                                                                            |
 | Test assertion SDKs | TypeScript, Python, Go, Rust                       | Python, Java                                                                   |
 | Cognito User Pools  | 80 operations                                      | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | SES v2              | 97 operations                                      | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
@@ -156,7 +156,7 @@ aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name my-queue
 
 ## Supported Services
 
-18 AWS services, 1002 API operations:
+19 AWS services, 1016 API operations:
 
 | Service                | Actions | Highlights                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -178,6 +178,7 @@ aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name my-queue
 | **Kinesis**            | 14      | Streams, records, shard iterators, retention changes, stream tagging                                                                                                                                                                                                                                                                                                                                        |
 | **RDS**                | 22      | DB instances (PostgreSQL, MySQL, MariaDB via Docker), snapshots, read replicas, parameter groups, subnet groups, engine/version discovery, tagging                                                                                                                                                                                                                                                          |
 | **ElastiCache**        | 44      | Cache clusters, replication groups, global replication groups, serverless caches and snapshots, subnet groups, users/user groups, failover, tagging (Redis and Valkey via Docker)                                                                                                                                                                                                                           |
+| **Step Functions**     | 14      | State machine CRUD, executions, ASL interpreter (Pass, Task, Choice, Wait, Parallel, Map, Succeed, Fail), Retry/Catch, Lambda/SQS/SNS/EventBridge/DynamoDB task integrations                                                                                                                                                                                                                              |
 
 ### Cross-Service Integration
 
@@ -195,6 +196,7 @@ integration tests:
 - **Cognito -> Lambda**: Pre-signup, post-confirmation, pre/post-auth, custom message, token generation, migration, and custom auth challenge triggers
 - **SES -> SNS/EventBridge**: Email event fanout (send, delivery, bounce, complaint) via configured event destinations
 - **SES Inbound -> S3/SNS/Lambda**: Receipt rules evaluate inbound email and execute S3, SNS, and Lambda actions
+- **Step Functions -> Lambda/SQS/SNS/EventBridge/DynamoDB**: Task states invoke Lambda, send SQS messages, publish to SNS topics, put EventBridge events, and read/write DynamoDB items
 - **CloudFormation -> Lambda/SNS**: Custom resources invoke via ServiceToken, stack events notify via NotificationARNs
 - **SecretsManager -> Lambda**: Rotation invokes Lambda for all 4 steps
 - **S3 Lifecycle**: Background expiration and storage class transitions
@@ -281,6 +283,7 @@ fakecloud exposes `/_fakecloud/*` endpoints for testing behaviors that AWS runs 
 | `/_fakecloud/cognito/tokens`                                  | GET    | List all active access and refresh tokens (without exposing token strings).                                             |
 | `/_fakecloud/cognito/expire-tokens`                           | POST   | Expire tokens. Body: `{"userPoolId": "...", "username": "..."}` (both optional).                                        |
 | `/_fakecloud/cognito/auth-events`                             | GET    | List all auth events (sign-up, sign-in, failures, password changes).                                                    |
+| `/_fakecloud/stepfunctions/executions`                        | GET    | List all Step Functions executions with status, input, output, and timestamps.                                          |
 | `/_fakecloud/reset`                                           | POST   | Reset all state across all services.                                                                                    |
 | `/_fakecloud/reset/{service}`                                 | POST   | Reset only the specified service's state. Returns `{"reset": "service_name"}`.                                          |
 
@@ -362,7 +365,7 @@ Contributions are welcome.
 **fakecloud is** a free, open-source local AWS emulator for integration testing and
 local development. For every service it implements, the goal is 100% behavioral
 parity with real AWS — verified by 34,000+ automated conformance test variants
-against official AWS Smithy models across all API operations. 18 services,
+against official AWS Smithy models across all API operations. 19 services,
 100% conformance.
 
 **fakecloud is not** a production-ready cloud replacement. It's not designed to

--- a/crates/fakecloud-e2e/tests/cloudformation.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation.rs
@@ -633,12 +633,12 @@ def lambda_handler(event, context):
     assert_eq!(invocation_event["ResourceProperties"]["Count"], 42);
 
     let mut found = false;
-    for _ in 0..10 {
+    for _ in 0..20 {
         let msgs = sqs_client
             .receive_message()
             .queue_url(&queue_url)
             .max_number_of_messages(10)
-            .wait_time_seconds(2)
+            .wait_time_seconds(3)
             .send()
             .await
             .unwrap();
@@ -663,7 +663,7 @@ def lambda_handler(event, context):
             break;
         }
 
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     }
 
     assert!(

--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -2,6 +2,7 @@ mod helpers;
 
 use aws_sdk_sfn::types::Tag;
 use helpers::TestServer;
+use serde_json::json;
 use tokio::time::{sleep, Duration};
 
 fn simple_definition() -> String {
@@ -2890,4 +2891,608 @@ async fn sfn_parallel_then_map_workflow() {
     assert_eq!(arr[0]["value"], 10);
     assert_eq!(arr[0]["status"], "transformed");
     assert_eq!(arr[1]["value"], 20);
+}
+
+// --- Cross-service integration tests ---
+
+#[tokio::test]
+async fn sfn_task_sqs_send_message() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create an SQS queue
+    let queue = sqs
+        .create_queue()
+        .queue_name("sfn-test-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap();
+
+    // Create a state machine that sends a message to SQS
+    let definition = json!({
+        "StartAt": "SendMessage",
+        "States": {
+            "SendMessage": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::sqs:sendMessage",
+                "Parameters": {
+                    "QueueUrl": queue_url,
+                    "MessageBody": "hello from step functions"
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = sfn
+        .create_state_machine()
+        .name("sqs-send-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    // Verify the message was delivered to SQS
+    let receive = sqs
+        .receive_message()
+        .queue_url(queue_url)
+        .send()
+        .await
+        .unwrap();
+
+    let messages = receive.messages();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].body().unwrap(), "hello from step functions");
+}
+
+#[tokio::test]
+async fn sfn_task_sns_publish() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let sns = server.sns_client().await;
+
+    // Create an SNS topic
+    let topic = sns
+        .create_topic()
+        .name("sfn-test-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap();
+
+    // Create a state machine that publishes to SNS
+    let definition = json!({
+        "StartAt": "Publish",
+        "States": {
+            "Publish": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::sns:publish",
+                "Parameters": {
+                    "TopicArn": topic_arn,
+                    "Message": "hello from step functions"
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = sfn
+        .create_state_machine()
+        .name("sns-publish-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    // Verify the message was published via introspection endpoint
+    let url = format!("{}/_fakecloud/sns/messages", server.endpoint());
+    let resp: serde_json::Value = reqwest::get(&url).await.unwrap().json().await.unwrap();
+    let messages = resp["messages"].as_array().unwrap();
+    assert!(
+        messages
+            .iter()
+            .any(|m| m["message"].as_str() == Some("hello from step functions")),
+        "Expected SNS message not found: {messages:?}"
+    );
+}
+
+#[tokio::test]
+async fn sfn_task_dynamodb_put_and_get_item() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let ddb = server.dynamodb_client().await;
+
+    // Create a DynamoDB table
+    ddb.create_table()
+        .table_name("sfn-test-table")
+        .attribute_definitions(
+            aws_sdk_dynamodb::types::AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(aws_sdk_dynamodb::types::ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            aws_sdk_dynamodb::types::KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(aws_sdk_dynamodb::types::KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Create a state machine that puts an item, then gets it
+    let definition = json!({
+        "StartAt": "PutItem",
+        "States": {
+            "PutItem": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::dynamodb:putItem",
+                "Parameters": {
+                    "TableName": "sfn-test-table",
+                    "Item": {
+                        "pk": {"S": "item-1"},
+                        "data": {"S": "from-step-functions"}
+                    }
+                },
+                "ResultPath": "$.putResult",
+                "Next": "GetItem"
+            },
+            "GetItem": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::dynamodb:getItem",
+                "Parameters": {
+                    "TableName": "sfn-test-table",
+                    "Key": {
+                        "pk": {"S": "item-1"}
+                    }
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = sfn
+        .create_state_machine()
+        .name("ddb-put-get-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    // Verify the output contains the item
+    let desc = sfn
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output["Item"]["pk"]["S"], "item-1");
+    assert_eq!(output["Item"]["data"]["S"], "from-step-functions");
+}
+
+#[tokio::test]
+async fn sfn_task_dynamodb_delete_item() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let ddb = server.dynamodb_client().await;
+
+    // Create a DynamoDB table and put an item
+    ddb.create_table()
+        .table_name("sfn-del-table")
+        .attribute_definitions(
+            aws_sdk_dynamodb::types::AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(aws_sdk_dynamodb::types::ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            aws_sdk_dynamodb::types::KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(aws_sdk_dynamodb::types::KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    ddb.put_item()
+        .table_name("sfn-del-table")
+        .item(
+            "pk",
+            aws_sdk_dynamodb::types::AttributeValue::S("to-delete".to_string()),
+        )
+        .item(
+            "data",
+            aws_sdk_dynamodb::types::AttributeValue::S("will be gone".to_string()),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Delete the item via Step Functions
+    let definition = json!({
+        "StartAt": "DeleteItem",
+        "States": {
+            "DeleteItem": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::dynamodb:deleteItem",
+                "Parameters": {
+                    "TableName": "sfn-del-table",
+                    "Key": {
+                        "pk": {"S": "to-delete"}
+                    }
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = sfn
+        .create_state_machine()
+        .name("ddb-delete-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    // Verify the item was deleted
+    let get = ddb
+        .get_item()
+        .table_name("sfn-del-table")
+        .key(
+            "pk",
+            aws_sdk_dynamodb::types::AttributeValue::S("to-delete".to_string()),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(get.item().is_none());
+}
+
+#[tokio::test]
+async fn sfn_task_eventbridge_put_events() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+
+    // Create a state machine that puts events to EventBridge
+    let definition = json!({
+        "StartAt": "PutEvents",
+        "States": {
+            "PutEvents": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::events:putEvents",
+                "Parameters": {
+                    "Entries": [
+                        {
+                            "Source": "my.app",
+                            "DetailType": "OrderCreated",
+                            "Detail": "{\"orderId\": \"123\"}",
+                            "EventBusName": "default"
+                        }
+                    ]
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = sfn
+        .create_state_machine()
+        .name("eb-putevents-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    // Verify the event was recorded via introspection
+    let url = format!("{}/_fakecloud/events/history", server.endpoint());
+    let resp: serde_json::Value = reqwest::get(&url).await.unwrap().json().await.unwrap();
+    let events = resp["events"].as_array().unwrap();
+    assert!(
+        events.iter().any(|e| e["source"].as_str() == Some("my.app")
+            && e["detailType"].as_str() == Some("OrderCreated")),
+        "Expected EventBridge event not found: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn sfn_task_sqs_with_dynamic_parameters() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create an SQS queue
+    let queue = sqs
+        .create_queue()
+        .queue_name("sfn-dynamic-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap();
+
+    // Create a state machine that uses Parameters.$ to extract from input
+    let definition = json!({
+        "StartAt": "SendMessage",
+        "States": {
+            "SendMessage": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::sqs:sendMessage",
+                "Parameters": {
+                    "QueueUrl": queue_url,
+                    "MessageBody.$": "$.message"
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = sfn
+        .create_state_machine()
+        .name("sqs-dynamic-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"message": "dynamic message content"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    // Verify the dynamic message was sent
+    let receive = sqs
+        .receive_message()
+        .queue_url(queue_url)
+        .send()
+        .await
+        .unwrap();
+
+    let messages = receive.messages();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].body().unwrap(), "dynamic message content");
+}
+
+#[tokio::test]
+async fn sfn_introspection_executions_endpoint() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+
+    let create = sfn
+        .create_state_machine()
+        .name("introspect-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("introspect-exec")
+        .input(r#"{"test": true}"#)
+        .send()
+        .await
+        .unwrap();
+
+    wait_for_execution(&sfn, start.execution_arn()).await;
+
+    // Check the introspection endpoint
+    let url = format!("{}/_fakecloud/stepfunctions/executions", server.endpoint());
+    let resp: serde_json::Value = reqwest::get(&url).await.unwrap().json().await.unwrap();
+    let executions = resp["executions"].as_array().unwrap();
+    assert!(!executions.is_empty());
+
+    let exec = executions
+        .iter()
+        .find(|e| e["name"].as_str() == Some("introspect-exec"))
+        .expect("Expected execution not found");
+    assert_eq!(exec["status"], "SUCCEEDED");
+    assert!(exec["executionArn"]
+        .as_str()
+        .unwrap()
+        .contains("introspect"));
+    assert!(exec["stateMachineArn"]
+        .as_str()
+        .unwrap()
+        .contains("introspect-sm"));
+    assert!(exec["startDate"].as_str().is_some());
+    assert!(exec["stopDate"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn sfn_cross_service_workflow_sqs_then_choice() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create two SQS queues for routing
+    let high_queue = sqs
+        .create_queue()
+        .queue_name("high-priority")
+        .send()
+        .await
+        .unwrap();
+    let high_url = high_queue.queue_url().unwrap();
+
+    let low_queue = sqs
+        .create_queue()
+        .queue_name("low-priority")
+        .send()
+        .await
+        .unwrap();
+    let low_url = low_queue.queue_url().unwrap();
+
+    // Workflow: Choice routes to different SQS queues based on priority
+    let definition = json!({
+        "StartAt": "Route",
+        "States": {
+            "Route": {
+                "Type": "Choice",
+                "Choices": [
+                    {
+                        "Variable": "$.priority",
+                        "StringEquals": "high",
+                        "Next": "SendHigh"
+                    }
+                ],
+                "Default": "SendLow"
+            },
+            "SendHigh": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::sqs:sendMessage",
+                "Parameters": {
+                    "QueueUrl": high_url,
+                    "MessageBody.$": "$.payload"
+                },
+                "End": true
+            },
+            "SendLow": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::sqs:sendMessage",
+                "Parameters": {
+                    "QueueUrl": low_url,
+                    "MessageBody.$": "$.payload"
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = sfn
+        .create_state_machine()
+        .name("cross-service-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    // Send a high-priority message
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-high")
+        .input(r#"{"priority": "high", "payload": "urgent order"}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    // Send a low-priority message
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("exec-low")
+        .input(r#"{"priority": "low", "payload": "regular order"}"#)
+        .send()
+        .await
+        .unwrap();
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    // Verify high-priority queue got the right message
+    let receive = sqs
+        .receive_message()
+        .queue_url(high_url)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(receive.messages().len(), 1);
+    assert_eq!(receive.messages()[0].body().unwrap(), "urgent order");
+
+    // Verify low-priority queue got the right message
+    let receive = sqs
+        .receive_message()
+        .queue_url(low_url)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(receive.messages().len(), 1);
+    assert_eq!(receive.messages()[0].body().unwrap(), "regular order");
 }

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -400,6 +400,30 @@ pub struct ElastiCacheServerlessCachesResponse {
     pub serverless_caches: Vec<ElastiCacheServerlessCacheIntrospection>,
 }
 
+// ── Step Functions ──────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StepFunctionsExecution {
+    pub execution_arn: String,
+    pub state_machine_arn: String,
+    pub name: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+    pub start_date: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_date: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StepFunctionsExecutionsResponse {
+    pub executions: Vec<StepFunctionsExecution>,
+}
+
 // ── Cognito ─────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -440,9 +440,13 @@ async fn main() {
     registry.register(Arc::new(elasticache_service));
     let mut sfn_service = StepFunctionsService::new(stepfunctions_state.clone());
     {
+        let mut sns_eb_bus = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+        if let Some(ref ld) = lambda_delivery {
+            sns_eb_bus = sns_eb_bus.with_lambda(ld.clone());
+        }
         let sns_delivery_for_sfn_eb = Arc::new(fakecloud_sns::delivery::SnsDeliveryImpl::new(
             sns_state_for_sfn.clone(),
-            Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+            Arc::new(sns_eb_bus),
         ));
         let mut eb_target_bus = DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -440,10 +440,20 @@ async fn main() {
     registry.register(Arc::new(elasticache_service));
     let mut sfn_service = StepFunctionsService::new(stepfunctions_state.clone());
     {
+        let sns_delivery_for_sfn_eb = Arc::new(fakecloud_sns::delivery::SnsDeliveryImpl::new(
+            sns_state_for_sfn.clone(),
+            Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+        ));
+        let mut eb_target_bus = DeliveryBus::new()
+            .with_sqs(sqs_delivery.clone())
+            .with_sns(sns_delivery_for_sfn_eb);
+        if let Some(ref ld) = lambda_delivery {
+            eb_target_bus = eb_target_bus.with_lambda(ld.clone());
+        }
         let eb_delivery_for_sfn = Arc::new(
             fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
                 eb_state_for_sfn,
-                Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+                Arc::new(eb_target_bus),
             ),
         );
         let sns_delivery_for_sfn = Arc::new(fakecloud_sns::delivery::SnsDeliveryImpl::new(

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -341,6 +341,8 @@ async fn main() {
         delivery_for_cf,
     )));
     registry.register(Arc::new(SqsService::new(sqs_state.clone())));
+    let sns_state_for_sfn = sns_state.clone();
+    let delivery_for_sns_sfn = delivery_for_sns.clone();
     registry.register(Arc::new(SnsService::new(sns_state, delivery_for_sns)));
     let mut eb_service = EventBridgeService::new(eb_state.clone(), delivery_for_eb.clone())
         .with_lambda(lambda_state.clone())
@@ -352,6 +354,7 @@ async fn main() {
 
     // Spawn the EventBridge scheduler as a background task
     let eb_state_for_ses = eb_state.clone();
+    let eb_state_for_sfn = eb_state.clone();
     let mut scheduler = fakecloud_eventbridge::scheduler::Scheduler::new(eb_state, delivery_for_eb)
         .with_lambda(lambda_state.clone())
         .with_logs(logs_state.clone());
@@ -437,11 +440,26 @@ async fn main() {
     registry.register(Arc::new(elasticache_service));
     let mut sfn_service = StepFunctionsService::new(stepfunctions_state.clone());
     {
-        let mut bus = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+        let eb_delivery_for_sfn = Arc::new(
+            fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
+                eb_state_for_sfn,
+                Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+            ),
+        );
+        let sns_delivery_for_sfn = Arc::new(fakecloud_sns::delivery::SnsDeliveryImpl::new(
+            sns_state_for_sfn,
+            delivery_for_sns_sfn,
+        ));
+        let mut bus = DeliveryBus::new()
+            .with_sqs(sqs_delivery.clone())
+            .with_sns(sns_delivery_for_sfn)
+            .with_eventbridge(eb_delivery_for_sfn);
         if let Some(ref ld) = lambda_delivery {
             bus = bus.with_lambda(ld.clone());
         }
-        sfn_service = sfn_service.with_delivery(Arc::new(bus));
+        sfn_service = sfn_service
+            .with_delivery(Arc::new(bus))
+            .with_dynamodb(dynamodb_state.clone());
     }
     registry.register(Arc::new(sfn_service));
 
@@ -1132,6 +1150,34 @@ async fn main() {
                         serverless_caches
                             .sort_by(|a, b| a.serverless_cache_name.cmp(&b.serverless_cache_name));
                         axum::Json(types::ElastiCacheServerlessCachesResponse { serverless_caches })
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/stepfunctions/executions",
+            axum::routing::get({
+                let ss = stepfunctions_state.clone();
+                move || {
+                    let ss = ss.clone();
+                    async move {
+                        let state = ss.read();
+                        let mut executions: Vec<types::StepFunctionsExecution> = state
+                            .executions
+                            .values()
+                            .map(|exec| types::StepFunctionsExecution {
+                                execution_arn: exec.execution_arn.clone(),
+                                state_machine_arn: exec.state_machine_arn.clone(),
+                                name: exec.name.clone(),
+                                status: exec.status.as_str().to_string(),
+                                input: exec.input.clone(),
+                                output: exec.output.clone(),
+                                start_date: exec.start_date.to_rfc3339(),
+                                stop_date: exec.stop_date.map(|d| d.to_rfc3339()),
+                            })
+                            .collect();
+                        executions.sort_by(|a, b| b.start_date.cmp(&a.start_date));
+                        axum::Json(types::StepFunctionsExecutionsResponse { executions })
                     }
                 }
             }),

--- a/crates/fakecloud-stepfunctions/Cargo.toml
+++ b/crates/fakecloud-stepfunctions/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 fakecloud-core = { workspace = true }
+fakecloud-dynamodb = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-stepfunctions/Cargo.toml
+++ b/crates/fakecloud-stepfunctions/Cargo.toml
@@ -18,4 +18,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+md-5 = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::Utc;
@@ -5,6 +6,7 @@ use serde_json::{json, Value};
 use tracing::debug;
 
 use fakecloud_core::delivery::DeliveryBus;
+use fakecloud_dynamodb::state::SharedDynamoDbState;
 
 use crate::choice::evaluate_choice;
 use crate::error_handling::{find_catcher, should_retry};
@@ -19,6 +21,7 @@ pub async fn execute_state_machine(
     definition: String,
     input: Option<String>,
     delivery: Option<Arc<DeliveryBus>>,
+    dynamodb_state: Option<SharedDynamoDbState>,
 ) {
     let def: Value = match serde_json::from_str(&definition) {
         Ok(v) => v,
@@ -50,7 +53,16 @@ pub async fn execute_state_machine(
         }),
     );
 
-    match run_states(&def, raw_input, &delivery, &state, &execution_arn).await {
+    match run_states(
+        &def,
+        raw_input,
+        &delivery,
+        &dynamodb_state,
+        &state,
+        &execution_arn,
+    )
+    .await
+    {
         Ok(output) => {
             succeed_execution(&state, &execution_arn, &output);
         }
@@ -70,6 +82,7 @@ fn run_states<'a>(
     def: &'a Value,
     input: Value,
     delivery: &'a Option<Arc<DeliveryBus>>,
+    dynamodb_state: &'a Option<SharedDynamoDbState>,
     shared_state: &'a SharedStepFunctionsState,
     execution_arn: &'a str,
 ) -> StatesResult<'a> {
@@ -244,6 +257,7 @@ fn run_states<'a>(
                         &state_def,
                         &effective_input,
                         delivery,
+                        dynamodb_state,
                         shared_state,
                         execution_arn,
                         entered_event_id,
@@ -389,6 +403,7 @@ fn run_states<'a>(
                         &state_def,
                         &effective_input,
                         delivery,
+                        dynamodb_state,
                         shared_state,
                         execution_arn,
                     )
@@ -455,6 +470,7 @@ fn run_states<'a>(
                         &state_def,
                         &effective_input,
                         delivery,
+                        dynamodb_state,
                         shared_state,
                         execution_arn,
                     )
@@ -589,11 +605,13 @@ fn execute_pass_state(state_def: &Value, input: &Value) -> Value {
     }
 }
 
-/// Execute a Task state: invoke the resource (Lambda), apply I/O processing, handle Retry.
+/// Execute a Task state: invoke the resource (Lambda, SQS, SNS, EventBridge, DynamoDB),
+/// apply I/O processing, handle Retry.
 async fn execute_task_state(
     state_def: &Value,
     input: &Value,
     delivery: &Option<Arc<DeliveryBus>>,
+    dynamodb_state: &Option<SharedDynamoDbState>,
     shared_state: &SharedStepFunctionsState,
     execution_arn: &str,
     entered_event_id: i64,
@@ -641,8 +659,14 @@ async fn execute_task_state(
             json!({ "resource": resource }),
         );
 
-        let invoke_result =
-            invoke_resource(&resource, &task_input, delivery, timeout_seconds).await;
+        let invoke_result = invoke_resource(
+            &resource,
+            &task_input,
+            delivery,
+            dynamodb_state,
+            timeout_seconds,
+        )
+        .await;
 
         match invoke_result {
             Ok(result) => {
@@ -704,6 +728,7 @@ async fn execute_parallel_state(
     state_def: &Value,
     input: &Value,
     delivery: &Option<Arc<DeliveryBus>>,
+    dynamodb_state: &Option<SharedDynamoDbState>,
     shared_state: &SharedStepFunctionsState,
     execution_arn: &str,
 ) -> Result<Value, (String, String)> {
@@ -735,11 +760,12 @@ async fn execute_parallel_state(
         let branch = branch_def.clone();
         let branch_input = effective_input.clone();
         let delivery = delivery.clone();
+        let ddb = dynamodb_state.clone();
         let state = shared_state.clone();
         let arn = execution_arn.to_string();
 
         handles.push(tokio::spawn(async move {
-            run_states(&branch, branch_input, &delivery, &state, &arn).await
+            run_states(&branch, branch_input, &delivery, &ddb, &state, &arn).await
         }));
     }
 
@@ -786,6 +812,7 @@ async fn execute_map_state(
     state_def: &Value,
     input: &Value,
     delivery: &Option<Arc<DeliveryBus>>,
+    dynamodb_state: &Option<SharedDynamoDbState>,
     shared_state: &SharedStepFunctionsState,
     execution_arn: &str,
 ) -> Result<Value, (String, String)> {
@@ -830,6 +857,7 @@ async fn execute_map_state(
     for (index, item) in items.into_iter().enumerate() {
         let iter_def = iterator_def.clone();
         let delivery = delivery.clone();
+        let ddb = dynamodb_state.clone();
         let state = shared_state.clone();
         let arn = execution_arn.to_string();
         let sem = semaphore.clone();
@@ -857,7 +885,7 @@ async fn execute_map_state(
                 .acquire()
                 .await
                 .map_err(|_| ("States.Runtime".to_string(), "Semaphore closed".to_string()))?;
-            let result = run_states(&iter_def, item_input, &delivery, &state, &arn).await;
+            let result = run_states(&iter_def, item_input, &delivery, &ddb, &state, &arn).await;
             Ok::<(usize, Result<Value, (String, String)>), (String, String)>((index, result))
         }));
     }
@@ -929,17 +957,17 @@ async fn invoke_resource(
     resource: &str,
     input: &Value,
     delivery: &Option<Arc<DeliveryBus>>,
+    dynamodb_state: &Option<SharedDynamoDbState>,
     timeout_seconds: Option<u64>,
 ) -> Result<Value, (String, String)> {
+    // Direct Lambda ARN: arn:aws:lambda:<region>:<account>:function:<name>
     if resource.contains(":lambda:") && resource.contains(":function:") {
         return invoke_lambda_direct(resource, input, delivery, timeout_seconds).await;
     }
 
+    // SDK integration patterns: arn:aws:states:::<service>:<action>
     if resource.starts_with("arn:aws:states:::lambda:invoke") {
-        let function_name = input["FunctionName"]
-            .as_str()
-            .or_else(|| input["Payload"].as_object().and(None))
-            .unwrap_or("");
+        let function_name = input["FunctionName"].as_str().unwrap_or("");
         let payload = if let Some(p) = input.get("Payload") {
             p.clone()
         } else {
@@ -948,10 +976,435 @@ async fn invoke_resource(
         return invoke_lambda_direct(function_name, &payload, delivery, timeout_seconds).await;
     }
 
+    if resource.starts_with("arn:aws:states:::sqs:sendMessage") {
+        return invoke_sqs_send_message(input, delivery);
+    }
+
+    if resource.starts_with("arn:aws:states:::sns:publish") {
+        return invoke_sns_publish(input, delivery);
+    }
+
+    if resource.starts_with("arn:aws:states:::events:putEvents") {
+        return invoke_eventbridge_put_events(input, delivery);
+    }
+
+    if resource.starts_with("arn:aws:states:::dynamodb:getItem") {
+        return invoke_dynamodb_get_item(input, dynamodb_state);
+    }
+
+    if resource.starts_with("arn:aws:states:::dynamodb:putItem") {
+        return invoke_dynamodb_put_item(input, dynamodb_state);
+    }
+
+    if resource.starts_with("arn:aws:states:::dynamodb:deleteItem") {
+        return invoke_dynamodb_delete_item(input, dynamodb_state);
+    }
+
+    if resource.starts_with("arn:aws:states:::dynamodb:updateItem") {
+        return invoke_dynamodb_update_item(input, dynamodb_state);
+    }
+
     Err((
         "States.TaskFailed".to_string(),
         format!("Unsupported resource: {resource}"),
     ))
+}
+
+/// Send a message to an SQS queue via DeliveryBus.
+fn invoke_sqs_send_message(
+    input: &Value,
+    delivery: &Option<Arc<DeliveryBus>>,
+) -> Result<Value, (String, String)> {
+    let delivery = delivery.as_ref().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "No delivery bus configured for SQS".to_string(),
+        )
+    })?;
+
+    let queue_url = input["QueueUrl"].as_str().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "Missing QueueUrl in SQS sendMessage parameters".to_string(),
+        )
+    })?;
+
+    let message_body = input["MessageBody"]
+        .as_str()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            // If MessageBody is not a string, serialize the value
+            serde_json::to_string(&input["MessageBody"]).unwrap_or_default()
+        });
+
+    // Convert QueueUrl to ARN format for the delivery bus
+    // QueueUrl format: http://.../<account>/<queue-name>
+    // ARN format: arn:aws:sqs:<region>:<account>:<queue-name>
+    let queue_arn = queue_url_to_arn(queue_url);
+
+    delivery.send_to_sqs(&queue_arn, &message_body, &HashMap::new());
+
+    Ok(json!({
+        "MessageId": uuid::Uuid::new_v4().to_string(),
+        "MD5OfMessageBody": format!("{:x}", md5_hash(&message_body)),
+    }))
+}
+
+/// Publish a message to an SNS topic via DeliveryBus.
+fn invoke_sns_publish(
+    input: &Value,
+    delivery: &Option<Arc<DeliveryBus>>,
+) -> Result<Value, (String, String)> {
+    let delivery = delivery.as_ref().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "No delivery bus configured for SNS".to_string(),
+        )
+    })?;
+
+    let topic_arn = input["TopicArn"].as_str().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "Missing TopicArn in SNS publish parameters".to_string(),
+        )
+    })?;
+
+    let message = input["Message"]
+        .as_str()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| serde_json::to_string(&input["Message"]).unwrap_or_default());
+
+    let subject = input["Subject"].as_str();
+
+    delivery.publish_to_sns(topic_arn, &message, subject);
+
+    Ok(json!({
+        "MessageId": uuid::Uuid::new_v4().to_string(),
+    }))
+}
+
+/// Put events onto an EventBridge bus via DeliveryBus.
+fn invoke_eventbridge_put_events(
+    input: &Value,
+    delivery: &Option<Arc<DeliveryBus>>,
+) -> Result<Value, (String, String)> {
+    let delivery = delivery.as_ref().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "No delivery bus configured for EventBridge".to_string(),
+        )
+    })?;
+
+    let entries = input["Entries"]
+        .as_array()
+        .ok_or_else(|| {
+            (
+                "States.TaskFailed".to_string(),
+                "Missing Entries in EventBridge putEvents parameters".to_string(),
+            )
+        })?
+        .clone();
+
+    let mut event_ids = Vec::new();
+    for entry in &entries {
+        let source = entry["Source"].as_str().unwrap_or("aws.stepfunctions");
+        let detail_type = entry["DetailType"].as_str().unwrap_or("StepFunctionsEvent");
+        let detail = entry["Detail"]
+            .as_str()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| serde_json::to_string(&entry["Detail"]).unwrap_or("{}".to_string()));
+        let bus_name = entry["EventBusName"].as_str().unwrap_or("default");
+
+        delivery.put_event_to_eventbridge(source, detail_type, &detail, bus_name);
+        event_ids.push(uuid::Uuid::new_v4().to_string());
+    }
+
+    Ok(json!({
+        "Entries": event_ids.iter().map(|id| json!({"EventId": id})).collect::<Vec<_>>(),
+        "FailedEntryCount": 0,
+    }))
+}
+
+/// Get an item from DynamoDB via direct state access.
+fn invoke_dynamodb_get_item(
+    input: &Value,
+    dynamodb_state: &Option<SharedDynamoDbState>,
+) -> Result<Value, (String, String)> {
+    let ddb = dynamodb_state.as_ref().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "No DynamoDB state configured".to_string(),
+        )
+    })?;
+
+    let table_name = input["TableName"].as_str().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "Missing TableName in DynamoDB getItem parameters".to_string(),
+        )
+    })?;
+
+    let key = input
+        .get("Key")
+        .and_then(|k| k.as_object())
+        .ok_or_else(|| {
+            (
+                "States.TaskFailed".to_string(),
+                "Missing Key in DynamoDB getItem parameters".to_string(),
+            )
+        })?;
+
+    let key_map: HashMap<String, Value> = key.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+    let state = ddb.read();
+    let table = state.tables.get(table_name).ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            format!("Table '{table_name}' not found"),
+        )
+    })?;
+
+    let item = table
+        .find_item_index(&key_map)
+        .map(|idx| table.items[idx].clone());
+
+    match item {
+        Some(item_map) => {
+            let item_value: serde_json::Map<String, Value> = item_map.into_iter().collect();
+            Ok(json!({ "Item": item_value }))
+        }
+        None => Ok(json!({})),
+    }
+}
+
+/// Put an item into DynamoDB via direct state access.
+fn invoke_dynamodb_put_item(
+    input: &Value,
+    dynamodb_state: &Option<SharedDynamoDbState>,
+) -> Result<Value, (String, String)> {
+    let ddb = dynamodb_state.as_ref().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "No DynamoDB state configured".to_string(),
+        )
+    })?;
+
+    let table_name = input["TableName"].as_str().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "Missing TableName in DynamoDB putItem parameters".to_string(),
+        )
+    })?;
+
+    let item = input
+        .get("Item")
+        .and_then(|i| i.as_object())
+        .ok_or_else(|| {
+            (
+                "States.TaskFailed".to_string(),
+                "Missing Item in DynamoDB putItem parameters".to_string(),
+            )
+        })?;
+
+    let item_map: HashMap<String, Value> =
+        item.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+    let mut state = ddb.write();
+    let table = state.tables.get_mut(table_name).ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            format!("Table '{table_name}' not found"),
+        )
+    })?;
+
+    // Replace existing item with same key, or insert new
+    if let Some(idx) = table.find_item_index(&item_map) {
+        table.items[idx] = item_map;
+    } else {
+        table.items.push(item_map);
+    }
+
+    Ok(json!({}))
+}
+
+/// Delete an item from DynamoDB via direct state access.
+fn invoke_dynamodb_delete_item(
+    input: &Value,
+    dynamodb_state: &Option<SharedDynamoDbState>,
+) -> Result<Value, (String, String)> {
+    let ddb = dynamodb_state.as_ref().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "No DynamoDB state configured".to_string(),
+        )
+    })?;
+
+    let table_name = input["TableName"].as_str().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "Missing TableName in DynamoDB deleteItem parameters".to_string(),
+        )
+    })?;
+
+    let key = input
+        .get("Key")
+        .and_then(|k| k.as_object())
+        .ok_or_else(|| {
+            (
+                "States.TaskFailed".to_string(),
+                "Missing Key in DynamoDB deleteItem parameters".to_string(),
+            )
+        })?;
+
+    let key_map: HashMap<String, Value> = key.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+    let mut state = ddb.write();
+    let table = state.tables.get_mut(table_name).ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            format!("Table '{table_name}' not found"),
+        )
+    })?;
+
+    if let Some(idx) = table.find_item_index(&key_map) {
+        table.items.remove(idx);
+    }
+
+    Ok(json!({}))
+}
+
+/// Update an item in DynamoDB via direct state access.
+/// Simplified: merges Key+ExpressionAttributeValues into the existing item.
+fn invoke_dynamodb_update_item(
+    input: &Value,
+    dynamodb_state: &Option<SharedDynamoDbState>,
+) -> Result<Value, (String, String)> {
+    let ddb = dynamodb_state.as_ref().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "No DynamoDB state configured".to_string(),
+        )
+    })?;
+
+    let table_name = input["TableName"].as_str().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "Missing TableName in DynamoDB updateItem parameters".to_string(),
+        )
+    })?;
+
+    let key = input
+        .get("Key")
+        .and_then(|k| k.as_object())
+        .ok_or_else(|| {
+            (
+                "States.TaskFailed".to_string(),
+                "Missing Key in DynamoDB updateItem parameters".to_string(),
+            )
+        })?;
+
+    let key_map: HashMap<String, Value> = key.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+    let mut state = ddb.write();
+    let table = state.tables.get_mut(table_name).ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            format!("Table '{table_name}' not found"),
+        )
+    })?;
+
+    // Parse UpdateExpression to apply SET operations
+    if let Some(update_expr) = input["UpdateExpression"].as_str() {
+        let attr_values = input
+            .get("ExpressionAttributeValues")
+            .and_then(|v| v.as_object())
+            .cloned()
+            .unwrap_or_default();
+        let attr_names = input
+            .get("ExpressionAttributeNames")
+            .and_then(|v| v.as_object())
+            .cloned()
+            .unwrap_or_default();
+
+        if let Some(idx) = table.find_item_index(&key_map) {
+            apply_update_expression(
+                &mut table.items[idx],
+                update_expr,
+                &attr_values,
+                &attr_names,
+            );
+        } else {
+            // Create new item with key + update expression values
+            let mut new_item = key_map;
+            apply_update_expression(&mut new_item, update_expr, &attr_values, &attr_names);
+            table.items.push(new_item);
+        }
+    }
+
+    Ok(json!({}))
+}
+
+/// Apply a simple SET UpdateExpression to an item.
+fn apply_update_expression(
+    item: &mut HashMap<String, Value>,
+    expr: &str,
+    attr_values: &serde_json::Map<String, Value>,
+    attr_names: &serde_json::Map<String, Value>,
+) {
+    // Parse "SET #name1 = :val1, #name2 = :val2" or "SET field = :val"
+    let set_part = expr
+        .trim()
+        .strip_prefix("SET ")
+        .or_else(|| expr.trim().strip_prefix("set "))
+        .unwrap_or(expr);
+
+    for assignment in set_part.split(',') {
+        let parts: Vec<&str> = assignment.splitn(2, '=').collect();
+        if parts.len() == 2 {
+            let attr_ref = parts[0].trim();
+            let val_ref = parts[1].trim();
+
+            // Resolve attribute name (could be #alias or direct name)
+            let attr_name = if attr_ref.starts_with('#') {
+                attr_names
+                    .get(attr_ref)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(attr_ref)
+                    .to_string()
+            } else {
+                attr_ref.to_string()
+            };
+
+            // Resolve value
+            if val_ref.starts_with(':') {
+                if let Some(val) = attr_values.get(val_ref) {
+                    item.insert(attr_name, val.clone());
+                }
+            }
+        }
+    }
+}
+
+/// Convert an SQS queue URL to an ARN.
+/// QueueUrl format: http://localhost:4566/123456789012/my-queue
+fn queue_url_to_arn(url: &str) -> String {
+    let parts: Vec<&str> = url.rsplitn(3, '/').collect();
+    if parts.len() >= 2 {
+        let queue_name = parts[0];
+        let account_id = parts[1];
+        format!("arn:aws:sqs:us-east-1:{account_id}:{queue_name}")
+    } else {
+        url.to_string()
+    }
+}
+
+/// Simple hash function for MD5-like output (not cryptographic, just for response format).
+fn md5_hash(data: &str) -> u64 {
+    let mut hash: u64 = 0;
+    for byte in data.bytes() {
+        hash = hash.wrapping_mul(31).wrapping_add(byte as u64);
+    }
+    hash
 }
 
 /// Invoke a Lambda function directly via DeliveryBus.
@@ -1161,6 +1614,7 @@ mod tests {
             definition,
             Some(r#"{"hello":"world"}"#.to_string()),
             None,
+            None,
         )
         .await;
 
@@ -1203,6 +1657,7 @@ mod tests {
             definition,
             Some("{}".to_string()),
             None,
+            None,
         )
         .await;
 
@@ -1236,6 +1691,7 @@ mod tests {
             definition,
             Some(r#"{"data": "value"}"#.to_string()),
             None,
+            None,
         )
         .await;
 
@@ -1262,7 +1718,7 @@ mod tests {
         })
         .to_string();
 
-        execute_state_machine(state.clone(), arn.to_string(), definition, None, None).await;
+        execute_state_machine(state.clone(), arn.to_string(), definition, None, None, None).await;
 
         let s = state.read();
         let exec = s.executions.get(arn).unwrap();
@@ -1293,6 +1749,7 @@ mod tests {
             arn.to_string(),
             definition,
             Some("{}".to_string()),
+            None,
             None,
         )
         .await;

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1046,7 +1046,7 @@ fn invoke_sqs_send_message(
 
     Ok(json!({
         "MessageId": uuid::Uuid::new_v4().to_string(),
-        "MD5OfMessageBody": format!("{:x}", md5_hash(&message_body)),
+        "MD5OfMessageBody": md5_hex(&message_body),
     }))
 }
 
@@ -1352,11 +1352,13 @@ fn apply_update_expression(
     attr_names: &serde_json::Map<String, Value>,
 ) {
     // Parse "SET #name1 = :val1, #name2 = :val2" or "SET field = :val"
-    let set_part = expr
-        .trim()
-        .strip_prefix("SET ")
-        .or_else(|| expr.trim().strip_prefix("set "))
-        .unwrap_or(expr);
+    // DynamoDB keywords are case-insensitive
+    let trimmed = expr.trim();
+    let set_part = if trimmed.len() >= 4 && trimmed[..4].eq_ignore_ascii_case("SET ") {
+        &trimmed[4..]
+    } else {
+        trimmed
+    };
 
     for assignment in set_part.split(',') {
         let parts: Vec<&str> = assignment.splitn(2, '=').collect();
@@ -1398,13 +1400,11 @@ fn queue_url_to_arn(url: &str) -> String {
     }
 }
 
-/// Simple hash function for MD5-like output (not cryptographic, just for response format).
-fn md5_hash(data: &str) -> u64 {
-    let mut hash: u64 = 0;
-    for byte in data.bytes() {
-        hash = hash.wrapping_mul(31).wrapping_add(byte as u64);
-    }
-    hash
+/// Compute MD5 hex digest for SQS message response format.
+fn md5_hex(data: &str) -> String {
+    use md5::Digest;
+    let result = md5::Md5::digest(data.as_bytes());
+    format!("{result:032x}")
 }
 
 /// Invoke a Lambda function directly via DeliveryBus.

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -10,6 +10,7 @@ use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
+use fakecloud_dynamodb::state::SharedDynamoDbState;
 
 use crate::interpreter;
 use crate::state::{
@@ -37,6 +38,7 @@ const SUPPORTED: &[&str] = &[
 pub struct StepFunctionsService {
     state: SharedStepFunctionsState,
     delivery: Option<Arc<DeliveryBus>>,
+    dynamodb_state: Option<SharedDynamoDbState>,
 }
 
 impl StepFunctionsService {
@@ -44,11 +46,17 @@ impl StepFunctionsService {
         Self {
             state,
             delivery: None,
+            dynamodb_state: None,
         }
     }
 
     pub fn with_delivery(mut self, delivery: Arc<DeliveryBus>) -> Self {
         self.delivery = Some(delivery);
+        self
+    }
+
+    pub fn with_dynamodb(mut self, dynamodb_state: SharedDynamoDbState) -> Self {
+        self.dynamodb_state = Some(dynamodb_state);
         self
     }
 }
@@ -363,6 +371,7 @@ impl StepFunctionsService {
         let exec_arn_clone = exec_arn.clone();
         let input_clone = input;
         let delivery = self.delivery.clone();
+        let dynamodb_state = self.dynamodb_state.clone();
         tokio::spawn(async move {
             interpreter::execute_state_machine(
                 shared_state,
@@ -370,6 +379,7 @@ impl StepFunctionsService {
                 definition,
                 input_clone,
                 delivery,
+                dynamodb_state,
             )
             .await;
         });


### PR DESCRIPTION
## Summary

- Add SDK integration routing in the ASL interpreter for SQS (`sendMessage`), SNS (`publish`), EventBridge (`putEvents`), and DynamoDB (`getItem`, `putItem`, `deleteItem`, `updateItem`) task resources
- Wire full DeliveryBus (SNS + EventBridge + SQS + Lambda) into StepFunctions service, with DynamoDB state passed directly for request-response operations
- Add `/_fakecloud/stepfunctions/executions` introspection endpoint with SDK types
- Update README to 19 services, 1016 operations, add Step Functions cross-service integration line
- 8 new E2E tests covering all cross-service integrations (total 60 Step Functions E2E tests)

## Test plan

- [x] 39 unit tests pass (`cargo test -p fakecloud-stepfunctions`)
- [x] 60 E2E tests pass (8 new cross-service integration tests)
- [x] 14 conformance tests pass
- [x] Clippy clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Formatting clean (`cargo fmt --check`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Step Functions cross-service Task integrations for SQS, SNS, EventBridge, and DynamoDB using ASL `arn:aws:states:::` patterns, plus an executions introspection endpoint. Also wires DeliveryBus and DynamoDB state into Step Functions and fixes delivery/hashing correctness.

- **New Features**
  - ASL interpreter supports `lambda:invoke`, `sqs:sendMessage`, `sns:publish`, `events:putEvents`, and `dynamodb:{getItem,putItem,deleteItem,updateItem}`.
  - Step Functions now uses DeliveryBus for SQS/SNS/EventBridge; EventBridge targets include SNS and Lambda; DynamoDB state is passed for request/response ops.
  - New `/_fakecloud/stepfunctions/executions` endpoint returning typed execution data.
  - 8 new E2E tests; README updated to 19 services and 1016 operations.

- **Bug Fixes**
  - Handle `SET` in DynamoDB UpdateExpression case-insensitively.
  - Use real MD5 (`md-5`) for SQS `MD5OfMessageBody`.
  - Ensure EventBridge events from Step Functions fan out to SNS and invoke Lambda subscriptions correctly.
  - Increase CloudFormation custom resource SQS polling (retries and wait time) for CI stability.

<sup>Written for commit 5655cc39869ca0744fed3a3de5c3fc8cbd9de70f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

