### PR TITLE
feat(bedrock): add Model Invocation Jobs and Evaluation Jobs (9 ops)

### DIFF
--- a/crates/fakecloud-bedrock/src/evaluation.rs
+++ b/crates/fakecloud-bedrock/src/evaluation.rs
@@ -1,0 +1,223 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{EvaluationJob, SharedBedrockState};
+
+pub fn create_evaluation_job(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let job_name = body["jobName"].as_str().unwrap_or("eval-job");
+    let role_arn = body["roleArn"].as_str().unwrap_or_default();
+
+    let job_id = Uuid::new_v4().to_string();
+    let job_arn = format!(
+        "arn:aws:bedrock:{}:{}:evaluation-job/{}",
+        req.region, req.account_id, job_id
+    );
+
+    let now = Utc::now();
+    let job = EvaluationJob {
+        job_arn: job_arn.clone(),
+        job_name: job_name.to_string(),
+        job_description: body["jobDescription"].as_str().map(|s| s.to_string()),
+        role_arn: role_arn.to_string(),
+        status: "InProgress".to_string(),
+        job_type: body["evaluationConfig"]["automated"]
+            .as_object()
+            .map(|_| "Automated")
+            .unwrap_or("Human")
+            .to_string(),
+        evaluation_config: body.get("evaluationConfig").cloned().unwrap_or(json!({})),
+        inference_config: body.get("inferenceConfig").cloned().unwrap_or(json!({})),
+        output_data_config: body.get("outputDataConfig").cloned().unwrap_or(json!({})),
+        creation_time: now,
+        last_modified_time: now,
+    };
+
+    let mut s = state.write();
+    s.evaluation_jobs.insert(job_arn.clone(), job);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "jobArn": job_arn })).unwrap(),
+    ))
+}
+
+pub fn get_evaluation_job(
+    state: &SharedBedrockState,
+    job_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let job = find_job(&s.evaluation_jobs, job_identifier)?;
+
+    Ok(AwsResponse::ok_json(json!({
+        "jobArn": job.job_arn,
+        "jobName": job.job_name,
+        "jobDescription": job.job_description,
+        "roleArn": job.role_arn,
+        "status": job.status,
+        "jobType": job.job_type,
+        "evaluationConfig": job.evaluation_config,
+        "inferenceConfig": job.inference_config,
+        "outputDataConfig": job.output_data_config,
+        "creationTime": job.creation_time.to_rfc3339(),
+        "lastModifiedTime": job.last_modified_time.to_rfc3339(),
+    })))
+}
+
+pub fn list_evaluation_jobs(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&EvaluationJob> = s.evaluation_jobs.values().collect();
+    items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|j| j.job_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|j| {
+            json!({
+                "jobArn": j.job_arn,
+                "jobName": j.job_name,
+                "status": j.status,
+                "jobType": j.job_type,
+                "creationTime": j.creation_time.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "jobSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.job_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn stop_evaluation_job(
+    state: &SharedBedrockState,
+    job_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+    let key = find_job_key(&s.evaluation_jobs, job_identifier)?;
+    let job = s.evaluation_jobs.get_mut(&key).unwrap();
+
+    if job.status != "InProgress" {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "ConflictException",
+            format!("Job is not in InProgress status (current: {})", job.status),
+        ));
+    }
+
+    job.status = "Stopped".to_string();
+    job.last_modified_time = Utc::now();
+
+    Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+}
+
+pub fn batch_delete_evaluation_job(
+    state: &SharedBedrockState,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let job_identifiers = body["jobIdentifiers"].as_array().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "jobIdentifiers is required",
+        )
+    })?;
+
+    let mut s = state.write();
+    let mut errors: Vec<Value> = Vec::new();
+
+    for identifier in job_identifiers {
+        let id = identifier.as_str().unwrap_or_default();
+        let key = s
+            .evaluation_jobs
+            .iter()
+            .find(|(k, j)| *k == id || j.job_name == id || j.job_arn.ends_with(&format!("/{id}")))
+            .map(|(k, _)| k.clone());
+
+        match key {
+            Some(k) => {
+                s.evaluation_jobs.remove(&k);
+            }
+            None => {
+                errors.push(json!({
+                    "jobIdentifier": id,
+                    "code": "JobNotFound",
+                    "message": format!("Evaluation job {id} not found")
+                }));
+            }
+        }
+    }
+
+    Ok(AwsResponse::ok_json(json!({ "errors": errors })))
+}
+
+fn find_job<'a>(
+    jobs: &'a std::collections::HashMap<String, EvaluationJob>,
+    id_or_arn: &str,
+) -> Result<&'a EvaluationJob, AwsServiceError> {
+    jobs.get(id_or_arn)
+        .or_else(|| {
+            jobs.values()
+                .find(|j| j.job_name == id_or_arn || j.job_arn.ends_with(&format!("/{id_or_arn}")))
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Evaluation job {id_or_arn} not found"),
+            )
+        })
+}
+
+fn find_job_key(
+    jobs: &std::collections::HashMap<String, EvaluationJob>,
+    id_or_arn: &str,
+) -> Result<String, AwsServiceError> {
+    jobs.iter()
+        .find(|(k, j)| {
+            *k == id_or_arn
+                || j.job_name == id_or_arn
+                || j.job_arn.ends_with(&format!("/{id_or_arn}"))
+        })
+        .map(|(k, _)| k.clone())
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Evaluation job {id_or_arn} not found"),
+            )
+        })
+}

