### PR TITLE
feat(bedrock): add Custom Models and Custom Model Deployments (9 ops)

### DIFF
--- a/crates/fakecloud-bedrock/src/custom_model_deployments.rs
+++ b/crates/fakecloud-bedrock/src/custom_model_deployments.rs
@@ -1,0 +1,198 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{CustomModelDeployment, SharedBedrockState};
+
+pub fn create_custom_model_deployment(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let deployment_name = body["modelDeploymentName"].as_str().unwrap_or("deployment");
+    let model_arn = body["modelArn"].as_str().unwrap_or_default();
+
+    let deployment_id = Uuid::new_v4().to_string();
+    let deployment_arn = format!(
+        "arn:aws:bedrock:{}:{}:custom-model-deployment/{}",
+        req.region, req.account_id, deployment_id
+    );
+
+    let now = Utc::now();
+    let deployment = CustomModelDeployment {
+        deployment_arn: deployment_arn.clone(),
+        deployment_name: deployment_name.to_string(),
+        model_arn: model_arn.to_string(),
+        description: body["description"].as_str().map(|s| s.to_string()),
+        status: "Active".to_string(),
+        created_at: now,
+        last_updated_at: now,
+    };
+
+    let mut s = state.write();
+    s.custom_model_deployments
+        .insert(deployment_arn.clone(), deployment);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "customModelDeploymentArn": deployment_arn })).unwrap(),
+    ))
+}
+
+pub fn get_custom_model_deployment(
+    state: &SharedBedrockState,
+    deployment_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let deployment = find_deployment(&s.custom_model_deployments, deployment_identifier)?;
+
+    Ok(AwsResponse::ok_json(deployment_to_json(deployment)))
+}
+
+pub fn list_custom_model_deployments(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&CustomModelDeployment> = s.custom_model_deployments.values().collect();
+    items.sort_by(|a, b| a.deployment_arn.cmp(&b.deployment_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|d| d.deployment_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|d| deployment_summary_json(d))
+        .collect();
+
+    let mut resp = json!({ "modelDeploymentSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.deployment_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn update_custom_model_deployment(
+    state: &SharedBedrockState,
+    deployment_identifier: &str,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+    let key = find_deployment_key(&s.custom_model_deployments, deployment_identifier)?;
+    let deployment = s.custom_model_deployments.get_mut(&key).unwrap();
+
+    if let Some(model_arn) = body["modelArn"].as_str() {
+        deployment.model_arn = model_arn.to_string();
+    }
+    deployment.last_updated_at = Utc::now();
+
+    let arn = deployment.deployment_arn.clone();
+    Ok(AwsResponse::ok_json(
+        json!({ "customModelDeploymentArn": arn }),
+    ))
+}
+
+pub fn delete_custom_model_deployment(
+    state: &SharedBedrockState,
+    deployment_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+    let key = find_deployment_key(&s.custom_model_deployments, deployment_identifier)?;
+    s.custom_model_deployments.remove(&key);
+    Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+}
+
+fn find_deployment<'a>(
+    deployments: &'a std::collections::HashMap<String, CustomModelDeployment>,
+    id_or_arn: &str,
+) -> Result<&'a CustomModelDeployment, AwsServiceError> {
+    deployments
+        .get(id_or_arn)
+        .or_else(|| {
+            deployments.values().find(|d| {
+                d.deployment_name == id_or_arn
+                    || d.deployment_arn.ends_with(&format!("/{id_or_arn}"))
+            })
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Custom model deployment {id_or_arn} not found"),
+            )
+        })
+}
+
+fn find_deployment_key(
+    deployments: &std::collections::HashMap<String, CustomModelDeployment>,
+    id_or_arn: &str,
+) -> Result<String, AwsServiceError> {
+    deployments
+        .iter()
+        .find(|(k, d)| {
+            *k == id_or_arn
+                || d.deployment_name == id_or_arn
+                || d.deployment_arn.ends_with(&format!("/{id_or_arn}"))
+        })
+        .map(|(k, _)| k.clone())
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Custom model deployment {id_or_arn} not found"),
+            )
+        })
+}
+
+fn deployment_to_json(d: &CustomModelDeployment) -> Value {
+    let mut obj = json!({
+        "customModelDeploymentArn": d.deployment_arn,
+        "modelDeploymentName": d.deployment_name,
+        "modelArn": d.model_arn,
+        "status": d.status,
+        "createdAt": d.created_at.to_rfc3339(),
+        "lastUpdatedAt": d.last_updated_at.to_rfc3339(),
+    });
+    if let Some(ref desc) = d.description {
+        obj["description"] = json!(desc);
+    }
+    obj
+}
+
+fn deployment_summary_json(d: &CustomModelDeployment) -> Value {
+    let mut obj = json!({
+        "customModelDeploymentArn": d.deployment_arn,
+        "modelDeploymentName": d.deployment_name,
+        "modelArn": d.model_arn,
+        "status": d.status,
+        "createdAt": d.created_at.to_rfc3339(),
+        "lastUpdatedAt": d.last_updated_at.to_rfc3339(),
+    });
+    if let Some(ref desc) = d.description {
+        obj["description"] = json!(desc);
+    }
+    obj
+}

