### PR TITLE
feat(bedrock): add Marketplace, Agreements, Enforced Guardrails, and Misc (16 ops)

### DIFF
--- a/crates/fakecloud-bedrock/src/enforced_guardrails.rs
+++ b/crates/fakecloud-bedrock/src/enforced_guardrails.rs
@@ -1,0 +1,87 @@
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::SharedBedrockState;
+
+pub fn put_enforced_guardrail_configuration(
+    state: &SharedBedrockState,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let config_id = Uuid::new_v4().to_string();
+
+    let mut s = state.write();
+    s.enforced_guardrail_configs
+        .insert(config_id.clone(), body.clone());
+
+    Ok(AwsResponse::ok_json(json!({
+        "configId": config_id,
+    })))
+}
+
+pub fn list_enforced_guardrails_configuration(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<(&String, &Value)> = s.enforced_guardrail_configs.iter().collect();
+    items.sort_by(|a, b| a.0.cmp(b.0));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|(k, _)| k.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|(k, v)| {
+            let mut entry = (*v).clone();
+            if let Some(obj) = entry.as_object_mut() {
+                obj.insert("configId".to_string(), json!(k));
+            }
+            entry
+        })
+        .collect();
+
+    let mut resp = json!({ "enforcedGuardrailsConfigurations": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.0);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn delete_enforced_guardrail_configuration(
+    state: &SharedBedrockState,
+    config_id: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    match s.enforced_guardrail_configs.remove(config_id) {
+        Some(_) => Ok(AwsResponse::json(StatusCode::OK, "{}".to_string())),
+        None => Err(AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Enforced guardrail configuration {config_id} not found"),
+        )),
+    }
+}

--- a/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
+++ b/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
@@ -1,0 +1,127 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{FoundationModelAgreement, SharedBedrockState};
+
+pub fn create_foundation_model_agreement(
+    state: &SharedBedrockState,
+    _req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let model_id = body["modelId"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "modelId is required",
+        )
+    })?;
+
+    let agreement_id = Uuid::new_v4().to_string();
+
+    let agreement = FoundationModelAgreement {
+        agreement_id: agreement_id.clone(),
+        model_id: model_id.to_string(),
+        created_at: Utc::now(),
+    };
+
+    let mut s = state.write();
+    s.foundation_model_agreements
+        .insert(agreement_id, agreement);
+
+    Ok(AwsResponse::ok_json(json!({
+        "modelId": model_id,
+    })))
+}
+
+pub fn delete_foundation_model_agreement(
+    state: &SharedBedrockState,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let model_id = body["modelId"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "modelId is required",
+        )
+    })?;
+
+    let mut s = state.write();
+    let key = s
+        .foundation_model_agreements
+        .iter()
+        .find(|(_, a)| a.model_id == model_id)
+        .map(|(k, _)| k.clone());
+
+    match key {
+        Some(k) => {
+            s.foundation_model_agreements.remove(&k);
+            Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+        }
+        None => Err(AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Foundation model agreement for {model_id} not found"),
+        )),
+    }
+}
+
+pub fn list_foundation_model_agreement_offers(
+    _state: &SharedBedrockState,
+    model_id: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    Ok(AwsResponse::ok_json(json!({
+        "modelId": model_id,
+        "offers": [],
+    })))
+}
+
+pub fn get_foundation_model_availability(
+    state: &SharedBedrockState,
+    model_id: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let has_agreement = s
+        .foundation_model_agreements
+        .values()
+        .any(|a| a.model_id == model_id);
+
+    Ok(AwsResponse::ok_json(json!({
+        "modelId": model_id,
+        "agreementAvailability": {
+            "status": if has_agreement { "AVAILABLE" } else { "NOT_AVAILABLE" },
+        },
+    })))
+}
+
+pub fn get_use_case_for_model_access(
+    state: &SharedBedrockState,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let use_case = s.use_case_for_model_access.clone().unwrap_or(json!(null));
+
+    Ok(AwsResponse::ok_json(json!({
+        "useCase": use_case,
+    })))
+}
+
+pub fn put_use_case_for_model_access(
+    state: &SharedBedrockState,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let use_case = body.get("useCase").cloned().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "useCase is required",
+        )
+    })?;
+
+    let mut s = state.write();
+    s.use_case_for_model_access = Some(use_case);
+
+    Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+}

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -4,12 +4,15 @@ pub mod custom_model_deployments;
 pub mod custom_models;
 pub mod customization;
 
