### PR TITLE
feat(bedrock): add Inference Profiles, Prompt Routers, and Resource Policies (11 ops)

### DIFF
--- a/crates/fakecloud-bedrock/src/inference_profiles.rs
+++ b/crates/fakecloud-bedrock/src/inference_profiles.rs
@@ -1,0 +1,177 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{InferenceProfile, SharedBedrockState};
+
+pub fn create_inference_profile(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let default_name = Uuid::new_v4().to_string()[..8].to_string();
+    let profile_name = body["inferenceProfileName"]
+        .as_str()
+        .unwrap_or(&default_name);
+
+    let profile_id = Uuid::new_v4().to_string();
+    let profile_arn = format!(
+        "arn:aws:bedrock:{}:{}:inference-profile/{}",
+        req.region, req.account_id, profile_id
+    );
+
+    let now = Utc::now();
+    let profile = InferenceProfile {
+        inference_profile_arn: profile_arn.clone(),
+        inference_profile_name: profile_name.to_string(),
+        description: body["description"].as_str().map(|s| s.to_string()),
+        model_source: body.get("modelSource").cloned().unwrap_or(json!({})),
+        status: "Active".to_string(),
+        inference_profile_type: "APPLICATION".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+
+    let mut s = state.write();
+
+    if let Some(tags) = body["tags"].as_array() {
+        let tag_map: std::collections::HashMap<String, String> = tags
+            .iter()
+            .filter_map(|t| {
+                Some((
+                    t["key"].as_str()?.to_string(),
+                    t["value"].as_str()?.to_string(),
+                ))
+            })
+            .collect();
+        if !tag_map.is_empty() {
+            s.tags.insert(profile_arn.clone(), tag_map);
+        }
+    }
+
+    s.inference_profiles.insert(profile_arn.clone(), profile);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "inferenceProfileArn": profile_arn })).unwrap(),
+    ))
+}
+
+pub fn get_inference_profile(
+    state: &SharedBedrockState,
+    identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let profile = s
+        .inference_profiles
+        .get(identifier)
+        .or_else(|| {
+            s.inference_profiles.values().find(|p| {
+                p.inference_profile_name == identifier
+                    || p.inference_profile_arn.ends_with(&format!("/{identifier}"))
+            })
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Inference profile {identifier} not found"),
+            )
+        })?;
+
+    Ok(AwsResponse::ok_json(json!({
+        "inferenceProfileArn": profile.inference_profile_arn,
+        "inferenceProfileName": profile.inference_profile_name,
+        "description": profile.description,
+        "modelSource": profile.model_source,
+        "status": profile.status,
+        "type": profile.inference_profile_type,
+        "createdAt": profile.created_at.to_rfc3339(),
+        "updatedAt": profile.updated_at.to_rfc3339(),
+    })))
+}
+
+pub fn list_inference_profiles(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&InferenceProfile> = s.inference_profiles.values().collect();
+    items.sort_by(|a, b| a.inference_profile_arn.cmp(&b.inference_profile_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|p| p.inference_profile_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|p| {
+            json!({
+                "inferenceProfileArn": p.inference_profile_arn,
+                "inferenceProfileName": p.inference_profile_name,
+                "description": p.description,
+                "status": p.status,
+                "type": p.inference_profile_type,
+                "createdAt": p.created_at.to_rfc3339(),
+                "updatedAt": p.updated_at.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "inferenceProfileSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.inference_profile_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn delete_inference_profile(
+    state: &SharedBedrockState,
+    identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = s
+        .inference_profiles
+        .iter()
+        .find(|(k, p)| {
+            *k == identifier
+                || p.inference_profile_name == identifier
+                || p.inference_profile_arn.ends_with(&format!("/{identifier}"))
+        })
+        .map(|(k, _)| k.clone());
+
+    match key {
+        Some(k) => {
+            s.inference_profiles.remove(&k);
+            Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+        }
+        None => Err(AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Inference profile {identifier} not found"),
+        )),
+    }
+}

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -6,12 +6,15 @@ pub mod customization;
 
 pub mod evaluation;
 pub mod guardrails;
+pub mod inference_profiles;
 pub mod invocation_jobs;
 pub mod invoke;
 pub mod logging;
 pub mod model_copy;
 pub mod model_import;
 pub mod models;
+pub mod prompt_routers;
+pub mod resource_policies;
 pub mod service;
 pub mod state;
 pub mod streaming;

--- a/crates/fakecloud-bedrock/src/prompt_routers.rs
+++ b/crates/fakecloud-bedrock/src/prompt_routers.rs
@@ -1,0 +1,163 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{PromptRouter, SharedBedrockState};
+
+pub fn create_prompt_router(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let default_name = Uuid::new_v4().to_string()[..8].to_string();
+    let router_name = body["promptRouterName"].as_str().unwrap_or(&default_name);
+
+    let router_id = Uuid::new_v4().to_string();
+    let router_arn = format!(
+        "arn:aws:bedrock:{}:{}:prompt-router/{}",
+        req.region, req.account_id, router_id
+    );
+
+    let now = Utc::now();
+    let router = PromptRouter {
+        prompt_router_arn: router_arn.clone(),
+        prompt_router_name: router_name.to_string(),
+        description: body["description"].as_str().map(|s| s.to_string()),
+        models: body.get("models").cloned().unwrap_or(json!([])),
+        routing_criteria: body.get("routingCriteria").cloned().unwrap_or(json!({})),
+        fallback_model: body.get("fallbackModel").cloned().unwrap_or(json!({})),
+        status: "Active".to_string(),
+        prompt_router_type: "custom".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+
+    let mut s = state.write();
+    s.prompt_routers.insert(router_arn.clone(), router);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "promptRouterArn": router_arn })).unwrap(),
+    ))
+}
+
+pub fn get_prompt_router(
+    state: &SharedBedrockState,
+    identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let router = s
+        .prompt_routers
+        .get(identifier)
+        .or_else(|| {
+            s.prompt_routers.values().find(|r| {
+                r.prompt_router_name == identifier
+                    || r.prompt_router_arn.ends_with(&format!("/{identifier}"))
+            })
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Prompt router {identifier} not found"),
+            )
+        })?;
+
+    Ok(AwsResponse::ok_json(json!({
+        "promptRouterArn": router.prompt_router_arn,
+        "promptRouterName": router.prompt_router_name,
+        "description": router.description,
+        "models": router.models,
+        "routingCriteria": router.routing_criteria,
+        "fallbackModel": router.fallback_model,
+        "status": router.status,
+        "type": router.prompt_router_type,
+        "createdAt": router.created_at.to_rfc3339(),
+        "updatedAt": router.updated_at.to_rfc3339(),
+    })))
+}
+
+pub fn list_prompt_routers(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&PromptRouter> = s.prompt_routers.values().collect();
+    items.sort_by(|a, b| a.prompt_router_arn.cmp(&b.prompt_router_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|r| r.prompt_router_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|r| {
+            json!({
+                "promptRouterArn": r.prompt_router_arn,
+                "promptRouterName": r.prompt_router_name,
+                "description": r.description,
+                "status": r.status,
+                "type": r.prompt_router_type,
+                "createdAt": r.created_at.to_rfc3339(),
+                "updatedAt": r.updated_at.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "promptRouterSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.prompt_router_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn delete_prompt_router(
+    state: &SharedBedrockState,
+    identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = s
+        .prompt_routers
+        .iter()
+        .find(|(k, r)| {
+            *k == identifier
+                || r.prompt_router_name == identifier
+                || r.prompt_router_arn.ends_with(&format!("/{identifier}"))
+        })
+        .map(|(k, _)| k.clone());
+
+    match key {
+        Some(k) => {
+            s.prompt_routers.remove(&k);
+            Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+        }
+        None => Err(AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Prompt router {identifier} not found"),
+        )),
+    }
+}

--- a/crates/fakecloud-bedrock/src/resource_policies.rs
+++ b/crates/fakecloud-bedrock/src/resource_policies.rs
@@ -1,0 +1,97 @@
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsResponse, AwsServiceError};
+
+use crate::state::SharedBedrockState;
+
+pub fn put_resource_policy(
+    state: &SharedBedrockState,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let resource_arn = body["resourceArn"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "resourceArn is required",
+        )
+    })?;
+
+    let policy = body["resourcePolicy"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "resourcePolicy is required",
+        )
+    })?;
+
+    let revision_id = Uuid::new_v4().to_string();
+
+    let mut s = state.write();
+    s.resource_policies
+        .insert(resource_arn.to_string(), policy.to_string());
+
+    Ok(AwsResponse::ok_json(json!({
+        "resourceArn": resource_arn,
+        "revisionId": revision_id,
+    })))
+}
+
+pub fn get_resource_policy(
+    state: &SharedBedrockState,
+    resource_arn: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let policy = s
+        .resource_policies
+        .get(resource_arn)
+        .or_else(|| {
+            s.resource_policies
+                .iter()
+                .find(|(k, _)| k.ends_with(&format!("/{resource_arn}")))
+                .map(|(_, v)| v)
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Resource policy for {resource_arn} not found"),
+            )
+        })?;
+
+    let revision_id = Uuid::new_v4().to_string();
+
+    Ok(AwsResponse::ok_json(json!({
+        "resourcePolicy": policy,
+        "revisionId": revision_id,
+    })))
+}
+
+pub fn delete_resource_policy(
+    state: &SharedBedrockState,
+    resource_arn: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = if s.resource_policies.contains_key(resource_arn) {
+        Some(resource_arn.to_string())
+    } else {
+        s.resource_policies
+            .keys()
+            .find(|k| k.ends_with(&format!("/{resource_arn}")))
+            .cloned()
+    };
+
+    match key {
+        Some(k) => {
+            s.resource_policies.remove(&k);
+            Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+        }
+        None => Err(AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Resource policy for {resource_arn} not found"),
+        )),
+    }
+}

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -158,6 +158,45 @@ impl BedrockService {
                 Some(("BatchDeleteEvaluationJob", None, None))
             }
 
