### PR TITLE
feat(apigatewayv2): add routes, integrations, and router

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/lib.rs
+++ b/crates/fakecloud-apigatewayv2/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod router;
 pub mod service;
 pub mod state;
 

--- a/crates/fakecloud-apigatewayv2/src/router.rs
+++ b/crates/fakecloud-apigatewayv2/src/router.rs
@@ -1,0 +1,334 @@
+use crate::state::Route;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct RouteMatch {
+    pub route: Route,
+    pub path_parameters: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedRoute {
+    method: String,
+    segments: Vec<RouteSegment>,
+    priority: i32,
+}
+
+#[derive(Debug, Clone)]
+enum RouteSegment {
+    Exact(String),
+    Parameter(String),
+    Greedy(String),
+}
+
+impl ParsedRoute {
+    fn from_route_key(route_key: &str) -> Option<Self> {
+        let parts: Vec<&str> = route_key.splitn(2, ' ').collect();
+        if parts.len() != 2 {
+            return None;
+        }
+
+        let method = parts[0].to_string();
+        let path = parts[1];
+
+        let segments = Self::parse_path(path);
+        let priority = Self::calculate_priority(&segments);
+
+        Some(Self {
+            method,
+            segments,
+            priority,
+        })
+    }
+
+    fn parse_path(path: &str) -> Vec<RouteSegment> {
+        path.trim_start_matches('/')
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .map(|seg| {
+                if seg.starts_with('{') && seg.ends_with('}') {
+                    let param_name = seg.trim_start_matches('{').trim_end_matches('}');
+                    if param_name.ends_with('+') {
+                        RouteSegment::Greedy(param_name.trim_end_matches('+').to_string())
+                    } else {
+                        RouteSegment::Parameter(param_name.to_string())
+                    }
+                } else {
+                    RouteSegment::Exact(seg.to_string())
+                }
+            })
+            .collect()
+    }
+
+    fn calculate_priority(segments: &[RouteSegment]) -> i32 {
+        let mut priority = 0;
+        for seg in segments {
+            priority += match seg {
+                RouteSegment::Exact(_) => 100,
+                RouteSegment::Parameter(_) => 50,
+                RouteSegment::Greedy(_) => 10,
+            };
+        }
+        priority
+    }
+
+    fn matches(&self, method: &str, path_segments: &[String]) -> Option<HashMap<String, String>> {
+        // Check method match (ANY matches all methods)
+        if self.method != "ANY" && self.method != method {
+            return None;
+        }
+
+        let mut params = HashMap::new();
+        let mut route_idx = 0;
+        let mut path_idx = 0;
+
+        while route_idx < self.segments.len() {
+            match &self.segments[route_idx] {
+                RouteSegment::Exact(expected) => {
+                    if path_idx >= path_segments.len() || path_segments[path_idx] != *expected {
+                        return None;
+                    }
+                    path_idx += 1;
+                }
+                RouteSegment::Parameter(name) => {
+                    if path_idx >= path_segments.len() {
+                        return None;
+                    }
+                    params.insert(name.clone(), path_segments[path_idx].clone());
+                    path_idx += 1;
+                }
+                RouteSegment::Greedy(name) => {
+                    // Greedy parameter consumes all remaining segments
+                    if path_idx >= path_segments.len() {
+                        return None;
+                    }
+                    let remaining = path_segments[path_idx..].join("/");
+                    params.insert(name.clone(), remaining);
+                    path_idx = path_segments.len();
+                }
+            }
+            route_idx += 1;
+        }
+
+        // All segments must be consumed
+        if path_idx != path_segments.len() {
+            return None;
+        }
+
+        Some(params)
+    }
+}
+
+pub struct Router {
+    routes: Vec<(Route, ParsedRoute)>,
+}
+
+impl Router {
+    pub fn new(routes: Vec<Route>) -> Self {
+        let mut parsed_routes: Vec<(Route, ParsedRoute)> = routes
+            .into_iter()
+            .filter_map(|route| {
+                ParsedRoute::from_route_key(&route.route_key).map(|parsed| (route, parsed))
+            })
+            .collect();
+
+        // Sort by priority (highest first)
+        parsed_routes.sort_by(|a, b| b.1.priority.cmp(&a.1.priority));
+
+        Self {
+            routes: parsed_routes,
+        }
+    }
+
+    pub fn match_route(&self, method: &str, path: &str) -> Option<RouteMatch> {
+        let path_segments: Vec<String> = path
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+
+        for (route, parsed) in &self.routes {
+            if let Some(params) = parsed.matches(method, &path_segments) {
+                return Some(RouteMatch {
+                    route: route.clone(),
+                    path_parameters: params,
+                });
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exact_path() {
+        let routes = vec![Route {
+            route_id: "r1".to_string(),
+            route_key: "GET /pets".to_string(),
+            target: None,
+            authorization_type: None,
+            authorizer_id: None,
+        }];
+
+        let router = Router::new(routes);
+        let result = router.match_route("GET", "/pets");
+        assert!(result.is_some());
+        let route_match = result.unwrap();
+        assert_eq!(route_match.route.route_id, "r1");
+        assert!(route_match.path_parameters.is_empty());
+    }
+
+    #[test]
+    fn test_path_parameter() {
+        let routes = vec![Route {
+            route_id: "r1".to_string(),
+            route_key: "GET /pets/{id}".to_string(),
+            target: None,
+            authorization_type: None,
+            authorizer_id: None,
+        }];
+
+        let router = Router::new(routes);
+        let result = router.match_route("GET", "/pets/123");
+        assert!(result.is_some());
+        let route_match = result.unwrap();
+        assert_eq!(route_match.route.route_id, "r1");
+        assert_eq!(
+            route_match.path_parameters.get("id"),
+            Some(&"123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_greedy_parameter() {
+        let routes = vec![Route {
+            route_id: "r1".to_string(),
+            route_key: "GET /api/{proxy+}".to_string(),
+            target: None,
+            authorization_type: None,
+            authorizer_id: None,
+        }];
+
+        let router = Router::new(routes);
+        let result = router.match_route("GET", "/api/v1/users/123");
+        assert!(result.is_some());
+        let route_match = result.unwrap();
+        assert_eq!(route_match.route.route_id, "r1");
+        assert_eq!(
+            route_match.path_parameters.get("proxy"),
+            Some(&"v1/users/123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_priority_exact_over_parameter() {
+        let routes = vec![
+            Route {
+                route_id: "r1".to_string(),
+                route_key: "GET /pets/{id}".to_string(),
+                target: None,
+                authorization_type: None,
+                authorizer_id: None,
+            },
+            Route {
+                route_id: "r2".to_string(),
+                route_key: "GET /pets/special".to_string(),
+                target: None,
+                authorization_type: None,
+                authorizer_id: None,
+            },
+        ];
+
+        let router = Router::new(routes);
+        let result = router.match_route("GET", "/pets/special");
+        assert!(result.is_some());
+        let route_match = result.unwrap();
+        assert_eq!(route_match.route.route_id, "r2"); // Exact match wins
+    }
+
+    #[test]
+    fn test_priority_parameter_over_greedy() {
+        let routes = vec![
+            Route {
+                route_id: "r1".to_string(),
+                route_key: "GET /api/{proxy+}".to_string(),
+                target: None,
+                authorization_type: None,
+                authorizer_id: None,
+            },
+            Route {
+                route_id: "r2".to_string(),
+                route_key: "GET /api/{version}/users".to_string(),
+                target: None,
+                authorization_type: None,
+                authorizer_id: None,
+            },
+        ];
+
+        let router = Router::new(routes);
+        let result = router.match_route("GET", "/api/v1/users");
+        assert!(result.is_some());
+        let route_match = result.unwrap();
+        assert_eq!(route_match.route.route_id, "r2"); // Parameter match wins over greedy
+    }
+
+    #[test]
+    fn test_any_method() {
+        let routes = vec![Route {
+            route_id: "r1".to_string(),
+            route_key: "ANY /pets".to_string(),
+            target: None,
+            authorization_type: None,
+            authorizer_id: None,
+        }];
+
+        let router = Router::new(routes);
+        assert!(router.match_route("GET", "/pets").is_some());
+        assert!(router.match_route("POST", "/pets").is_some());
+        assert!(router.match_route("DELETE", "/pets").is_some());
+    }
+
+    #[test]
+    fn test_no_match() {
+        let routes = vec![Route {
+            route_id: "r1".to_string(),
+            route_key: "GET /pets".to_string(),
+            target: None,
+            authorization_type: None,
+            authorizer_id: None,
+        }];
+
+        let router = Router::new(routes);
+        assert!(router.match_route("GET", "/users").is_none());
+        assert!(router.match_route("POST", "/pets").is_none());
+    }
+
+    #[test]
+    fn test_multiple_parameters() {
+        let routes = vec![Route {
+            route_id: "r1".to_string(),
+            route_key: "GET /users/{userId}/posts/{postId}".to_string(),
+            target: None,
+            authorization_type: None,
+            authorizer_id: None,
+        }];
+
+        let router = Router::new(routes);
+        let result = router.match_route("GET", "/users/123/posts/456");
+        assert!(result.is_some());
+        let route_match = result.unwrap();
+        assert_eq!(
+            route_match.path_parameters.get("userId"),
+            Some(&"123".to_string())
+        );
+        assert_eq!(
+            route_match.path_parameters.get("postId"),
+            Some(&"456".to_string())
+        );
+    }
+}

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -5,9 +5,25 @@ use serde_json::json;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{HttpApi, SharedApiGatewayV2State};
+use crate::state::{HttpApi, Integration, Route, SharedApiGatewayV2State};
 
-const SUPPORTED: &[&str] = &["CreateApi", "GetApi", "GetApis", "UpdateApi", "DeleteApi"];
+const SUPPORTED: &[&str] = &[
+    "CreateApi",
+    "GetApi",
+    "GetApis",
+    "UpdateApi",
+    "DeleteApi",
+    "CreateRoute",
+    "GetRoute",
+    "GetRoutes",
+    "UpdateRoute",
+    "DeleteRoute",
+    "CreateIntegration",
+    "GetIntegration",
+    "GetIntegrations",
+    "UpdateIntegration",
+    "DeleteIntegration",
+];
 
 pub struct ApiGatewayV2Service {
     state: SharedApiGatewayV2State,
@@ -25,7 +41,17 @@ impl ApiGatewayV2Service {
     ///   GET    /v2/apis/{api-id}     -> GetApi
     ///   PATCH  /v2/apis/{api-id}     -> UpdateApi
     ///   DELETE /v2/apis/{api-id}     -> DeleteApi
-    fn resolve_action(req: &AwsRequest) -> Option<(&str, Option<String>)> {
+    ///   POST   /v2/apis/{api-id}/routes -> CreateRoute
+    ///   GET    /v2/apis/{api-id}/routes -> GetRoutes
+    ///   GET    /v2/apis/{api-id}/routes/{route-id} -> GetRoute
+    ///   PATCH  /v2/apis/{api-id}/routes/{route-id} -> UpdateRoute
+    ///   DELETE /v2/apis/{api-id}/routes/{route-id} -> DeleteRoute
+    ///   POST   /v2/apis/{api-id}/integrations -> CreateIntegration
+    ///   GET    /v2/apis/{api-id}/integrations -> GetIntegrations
+    ///   GET    /v2/apis/{api-id}/integrations/{int-id} -> GetIntegration
+    ///   PATCH  /v2/apis/{api-id}/integrations/{int-id} -> UpdateIntegration
+    ///   DELETE /v2/apis/{api-id}/integrations/{int-id} -> DeleteIntegration
+    fn resolve_action(req: &AwsRequest) -> Option<(&str, Option<String>, Option<String>)> {
         let segs = &req.path_segments;
         if segs.len() < 2 {
             return None;
@@ -38,12 +64,50 @@ impl ApiGatewayV2Service {
 
         match (req.method.clone(), segs.len()) {
             // /v2/apis
-            (Method::POST, 2) => Some(("CreateApi", None)),
-            (Method::GET, 2) => Some(("GetApis", None)),
+            (Method::POST, 2) => Some(("CreateApi", None, None)),
+            (Method::GET, 2) => Some(("GetApis", None, None)),
             // /v2/apis/{api-id}
-            (Method::GET, 3) => Some(("GetApi", Some(segs[2].clone()))),
-            (Method::PATCH, 3) => Some(("UpdateApi", Some(segs[2].clone()))),
-            (Method::DELETE, 3) => Some(("DeleteApi", Some(segs[2].clone()))),
+            (Method::GET, 3) => Some(("GetApi", Some(segs[2].clone()), None)),
+            (Method::PATCH, 3) => Some(("UpdateApi", Some(segs[2].clone()), None)),
+            (Method::DELETE, 3) => Some(("DeleteApi", Some(segs[2].clone()), None)),
+            // /v2/apis/{api-id}/routes or /v2/apis/{api-id}/integrations
+            (Method::POST, 4) if segs[3] == "routes" => {
+                Some(("CreateRoute", Some(segs[2].clone()), None))
+            }
+            (Method::GET, 4) if segs[3] == "routes" => {
+                Some(("GetRoutes", Some(segs[2].clone()), None))
+            }
+            (Method::POST, 4) if segs[3] == "integrations" => {
+                Some(("CreateIntegration", Some(segs[2].clone()), None))
+            }
+            (Method::GET, 4) if segs[3] == "integrations" => {
+                Some(("GetIntegrations", Some(segs[2].clone()), None))
+            }
+            // /v2/apis/{api-id}/routes/{route-id} or /v2/apis/{api-id}/integrations/{int-id}
+            (Method::GET, 5) if segs[3] == "routes" => {
+                Some(("GetRoute", Some(segs[2].clone()), Some(segs[4].clone())))
+            }
+            (Method::PATCH, 5) if segs[3] == "routes" => {
+                Some(("UpdateRoute", Some(segs[2].clone()), Some(segs[4].clone())))
+            }
+            (Method::DELETE, 5) if segs[3] == "routes" => {
+                Some(("DeleteRoute", Some(segs[2].clone()), Some(segs[4].clone())))
+            }
+            (Method::GET, 5) if segs[3] == "integrations" => Some((
+                "GetIntegration",
+                Some(segs[2].clone()),
+                Some(segs[4].clone()),
+            )),
+            (Method::PATCH, 5) if segs[3] == "integrations" => Some((
+                "UpdateIntegration",
+                Some(segs[2].clone()),
+                Some(segs[4].clone()),
+            )),
+            (Method::DELETE, 5) if segs[3] == "integrations" => Some((
+                "DeleteIntegration",
+                Some(segs[2].clone()),
+                Some(segs[4].clone()),
+            )),
             _ => None,
         }
     }
@@ -56,7 +120,7 @@ impl AwsService for ApiGatewayV2Service {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let (action, resource_id) = Self::resolve_action(&req).ok_or_else(|| {
+        let (action, api_id, resource_id) = Self::resolve_action(&req).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NotFoundException",
@@ -66,10 +130,26 @@ impl AwsService for ApiGatewayV2Service {
 
         match action {
             "CreateApi" => self.create_api(&req),
-            "GetApi" => self.get_api(&req, resource_id.as_deref()),
+            "GetApi" => self.get_api(&req, api_id.as_deref()),
             "GetApis" => self.get_apis(&req),
-            "UpdateApi" => self.update_api(&req, resource_id.as_deref()),
-            "DeleteApi" => self.delete_api(&req, resource_id.as_deref()),
+            "UpdateApi" => self.update_api(&req, api_id.as_deref()),
+            "DeleteApi" => self.delete_api(&req, api_id.as_deref()),
+            "CreateRoute" => self.create_route(&req, api_id.as_deref()),
+            "GetRoute" => self.get_route(&req, api_id.as_deref(), resource_id.as_deref()),
+            "GetRoutes" => self.get_routes(&req, api_id.as_deref()),
+            "UpdateRoute" => self.update_route(&req, api_id.as_deref(), resource_id.as_deref()),
+            "DeleteRoute" => self.delete_route(&req, api_id.as_deref(), resource_id.as_deref()),
+            "CreateIntegration" => self.create_integration(&req, api_id.as_deref()),
+            "GetIntegration" => {
+                self.get_integration(&req, api_id.as_deref(), resource_id.as_deref())
+            }
+            "GetIntegrations" => self.get_integrations(&req, api_id.as_deref()),
+            "UpdateIntegration" => {
+                self.update_integration(&req, api_id.as_deref(), resource_id.as_deref())
+            }
+            "DeleteIntegration" => {
+                self.delete_integration(&req, api_id.as_deref(), resource_id.as_deref())
+            }
             _ => Err(AwsServiceError::action_not_implemented(
                 "apigateway",
                 action,
@@ -226,6 +306,494 @@ impl ApiGatewayV2Service {
                 StatusCode::NOT_FOUND,
                 "NotFoundException",
                 format!("API not found: {}", api_id),
+            )
+        })?;
+
+        Ok(AwsResponse::json(StatusCode::NO_CONTENT, vec![]))
+    }
+
+    // ─── ROUTE CRUD ─────────────────────────────────────────────────────
+
+    fn create_route(
+        &self,
+        req: &AwsRequest,
+        api_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let body = req.json_body();
+
+        validate_required("routeKey", &body["routeKey"])?;
+        let route_key = body["routeKey"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "routeKey is required",
+                )
+            })?
+            .to_string();
+
+        let target = body["target"].as_str().map(|s| s.to_string());
+        let authorization_type = body["authorizationType"].as_str().map(|s| s.to_string());
+        let authorizer_id = body["authorizerId"].as_str().map(|s| s.to_string());
+
+        let route_id = generate_id("route");
+
+        let route = Route {
+            route_id: route_id.clone(),
+            route_key,
+            target,
+            authorization_type,
+            authorizer_id,
+        };
+
+        let mut state = self.state.write();
+
+        // Verify API exists
+        if !state.apis.contains_key(api_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            ));
+        }
+
+        state
+            .routes
+            .entry(api_id.to_string())
+            .or_default()
+            .insert(route_id, route.clone());
+
+        Ok(AwsResponse::ok_json(json!(route)))
+    }
+
+    fn get_route(
+        &self,
+        _req: &AwsRequest,
+        api_id: Option<&str>,
+        route_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let route_id = route_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "Route ID is required",
+            )
+        })?;
+
+        let state = self.state.read();
+
+        let routes = state.routes.get(api_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            )
+        })?;
+
+        let route = routes.get(route_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("Route not found: {}", route_id),
+            )
+        })?;
+
+        Ok(AwsResponse::ok_json(json!(route)))
+    }
+
+    fn get_routes(
+        &self,
+        _req: &AwsRequest,
+        api_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let state = self.state.read();
+
+        // Verify API exists
+        if !state.apis.contains_key(api_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            ));
+        }
+
+        let routes: Vec<&Route> = state
+            .routes
+            .get(api_id)
+            .map(|r| r.values().collect())
+            .unwrap_or_default();
+
+        Ok(AwsResponse::ok_json(json!({
+            "items": routes,
+        })))
+    }
+
+    fn update_route(
+        &self,
+        req: &AwsRequest,
+        api_id: Option<&str>,
+        route_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let route_id = route_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "Route ID is required",
+            )
+        })?;
+
+        let body = req.json_body();
+        let mut state = self.state.write();
+
+        let routes = state.routes.get_mut(api_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            )
+        })?;
+
+        let route = routes.get_mut(route_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("Route not found: {}", route_id),
+            )
+        })?;
+
+        if let Some(route_key) = body["routeKey"].as_str() {
+            route.route_key = route_key.to_string();
+        }
+
+        if let Some(target) = body["target"].as_str() {
+            route.target = Some(target.to_string());
+        }
+
+        if let Some(authorization_type) = body["authorizationType"].as_str() {
+            route.authorization_type = Some(authorization_type.to_string());
+        }
+
+        if let Some(authorizer_id) = body["authorizerId"].as_str() {
+            route.authorizer_id = Some(authorizer_id.to_string());
+        }
+
+        Ok(AwsResponse::ok_json(json!(route)))
+    }
+
+    fn delete_route(
+        &self,
+        _req: &AwsRequest,
+        api_id: Option<&str>,
+        route_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let route_id = route_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "Route ID is required",
+            )
+        })?;
+
+        let mut state = self.state.write();
+
+        let routes = state.routes.get_mut(api_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            )
+        })?;
+
+        routes.remove(route_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("Route not found: {}", route_id),
+            )
+        })?;
+
+        Ok(AwsResponse::json(StatusCode::NO_CONTENT, vec![]))
+    }
+
+    // ─── INTEGRATION CRUD ───────────────────────────────────────────────
+
+    fn create_integration(
+        &self,
+        req: &AwsRequest,
+        api_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let body = req.json_body();
+
+        validate_required("integrationType", &body["integrationType"])?;
+        let integration_type = body["integrationType"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "integrationType is required",
+                )
+            })?
+            .to_string();
+
+        let integration_uri = body["integrationUri"].as_str().map(|s| s.to_string());
+        let payload_format_version = body["payloadFormatVersion"].as_str().map(|s| s.to_string());
+        let timeout_in_millis = body["timeoutInMillis"].as_i64();
+
+        let integration_id = generate_id("integration");
+
+        let integration = Integration {
+            integration_id: integration_id.clone(),
+            integration_type,
+            integration_uri,
+            payload_format_version,
+            timeout_in_millis,
+        };
+
+        let mut state = self.state.write();
+
+        // Verify API exists
+        if !state.apis.contains_key(api_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            ));
+        }
+
+        state
+            .integrations
+            .entry(api_id.to_string())
+            .or_default()
+            .insert(integration_id, integration.clone());
+
+        Ok(AwsResponse::ok_json(json!(integration)))
+    }
+
+    fn get_integration(
+        &self,
+        _req: &AwsRequest,
+        api_id: Option<&str>,
+        integration_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let integration_id = integration_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "Integration ID is required",
+            )
+        })?;
+
+        let state = self.state.read();
+
+        let integrations = state.integrations.get(api_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            )
+        })?;
+
+        let integration = integrations.get(integration_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("Integration not found: {}", integration_id),
+            )
+        })?;
+
+        Ok(AwsResponse::ok_json(json!(integration)))
+    }
+
+    fn get_integrations(
+        &self,
+        _req: &AwsRequest,
+        api_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let state = self.state.read();
+
+        // Verify API exists
+        if !state.apis.contains_key(api_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            ));
+        }
+
+        let integrations: Vec<&Integration> = state
+            .integrations
+            .get(api_id)
+            .map(|i| i.values().collect())
+            .unwrap_or_default();
+
+        Ok(AwsResponse::ok_json(json!({
+            "items": integrations,
+        })))
+    }
+
+    fn update_integration(
+        &self,
+        req: &AwsRequest,
+        api_id: Option<&str>,
+        integration_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let integration_id = integration_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "Integration ID is required",
+            )
+        })?;
+
+        let body = req.json_body();
+        let mut state = self.state.write();
+
+        let integrations = state.integrations.get_mut(api_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            )
+        })?;
+
+        let integration = integrations.get_mut(integration_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("Integration not found: {}", integration_id),
+            )
+        })?;
+
+        if let Some(integration_type) = body["integrationType"].as_str() {
+            integration.integration_type = integration_type.to_string();
+        }
+
+        if let Some(integration_uri) = body["integrationUri"].as_str() {
+            integration.integration_uri = Some(integration_uri.to_string());
+        }
+
+        if let Some(payload_format_version) = body["payloadFormatVersion"].as_str() {
+            integration.payload_format_version = Some(payload_format_version.to_string());
+        }
+
+        if let Some(timeout_in_millis) = body["timeoutInMillis"].as_i64() {
+            integration.timeout_in_millis = Some(timeout_in_millis);
+        }
+
+        Ok(AwsResponse::ok_json(json!(integration)))
+    }
+
+    fn delete_integration(
+        &self,
+        _req: &AwsRequest,
+        api_id: Option<&str>,
+        integration_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let integration_id = integration_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "Integration ID is required",
+            )
+        })?;
+
+        let mut state = self.state.write();
+
+        let integrations = state.integrations.get_mut(api_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            )
+        })?;
+
+        integrations.remove(integration_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("Integration not found: {}", integration_id),
             )
         })?;
 

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -10,6 +10,8 @@ pub struct ApiGatewayV2State {
     pub account_id: String,
     pub region: String,
     pub apis: HashMap<String, HttpApi>,
+    pub routes: HashMap<String, HashMap<String, Route>>, // api-id -> (route-id -> Route)
+    pub integrations: HashMap<String, HashMap<String, Integration>>, // api-id -> (integration-id -> Integration)
 }
 
 impl ApiGatewayV2State {
@@ -18,6 +20,8 @@ impl ApiGatewayV2State {
             account_id: account_id.to_string(),
             region: region.to_string(),
             apis: HashMap::new(),
+            routes: HashMap::new(),
+            integrations: HashMap::new(),
         }
     }
 }
