### PR TITLE
test(ssm): unignore ops item related items coverage

### DIFF
--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -1382,6 +1382,7 @@ async fn ssm_ops_item_related_items() {
     let create = client
         .create_ops_item()
         .title("Related test")
+        .description("Related item test description")
         .source("test")
         .send()
         .await


### PR DESCRIPTION
## Summary\n- unignore ssm_ops_item_related_items\n- satisfy the current OpsItem validation rule by providing a description\n- keep the related-items coverage path green\n\n## Testing\n- cargo test -p fakecloud-e2e ssm_ops_item_related_items -- --ignored --exact --nocapture

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled the SSM OpsItem related-items e2e test by adding the required `description` field to the create request to satisfy validation. Keeps related-items coverage green.

<sup>Written for commit e5d632ba458942d141602357a42bf4c5e9d73985. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

