### PR TITLE
feat(bedrock): quality fixes, pagination, and 6 new runtime operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ tests; they are an extra layer, not the whole story.
 | Startup time        | ~500ms                                             | ~3s                                                                            |
 | Idle memory         | ~10 MiB                                            | ~150 MiB                                                                       |
 | Install size        | ~19 MB binary                                      | ~1 GB Docker image                                                             |
-| AWS services        | 19                                                 | 30+                                                                            |
+| AWS services        | 22                                                 | 30+                                                                            |
 | Test assertion SDKs | TypeScript, Python, Go, Rust                       | Python, Java                                                                   |
 | Cognito User Pools  | 80 operations                                      | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | SES v2              | 97 operations                                      | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
@@ -156,7 +156,7 @@ aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name my-queue
 
 ## Supported Services
 
-21 AWS services, 1071 API operations:
+22 AWS services, 1077 API operations:
 
 | Service                | Actions | Highlights                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -180,7 +180,8 @@ aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name my-queue
 | **ElastiCache**        | 44      | Cache clusters, replication groups, global replication groups, serverless caches and snapshots, subnet groups, users/user groups, failover, tagging (Redis and Valkey via Docker)                                                                                                                                                                                                                           |
 | **Step Functions**     | 14      | State machine CRUD, executions, ASL interpreter (Pass, Task, Choice, Wait, Parallel, Map, Succeed, Fail), Retry/Catch, Lambda/SQS/SNS/EventBridge/DynamoDB task integrations                                                                                                                                                                                                                              |
 | **API Gateway v2**     | 28      | HTTP APIs, routes with path parameters and wildcards, Lambda proxy integration, HTTP proxy integration, Mock integration, stages, deployments, authorizers (JWT and Lambda), CORS configuration, request history                                                                                                                                                                                          |
-| **Bedrock**            | 27      | Foundation models, guardrails with versioning, model customization jobs, provisioned throughput, invocation logging, InvokeModel/Converse (sync and streaming), tagging                                                                                                                                                                                                                                    |
+| **Bedrock**            | 27      | Foundation models, guardrails (CRUD, versioning, content evaluation), model customization jobs, provisioned throughput, logging configuration, tagging                                                                                                                                                                                                                                                     |
+| **Bedrock Runtime**    | 6       | InvokeModel (Anthropic, Titan, Meta, Cohere, Mistral), Converse, streaming, ApplyGuardrail, CountTokens, async invoke                                                                                                                                                                                                                                                                                     |
 
 ### Cross-Service Integration
 

