### PR TITLE
feat(apigatewayv2): add authorizers, request history, and simulation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name my-queue
 
 ## Supported Services
 
-19 AWS services, 1016 API operations:
+20 AWS services, 1044 API operations:
 
 | Service                | Actions | Highlights                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -179,6 +179,7 @@ aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name my-queue
 | **RDS**                | 22      | DB instances (PostgreSQL, MySQL, MariaDB via Docker), snapshots, read replicas, parameter groups, subnet groups, engine/version discovery, tagging                                                                                                                                                                                                                                                          |
 | **ElastiCache**        | 44      | Cache clusters, replication groups, global replication groups, serverless caches and snapshots, subnet groups, users/user groups, failover, tagging (Redis and Valkey via Docker)                                                                                                                                                                                                                           |
 | **Step Functions**     | 14      | State machine CRUD, executions, ASL interpreter (Pass, Task, Choice, Wait, Parallel, Map, Succeed, Fail), Retry/Catch, Lambda/SQS/SNS/EventBridge/DynamoDB task integrations                                                                                                                                                                                                                              |
+| **API Gateway v2**     | 28      | HTTP APIs, routes with path parameters and wildcards, Lambda proxy integration, HTTP proxy integration, Mock integration, stages, deployments, authorizers (JWT and Lambda), CORS configuration, request history                                                                                                                                                                                          |
 
 ### Cross-Service Integration
 
@@ -197,6 +198,7 @@ integration tests:
 - **SES -> SNS/EventBridge**: Email event fanout (send, delivery, bounce, complaint) via configured event destinations
 - **SES Inbound -> S3/SNS/Lambda**: Receipt rules evaluate inbound email and execute S3, SNS, and Lambda actions
 - **Step Functions -> Lambda/SQS/SNS/EventBridge/DynamoDB**: Task states invoke Lambda, send SQS messages, publish to SNS topics, put EventBridge events, and read/write DynamoDB items
+- **API Gateway v2 -> Lambda**: HTTP API routes invoke Lambda functions with proxy integration v2.0 format
 - **CloudFormation -> Lambda/SNS**: Custom resources invoke via ServiceToken, stack events notify via NotificationARNs
 - **SecretsManager -> Lambda**: Rotation invokes Lambda for all 4 steps
 - **S3 Lifecycle**: Background expiration and storage class transitions
@@ -345,7 +347,7 @@ server per test.
 
 ## Roadmap
 
-See [ROADMAP.md](ROADMAP.md) for what's coming next: ECS, Elastic Load Balancing, CloudFront, API Gateway v2, and more.
+See [ROADMAP.md](ROADMAP.md) for what's coming next: ECS, Elastic Load Balancing, CloudFront, and more.
 
 ## Contributing
 

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -8,8 +8,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 use fakecloud_core::validation::*;
 
 use crate::state::{
-    ApiRequest, Authorizer, Deployment, HttpApi, Integration, Route, SharedApiGatewayV2State,
-    Stage,
+    ApiRequest, Authorizer, Deployment, HttpApi, Integration, Route, SharedApiGatewayV2State, Stage,
 };
 use crate::{cors, http_proxy, lambda_proxy, mock, router::Router};
 
