### PR TITLE
fix(apigatewayv2): fix route priority, proxy errors, CORS, and dispatch

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/cors.rs
+++ b/crates/fakecloud-apigatewayv2/src/cors.rs
@@ -5,16 +5,12 @@ use crate::state::CorsConfiguration;
 use fakecloud_core::service::{AwsRequest, AwsResponse};
 
 /// Handle CORS preflight OPTIONS request
-pub fn handle_preflight(cors_config: &CorsConfiguration, _req: &AwsRequest) -> AwsResponse {
+pub fn handle_preflight(cors_config: &CorsConfiguration, req: &AwsRequest) -> AwsResponse {
     let mut headers = HeaderMap::new();
 
-    // Add Access-Control-Allow-Origin
+    // Add Access-Control-Allow-Origin — reflect the matching origin from the request
     if let Some(ref origins) = cors_config.allow_origins {
-        let origin_value = if origins.contains(&"*".to_string()) {
-            "*"
-        } else {
-            origins.first().map(|s| s.as_str()).unwrap_or("*")
-        };
+        let origin_value = resolve_origin(origins, req);
         if let Ok(val) = origin_value.parse() {
             headers.insert("access-control-allow-origin", val);
         }
@@ -60,7 +56,7 @@ pub fn handle_preflight(cors_config: &CorsConfiguration, _req: &AwsRequest) -> A
 
 /// Add CORS headers to an existing response
 pub fn add_cors_headers(mut response: AwsResponse, cors_config: &CorsConfiguration) -> AwsResponse {
-    // Add Access-Control-Allow-Origin
+    // Add Access-Control-Allow-Origin — use wildcard for non-preflight responses
     if let Some(ref origins) = cors_config.allow_origins {
         let origin_value = if origins.contains(&"*".to_string()) {
             "*"
@@ -92,6 +88,20 @@ pub fn add_cors_headers(mut response: AwsResponse, cors_config: &CorsConfigurati
     }
 
     response
+}
+
+/// Resolve which origin to reflect: if the request's Origin header matches a configured origin,
+/// reflect it back. Otherwise fall back to the first configured origin or "*".
+fn resolve_origin<'a>(origins: &'a [String], req: &AwsRequest) -> &'a str {
+    if origins.contains(&"*".to_string()) {
+        return "*";
+    }
+    if let Some(request_origin) = req.headers.get("origin").and_then(|v| v.to_str().ok()) {
+        if let Some(matching) = origins.iter().find(|o| o.as_str() == request_origin) {
+            return matching.as_str();
+        }
+    }
+    origins.first().map(|s| s.as_str()).unwrap_or("*")
 }
 
 /// Check if the request is a CORS preflight request

--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -193,10 +193,7 @@ fn parse_lambda_response(response: serde_json::Value) -> Result<AwsResponse, Aws
                 AwsServiceError::aws_error(
                     StatusCode::BAD_GATEWAY,
                     "BadGatewayException",
-                    format!(
-                        "Lambda response has invalid base64 body: {}",
-                        e
-                    ),
+                    format!("Lambda response has invalid base64 body: {}", e),
                 )
             })?)
         } else {

--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -148,13 +148,30 @@ pub async fn invoke_lambda(
 
 /// Parses a Lambda proxy integration response in v2.0 format.
 fn parse_lambda_response(response: serde_json::Value) -> Result<AwsResponse, AwsServiceError> {
-    let status_code = response["statusCode"]
-        .as_i64()
-        .unwrap_or(200)
-        .try_into()
-        .unwrap_or(200);
-
-    let status_code = StatusCode::from_u16(status_code).unwrap_or(StatusCode::OK);
+    let status_code = match response.get("statusCode") {
+        Some(v) => v.as_i64().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_GATEWAY,
+                "BadGatewayException",
+                "Lambda response has invalid statusCode",
+            )
+        })?,
+        None => 200,
+    };
+    let status_code: u16 = status_code.try_into().map_err(|_| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_GATEWAY,
+            "BadGatewayException",
+            format!("Lambda response has invalid statusCode: {}", status_code),
+        )
+    })?;
+    let status_code = StatusCode::from_u16(status_code).map_err(|_| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_GATEWAY,
+            "BadGatewayException",
+            format!("Lambda response has invalid statusCode: {}", status_code),
+        )
+    })?;
 
     let mut headers = HeaderMap::new();
     if let Some(response_headers) = response["headers"].as_object() {
@@ -172,11 +189,16 @@ fn parse_lambda_response(response: serde_json::Value) -> Result<AwsResponse, Aws
     let is_base64 = response["isBase64Encoded"].as_bool().unwrap_or(false);
     let body = if let Some(body_str) = response["body"].as_str() {
         if is_base64 {
-            Bytes::from(
-                BASE64_STANDARD
-                    .decode(body_str)
-                    .unwrap_or_else(|_| body_str.as_bytes().to_vec()),
-            )
+            Bytes::from(BASE64_STANDARD.decode(body_str).map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_GATEWAY,
+                    "BadGatewayException",
+                    format!(
+                        "Lambda response has invalid base64 body: {}",
+                        e
+                    ),
+                )
+            })?)
         } else {
             Bytes::from(body_str.as_bytes().to_vec())
         }

