### PR TITLE
fix: prevent panics from unwrap calls and unsafe integer casts

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/cors.rs
+++ b/crates/fakecloud-apigatewayv2/src/cors.rs
@@ -15,38 +15,39 @@ pub fn handle_preflight(cors_config: &CorsConfiguration, _req: &AwsRequest) -> A
         } else {
             origins.first().map(|s| s.as_str()).unwrap_or("*")
         };
-        headers.insert("access-control-allow-origin", origin_value.parse().unwrap());
+        if let Ok(val) = origin_value.parse() {
+            headers.insert("access-control-allow-origin", val);
+        }
     }
 
     // Add Access-Control-Allow-Methods
     if let Some(ref methods) = cors_config.allow_methods {
         let methods_value = methods.join(",");
-        headers.insert(
-            "access-control-allow-methods",
-            methods_value.parse().unwrap(),
-        );
+        if let Ok(val) = methods_value.parse() {
+            headers.insert("access-control-allow-methods", val);
+        }
     }
 
     // Add Access-Control-Allow-Headers
     if let Some(ref allow_headers) = cors_config.allow_headers {
         let headers_value = allow_headers.join(",");
-        headers.insert(
-            "access-control-allow-headers",
-            headers_value.parse().unwrap(),
-        );
+        if let Ok(val) = headers_value.parse() {
+            headers.insert("access-control-allow-headers", val);
+        }
     }
 
     // Add Access-Control-Max-Age
     if let Some(max_age) = cors_config.max_age {
-        headers.insert(
-            "access-control-max-age",
-            max_age.to_string().parse().unwrap(),
-        );
+        if let Ok(val) = max_age.to_string().parse() {
+            headers.insert("access-control-max-age", val);
+        }
     }
 
     // Add Access-Control-Allow-Credentials
     if let Some(true) = cors_config.allow_credentials {
-        headers.insert("access-control-allow-credentials", "true".parse().unwrap());
+        if let Ok(val) = "true".parse() {
+            headers.insert("access-control-allow-credentials", val);
+        }
     }
 
     AwsResponse {
@@ -66,25 +67,28 @@ pub fn add_cors_headers(mut response: AwsResponse, cors_config: &CorsConfigurati
         } else {
             origins.first().map(|s| s.as_str()).unwrap_or("*")
         };
-        response
-            .headers
-            .insert("access-control-allow-origin", origin_value.parse().unwrap());
+        if let Ok(val) = origin_value.parse() {
+            response.headers.insert("access-control-allow-origin", val);
+        }
     }
 
     // Add Access-Control-Expose-Headers
     if let Some(ref expose_headers) = cors_config.expose_headers {
         let headers_value = expose_headers.join(",");
-        response.headers.insert(
-            "access-control-expose-headers",
-            headers_value.parse().unwrap(),
-        );
+        if let Ok(val) = headers_value.parse() {
+            response
+                .headers
+                .insert("access-control-expose-headers", val);
+        }
     }
 
     // Add Access-Control-Allow-Credentials
     if let Some(true) = cors_config.allow_credentials {
-        response
-            .headers
-            .insert("access-control-allow-credentials", "true".parse().unwrap());
+        if let Ok(val) = "true".parse() {
+            response
+                .headers
+                .insert("access-control-allow-credentials", val);
+        }
     }
 
     response

