### PR TITLE
fix(dynamodb,sns,logs): fail-closed on unrecognized/malformed input

### DIFF
--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -4342,10 +4342,7 @@ fn apply_update_expression(
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "ValidationException",
-                    format!(
-                        "Invalid UpdateExpression: Invalid action: {}",
-                        other
-                    ),
+                    format!("Invalid UpdateExpression: Invalid action: {}", other),
                 ));
             }
         }

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -4308,6 +4308,13 @@ fn apply_update_expression(
     expr_attr_values: &HashMap<String, Value>,
 ) -> Result<(), AwsServiceError> {
     let clauses = parse_update_clauses(expr);
+    if clauses.is_empty() && !expr.trim().is_empty() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "Invalid UpdateExpression: Syntax error; token: \"<expression>\"",
+        ));
+    }
     for (action, assignments) in &clauses {
         match action.to_ascii_uppercase().as_str() {
             "SET" => {
@@ -4331,7 +4338,16 @@ fn apply_update_expression(
                     apply_delete_assignment(item, assignment, expr_attr_names, expr_attr_values)?;
                 }
             }
-            _ => {}
+            other => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!(
+                        "Invalid UpdateExpression: Invalid action: {}",
+                        other
+                    ),
+                ));
+            }
         }
     }
     Ok(())
@@ -7344,6 +7360,27 @@ mod tests {
         assert!(
             result.is_err(),
             "list index on non-list attribute must return an error"
+        );
+    }
+
+    #[test]
+    fn test_unrecognized_update_action_returns_error() {
+        let mut item = HashMap::new();
+        item.insert("name".to_string(), json!({"S": "hello"}));
+
+        let names: HashMap<String, String> = HashMap::new();
+        let mut values = HashMap::new();
+        values.insert(":bar".to_string(), json!({"S": "baz"}));
+
+        let result = apply_update_expression(&mut item, "INVALID foo = :bar", &names, &values);
+        assert!(
+            result.is_err(),
+            "unrecognized UpdateExpression action must return an error"
+        );
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("Invalid UpdateExpression") || err_msg.contains("Syntax error"),
+            "error should mention Invalid UpdateExpression, got: {err_msg}"
         );
     }
 }

--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -386,9 +386,9 @@ fn matches_filter_pattern(pattern: &str, message: &str) -> bool {
         return matches_json_filter_pattern(pattern, message);
     }
 
-    // Array-style metric filter patterns - match everything (not implemented)
+    // Array-style metric filter patterns - not implemented, fail closed
     if pattern.starts_with('[') {
-        return true;
+        return false;
     }
 
     // Quoted pattern: exact substring match (handles escaped inner quotes)
@@ -528,7 +528,7 @@ fn matches_single_json_condition(condition: &str, json: &serde_json::Value) -> b
     // Extract JSON path from field_part (must start with $.)
     let path = match field_part.strip_prefix("$.") {
         Some(p) => p,
-        None => return true, // Don't understand this pattern, match everything
+        None => return false, // Don't understand this pattern, fail closed
     };
 
     let actual_value = match resolve_json_path_simple(json, path) {
@@ -565,7 +565,7 @@ fn matches_single_json_condition(condition: &str, json: &serde_json::Value) -> b
             _ => false,
         }
     } else {
-        true // Unknown value format, match everything
+        false // Unknown value format, fail closed
     };
 
     expected_str
@@ -660,5 +660,38 @@ pub(crate) mod test_helpers {
             }),
         );
         svc.put_log_events(&req).unwrap();