--- a/crates/fakecloud-apigatewayv2/src/router.rs
+++ b/crates/fakecloud-apigatewayv2/src/router.rs
@@ -32,7 +32,7 @@ impl ParsedRoute {
         let path = parts[1];
 
         let segments = Self::parse_path(path);
-        let priority = Self::calculate_priority(&segments);
+        let priority = Self::calculate_priority(&method, &segments);
 
         Some(Self {
             method,
@@ -60,7 +60,7 @@ impl ParsedRoute {
             .collect()
     }
 
-    fn calculate_priority(segments: &[RouteSegment]) -> i32 {
+    fn calculate_priority(method: &str, segments: &[RouteSegment]) -> i32 {
         let mut priority = 0;
         for seg in segments {
             priority += match seg {
@@ -68,6 +68,10 @@ impl ParsedRoute {
                 RouteSegment::Parameter(_) => 50,
                 RouteSegment::Greedy(_) => 10,
             };
+        }
+        // ANY routes should have lower priority than exact-method routes
+        if method == "ANY" {
+            priority -= 1;
         }
         priority
     }
@@ -291,6 +295,31 @@ mod tests {
         assert!(router.match_route("GET", "/pets").is_some());
         assert!(router.match_route("POST", "/pets").is_some());
         assert!(router.match_route("DELETE", "/pets").is_some());
+    }
+
+    #[test]
+    fn test_exact_method_over_any() {
+        let routes = vec![
+            Route {
+                route_id: "any".to_string(),
+                route_key: "ANY /pets".to_string(),
+                target: None,
+                authorization_type: None,
+                authorizer_id: None,
+            },
+            Route {
+                route_id: "get".to_string(),
+                route_key: "GET /pets".to_string(),
+                target: None,
+                authorization_type: None,
+                authorizer_id: None,
+            },
+        ];
+
+        let router = Router::new(routes);
+        let result = router.match_route("GET", "/pets");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().route.route_id, "get"); // Exact method wins over ANY
     }
 
     #[test]

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -1666,12 +1666,12 @@ impl ApiGatewayV2Service {
                 .collect();
             stage_entries.sort_by(|a, b| a.0.cmp(&b.0));
             let (api_id, _stage) = stage_entries.into_iter().next().ok_or_else(|| {
-                    AwsServiceError::aws_error(
-                        StatusCode::NOT_FOUND,
-                        "NotFoundException",
-                        format!("Stage not found: {}", stage_name),
-                    )
-                })?;
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "NotFoundException",
+                    format!("Stage not found: {}", stage_name),
+                )
+            })?;
 
             // Get routes for this API
             let routes = state
@@ -1801,7 +1801,13 @@ impl ApiGatewayV2Service {
         }
 
         // Record this request to history
-        self.record_request(&req, &api_id, stage_name, &resource_path, response.status.as_u16());
+        self.record_request(
+            &req,
+            &api_id,
+            stage_name,
+            &resource_path,
+            response.status.as_u16(),
+        );
 
         Ok(response)
     }

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -210,8 +210,10 @@ impl AwsService for ApiGatewayV2Service {
         // Check if this is a management API request or an execute API request
         // Management API: /v2/apis/*
         // Execute API: /{stage}/{path}
-        if req.path_segments.first().map(|s| s.as_str()) == Some("v2") {
-            // Management API
+        if req.path_segments.first().map(|s| s.as_str()) == Some("v2")
+            && req.path_segments.get(1).map(|s| s.as_str()) == Some("apis")
+        {
+            // Management API: /v2/apis/*
             return self.handle_management_api(req).await;
         }
 
@@ -996,6 +998,19 @@ impl ApiGatewayV2Service {
             ));
         }
 
+        // Check for duplicate stage
+        if state
+            .stages
+            .get(api_id)
+            .is_some_and(|stages| stages.contains_key(&stage_name))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::CONFLICT,
+                "ConflictException",
+                format!("Stage already exists: {}", stage_name),
+            ));
+        }
+
         state
             .stages
             .entry(api_id.to_string())