--- a/crates/fakecloud-apigatewayv2/src/http_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/http_proxy.rs
@@ -11,7 +11,9 @@ pub async fn forward_request(
     timeout_millis: Option<i64>,
 ) -> Result<AwsResponse, AwsServiceError> {
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_millis(timeout_millis.unwrap_or(30000).max(0) as u64))
+        .timeout(Duration::from_millis(
+            timeout_millis.unwrap_or(30000).max(0) as u64,
+        ))
         .build()
         .map_err(|e| {
             AwsServiceError::aws_error(

--- a/crates/fakecloud-apigatewayv2/src/http_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/http_proxy.rs
@@ -11,7 +11,7 @@ pub async fn forward_request(
     timeout_millis: Option<i64>,
 ) -> Result<AwsResponse, AwsServiceError> {
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_millis(timeout_millis.unwrap_or(30000) as u64))
+        .timeout(Duration::from_millis(timeout_millis.unwrap_or(30000).max(0) as u64))
         .build()
         .map_err(|e| {
             AwsServiceError::aws_error(

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -3969,7 +3969,12 @@ fn split_on_and(expr: &str) -> Vec<&str> {
             if depth > 0 {
                 depth -= 1;
             }
-        } else if depth == 0 && i + 5 <= len && expr[i..i + 5].eq_ignore_ascii_case(" AND ") {
+        } else if depth == 0
+            && i + 5 <= len
+            && expr.is_char_boundary(i)
+            && expr.is_char_boundary(i + 5)
+            && expr[i..i + 5].eq_ignore_ascii_case(" AND ")
+        {
             parts.push(&expr[start..i]);
             start = i + 5;
             i = start;
@@ -3995,7 +4000,12 @@ fn split_on_or(expr: &str) -> Vec<&str> {
             if depth > 0 {
                 depth -= 1;
             }
-        } else if depth == 0 && i + 4 <= len && expr[i..i + 4].eq_ignore_ascii_case(" OR ") {
+        } else if depth == 0
+            && i + 4 <= len
+            && expr.is_char_boundary(i)
+            && expr.is_char_boundary(i + 4)
+            && expr[i..i + 4].eq_ignore_ascii_case(" OR ")
+        {
             parts.push(&expr[start..i]);
             start = i + 4;
             i = start;

--- a/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
+++ b/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
@@ -106,7 +106,7 @@ impl DynamoDbStreamsLambdaPoller {
                             true
                         }
                     })
-                    .take(batch_size as usize)
+                    .take(batch_size.max(0) as usize)
                     .cloned()
                     .collect();
 

--- a/crates/fakecloud-stepfunctions/src/io_processing.rs
+++ b/crates/fakecloud-stepfunctions/src/io_processing.rs
@@ -85,7 +85,10 @@ fn set_at_path(root: &Value, path: &str, value: &Value) -> Value {
                     obj.insert(segment.to_string(), serde_json::json!({}));
                 }
             }
-            current = current.get_mut(*segment).unwrap();
+            match current.get_mut(*segment) {
+                Some(v) => current = v,
+                None => return result, // non-object intermediate, bail out
+            }
         }
     }
 
@@ -182,6 +185,17 @@ mod tests {
         let result = json!("hello");
         let output = apply_result_path(&input, &result, Some("$.result"));
         assert_eq!(output, json!({"x": 1, "result": "hello"}));
+    }
+
+    #[test]
+    fn test_set_at_path_non_object_intermediate() {
+        // When an intermediate path segment is a non-object (e.g., a number),
+        // set_at_path should not panic — it should bail out gracefully.
+        let input = json!({"x": 42});
+        let result = json!("hello");
+        let output = apply_result_path(&input, &result, Some("$.x.nested"));
+        // x is a number, can't set nested on it — should return input unchanged
+        assert_eq!(output, json!({"x": 42}));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- DynamoDB streams poller: clamp `batch_size` before `i64→usize` cast to prevent wrapping on negative values
- DynamoDB: guard `split_on_and`/`split_on_or` with `is_char_boundary` checks to prevent panics on non-ASCII expression strings
- Step Functions: replace `.unwrap()` with graceful bail-out in `set_at_path` when intermediate path segments are non-objects
- API Gateway v2 CORS: replace all `.parse().unwrap()` with `.parse().ok()` on user-controlled header values to prevent panics on malformed CORS config
- API Gateway v2 HTTP proxy: clamp negative timeout before `i64→u64` cast

Addresses unresolved Cubic findings from PRs #232, #257, #241, #255, #255.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] All unit tests pass (`cargo test -p fakecloud-stepfunctions -p fakecloud-apigatewayv2 -p fakecloud-dynamodb`)
- [x] New unit test for `set_at_path` non-object intermediate path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes several panic paths by replacing unsafe unwraps and clamping integer casts, improving resilience to malformed config and non-ASCII inputs without changing valid behavior.

- **Bug Fixes**
  - `fakecloud-server` (DynamoDB Streams poller): clamp `batch_size` with `.max(0)` before `i64→usize` cast.
  - `fakecloud-dynamodb`: guard `split_on_and`/`split_on_or` with `is_char_boundary` to avoid panics on UTF‑8 expressions.
  - `fakecloud-stepfunctions`: make `set_at_path` bail out when intermediate segments aren’t objects; added unit test.
  - `fakecloud-apigatewayv2` (CORS): replace `.parse().unwrap()` with conditional inserts to avoid panics on malformed header values.
  - `fakecloud-apigatewayv2` (HTTP proxy): clamp negative timeouts with `.max(0)` before `i64→u64` cast.

<sup>Written for commit c8878b7b5f096ffdff1ef9e54cfa7fed719ec507. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