+            // Inference profiles
+            (Method::POST, 1) if segs[0] == "inference-profiles" => {
+                Some(("CreateInferenceProfile", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "inference-profiles" => {
+                Some(("ListInferenceProfiles", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "inference-profiles" => {
+                Some(("GetInferenceProfile", Some(decode(&segs[1])), None))
+            }
+            (Method::DELETE, 2) if segs[0] == "inference-profiles" => {
+                Some(("DeleteInferenceProfile", Some(decode(&segs[1])), None))
+            }
+
+            // Prompt routers
+            (Method::POST, 1) if segs[0] == "prompt-routers" => {
+                Some(("CreatePromptRouter", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "prompt-routers" => {
+                Some(("ListPromptRouters", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "prompt-routers" => {
+                Some(("GetPromptRouter", Some(decode(&segs[1])), None))
+            }
+            (Method::DELETE, 2) if segs[0] == "prompt-routers" => {
+                Some(("DeletePromptRouter", Some(decode(&segs[1])), None))
+            }
+
+            // Resource policies
+            (Method::POST, 1) if segs[0] == "resource-policy" => {
+                Some(("PutResourcePolicy", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "resource-policy" => {
+                Some(("GetResourcePolicy", Some(decode(&segs[1])), None))
+            }
+            (Method::DELETE, 2) if segs[0] == "resource-policy" => {
+                Some(("DeleteResourcePolicy", Some(decode(&segs[1])), None))
+            }
+
             // Model customization jobs
             (Method::POST, 1) if segs[0] == "model-customization-jobs" => {
                 Some(("CreateModelCustomizationJob", None, None))
@@ -585,6 +624,49 @@ impl AwsService for BedrockService {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
                 crate::evaluation::batch_delete_evaluation_job(&self.state, &body)
             }
+            // Inference profiles
+            "CreateInferenceProfile" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::inference_profiles::create_inference_profile(&self.state, &req, &body)
+            }
+            "GetInferenceProfile" => crate::inference_profiles::get_inference_profile(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            "ListInferenceProfiles" => {
+                crate::inference_profiles::list_inference_profiles(&self.state, &req)
+            }
+            "DeleteInferenceProfile" => crate::inference_profiles::delete_inference_profile(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            // Prompt routers
+            "CreatePromptRouter" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::prompt_routers::create_prompt_router(&self.state, &req, &body)
+            }
+            "GetPromptRouter" => crate::prompt_routers::get_prompt_router(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            "ListPromptRouters" => crate::prompt_routers::list_prompt_routers(&self.state, &req),
+            "DeletePromptRouter" => crate::prompt_routers::delete_prompt_router(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            // Resource policies
+            "PutResourcePolicy" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::resource_policies::put_resource_policy(&self.state, &body)
+            }
+            "GetResourcePolicy" => crate::resource_policies::get_resource_policy(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            "DeleteResourcePolicy" => crate::resource_policies::delete_resource_policy(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
             // Model customization jobs
             "CreateModelCustomizationJob" => {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
@@ -758,6 +840,17 @@ impl AwsService for BedrockService {
             "ListEvaluationJobs",
             "StopEvaluationJob",
             "BatchDeleteEvaluationJob",
+            "CreateInferenceProfile",
+            "GetInferenceProfile",
+            "ListInferenceProfiles",
+            "DeleteInferenceProfile",
+            "CreatePromptRouter",
+            "GetPromptRouter",
+            "ListPromptRouters",
+            "DeletePromptRouter",
+            "PutResourcePolicy",
+            "GetResourcePolicy",
+            "DeleteResourcePolicy",
             "CreateModelCustomizationJob",
             "GetModelCustomizationJob",
             "ListModelCustomizationJobs",

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -41,6 +41,12 @@ pub struct BedrockState {
     pub model_invocation_jobs: HashMap<String, ModelInvocationJob>,
     /// Evaluation jobs keyed by job ARN.
     pub evaluation_jobs: HashMap<String, EvaluationJob>,
+    /// Inference profiles keyed by ARN.
+    pub inference_profiles: HashMap<String, InferenceProfile>,
+    /// Prompt routers keyed by ARN.
+    pub prompt_routers: HashMap<String, PromptRouter>,
+    /// Resource policies keyed by resource ARN.
+    pub resource_policies: HashMap<String, String>,
 }
 
 impl BedrockState {
@@ -64,6 +70,9 @@ impl BedrockState {
             model_copy_jobs: HashMap::new(),
             model_invocation_jobs: HashMap::new(),
             evaluation_jobs: HashMap::new(),
+            inference_profiles: HashMap::new(),
+            prompt_routers: HashMap::new(),
+            resource_policies: HashMap::new(),
         }
     }
 
@@ -84,6 +93,9 @@ impl BedrockState {
         self.model_copy_jobs.clear();
         self.model_invocation_jobs.clear();
         self.evaluation_jobs.clear();
+        self.inference_profiles.clear();
+        self.prompt_routers.clear();
+        self.resource_policies.clear();
     }
 }
 
@@ -263,4 +275,30 @@ pub struct EvaluationJob {
     pub output_data_config: serde_json::Value,
     pub creation_time: DateTime<Utc>,
     pub last_modified_time: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct InferenceProfile {
+    pub inference_profile_arn: String,
+    pub inference_profile_name: String,
+    pub description: Option<String>,
+    pub model_source: serde_json::Value,
+    pub status: String,
+    pub inference_profile_type: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct PromptRouter {
+    pub prompt_router_arn: String,
+    pub prompt_router_name: String,
+    pub description: Option<String>,
+    pub models: serde_json::Value,
+    pub routing_criteria: serde_json::Value,
+    pub fallback_model: serde_json::Value,
+    pub status: String,
+    pub prompt_router_type: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }

--- a/crates/fakecloud-conformance/tests/bedrock.rs
+++ b/crates/fakecloud-conformance/tests/bedrock.rs
@@ -705,6 +705,143 @@ async fn bedrock_bidirectional_stream_conformance() {
 }
 
 // ---------------------------------------------------------------------------
+// Inference Profiles + Prompt Routers + Resource Policies
+// ---------------------------------------------------------------------------
+
+#[test_action("bedrock", "CreateInferenceProfile", checksum = "388f64f4")]
+#[test_action("bedrock", "GetInferenceProfile", checksum = "fe429d75")]
+#[test_action("bedrock", "ListInferenceProfiles", checksum = "bfad176c")]
+#[test_action("bedrock", "DeleteInferenceProfile", checksum = "ce7ec24d")]
+#[tokio::test]
+async fn bedrock_inference_profile_crud() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+    let b = serde_json::json!({"inferenceProfileName": "conf-profile", "modelSource": {"copyFrom": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"}});
+    let r = h
+        .post(format!("{}/inference-profiles", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 201);
+    let v: serde_json::Value = r.json().await.unwrap();
+    let arn = v["inferenceProfileArn"].as_str().unwrap().to_string();
+    let id = arn.rsplit('/').next().unwrap();
+    let r = h
+        .get(format!("{}/inference-profiles/{}", server.endpoint(), id))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    let r = h
+        .get(format!("{}/inference-profiles", server.endpoint()))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    let r = h
+        .delete(format!("{}/inference-profiles/{}", server.endpoint(), id))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+}
+
+#[test_action("bedrock", "CreatePromptRouter", checksum = "fafd4f61")]
+#[test_action("bedrock", "GetPromptRouter", checksum = "2dd3ec96")]
+#[test_action("bedrock", "ListPromptRouters", checksum = "a5214114")]
+#[test_action("bedrock", "DeletePromptRouter", checksum = "c3558acb")]
+#[tokio::test]
+async fn bedrock_prompt_router_crud() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+    let b = serde_json::json!({"promptRouterName": "conf-router", "models": [{"modelIdentifier": "anthropic.claude-3-5-sonnet-20241022-v2:0"}], "routingCriteria": {"responseQualityDifference": 0.5}, "fallbackModel": {"modelIdentifier": "anthropic.claude-3-haiku-20240307-v1:0"}});
+    let r = h
+        .post(format!("{}/prompt-routers", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 201);
+    let v: serde_json::Value = r.json().await.unwrap();
+    let arn = v["promptRouterArn"].as_str().unwrap().to_string();
+    let id = arn.rsplit('/').next().unwrap();
+    let r = h
+        .get(format!("{}/prompt-routers/{}", server.endpoint(), id))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    let r = h
+        .get(format!("{}/prompt-routers", server.endpoint()))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    let r = h
+        .delete(format!("{}/prompt-routers/{}", server.endpoint(), id))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+}
+
+#[test_action("bedrock", "PutResourcePolicy", checksum = "63f426a5")]
+#[test_action("bedrock", "GetResourcePolicy", checksum = "fbded8d2")]
+#[test_action("bedrock", "DeleteResourcePolicy", checksum = "83805f9a")]
+#[tokio::test]
+async fn bedrock_resource_policy_crud() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+    let arn = "arn:aws:bedrock:us-east-1:123456789012:custom-model/test";
+    let b = serde_json::json!({"resourceArn": arn, "resourcePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[]}"});
+    let r = h
+        .post(format!("{}/resource-policy", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    let r = h
+        .get(format!(
+            "{}/resource-policy/{}",
+            server.endpoint(),
+            arn.replace(':', "%3A").replace('/', "%2F")
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    let r = h
+        .delete(format!(
+            "{}/resource-policy/{}",
+            server.endpoint(),
+            arn.replace(':', "%3A").replace('/', "%2F")
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+}
+
+// ---------------------------------------------------------------------------
 // Model Invocation Jobs + Evaluation Jobs
 // ---------------------------------------------------------------------------
 

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -1676,3 +1676,184 @@ async fn bedrock_evaluation_job_lifecycle() {
         .unwrap();
     assert_eq!(resp.status(), 404);
 }
+
+// ---------------------------------------------------------------------------
+// Inference Profiles
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_inference_profile_crud() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let b = serde_json::json!({"inferenceProfileName": "my-profile", "description": "Test", "modelSource": {"copyFrom": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"}});
+    let r = h
+        .post(format!("{}/inference-profiles", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 201);
+    let v: serde_json::Value = r.json().await.unwrap();
+    let id = v["inferenceProfileArn"]
+        .as_str()
+        .unwrap()
+        .rsplit('/')
+        .next()
+        .unwrap()
+        .to_string();
+
+    let r = h
+        .get(format!("{}/inference-profiles/{}", server.endpoint(), id))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    let v: serde_json::Value = r.json().await.unwrap();
+    assert_eq!(v["inferenceProfileName"], "my-profile");
+
+    let r = h
+        .get(format!("{}/inference-profiles", server.endpoint()))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+
+    let r = h
+        .delete(format!("{}/inference-profiles/{}", server.endpoint(), id))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+
+    let r = h
+        .get(format!("{}/inference-profiles/{}", server.endpoint(), id))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 404);
+}
+
+// ---------------------------------------------------------------------------
+// Prompt Routers
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_prompt_router_crud() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let b = serde_json::json!({"promptRouterName": "my-router", "models": [], "routingCriteria": {}, "fallbackModel": {"modelIdentifier": "anthropic.claude-3-haiku-20240307-v1:0"}});
+    let r = h
+        .post(format!("{}/prompt-routers", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 201);
+    let v: serde_json::Value = r.json().await.unwrap();
+    let id = v["promptRouterArn"]
+        .as_str()
+        .unwrap()
+        .rsplit('/')
+        .next()
+        .unwrap()
+        .to_string();
+
+    let r = h
+        .get(format!("{}/prompt-routers/{}", server.endpoint(), id))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+
+    let r = h
+        .get(format!("{}/prompt-routers", server.endpoint()))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+
+    let r = h
+        .delete(format!("{}/prompt-routers/{}", server.endpoint(), id))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+}
+
+// ---------------------------------------------------------------------------
+// Resource Policies
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bedrock_resource_policy_crud() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+    let arn = "arn:aws:bedrock:us-east-1:123456789012:custom-model/test-res-policy";
+
+    let b =
+        serde_json::json!({"resourceArn": arn, "resourcePolicy": "{\"Version\":\"2012-10-17\"}"});
+    let r = h
+        .post(format!("{}/resource-policy", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+
+    let encoded_arn = arn.replace(':', "%3A").replace('/', "%2F");
+    let r = h
+        .get(format!(
+            "{}/resource-policy/{}",
+            server.endpoint(),
+            encoded_arn
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    let v: serde_json::Value = r.json().await.unwrap();
+    assert!(v["resourcePolicy"].as_str().is_some());
+
+    let r = h
+        .delete(format!(
+            "{}/resource-policy/{}",
+            server.endpoint(),
+            encoded_arn
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+
+    let r = h
+        .get(format!(
+            "{}/resource-policy/{}",
+            server.endpoint(),
+            encoded_arn
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 404);
+}


### PR DESCRIPTION
## Summary

- Implement 11 new Bedrock control plane operations
- Inference Profiles: Create, Get, List, Delete (4 ops)
- Prompt Routers: Create, Get, List, Delete (4 ops)
- Resource Policies: Put, Get, Delete (3 ops)

## Test plan

- [x] 35 E2E tests passing
- [x] 30 conformance tests passing
- [x] clippy clean, fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 11 Bedrock control plane operations: Inference Profiles (Create/Get/List/Delete), Prompt Routers (Create/Get/List/Delete), and Resource Policies (Put/Get/Delete). Enables creating and managing these resources with pagination and flexible ARN/name lookups in `fakecloud-bedrock`.

- **New Features**
  - Route new endpoints in `service.rs` with handlers in `inference_profiles.rs`, `prompt_routers.rs`, and `resource_policies.rs`.
  - Store resources in `state.rs` with in-memory maps; support `maxResults`/`nextToken` pagination and identifier matching by ARN/name/ID.
  - Add tests for all 11 ops in `fakecloud-e2e` and `fakecloud-conformance`.

<sup>Written for commit 33827433ded009ff00fcfaab6b1807f4f7ef1b6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

