### PR TITLE
feat(bedrock): add Model Import and Model Copy operations (9 ops)

### DIFF
--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -7,6 +7,8 @@ pub mod customization;
 pub mod guardrails;
 pub mod invoke;
 pub mod logging;
+pub mod model_copy;
+pub mod model_import;
 pub mod models;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-bedrock/src/model_copy.rs
+++ b/crates/fakecloud-bedrock/src/model_copy.rs
@@ -1,0 +1,126 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{ModelCopyJob, SharedBedrockState};
+
+pub fn create_model_copy_job(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let source_model_arn = body["sourceModelArn"].as_str().unwrap_or_default();
+    let target_model_name = body["targetModelName"].as_str().unwrap_or("copied-model");
+
+    let job_id = Uuid::new_v4().to_string();
+    let job_arn = format!(
+        "arn:aws:bedrock:{}:{}:model-copy-job/{}",
+        req.region, req.account_id, job_id
+    );
+    let target_model_arn = format!(
+        "arn:aws:bedrock:{}:{}:custom-model/{}",
+        req.region, req.account_id, target_model_name
+    );
+
+    let job = ModelCopyJob {
+        job_arn: job_arn.clone(),
+        source_model_arn: source_model_arn.to_string(),
+        target_model_arn,
+        target_model_name: target_model_name.to_string(),
+        status: "Completed".to_string(),
+        creation_time: Utc::now(),
+    };
+
+    let mut s = state.write();
+    s.model_copy_jobs.insert(job_arn.clone(), job);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "jobArn": job_arn })).unwrap(),
+    ))
+}
+
+pub fn get_model_copy_job(
+    state: &SharedBedrockState,
+    job_arn: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let job = s
+        .model_copy_jobs
+        .get(job_arn)
+        .or_else(|| {
+            s.model_copy_jobs
+                .values()
+                .find(|j| j.job_arn.ends_with(&format!("/{job_arn}")))
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Model copy job {job_arn} not found"),
+            )
+        })?;
+
+    Ok(AwsResponse::ok_json(json!({
+        "jobArn": job.job_arn,
+        "status": job.status,
+        "creationTime": job.creation_time.to_rfc3339(),
+        "sourceModelArn": job.source_model_arn,
+        "targetModelArn": job.target_model_arn,
+        "targetModelName": job.target_model_name,
+    })))
+}
+
+pub fn list_model_copy_jobs(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&ModelCopyJob> = s.model_copy_jobs.values().collect();
+    items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|j| j.job_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|j| {
+            json!({
+                "jobArn": j.job_arn,
+                "status": j.status,
+                "creationTime": j.creation_time.to_rfc3339(),
+                "sourceModelArn": j.source_model_arn,
+                "targetModelArn": j.target_model_arn,
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "modelCopyJobSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.job_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}

--- a/crates/fakecloud-bedrock/src/model_import.rs
+++ b/crates/fakecloud-bedrock/src/model_import.rs
@@ -1,0 +1,256 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{ImportedModel, ModelImportJob, SharedBedrockState};
+
+pub fn create_model_import_job(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let job_name = body["jobName"].as_str().unwrap_or("import-job");
+    let imported_model_name = body["importedModelName"].as_str().unwrap_or(job_name);
+    let role_arn = body["roleArn"].as_str().unwrap_or_default();
+
+    let job_id = Uuid::new_v4().to_string();
+    let job_arn = format!(
+        "arn:aws:bedrock:{}:{}:model-import-job/{}",
+        req.region, req.account_id, job_id
+    );
+    let imported_model_arn = format!(
+        "arn:aws:bedrock:{}:{}:imported-model/{}",
+        req.region, req.account_id, imported_model_name
+    );
+
+    let now = Utc::now();
+    let model_data_source = body.get("modelDataSource").cloned().unwrap_or(json!({}));
+
+    let job = ModelImportJob {
+        job_arn: job_arn.clone(),
+        job_name: job_name.to_string(),
+        imported_model_name: imported_model_name.to_string(),
+        imported_model_arn: imported_model_arn.clone(),
+        role_arn: role_arn.to_string(),
+        model_data_source: model_data_source.clone(),
+        status: "Completed".to_string(),
+        creation_time: now,
+        last_modified_time: now,
+    };
+
+    let imported_model = ImportedModel {
+        model_arn: imported_model_arn.clone(),
+        model_name: imported_model_name.to_string(),
+        job_arn: job_arn.clone(),
+        model_data_source,
+        creation_time: now,
+    };
+
+    let mut s = state.write();
+    s.model_import_jobs.insert(job_arn.clone(), job);
+    s.imported_models
+        .insert(imported_model_arn.clone(), imported_model);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "jobArn": job_arn })).unwrap(),
+    ))
+}
+
+pub fn get_model_import_job(
+    state: &SharedBedrockState,
+    job_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let job = s
+        .model_import_jobs
+        .get(job_identifier)
+        .or_else(|| {
+            s.model_import_jobs.values().find(|j| {
+                j.job_name == job_identifier || j.job_arn.ends_with(&format!("/{job_identifier}"))
+            })
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Model import job {job_identifier} not found"),
+            )
+        })?;
+
+    Ok(AwsResponse::ok_json(json!({
+        "jobArn": job.job_arn,
+        "jobName": job.job_name,
+        "importedModelName": job.imported_model_name,
+        "importedModelArn": job.imported_model_arn,
+        "roleArn": job.role_arn,
+        "modelDataSource": job.model_data_source,
+        "status": job.status,
+        "creationTime": job.creation_time.to_rfc3339(),
+        "lastModifiedTime": job.last_modified_time.to_rfc3339(),
+    })))
+}
+
+pub fn list_model_import_jobs(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&ModelImportJob> = s.model_import_jobs.values().collect();
+    items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|j| j.job_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|j| {
+            json!({
+                "jobArn": j.job_arn,
+                "jobName": j.job_name,
+                "status": j.status,
+                "importedModelName": j.imported_model_name,
+                "importedModelArn": j.imported_model_arn,
+                "creationTime": j.creation_time.to_rfc3339(),
+                "lastModifiedTime": j.last_modified_time.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "modelImportJobSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.job_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn get_imported_model(
+    state: &SharedBedrockState,
+    model_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let model = s
+        .imported_models
+        .get(model_identifier)
+        .or_else(|| {
+            s.imported_models.values().find(|m| {
+                m.model_name == model_identifier
+                    || m.model_arn.ends_with(&format!("/{model_identifier}"))
+            })
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Imported model {model_identifier} not found"),
+            )
+        })?;
+
+    Ok(AwsResponse::ok_json(json!({
+        "modelArn": model.model_arn,
+        "modelName": model.model_name,
+        "jobArn": model.job_arn,
+        "modelDataSource": model.model_data_source,
+        "creationTime": model.creation_time.to_rfc3339(),
+    })))
+}
+
+pub fn list_imported_models(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&ImportedModel> = s.imported_models.values().collect();
+    items.sort_by(|a, b| a.model_arn.cmp(&b.model_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|m| m.model_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|m| {
+            json!({
+                "modelArn": m.model_arn,
+                "modelName": m.model_name,
+                "creationTime": m.creation_time.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "modelSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.model_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn delete_imported_model(
+    state: &SharedBedrockState,
+    model_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+    let key = s
+        .imported_models
+        .iter()
+        .find(|(k, m)| {
+            *k == model_identifier
+                || m.model_name == model_identifier
+                || m.model_arn.ends_with(&format!("/{model_identifier}"))
+        })
+        .map(|(k, _)| k.clone());
+
+    match key {
+        Some(k) => {
+            s.imported_models.remove(&k);
+            Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+        }
+        None => Err(AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Imported model {model_identifier} not found"),
+        )),
+    }
+}

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -94,6 +94,39 @@ impl BedrockService {
                 Some(("DeleteCustomModelDeployment", Some(decode(&segs[2])), None))
             }
 
+            // Model import jobs
+            (Method::POST, 1) if segs[0] == "model-import-jobs" => {
+                Some(("CreateModelImportJob", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "model-import-jobs" => {
+                Some(("ListModelImportJobs", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "model-import-jobs" => {
+                Some(("GetModelImportJob", Some(decode(&segs[1])), None))
+            }
+
+            // Imported models
+            (Method::GET, 1) if segs[0] == "imported-models" => {
+                Some(("ListImportedModels", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "imported-models" => {
+                Some(("GetImportedModel", Some(decode(&segs[1])), None))
+            }
+            (Method::DELETE, 2) if segs[0] == "imported-models" => {
+                Some(("DeleteImportedModel", Some(decode(&segs[1])), None))
+            }
+
+            // Model copy jobs
+            (Method::POST, 1) if segs[0] == "model-copy-jobs" => {
+                Some(("CreateModelCopyJob", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "model-copy-jobs" => {
+                Some(("ListModelCopyJobs", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "model-copy-jobs" => {
+                Some(("GetModelCopyJob", Some(decode(&segs[1])), None))
+            }
+
             // Model customization jobs
             (Method::POST, 1) if segs[0] == "model-customization-jobs" => {
                 Some(("CreateModelCustomizationJob", None, None))
@@ -460,6 +493,34 @@ impl AwsService for BedrockService {
                     &resource_id.unwrap_or_default(),
                 )
             }
+            // Model import jobs
+            "CreateModelImportJob" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::model_import::create_model_import_job(&self.state, &req, &body)
+            }
+            "GetModelImportJob" => crate::model_import::get_model_import_job(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            "ListModelImportJobs" => crate::model_import::list_model_import_jobs(&self.state, &req),
+            "GetImportedModel" => crate::model_import::get_imported_model(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            "ListImportedModels" => crate::model_import::list_imported_models(&self.state, &req),
+            "DeleteImportedModel" => crate::model_import::delete_imported_model(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            // Model copy jobs
+            "CreateModelCopyJob" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::model_copy::create_model_copy_job(&self.state, &req, &body)
+            }
+            "GetModelCopyJob" => {
+                crate::model_copy::get_model_copy_job(&self.state, &resource_id.unwrap_or_default())
+            }
+            "ListModelCopyJobs" => crate::model_copy::list_model_copy_jobs(&self.state, &req),
             // Model customization jobs
             "CreateModelCustomizationJob" => {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
@@ -615,6 +676,15 @@ impl AwsService for BedrockService {
             "ListCustomModelDeployments",
             "UpdateCustomModelDeployment",
             "DeleteCustomModelDeployment",
+            "CreateModelImportJob",
+            "GetModelImportJob",
+            "ListModelImportJobs",
+            "GetImportedModel",
+            "ListImportedModels",
+            "DeleteImportedModel",
+            "CreateModelCopyJob",
+            "GetModelCopyJob",
+            "ListModelCopyJobs",
             "CreateModelCustomizationJob",
             "GetModelCustomizationJob",
             "ListModelCustomizationJobs",

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -31,6 +31,12 @@ pub struct BedrockState {
     pub custom_models: HashMap<String, CustomModel>,
     /// Custom model deployments keyed by deployment ARN.
     pub custom_model_deployments: HashMap<String, CustomModelDeployment>,
+    /// Model import jobs keyed by job ARN.
+    pub model_import_jobs: HashMap<String, ModelImportJob>,
+    /// Imported models keyed by model ARN.
+    pub imported_models: HashMap<String, ImportedModel>,
+    /// Model copy jobs keyed by job ARN.
+    pub model_copy_jobs: HashMap<String, ModelCopyJob>,
 }
 
 impl BedrockState {
@@ -49,6 +55,9 @@ impl BedrockState {
             async_invocations: HashMap::new(),
             custom_models: HashMap::new(),
             custom_model_deployments: HashMap::new(),
+            model_import_jobs: HashMap::new(),
+            imported_models: HashMap::new(),
+            model_copy_jobs: HashMap::new(),
         }
     }
 
@@ -64,6 +73,9 @@ impl BedrockState {
         self.async_invocations.clear();
         self.custom_models.clear();
         self.custom_model_deployments.clear();
+        self.model_import_jobs.clear();
+        self.imported_models.clear();
+        self.model_copy_jobs.clear();
     }
 }
 
@@ -182,4 +194,36 @@ pub struct CustomModelDeployment {
     pub status: String,
     pub created_at: DateTime<Utc>,
     pub last_updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct ModelImportJob {
+    pub job_arn: String,
+    pub job_name: String,
+    pub imported_model_name: String,
+    pub imported_model_arn: String,
+    pub role_arn: String,
+    pub model_data_source: serde_json::Value,
+    pub status: String,
+    pub creation_time: DateTime<Utc>,
+    pub last_modified_time: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct ImportedModel {
+    pub model_arn: String,
+    pub model_name: String,
+    pub job_arn: String,
+    pub model_data_source: serde_json::Value,
+    pub creation_time: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct ModelCopyJob {
+    pub job_arn: String,
+    pub source_model_arn: String,
+    pub target_model_arn: String,
+    pub target_model_name: String,
+    pub status: String,
+    pub creation_time: DateTime<Utc>,
 }

--- a/crates/fakecloud-conformance/tests/bedrock.rs
+++ b/crates/fakecloud-conformance/tests/bedrock.rs
@@ -705,6 +705,145 @@ async fn bedrock_bidirectional_stream_conformance() {
 }
 
 // ---------------------------------------------------------------------------
+// Model Import
+// ---------------------------------------------------------------------------
+
+#[test_action("bedrock", "CreateModelImportJob", checksum = "aa03dfa3")]
+#[test_action("bedrock", "GetModelImportJob", checksum = "49328baf")]
+#[test_action("bedrock", "ListModelImportJobs", checksum = "77700f04")]
+#[test_action("bedrock", "GetImportedModel", checksum = "4043fd91")]
+#[test_action("bedrock", "ListImportedModels", checksum = "7ece5cb8")]
+#[test_action("bedrock", "DeleteImportedModel", checksum = "c62da780")]
+#[tokio::test]
+async fn bedrock_model_import_lifecycle() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({
+        "jobName": "conf-import",
+        "importedModelName": "conf-imported",
+        "roleArn": "arn:aws:iam::123456789012:role/test",
+        "modelDataSource": {"s3DataSource": {"s3Uri": "s3://bucket/model/"}}
+    });
+    let resp = http_client
+        .post(format!("{}/model-import-jobs", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let job_arn = result["jobArn"].as_str().unwrap().to_string();
+    let job_id = job_arn.rsplit('/').next().unwrap();
+
+    // Get job
+    let resp = http_client
+        .get(format!(
+            "{}/model-import-jobs/{}",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // List jobs
+    let resp = http_client
+        .get(format!("{}/model-import-jobs", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Get imported model
+    let resp = http_client
+        .get(format!(
+            "{}/imported-models/conf-imported",
+            server.endpoint()
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // List imported models
+    let resp = http_client
+        .get(format!("{}/imported-models", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Delete imported model
+    let resp = http_client
+        .delete(format!(
+            "{}/imported-models/conf-imported",
+            server.endpoint()
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[test_action("bedrock", "CreateModelCopyJob", checksum = "75268069")]
+#[test_action("bedrock", "GetModelCopyJob", checksum = "b0dec5ba")]
+#[test_action("bedrock", "ListModelCopyJobs", checksum = "454a776c")]
+#[tokio::test]
+async fn bedrock_model_copy_lifecycle() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({
+        "sourceModelArn": "arn:aws:bedrock:us-east-1:123456789012:custom-model/source",
+        "targetModelName": "conf-copy-target"
+    });
+    let resp = http_client
+        .post(format!("{}/model-copy-jobs", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let job_arn = result["jobArn"].as_str().unwrap().to_string();
+    let job_id = job_arn.rsplit('/').next().unwrap();
+
+    let resp = http_client
+        .get(format!("{}/model-copy-jobs/{}", server.endpoint(), job_id))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .get(format!("{}/model-copy-jobs", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert!(!result["modelCopyJobSummaries"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+}
+
+// ---------------------------------------------------------------------------
 // Custom Models
 // ---------------------------------------------------------------------------
 

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -1372,3 +1372,129 @@ async fn bedrock_custom_model_deployment_crud() {
         .unwrap();
     assert_eq!(resp.status(), 404);
 }
+
+// ---------------------------------------------------------------------------
+// Model Import Jobs + Imported Models
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_model_import_lifecycle() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({
+        "jobName": "my-import-job",
+        "importedModelName": "my-imported-model",
+        "roleArn": "arn:aws:iam::123456789012:role/test",
+        "modelDataSource": {"s3DataSource": {"s3Uri": "s3://bucket/model/"}}
+    });
+    let resp = http_client
+        .post(format!("{}/model-import-jobs", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let job_arn = result["jobArn"].as_str().unwrap().to_string();
+    let job_id = job_arn.rsplit('/').next().unwrap();
+
+    let resp = http_client
+        .get(format!(
+            "{}/model-import-jobs/{}",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(result["jobName"], "my-import-job");
+    assert_eq!(result["status"], "Completed");
+
+    let resp = http_client
+        .get(format!(
+            "{}/imported-models/my-imported-model",
+            server.endpoint()
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .get(format!("{}/imported-models", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .delete(format!(
+            "{}/imported-models/my-imported-model",
+            server.endpoint()
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+// ---------------------------------------------------------------------------
+// Model Copy Jobs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_model_copy_lifecycle() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({
+        "sourceModelArn": "arn:aws:bedrock:us-east-1:123456789012:custom-model/source-model",
+        "targetModelName": "my-copy-target"
+    });
+    let resp = http_client
+        .post(format!("{}/model-copy-jobs", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let job_arn = result["jobArn"].as_str().unwrap().to_string();
+    let job_id = job_arn.rsplit('/').next().unwrap();
+
+    let resp = http_client
+        .get(format!("{}/model-copy-jobs/{}", server.endpoint(), job_id))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(result["status"], "Completed");
+
+    let resp = http_client
+        .get(format!("{}/model-copy-jobs", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert!(!result["modelCopyJobSummaries"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+}


### PR DESCRIPTION
## Summary

- Implement 9 new Bedrock control plane operations for Model Import and Model Copy
- Model Import: CreateModelImportJob, GetModelImportJob, ListModelImportJobs, GetImportedModel, ListImportedModels, DeleteImportedModel
- Model Copy: CreateModelCopyJob, GetModelCopyJob, ListModelCopyJobs
- Import jobs auto-complete and create corresponding imported model entries
- All operations include pagination, flexible lookup, and proper ARN formats

## Test plan

- [x] 30 E2E tests passing (all existing + 2 new)
- [x] 25 conformance tests passing (all existing + 2 new covering 9 ops)
- [x] clippy clean, fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 9 Bedrock control-plane APIs for Model Import and Model Copy. Supports list/get/create/delete with pagination and flexible lookup; import and copy jobs auto-complete.

- New Features
  - Model Import: CreateModelImportJob, GetModelImportJob, ListModelImportJobs, GetImportedModel, ListImportedModels, DeleteImportedModel
  - Model Copy: CreateModelCopyJob, GetModelCopyJob, ListModelCopyJobs
  - Jobs auto-complete; import jobs create `imported-model` records and copy jobs generate target model ARNs
  - Consistent ARN formats, ARN/name/ID-suffix lookups, and pagination via maxResults/nextToken

<sup>Written for commit 59d2a10d9d3102df944ba4990d78769a00f4c628. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

