### PR TITLE
feat(apigatewayv2): add Lambda proxy integration for execute API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,6 +1890,8 @@ name = "fakecloud-apigatewayv2"
 version = "0.6.1"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
+ "bytes",
  "chrono",
  "fakecloud-core",
  "http 1.4.0",

--- a/crates/fakecloud-apigatewayv2/Cargo.toml
+++ b/crates/fakecloud-apigatewayv2/Cargo.toml
@@ -10,6 +10,8 @@ version.workspace = true
 [dependencies]
 fakecloud-core = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
+bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -134,13 +134,14 @@ pub async fn invoke_lambda(
     })?;
 
     // Parse Lambda response
-    let response_json: serde_json::Value = serde_json::from_slice(&response_bytes).map_err(|e| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_GATEWAY,
-            "BadGatewayException",
-            format!("Failed to parse Lambda response: {}", e),
-        )
-    })?;
+    let response_json: serde_json::Value =
+        serde_json::from_slice(&response_bytes).map_err(|e| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_GATEWAY,
+                "BadGatewayException",
+                format!("Failed to parse Lambda response: {}", e),
+            )
+        })?;
 
     parse_lambda_response(response_json)
 }
@@ -258,7 +259,10 @@ mod tests {
 
         assert_eq!(result.status, StatusCode::OK);
         assert_eq!(result.content_type, "application/json");
-        assert_eq!(result.body, Bytes::from(br#"{"message":"success"}"#.to_vec()));
+        assert_eq!(
+            result.body,
+            Bytes::from(br#"{"message":"success"}"#.to_vec())
+        );
     }
 
     #[test]

--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -1,0 +1,278 @@
+use base64::prelude::*;
+use bytes::Bytes;
+use http::{HeaderMap, StatusCode};
+use serde_json::json;
+use std::collections::HashMap;
+
+use fakecloud_core::delivery::DeliveryBus;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+/// Constructs a Lambda proxy integration event in v2.0 format.
+/// https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+pub fn construct_event(
+    req: &AwsRequest,
+    route_key: &str,
+    stage: &str,
+    path_parameters: HashMap<String, String>,
+) -> serde_json::Value {
+    let (is_base64_encoded, body) = encode_body(req);
+
+    let query_string_parameters = if req.query_params.is_empty() {
+        None
+    } else {
+        Some(req.query_params.clone())
+    };
+
+    let raw_query_string = &req.raw_query;
+
+    let path_parameters = if path_parameters.is_empty() {
+        None
+    } else {
+        Some(path_parameters)
+    };
+
+    // Convert HeaderMap to HashMap<String, String> for JSON serialization
+    let headers: HashMap<String, String> = req
+        .headers
+        .iter()
+        .filter_map(|(k, v)| {
+            v.to_str()
+                .ok()
+                .map(|v_str| (k.as_str().to_string(), v_str.to_string()))
+        })
+        .collect();
+
+    json!({
+        "version": "2.0",
+        "routeKey": route_key,
+        "rawPath": req.raw_path,
+        "rawQueryString": raw_query_string,
+        "headers": headers,
+        "requestContext": {
+            "http": {
+                "method": req.method.as_str(),
+                "path": req.raw_path,
+                "sourceIp": "127.0.0.1"
+            },
+            "routeKey": route_key,
+            "stage": stage,
+            "requestId": &req.request_id,
+            "accountId": &req.account_id,
+            "domainName": "localhost",
+            "time": chrono::Utc::now().to_rfc3339(),
+            "timeEpoch": chrono::Utc::now().timestamp_millis()
+        },
+        "pathParameters": path_parameters,
+        "queryStringParameters": query_string_parameters,
+        "body": body,
+        "isBase64Encoded": is_base64_encoded
+    })
+}
+
+fn encode_body(req: &AwsRequest) -> (bool, Option<String>) {
+    if req.body.is_empty() {
+        return (false, None);
+    }
+
+    // Check if body is binary by looking at content-type header
+    let is_binary = req
+        .headers
+        .get("content-type")
+        .and_then(|ct| ct.to_str().ok())
+        .map(|ct_str| {
+            let ct_lower = ct_str.to_lowercase();
+            ct_lower.contains("octet-stream")
+                || ct_lower.contains("image/")
+                || ct_lower.contains("video/")
+                || ct_lower.contains("audio/")
+        })
+        .unwrap_or(false);
+
+    if is_binary {
+        (true, Some(BASE64_STANDARD.encode(&req.body)))
+    } else {
+        // Try to interpret as UTF-8 string
+        match String::from_utf8(req.body.to_vec()) {
+            Ok(s) => (false, Some(s)),
+            Err(_) => (true, Some(BASE64_STANDARD.encode(&req.body))),
+        }
+    }
+}
+
+/// Invokes a Lambda function via the delivery bus and parses the response.
+pub async fn invoke_lambda(
+    delivery: &DeliveryBus,
+    function_arn: &str,
+    event: serde_json::Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let event_json = serde_json::to_string(&event).map_err(|e| {
+        AwsServiceError::aws_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "InternalError",
+            format!("Failed to serialize event: {}", e),
+        )
+    })?;
+
+    // Invoke Lambda via delivery bus
+    let response_result = delivery
+        .invoke_lambda(function_arn, &event_json)
+        .await
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                "Lambda delivery not configured",
+            )
+        })?;
+
+    let response_bytes = response_result.map_err(|e| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_GATEWAY,
+            "BadGatewayException",
+            format!("Lambda invocation failed: {}", e),
+        )
+    })?;
+
+    // Parse Lambda response
+    let response_json: serde_json::Value = serde_json::from_slice(&response_bytes).map_err(|e| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_GATEWAY,
+            "BadGatewayException",
+            format!("Failed to parse Lambda response: {}", e),
+        )
+    })?;
+
+    parse_lambda_response(response_json)
+}
+
+/// Parses a Lambda proxy integration response in v2.0 format.
+fn parse_lambda_response(response: serde_json::Value) -> Result<AwsResponse, AwsServiceError> {
+    let status_code = response["statusCode"]
+        .as_i64()
+        .unwrap_or(200)
+        .try_into()
+        .unwrap_or(200);
+
+    let status_code = StatusCode::from_u16(status_code).unwrap_or(StatusCode::OK);
+
+    let mut headers = HeaderMap::new();
+    if let Some(response_headers) = response["headers"].as_object() {
+        for (k, v) in response_headers {
+            if let Some(v_str) = v.as_str() {
+                if let Ok(header_value) = http::HeaderValue::from_str(v_str) {
+                    if let Ok(header_name) = http::HeaderName::from_bytes(k.as_bytes()) {
+                        headers.insert(header_name, header_value);
+                    }
+                }
+            }
+        }
+    }
+
+    let is_base64 = response["isBase64Encoded"].as_bool().unwrap_or(false);
+    let body = if let Some(body_str) = response["body"].as_str() {
+        if is_base64 {
+            Bytes::from(
+                BASE64_STANDARD
+                    .decode(body_str)
+                    .unwrap_or_else(|_| body_str.as_bytes().to_vec()),
+            )
+        } else {
+            Bytes::from(body_str.as_bytes().to_vec())
+        }
+    } else {
+        Bytes::new()
+    };
+
+    // Determine content type from headers or default to application/json
+    let content_type = headers
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/json")
+        .to_string();
+
+    Ok(AwsResponse {
+        status: status_code,
+        content_type,
+        headers,
+        body,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::Method;
+
+    fn create_test_request() -> AwsRequest {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+
+        AwsRequest {
+            service: "apigateway".to_string(),
+            action: "Execute".to_string(),
+            method: Method::POST,
+            raw_path: "/prod/pets".to_string(),
+            raw_query: "filter=available".to_string(),
+            path_segments: vec!["prod".to_string(), "pets".to_string()],
+            query_params: HashMap::from([("filter".to_string(), "available".to_string())]),
+            headers,
+            body: Bytes::from(br#"{"name":"Fluffy"}"#.to_vec()),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "request-id".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+        }
+    }
+
+    #[test]
+    fn test_construct_event() {
+        let req = create_test_request();
+        let path_params = HashMap::from([("id".to_string(), "123".to_string())]);
+
+        let event = construct_event(&req, "POST /pets/{id}", "prod", path_params);
+
+        assert_eq!(event["version"], "2.0");
+        assert_eq!(event["routeKey"], "POST /pets/{id}");
+        assert_eq!(event["rawPath"], "/prod/pets");
+        assert_eq!(event["rawQueryString"], "filter=available");
+        assert_eq!(event["requestContext"]["stage"], "prod");
+        assert_eq!(event["pathParameters"]["id"], "123");
+        assert_eq!(event["queryStringParameters"]["filter"], "available");
+        assert_eq!(event["body"], r#"{"name":"Fluffy"}"#);
+        assert_eq!(event["isBase64Encoded"], false);
+    }
+
+    #[test]
+    fn test_parse_lambda_response() {
+        let response = json!({
+            "statusCode": 200,
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "body": r#"{"message":"success"}"#,
+            "isBase64Encoded": false
+        });
+
+        let result = parse_lambda_response(response).unwrap();
+
+        assert_eq!(result.status, StatusCode::OK);
+        assert_eq!(result.content_type, "application/json");
+        assert_eq!(result.body, Bytes::from(br#"{"message":"success"}"#.to_vec()));
+    }
+
+    #[test]
+    fn test_parse_lambda_response_base64() {
+        let base64_body = BASE64_STANDARD.encode(b"binary data");
+        let response = json!({
+            "statusCode": 200,
+            "body": base64_body,
+            "isBase64Encoded": true
+        });
+
+        let result = parse_lambda_response(response).unwrap();
+
+        assert_eq!(result.status, StatusCode::OK);
+        assert_eq!(result.body, Bytes::from(b"binary data".to_vec()));
+    }
+}

--- a/crates/fakecloud-apigatewayv2/src/lib.rs
+++ b/crates/fakecloud-apigatewayv2/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod lambda_proxy;
 pub mod router;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -1,10 +1,13 @@
 use async_trait::async_trait;
 use http::{Method, StatusCode};
 use serde_json::json;
+use std::sync::Arc;
 
+use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
+use crate::{lambda_proxy, router::Router};
 use crate::state::{Deployment, HttpApi, Integration, Route, SharedApiGatewayV2State, Stage};
 
 const SUPPORTED: &[&str] = &[
@@ -35,11 +38,17 @@ const SUPPORTED: &[&str] = &[
 
 pub struct ApiGatewayV2Service {
     state: SharedApiGatewayV2State,
+    delivery: Option<Arc<DeliveryBus>>,
 }
 
 impl ApiGatewayV2Service {
     pub fn new(state: SharedApiGatewayV2State) -> Self {
-        Self { state }
+        Self { state, delivery: None }
+    }
+
+    pub fn with_delivery(mut self, delivery: Arc<DeliveryBus>) -> Self {
+        self.delivery = Some(delivery);
+        self
     }
 
     /// Determine the action from the HTTP method and path segments.
@@ -162,6 +171,25 @@ impl AwsService for ApiGatewayV2Service {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        // Check if this is a management API request or an execute API request
+        // Management API: /v2/apis/*
+        // Execute API: /{stage}/{path}
+        if req.path_segments.first().map(|s| s.as_str()) == Some("v2") {
+            // Management API
+            return self.handle_management_api(req).await;
+        }
+
+        // Execute API
+        self.handle_execute_api(req).await
+    }
+
+    fn supported_actions(&self) -> &[&str] {
+        SUPPORTED
+    }
+}
+
+impl ApiGatewayV2Service {
+    async fn handle_management_api(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let (action, api_id, resource_id) = Self::resolve_action(&req).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -207,12 +235,6 @@ impl AwsService for ApiGatewayV2Service {
         }
     }
 
-    fn supported_actions(&self) -> &[&str] {
-        SUPPORTED
-    }
-}
-
-impl ApiGatewayV2Service {
     // ─── API CRUD ───────────────────────────────────────────────────────
 
     fn create_api(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1228,6 +1250,131 @@ impl ApiGatewayV2Service {
         Ok(AwsResponse::ok_json(json!({
             "items": deployments,
         })))
+    }
+
+    // ─── EXECUTE API ────────────────────────────────────────────────────
+
+    async fn handle_execute_api(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        // Execute API format: /{stage}/{path...}
+        if req.path_segments.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                "Stage not specified",
+            ));
+        }
+
+        let stage_name = &req.path_segments[0];
+        let resource_path = format!("/{}", req.path_segments[1..].join("/"));
+
+        // Find the API for this stage
+        let (api_id, routes) = {
+            let state = self.state.read();
+
+            // Find which API has this stage
+            let (api_id, _stage) = state
+                .stages
+                .iter()
+                .find_map(|(api_id, stages)| {
+                    stages
+                        .get(stage_name)
+                        .map(|stage| (api_id.clone(), stage.clone()))
+                })
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "NotFoundException",
+                        format!("Stage not found: {}", stage_name),
+                    )
+                })?;
+
+            // Get routes for this API
+            let routes = state
+                .routes
+                .get(&api_id)
+                .map(|r| r.values().cloned().collect())
+                .unwrap_or_default();
+
+            Ok::<_, AwsServiceError>((api_id, routes))
+        }?;
+
+        // Match the request against routes
+        let router = Router::new(routes);
+        let route_match = router
+            .match_route(req.method.as_str(), &resource_path)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "NotFoundException",
+                    format!("No route matches: {} {}", req.method, resource_path),
+                )
+            })?;
+
+        // Get the integration for this route
+        let integration_id = route_match
+            .route
+            .target
+            .as_ref()
+            .and_then(|target| target.strip_prefix("integrations/"))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "InternalError",
+                    "Route has no integration",
+                )
+            })?;
+
+        let integration = {
+            let state = self.state.read();
+            state
+                .integrations
+                .get(&api_id)
+                .and_then(|integrations| integrations.get(integration_id))
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "InternalError",
+                        format!("Integration not found: {}", integration_id),
+                    )
+                })?
+                .clone()
+        };
+
+        // Handle based on integration type
+        match integration.integration_type.as_str() {
+            "AWS_PROXY" => {
+                // Lambda proxy integration
+                let delivery = self.delivery.as_ref().ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "InternalError",
+                        "Lambda delivery not configured",
+                    )
+                })?;
+
+                let function_arn = integration.integration_uri.as_ref().ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "InternalError",
+                        "Integration has no URI",
+                    )
+                })?;
+
+                let event = lambda_proxy::construct_event(
+                    &req,
+                    &route_match.route.route_key,
+                    stage_name,
+                    route_match.path_parameters,
+                );
+
+                lambda_proxy::invoke_lambda(delivery, function_arn, event).await
+            }
+            _ => Err(AwsServiceError::aws_error(
+                StatusCode::NOT_IMPLEMENTED,
+                "NotImplemented",
+                format!("Integration type not supported: {}", integration.integration_type),
+            )),
+        }
     }
 }
 

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -7,8 +7,8 @@ use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::{lambda_proxy, router::Router};
 use crate::state::{Deployment, HttpApi, Integration, Route, SharedApiGatewayV2State, Stage};