@@ -57,4 +61,30 @@ impl HttpApi {
             api_endpoint,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Route {
+    pub route_id: String,
+    pub route_key: String, // "GET /pets/{id}"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>, // "integrations/{integration-id}"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization_type: Option<String>, // "NONE", "JWT", "CUSTOM"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorizer_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Integration {
+    pub integration_id: String,
+    pub integration_type: String, // "AWS_PROXY", "HTTP_PROXY", "MOCK"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub integration_uri: Option<String>, // Lambda ARN or HTTP endpoint
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_format_version: Option<String>, // "2.0"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_in_millis: Option<i64>,
 }

--- a/crates/fakecloud-e2e/tests/apigatewayv2.rs
+++ b/crates/fakecloud-e2e/tests/apigatewayv2.rs
@@ -140,3 +140,431 @@ async fn test_api_with_tags() {
     assert_eq!(tags.get("env"), Some(&"test".to_string()));
     assert_eq!(tags.get("team"), Some(&"platform".to_string()));
 }
+
+#[tokio::test]
+async fn test_create_route() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    let route = client
+        .create_route()
+        .api_id(api_id)
+        .route_key("GET /pets")
+        .send()
+        .await
+        .unwrap();
+
+    assert!(route.route_id().is_some());
+    assert_eq!(route.route_key(), Some("GET /pets"));
+}
+
+#[tokio::test]
+async fn test_get_route() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    let created = client
+        .create_route()
+        .api_id(api_id)
+        .route_key("GET /pets")
+        .send()
+        .await
+        .unwrap();
+
+    let route_id = created.route_id().unwrap();
+
+    let result = client
+        .get_route()
+        .api_id(api_id)
+        .route_id(route_id)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(result.route_id(), Some(route_id));
+    assert_eq!(result.route_key(), Some("GET /pets"));
+}
+
+#[tokio::test]
+async fn test_get_routes() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    client
+        .create_route()
+        .api_id(api_id)
+        .route_key("GET /pets")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_route()
+        .api_id(api_id)
+        .route_key("POST /pets")
+        .send()
+        .await
+        .unwrap();
+
+    let result = client.get_routes().api_id(api_id).send().await.unwrap();
+
+    let items = result.items();
+    assert_eq!(items.len(), 2);
+}
+
+#[tokio::test]
+async fn test_update_route() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    let created = client
+        .create_route()
+        .api_id(api_id)
+        .route_key("GET /pets")
+        .send()
+        .await
+        .unwrap();
+
+    let route_id = created.route_id().unwrap();
+
+    let result = client
+        .update_route()
+        .api_id(api_id)
+        .route_id(route_id)
+        .route_key("GET /pets/{id}")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(result.route_key(), Some("GET /pets/{id}"));
+}
+
+#[tokio::test]
+async fn test_delete_route() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    let created = client
+        .create_route()
+        .api_id(api_id)
+        .route_key("GET /pets")
+        .send()
+        .await
+        .unwrap();
+
+    let route_id = created.route_id().unwrap();
+
+    client
+        .delete_route()
+        .api_id(api_id)
+        .route_id(route_id)
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .get_route()
+        .api_id(api_id)
+        .route_id(route_id)
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_create_integration() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    let integration = client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:my-function")
+        .payload_format_version("2.0")
+        .send()
+        .await
+        .unwrap();
+
+    assert!(integration.integration_id().is_some());
+    assert_eq!(
+        integration.integration_type(),
+        Some(&aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+    );
+    assert_eq!(
+        integration.integration_uri(),
+        Some("arn:aws:lambda:us-east-1:123456789012:function:my-function")
+    );
+}
+
+#[tokio::test]
+async fn test_get_integration() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    let created = client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:my-function")
+        .send()
+        .await
+        .unwrap();
+
+    let integration_id = created.integration_id().unwrap();
+
+    let result = client
+        .get_integration()
+        .api_id(api_id)
+        .integration_id(integration_id)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(result.integration_id(), Some(integration_id));
+    assert_eq!(
+        result.integration_type(),
+        Some(&aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+    );
+}
+
+#[tokio::test]
+async fn test_get_integrations() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:fn1")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::HttpProxy)
+        .integration_uri("https://example.com")
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .get_integrations()
+        .api_id(api_id)
+        .send()
+        .await
+        .unwrap();
+
+    let items = result.items();
+    assert_eq!(items.len(), 2);
+}
+
+#[tokio::test]
+async fn test_update_integration() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    let created = client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:fn1")
+        .send()
+        .await
+        .unwrap();
+
+    let integration_id = created.integration_id().unwrap();
+
+    let result = client
+        .update_integration()
+        .api_id(api_id)
+        .integration_id(integration_id)
+        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:fn2")
+        .payload_format_version("2.0")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.integration_uri(),
+        Some("arn:aws:lambda:us-east-1:123456789012:function:fn2")
+    );
+    assert_eq!(result.payload_format_version(), Some("2.0"));
+}
+
+#[tokio::test]
+async fn test_delete_integration() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    let created = client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:my-function")
+        .send()
+        .await
+        .unwrap();
+
+    let integration_id = created.integration_id().unwrap();
+
+    client
+        .delete_integration()
+        .api_id(api_id)
+        .integration_id(integration_id)
+        .send()
+        .await
+        .unwrap();
+
+    let result = client
+        .get_integration()
+        .api_id(api_id)
+        .integration_id(integration_id)
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_route_with_target_integration() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("test-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    let integration = client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:my-function")
+        .send()
+        .await
+        .unwrap();
+
+    let integration_id = integration.integration_id().unwrap();
+
+    let route = client
+        .create_route()
+        .api_id(api_id)
+        .route_key("GET /pets")
+        .target(format!("integrations/{}", integration_id))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        route.target(),
+        Some(format!("integrations/{}", integration_id).as_str())
+    );
+}


