### PR TITLE
test(ssm): actually unignore ops item related items coverage

### DIFF
--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -1373,7 +1373,6 @@ async fn ssm_patch_baseline_update() {
 // ── OpsItem Related Items ─────────────────────────────────────
 
 #[tokio::test]
-#[ignore] // SDK has timestamp deserialization issues with ListOpsItemRelatedItems — tested via raw HTTP in PR 78
 async fn ssm_ops_item_related_items() {
     let server = TestServer::start().await;
     let client = server.ssm_client().await;


### PR DESCRIPTION
## Summary\n- remove the lingering ignore from ssm_ops_item_related_items\n- keep the earlier validation fix that adds the required OpsItem description\n- make the related-items coverage count in the ignored-test cleanup campaign\n\n## Testing\n- cargo test -p fakecloud-e2e ssm_ops_item_related_items -- --exact --nocapture

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unignored the `ssm_ops_item_related_items` e2e test so it runs in CI and restores coverage for OpsItem Related Items.

<sup>Written for commit 22d39cf0ddab73dec23641a7190db224d988116a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