@@ -1639,16 +1654,18 @@ impl ApiGatewayV2Service {
         let (api_id, routes, cors_config) = {
             let state = self.state.read();
 
-            // Find which API has this stage
-            let (api_id, _stage) = state
+            // Find which API has this stage (sort by API ID for deterministic resolution)
+            let mut stage_entries: Vec<_> = state
                 .stages
                 .iter()
-                .find_map(|(api_id, stages)| {
+                .filter_map(|(api_id, stages)| {
                     stages
                         .get(stage_name)
                         .map(|stage| (api_id.clone(), stage.clone()))
                 })
-                .ok_or_else(|| {
+                .collect();
+            stage_entries.sort_by(|a, b| a.0.cmp(&b.0));
+            let (api_id, _stage) = stage_entries.into_iter().next().ok_or_else(|| {
                     AwsServiceError::aws_error(
                         StatusCode::NOT_FOUND,
                         "NotFoundException",
@@ -1784,6 +1801,19 @@ impl ApiGatewayV2Service {
         }
 
         // Record this request to history
+        self.record_request(&req, &api_id, stage_name, &resource_path, response.status.as_u16());
+
+        Ok(response)
+    }
+
+    fn record_request(
+        &self,
+        req: &AwsRequest,
+        api_id: &str,
+        stage: &str,
+        path: &str,
+        status_code: u16,
+    ) {
         let headers_map: std::collections::HashMap<String, String> = req
             .headers
             .iter()
@@ -1802,23 +1832,19 @@ impl ApiGatewayV2Service {
 
         let request_record = ApiRequest {
             request_id: uuid::Uuid::new_v4().to_string(),
-            api_id: api_id.clone(),
-            stage: stage_name.to_string(),
+            api_id: api_id.to_string(),
+            stage: stage.to_string(),
             method: req.method.to_string(),
-            path: resource_path,
+            path: path.to_string(),
             headers: headers_map,
             query_params: req.query_params.clone(),
             body: body_string,
             timestamp: chrono::Utc::now(),
-            status_code: response.status.as_u16(),
+            status_code,
         };
 
-        {
-            let mut state = self.state.write();
-            state.request_history.push(request_record);
-        }
-
-        Ok(response)
+        let mut state = self.state.write();
+        state.request_history.push(request_record);
     }
 }
 


### PR DESCRIPTION
## Summary
- De-prioritize ANY routes vs exact-method routes for same path
- Deterministic stage resolution (sort by API ID) when multiple APIs share a stage name
- Return 502 on malformed Lambda proxy response instead of silently defaulting to 200
- Return 502 on invalid base64 body instead of silently falling back to raw bytes
- Reject duplicate stage names in CreateStage with ConflictException
- Require /v2/apis/* for management API dispatch (not just /v2/*)
- Replace all .parse().unwrap() in CORS with safe fallbacks
- Reflect matching Origin header in CORS preflight responses
- Clamp negative timeout in HTTP proxy

Addresses unresolved Cubic findings from PRs #252, #253, #254, #255, #256.

## Test plan
- [x] `cargo clippy -p fakecloud-apigatewayv2 -- -D warnings` passes
- [x] All 17 unit tests pass (1 new: `test_exact_method_over_any`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API Gateway v2 routing, CORS, and proxy error handling to prevent silent defaults and panics. Stage resolution is now deterministic and management API dispatch is stricter.

- **Bug Fixes**
  - Routing: exact-method routes outrank ANY for the same path.
  - Stage resolution: when multiple APIs share a stage name, pick deterministically by sorting API IDs.
  - Dispatch: require /v2/apis/* for management API (no longer any /v2/*).
  - CreateStage: reject duplicate stage names with ConflictException.
  - Lambda proxy: return 502 for invalid statusCode or invalid base64 body (no fallback to 200/raw bytes).
  - CORS preflight: reflect the matching Origin header; replace unsafe header parsing to avoid panics.
  - HTTP proxy: clamp negative timeout before casting.

- **Refactors**
  - Extracted request recording into a helper to ensure requests (including failures) are logged.

<sup>Written for commit 69e37d43a44c866755a96dcdc0b88a8c6a8d2387. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

