### PR TITLE
feat(bedrock): add Automated Reasoning Policies — Core (12 ops)

### DIFF
--- a/crates/fakecloud-bedrock/src/automated_reasoning.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning.rs
@@ -1,0 +1,524 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{AutomatedReasoningPolicy, AutomatedReasoningTestCase, SharedBedrockState};
+
+// ---------------------------------------------------------------------------
+// Policy CRUD
+// ---------------------------------------------------------------------------
+
+pub fn create_automated_reasoning_policy(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let policy_name = body["policyName"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "policyName is required",
+        )
+    })?;
+
+    let policy_id = Uuid::new_v4().to_string();
+    let policy_arn = format!(
+        "arn:aws:bedrock:{}:{}:automated-reasoning-policy/{}",
+        req.region, req.account_id, policy_id
+    );
+
+    let now = Utc::now();
+    let policy = AutomatedReasoningPolicy {
+        policy_arn: policy_arn.clone(),
+        policy_name: policy_name.to_string(),
+        description: body["description"].as_str().map(String::from),
+        policy_document: body.get("policyDocument").cloned().unwrap_or(json!({})),
+        status: "ACTIVE".to_string(),
+        version: "1".to_string(),
+        versions: vec!["1".to_string()],
+        created_at: now,
+        updated_at: now,
+    };
+
+    let mut s = state.write();
+    s.automated_reasoning_policies
+        .insert(policy_arn.clone(), policy);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "policyArn": policy_arn })).unwrap(),
+    ))
+}
+
+pub fn get_automated_reasoning_policy(
+    state: &SharedBedrockState,
+    identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let policy = find_policy(&s.automated_reasoning_policies, identifier).ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Automated reasoning policy {identifier} not found"),
+        )
+    })?;
+
+    Ok(AwsResponse::ok_json(policy_to_json(policy)))
+}
+
+pub fn list_automated_reasoning_policies(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+    let mut items: Vec<&AutomatedReasoningPolicy> =
+        s.automated_reasoning_policies.values().collect();
+    items.sort_by(|a, b| a.policy_arn.cmp(&b.policy_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|p| p.policy_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|p| {
+            json!({
+                "policyArn": p.policy_arn,
+                "policyName": p.policy_name,
+                "description": p.description,
+                "status": p.status,
+                "version": p.version,
+                "createdAt": p.created_at.to_rfc3339(),
+                "updatedAt": p.updated_at.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "policySummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.policy_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn update_automated_reasoning_policy(
+    state: &SharedBedrockState,
+    identifier: &str,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = find_policy_key(&s.automated_reasoning_policies, identifier).ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Automated reasoning policy {identifier} not found"),
+        )
+    })?;
+
+    let policy = s.automated_reasoning_policies.get_mut(&key).unwrap();
+
+    if let Some(name) = body["policyName"].as_str() {
+        policy.policy_name = name.to_string();
+    }
+    if let Some(desc) = body.get("description") {
+        policy.description = desc.as_str().map(String::from);
+    }
+    if let Some(doc) = body.get("policyDocument") {
+        policy.policy_document = doc.clone();
+    }
+    policy.updated_at = Utc::now();
+
+    Ok(AwsResponse::ok_json(policy_to_json(policy)))
+}
+
+pub fn delete_automated_reasoning_policy(
+    state: &SharedBedrockState,
+    identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = find_policy_key(&s.automated_reasoning_policies, identifier).ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Automated reasoning policy {identifier} not found"),
+        )
+    })?;
+
+    // Remove associated test cases
+    let policy_arn = key.clone();
+    s.automated_reasoning_test_cases
+        .retain(|(arn, _), _| *arn != policy_arn);
+
+    s.automated_reasoning_policies.remove(&key);
+    Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Policy versions
+// ---------------------------------------------------------------------------
+
+pub fn create_automated_reasoning_policy_version(
+    state: &SharedBedrockState,
+    identifier: &str,
+    _body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let key = find_policy_key(&s.automated_reasoning_policies, identifier).ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Automated reasoning policy {identifier} not found"),
+        )
+    })?;
+
+    let policy = s.automated_reasoning_policies.get_mut(&key).unwrap();
+
+    let current: u32 = policy.version.parse().unwrap_or(1);
+    let next = current.saturating_add(1);
+    let version_str = next.to_string();
+    policy.version = version_str.clone();
+    policy.versions.push(version_str.clone());
+    policy.updated_at = Utc::now();
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({
+            "policyArn": policy.policy_arn,
+            "version": version_str,
+        }))
+        .unwrap(),
+    ))
+}
+
+pub fn export_automated_reasoning_policy_version(
+    state: &SharedBedrockState,
+    identifier: &str,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+    let policy = find_policy(&s.automated_reasoning_policies, identifier).ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Automated reasoning policy {identifier} not found"),
+        )
+    })?;
+
+    let requested_version = req.query_params.get("policyVersion");
+    if let Some(ver) = requested_version {
+        if !policy.versions.contains(ver) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Version {ver} not found for policy {identifier}"),
+            ));
+        }
+    }
+
+    Ok(AwsResponse::ok_json(json!({
+        "policyArn": policy.policy_arn,
+        "policyDocument": policy.policy_document,
+        "version": requested_version.unwrap_or(&policy.version),
+    })))
+}
+
+// ---------------------------------------------------------------------------
+// Test cases
+// ---------------------------------------------------------------------------
+
+pub fn create_automated_reasoning_policy_test_case(
+    state: &SharedBedrockState,
+    policy_identifier: &str,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let test_case_name = body["testCaseName"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "testCaseName is required",
+        )
+    })?;
+
+    let mut s = state.write();
+
+    let policy_arn = find_policy_key(&s.automated_reasoning_policies, policy_identifier)
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Automated reasoning policy {policy_identifier} not found"),
+            )
+        })?;
+
+    let test_case_id = Uuid::new_v4().to_string();
+    let now = Utc::now();
+    let tc = AutomatedReasoningTestCase {
+        test_case_id: test_case_id.clone(),
+        policy_arn: policy_arn.clone(),
+        test_case_name: test_case_name.to_string(),
+        description: body["description"].as_str().map(String::from),
+        input: body.get("input").cloned().unwrap_or(json!({})),
+        expected_output: body.get("expectedOutput").cloned().unwrap_or(json!({})),
+        created_at: now,
+        updated_at: now,
+    };
+
+    s.automated_reasoning_test_cases
+        .insert((policy_arn, test_case_id.clone()), tc);
+
+    Ok(AwsResponse::json(
+        StatusCode::CREATED,
+        serde_json::to_string(&json!({ "testCaseId": test_case_id })).unwrap(),
+    ))
+}
+
+pub fn get_automated_reasoning_policy_test_case(
+    state: &SharedBedrockState,
+    policy_identifier: &str,
+    test_case_id: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let s = state.read();
+
+    let policy_arn = find_policy_key(&s.automated_reasoning_policies, policy_identifier)
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Automated reasoning policy {policy_identifier} not found"),
+            )
+        })?;
+
+    let tc = s
+        .automated_reasoning_test_cases
+        .get(&(policy_arn, test_case_id.to_string()))
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Test case {test_case_id} not found"),
+            )
+        })?;
+
+    Ok(AwsResponse::ok_json(test_case_to_json(tc)))
+}
+
+pub fn list_automated_reasoning_policy_test_cases(
+    state: &SharedBedrockState,
+    policy_identifier: &str,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let s = state.read();
+
+    let policy_arn = find_policy_key(&s.automated_reasoning_policies, policy_identifier)
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Automated reasoning policy {policy_identifier} not found"),
+            )
+        })?;
+
+    let mut items: Vec<&AutomatedReasoningTestCase> = s
+        .automated_reasoning_test_cases
+        .iter()
+        .filter(|((arn, _), _)| *arn == policy_arn)
+        .map(|(_, tc)| tc)
+        .collect();
+    items.sort_by(|a, b| a.test_case_id.cmp(&b.test_case_id));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|tc| tc.test_case_id.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|tc| {
+            json!({
+                "testCaseId": tc.test_case_id,
+                "testCaseName": tc.test_case_name,
+                "description": tc.description,
+                "createdAt": tc.created_at.to_rfc3339(),
+                "updatedAt": tc.updated_at.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "testCaseSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.test_case_id);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub fn update_automated_reasoning_policy_test_case(
+    state: &SharedBedrockState,
+    policy_identifier: &str,
+    test_case_id: &str,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let policy_arn = find_policy_key(&s.automated_reasoning_policies, policy_identifier)
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Automated reasoning policy {policy_identifier} not found"),
+            )
+        })?;
+
+    let tc = s
+        .automated_reasoning_test_cases
+        .get_mut(&(policy_arn, test_case_id.to_string()))
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Test case {test_case_id} not found"),
+            )
+        })?;
+
+    if let Some(name) = body["testCaseName"].as_str() {
+        tc.test_case_name = name.to_string();
+    }
+    if let Some(desc) = body.get("description") {
+        tc.description = desc.as_str().map(String::from);
+    }
+    if let Some(input) = body.get("input") {
+        tc.input = input.clone();
+    }
+    if let Some(output) = body.get("expectedOutput") {
+        tc.expected_output = output.clone();
+    }
+    tc.updated_at = Utc::now();
+
+    Ok(AwsResponse::ok_json(test_case_to_json(tc)))
+}
+
+pub fn delete_automated_reasoning_policy_test_case(
+    state: &SharedBedrockState,
+    policy_identifier: &str,
+    test_case_id: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut s = state.write();
+
+    let policy_arn = find_policy_key(&s.automated_reasoning_policies, policy_identifier)
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Automated reasoning policy {policy_identifier} not found"),
+            )
+        })?;
+
+    let key = (policy_arn, test_case_id.to_string());
+    if s.automated_reasoning_test_cases.remove(&key).is_none() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Test case {test_case_id} not found"),
+        ));
+    }
+
+    Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn find_policy<'a>(
+    policies: &'a std::collections::HashMap<String, AutomatedReasoningPolicy>,
+    identifier: &str,
+) -> Option<&'a AutomatedReasoningPolicy> {
+    policies.get(identifier).or_else(|| {
+        policies.values().find(|p| {
+            p.policy_name == identifier || p.policy_arn.ends_with(&format!("/{identifier}"))
+        })
+    })
+}
+
+fn find_policy_key(
+    policies: &std::collections::HashMap<String, AutomatedReasoningPolicy>,
+    identifier: &str,
+) -> Option<String> {
+    policies
+        .iter()
+        .find(|(k, p)| {
+            *k == identifier
+                || p.policy_name == identifier
+                || p.policy_arn.ends_with(&format!("/{identifier}"))
+        })
+        .map(|(k, _)| k.clone())
+}
+
+fn policy_to_json(p: &AutomatedReasoningPolicy) -> Value {
+    json!({
+        "policyArn": p.policy_arn,
+        "policyName": p.policy_name,
+        "description": p.description,
+        "policyDocument": p.policy_document,
+        "status": p.status,
+        "version": p.version,
+        "versions": p.versions,
+        "createdAt": p.created_at.to_rfc3339(),
+        "updatedAt": p.updated_at.to_rfc3339(),
+    })
+}
+
+fn test_case_to_json(tc: &AutomatedReasoningTestCase) -> Value {
+    json!({
+        "testCaseId": tc.test_case_id,
+        "policyArn": tc.policy_arn,
+        "testCaseName": tc.test_case_name,
+        "description": tc.description,
+        "input": tc.input,
+        "expectedOutput": tc.expected_output,
+        "createdAt": tc.created_at.to_rfc3339(),
+        "updatedAt": tc.updated_at.to_rfc3339(),
+    })
+}

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod async_invoke;
+pub mod automated_reasoning;
 pub mod converse;
 pub mod custom_model_deployments;
 pub mod custom_models;

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -281,6 +281,90 @@ impl BedrockService {
                 None,
             )),
 