--- a/crates/fakecloud-bedrock/src/custom_models.rs
+++ b/crates/fakecloud-bedrock/src/custom_models.rs
@@ -1,0 +1,150 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{CustomModel, SharedBedrockState};
+
+pub fn create_custom_model(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let default_name = Uuid::new_v4().to_string()[..8].to_string();
+    let model_name = body["modelName"].as_str().unwrap_or(&default_name);
+
+    let model_id = Uuid::new_v4().to_string();
+    let model_arn = format!(
+        "arn:aws:bedrock:{}:{}:custom-model/{}",
+        req.region, req.account_id, model_id
+    );
+
+    let model = CustomModel {
+        model_arn: model_arn.clone(),
+        model_name: model_name.to_string(),
+        model_source_config: body.get("modelSourceConfig").cloned().unwrap_or(json!({})),
+        model_kms_key_arn: body["modelKmsKeyArn"].as_str().map(|s| s.to_string()),
+        role_arn: body["roleArn"].as_str().map(|s| s.to_string()),
+        model_status: "Active".to_string(),
+        creation_time: Utc::now(),
+    };
+
+    let mut s = state.write();
+    s.custom_models.insert(model_arn.clone(), model);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "modelArn": model_arn })).unwrap(),
+    ))
+}
+
+pub fn get_custom_model(
+    state: &SharedBedrockState,
+    model_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let model = s
+        .custom_models
+        .get(model_identifier)
+        .or_else(|| {
+            s.custom_models.values().find(|m| {
+                m.model_name == model_identifier
+                    || m.model_arn.ends_with(&format!("/{model_identifier}"))
+            })
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Custom model {model_identifier} not found"),
+            )
+        })?;
+
+    Ok(AwsResponse::ok_json(json!({
+        "modelArn": model.model_arn,
+        "modelName": model.model_name,
+        "modelStatus": model.model_status,
+        "creationTime": model.creation_time.to_rfc3339(),
+    })))
+}
+
+pub fn list_custom_models(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&CustomModel> = s.custom_models.values().collect();
+    items.sort_by(|a, b| a.model_arn.cmp(&b.model_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|m| m.model_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|m| {
+            json!({
+                "modelArn": m.model_arn,
+                "modelName": m.model_name,
+                "modelStatus": m.model_status,
+                "creationTime": m.creation_time.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "modelSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.model_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn delete_custom_model(
+    state: &SharedBedrockState,
+    model_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = s
+        .custom_models
+        .iter()
+        .find(|(k, m)| {
+            *k == model_identifier
+                || m.model_name == model_identifier
+                || m.model_arn.ends_with(&format!("/{model_identifier}"))
+        })
+        .map(|(k, _)| k.clone());
+
+    match key {
+        Some(k) => {
+            s.custom_models.remove(&k);
+            Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+        }
+        None => Err(AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Custom model {model_identifier} not found"),
+        )),
+    }
+}

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod async_invoke;
 pub mod converse;
+pub mod custom_model_deployments;
+pub mod custom_models;
 pub mod customization;
 
 pub mod guardrails;

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -53,6 +53,47 @@ impl BedrockService {
                 Some(("CreateGuardrailVersion", Some(decode(&segs[1])), None))
             }
 
+            // Custom models
+            (Method::POST, 2) if segs[0] == "custom-models" && segs[1] == "create-custom-model" => {
+                Some(("CreateCustomModel", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "custom-models" => {
+                Some(("ListCustomModels", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "custom-models" => {
+                Some(("GetCustomModel", Some(decode(&segs[1])), None))
+            }
+            (Method::DELETE, 2) if segs[0] == "custom-models" => {
+                Some(("DeleteCustomModel", Some(decode(&segs[1])), None))
+            }
+
+            // Custom model deployments
+            (Method::POST, 2)
+                if segs[0] == "model-customization" && segs[1] == "custom-model-deployments" =>
+            {
+                Some(("CreateCustomModelDeployment", None, None))
+            }
+            (Method::GET, 2)
+                if segs[0] == "model-customization" && segs[1] == "custom-model-deployments" =>
+            {
+                Some(("ListCustomModelDeployments", None, None))
+            }
+            (Method::GET, 3)
+                if segs[0] == "model-customization" && segs[1] == "custom-model-deployments" =>
+            {
+                Some(("GetCustomModelDeployment", Some(decode(&segs[2])), None))
+            }
+            (Method::PATCH, 3)
+                if segs[0] == "model-customization" && segs[1] == "custom-model-deployments" =>
+            {
+                Some(("UpdateCustomModelDeployment", Some(decode(&segs[2])), None))
+            }
+            (Method::DELETE, 3)
+                if segs[0] == "model-customization" && segs[1] == "custom-model-deployments" =>
+            {
+                Some(("DeleteCustomModelDeployment", Some(decode(&segs[2])), None))
+            }
+
             // Model customization jobs
             (Method::POST, 1) if segs[0] == "model-customization-jobs" => {
                 Some(("CreateModelCustomizationJob", None, None))
@@ -373,6 +414,52 @@ impl AwsService for BedrockService {
                 &extra_id.unwrap_or_default(),
                 &req.body,
             ),
+            // Custom models
+            "CreateCustomModel" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::custom_models::create_custom_model(&self.state, &req, &body)
+            }
+            "GetCustomModel" => crate::custom_models::get_custom_model(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            "ListCustomModels" => crate::custom_models::list_custom_models(&self.state, &req),
+            "DeleteCustomModel" => crate::custom_models::delete_custom_model(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            // Custom model deployments
+            "CreateCustomModelDeployment" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::custom_model_deployments::create_custom_model_deployment(
+                    &self.state,
+                    &req,
+                    &body,
+                )
+            }
+            "GetCustomModelDeployment" => {
+                crate::custom_model_deployments::get_custom_model_deployment(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
+            "ListCustomModelDeployments" => {
+                crate::custom_model_deployments::list_custom_model_deployments(&self.state, &req)
+            }
+            "UpdateCustomModelDeployment" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::custom_model_deployments::update_custom_model_deployment(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                    &body,
+                )
+            }
+            "DeleteCustomModelDeployment" => {
+                crate::custom_model_deployments::delete_custom_model_deployment(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
             // Model customization jobs
             "CreateModelCustomizationJob" => {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
@@ -519,6 +606,15 @@ impl AwsService for BedrockService {
             "DeleteGuardrail",
             "CreateGuardrailVersion",
             "ApplyGuardrail",
+            "CreateCustomModel",
+            "GetCustomModel",
+            "ListCustomModels",
+            "DeleteCustomModel",
+            "CreateCustomModelDeployment",
+            "GetCustomModelDeployment",
+            "ListCustomModelDeployments",
+            "UpdateCustomModelDeployment",
+            "DeleteCustomModelDeployment",
             "CreateModelCustomizationJob",
             "GetModelCustomizationJob",
             "ListModelCustomizationJobs",

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -27,6 +27,10 @@ pub struct BedrockState {
     pub custom_responses: HashMap<String, String>,
     /// Async invocations keyed by invocation ARN.
     pub async_invocations: HashMap<String, AsyncInvocation>,
+    /// Custom models keyed by model ARN.
+    pub custom_models: HashMap<String, CustomModel>,
+    /// Custom model deployments keyed by deployment ARN.
+    pub custom_model_deployments: HashMap<String, CustomModelDeployment>,
 }
 
 impl BedrockState {
@@ -43,6 +47,8 @@ impl BedrockState {
             invocations: Vec::new(),
             custom_responses: HashMap::new(),
             async_invocations: HashMap::new(),
+            custom_models: HashMap::new(),
+            custom_model_deployments: HashMap::new(),
         }
     }
 
@@ -56,6 +62,8 @@ impl BedrockState {
         self.invocations.clear();
         self.custom_responses.clear();
         self.async_invocations.clear();
+        self.custom_models.clear();
+        self.custom_model_deployments.clear();
     }
 }
 
@@ -152,4 +160,26 @@ pub struct AsyncInvocation {
     pub submit_time: DateTime<Utc>,
     pub last_modified_time: DateTime<Utc>,
     pub end_time: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone)]
+pub struct CustomModel {
+    pub model_arn: String,
+    pub model_name: String,
+    pub model_source_config: serde_json::Value,
+    pub model_kms_key_arn: Option<String>,
+    pub role_arn: Option<String>,
+    pub model_status: String,
+    pub creation_time: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct CustomModelDeployment {
+    pub deployment_arn: String,
+    pub deployment_name: String,
+    pub model_arn: String,
+    pub description: Option<String>,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub last_updated_at: DateTime<Utc>,
 }

--- a/crates/fakecloud-conformance/tests/bedrock.rs
+++ b/crates/fakecloud-conformance/tests/bedrock.rs
@@ -705,6 +705,147 @@ async fn bedrock_bidirectional_stream_conformance() {
 }
 
 // ---------------------------------------------------------------------------
+// Custom Models
+// ---------------------------------------------------------------------------
+
+#[test_action("bedrock", "CreateCustomModel", checksum = "4887448e")]
+#[test_action("bedrock", "GetCustomModel", checksum = "93aaf6da")]
+#[test_action("bedrock", "ListCustomModels", checksum = "0966941c")]
+#[test_action("bedrock", "DeleteCustomModel", checksum = "287a1b06")]
+#[tokio::test]
+async fn bedrock_custom_model_crud() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({"modelName": "conf-model", "modelSourceConfig": {}});
+    let resp = http_client
+        .post(format!(
+            "{}/custom-models/create-custom-model",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let arn = result["modelArn"].as_str().unwrap().to_string();
+    let id = arn.rsplit('/').next().unwrap();
+
+    let resp = http_client
+        .get(format!("{}/custom-models/{}", server.endpoint(), id))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .get(format!("{}/custom-models", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .delete(format!("{}/custom-models/{}", server.endpoint(), id))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[test_action("bedrock", "CreateCustomModelDeployment", checksum = "798775b9")]
+#[test_action("bedrock", "GetCustomModelDeployment", checksum = "452bbfdb")]
+#[test_action("bedrock", "ListCustomModelDeployments", checksum = "8b36e796")]
+#[test_action("bedrock", "UpdateCustomModelDeployment", checksum = "860d20f9")]
+#[test_action("bedrock", "DeleteCustomModelDeployment", checksum = "74d8fc2e")]
+#[tokio::test]
+async fn bedrock_custom_model_deployment_crud() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({
+        "modelDeploymentName": "conf-deployment",
+        "modelArn": "arn:aws:bedrock:us-east-1:123456789012:custom-model/test"
+    });
+    let resp = http_client
+        .post(format!(
+            "{}/model-customization/custom-model-deployments",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let arn = result["customModelDeploymentArn"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let id = arn.rsplit('/').next().unwrap();
+
+    let resp = http_client
+        .get(format!(
+            "{}/model-customization/custom-model-deployments/{}",
+            server.endpoint(),
+            id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .get(format!(
+            "{}/model-customization/custom-model-deployments",
+            server.endpoint()
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = serde_json::json!({"modelArn": "arn:aws:bedrock:us-east-1:123456789012:custom-model/updated"});
+    let resp = http_client
+        .patch(format!(
+            "{}/model-customization/custom-model-deployments/{}",
+            server.endpoint(),
+            id
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .delete(format!(
+            "{}/model-customization/custom-model-deployments/{}",
+            server.endpoint(),
+            id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+// ---------------------------------------------------------------------------
 // Streaming (raw HTTP since SDK event stream parsing is complex)
 // ---------------------------------------------------------------------------
 

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -1183,3 +1183,192 @@ async fn bedrock_converse_stream_raw() {
         "converse stream should have multiple events"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Custom Models
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_custom_model_crud() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    // Create custom model
+    let body = serde_json::json!({
+        "modelName": "my-custom-model",
+        "modelSourceConfig": {"s3DataSource": {"s3Uri": "s3://bucket/model/"}}
+    });
+    let resp = http_client
+        .post(format!(
+            "{}/custom-models/create-custom-model",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let model_arn = result["modelArn"].as_str().unwrap().to_string();
+    assert!(model_arn.contains("custom-model/"));
+
+    // Get custom model
+    let model_id = model_arn.rsplit('/').next().unwrap();
+    let resp = http_client
+        .get(format!("{}/custom-models/{}", server.endpoint(), model_id))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(result["modelName"], "my-custom-model");
+    assert_eq!(result["modelStatus"], "Active");
+
+    // List custom models
+    let resp = http_client
+        .get(format!("{}/custom-models", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert!(!result["modelSummaries"].as_array().unwrap().is_empty());
+
+    // Delete custom model
+    let resp = http_client
+        .delete(format!("{}/custom-models/{}", server.endpoint(), model_id))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Verify deleted
+    let resp = http_client
+        .get(format!("{}/custom-models/{}", server.endpoint(), model_id))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+// ---------------------------------------------------------------------------
+// Custom Model Deployments
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_custom_model_deployment_crud() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    // Create deployment
+    let body = serde_json::json!({
+        "modelDeploymentName": "my-deployment",
+        "modelArn": "arn:aws:bedrock:us-east-1:123456789012:custom-model/test-model",
+        "description": "Test deployment"
+    });
+    let resp = http_client
+        .post(format!(
+            "{}/model-customization/custom-model-deployments",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let deployment_arn = result["customModelDeploymentArn"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(deployment_arn.contains("custom-model-deployment/"));
+
+    // Get deployment
+    let deployment_id = deployment_arn.rsplit('/').next().unwrap();
+    let resp = http_client
+        .get(format!(
+            "{}/model-customization/custom-model-deployments/{}",
+            server.endpoint(),
+            deployment_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(result["modelDeploymentName"], "my-deployment");
+    assert_eq!(result["status"], "Active");
+    assert_eq!(result["description"], "Test deployment");
+
+    // List deployments
+    let resp = http_client
+        .get(format!(
+            "{}/model-customization/custom-model-deployments",
+            server.endpoint()
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert!(!result["modelDeploymentSummaries"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+
+    // Update deployment
+    let body = serde_json::json!({
+        "modelArn": "arn:aws:bedrock:us-east-1:123456789012:custom-model/updated-model"
+    });
+    let resp = http_client
+        .patch(format!(
+            "{}/model-customization/custom-model-deployments/{}",
+            server.endpoint(),
+            deployment_id
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Delete deployment
+    let resp = http_client
+        .delete(format!(
+            "{}/model-customization/custom-model-deployments/{}",
+            server.endpoint(),
+            deployment_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Verify deleted
+    let resp = http_client
+        .get(format!(
+            "{}/model-customization/custom-model-deployments/{}",
+            server.endpoint(),
+            deployment_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}


### PR DESCRIPTION
## Summary

- Implement 9 new Bedrock control plane operations for Custom Models and Custom Model Deployments
- Custom Models: CreateCustomModel, GetCustomModel, ListCustomModels, DeleteCustomModel
- Custom Model Deployments: CreateCustomModelDeployment, GetCustomModelDeployment, ListCustomModelDeployments, UpdateCustomModelDeployment, DeleteCustomModelDeployment
- All operations include state storage, ARN generation, pagination (nextToken/maxResults), and flexible lookup by ARN, name, or ID suffix

## Test plan

- [x] 28 E2E tests passing (all existing + 2 new)
- [x] 23 conformance tests passing (all existing + 2 new covering 9 ops)
- [x] clippy clean, fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 9 Bedrock control plane ops for Custom Models and Custom Model Deployments with in-memory state, ARNs, pagination, and flexible identifiers. Routes are wired into the Bedrock service, with E2E and conformance tests added.

- **New Features**
  - Custom Models: Create, Get, List, Delete.
  - Custom Model Deployments: Create, Get, List, Update, Delete.
  - State storage with ARN generation and list pagination via `nextToken`/`maxResults`.
  - Lookup by ARN, resource name, or ID suffix; HTTP routes for `/custom-models` and `/model-customization/custom-model-deployments`.

<sup>Written for commit 6123f4d45cd5631a59f94ce53550fd63ee6244a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