+use crate::{lambda_proxy, router::Router};
 
 const SUPPORTED: &[&str] = &[
     "CreateApi",
@@ -43,7 +43,10 @@ pub struct ApiGatewayV2Service {
 
 impl ApiGatewayV2Service {
     pub fn new(state: SharedApiGatewayV2State) -> Self {
-        Self { state, delivery: None }
+        Self {
+            state,
+            delivery: None,
+        }
     }
 
     pub fn with_delivery(mut self, delivery: Arc<DeliveryBus>) -> Self {
@@ -1372,7 +1375,10 @@ impl ApiGatewayV2Service {
             _ => Err(AwsServiceError::aws_error(
                 StatusCode::NOT_IMPLEMENTED,
                 "NotImplemented",
-                format!("Integration type not supported: {}", integration.integration_type),
+                format!(
+                    "Integration type not supported: {}",
+                    integration.integration_type
+                ),
             )),
         }
     }

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -44,6 +44,16 @@ pub async fn dispatch(
                     action: String::new(),
                     protocol: AwsProtocol::Rest,
                 }
+            } else if !parts.uri.path().starts_with("/_") {
+                // Requests without AWS auth that don't match any service might be
+                // API Gateway execute API calls (plain HTTP without signatures).
+                // Route them to apigateway service which will validate if a matching
+                // API/stage exists. Skip special FakeCloud endpoints (/_*).
+                protocol::DetectedRequest {
+                    service: "apigateway".to_string(),
+                    action: String::new(),
+                    protocol: AwsProtocol::RestJson,
+                }
             } else {
                 return build_error_response(
                     StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-e2e/tests/apigatewayv2.rs
+++ b/crates/fakecloud-e2e/tests/apigatewayv2.rs
@@ -892,3 +892,118 @@ async fn test_deployment_with_stage() {
 
     assert_eq!(updated_stage.deployment_id(), Some(deployment_id));
 }
+
+#[tokio::test]
+async fn test_lambda_proxy_integration() {
+    use aws_sdk_lambda::primitives::Blob;
+    use std::io::Write;
+
+    let server = TestServer::start().await;
+    let lambda_client = server.lambda_client().await;
+    let apigw_client = server.apigatewayv2_client().await;
+
+    // Create a Lambda function
+    let function_code = r#"
+exports.handler = async (event) => {
+    return {
+        statusCode: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            message: "Hello from Lambda",
+            routeKey: event.routeKey,
+            path: event.rawPath,
+            pathParams: event.pathParameters,
+            queryParams: event.queryStringParameters
+        })
+    };
+};
+    "#;
+
+    // Create zip file
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    let options = zip::write::SimpleFileOptions::default();
+    writer.start_file("index.js", options).unwrap();
+    writer.write_all(function_code.as_bytes()).unwrap();
+    let cursor = writer.finish().unwrap();
+    let zip_bytes = cursor.into_inner();
+
+    lambda_client
+        .create_function()
+        .function_name("test-apigw-function")
+        .runtime(aws_sdk_lambda::types::Runtime::Nodejs20x)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(zip_bytes))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Create API Gateway API
+    let api = apigw_client
+        .create_api()
+        .name("test-lambda-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+
+    let api_id = api.api_id().unwrap();
+
+    // Create integration with Lambda
+    let integration = apigw_client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:test-apigw-function")
+        .payload_format_version("2.0")
+        .send()
+        .await
+        .unwrap();
+
+    let integration_id = integration.integration_id().unwrap();
+
+    // Create route
+    apigw_client
+        .create_route()
+        .api_id(api_id)
+        .route_key("GET /hello/{name}")
+        .target(format!("integrations/{}", integration_id))
+        .send()
+        .await
+        .unwrap();
+
+    // Create stage
+    apigw_client
+        .create_stage()
+        .api_id(api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .unwrap();
+
+    // Invoke the API via HTTP
+    let http_client = reqwest::Client::new();
+    let response = http_client
+        .get(format!(
+            "{}/prod/hello/world?greeting=hi",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(body["message"], "Hello from Lambda");
+    assert_eq!(body["routeKey"], "GET /hello/{name}");
+    assert_eq!(body["path"], "/prod/hello/world");
+    assert_eq!(body["pathParams"]["name"], "world");
+    assert_eq!(body["queryParams"]["greeting"], "hi");
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -483,7 +483,11 @@ async fn main() {
     }
     registry.register(Arc::new(sfn_service));
 
-    let apigw_service = ApiGatewayV2Service::new(apigatewayv2_state.clone());
+    let mut apigw_service = ApiGatewayV2Service::new(apigatewayv2_state.clone());
+    if let Some(ref ld) = lambda_delivery {
+        let delivery_for_apigw = Arc::new(DeliveryBus::new().with_lambda(ld.clone()));
+        apigw_service = apigw_service.with_delivery(delivery_for_apigw);
+    }
     registry.register(Arc::new(apigw_service));
 
     // Spawn background tasks


### PR DESCRIPTION
## Summary
- Lambda proxy integration v2.0 with event construction and response parsing
- Execute API handler (stage lookup → route matching → integration resolution → Lambda invocation)
- Dispatch routing for plain HTTP requests to API Gateway service
- Full E2E test for Lambda proxy integration workflow

## Test plan
- [x] test_lambda_proxy_integration: creates API + route + Lambda integration + stage, invokes via HTTP, verifies Lambda response
- [x] All 27 API Gateway v2 E2E tests passing
- [x] cargo clippy --workspace --all-targets -- -D warnings (passes)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Lambda proxy integration for API Gateway v2 execute API so HTTP routes invoke Lambda with v2.0 events and return parsed responses. Also splits management and execute paths and routes plain HTTP requests to API Gateway.

- **New Features**
  - Added `lambda_proxy` with v2.0 event construction and response parsing (includes base64 body handling) in `fakecloud-apigatewayv2`.
  - Execute API flow: stage lookup → route match → integration resolve → Lambda invoke via `DeliveryBus`.
  - Routed unauthenticated HTTP to API Gateway in `fakecloud-core` dispatch; wired delivery in `fakecloud-server`.
  - Added E2E `test_lambda_proxy_integration` covering the full workflow.

- **Bug Fixes**
  - Scoped state locks before await to satisfy `Send`.
  - Converted `HeaderMap` to `HashMap<String, String>` for event serialization.

<sup>Written for commit 09decc03bdb5864c92ae1a5588e0142609b5c5d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