--- a/crates/fakecloud-bedrock/src/invocation_jobs.rs
+++ b/crates/fakecloud-bedrock/src/invocation_jobs.rs
@@ -1,0 +1,185 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{ModelInvocationJob, SharedBedrockState};
+
+pub fn create_model_invocation_job(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let job_name = body["jobName"].as_str().unwrap_or("invocation-job");
+    let model_id = body["modelId"].as_str().unwrap_or_default();
+    let role_arn = body["roleArn"].as_str().unwrap_or_default();
+
+    let job_id = Uuid::new_v4().to_string();
+    let job_arn = format!(
+        "arn:aws:bedrock:{}:{}:model-invocation-job/{}",
+        req.region, req.account_id, job_id
+    );
+
+    let now = Utc::now();
+    let job = ModelInvocationJob {
+        job_arn: job_arn.clone(),
+        job_name: job_name.to_string(),
+        model_id: model_id.to_string(),
+        role_arn: role_arn.to_string(),
+        input_data_config: body.get("inputDataConfig").cloned().unwrap_or(json!({})),
+        output_data_config: body.get("outputDataConfig").cloned().unwrap_or(json!({})),
+        status: "InProgress".to_string(),
+        submit_time: now,
+        last_modified_time: now,
+        end_time: None,
+    };
+
+    let mut s = state.write();
+    s.model_invocation_jobs.insert(job_arn.clone(), job);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "jobArn": job_arn })).unwrap(),
+    ))
+}
+
+pub fn get_model_invocation_job(
+    state: &SharedBedrockState,
+    job_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let job = find_job(&s.model_invocation_jobs, job_identifier)?;
+
+    let mut resp = json!({
+        "jobArn": job.job_arn,
+        "jobName": job.job_name,
+        "modelId": job.model_id,
+        "roleArn": job.role_arn,
+        "status": job.status,
+        "inputDataConfig": job.input_data_config,
+        "outputDataConfig": job.output_data_config,
+        "submitTime": job.submit_time.to_rfc3339(),
+        "lastModifiedTime": job.last_modified_time.to_rfc3339(),
+    });
+    if let Some(ref end_time) = job.end_time {
+        resp["endTime"] = json!(end_time.to_rfc3339());
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn list_model_invocation_jobs(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&ModelInvocationJob> = s.model_invocation_jobs.values().collect();
+    items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|j| j.job_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|j| {
+            json!({
+                "jobArn": j.job_arn,
+                "jobName": j.job_name,
+                "modelId": j.model_id,
+                "status": j.status,
+                "submitTime": j.submit_time.to_rfc3339(),
+                "lastModifiedTime": j.last_modified_time.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "invocationJobSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.job_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn stop_model_invocation_job(
+    state: &SharedBedrockState,
+    job_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+    let key = find_job_key(&s.model_invocation_jobs, job_identifier)?;
+    let job = s.model_invocation_jobs.get_mut(&key).unwrap();
+
+    if job.status != "InProgress" {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "ConflictException",
+            format!("Job is not in InProgress status (current: {})", job.status),
+        ));
+    }
+
+    let now = Utc::now();
+    job.status = "Stopped".to_string();
+    job.last_modified_time = now;
+    job.end_time = Some(now);
+
+    Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+}
+
+fn find_job<'a>(
+    jobs: &'a std::collections::HashMap<String, ModelInvocationJob>,
+    id_or_arn: &str,
+) -> Result<&'a ModelInvocationJob, AwsServiceError> {
+    jobs.get(id_or_arn)
+        .or_else(|| {
+            jobs.values()
+                .find(|j| j.job_name == id_or_arn || j.job_arn.ends_with(&format!("/{id_or_arn}")))
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Model invocation job {id_or_arn} not found"),
+            )
+        })
+}
+
+fn find_job_key(
+    jobs: &std::collections::HashMap<String, ModelInvocationJob>,
+    id_or_arn: &str,
+) -> Result<String, AwsServiceError> {
+    jobs.iter()
+        .find(|(k, j)| {
+            *k == id_or_arn
+                || j.job_name == id_or_arn
+                || j.job_arn.ends_with(&format!("/{id_or_arn}"))
+        })
+        .map(|(k, _)| k.clone())
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Model invocation job {id_or_arn} not found"),
+            )
+        })
+}

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -4,7 +4,9 @@ pub mod custom_model_deployments;
 pub mod custom_models;
 pub mod customization;
 