### PR DESCRIPTION
## Summary
- Add Route and Integration structs to state management with nested HashMaps (api-id -> resource-id -> resource)
- Implement 10 new CRUD operations: routes (Create, Get, GetAll, Update, Delete) and integrations (Create, Get, GetAll, Update, Delete)
- Create router module with priority-based route matching engine
- Support exact paths, path parameters `{id}`, greedy parameters `{proxy+}`, and ANY method wildcard
- Router calculates priority: exact (100) > parameters (50) > greedy (10)
- Extract path parameters from matched routes into HashMap

## Test plan
- ✅ 17 E2E tests pass (6 existing API tests + 11 new route/integration tests)
- ✅ 8 router unit tests verify matching logic, priority calculation, and parameter extraction
- ✅ All clippy checks pass
- ✅ Tests verify: route CRUD, integration CRUD, route targeting integration, parameter extraction, multiple routes/integrations per API

Part of API Gateway v2 implementation (Batch 2/5).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Route and Integration resources to `fakecloud-apigatewayv2` with full CRUD and a priority-based router for realistic API Gateway v2 behavior. Supports exact, parameterized, and greedy paths, `ANY` methods, and path parameter extraction.

- **New Features**
  - Add Route and Integration types to state with per-API maps.
  - Implement Create/Get/List/Update/Delete for routes and integrations with AWS-style endpoints under /v2/apis/{api-id}/(routes|integrations).
  - Introduce router with priority matching (exact > parameter > greedy), supports `{id}`, `{proxy+}`, `ANY`, and extracts path parameters.
  - Add E2E and unit tests covering CRUD, matching priority, and parameter extraction.

<sup>Written for commit e45851b72c954f4ff268161e0c992fc33633a6ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