+pub mod enforced_guardrails;
 pub mod evaluation;
+pub mod foundation_model_agreements;
 pub mod guardrails;
 pub mod inference_profiles;
 pub mod invocation_jobs;
 pub mod invoke;
 pub mod logging;
+pub mod marketplace;
 pub mod model_copy;
 pub mod model_import;
 pub mod models;

--- a/crates/fakecloud-bedrock/src/marketplace.rs
+++ b/crates/fakecloud-bedrock/src/marketplace.rs
@@ -1,0 +1,295 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{MarketplaceModelEndpoint, SharedBedrockState};
+
+pub fn create_marketplace_model_endpoint(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let endpoint_name = body["endpointName"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "endpointName is required",
+        )
+    })?;
+
+    let model_source_identifier = body["modelSourceIdentifier"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "modelSourceIdentifier is required",
+        )
+    })?;
+
+    let endpoint_id = Uuid::new_v4().to_string();
+    let endpoint_arn = format!(
+        "arn:aws:bedrock:{}:{}:marketplace-model-endpoint/{}",
+        req.region, req.account_id, endpoint_id
+    );
+
+    let now = Utc::now();
+    let endpoint = MarketplaceModelEndpoint {
+        endpoint_arn: endpoint_arn.clone(),
+        endpoint_name: endpoint_name.to_string(),
+        model_source_identifier: model_source_identifier.to_string(),
+        status: "Active".to_string(),
+        endpoint_config: body.get("endpointConfig").cloned().unwrap_or(json!({})),
+        created_at: now,
+        updated_at: now,
+    };
+
+    let mut s = state.write();
+    s.marketplace_endpoints
+        .insert(endpoint_arn.clone(), endpoint);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "marketplaceModelEndpointArn": endpoint_arn })).unwrap(),
+    ))
+}
+
+pub fn get_marketplace_model_endpoint(
+    state: &SharedBedrockState,
+    identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let endpoint = s
+        .marketplace_endpoints
+        .get(identifier)
+        .or_else(|| {
+            s.marketplace_endpoints.values().find(|e| {
+                e.endpoint_name == identifier || e.endpoint_arn.ends_with(&format!("/{identifier}"))
+            })
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Marketplace model endpoint {identifier} not found"),
+            )
+        })?;
+
+    Ok(AwsResponse::ok_json(json!({
+        "marketplaceModelEndpoint": {
+            "endpointArn": endpoint.endpoint_arn,
+            "endpointName": endpoint.endpoint_name,
+            "modelSourceIdentifier": endpoint.model_source_identifier,
+            "status": endpoint.status,
+            "endpointConfig": endpoint.endpoint_config,
+            "createdAt": endpoint.created_at.to_rfc3339(),
+            "updatedAt": endpoint.updated_at.to_rfc3339(),
+        }
+    })))
+}
+
+pub fn list_marketplace_model_endpoints(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&MarketplaceModelEndpoint> = s.marketplace_endpoints.values().collect();
+    items.sort_by(|a, b| a.endpoint_arn.cmp(&b.endpoint_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|e| e.endpoint_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|e| {
+            json!({
+                "endpointArn": e.endpoint_arn,
+                "endpointName": e.endpoint_name,
+                "modelSourceIdentifier": e.model_source_identifier,
+                "status": e.status,
+                "createdAt": e.created_at.to_rfc3339(),
+                "updatedAt": e.updated_at.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "marketplaceModelEndpoints": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.endpoint_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn update_marketplace_model_endpoint(
+    state: &SharedBedrockState,
+    identifier: &str,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = s
+        .marketplace_endpoints
+        .iter()
+        .find(|(k, e)| {
+            *k == identifier
+                || e.endpoint_name == identifier
+                || e.endpoint_arn.ends_with(&format!("/{identifier}"))
+        })
+        .map(|(k, _)| k.clone())
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Marketplace model endpoint {identifier} not found"),
+            )
+        })?;
+
+    let endpoint = s.marketplace_endpoints.get_mut(&key).unwrap();
+
+    if let Some(config) = body.get("endpointConfig") {
+        endpoint.endpoint_config = config.clone();
+    }
+    endpoint.updated_at = Utc::now();
+
+    Ok(AwsResponse::ok_json(json!({
+        "marketplaceModelEndpoint": {
+            "endpointArn": endpoint.endpoint_arn,
+            "endpointName": endpoint.endpoint_name,
+            "modelSourceIdentifier": endpoint.model_source_identifier,
+            "status": endpoint.status,
+            "endpointConfig": endpoint.endpoint_config,
+            "createdAt": endpoint.created_at.to_rfc3339(),
+            "updatedAt": endpoint.updated_at.to_rfc3339(),
+        }
+    })))
+}
+
+pub fn delete_marketplace_model_endpoint(
+    state: &SharedBedrockState,
+    identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = s
+        .marketplace_endpoints
+        .iter()
+        .find(|(k, e)| {
+            *k == identifier
+                || e.endpoint_name == identifier
+                || e.endpoint_arn.ends_with(&format!("/{identifier}"))
+        })
+        .map(|(k, _)| k.clone());
+
+    match key {
+        Some(k) => {
+            s.marketplace_endpoints.remove(&k);
+            Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+        }
+        None => Err(AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Marketplace model endpoint {identifier} not found"),
+        )),
+    }
+}
+
+pub fn register_marketplace_model_endpoint(
+    state: &SharedBedrockState,
+    identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = s
+        .marketplace_endpoints
+        .iter()
+        .find(|(k, e)| {
+            *k == identifier
+                || e.endpoint_name == identifier
+                || e.endpoint_arn.ends_with(&format!("/{identifier}"))
+        })
+        .map(|(k, _)| k.clone())
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Marketplace model endpoint {identifier} not found"),
+            )
+        })?;
+
+    let endpoint = s.marketplace_endpoints.get_mut(&key).unwrap();
+    endpoint.status = "Registered".to_string();
+    endpoint.updated_at = Utc::now();
+
+    Ok(AwsResponse::ok_json(json!({
+        "marketplaceModelEndpoint": {
+            "endpointArn": endpoint.endpoint_arn,
+            "endpointName": endpoint.endpoint_name,
+            "modelSourceIdentifier": endpoint.model_source_identifier,
+            "status": endpoint.status,
+            "endpointConfig": endpoint.endpoint_config,
+            "createdAt": endpoint.created_at.to_rfc3339(),
+            "updatedAt": endpoint.updated_at.to_rfc3339(),
+        }
+    })))
+}
+
+pub fn deregister_marketplace_model_endpoint(
+    state: &SharedBedrockState,
+    identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = s
+        .marketplace_endpoints
+        .iter()
+        .find(|(k, e)| {
+            *k == identifier
+                || e.endpoint_name == identifier
+                || e.endpoint_arn.ends_with(&format!("/{identifier}"))
+        })
+        .map(|(k, _)| k.clone())
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Marketplace model endpoint {identifier} not found"),
+            )
+        })?;
+
+    let endpoint = s.marketplace_endpoints.get_mut(&key).unwrap();
+    endpoint.status = "Active".to_string();
+    endpoint.updated_at = Utc::now();
+
+    Ok(AwsResponse::ok_json(json!({
+        "marketplaceModelEndpoint": {
+            "endpointArn": endpoint.endpoint_arn,
+            "endpointName": endpoint.endpoint_name,
+            "modelSourceIdentifier": endpoint.model_source_identifier,
+            "status": endpoint.status,
+            "endpointConfig": endpoint.endpoint_config,
+            "createdAt": endpoint.created_at.to_rfc3339(),
+            "updatedAt": endpoint.updated_at.to_rfc3339(),
+        }
+    })))
+}

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -197,6 +197,90 @@ impl BedrockService {
                 Some(("DeleteResourcePolicy", Some(decode(&segs[1])), None))
             }
 
