### PR TITLE
fix(stepfunctions): fix execution overwrite, IsPresent null, catcher short-circuit

### DIFF
--- a/crates/fakecloud-stepfunctions/src/choice.rs
+++ b/crates/fakecloud-stepfunctions/src/choice.rs
@@ -39,7 +39,10 @@ fn evaluate_rule(rule: &Value, input: &Value) -> bool {
 
     // Presence/type checks
     if let Some(expected) = rule.get("IsPresent") {
-        let is_present = !value.is_null();
+        // Check if the field exists in the input (including explicit null).
+        // resolve_path returns Value::Null for both missing and null fields,
+        // so we need to check the parent object directly.
+        let is_present = field_exists_in_input(input, variable);
         return expected.as_bool().unwrap_or(false) == is_present;
     }
     if let Some(expected) = rule.get("IsNull") {
@@ -231,6 +234,34 @@ fn string_matches(value: &str, pattern: &str) -> bool {
     dp[m][n]
 }
 
+/// Check if a field referenced by a JsonPath expression actually exists in the input,
+/// including fields explicitly set to null. This is different from resolve_path which
+/// returns Value::Null for both missing and null fields.
+fn field_exists_in_input(root: &Value, path: &str) -> bool {
+    if path == "$" {
+        return true;
+    }
+    let path = path.strip_prefix("$.").unwrap_or(path);
+    let segments: Vec<&str> = path.split('.').collect();
+    let mut current = root;
+
+    for (i, segment) in segments.iter().enumerate() {
+        if i == segments.len() - 1 {
+            // Last segment — check if it exists (even if null)
+            return match current.as_object() {
+                Some(obj) => obj.contains_key(*segment),
+                None => false,
+            };
+        } else {
+            match current.get(*segment) {
+                Some(v) => current = v,
+                None => return false,
+            }
+        }
+    }
+    false
+}
+
 enum PatternSegment {
     Literal(String),
     Wildcard,
@@ -343,6 +374,18 @@ mod tests {
 
         let input = json!({"other": "value"});
         assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_is_present_with_null_value() {
+        // A field that is explicitly set to null should be considered "present"
+        let rule = json!({
+            "Variable": "$.optional",
+            "IsPresent": true,
+            "Next": "HasField"
+        });
+        let input = json!({"optional": null});
+        assert!(evaluate_rule(&rule, &input));
     }
 
     #[test]

--- a/crates/fakecloud-stepfunctions/src/choice.rs
+++ b/crates/fakecloud-stepfunctions/src/choice.rs
@@ -237,23 +237,46 @@ fn string_matches(value: &str, pattern: &str) -> bool {
 /// Check if a field referenced by a JsonPath expression actually exists in the input,
 /// including fields explicitly set to null. This is different from resolve_path which
 /// returns Value::Null for both missing and null fields.
+/// Handles both object fields ($.foo.bar) and array indices ($.items[0]).
 fn field_exists_in_input(root: &Value, path: &str) -> bool {
     if path == "$" {
         return true;
     }
     let path = path.strip_prefix("$.").unwrap_or(path);
-    let segments: Vec<&str> = path.split('.').collect();
+    let parts: Vec<&str> = path.split('.').collect();
     let mut current = root;
 
-    for (i, segment) in segments.iter().enumerate() {
-        if i == segments.len() - 1 {
-            // Last segment — check if it exists (even if null)
+    for (i, part) in parts.iter().enumerate() {
+        let is_last = i == parts.len() - 1;
+
+        // Check for array index syntax: field[idx]
+        if let Some(bracket_pos) = part.find('[') {
+            let field_name = &part[..bracket_pos];
+            let idx_str = &part[bracket_pos + 1..part.len() - 1];
+
+            match current.get(field_name) {
+                Some(arr) => {
+                    if let Ok(idx) = idx_str.parse::<usize>() {
+                        if is_last {
+                            return arr.as_array().is_some_and(|a| idx < a.len());
+                        }
+                        match arr.get(idx) {
+                            Some(v) => current = v,
+                            None => return false,
+                        }
+                    } else {
+                        return false;
+                    }
+                }
+                None => return false,
+            }
+        } else if is_last {
             return match current.as_object() {
-                Some(obj) => obj.contains_key(*segment),
+                Some(obj) => obj.contains_key(*part),
                 None => false,
             };
         } else {
-            match current.get(*segment) {
+            match current.get(*part) {
                 Some(v) => current = v,
                 None => return false,
             }
@@ -373,6 +396,20 @@ mod tests {
         assert!(evaluate_rule(&rule, &input));
 
         let input = json!({"other": "value"});
+        assert!(!evaluate_rule(&rule, &input));
+    }
+
+    #[test]
+    fn test_is_present_with_array_index() {
+        let rule = json!({
+            "Variable": "$.items[0]",
+            "IsPresent": true,
+            "Next": "HasItem"
+        });
+        let input = json!({"items": [10, 20, 30]});
+        assert!(evaluate_rule(&rule, &input));
+
+        let input = json!({"items": []});
         assert!(!evaluate_rule(&rule, &input));
     }
 

--- a/crates/fakecloud-stepfunctions/src/choice.rs
+++ b/crates/fakecloud-stepfunctions/src/choice.rs
@@ -252,7 +252,12 @@ fn field_exists_in_input(root: &Value, path: &str) -> bool {
         // Check for array index syntax: field[idx]
         if let Some(bracket_pos) = part.find('[') {
             let field_name = &part[..bracket_pos];
-            let idx_str = &part[bracket_pos + 1..part.len() - 1];
+            // Ensure closing bracket exists
+            let close_bracket = match part.rfind(']') {
+                Some(pos) if pos > bracket_pos => pos,
+                _ => return false, // malformed segment like "foo[bar"
+            };
+            let idx_str = &part[bracket_pos + 1..close_bracket];
 
             match current.get(field_name) {
                 Some(arr) => {

--- a/crates/fakecloud-stepfunctions/src/choice.rs
+++ b/crates/fakecloud-stepfunctions/src/choice.rs
@@ -252,11 +252,14 @@ fn field_exists_in_input(root: &Value, path: &str) -> bool {
         // Check for array index syntax: field[idx]
         if let Some(bracket_pos) = part.find('[') {
             let field_name = &part[..bracket_pos];
-            // Ensure closing bracket exists
-            let close_bracket = match part.rfind(']') {
-                Some(pos) if pos > bracket_pos => pos,
-                _ => return false, // malformed segment like "foo[bar"
-            };
+            // Ensure closing bracket exists and is at the end of the segment
+            if !part.ends_with(']') {
+                return false; // malformed segment like "foo[0]extra"
+            }
+            let close_bracket = part.len() - 1;
+            if close_bracket <= bracket_pos {
+                return false;
+            }
             let idx_str = &part[bracket_pos + 1..close_bracket];
 
             match current.get(field_name) {

--- a/crates/fakecloud-stepfunctions/src/error_handling.rs
+++ b/crates/fakecloud-stepfunctions/src/error_handling.rs
@@ -14,7 +14,10 @@ pub fn find_catcher(catchers: &[Value], error: &str) -> Option<(String, Option<S
         });
 
         if matches {
-            let next = catcher["Next"].as_str()?.to_string();
+            let next = match catcher["Next"].as_str() {
+                Some(s) => s.to_string(),
+                None => continue, // skip malformed catcher, try next one
+            };
             // Distinguish between absent ResultPath (None) and JSON null ResultPath
             let result_path = if catcher.get("ResultPath").is_some_and(|v| v.is_null()) {
                 Some("null".to_string())
@@ -107,6 +110,23 @@ mod tests {
             result,
             Some(("Handle".to_string(), Some("$.error".to_string())))
         );
+    }
+
+    #[test]
+    fn test_find_catcher_skips_malformed_and_finds_next() {
+        // First catcher matches but has no Next field — should skip to second catcher
+        let catchers = vec![
+            json!({
+                "ErrorEquals": ["States.ALL"]
+                // missing "Next"
+            }),
+            json!({
+                "ErrorEquals": ["States.ALL"],
+                "Next": "FallbackHandler"
+            }),
+        ];
+        let result = find_catcher(&catchers, "AnyError");
+        assert_eq!(result, Some(("FallbackHandler".to_string(), None)));
     }
 
     #[test]

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1523,6 +1523,16 @@ fn add_event(
 }
 
 fn succeed_execution(state: &SharedStepFunctionsState, execution_arn: &str, output: &Value) {
+    // Check terminal status before recording events to avoid inconsistent history
+    {
+        let s = state.read();
+        if let Some(exec) = s.executions.get(execution_arn) {
+            if exec.status != ExecutionStatus::Running {
+                return;
+            }
+        }
+    }
+
     let output_str = serde_json::to_string(output).unwrap_or_default();
 
     add_event(
@@ -1535,10 +1545,6 @@ fn succeed_execution(state: &SharedStepFunctionsState, execution_arn: &str, outp
 
     let mut s = state.write();
     if let Some(exec) = s.executions.get_mut(execution_arn) {
-        // Don't overwrite terminal states (e.g. ABORTED by StopExecution)
-        if exec.status != ExecutionStatus::Running {
-            return;
-        }
         exec.status = ExecutionStatus::Succeeded;
         exec.output = Some(output_str);
         exec.stop_date = Some(Utc::now());
@@ -1546,6 +1552,16 @@ fn succeed_execution(state: &SharedStepFunctionsState, execution_arn: &str, outp
 }
 
 fn fail_execution(state: &SharedStepFunctionsState, execution_arn: &str, error: &str, cause: &str) {
+    // Check terminal status before recording events to avoid inconsistent history
+    {
+        let s = state.read();
+        if let Some(exec) = s.executions.get(execution_arn) {
+            if exec.status != ExecutionStatus::Running {
+                return;
+            }
+        }
+    }
+
     add_event(
         state,
         execution_arn,
@@ -1556,10 +1572,6 @@ fn fail_execution(state: &SharedStepFunctionsState, execution_arn: &str, error: 
 
     let mut s = state.write();
     if let Some(exec) = s.executions.get_mut(execution_arn) {
-        // Don't overwrite terminal states (e.g. ABORTED by StopExecution)
-        if exec.status != ExecutionStatus::Running {
-            return;
-        }
         exec.status = ExecutionStatus::Failed;
         exec.error = Some(error.to_string());
         exec.cause = Some(cause.to_string());

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use serde_json::{json, Value};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_dynamodb::state::SharedDynamoDbState;
@@ -571,7 +571,12 @@ async fn execute_wait_state(state_def: &Value, input: &Value) {
                 }
             }
         }
+        return;
     }
+
+    warn!(
+        "Wait state has no valid Seconds, SecondsPath, Timestamp, or TimestampPath — skipping wait"
+    );
 }
 
 /// Execute a Pass state: apply InputPath, use Result if present, apply ResultPath and OutputPath.
@@ -1530,6 +1535,10 @@ fn succeed_execution(state: &SharedStepFunctionsState, execution_arn: &str, outp
 
     let mut s = state.write();
     if let Some(exec) = s.executions.get_mut(execution_arn) {
+        // Don't overwrite terminal states (e.g. ABORTED by StopExecution)
+        if exec.status != ExecutionStatus::Running {
+            return;
+        }
         exec.status = ExecutionStatus::Succeeded;
         exec.output = Some(output_str);
         exec.stop_date = Some(Utc::now());
@@ -1547,6 +1556,10 @@ fn fail_execution(state: &SharedStepFunctionsState, execution_arn: &str, error: 
 
     let mut s = state.write();
     if let Some(exec) = s.executions.get_mut(execution_arn) {
+        // Don't overwrite terminal states (e.g. ABORTED by StopExecution)
+        if exec.status != ExecutionStatus::Running {
+            return;
+        }
         exec.status = ExecutionStatus::Failed;
         exec.error = Some(error.to_string());
         exec.cause = Some(cause.to_string());


### PR DESCRIPTION
## Summary
- Guard `succeed_execution`/`fail_execution` against overwriting terminal states (e.g., ABORTED by `StopExecution`) — background interpreter no longer clobbers stopped executions
- Fix `IsPresent` to correctly return `true` for fields explicitly set to `null` — checks parent object instead of relying on `resolve_path` which returns `Value::Null` for both missing and null
- Fix `find_catcher` to skip malformed catchers (missing `Next`) instead of aborting the entire search via `?` operator
- Add warning log when Wait state has no valid Seconds/SecondsPath/Timestamp/TimestampPath

Addresses unresolved Cubic findings from PRs #241, #244, #242.

## Test plan
- [x] `cargo clippy -p fakecloud-stepfunctions -- -D warnings` passes
- [x] All 41 unit tests pass (2 new: `test_is_present_with_null_value`, `test_find_catcher_skips_malformed_and_finds_next`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes in `fakecloud-stepfunctions`: stop overwriting terminal executions by guarding before `add_event`, treat explicit nulls as present for `IsPresent` (including array indices; reject malformed segments like `foo[0]extra`), skip catchers without `Next`, and warn when Wait lacks valid Seconds/SecondsPath/Timestamp/TimestampPath. Prevents clobbered ABORTED runs and addresses Cubic findings from #241, #242, and #244.

<sup>Written for commit 5aad2bffa793a27b8e7542f11eee107178762737. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