@@ -266,9 +265,7 @@ impl ApiGatewayV2Service {
             "GetDeployment" => self.get_deployment(&req, api_id.as_deref(), resource_id.as_deref()),
             "GetDeployments" => self.get_deployments(&req, api_id.as_deref()),
             "CreateAuthorizer" => self.create_authorizer(&req, api_id.as_deref()),
-            "GetAuthorizer" => {
-                self.get_authorizer(&req, api_id.as_deref(), resource_id.as_deref())
-            }
+            "GetAuthorizer" => self.get_authorizer(&req, api_id.as_deref(), resource_id.as_deref()),
             "GetAuthorizers" => self.get_authorizers(&req, api_id.as_deref()),
             "UpdateAuthorizer" => {
                 self.update_authorizer(&req, api_id.as_deref(), resource_id.as_deref())
@@ -1366,13 +1363,11 @@ impl ApiGatewayV2Service {
             .to_string();
 
         let authorizer_uri = body["authorizerUri"].as_str().map(|s| s.to_string());
-        let identity_source = body["identitySource"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect()
-            });
+        let identity_source = body["identitySource"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        });
 
         let jwt_configuration = if let Some(jwt) = body.get("jwtConfiguration") {
             Some(serde_json::from_value(jwt.clone()).map_err(|e| {
@@ -1564,15 +1559,14 @@ impl ApiGatewayV2Service {
         }
 
         if let Some(jwt) = body.get("jwtConfiguration") {
-            authorizer.jwt_configuration = Some(serde_json::from_value(jwt.clone()).map_err(
-                |e| {
+            authorizer.jwt_configuration =
+                Some(serde_json::from_value(jwt.clone()).map_err(|e| {
                     AwsServiceError::aws_error(
                         StatusCode::BAD_REQUEST,
                         "ValidationException",
                         format!("Invalid jwtConfiguration: {}", e),
                     )
-                },
-            )?);
+                })?);
         }
 
         Ok(AwsResponse::ok_json(json!(authorizer)))

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -7,7 +7,10 @@ use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{Deployment, HttpApi, Integration, Route, SharedApiGatewayV2State, Stage};
+use crate::state::{
+    ApiRequest, Authorizer, Deployment, HttpApi, Integration, Route, SharedApiGatewayV2State,
+    Stage,
+};
 use crate::{cors, http_proxy, lambda_proxy, mock, router::Router};
 
 const SUPPORTED: &[&str] = &[
@@ -34,6 +37,11 @@ const SUPPORTED: &[&str] = &[
     "CreateDeployment",
     "GetDeployment",
     "GetDeployments",
+    "CreateAuthorizer",
+    "GetAuthorizer",
+    "GetAuthorizers",
+    "UpdateAuthorizer",
+    "DeleteAuthorizer",
 ];
 
 pub struct ApiGatewayV2Service {
@@ -79,6 +87,11 @@ impl ApiGatewayV2Service {
     ///   POST   /v2/apis/{api-id}/deployments -> CreateDeployment
     ///   GET    /v2/apis/{api-id}/deployments -> GetDeployments
     ///   GET    /v2/apis/{api-id}/deployments/{deployment-id} -> GetDeployment
+    ///   POST   /v2/apis/{api-id}/authorizers -> CreateAuthorizer
+    ///   GET    /v2/apis/{api-id}/authorizers -> GetAuthorizers
+    ///   GET    /v2/apis/{api-id}/authorizers/{auth-id} -> GetAuthorizer
+    ///   PATCH  /v2/apis/{api-id}/authorizers/{auth-id} -> UpdateAuthorizer
+    ///   DELETE /v2/apis/{api-id}/authorizers/{auth-id} -> DeleteAuthorizer
     fn resolve_action(req: &AwsRequest) -> Option<(&str, Option<String>, Option<String>)> {
         let segs = &req.path_segments;
         if segs.len() < 2 {
@@ -123,6 +136,12 @@ impl ApiGatewayV2Service {
             (Method::GET, 4) if segs[3] == "deployments" => {
                 Some(("GetDeployments", Some(segs[2].clone()), None))
             }
+            (Method::POST, 4) if segs[3] == "authorizers" => {
+                Some(("CreateAuthorizer", Some(segs[2].clone()), None))
+            }
+            (Method::GET, 4) if segs[3] == "authorizers" => {
+                Some(("GetAuthorizers", Some(segs[2].clone()), None))
+            }
             // /v2/apis/{api-id}/routes/{route-id} or /v2/apis/{api-id}/integrations/{int-id}
             (Method::GET, 5) if segs[3] == "routes" => {
                 Some(("GetRoute", Some(segs[2].clone()), Some(segs[4].clone())))
@@ -159,6 +178,21 @@ impl ApiGatewayV2Service {
             }
             (Method::GET, 5) if segs[3] == "deployments" => Some((
                 "GetDeployment",
+                Some(segs[2].clone()),
+                Some(segs[4].clone()),
+            )),
+            (Method::GET, 5) if segs[3] == "authorizers" => Some((
+                "GetAuthorizer",
+                Some(segs[2].clone()),
+                Some(segs[4].clone()),
+            )),
+            (Method::PATCH, 5) if segs[3] == "authorizers" => Some((
+                "UpdateAuthorizer",
+                Some(segs[2].clone()),
+                Some(segs[4].clone()),
+            )),
+            (Method::DELETE, 5) if segs[3] == "authorizers" => Some((
+                "DeleteAuthorizer",
                 Some(segs[2].clone()),
                 Some(segs[4].clone()),
             )),
@@ -231,6 +265,17 @@ impl ApiGatewayV2Service {
             "CreateDeployment" => self.create_deployment(&req, api_id.as_deref()),
             "GetDeployment" => self.get_deployment(&req, api_id.as_deref(), resource_id.as_deref()),
             "GetDeployments" => self.get_deployments(&req, api_id.as_deref()),
+            "CreateAuthorizer" => self.create_authorizer(&req, api_id.as_deref()),
+            "GetAuthorizer" => {
+                self.get_authorizer(&req, api_id.as_deref(), resource_id.as_deref())
+            }
+            "GetAuthorizers" => self.get_authorizers(&req, api_id.as_deref()),
+            "UpdateAuthorizer" => {
+                self.update_authorizer(&req, api_id.as_deref(), resource_id.as_deref())
+            }
+            "DeleteAuthorizer" => {
+                self.delete_authorizer(&req, api_id.as_deref(), resource_id.as_deref())
+            }
             _ => Err(AwsServiceError::action_not_implemented(
                 "apigateway",
                 action,
@@ -1279,6 +1324,308 @@ impl ApiGatewayV2Service {
         })))
     }
 
+    // ─── AUTHORIZER CRUD ────────────────────────────────────────────────
+
+    fn create_authorizer(
+        &self,
+        req: &AwsRequest,
+        api_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let body = req.json_body();
+
+        validate_required("name", &body["name"])?;
+        let name = body["name"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "name is required",
+                )
+            })?
+            .to_string();
+
+        validate_required("authorizerType", &body["authorizerType"])?;
+        let authorizer_type = body["authorizerType"]
+            .as_str()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "authorizerType is required",
+                )
+            })?
+            .to_string();
+
+        let authorizer_uri = body["authorizerUri"].as_str().map(|s| s.to_string());
+        let identity_source = body["identitySource"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            });
+
+        let jwt_configuration = if let Some(jwt) = body.get("jwtConfiguration") {
+            Some(serde_json::from_value(jwt.clone()).map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("Invalid jwtConfiguration: {}", e),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let authorizer_id = generate_id("auth");
+
+        let authorizer = Authorizer {
+            authorizer_id: authorizer_id.clone(),
+            name,
+            authorizer_type,
+            authorizer_uri,
+            identity_source,
+            jwt_configuration,
+        };
+
+        let mut state = self.state.write();
+
+        // Verify API exists
+        if !state.apis.contains_key(api_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            ));
+        }
+
+        state
+            .authorizers
+            .entry(api_id.to_string())
+            .or_default()
+            .insert(authorizer_id, authorizer.clone());
+
+        Ok(AwsResponse::ok_json(json!(authorizer)))
+    }
+
+    fn get_authorizer(
+        &self,
+        _req: &AwsRequest,
+        api_id: Option<&str>,
+        authorizer_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let authorizer_id = authorizer_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "Authorizer ID is required",
+            )
+        })?;
+
+        let state = self.state.read();
+
+        // Verify API exists
+        if !state.apis.contains_key(api_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            ));
+        }
+
+        let authorizer = state
+            .authorizers
+            .get(api_id)
+            .and_then(|auths| auths.get(authorizer_id))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "NotFoundException",
+                    format!("Authorizer not found: {}", authorizer_id),
+                )
+            })?;
+
+        Ok(AwsResponse::ok_json(json!(authorizer)))
+    }
+
+    fn get_authorizers(
+        &self,
+        _req: &AwsRequest,
+        api_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let state = self.state.read();
+
+        // Verify API exists
+        if !state.apis.contains_key(api_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            ));
+        }
+
+        let authorizers: Vec<&Authorizer> = state
+            .authorizers
+            .get(api_id)
+            .map(|auths| auths.values().collect())
+            .unwrap_or_default();
+
+        Ok(AwsResponse::ok_json(json!({
+            "items": authorizers,
+        })))
+    }
+
+    fn update_authorizer(
+        &self,
+        req: &AwsRequest,
+        api_id: Option<&str>,
+        authorizer_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let authorizer_id = authorizer_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "Authorizer ID is required",
+            )
+        })?;
+
+        let body = req.json_body();
+        let mut state = self.state.write();
+
+        // Verify API exists
+        if !state.apis.contains_key(api_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            ));
+        }
+
+        let authorizer = state
+            .authorizers
+            .get_mut(api_id)
+            .and_then(|auths| auths.get_mut(authorizer_id))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "NotFoundException",
+                    format!("Authorizer not found: {}", authorizer_id),
+                )
+            })?;
+
+        if let Some(name) = body["name"].as_str() {
+            authorizer.name = name.to_string();
+        }
+
+        if let Some(authorizer_uri) = body["authorizerUri"].as_str() {
+            authorizer.authorizer_uri = Some(authorizer_uri.to_string());
+        }
+
+        if let Some(identity_source) = body["identitySource"].as_array() {
+            authorizer.identity_source = Some(
+                identity_source
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect(),
+            );
+        }
+
+        if let Some(jwt) = body.get("jwtConfiguration") {
+            authorizer.jwt_configuration = Some(serde_json::from_value(jwt.clone()).map_err(
+                |e| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationException",
+                        format!("Invalid jwtConfiguration: {}", e),
+                    )
+                },
+            )?);
+        }
+
+        Ok(AwsResponse::ok_json(json!(authorizer)))
+    }
+
+    fn delete_authorizer(
+        &self,
+        _req: &AwsRequest,
+        api_id: Option<&str>,
+        authorizer_id: Option<&str>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let api_id = api_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "API ID is required",
+            )
+        })?;
+
+        let authorizer_id = authorizer_id.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "Authorizer ID is required",
+            )
+        })?;
+
+        let mut state = self.state.write();
+
+        // Verify API exists
+        if !state.apis.contains_key(api_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("API not found: {}", api_id),
+            ));
+        }
+
+        state
+            .authorizers
+            .get_mut(api_id)
+            .and_then(|auths| auths.remove(authorizer_id))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "NotFoundException",
+                    format!("Authorizer not found: {}", authorizer_id),
+                )
+            })?;
+
+        Ok(AwsResponse::json(StatusCode::NO_CONTENT, vec![]))
+    }
+
     // ─── EXECUTE API ────────────────────────────────────────────────────
 
     async fn handle_execute_api(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1440,6 +1787,41 @@ impl ApiGatewayV2Service {
         // Add CORS headers if CORS is configured
         if let Some(ref cors_cfg) = cors_config {
             response = cors::add_cors_headers(response, cors_cfg);
+        }
+
+        // Record this request to history
+        let headers_map: std::collections::HashMap<String, String> = req
+            .headers
+            .iter()
+            .filter_map(|(k, v)| {
+                v.to_str()
+                    .ok()
+                    .map(|v_str| (k.as_str().to_string(), v_str.to_string()))
+            })
+            .collect();
+
+        let body_string = if req.body.is_empty() {
+            None
+        } else {
+            String::from_utf8(req.body.to_vec()).ok()
+        };
+
+        let request_record = ApiRequest {
+            request_id: uuid::Uuid::new_v4().to_string(),
+            api_id: api_id.clone(),
+            stage: stage_name.to_string(),
+            method: req.method.to_string(),
+            path: resource_path,
+            headers: headers_map,
+            query_params: req.query_params.clone(),
+            body: body_string,
+            timestamp: chrono::Utc::now(),
+            status_code: response.status.as_u16(),
+        };
+
+        {
+            let mut state = self.state.write();
+            state.request_history.push(request_record);
         }
 
         Ok(response)

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -14,6 +14,8 @@ pub struct ApiGatewayV2State {
     pub integrations: HashMap<String, HashMap<String, Integration>>, // api-id -> (integration-id -> Integration)
     pub stages: HashMap<String, HashMap<String, Stage>>, // api-id -> (stage-name -> Stage)
     pub deployments: HashMap<String, HashMap<String, Deployment>>, // api-id -> (deployment-id -> Deployment)
+    pub authorizers: HashMap<String, HashMap<String, Authorizer>>, // api-id -> (authorizer-id -> Authorizer)
+    pub request_history: Vec<ApiRequest>, // For /_fakecloud/apigatewayv2/requests
 }
 
 impl ApiGatewayV2State {
@@ -26,6 +28,8 @@ impl ApiGatewayV2State {
             integrations: HashMap::new(),
             stages: HashMap::new(),
             deployments: HashMap::new(),
+            authorizers: HashMap::new(),
+            request_history: Vec::new(),
         }
     }
 }
@@ -135,4 +139,43 @@ pub struct Deployment {
     pub description: Option<String>,
     pub created_date: DateTime<Utc>,
     pub auto_deployed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Authorizer {
+    pub authorizer_id: String,
+    pub name: String,
+    pub authorizer_type: String, // "JWT" or "REQUEST"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorizer_uri: Option<String>, // Lambda ARN for REQUEST type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identity_source: Option<Vec<String>>, // e.g., ["$request.header.Authorization"]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwt_configuration: Option<JwtConfiguration>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JwtConfiguration {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audience: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiRequest {
+    pub request_id: String,
+    pub api_id: String,
+    pub stage: String,
+    pub method: String,
+    pub path: String,
+    pub headers: HashMap<String, String>,
+    pub query_params: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    pub timestamp: DateTime<Utc>,
+    pub status_code: u16,
 }

--- a/crates/fakecloud-e2e/tests/apigatewayv2.rs
+++ b/crates/fakecloud-e2e/tests/apigatewayv2.rs
@@ -1141,3 +1141,203 @@ async fn test_mock_integration() {
     let body: serde_json::Value = response.json().await.unwrap();
     assert_eq!(body["message"], "This is a mock response");
 }
+
+#[tokio::test]
+async fn test_authorizer_crud() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    // Create API
+    let api = client
+        .create_api()
+        .name("test-api-authorizers")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+    let api_id = api.api_id.as_ref().unwrap();
+
+    // Create JWT authorizer
+    let jwt_auth = client
+        .create_authorizer()
+        .api_id(api_id)
+        .authorizer_type(aws_sdk_apigatewayv2::types::AuthorizerType::Jwt)
+        .name("jwt-authorizer")
+        .identity_source("$request.header.Authorization")
+        .jwt_configuration(
+            aws_sdk_apigatewayv2::types::JwtConfiguration::builder()
+                .audience("https://api.example.com")
+                .issuer("https://auth.example.com")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let jwt_auth_id = jwt_auth.authorizer_id.as_ref().unwrap();
+
+    assert_eq!(jwt_auth.name.as_ref().unwrap(), "jwt-authorizer");
+    assert_eq!(
+        jwt_auth.authorizer_type.as_ref().unwrap(),
+        &aws_sdk_apigatewayv2::types::AuthorizerType::Jwt
+    );
+
+    // Create REQUEST authorizer
+    let request_auth = client
+        .create_authorizer()
+        .api_id(api_id)
+        .authorizer_type(aws_sdk_apigatewayv2::types::AuthorizerType::Request)
+        .name("lambda-authorizer")
+        .authorizer_uri("arn:aws:lambda:us-east-1:000000000000:function:my-authorizer")
+        .identity_source("$request.header.Authorization")
+        .send()
+        .await
+        .unwrap();
+    let request_auth_id = request_auth.authorizer_id.as_ref().unwrap();
+
+    assert_eq!(request_auth.name.as_ref().unwrap(), "lambda-authorizer");
+    assert_eq!(
+        request_auth.authorizer_type.as_ref().unwrap(),
+        &aws_sdk_apigatewayv2::types::AuthorizerType::Request
+    );
+
+    // Get authorizer
+    let get_result = client
+        .get_authorizer()
+        .api_id(api_id)
+        .authorizer_id(jwt_auth_id)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(get_result.name.as_ref().unwrap(), "jwt-authorizer");
+
+    // List authorizers
+    let list_result = client
+        .get_authorizers()
+        .api_id(api_id)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(list_result.items.as_ref().unwrap().len(), 2);
+
+    // Update authorizer
+    let update_result = client
+        .update_authorizer()
+        .api_id(api_id)
+        .authorizer_id(jwt_auth_id)
+        .name("updated-jwt-authorizer")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        update_result.name.as_ref().unwrap(),
+        "updated-jwt-authorizer"
+    );
+
+    // Delete authorizer
+    client
+        .delete_authorizer()
+        .api_id(api_id)
+        .authorizer_id(request_auth_id)
+        .send()
+        .await
+        .unwrap();
+
+    // Verify deletion
+    let list_after_delete = client
+        .get_authorizers()
+        .api_id(api_id)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(list_after_delete.items.as_ref().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_simulation_endpoint() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    // Create API with Lambda integration
+    let api = client
+        .create_api()
+        .name("test-api-simulation")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+    let api_id = api.api_id.as_ref().unwrap();
+
+    // Create mock integration
+    let integration = client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::Mock)
+        .send()
+        .await
+        .unwrap();
+    let integration_id = integration.integration_id.as_ref().unwrap();
+
+    // Create route
+    client
+        .create_route()
+        .api_id(api_id)
+        .route_key("GET /test")
+        .target(format!("integrations/{}", integration_id))
+        .send()
+        .await
+        .unwrap();
+
+    // Create stage
+    client
+        .create_stage()
+        .api_id(api_id)
+        .stage_name("prod")
+        .auto_deploy(true)
+        .send()
+        .await
+        .unwrap();
+
+    // Make a request to the API
+    let http_client = reqwest::Client::new();
+    let response = http_client
+        .get(format!("{}/prod/test?param1=value1", server.endpoint()))
+        .header("X-Custom-Header", "test-value")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    // Check simulation endpoint
+    let history_response = http_client
+        .get(format!(
+            "{}/_fakecloud/apigatewayv2/requests",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(history_response.status(), 200);
+    let history: serde_json::Value = history_response.json().await.unwrap();
+    let requests = history["requests"].as_array().unwrap();
+
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["method"].as_str().unwrap(), "GET");
+    assert_eq!(requests[0]["path"].as_str().unwrap(), "/test");
+    assert_eq!(requests[0]["stage"].as_str().unwrap(), "prod");
+    assert_eq!(requests[0]["apiId"].as_str().unwrap(), api_id);
+    assert_eq!(
+        requests[0]["headers"]["x-custom-header"].as_str().unwrap(),
+        "test-value"
+    );
+    assert_eq!(
+        requests[0]["queryParams"]["param1"].as_str().unwrap(),
+        "value1"
+    );
+    assert_eq!(requests[0]["statusCode"].as_u64().unwrap(), 200);
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1210,6 +1210,21 @@ async fn main() {
             }),
         )
         .route(
+            "/_fakecloud/apigatewayv2/requests",
+            axum::routing::get({
+                let apigw_state = apigatewayv2_state.clone();
+                move || {
+                    let apigw_state = apigw_state.clone();
+                    async move {
+                        let state = apigw_state.read();
+                        axum::Json(serde_json::json!({
+                            "requests": state.request_history
+                        }))
+                    }
+                }
+            }),
+        )
+        .route(
             "/_fakecloud/lambda/{function_name}/evict-container",
             axum::routing::post({
                 let rt = lambda_sim_evict_runtime;


### PR DESCRIPTION
## Summary
- Add JWT and REQUEST authorizer types with full CRUD operations (CreateAuthorizer, GetAuthorizer, GetAuthorizers, UpdateAuthorizer, DeleteAuthorizer)
- Add request history tracking that records all execute API requests with full details (method, path, headers, query params, body, status code, timestamp)
- Add simulation endpoint `/_fakecloud/apigatewayv2/requests` to list all recorded requests for testing and debugging
- Update README: 20 services, 1044 operations total

## Test plan
- [x] E2E test for authorizer CRUD operations (create JWT and REQUEST authorizers, get, list, update, delete)
- [x] E2E test for simulation endpoint (make API request, verify it appears in history with correct fields)
- [x] All 31 apigatewayv2 tests passing
- [x] Clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds API Gateway v2 authorizers (JWT and REQUEST) with full CRUD, plus request history and a simulation endpoint to inspect executed calls. This improves testing and debugging for HTTP APIs and expands API Gateway v2 coverage.

- **New Features**
  - Authorizers: JWT and REQUEST types with create/get/list/update/delete APIs; state includes authorizerUri, identitySource, and jwtConfiguration.
  - Request history: records all executed API requests (method, path, headers, query params, body, status, timestamp).
  - Simulation endpoint: `/_fakecloud/apigatewayv2/requests` returns recorded requests.
  - Docs: README updated to 20 services, 1044 operations; adds API Gateway v2 details and Lambda integration note.

<sup>Written for commit 12d105d1d753f815c8b29a2bda8f07e4de5839cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