+            // Marketplace model endpoints
+            (Method::POST, 2) if segs[0] == "marketplace-model" && segs[1] == "endpoints" => {
+                Some(("CreateMarketplaceModelEndpoint", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "marketplace-model" && segs[1] == "endpoints" => {
+                Some(("ListMarketplaceModelEndpoints", None, None))
+            }
+            (Method::GET, 3) if segs[0] == "marketplace-model" && segs[1] == "endpoints" => {
+                Some(("GetMarketplaceModelEndpoint", Some(decode(&segs[2])), None))
+            }
+            (Method::PATCH, 3) if segs[0] == "marketplace-model" && segs[1] == "endpoints" => {
+                Some((
+                    "UpdateMarketplaceModelEndpoint",
+                    Some(decode(&segs[2])),
+                    None,
+                ))
+            }
+            (Method::DELETE, 3) if segs[0] == "marketplace-model" && segs[1] == "endpoints" => {
+                Some((
+                    "DeleteMarketplaceModelEndpoint",
+                    Some(decode(&segs[2])),
+                    None,
+                ))
+            }
+            (Method::POST, 4)
+                if segs[0] == "marketplace-model"
+                    && segs[1] == "endpoints"
+                    && segs[3] == "registration" =>
+            {
+                Some((
+                    "RegisterMarketplaceModelEndpoint",
+                    Some(decode(&segs[2])),
+                    None,
+                ))
+            }
+            (Method::DELETE, 4)
+                if segs[0] == "marketplace-model"
+                    && segs[1] == "endpoints"
+                    && segs[3] == "registration" =>
+            {
+                Some((
+                    "DeregisterMarketplaceModelEndpoint",
+                    Some(decode(&segs[2])),
+                    None,
+                ))
+            }
+
+            // Foundation model agreements
+            (Method::POST, 1) if segs[0] == "create-foundation-model-agreement" => {
+                Some(("CreateFoundationModelAgreement", None, None))
+            }
+            (Method::POST, 1) if segs[0] == "delete-foundation-model-agreement" => {
+                Some(("DeleteFoundationModelAgreement", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "list-foundation-model-agreement-offers" => Some((
+                "ListFoundationModelAgreementOffers",
+                Some(decode(&segs[1])),
+                None,
+            )),
+            (Method::GET, 2) if segs[0] == "foundation-model-availability" => Some((
+                "GetFoundationModelAvailability",
+                Some(decode(&segs[1])),
+                None,
+            )),
+            (Method::GET, 1) if segs[0] == "use-case-for-model-access" => {
+                Some(("GetUseCaseForModelAccess", None, None))
+            }
+            (Method::POST, 1) if segs[0] == "use-case-for-model-access" => {
+                Some(("PutUseCaseForModelAccess", None, None))
+            }
+
+            // Enforced guardrails
+            (Method::PUT, 1) if segs[0] == "enforcedGuardrailsConfiguration" => {
+                Some(("PutEnforcedGuardrailConfiguration", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "enforcedGuardrailsConfiguration" => {
+                Some(("ListEnforcedGuardrailsConfiguration", None, None))
+            }
+            (Method::DELETE, 2) if segs[0] == "enforcedGuardrailsConfiguration" => Some((
+                "DeleteEnforcedGuardrailConfiguration",
+                Some(decode(&segs[1])),
+                None,
+            )),
+
             // Model customization jobs
             (Method::POST, 1) if segs[0] == "model-customization-jobs" => {
                 Some(("CreateModelCustomizationJob", None, None))
@@ -667,6 +751,99 @@ impl AwsService for BedrockService {
                 &self.state,
                 &resource_id.unwrap_or_default(),
             ),
+            // Marketplace model endpoints
+            "CreateMarketplaceModelEndpoint" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::marketplace::create_marketplace_model_endpoint(&self.state, &req, &body)
+            }
+            "GetMarketplaceModelEndpoint" => crate::marketplace::get_marketplace_model_endpoint(
+                &self.state,
+                &resource_id.unwrap_or_default(),
+            ),
+            "ListMarketplaceModelEndpoints" => {
+                crate::marketplace::list_marketplace_model_endpoints(&self.state, &req)
+            }
+            "UpdateMarketplaceModelEndpoint" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::marketplace::update_marketplace_model_endpoint(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                    &body,
+                )
+            }
+            "DeleteMarketplaceModelEndpoint" => {
+                crate::marketplace::delete_marketplace_model_endpoint(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
+            "RegisterMarketplaceModelEndpoint" => {
+                crate::marketplace::register_marketplace_model_endpoint(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
+            "DeregisterMarketplaceModelEndpoint" => {
+                crate::marketplace::deregister_marketplace_model_endpoint(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
+            // Foundation model agreements
+            "CreateFoundationModelAgreement" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::foundation_model_agreements::create_foundation_model_agreement(
+                    &self.state,
+                    &req,
+                    &body,
+                )
+            }
+            "DeleteFoundationModelAgreement" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::foundation_model_agreements::delete_foundation_model_agreement(
+                    &self.state,
+                    &body,
+                )
+            }
+            "ListFoundationModelAgreementOffers" => {
+                crate::foundation_model_agreements::list_foundation_model_agreement_offers(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
+            "GetFoundationModelAvailability" => {
+                crate::foundation_model_agreements::get_foundation_model_availability(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
+            "GetUseCaseForModelAccess" => {
+                crate::foundation_model_agreements::get_use_case_for_model_access(&self.state)
+            }
+            "PutUseCaseForModelAccess" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::foundation_model_agreements::put_use_case_for_model_access(
+                    &self.state,
+                    &body,
+                )
+            }
+            // Enforced guardrails
+            "PutEnforcedGuardrailConfiguration" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::enforced_guardrails::put_enforced_guardrail_configuration(&self.state, &body)
+            }
+            "ListEnforcedGuardrailsConfiguration" => {
+                crate::enforced_guardrails::list_enforced_guardrails_configuration(
+                    &self.state,
+                    &req,
+                )
+            }
+            "DeleteEnforcedGuardrailConfiguration" => {
+                crate::enforced_guardrails::delete_enforced_guardrail_configuration(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
             // Model customization jobs
             "CreateModelCustomizationJob" => {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
@@ -851,6 +1028,22 @@ impl AwsService for BedrockService {
             "PutResourcePolicy",
             "GetResourcePolicy",
             "DeleteResourcePolicy",
+            "CreateMarketplaceModelEndpoint",
+            "GetMarketplaceModelEndpoint",
+            "ListMarketplaceModelEndpoints",
+            "UpdateMarketplaceModelEndpoint",
+            "DeleteMarketplaceModelEndpoint",
+            "RegisterMarketplaceModelEndpoint",
+            "DeregisterMarketplaceModelEndpoint",
+            "CreateFoundationModelAgreement",
+            "DeleteFoundationModelAgreement",
+            "ListFoundationModelAgreementOffers",
+            "GetFoundationModelAvailability",
+            "GetUseCaseForModelAccess",
+            "PutUseCaseForModelAccess",
+            "PutEnforcedGuardrailConfiguration",
+            "ListEnforcedGuardrailsConfiguration",
+            "DeleteEnforcedGuardrailConfiguration",
             "CreateModelCustomizationJob",
             "GetModelCustomizationJob",
             "ListModelCustomizationJobs",

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -47,6 +47,14 @@ pub struct BedrockState {
     pub prompt_routers: HashMap<String, PromptRouter>,
     /// Resource policies keyed by resource ARN.
     pub resource_policies: HashMap<String, String>,
+    /// Marketplace model endpoints keyed by endpoint ARN.
+    pub marketplace_endpoints: HashMap<String, MarketplaceModelEndpoint>,
+    /// Foundation model agreements keyed by agreement ID.
+    pub foundation_model_agreements: HashMap<String, FoundationModelAgreement>,
+    /// Use case for model access.
+    pub use_case_for_model_access: Option<serde_json::Value>,
+    /// Enforced guardrail configurations keyed by config ID.
+    pub enforced_guardrail_configs: HashMap<String, serde_json::Value>,
 }
 
 impl BedrockState {
@@ -73,6 +81,10 @@ impl BedrockState {
             inference_profiles: HashMap::new(),
             prompt_routers: HashMap::new(),
             resource_policies: HashMap::new(),
+            marketplace_endpoints: HashMap::new(),
+            foundation_model_agreements: HashMap::new(),
+            use_case_for_model_access: None,
+            enforced_guardrail_configs: HashMap::new(),
         }
     }
 
@@ -96,6 +108,10 @@ impl BedrockState {
         self.inference_profiles.clear();
         self.prompt_routers.clear();
         self.resource_policies.clear();
+        self.marketplace_endpoints.clear();
+        self.foundation_model_agreements.clear();
+        self.use_case_for_model_access = None;
+        self.enforced_guardrail_configs.clear();
     }
 }
 
@@ -301,4 +317,22 @@ pub struct PromptRouter {
     pub prompt_router_type: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct MarketplaceModelEndpoint {
+    pub endpoint_arn: String,
+    pub endpoint_name: String,
+    pub model_source_identifier: String,
+    pub status: String,
+    pub endpoint_config: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct FoundationModelAgreement {
+    pub agreement_id: String,
+    pub model_id: String,
+    pub created_at: DateTime<Utc>,
 }

--- a/crates/fakecloud-conformance/tests/bedrock.rs
+++ b/crates/fakecloud-conformance/tests/bedrock.rs
@@ -705,6 +705,262 @@ async fn bedrock_bidirectional_stream_conformance() {
 }
 
 // ---------------------------------------------------------------------------
+// Marketplace + Agreements + Enforced Guardrails + Misc
+// ---------------------------------------------------------------------------
+
+#[test_action("bedrock", "CreateMarketplaceModelEndpoint", checksum = "04141127")]
+#[test_action("bedrock", "GetMarketplaceModelEndpoint", checksum = "2c3c9e3a")]
+#[test_action("bedrock", "ListMarketplaceModelEndpoints", checksum = "38615071")]
+#[test_action("bedrock", "UpdateMarketplaceModelEndpoint", checksum = "f27ced48")]
+#[test_action("bedrock", "DeleteMarketplaceModelEndpoint", checksum = "f9674669")]
+#[test_action("bedrock", "RegisterMarketplaceModelEndpoint", checksum = "12b80572")]
+#[test_action("bedrock", "DeregisterMarketplaceModelEndpoint", checksum = "3abacdc6")]
+#[tokio::test]
+async fn bedrock_marketplace_endpoint_lifecycle() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+    let b = serde_json::json!({"endpointName": "conf-ep", "modelSourceIdentifier": "model-1"});
+    let r = h
+        .post(format!("{}/marketplace-model/endpoints", server.endpoint()))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 201);
+    let v: serde_json::Value = r.json().await.unwrap();
+    let arn = v["marketplaceModelEndpointArn"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let id = arn.rsplit('/').next().unwrap();
+    assert_eq!(
+        h.get(format!(
+            "{}/marketplace-model/endpoints/{}",
+            server.endpoint(),
+            id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.get(format!("{}/marketplace-model/endpoints", server.endpoint()))
+            .header("authorization", a)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+    let b = serde_json::json!({"endpointConfig": {"sageMakerEndpoint": {}}});
+    assert_eq!(
+        h.patch(format!(
+            "{}/marketplace-model/endpoints/{}",
+            server.endpoint(),
+            id
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.post(format!(
+            "{}/marketplace-model/endpoints/{}/registration",
+            server.endpoint(),
+            id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.delete(format!(
+            "{}/marketplace-model/endpoints/{}/registration",
+            server.endpoint(),
+            id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.delete(format!(
+            "{}/marketplace-model/endpoints/{}",
+            server.endpoint(),
+            id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+}
+
+#[test_action("bedrock", "CreateFoundationModelAgreement", checksum = "73bee202")]
+#[test_action("bedrock", "DeleteFoundationModelAgreement", checksum = "4e58b5fc")]
+#[test_action("bedrock", "ListFoundationModelAgreementOffers", checksum = "452337b9")]
+#[test_action("bedrock", "GetFoundationModelAvailability", checksum = "f22978bc")]
+#[test_action("bedrock", "GetUseCaseForModelAccess", checksum = "4bb00bb9")]
+#[test_action("bedrock", "PutUseCaseForModelAccess", checksum = "4c020e02")]
+#[tokio::test]
+async fn bedrock_agreements_and_misc() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+    let b = serde_json::json!({"modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0"});
+    assert_eq!(
+        h.post(format!(
+            "{}/create-foundation-model-agreement",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.post(format!(
+            "{}/delete-foundation-model-agreement",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.get(format!(
+            "{}/list-foundation-model-agreement-offers/anthropic.claude-3-5-sonnet-20241022-v2:0",
+            server.endpoint()
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.get(format!(
+            "{}/foundation-model-availability/anthropic.claude-3-5-sonnet-20241022-v2:0",
+            server.endpoint()
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    let b = serde_json::json!({"useCase": "testing"});
+    assert_eq!(
+        h.post(format!("{}/use-case-for-model-access", server.endpoint()))
+            .header("content-type", "application/json")
+            .header("authorization", a)
+            .body(serde_json::to_string(&b).unwrap())
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+    assert_eq!(
+        h.get(format!("{}/use-case-for-model-access", server.endpoint()))
+            .header("authorization", a)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+}
+
+#[test_action("bedrock", "PutEnforcedGuardrailConfiguration", checksum = "c1a65cc8")]
+#[test_action(
+    "bedrock",
+    "ListEnforcedGuardrailsConfiguration",
+    checksum = "897cb129"
+)]
+#[test_action(
+    "bedrock",
+    "DeleteEnforcedGuardrailConfiguration",
+    checksum = "28e115e4"
+)]
+#[tokio::test]
+async fn bedrock_enforced_guardrails() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+    let b = serde_json::json!({"guardrailIdentifier": "test-guard", "guardrailVersion": "1"});
+    let r = h
+        .put(format!(
+            "{}/enforcedGuardrailsConfiguration",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    let v: serde_json::Value = r.json().await.unwrap();
+    let config_id = v["configId"].as_str().unwrap();
+    assert_eq!(
+        h.get(format!(
+            "{}/enforcedGuardrailsConfiguration",
+            server.endpoint()
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.delete(format!(
+            "{}/enforcedGuardrailsConfiguration/{}",
+            server.endpoint(),
+            config_id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Inference Profiles + Prompt Routers + Resource Policies
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Implement 16 new Bedrock control plane operations
- Marketplace Model Endpoints (7): Create, Get, List, Update, Delete, Register, Deregister
- Foundation Model Agreements (4): Create, Delete, ListOffers, GetAvailability
- Enforced Guardrails (3): Put, List, Delete configuration
- Use Case Access (2): Get, Put

## Test plan

- [x] 35 E2E tests passing
- [x] 33 conformance tests passing (16 new ops)
- [x] clippy clean, fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 16 Bedrock control plane operations for Marketplace model endpoints, foundation model agreements, enforced guardrails, and use case access. This enables full endpoint lifecycle, agreement checks, guardrail configuration, and basic pagination in listings.

- **New Features**
  - Marketplace Model Endpoints: Create, Get, List (paginated), Update, Delete, Register, Deregister
  - Foundation Model Agreements: Create/Delete agreement, ListOffers, GetAvailability
  - Enforced Guardrails: Put, List (paginated), Delete configuration
  - Use Case Access: Get, Put

<sup>Written for commit d562a59637d587b630cf35cdd5f434102097bccc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