+            // Automated reasoning policies
+            (Method::POST, 1) if segs[0] == "automated-reasoning-policies" => {
+                Some(("CreateAutomatedReasoningPolicy", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "automated-reasoning-policies" => {
+                Some(("ListAutomatedReasoningPolicies", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "automated-reasoning-policies" => {
+                Some(("GetAutomatedReasoningPolicy", Some(decode(&segs[1])), None))
+            }
+            (Method::PATCH, 2) if segs[0] == "automated-reasoning-policies" => Some((
+                "UpdateAutomatedReasoningPolicy",
+                Some(decode(&segs[1])),
+                None,
+            )),
+            (Method::DELETE, 2) if segs[0] == "automated-reasoning-policies" => Some((
+                "DeleteAutomatedReasoningPolicy",
+                Some(decode(&segs[1])),
+                None,
+            )),
+            (Method::POST, 3)
+                if segs[0] == "automated-reasoning-policies" && segs[2] == "versions" =>
+            {
+                Some((
+                    "CreateAutomatedReasoningPolicyVersion",
+                    Some(decode(&segs[1])),
+                    None,
+                ))
+            }
+            (Method::GET, 3)
+                if segs[0] == "automated-reasoning-policies" && segs[2] == "export" =>
+            {
+                Some((
+                    "ExportAutomatedReasoningPolicyVersion",
+                    Some(decode(&segs[1])),
+                    None,
+                ))
+            }
+            (Method::POST, 3)
+                if segs[0] == "automated-reasoning-policies" && segs[2] == "test-cases" =>
+            {
+                Some((
+                    "CreateAutomatedReasoningPolicyTestCase",
+                    Some(decode(&segs[1])),
+                    None,
+                ))
+            }
+            (Method::GET, 3)
+                if segs[0] == "automated-reasoning-policies" && segs[2] == "test-cases" =>
+            {
+                Some((
+                    "ListAutomatedReasoningPolicyTestCases",
+                    Some(decode(&segs[1])),
+                    None,
+                ))
+            }
+            (Method::GET, 4)
+                if segs[0] == "automated-reasoning-policies" && segs[2] == "test-cases" =>
+            {
+                Some((
+                    "GetAutomatedReasoningPolicyTestCase",
+                    Some(decode(&segs[1])),
+                    Some(decode(&segs[3])),
+                ))
+            }
+            (Method::PATCH, 4)
+                if segs[0] == "automated-reasoning-policies" && segs[2] == "test-cases" =>
+            {
+                Some((
+                    "UpdateAutomatedReasoningPolicyTestCase",
+                    Some(decode(&segs[1])),
+                    Some(decode(&segs[3])),
+                ))
+            }
+            (Method::DELETE, 4)
+                if segs[0] == "automated-reasoning-policies" && segs[2] == "test-cases" =>
+            {
+                Some((
+                    "DeleteAutomatedReasoningPolicyTestCase",
+                    Some(decode(&segs[1])),
+                    Some(decode(&segs[3])),
+                ))
+            }
+
             // Model customization jobs
             (Method::POST, 1) if segs[0] == "model-customization-jobs" => {
                 Some(("CreateModelCustomizationJob", None, None))
@@ -844,6 +928,91 @@ impl AwsService for BedrockService {
                     &resource_id.unwrap_or_default(),
                 )
             }
+            // Automated reasoning policies
+            "CreateAutomatedReasoningPolicy" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::automated_reasoning::create_automated_reasoning_policy(
+                    &self.state,
+                    &req,
+                    &body,
+                )
+            }
+            "GetAutomatedReasoningPolicy" => {
+                crate::automated_reasoning::get_automated_reasoning_policy(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
+            "ListAutomatedReasoningPolicies" => {
+                crate::automated_reasoning::list_automated_reasoning_policies(&self.state, &req)
+            }
+            "UpdateAutomatedReasoningPolicy" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::automated_reasoning::update_automated_reasoning_policy(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                    &body,
+                )
+            }
+            "DeleteAutomatedReasoningPolicy" => {
+                crate::automated_reasoning::delete_automated_reasoning_policy(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
+            "CreateAutomatedReasoningPolicyVersion" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::automated_reasoning::create_automated_reasoning_policy_version(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                    &body,
+                )
+            }
+            "ExportAutomatedReasoningPolicyVersion" => {
+                crate::automated_reasoning::export_automated_reasoning_policy_version(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                    &req,
+                )
+            }
+            "CreateAutomatedReasoningPolicyTestCase" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::automated_reasoning::create_automated_reasoning_policy_test_case(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                    &body,
+                )
+            }
+            "GetAutomatedReasoningPolicyTestCase" => {
+                crate::automated_reasoning::get_automated_reasoning_policy_test_case(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                    extra_id.as_deref().unwrap_or_default(),
+                )
+            }
+            "ListAutomatedReasoningPolicyTestCases" => {
+                crate::automated_reasoning::list_automated_reasoning_policy_test_cases(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                    &req,
+                )
+            }
+            "UpdateAutomatedReasoningPolicyTestCase" => {
+                let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+                crate::automated_reasoning::update_automated_reasoning_policy_test_case(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                    extra_id.as_deref().unwrap_or_default(),
+                    &body,
+                )
+            }
+            "DeleteAutomatedReasoningPolicyTestCase" => {
+                crate::automated_reasoning::delete_automated_reasoning_policy_test_case(
+                    &self.state,
+                    &resource_id.unwrap_or_default(),
+                    extra_id.as_deref().unwrap_or_default(),
+                )
+            }
             // Model customization jobs
             "CreateModelCustomizationJob" => {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
@@ -1044,6 +1213,18 @@ impl AwsService for BedrockService {
             "PutEnforcedGuardrailConfiguration",
             "ListEnforcedGuardrailsConfiguration",
             "DeleteEnforcedGuardrailConfiguration",
+            "CreateAutomatedReasoningPolicy",
+            "GetAutomatedReasoningPolicy",
+            "ListAutomatedReasoningPolicies",
+            "UpdateAutomatedReasoningPolicy",
+            "DeleteAutomatedReasoningPolicy",
+            "CreateAutomatedReasoningPolicyVersion",
+            "ExportAutomatedReasoningPolicyVersion",
+            "CreateAutomatedReasoningPolicyTestCase",
+            "GetAutomatedReasoningPolicyTestCase",
+            "ListAutomatedReasoningPolicyTestCases",
+            "UpdateAutomatedReasoningPolicyTestCase",
+            "DeleteAutomatedReasoningPolicyTestCase",
             "CreateModelCustomizationJob",
             "GetModelCustomizationJob",
             "ListModelCustomizationJobs",

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -55,6 +55,10 @@ pub struct BedrockState {
     pub use_case_for_model_access: Option<serde_json::Value>,
     /// Enforced guardrail configurations keyed by config ID.
     pub enforced_guardrail_configs: HashMap<String, serde_json::Value>,
+    /// Automated reasoning policies keyed by policy ARN.
+    pub automated_reasoning_policies: HashMap<String, AutomatedReasoningPolicy>,
+    /// Automated reasoning test cases keyed by (policy_arn, test_case_id).
+    pub automated_reasoning_test_cases: HashMap<(String, String), AutomatedReasoningTestCase>,
 }
 
 impl BedrockState {
@@ -85,6 +89,8 @@ impl BedrockState {
             foundation_model_agreements: HashMap::new(),
             use_case_for_model_access: None,
             enforced_guardrail_configs: HashMap::new(),
+            automated_reasoning_policies: HashMap::new(),
+            automated_reasoning_test_cases: HashMap::new(),
         }
     }
 
@@ -112,6 +118,8 @@ impl BedrockState {
         self.foundation_model_agreements.clear();
         self.use_case_for_model_access = None;
         self.enforced_guardrail_configs.clear();
+        self.automated_reasoning_policies.clear();
+        self.automated_reasoning_test_cases.clear();
     }
 }
 
@@ -335,4 +343,29 @@ pub struct FoundationModelAgreement {
     pub agreement_id: String,
     pub model_id: String,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct AutomatedReasoningPolicy {
+    pub policy_arn: String,
+    pub policy_name: String,
+    pub description: Option<String>,
+    pub policy_document: serde_json::Value,
+    pub status: String,
+    pub version: String,
+    pub versions: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct AutomatedReasoningTestCase {
+    pub test_case_id: String,
+    pub policy_arn: String,
+    pub test_case_name: String,
+    pub description: Option<String>,
+    pub input: serde_json::Value,
+    pub expected_output: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }

--- a/crates/fakecloud-conformance/tests/bedrock.rs
+++ b/crates/fakecloud-conformance/tests/bedrock.rs
@@ -705,6 +705,258 @@ async fn bedrock_bidirectional_stream_conformance() {
 }
 
 // ---------------------------------------------------------------------------
+// Automated Reasoning Policies — Core
+// ---------------------------------------------------------------------------
+
+#[test_action("bedrock", "CreateAutomatedReasoningPolicy", checksum = "f393af04")]
+#[test_action("bedrock", "GetAutomatedReasoningPolicy", checksum = "72f1e179")]
+#[test_action("bedrock", "ListAutomatedReasoningPolicies", checksum = "8f74b1fa")]
+#[test_action("bedrock", "UpdateAutomatedReasoningPolicy", checksum = "152863e5")]
+#[test_action("bedrock", "DeleteAutomatedReasoningPolicy", checksum = "395df130")]
+#[test_action(
+    "bedrock",
+    "CreateAutomatedReasoningPolicyVersion",
+    checksum = "0d12d2b2"
+)]
+#[test_action(
+    "bedrock",
+    "ExportAutomatedReasoningPolicyVersion",
+    checksum = "07d318c1"
+)]
+#[tokio::test]
+async fn bedrock_automated_reasoning_policy_lifecycle() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+    let b = serde_json::json!({"policyName": "conf-policy", "policyDocument": {"rules": []}});
+    let r = h
+        .post(format!(
+            "{}/automated-reasoning-policies",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 201);
+    let v: serde_json::Value = r.json().await.unwrap();
+    let arn = v["policyArn"].as_str().unwrap().to_string();
+    let id = arn.rsplit('/').next().unwrap();
+    assert_eq!(
+        h.get(format!(
+            "{}/automated-reasoning-policies/{}",
+            server.endpoint(),
+            id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.get(format!(
+            "{}/automated-reasoning-policies",
+            server.endpoint()
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    let b = serde_json::json!({"description": "updated"});
+    assert_eq!(
+        h.patch(format!(
+            "{}/automated-reasoning-policies/{}",
+            server.endpoint(),
+            id
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.post(format!(
+            "{}/automated-reasoning-policies/{}/versions",
+            server.endpoint(),
+            id
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body("{}")
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        201
+    );
+    assert_eq!(
+        h.get(format!(
+            "{}/automated-reasoning-policies/{}/export",
+            server.endpoint(),
+            id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.delete(format!(
+            "{}/automated-reasoning-policies/{}",
+            server.endpoint(),
+            id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+}
+
+#[test_action(
+    "bedrock",
+    "CreateAutomatedReasoningPolicyTestCase",
+    checksum = "dbbd6c0c"
+)]
+#[test_action(
+    "bedrock",
+    "GetAutomatedReasoningPolicyTestCase",
+    checksum = "8847960f"
+)]
+#[test_action(
+    "bedrock",
+    "ListAutomatedReasoningPolicyTestCases",
+    checksum = "61acc65a"
+)]
+#[test_action(
+    "bedrock",
+    "UpdateAutomatedReasoningPolicyTestCase",
+    checksum = "ee06d0d0"
+)]
+#[test_action(
+    "bedrock",
+    "DeleteAutomatedReasoningPolicyTestCase",
+    checksum = "ec4f201a"
+)]
+#[tokio::test]
+async fn bedrock_automated_reasoning_test_case_lifecycle() {
+    let server = TestServer::start().await;
+    let h = reqwest::Client::new();
+    let a = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+    // Create a policy first
+    let b = serde_json::json!({"policyName": "tc-policy", "policyDocument": {}});
+    let r = h
+        .post(format!(
+            "{}/automated-reasoning-policies",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    let v: serde_json::Value = r.json().await.unwrap();
+    let policy_id = v["policyArn"]
+        .as_str()
+        .unwrap()
+        .rsplit('/')
+        .next()
+        .unwrap()
+        .to_string();
+    // Create test case
+    let b = serde_json::json!({"testCaseName": "conf-tc", "input": {"query": "test"}, "expectedOutput": {"result": true}});
+    let r = h
+        .post(format!(
+            "{}/automated-reasoning-policies/{}/test-cases",
+            server.endpoint(),
+            policy_id
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 201);
+    let v: serde_json::Value = r.json().await.unwrap();
+    let tc_id = v["testCaseId"].as_str().unwrap();
+    assert_eq!(
+        h.get(format!(
+            "{}/automated-reasoning-policies/{}/test-cases/{}",
+            server.endpoint(),
+            policy_id,
+            tc_id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.get(format!(
+            "{}/automated-reasoning-policies/{}/test-cases",
+            server.endpoint(),
+            policy_id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    let b = serde_json::json!({"description": "updated tc"});
+    assert_eq!(
+        h.patch(format!(
+            "{}/automated-reasoning-policies/{}/test-cases/{}",
+            server.endpoint(),
+            policy_id,
+            tc_id
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", a)
+        .body(serde_json::to_string(&b).unwrap())
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+    assert_eq!(
+        h.delete(format!(
+            "{}/automated-reasoning-policies/{}/test-cases/{}",
+            server.endpoint(),
+            policy_id,
+            tc_id
+        ))
+        .header("authorization", a)
+        .send()
+        .await
+        .unwrap()
+        .status(),
+        200
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Marketplace + Agreements + Enforced Guardrails + Misc
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Implement 12 Automated Reasoning Policy operations (core CRUD + versions + test cases)
- Policy CRUD: Create, Get, List, Update, Delete
- Versions: CreateVersion (incremental), ExportVersion
- Test Cases: Create, Get, List, Update, Delete

## Test plan

- [x] 35 E2E tests passing
- [x] 35 conformance tests passing (12 new ops)
- [x] clippy clean, fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Automated Reasoning Policies to Bedrock with policy CRUD, versioning, and test case management (12 ops). Supports pagination, flexible identifiers, and cleans up related test cases on delete.

- New Features
  - Policy CRUD: create, get, list, update, delete.
  - Versions: increment version and export via `policyVersion` query.
  - Test cases: create, get, list, update, delete; scoped to a policy.
  - Flexible identifiers: resolve by ARN, name, or trailing ID.
  - Pagination: `maxResults` and `nextToken` on list endpoints.
  - Cascade delete: deleting a policy removes its test cases.
  - Added routes in `crates/fakecloud-bedrock/src/service.rs` and state types in `state.rs`.
  - Conformance and E2E coverage for all 12 ops.

<sup>Written for commit 447269022e1d345a1c5a001dfb5c92941ea214b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