--- a/crates/fakecloud-bedrock/src/async_invoke.rs
+++ b/crates/fakecloud-bedrock/src/async_invoke.rs
@@ -1,0 +1,186 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{AsyncInvocation, SharedBedrockState};
+
+pub fn start_async_invoke(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let model_id = body["modelId"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "modelId is required",
+        )
+    })?;
+
+    let output_data_config = body.get("outputDataConfig").ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "outputDataConfig is required",
+        )
+    })?;
+
+    let model_input = body.get("modelInput").ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "modelInput is required",
+        )
+    })?;
+
+    let invocation_id = Uuid::new_v4().to_string();
+    let invocation_arn = format!(
+        "arn:aws:bedrock:{}:{}:async-invoke/{}",
+        req.region, req.account_id, invocation_id
+    );
+
+    let model_arn = if model_id.starts_with("arn:") {
+        model_id.to_string()
+    } else {
+        format!(
+            "arn:aws:bedrock:{}::foundation-model/{}",
+            req.region, model_id
+        )
+    };
+
+    let now = Utc::now();
+    let invocation = AsyncInvocation {
+        invocation_arn: invocation_arn.clone(),
+        model_arn,
+        model_input: model_input.clone(),
+        output_data_config: output_data_config.clone(),
+        client_request_token: body["clientRequestToken"].as_str().map(|s| s.to_string()),
+        status: "Completed".to_string(),
+        submit_time: now,
+        last_modified_time: now,
+        end_time: Some(now),
+    };
+
+    let mut s = state.write();
+    s.async_invocations
+        .insert(invocation_arn.clone(), invocation);
+
+    Ok(AwsResponse::json(
+        StatusCode::OK,
+        serde_json::to_string(&json!({ "invocationArn": invocation_arn })).unwrap(),
+    ))
+}
+
+pub fn get_async_invoke(
+    state: &SharedBedrockState,
+    invocation_id: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    // Look up by full ARN or by the UUID suffix
+    let invocation = s
+        .async_invocations
+        .get(invocation_id)
+        .or_else(|| {
+            s.async_invocations
+                .values()
+                .find(|inv| inv.invocation_arn.ends_with(invocation_id))
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Async invocation {invocation_id} not found"),
+            )
+        })?;
+
+    Ok(AwsResponse::ok_json(invocation_to_json(invocation)))
+}
+
+pub fn list_async_invokes(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100);
+    let next_token = req.query_params.get("nextToken");
+    let status_filter = req.query_params.get("statusEquals");
+
+    let s = state.read();
+    let mut items: Vec<&AsyncInvocation> = s
+        .async_invocations
+        .values()
+        .filter(|inv| {
+            if let Some(status) = status_filter {
+                inv.status == *status
+            } else {
+                true
+            }
+        })
+        .collect();
+    items.sort_by(|a, b| b.submit_time.cmp(&a.submit_time)); // Descending by default
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|inv| inv.invocation_arn.as_str() == token.as_str())
+            .map(|p| p + 1)
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|inv| invocation_summary_json(inv))
+        .collect();
+
+    let mut resp = json!({ "asyncInvokeSummaries": page });
+    if start + max_results < items.len() {
+        if let Some(last) = items.get(start + max_results - 1) {
+            resp["nextToken"] = json!(last.invocation_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+fn invocation_to_json(inv: &AsyncInvocation) -> Value {
+    let mut obj = json!({
+        "invocationArn": inv.invocation_arn,
+        "modelArn": inv.model_arn,
+        "status": inv.status,
+        "submitTime": inv.submit_time.to_rfc3339(),
+        "lastModifiedTime": inv.last_modified_time.to_rfc3339(),
+        "outputDataConfig": inv.output_data_config,
+    });
+    if let Some(ref token) = inv.client_request_token {
+        obj["clientRequestToken"] = json!(token);
+    }
+    if let Some(ref end_time) = inv.end_time {
+        obj["endTime"] = json!(end_time.to_rfc3339());
+    }
+    obj
+}
+
+fn invocation_summary_json(inv: &AsyncInvocation) -> Value {
+    let mut obj = json!({
+        "invocationArn": inv.invocation_arn,
+        "modelArn": inv.model_arn,
+        "status": inv.status,
+        "submitTime": inv.submit_time.to_rfc3339(),
+        "lastModifiedTime": inv.last_modified_time.to_rfc3339(),
+        "outputDataConfig": inv.output_data_config,
+    });
+    if let Some(ref end_time) = inv.end_time {
+        obj["endTime"] = json!(end_time.to_rfc3339());
+    }
+    obj
+}

--- a/crates/fakecloud-bedrock/src/async_invoke.rs
+++ b/crates/fakecloud-bedrock/src/async_invoke.rs
@@ -107,7 +107,8 @@ pub fn list_async_invokes(
         .query_params
         .get("maxResults")
         .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(100);
+        .unwrap_or(100)
+        .max(1);
     let next_token = req.query_params.get("nextToken");
     let status_filter = req.query_params.get("statusEquals");
 
@@ -143,8 +144,9 @@ pub fn list_async_invokes(
         .collect();
 
     let mut resp = json!({ "asyncInvokeSummaries": page });
-    if start + max_results < items.len() {
-        if let Some(last) = items.get(start + max_results - 1) {
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
             resp["nextToken"] = json!(last.invocation_arn);
         }
     }

--- a/crates/fakecloud-bedrock/src/converse.rs
+++ b/crates/fakecloud-bedrock/src/converse.rs
@@ -37,8 +37,8 @@ pub fn converse(
     // Respect maxTokens by truncating (rough approximation: 1 token ~= 4 chars)
     let truncated_text = if max_tokens < u64::MAX {
         let char_limit = (max_tokens as usize) * 4;
-        if response_text.len() > char_limit {
-            response_text[..char_limit].to_string()
+        if response_text.chars().count() > char_limit {
+            response_text.chars().take(char_limit).collect::<String>()
         } else {
             response_text
         }

--- a/crates/fakecloud-bedrock/src/converse.rs
+++ b/crates/fakecloud-bedrock/src/converse.rs
@@ -14,10 +14,15 @@ pub fn converse(
 ) -> Result<AwsResponse, AwsServiceError> {
     let input: Value = serde_json::from_slice(body).unwrap_or_default();
 
+    let inference_config = input.get("inferenceConfig");
+    let max_tokens = inference_config
+        .and_then(|c| c["maxTokens"].as_u64())
+        .unwrap_or(u64::MAX);
+    let tool_config = input.get("toolConfig");
+
     let response_text = {
         let s = state.read();
         if let Some(custom) = s.custom_responses.get(model_id) {
-            // Parse custom response to extract text if it's a Converse-format response
             let parsed: Value = serde_json::from_str(custom).unwrap_or_default();
             if let Some(text) = parsed["output"]["message"]["content"][0]["text"].as_str() {
                 text.to_string()
@@ -29,22 +34,66 @@ pub fn converse(
         }
     };
 
+    // Respect maxTokens by truncating (rough approximation: 1 token ~= 4 chars)
+    let truncated_text = if max_tokens < u64::MAX {
+        let char_limit = (max_tokens as usize) * 4;
+        if response_text.len() > char_limit {
+            response_text[..char_limit].to_string()
+        } else {
+            response_text
+        }
+    } else {
+        response_text
+    };
+
+    // Build content blocks
+    let mut content = vec![json!({"text": truncated_text})];
+
+    // If toolConfig is provided with tools, include a toolUse block
+    if let Some(tc) = tool_config {
+        if let Some(tools) = tc["tools"].as_array() {
+            if let Some(first_tool) = tools.first() {
+                if let Some(tool_spec) = first_tool.get("toolSpec") {
+                    let tool_name = tool_spec["name"].as_str().unwrap_or("tool");
+                    content.push(json!({
+                        "toolUse": {
+                            "toolUseId": "tooluse_fakecloud_01",
+                            "name": tool_name,
+                            "input": {}
+                        }
+                    }));
+                }
+            }
+        }
+    }
+
+    let stop_reason = if tool_config.is_some()
+        && content.len() > 1
+        && content
+            .last()
+            .map(|c| c.get("toolUse").is_some())
+            .unwrap_or(false)
+    {
+        "tool_use"
+    } else {
+        "end_turn"
+    };
+
+    let input_tokens = estimate_tokens(&input);
+    let output_tokens = truncated_text.split_whitespace().count().max(1) as u64;
+
     let response = json!({
         "output": {
             "message": {
                 "role": "assistant",
-                "content": [
-                    {
-                        "text": response_text
-                    }
-                ]
+                "content": content
             }
         },
-        "stopReason": "end_turn",
+        "stopReason": stop_reason,
         "usage": {
-            "inputTokens": 10,
-            "outputTokens": 20,
-            "totalTokens": 30
+            "inputTokens": input_tokens,
+            "outputTokens": output_tokens,
+            "totalTokens": input_tokens + output_tokens
         },
         "metrics": {
             "latencyMs": 100
@@ -64,7 +113,34 @@ pub fn converse(
         });
     }
 
-    let _ = input;
-
     Ok(AwsResponse::json(StatusCode::OK, response_str))
+}
+
+fn estimate_tokens(input: &Value) -> u64 {
+    let mut text_len = 0usize;
+
+    // Count system prompt tokens
+    if let Some(system) = input.get("system").and_then(|s| s.as_array()) {
+        for block in system {
+            if let Some(text) = block["text"].as_str() {
+                text_len += text.len();
+            }
+        }
+    }
+
+    // Count message tokens
+    if let Some(messages) = input.get("messages").and_then(|m| m.as_array()) {
+        for msg in messages {
+            if let Some(content) = msg.get("content").and_then(|c| c.as_array()) {
+                for block in content {
+                    if let Some(text) = block["text"].as_str() {
+                        text_len += text.len();
+                    }
+                }
+            }
+        }
+    }
+
+    // Rough approximation: 1 token ~= 4 characters, minimum 1
+    (text_len / 4).max(1) as u64
 }

--- a/crates/fakecloud-bedrock/src/customization.rs
+++ b/crates/fakecloud-bedrock/src/customization.rs
@@ -113,11 +113,32 @@ pub fn get_model_customization_job(
 
 pub fn list_model_customization_jobs(
     state: &SharedBedrockState,
+    req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100);
+    let next_token = req.query_params.get("nextToken");
+
     let s = state.read();
-    let summaries: Vec<Value> = s
-        .customization_jobs
-        .values()
+    let mut items: Vec<&crate::state::CustomizationJob> = s.customization_jobs.values().collect();
+    items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|j| j.job_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
         .map(|j| {
             json!({
                 "jobArn": j.job_arn,
@@ -131,9 +152,14 @@ pub fn list_model_customization_jobs(
         })
         .collect();
 
-    Ok(AwsResponse::ok_json(
-        json!({ "modelCustomizationJobSummaries": summaries }),
-    ))
+    let mut resp = json!({ "modelCustomizationJobSummaries": page });
+    if start + max_results < items.len() {
+        if let Some(last) = items.get(start + max_results - 1) {
+            resp["nextToken"] = json!(last.job_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
 }
 
 pub fn stop_model_customization_job(

--- a/crates/fakecloud-bedrock/src/customization.rs
+++ b/crates/fakecloud-bedrock/src/customization.rs
@@ -119,7 +119,8 @@ pub fn list_model_customization_jobs(
         .query_params
         .get("maxResults")
         .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(100);
+        .unwrap_or(100)
+        .max(1);
     let next_token = req.query_params.get("nextToken");
 
     let s = state.read();
@@ -153,8 +154,9 @@ pub fn list_model_customization_jobs(
         .collect();
 
     let mut resp = json!({ "modelCustomizationJobSummaries": page });
-    if start + max_results < items.len() {
-        if let Some(last) = items.get(start + max_results - 1) {
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
             resp["nextToken"] = json!(last.job_arn);
         }
     }

--- a/crates/fakecloud-bedrock/src/guardrails.rs
+++ b/crates/fakecloud-bedrock/src/guardrails.rs
@@ -106,11 +106,34 @@ pub fn get_guardrail(
     Ok(AwsResponse::ok_json(guardrail_to_json(guardrail)))
 }
 
-pub fn list_guardrails(state: &SharedBedrockState) -> Result<AwsResponse, AwsServiceError> {
+pub fn list_guardrails(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100);
+    let next_token = req.query_params.get("nextToken");
+
     let s = state.read();
-    let guardrails: Vec<Value> = s
-        .guardrails
-        .values()
+    let mut items: Vec<&Guardrail> = s.guardrails.values().collect();
+    items.sort_by(|a, b| a.guardrail_id.cmp(&b.guardrail_id));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|g| g.guardrail_id.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
         .map(|g| {
             json!({
                 "id": g.guardrail_id,
@@ -125,7 +148,14 @@ pub fn list_guardrails(state: &SharedBedrockState) -> Result<AwsResponse, AwsSer
         })
         .collect();
 
-    Ok(AwsResponse::ok_json(json!({ "guardrails": guardrails })))
+    let mut resp = json!({ "guardrails": page });
+    if start + max_results < items.len() {
+        if let Some(last) = items.get(start + max_results - 1) {
+            resp["nextToken"] = json!(last.guardrail_id);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
 }
 
 pub fn update_guardrail(
@@ -249,6 +279,128 @@ pub fn create_guardrail_version(
         }))
         .unwrap(),
     ))
+}
+
+/// Handle the ApplyGuardrail API — evaluate content against a guardrail.
+pub fn apply_guardrail(
+    state: &SharedBedrockState,
+    guardrail_id: &str,
+    guardrail_version: &str,
+    body: &[u8],
+) -> Result<AwsResponse, AwsServiceError> {
+    let input: Value = serde_json::from_slice(body).unwrap_or_default();
+
+    let s = state.read();
+
+    // Build a temporary guardrail for evaluation from DRAFT or versioned
+    let not_found_err = || {
+        AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Guardrail {guardrail_id} version {guardrail_version} not found"),
+        )
+    };
+
+    let temp_guardrail = if guardrail_version == "DRAFT" {
+        let g = s.guardrails.get(guardrail_id).ok_or_else(not_found_err)?;
+        Guardrail {
+            guardrail_id: g.guardrail_id.clone(),
+            guardrail_arn: g.guardrail_arn.clone(),
+            name: g.name.clone(),
+            description: g.description.clone(),
+            status: g.status.clone(),
+            version: g.version.clone(),
+            next_version_number: g.next_version_number,
+            blocked_input_messaging: g.blocked_input_messaging.clone(),
+            blocked_outputs_messaging: g.blocked_outputs_messaging.clone(),
+            content_policy: g.content_policy.clone(),
+            word_policy: g.word_policy.clone(),
+            sensitive_information_policy: g.sensitive_information_policy.clone(),
+            topic_policy: g.topic_policy.clone(),
+            created_at: g.created_at,
+            updated_at: g.updated_at,
+        }
+    } else {
+        let key = (guardrail_id.to_string(), guardrail_version.to_string());
+        let gv = s.guardrail_versions.get(&key).ok_or_else(not_found_err)?;
+        Guardrail {
+            guardrail_id: gv.guardrail_id.clone(),
+            guardrail_arn: gv.guardrail_arn.clone(),
+            name: gv.name.clone(),
+            description: gv.description.clone(),
+            status: gv.status.clone(),
+            version: gv.version.clone(),
+            next_version_number: 0,
+            blocked_input_messaging: gv.blocked_input_messaging.clone(),
+            blocked_outputs_messaging: gv.blocked_outputs_messaging.clone(),
+            content_policy: gv.content_policy.clone(),
+            word_policy: gv.word_policy.clone(),
+            sensitive_information_policy: gv.sensitive_information_policy.clone(),
+            topic_policy: gv.topic_policy.clone(),
+            created_at: gv.created_at,
+            updated_at: gv.created_at,
+        }
+    };
+
+    // Extract text from content blocks
+    // Content blocks can be: {"text": {"text": "..."}} (GuardrailTextBlock union variant)
+    // or {"text": "..."} (simple text)
+    let content_blocks = input["content"].as_array();
+    let mut all_text = String::new();
+    if let Some(blocks) = content_blocks {
+        for block in blocks {
+            let text_str = block["text"]["text"]
+                .as_str()
+                .or_else(|| block["text"].as_str());
+            if let Some(text) = text_str {
+                if !all_text.is_empty() {
+                    all_text.push(' ');
+                }
+                all_text.push_str(text);
+            }
+        }
+    }
+
+    let assessments = evaluate_content(&temp_guardrail, &all_text);
+    let action = if assessments.is_empty() {
+        "NONE"
+    } else {
+        "GUARDRAIL_INTERVENED"
+    };
+
+    let source = input["source"].as_str().unwrap_or("INPUT");
+    let outputs = if action == "GUARDRAIL_INTERVENED" {
+        let msg = if source == "INPUT" {
+            &temp_guardrail.blocked_input_messaging
+        } else {
+            &temp_guardrail.blocked_outputs_messaging
+        };
+        vec![json!({"text": msg})]
+    } else {
+        content_blocks
+            .map(|blocks| {
+                blocks
+                    .iter()
+                    .filter_map(|b| b["text"].as_str().map(|t| json!({"text": t})))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+
+    let resp = json!({
+        "usage": {
+            "topicPolicyUnits": 1,
+            "contentPolicyUnits": 1,
+            "wordPolicyUnits": 1,
+            "sensitiveInformationPolicyUnits": 1,
+            "sensitiveInformationPolicyFreeUnits": 0
+        },
+        "action": action,
+        "outputs": outputs,
+        "assessments": assessments,
+    });
+
+    Ok(AwsResponse::ok_json(resp))
 }
 
 // ── Content evaluation ─────────────────────────────────────────────

--- a/crates/fakecloud-bedrock/src/guardrails.rs
+++ b/crates/fakecloud-bedrock/src/guardrails.rs
@@ -114,7 +114,8 @@ pub fn list_guardrails(
         .query_params
         .get("maxResults")
         .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(100);
+        .unwrap_or(100)
+        .max(1);
     let next_token = req.query_params.get("nextToken");
 
     let s = state.read();
@@ -149,8 +150,9 @@ pub fn list_guardrails(
         .collect();
 
     let mut resp = json!({ "guardrails": page });
-    if start + max_results < items.len() {
-        if let Some(last) = items.get(start + max_results - 1) {
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
             resp["nextToken"] = json!(last.guardrail_id);
         }
     }
@@ -381,7 +383,12 @@ pub fn apply_guardrail(
             .map(|blocks| {
                 blocks
                     .iter()
-                    .filter_map(|b| b["text"].as_str().map(|t| json!({"text": t})))
+                    .filter_map(|b| {
+                        b["text"]["text"]
+                            .as_str()
+                            .or_else(|| b["text"].as_str())
+                            .map(|t| json!({"text": t}))
+                    })
                     .collect()
             })
             .unwrap_or_default()

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -13,6 +13,15 @@ pub fn invoke_model(
     model_id: &str,
     body: &[u8],
 ) -> Result<AwsResponse, AwsServiceError> {
+    // Validate model ID
+    if model_id.is_empty() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "modelId is required",
+        ));
+    }
+
     let input: Value = serde_json::from_slice(body).unwrap_or_default();
 
     let response_body = {
@@ -38,6 +47,10 @@ pub fn invoke_model(
     let mut headers = http::HeaderMap::new();
     headers.insert("x-amzn-bedrock-input-token-count", "10".parse().unwrap());
     headers.insert("x-amzn-bedrock-output-token-count", "20".parse().unwrap());
+    headers.insert(
+        "x-amzn-bedrock-performanceconfig-latency",
+        "standard".parse().unwrap(),
+    );
 
     Ok(AwsResponse {
         status: StatusCode::OK,
@@ -45,6 +58,74 @@ pub fn invoke_model(
         body: bytes::Bytes::from(response_body),
         headers,
     })
+}
+
+/// Count tokens for the given input text (rough approximation).
+pub fn count_tokens(
+    _state: &SharedBedrockState,
+    model_id: &str,
+    body: &[u8],
+) -> Result<AwsResponse, AwsServiceError> {
+    if model_id.is_empty() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "modelId is required",
+        ));
+    }
+
+    let input: Value = serde_json::from_slice(body).unwrap_or_default();
+
+    // Extract text from either invokeModel or converse format
+    let text = if let Some(invoke_input) = input.get("input") {
+        if let Some(invoke_model) = invoke_input.get("invokeModel") {
+            // InvokeModel format — body is a document
+            if let Some(body_doc) = invoke_model.get("body") {
+                serde_json::to_string(body_doc).unwrap_or_default()
+            } else {
+                String::new()
+            }
+        } else if let Some(converse) = invoke_input.get("converse") {
+            // Converse format — extract messages and system text
+            let mut all_text = String::new();
+            if let Some(system) = converse.get("system").and_then(|s| s.as_array()) {
+                for block in system {
+                    if let Some(t) = block["text"].as_str() {
+                        all_text.push_str(t);
+                        all_text.push(' ');
+                    }
+                }
+            }
+            if let Some(messages) = converse.get("messages").and_then(|m| m.as_array()) {
+                for msg in messages {
+                    if let Some(content) = msg.get("content").and_then(|c| c.as_array()) {
+                        for block in content {
+                            if let Some(t) = block["text"].as_str() {
+                                all_text.push_str(t);
+                                all_text.push(' ');
+                            }
+                        }
+                    }
+                }
+            }
+            all_text
+        } else {
+            serde_json::to_string(&input).unwrap_or_default()
+        }
+    } else {
+        serde_json::to_string(&input).unwrap_or_default()
+    };
+
+    // Rough token count: split by whitespace
+    let token_count = if text.is_empty() {
+        0
+    } else {
+        text.split_whitespace().count()
+    };
+
+    Ok(AwsResponse::ok_json(json!({
+        "inputTokens": token_count
+    })))
 }
 
 /// Generate a deterministic canned response based on the model provider.

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod async_invoke;
 pub mod converse;
 pub mod customization;
 

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -16,32 +16,7 @@ impl BedrockService {
         Self { state }
     }
 
-    /// Determine the action from the HTTP method and path segments.
-    /// Bedrock control plane uses REST-JSON routing:
-    ///   GET    /foundation-models                                  -> ListFoundationModels
-    ///   GET    /foundation-models/{modelIdentifier}                -> GetFoundationModel
-    ///   POST   /guardrails                                         -> CreateGuardrail
-    ///   GET    /guardrails                                          -> ListGuardrails
-    ///   GET    /guardrails/{guardrailIdentifier}                   -> GetGuardrail
-    ///   PUT    /guardrails/{guardrailIdentifier}                   -> UpdateGuardrail
-    ///   DELETE /guardrails/{guardrailIdentifier}                   -> DeleteGuardrail
-    ///   POST   /guardrails/{guardrailIdentifier}                   -> CreateGuardrailVersion
-    ///   POST   /model-customization-jobs                           -> CreateModelCustomizationJob
-    ///   GET    /model-customization-jobs                            -> ListModelCustomizationJobs
-    ///   GET    /model-customization-jobs/{jobIdentifier}           -> GetModelCustomizationJob
-    ///   POST   /model-customization-jobs/{jobIdentifier}/stop      -> StopModelCustomizationJob
-    ///   POST   /provisioned-model-throughput                       -> CreateProvisionedModelThroughput
-    ///   GET    /provisioned-model-throughputs                       -> ListProvisionedModelThroughputs
-    ///   GET    /provisioned-model-throughput/{provisionedModelId}  -> GetProvisionedModelThroughput
-    ///   PATCH  /provisioned-model-throughput/{provisionedModelId}  -> UpdateProvisionedModelThroughput
-    ///   DELETE /provisioned-model-throughput/{provisionedModelId}  -> DeleteProvisionedModelThroughput
-    ///   PUT    /logging/modelinvocations                            -> PutModelInvocationLoggingConfiguration
-    ///   GET    /logging/modelinvocations                            -> GetModelInvocationLoggingConfiguration
-    ///   DELETE /logging/modelinvocations                            -> DeleteModelInvocationLoggingConfiguration
-    ///   POST   /tagResource                                          -> TagResource
-    ///   POST   /untagResource                                        -> UntagResource
-    ///   POST   /listTagsForResource                                  -> ListTagsForResource
-    fn resolve_action(req: &AwsRequest) -> Option<(&str, Option<String>)> {
+    fn resolve_action(req: &AwsRequest) -> Option<(&str, Option<String>, Option<String>)> {
         let segs = &req.path_segments;
         if segs.is_empty() {
             return None;
@@ -56,89 +31,131 @@ impl BedrockService {
         match (req.method.clone(), segs.len()) {
             // Foundation models
             (Method::GET, 1) if segs[0] == "foundation-models" => {
-                Some(("ListFoundationModels", None))
+                Some(("ListFoundationModels", None, None))
             }
             (Method::GET, 2) if segs[0] == "foundation-models" => {
-                Some(("GetFoundationModel", Some(decode(&segs[1]))))
+                Some(("GetFoundationModel", Some(decode(&segs[1])), None))
             }
 
             // Guardrails
-            (Method::POST, 1) if segs[0] == "guardrails" => Some(("CreateGuardrail", None)),
-            (Method::GET, 1) if segs[0] == "guardrails" => Some(("ListGuardrails", None)),
+            (Method::POST, 1) if segs[0] == "guardrails" => Some(("CreateGuardrail", None, None)),
+            (Method::GET, 1) if segs[0] == "guardrails" => Some(("ListGuardrails", None, None)),
             (Method::GET, 2) if segs[0] == "guardrails" => {
-                Some(("GetGuardrail", Some(decode(&segs[1]))))
+                Some(("GetGuardrail", Some(decode(&segs[1])), None))
             }
             (Method::PUT, 2) if segs[0] == "guardrails" => {
-                Some(("UpdateGuardrail", Some(decode(&segs[1]))))
+                Some(("UpdateGuardrail", Some(decode(&segs[1])), None))
             }
             (Method::DELETE, 2) if segs[0] == "guardrails" => {
-                Some(("DeleteGuardrail", Some(decode(&segs[1]))))
+                Some(("DeleteGuardrail", Some(decode(&segs[1])), None))
             }
-            // POST /guardrails/{id} -> CreateGuardrailVersion (distinguished from CreateGuardrail by path length)
             (Method::POST, 2) if segs[0] == "guardrails" => {
-                Some(("CreateGuardrailVersion", Some(decode(&segs[1]))))
+                Some(("CreateGuardrailVersion", Some(decode(&segs[1])), None))
             }
+
             // Model customization jobs
             (Method::POST, 1) if segs[0] == "model-customization-jobs" => {
-                Some(("CreateModelCustomizationJob", None))
+                Some(("CreateModelCustomizationJob", None, None))
             }
             (Method::GET, 1) if segs[0] == "model-customization-jobs" => {
-                Some(("ListModelCustomizationJobs", None))
+                Some(("ListModelCustomizationJobs", None, None))
             }
             (Method::GET, 2) if segs[0] == "model-customization-jobs" => {
-                Some(("GetModelCustomizationJob", Some(decode(&segs[1]))))
+                Some(("GetModelCustomizationJob", Some(decode(&segs[1])), None))
             }
             (Method::POST, 3) if segs[0] == "model-customization-jobs" && segs[2] == "stop" => {
-                Some(("StopModelCustomizationJob", Some(decode(&segs[1]))))
+                Some(("StopModelCustomizationJob", Some(decode(&segs[1])), None))
             }
 
             // Provisioned model throughput
             (Method::POST, 1) if segs[0] == "provisioned-model-throughput" => {
-                Some(("CreateProvisionedModelThroughput", None))
+                Some(("CreateProvisionedModelThroughput", None, None))
             }
             (Method::GET, 1) if segs[0] == "provisioned-model-throughputs" => {
-                Some(("ListProvisionedModelThroughputs", None))
+                Some(("ListProvisionedModelThroughputs", None, None))
             }
-            (Method::GET, 2) if segs[0] == "provisioned-model-throughput" => {
-                Some(("GetProvisionedModelThroughput", Some(decode(&segs[1]))))
-            }
-            (Method::PATCH, 2) if segs[0] == "provisioned-model-throughput" => {
-                Some(("UpdateProvisionedModelThroughput", Some(decode(&segs[1]))))
-            }
-            (Method::DELETE, 2) if segs[0] == "provisioned-model-throughput" => {
-                Some(("DeleteProvisionedModelThroughput", Some(decode(&segs[1]))))
-            }
+            (Method::GET, 2) if segs[0] == "provisioned-model-throughput" => Some((
+                "GetProvisionedModelThroughput",
+                Some(decode(&segs[1])),
+                None,
+            )),
+            (Method::PATCH, 2) if segs[0] == "provisioned-model-throughput" => Some((
+                "UpdateProvisionedModelThroughput",
+                Some(decode(&segs[1])),
+                None,
+            )),
+            (Method::DELETE, 2) if segs[0] == "provisioned-model-throughput" => Some((
+                "DeleteProvisionedModelThroughput",
+                Some(decode(&segs[1])),
+                None,
+            )),
 
             // Logging configuration
             (Method::PUT, 2) if segs[0] == "logging" && segs[1] == "modelinvocations" => {
-                Some(("PutModelInvocationLoggingConfiguration", None))
+                Some(("PutModelInvocationLoggingConfiguration", None, None))
             }
             (Method::GET, 2) if segs[0] == "logging" && segs[1] == "modelinvocations" => {
-                Some(("GetModelInvocationLoggingConfiguration", None))
+                Some(("GetModelInvocationLoggingConfiguration", None, None))
             }
             (Method::DELETE, 2) if segs[0] == "logging" && segs[1] == "modelinvocations" => {
-                Some(("DeleteModelInvocationLoggingConfiguration", None))
+                Some(("DeleteModelInvocationLoggingConfiguration", None, None))
             }
 
-            // Runtime operations (same SigV4 service name "bedrock")
+            // Runtime: ApplyGuardrail — POST /guardrail/{id}/version/{version}/apply
+            (Method::POST, 5)
+                if segs[0] == "guardrail" && segs[2] == "version" && segs[4] == "apply" =>
+            {
+                Some((
+                    "ApplyGuardrail",
+                    Some(decode(&segs[1])),
+                    Some(decode(&segs[3])),
+                ))
+            }
+
+            // Runtime: model operations
             (Method::POST, 3) if segs[0] == "model" && segs[2] == "invoke" => {
-                Some(("InvokeModel", Some(decode(&segs[1]))))
+                Some(("InvokeModel", Some(decode(&segs[1])), None))
             }
             (Method::POST, 3) if segs[0] == "model" && segs[2] == "invoke-with-response-stream" => {
-                Some(("InvokeModelWithResponseStream", Some(decode(&segs[1]))))
+                Some((
+                    "InvokeModelWithResponseStream",
+                    Some(decode(&segs[1])),
+                    None,
+                ))
+            }
+            (Method::POST, 3)
+                if segs[0] == "model" && segs[2] == "invoke-with-bidirectional-stream" =>
+            {
+                Some((
+                    "InvokeModelWithBidirectionalStream",
+                    Some(decode(&segs[1])),
+                    None,
+                ))
             }
             (Method::POST, 3) if segs[0] == "model" && segs[2] == "converse" => {
-                Some(("Converse", Some(decode(&segs[1]))))
+                Some(("Converse", Some(decode(&segs[1])), None))
             }
             (Method::POST, 3) if segs[0] == "model" && segs[2] == "converse-stream" => {
-                Some(("ConverseStream", Some(decode(&segs[1]))))
+                Some(("ConverseStream", Some(decode(&segs[1])), None))
+            }
+            (Method::POST, 3) if segs[0] == "model" && segs[2] == "count-tokens" => {
+                Some(("CountTokens", Some(decode(&segs[1])), None))
+            }
+
+            // Runtime: async invoke
+            (Method::POST, 1) if segs[0] == "async-invoke" => {
+                Some(("StartAsyncInvoke", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "async-invoke" => Some(("ListAsyncInvokes", None, None)),
+            (Method::GET, 2) if segs[0] == "async-invoke" => {
+                Some(("GetAsyncInvoke", Some(decode(&segs[1])), None))
             }
 
             // Tags — all POST with ARN in body
-            (Method::POST, 1) if segs[0] == "tagResource" => Some(("TagResource", None)),
-            (Method::POST, 1) if segs[0] == "untagResource" => Some(("UntagResource", None)),
+            (Method::POST, 1) if segs[0] == "tagResource" => Some(("TagResource", None, None)),
+            (Method::POST, 1) if segs[0] == "untagResource" => Some(("UntagResource", None, None)),
             (Method::POST, 1) if segs[0] == "listTagsForResource" => {
-                Some(("ListTagsForResource", None))
+                Some(("ListTagsForResource", None, None))
             }
 
             _ => None,
@@ -148,7 +165,6 @@ impl BedrockService {
     fn list_foundation_models(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let mut model_summaries: Vec<Value> = Vec::new();
 
-        // Optional filters from query parameters
         let by_provider = req.query_params.get("byProvider");
         let by_output_modality = req.query_params.get("byOutputModality");
         let by_input_modality = req.query_params.get("byInputModality");
@@ -288,7 +304,7 @@ impl AwsService for BedrockService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let (action, resource_id) =
+        let (action, resource_id, extra_id) =
             Self::resolve_action(&req).ok_or_else(|| AwsServiceError::ActionNotImplemented {
                 service: "bedrock".to_string(),
                 action: format!("{} {}", req.method, req.raw_path),
@@ -331,7 +347,7 @@ impl AwsService for BedrockService {
                 &req,
                 &resource_id.unwrap_or_default(),
             ),
-            "ListGuardrails" => crate::guardrails::list_guardrails(&self.state),
+            "ListGuardrails" => crate::guardrails::list_guardrails(&self.state, &req),
             "UpdateGuardrail" => {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
                 crate::guardrails::update_guardrail(
@@ -351,6 +367,12 @@ impl AwsService for BedrockService {
                     &body,
                 )
             }
+            "ApplyGuardrail" => crate::guardrails::apply_guardrail(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+                &extra_id.unwrap_or_default(),
+                &req.body,
+            ),
             // Model customization jobs
             "CreateModelCustomizationJob" => {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
@@ -362,7 +384,7 @@ impl AwsService for BedrockService {
                 &resource_id.unwrap_or_default(),
             ),
             "ListModelCustomizationJobs" => {
-                crate::customization::list_model_customization_jobs(&self.state)
+                crate::customization::list_model_customization_jobs(&self.state, &req)
             }
             "StopModelCustomizationJob" => crate::customization::stop_model_customization_job(
                 &self.state,
@@ -378,7 +400,7 @@ impl AwsService for BedrockService {
                 &resource_id.unwrap_or_default(),
             ),
             "ListProvisionedModelThroughputs" => {
-                crate::throughput::list_provisioned_model_throughputs(&self.state)
+                crate::throughput::list_provisioned_model_throughputs(&self.state, &req)
             }
             "UpdateProvisionedModelThroughput" => {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
@@ -411,10 +433,15 @@ impl AwsService for BedrockService {
                 &resource_id.unwrap_or_default(),
                 &req.body,
             ),
+            "CountTokens" => crate::invoke::count_tokens(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+                &req.body,
+            ),
             "Converse" => {
                 crate::converse::converse(&self.state, &resource_id.unwrap_or_default(), &req.body)
             }
-            "InvokeModelWithResponseStream" => {
+            "InvokeModelWithResponseStream" | "InvokeModelWithBidirectionalStream" => {
                 let model_id = resource_id.unwrap_or_default();
                 let response_text = crate::streaming::get_response_text(&self.state, &model_id);
                 let body =
@@ -461,6 +488,16 @@ impl AwsService for BedrockService {
                     headers: http::HeaderMap::new(),
                 })
             }
+            // Async invoke
+            "StartAsyncInvoke" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::async_invoke::start_async_invoke(&self.state, &req, &body)
+            }
+            "GetAsyncInvoke" => {
+                crate::async_invoke::get_async_invoke(&self.state, &resource_id.unwrap_or_default())
+            }
+            "ListAsyncInvokes" => crate::async_invoke::list_async_invokes(&self.state, &req),
+
             _ => Err(AwsServiceError::ActionNotImplemented {
                 service: "bedrock".to_string(),
                 action: action.to_string(),
@@ -481,6 +518,7 @@ impl AwsService for BedrockService {
             "UpdateGuardrail",
             "DeleteGuardrail",
             "CreateGuardrailVersion",
+            "ApplyGuardrail",
             "CreateModelCustomizationJob",
             "GetModelCustomizationJob",
             "ListModelCustomizationJobs",
@@ -495,8 +533,13 @@ impl AwsService for BedrockService {
             "DeleteModelInvocationLoggingConfiguration",
             "InvokeModel",
             "InvokeModelWithResponseStream",
+            "InvokeModelWithBidirectionalStream",
             "Converse",
             "ConverseStream",
+            "CountTokens",
+            "StartAsyncInvoke",
+            "GetAsyncInvoke",
+            "ListAsyncInvokes",
         ]
     }
 }

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -25,6 +25,8 @@ pub struct BedrockState {
     pub invocations: Vec<ModelInvocation>,
     /// Custom responses configured per model ID via simulation endpoint.
     pub custom_responses: HashMap<String, String>,
+    /// Async invocations keyed by invocation ARN.
+    pub async_invocations: HashMap<String, AsyncInvocation>,
 }
 
 impl BedrockState {
@@ -40,6 +42,7 @@ impl BedrockState {
             logging_config: None,
             invocations: Vec::new(),
             custom_responses: HashMap::new(),
+            async_invocations: HashMap::new(),
         }
     }
 
@@ -52,6 +55,7 @@ impl BedrockState {
         self.logging_config = None;
         self.invocations.clear();
         self.custom_responses.clear();
+        self.async_invocations.clear();
     }
 }
 
@@ -135,4 +139,17 @@ pub struct ModelInvocation {
     pub input: String,
     pub output: String,
     pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct AsyncInvocation {
+    pub invocation_arn: String,
+    pub model_arn: String,
+    pub model_input: serde_json::Value,
+    pub output_data_config: serde_json::Value,
+    pub client_request_token: Option<String>,
+    pub status: String,
+    pub submit_time: DateTime<Utc>,
+    pub last_modified_time: DateTime<Utc>,
+    pub end_time: Option<DateTime<Utc>>,
 }

--- a/crates/fakecloud-bedrock/src/throughput.rs
+++ b/crates/fakecloud-bedrock/src/throughput.rs
@@ -23,6 +23,26 @@ pub fn create_provisioned_model_throughput(
     let model_id = body["modelId"].as_str().unwrap_or_default();
     let model_units = body["modelUnits"].as_i64().unwrap_or(1) as i32;
 
+    if model_units < 1 {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "modelUnits must be at least 1",
+        ));
+    }
+
+    if let Some(duration) = body["commitmentDuration"].as_str() {
+        if !["OneMonth", "SixMonths"].contains(&duration) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "Invalid commitmentDuration: {duration}. Valid values: OneMonth, SixMonths"
+                ),
+            ));
+        }
+    }
+
     let provisioned_model_id = Uuid::new_v4().to_string()[..12].to_string();
     let provisioned_model_arn = format!(
         "arn:aws:bedrock:{}:{}:provisioned-model/{}",
@@ -77,11 +97,32 @@ pub fn get_provisioned_model_throughput(
 
 pub fn list_provisioned_model_throughputs(
     state: &SharedBedrockState,
+    req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100);
+    let next_token = req.query_params.get("nextToken");
+
     let s = state.read();
-    let summaries: Vec<Value> = s
-        .provisioned_throughputs
-        .values()
+    let mut items: Vec<&ProvisionedThroughput> = s.provisioned_throughputs.values().collect();
+    items.sort_by(|a, b| a.provisioned_model_id.cmp(&b.provisioned_model_id));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|t| t.provisioned_model_id.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
         .map(|t| {
             json!({
                 "provisionedModelName": t.provisioned_model_name,
@@ -98,9 +139,14 @@ pub fn list_provisioned_model_throughputs(
         })
         .collect();
 
-    Ok(AwsResponse::ok_json(
-        json!({ "provisionedModelSummaries": summaries }),
-    ))
+    let mut resp = json!({ "provisionedModelSummaries": page });
+    if start + max_results < items.len() {
+        if let Some(last) = items.get(start + max_results - 1) {
+            resp["nextToken"] = json!(last.provisioned_model_id);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
 }
 
 pub fn update_provisioned_model_throughput(

--- a/crates/fakecloud-bedrock/src/throughput.rs
+++ b/crates/fakecloud-bedrock/src/throughput.rs
@@ -103,7 +103,8 @@ pub fn list_provisioned_model_throughputs(
         .query_params
         .get("maxResults")
         .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(100);
+        .unwrap_or(100)
+        .max(1);
     let next_token = req.query_params.get("nextToken");
 
     let s = state.read();
@@ -140,8 +141,9 @@ pub fn list_provisioned_model_throughputs(
         .collect();
 
     let mut resp = json!({ "provisionedModelSummaries": page });
-    if start + max_results < items.len() {
-        if let Some(last) = items.get(start + max_results - 1) {
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
             resp["nextToken"] = json!(last.provisioned_model_id);
         }
     }

--- a/crates/fakecloud-conformance/tests/bedrock.rs
+++ b/crates/fakecloud-conformance/tests/bedrock.rs
@@ -513,6 +513,198 @@ async fn bedrock_converse_conformance() {
 }
 
 // ---------------------------------------------------------------------------
+// ApplyGuardrail (Runtime)
+// ---------------------------------------------------------------------------
+
+#[test_action("bedrock-runtime", "ApplyGuardrail", checksum = "ab609d3b")]
+#[tokio::test]
+async fn bedrock_apply_guardrail_conformance() {
+    let server = TestServer::start().await;
+    let bedrock_client = server.bedrock_client().await;
+    let runtime_client = server.bedrock_runtime_client().await;
+
+    let resp = bedrock_client
+        .create_guardrail()
+        .name("apply-conf")
+        .blocked_input_messaging("blocked")
+        .blocked_outputs_messaging("blocked")
+        .word_policy_config(
+            aws_sdk_bedrock::types::GuardrailWordPolicyConfig::builder()
+                .words_config(
+                    aws_sdk_bedrock::types::GuardrailWordConfig::builder()
+                        .text("badword")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let guardrail_id = resp.guardrail_id().to_string();
+
+    let version_resp = bedrock_client
+        .create_guardrail_version()
+        .guardrail_identifier(&guardrail_id)
+        .send()
+        .await
+        .unwrap();
+
+    let result = runtime_client
+        .apply_guardrail()
+        .guardrail_identifier(&guardrail_id)
+        .guardrail_version(version_resp.version())
+        .source(aws_sdk_bedrockruntime::types::GuardrailContentSource::Input)
+        .content(aws_sdk_bedrockruntime::types::GuardrailContentBlock::Text(
+            aws_sdk_bedrockruntime::types::GuardrailTextBlock::builder()
+                .text("this has badword in it")
+                .build()
+                .unwrap(),
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(result.action().as_str(), "GUARDRAIL_INTERVENED");
+}
+
+#[test_action("bedrock-runtime", "CountTokens", checksum = "6f28bb5c")]
+#[tokio::test]
+async fn bedrock_count_tokens_conformance() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    let body = serde_json::json!({
+        "input": {
+            "converse": {
+                "messages": [
+                    {"role": "user", "content": [{"text": "Hello world"}]}
+                ]
+            }
+        }
+    });
+
+    let resp = http_client
+        .post(format!(
+            "{}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/count-tokens",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert!(result["inputTokens"].as_i64().unwrap() > 0);
+}
+
+#[test_action("bedrock-runtime", "StartAsyncInvoke", checksum = "bee22eb2")]
+#[test_action("bedrock-runtime", "GetAsyncInvoke", checksum = "fa2624ed")]
+#[test_action("bedrock-runtime", "ListAsyncInvokes", checksum = "b76e6e1c")]
+#[tokio::test]
+async fn bedrock_async_invoke_conformance() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    let body = serde_json::json!({
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "modelInput": {"messages": [{"role": "user", "content": "Hello"}]},
+        "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://bucket/out/"}}
+    });
+
+    let resp = http_client
+        .post(format!("{}/async-invoke", server.endpoint()))
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let arn = result["invocationArn"].as_str().unwrap();
+    assert!(arn.contains("async-invoke/"));
+
+    // Get
+    let resp = http_client
+        .get(format!(
+            "{}/async-invoke/{}",
+            server.endpoint(),
+            arn.rsplit('/').next().unwrap()
+        ))
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // List
+    let resp = http_client
+        .get(format!("{}/async-invoke", server.endpoint()))
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert!(!result["asyncInvokeSummaries"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+}
+
+#[test_action(
+    "bedrock-runtime",
+    "InvokeModelWithBidirectionalStream",
+    checksum = "6b0e9775"
+)]
+#[tokio::test]
+async fn bedrock_bidirectional_stream_conformance() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    let body = serde_json::json!({"messages": [{"role": "user", "content": "Hello"}]});
+
+    let resp = http_client
+        .post(format!(
+            "{}/model/amazon.nova-sonic-v1:0/invoke-with-bidirectional-stream",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "application/vnd.amazon.eventstream"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Streaming (raw HTTP since SDK event stream parsing is complex)
 // ---------------------------------------------------------------------------
 

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -722,6 +722,378 @@ async fn bedrock_simulation_custom_response() {
 }
 
 // ---------------------------------------------------------------------------
+// ApplyGuardrail (Runtime)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_apply_guardrail() {
+    let server = TestServer::start().await;
+    let bedrock_client = server.bedrock_client().await;
+    let runtime_client = server.bedrock_runtime_client().await;
+
+    // Create a guardrail with a word policy
+    let word_policy = GuardrailWordPolicyConfig::builder()
+        .words_config(
+            GuardrailWordConfig::builder()
+                .text("forbidden")
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    let resp = bedrock_client
+        .create_guardrail()
+        .name("apply-test-guardrail")
+        .blocked_input_messaging("Input blocked")
+        .blocked_outputs_messaging("Output blocked")
+        .word_policy_config(word_policy)
+        .send()
+        .await
+        .unwrap();
+    let guardrail_id = resp.guardrail_id().to_string();
+
+    // Create a version
+    let version_resp = bedrock_client
+        .create_guardrail_version()
+        .guardrail_identifier(&guardrail_id)
+        .send()
+        .await
+        .unwrap();
+    let version = version_resp.version().to_string();
+
+    // Apply guardrail with safe content — should pass
+    let safe_resp = runtime_client
+        .apply_guardrail()
+        .guardrail_identifier(&guardrail_id)
+        .guardrail_version(&version)
+        .source(aws_sdk_bedrockruntime::types::GuardrailContentSource::Input)
+        .content(aws_sdk_bedrockruntime::types::GuardrailContentBlock::Text(
+            aws_sdk_bedrockruntime::types::GuardrailTextBlock::builder()
+                .text("Hello, this is safe content")
+                .build()
+                .unwrap(),
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(safe_resp.action().as_str(), "NONE");
+
+    // Apply guardrail with forbidden word — should block
+    let blocked_resp = runtime_client
+        .apply_guardrail()
+        .guardrail_identifier(&guardrail_id)
+        .guardrail_version(&version)
+        .source(aws_sdk_bedrockruntime::types::GuardrailContentSource::Input)
+        .content(aws_sdk_bedrockruntime::types::GuardrailContentBlock::Text(
+            aws_sdk_bedrockruntime::types::GuardrailTextBlock::builder()
+                .text("This contains the forbidden word")
+                .build()
+                .unwrap(),
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(blocked_resp.action().as_str(), "GUARDRAIL_INTERVENED");
+    assert!(!blocked_resp.assessments().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Converse with inferenceConfig and toolConfig
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_converse_with_system_and_inference_config() {
+    let server = TestServer::start().await;
+    let client = server.bedrock_runtime_client().await;
+
+    let resp = client
+        .converse()
+        .model_id("anthropic.claude-3-5-sonnet-20241022-v2:0")
+        .system(aws_sdk_bedrockruntime::types::SystemContentBlock::Text(
+            "You are a helpful assistant.".to_string(),
+        ))
+        .messages(
+            aws_sdk_bedrockruntime::types::Message::builder()
+                .role(aws_sdk_bedrockruntime::types::ConversationRole::User)
+                .content(aws_sdk_bedrockruntime::types::ContentBlock::Text(
+                    "Hello!".to_string(),
+                ))
+                .build()
+                .unwrap(),
+        )
+        .inference_config(
+            aws_sdk_bedrockruntime::types::InferenceConfiguration::builder()
+                .max_tokens(50)
+                .temperature(0.7_f32)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.stop_reason().as_str(), "end_turn");
+    let usage = resp.usage().expect("should have usage");
+    assert!(usage.input_tokens() > 0);
+    assert!(usage.output_tokens() > 0);
+}
+
+#[tokio::test]
+async fn bedrock_converse_with_tool_config() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    let body = serde_json::json!({
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "messages": [
+            {"role": "user", "content": [{"text": "What's the weather?"}]}
+        ],
+        "toolConfig": {
+            "tools": [
+                {
+                    "toolSpec": {
+                        "name": "get_weather",
+                        "description": "Get weather for a location",
+                        "inputSchema": {
+                            "json": {"type": "object", "properties": {}}
+                        }
+                    }
+                }
+            ]
+        }
+    });
+
+    let resp = http_client
+        .post(format!(
+            "{}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(result["stopReason"], "tool_use");
+
+    let content = result["output"]["message"]["content"].as_array().unwrap();
+    assert!(content.len() >= 2, "should have text and tool_use blocks");
+    assert!(
+        content.iter().any(|c| c.get("toolUse").is_some()),
+        "should have a toolUse block"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CountTokens (Runtime)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_count_tokens_raw() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    let body = serde_json::json!({
+        "input": {
+            "converse": {
+                "messages": [
+                    {"role": "user", "content": [{"text": "Hello world how are you today"}]}
+                ]
+            }
+        }
+    });
+
+    let resp = http_client
+        .post(format!(
+            "{}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/count-tokens",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let token_count = result["inputTokens"].as_i64().unwrap();
+    assert!(token_count > 0, "should count some tokens");
+}
+
+// ---------------------------------------------------------------------------
+// Async Invoke (Runtime)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_async_invoke_lifecycle_raw() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    // Start async invoke
+    let body = serde_json::json!({
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "modelInput": {"messages": [{"role": "user", "content": "Hello"}]},
+        "outputDataConfig": {
+            "s3OutputDataConfig": {
+                "s3Uri": "s3://my-bucket/output/"
+            }
+        }
+    });
+
+    let resp = http_client
+        .post(format!("{}/async-invoke", server.endpoint()))
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let invocation_arn = result["invocationArn"].as_str().unwrap();
+    assert!(invocation_arn.contains("async-invoke/"));
+
+    // Get async invoke
+    let resp = http_client
+        .get(format!(
+            "{}/async-invoke/{}",
+            server.endpoint(),
+            invocation_arn.rsplit('/').next().unwrap()
+        ))
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(result["status"], "Completed");
+    assert_eq!(result["invocationArn"], invocation_arn);
+
+    // List async invokes
+    let resp = http_client
+        .get(format!("{}/async-invoke", server.endpoint()))
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let summaries = result["asyncInvokeSummaries"].as_array().unwrap();
+    assert!(!summaries.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// InvokeModelWithBidirectionalStream (via raw HTTP)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_invoke_model_with_bidirectional_stream_raw() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    let body = serde_json::json!({
+        "messages": [{"role": "user", "content": "Hello"}]
+    });
+
+    let resp = http_client
+        .post(format!(
+            "{}/model/amazon.nova-sonic-v1:0/invoke-with-bidirectional-stream",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_eq!(content_type, "application/vnd.amazon.eventstream");
+    let body_bytes = resp.bytes().await.unwrap();
+    assert!(body_bytes.len() > 16, "should have event stream data");
+}
+
+// ---------------------------------------------------------------------------
+// InvokeModel response headers
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_invoke_model_response_headers() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    let body = serde_json::json!({
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 10,
+        "messages": [{"role": "user", "content": "Hi"}]
+    });
+
+    let resp = http_client
+        .post(format!(
+            "{}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    assert!(resp
+        .headers()
+        .contains_key("x-amzn-bedrock-input-token-count"));
+    assert!(resp
+        .headers()
+        .contains_key("x-amzn-bedrock-output-token-count"));
+    assert!(resp
+        .headers()
+        .contains_key("x-amzn-bedrock-performanceconfig-latency"));
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "application/json"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Streaming (via raw HTTP — AWS SDK event stream parsing is complex)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add nextToken/maxResults pagination to all existing List* operations (ListGuardrails, ListModelCustomizationJobs, ListProvisionedModelThroughputs)
- Improve Converse handler: parse inferenceConfig (maxTokens truncation), system prompts (accurate token counting), toolConfig (return tool_use blocks)
- Add missing InvokeModel response headers (X-Amzn-Bedrock-PerformanceConfig-Latency)
- Add input validation for provisioned throughput (modelUnits range, commitmentDuration values)
- Implement 6 new Bedrock Runtime operations: ApplyGuardrail, CountTokens, StartAsyncInvoke, GetAsyncInvoke, ListAsyncInvokes, InvokeModelWithBidirectionalStream
- Add Bedrock and Bedrock Runtime to README services table

## Test plan

- [x] 26 E2E tests passing (all existing + 8 new)
- [x] 21 conformance tests passing (all existing + 6 new)
- [x] clippy clean, fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pagination to Bedrock list APIs, improves Converse correctness and token accounting, and adds six Bedrock Runtime operations (guardrail application, token counting, async invoke, bidirectional streaming). Also adds provisioned throughput validation, a missing response header, and robustness fixes for UTF-8 truncation and pagination edge cases.

- **New Features**
  - Pagination: `ListGuardrails`, `ListModelCustomizationJobs`, `ListProvisionedModelThroughputs` now support `nextToken`/`maxResults`.
  - Converse: respects `inferenceConfig.maxTokens`, counts tokens including system prompts, emits `tool_use` blocks and `stopReason: "tool_use"` when `toolConfig` is provided.
  - InvokeModel: returns `x-amzn-bedrock-performanceconfig-latency` header.
  - Validation: `modelUnits >= 1`; `commitmentDuration` limited to `OneMonth` or `SixMonths`.
  - Runtime ops: `ApplyGuardrail`, `CountTokens`, `StartAsyncInvoke`, `GetAsyncInvoke`, `ListAsyncInvokes`, `InvokeModelWithBidirectionalStream`.
  - Docs: README adds Bedrock Runtime and updates service counts.

- **Bug Fixes**
  - Converse: UTF-8 safe `maxTokens` truncation to avoid panics on multi-byte characters.
  - Pagination: clamp `maxResults` to at least 1 and use safe offsets to prevent underflow when `maxResults=0`.
  - ApplyGuardrail: return original (non-intervened) text correctly, including nested `text.text` blocks.

<sup>Written for commit c215245a94b73a8ee2e49650c9b38da2dd8cbd47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