+    }
+
+    #[test]
+    fn array_filter_pattern_does_not_match() {
+        assert!(
+            !matches_filter_pattern("[w1, w2, w3]", "some log message"),
+            "array-style filter pattern must not match (fail closed)"
+        );
+    }
+
+    #[test]
+    fn unrecognized_json_filter_path_does_not_match() {
+        // A JSON filter condition where the field part doesn't start with $.
+        // should fail closed instead of matching everything.
+        assert!(
+            !matches_single_json_condition(
+                "level = \"ERROR\"",
+                &serde_json::json!({"level": "ERROR"}),
+            ),
+            "filter condition without $. prefix must not match (fail closed)"
+        );
+    }
+
+    #[test]
+    fn unknown_value_format_does_not_match() {
+        // A value that is not a string, number, or boolean should fail closed.
+        assert!(
+            !matches_single_json_condition(
+                "$.level = ERROR",
+                &serde_json::json!({"level": "ERROR"}),
+            ),
+            "unquoted non-numeric non-boolean value must not match (fail closed)"
+        );
     }
 }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -2922,7 +2922,7 @@ fn matches_filter_policy(
 
     let filter: HashMap<String, Value> = match serde_json::from_str(filter_json) {
         Ok(f) => f,
-        Err(_) => return true,
+        Err(_) => return false,
     };
 
     let scope = sub
@@ -4846,6 +4846,27 @@ mod tests {
             state.read().subscriptions.len(),
             0,
             "Subscriptions should be removed with topic"
+        );
+    }
+
+    #[test]
+    fn malformed_filter_policy_does_not_match() {
+        let sub = SnsSubscription {
+            subscription_arn: "arn:aws:sns:us-east-1:123456789012:t:sub-1".to_string(),
+            topic_arn: "arn:aws:sns:us-east-1:123456789012:t".to_string(),
+            protocol: "sqs".to_string(),
+            endpoint: "arn:aws:sqs:us-east-1:123456789012:q".to_string(),
+            owner: "123456789012".to_string(),
+            attributes: HashMap::from([
+                ("FilterPolicy".to_string(), "not valid json {{[".to_string()),
+            ]),
+            confirmed: true,
+            confirmation_token: None,
+        };
+        let attrs = HashMap::new();
+        assert!(
+            !matches_filter_policy(&sub, &attrs, "hello"),
+            "malformed FilterPolicy JSON must not match (fail closed)"
         );
     }
 }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -4857,9 +4857,10 @@ mod tests {
             protocol: "sqs".to_string(),
             endpoint: "arn:aws:sqs:us-east-1:123456789012:q".to_string(),
             owner: "123456789012".to_string(),
-            attributes: HashMap::from([
-                ("FilterPolicy".to_string(), "not valid json {{[".to_string()),
-            ]),
+            attributes: HashMap::from([(
+                "FilterPolicy".to_string(),
+                "not valid json {{[".to_string(),
+            )]),
             confirmed: true,
             confirmation_token: None,
         };


### PR DESCRIPTION
## Summary

- **DynamoDB**: `apply_update_expression` now rejects expressions with no valid action keywords (e.g. `INVALID foo = :bar`) and returns `ValidationException` for unknown actions. Previously silently succeeded.
- **SNS**: `matches_filter_policy` returns `false` when a subscription's `FilterPolicy` is malformed JSON. Previously returned `true`, delivering messages to all subscribers.
- **CloudWatch Logs**: Three fail-closed fixes in filter pattern matching:
  - Array-style metric filter patterns (`[w1, w2]`) no longer match everything
  - JSON filter conditions without `$.` path prefix no longer match everything
  - Unknown value formats in JSON conditions no longer match everything

All three follow the fail-closed principle: when we don't understand the input, reject rather than silently accept.

## Test plan

- [x] DynamoDB: unit test for unrecognized UpdateExpression action
- [x] SNS: unit test for malformed FilterPolicy JSON
- [x] CloudWatch Logs: unit tests for array pattern, missing `$.` prefix, and unknown value format
- [x] Full test suites pass: 72 DynamoDB, 48 SNS, 129 Logs — zero regressions
- [x] Clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make DynamoDB, SNS, and CloudWatch Logs fail closed on unrecognized or malformed inputs to stop silent matches and unintended deliveries.

- **Bug Fixes**
  - `fakecloud-dynamodb`: `apply_update_expression` now returns `ValidationException` for empty/invalid actions and unknown actions (was silently succeeding).
  - `fakecloud-sns`: `matches_filter_policy` returns `false` when `FilterPolicy` is malformed JSON, preventing delivery to all subscribers.
  - `fakecloud-logs`: filter matching now fails closed for array-style patterns (`[w1, w2]`), JSON conditions without `$.` prefix, and unknown value formats.

<sup>Written for commit 4727c0ee435b10538d82a6c67770800a7996e101. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

