### PR TITLE
fix(dynamodb): use configured region in stream records

### DIFF
--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -465,6 +465,7 @@ impl DynamoDbService {
         // Capture kinesis delivery info alongside the return value
         let (old_item, kinesis_info) = {
             let mut state = self.state.write();
+            let region = state.region.clone();
             let table = get_table_mut(&mut state.tables, table_name)?;
 
             validate_key_in_item(table, &item)?;
@@ -517,6 +518,7 @@ impl DynamoDbService {
                     key.clone(),
                     old_item_for_stream.clone(),
                     Some(item.clone()),
+                    &region,
                 ) {
                     crate::streams::add_stream_record(table, record);
                 }
@@ -631,6 +633,7 @@ impl DynamoDbService {
 
         let (result, kinesis_info) = {
             let mut state = self.state.write();
+            let region = state.region.clone();
             let table = get_table_mut(&mut state.tables, table_name)?;
 
             let condition = body["ConditionExpression"].as_str();
@@ -663,6 +666,7 @@ impl DynamoDbService {
                         key.clone(),
                         Some(old_item.clone()),
                         None,
+                        &region,
                     ) {
                         crate::streams::add_stream_record(table, record);
                     }
@@ -714,6 +718,7 @@ impl DynamoDbService {
         let key = require_object(&body, "Key")?;
 
         let mut state = self.state.write();
+        let region = state.region.clone();
         let table = get_table_mut(&mut state.tables, table_name)?;
 
         validate_key_attributes_in_key(table, &key)?;
@@ -789,6 +794,7 @@ impl DynamoDbService {
                 key.clone(),
                 old_item_for_stream.clone(),
                 Some(new_item_for_stream.clone()),
+                &region,
             ) {
                 crate::streams::add_stream_record(table, record);
             }

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -11,6 +11,7 @@ pub fn generate_stream_record(
     keys: HashMap<String, AttributeValue>,
     old_image: Option<HashMap<String, AttributeValue>>,
     new_image: Option<HashMap<String, AttributeValue>>,
+    region: &str,
 ) -> Option<StreamRecord> {
     if !table.stream_enabled {
         return None;
@@ -48,7 +49,7 @@ pub fn generate_stream_record(
         event_name: event_name.to_string(),
         event_version: "1.1".to_string(),
         event_source: "aws:dynamodb".to_string(),
-        aws_region: "us-east-1".to_string(), // TODO: get from state
+        aws_region: region.to_string(),
         dynamodb: DynamoDbStreamRecord {
             keys,
             new_image: filtered_new,
@@ -71,4 +72,75 @@ pub fn add_stream_record(table: &mut DynamoTable, record: StreamRecord) {
     // Clean up records older than 24 hours
     let cutoff = Utc::now() - chrono::Duration::hours(24);
     records.retain(|r| r.timestamp > cutoff);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{KeySchemaElement, ProvisionedThroughput};
+    use parking_lot::RwLock;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    fn make_stream_table() -> DynamoTable {
+        DynamoTable {
+            name: "test-table".to_string(),
+            arn: "arn:aws:dynamodb:eu-west-1:999999999999:table/test-table".to_string(),
+            key_schema: vec![KeySchemaElement {
+                attribute_name: "pk".to_string(),
+                key_type: "HASH".to_string(),
+            }],
+            attribute_definitions: vec![],
+            provisioned_throughput: ProvisionedThroughput {
+                read_capacity_units: 5,
+                write_capacity_units: 5,
+            },
+            items: vec![],
+            gsi: vec![],
+            lsi: vec![],
+            tags: HashMap::new(),
+            created_at: Utc::now(),
+            status: "ACTIVE".to_string(),
+            item_count: 0,
+            size_bytes: 0,
+            billing_mode: "PROVISIONED".to_string(),
+            ttl_attribute: None,
+            ttl_enabled: false,
+            resource_policy: None,
+            pitr_enabled: false,
+            kinesis_destinations: vec![],
+            contributor_insights_status: "DISABLED".to_string(),
+            contributor_insights_counters: HashMap::new(),
+            stream_enabled: true,
+            stream_view_type: Some("NEW_AND_OLD_IMAGES".to_string()),
+            stream_arn: Some(
+                "arn:aws:dynamodb:eu-west-1:999999999999:table/test-table/stream/123".to_string(),
+            ),
+            stream_records: Arc::new(RwLock::new(Vec::new())),
+            sse_type: None,
+            sse_kms_key_arn: None,
+        }
+    }
+
+    #[test]
+    fn stream_record_uses_configured_region() {
+        let table = make_stream_table();
+        let mut keys = HashMap::new();
+        keys.insert("pk".to_string(), json!({"S": "user1"}));
+
+        let record = generate_stream_record(
+            &table,
+            "INSERT",
+            keys,
+            None,
+            Some(HashMap::from([("pk".to_string(), json!({"S": "user1"}))])),
+            "eu-west-1",
+        )
+        .expect("stream record should be generated");
+
+        assert_eq!(
+            record.aws_region, "eu-west-1",
+            "stream record must use the configured region, not a hardcoded value"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- DynamoDB stream records were hardcoded to `us-east-1` regardless of the server's configured region
- Thread the region from `DynamoDbState` through to `generate_stream_record()` for all three call sites (put_item, delete_item, update_item)
- The API Gateway v2 hardcoded values mentioned in the prompt are all in test code only — no production fix needed there

## Test plan

- [x] Unit test verifying stream record uses configured region (`eu-west-1`) instead of hardcoded value
- [x] All 73 DynamoDB unit tests pass
- [x] Clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB stream records to use the configured region instead of hardcoded `us-east-1`. Ensures correct `aws_region` in stream events for all item operations.

- **Bug Fixes**
  - Thread region from `DynamoDbState` into `generate_stream_record()` and call sites (put, delete, update).
  - Set `aws_region` on stream records from the server’s region.
  - Added unit test verifying region is respected (e.g., `eu-west-1`).

<sup>Written for commit 13236d3f0008e488ca53d115860fd95a549b7764. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