+pub mod evaluation;
 pub mod guardrails;
+pub mod invocation_jobs;
 pub mod invoke;
 pub mod logging;
 pub mod model_copy;

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -127,6 +127,37 @@ impl BedrockService {
                 Some(("GetModelCopyJob", Some(decode(&segs[1])), None))
             }
 
+            // Model invocation jobs (batch inference)
+            (Method::POST, 1) if segs[0] == "model-invocation-job" => {
+                Some(("CreateModelInvocationJob", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "model-invocation-jobs" => {
+                Some(("ListModelInvocationJobs", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "model-invocation-job" => {
+                Some(("GetModelInvocationJob", Some(decode(&segs[1])), None))
+            }
+            (Method::POST, 3) if segs[0] == "model-invocation-job" && segs[2] == "stop" => {
+                Some(("StopModelInvocationJob", Some(decode(&segs[1])), None))
+            }
+
+            // Evaluation jobs
+            (Method::POST, 1) if segs[0] == "evaluation-jobs" => {
+                Some(("CreateEvaluationJob", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "evaluation-jobs" => {
+                Some(("ListEvaluationJobs", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "evaluation-jobs" => {
+                Some(("GetEvaluationJob", Some(decode(&segs[1])), None))
+            }
+            (Method::POST, 3) if segs[0] == "evaluation-job" && segs[2] == "stop" => {
+                Some(("StopEvaluationJob", Some(decode(&segs[1])), None))
+            }
+            (Method::POST, 2) if segs[0] == "evaluation-jobs" && segs[1] == "batch-delete" => {
+                Some(("BatchDeleteEvaluationJob", None, None))
+            }
+
             // Model customization jobs
             (Method::POST, 1) if segs[0] == "model-customization-jobs" => {
                 Some(("CreateModelCustomizationJob", None, None))
@@ -521,6 +552,39 @@ impl AwsService for BedrockService {
                 crate::model_copy::get_model_copy_job(&self.state, &resource_id.unwrap_or_default())
             }
             "ListModelCopyJobs" => crate::model_copy::list_model_copy_jobs(&self.state, &req),
+            // Model invocation jobs
+            "CreateModelInvocationJob" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::invocation_jobs::create_model_invocation_job(&self.state, &req, &body)
+            }
+            "GetModelInvocationJob" => crate::invocation_jobs::get_model_invocation_job(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            "ListModelInvocationJobs" => {
+                crate::invocation_jobs::list_model_invocation_jobs(&self.state, &req)
+            }
+            "StopModelInvocationJob" => crate::invocation_jobs::stop_model_invocation_job(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            // Evaluation jobs
+            "CreateEvaluationJob" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::evaluation::create_evaluation_job(&self.state, &req, &body)
+            }
+            "GetEvaluationJob" => {
+                crate::evaluation::get_evaluation_job(&self.state, &resource_id.unwrap_or_default())
+            }
+            "ListEvaluationJobs" => crate::evaluation::list_evaluation_jobs(&self.state, &req),
+            "StopEvaluationJob" => crate::evaluation::stop_evaluation_job(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            "BatchDeleteEvaluationJob" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::evaluation::batch_delete_evaluation_job(&self.state, &body)
+            }
             // Model customization jobs
             "CreateModelCustomizationJob" => {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
@@ -685,6 +749,15 @@ impl AwsService for BedrockService {
             "CreateModelCopyJob",
             "GetModelCopyJob",
             "ListModelCopyJobs",
+            "CreateModelInvocationJob",
+            "GetModelInvocationJob",
+            "ListModelInvocationJobs",
+            "StopModelInvocationJob",
+            "CreateEvaluationJob",
+            "GetEvaluationJob",
+            "ListEvaluationJobs",
+            "StopEvaluationJob",
+            "BatchDeleteEvaluationJob",
             "CreateModelCustomizationJob",
             "GetModelCustomizationJob",
             "ListModelCustomizationJobs",

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -37,6 +37,10 @@ pub struct BedrockState {
     pub imported_models: HashMap<String, ImportedModel>,
     /// Model copy jobs keyed by job ARN.
     pub model_copy_jobs: HashMap<String, ModelCopyJob>,
+    /// Model invocation jobs (batch inference) keyed by job ARN.
+    pub model_invocation_jobs: HashMap<String, ModelInvocationJob>,
+    /// Evaluation jobs keyed by job ARN.
+    pub evaluation_jobs: HashMap<String, EvaluationJob>,
 }
 
 impl BedrockState {
@@ -58,6 +62,8 @@ impl BedrockState {
             model_import_jobs: HashMap::new(),
             imported_models: HashMap::new(),
             model_copy_jobs: HashMap::new(),
+            model_invocation_jobs: HashMap::new(),
+            evaluation_jobs: HashMap::new(),
         }
     }
 
@@ -76,6 +82,8 @@ impl BedrockState {
         self.model_import_jobs.clear();
         self.imported_models.clear();
         self.model_copy_jobs.clear();
+        self.model_invocation_jobs.clear();
+        self.evaluation_jobs.clear();
     }
 }
 
@@ -226,4 +234,33 @@ pub struct ModelCopyJob {
     pub target_model_name: String,
     pub status: String,
     pub creation_time: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct ModelInvocationJob {
+    pub job_arn: String,
+    pub job_name: String,
+    pub model_id: String,
+    pub role_arn: String,
+    pub input_data_config: serde_json::Value,
+    pub output_data_config: serde_json::Value,
+    pub status: String,
+    pub submit_time: DateTime<Utc>,
+    pub last_modified_time: DateTime<Utc>,
+    pub end_time: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone)]
+pub struct EvaluationJob {
+    pub job_arn: String,
+    pub job_name: String,
+    pub job_description: Option<String>,
+    pub role_arn: String,
+    pub status: String,
+    pub job_type: String,
+    pub evaluation_config: serde_json::Value,
+    pub inference_config: serde_json::Value,
+    pub output_data_config: serde_json::Value,
+    pub creation_time: DateTime<Utc>,
+    pub last_modified_time: DateTime<Utc>,
 }

--- a/crates/fakecloud-conformance/tests/bedrock.rs
+++ b/crates/fakecloud-conformance/tests/bedrock.rs
@@ -705,6 +705,148 @@ async fn bedrock_bidirectional_stream_conformance() {
 }
 
 // ---------------------------------------------------------------------------
+// Model Invocation Jobs + Evaluation Jobs
+// ---------------------------------------------------------------------------
+
+#[test_action("bedrock", "CreateModelInvocationJob", checksum = "5880c108")]
+#[test_action("bedrock", "GetModelInvocationJob", checksum = "480ec99e")]
+#[test_action("bedrock", "ListModelInvocationJobs", checksum = "b0e2ea2f")]
+#[test_action("bedrock", "StopModelInvocationJob", checksum = "88af9f13")]
+#[tokio::test]
+async fn bedrock_invocation_job_lifecycle() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({
+        "jobName": "conf-inv-job",
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "roleArn": "arn:aws:iam::123456789012:role/test",
+        "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://bucket/input/"}},
+        "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://bucket/output/"}}
+    });
+    let resp = http_client
+        .post(format!("{}/model-invocation-job", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let job_arn = result["jobArn"].as_str().unwrap().to_string();
+    let job_id = job_arn.rsplit('/').next().unwrap();
+
+    let resp = http_client
+        .get(format!(
+            "{}/model-invocation-job/{}",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .get(format!("{}/model-invocation-jobs", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .post(format!(
+            "{}/model-invocation-job/{}/stop",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[test_action("bedrock", "CreateEvaluationJob", checksum = "381c6747")]
+#[test_action("bedrock", "GetEvaluationJob", checksum = "78e37cc5")]
+#[test_action("bedrock", "ListEvaluationJobs", checksum = "90cf9a61")]
+#[test_action("bedrock", "StopEvaluationJob", checksum = "3b4c4189")]
+#[test_action("bedrock", "BatchDeleteEvaluationJob", checksum = "f6a3ed26")]
+#[tokio::test]
+async fn bedrock_evaluation_job_lifecycle() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({
+        "jobName": "conf-eval-job",
+        "roleArn": "arn:aws:iam::123456789012:role/test",
+        "evaluationConfig": {"automated": {"datasetMetricConfigs": []}},
+        "inferenceConfig": {"models": []},
+        "outputDataConfig": {"s3Uri": "s3://bucket/output/"}
+    });
+    let resp = http_client
+        .post(format!("{}/evaluation-jobs", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let job_arn = result["jobArn"].as_str().unwrap().to_string();
+    let job_id = job_arn.rsplit('/').next().unwrap();
+
+    let resp = http_client
+        .get(format!("{}/evaluation-jobs/{}", server.endpoint(), job_id))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .get(format!("{}/evaluation-jobs", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .post(format!(
+            "{}/evaluation-job/{}/stop",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Batch delete
+    let body = serde_json::json!({"jobIdentifiers": [job_arn]});
+    let resp = http_client
+        .post(format!(
+            "{}/evaluation-jobs/batch-delete",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+// ---------------------------------------------------------------------------
 // Model Import
 // ---------------------------------------------------------------------------
 

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -1498,3 +1498,181 @@ async fn bedrock_model_copy_lifecycle() {
         .unwrap()
         .is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// Model Invocation Jobs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_model_invocation_job_lifecycle() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({
+        "jobName": "my-batch-job",
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "roleArn": "arn:aws:iam::123456789012:role/test",
+        "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://bucket/input/"}},
+        "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://bucket/output/"}}
+    });
+    let resp = http_client
+        .post(format!("{}/model-invocation-job", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let job_arn = result["jobArn"].as_str().unwrap().to_string();
+    let job_id = job_arn.rsplit('/').next().unwrap();
+
+    let resp = http_client
+        .get(format!(
+            "{}/model-invocation-job/{}",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(result["jobName"], "my-batch-job");
+    assert_eq!(result["status"], "InProgress");
+
+    let resp = http_client
+        .get(format!("{}/model-invocation-jobs", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert!(!result["invocationJobSummaries"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+
+    // Stop job
+    let resp = http_client
+        .post(format!(
+            "{}/model-invocation-job/{}/stop",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Verify stopped
+    let resp = http_client
+        .get(format!(
+            "{}/model-invocation-job/{}",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(result["status"], "Stopped");
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation Jobs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_evaluation_job_lifecycle() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({
+        "jobName": "my-eval-job",
+        "jobDescription": "Test evaluation",
+        "roleArn": "arn:aws:iam::123456789012:role/test",
+        "evaluationConfig": {"automated": {"datasetMetricConfigs": []}},
+        "inferenceConfig": {"models": []},
+        "outputDataConfig": {"s3Uri": "s3://bucket/output/"}
+    });
+    let resp = http_client
+        .post(format!("{}/evaluation-jobs", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let job_arn = result["jobArn"].as_str().unwrap().to_string();
+    let job_id = job_arn.rsplit('/').next().unwrap();
+
+    let resp = http_client
+        .get(format!("{}/evaluation-jobs/{}", server.endpoint(), job_id))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(result["jobName"], "my-eval-job");
+    assert_eq!(result["status"], "InProgress");
+    assert_eq!(result["jobType"], "Automated");
+
+    let resp = http_client
+        .get(format!("{}/evaluation-jobs", server.endpoint()))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Stop
+    let resp = http_client
+        .post(format!(
+            "{}/evaluation-job/{}/stop",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Batch delete
+    let body = serde_json::json!({"jobIdentifiers": [job_arn]});
+    let resp = http_client
+        .post(format!(
+            "{}/evaluation-jobs/batch-delete",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    assert!(result["errors"].as_array().unwrap().is_empty());
+
+    // Verify deleted
+    let resp = http_client
+        .get(format!("{}/evaluation-jobs/{}", server.endpoint(), job_id))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}


### PR DESCRIPTION
## Summary

- Implement 9 new Bedrock control plane operations for batch inference and evaluation
- Model Invocation Jobs: CreateModelInvocationJob, GetModelInvocationJob, ListModelInvocationJobs, StopModelInvocationJob
- Evaluation Jobs: CreateEvaluationJob, GetEvaluationJob, ListEvaluationJobs, StopEvaluationJob, BatchDeleteEvaluationJob
- Jobs support status tracking (InProgress -> Stopped) with proper stop validation
- BatchDeleteEvaluationJob handles partial failures with error array

## Test plan

- [x] 32 E2E tests passing (all existing + 2 new)
- [x] 27 conformance tests passing (all existing + 2 new covering 9 ops)
- [x] clippy clean, fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds batch inference (Model Invocation Jobs) and evaluation job APIs to `fakecloud-bedrock` (9 ops). Supports create/get/list/stop with status tracking, and evaluation batch delete with per-item error reporting.

- **New Features**
  - Model Invocation Jobs: Create/Get/List/Stop with pagination and timestamps.
  - Evaluation Jobs: Create/Get/List/Stop plus BatchDelete with partial-failure errors.
  - Service/state wiring: new job structs and maps in state; routes and handlers under `invocation_jobs` and `evaluation`.
  - Tests: conformance and E2E cover all new operations in `fakecloud-conformance` and `fakecloud-e2e`.

<sup>Written for commit 49ff3008ea0e4efc71698208a74fb0cbe62ddf51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

