### PR TITLE
fix(bedrock): validate TagResource ARN, add embed schema, fix profanity and deployments

### DIFF
--- a/crates/fakecloud-bedrock/src/custom_model_deployments.rs
+++ b/crates/fakecloud-bedrock/src/custom_model_deployments.rs
@@ -12,7 +12,10 @@ pub fn create_custom_model_deployment(
     req: &AwsRequest,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let deployment_name = body["modelDeploymentName"].as_str().unwrap_or("deployment");
+    let default_name = format!("deployment-{}", &Uuid::new_v4().to_string()[..8]);
+    let deployment_name = body["modelDeploymentName"]
+        .as_str()
+        .unwrap_or(&default_name);
     let model_arn = body["modelArn"].as_str().unwrap_or_default();
 
     let deployment_id = Uuid::new_v4().to_string();

--- a/crates/fakecloud-bedrock/src/customization.rs
+++ b/crates/fakecloud-bedrock/src/customization.rs
@@ -48,7 +48,13 @@ pub fn create_model_customization_job(
             .and_then(|v| v.as_object())
             .map(|obj| {
                 obj.iter()
-                    .map(|(k, v)| (k.clone(), v.as_str().unwrap_or_default().to_string()))
+                    .map(|(k, v)| {
+                        let val = match v.as_str() {
+                            Some(s) => s.to_string(),
+                            None => v.to_string(), // serialize non-string values
+                        };
+                        (k.clone(), val)
+                    })
                     .collect()
             })
             .unwrap_or_default(),

--- a/crates/fakecloud-bedrock/src/guardrails.rs
+++ b/crates/fakecloud-bedrock/src/guardrails.rs
@@ -442,8 +442,9 @@ pub fn evaluate_content(guardrail: &Guardrail, text: &str) -> Vec<Value> {
             for entry in managed {
                 if entry["type"].as_str() == Some("PROFANITY") {
                     let profanity_words = ["damn", "hell", "shit", "fuck", "ass"];
+                    let text_lower = text.to_lowercase();
                     for word in &profanity_words {
-                        if text.to_lowercase().contains(word) {
+                        if word_boundary_match(&text_lower, word) {
                             assessments.push(json!({
                                 "wordPolicy": {
                                     "managedWordLists": [{
@@ -614,4 +615,21 @@ fn guardrail_version_to_json(gv: &GuardrailVersion) -> Value {
     }
 
     obj
+}
+
+/// Check if `word` appears in `text` at word boundaries (not as a substring of another word).
+fn word_boundary_match(text: &str, word: &str) -> bool {
+    let mut start = 0;
+    while let Some(pos) = text[start..].find(word) {
+        let abs_pos = start + pos;
+        let before_ok = abs_pos == 0 || !text.as_bytes()[abs_pos - 1].is_ascii_alphanumeric();
+        let after_pos = abs_pos + word.len();
+        let after_ok =
+            after_pos >= text.len() || !text.as_bytes()[after_pos].is_ascii_alphanumeric();
+        if before_ok && after_ok {
+            return true;
+        }
+        start = abs_pos + 1;
+    }
+    false
 }

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -176,7 +176,17 @@ fn anthropic_response(model_id: &str, _input: &Value) -> String {
     .unwrap()
 }
 
-fn amazon_titan_response(_model_id: &str, _input: &Value) -> String {
+fn amazon_titan_response(model_id: &str, _input: &Value) -> String {
+    // Titan embed models return embedding vectors, not text completions
+    if model_id.contains("embed") {
+        let embedding: Vec<f64> = (0..256).map(|i| (i as f64 * 0.001).sin()).collect();
+        return serde_json::to_string(&json!({
+            "embedding": embedding,
+            "inputTextTokenCount": 10
+        }))
+        .unwrap();
+    }
+
     serde_json::to_string(&json!({
         "inputTextTokenCount": 10,
         "results": [

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -178,7 +178,7 @@ fn anthropic_response(model_id: &str, _input: &Value) -> String {
 
 fn amazon_titan_response(model_id: &str, _input: &Value) -> String {
     // Titan embed models return embedding vectors, not text completions
-    if model_id.contains("embed") {
+    if model_id.starts_with("amazon.titan-embed") {
         let embedding: Vec<f64> = (0..256).map(|i| (i as f64 * 0.001).sin()).collect();
         return serde_json::to_string(&json!({
             "embedding": embedding,

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -758,7 +758,16 @@ impl AwsService for BedrockService {
             }
             "TagResource" => {
                 let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
-                let arn = body["resourceARN"].as_str().unwrap_or_default();
+                let arn = body["resourceARN"]
+                    .as_str()
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "ValidationException",
+                            "resourceARN is required",
+                        )
+                    })?;
                 self.tag_resource(&req, arn, &body)
             }
             "UntagResource" => {


### PR DESCRIPTION
## Summary
- Reject empty/missing `resourceARN` in TagResource with ValidationException instead of storing tags under empty key
- Return embedding vector schema for `amazon.titan-embed-*` models instead of text-generation schema
- Use word-boundary matching for profanity detection to prevent false positives (e.g., "assignment" no longer matches "ass")
- Serialize non-string hyperparameter values instead of silently converting to empty string
- Generate unique deployment names when `modelDeploymentName` is not provided

Addresses unresolved Cubic findings from PRs #260, #266.

## Test plan
- [x] `cargo clippy -p fakecloud-bedrock -- -D warnings` passes
- [x] All unit tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes correctness and robustness in `fakecloud-bedrock`: validates `TagResource` ARN, returns proper Titan embed schema across variants, improves profanity checks, and hardens deployment/hyperparameter handling. Addresses remaining Cubic findings from earlier PRs.

- **Bug Fixes**
  - Validate `TagResource` `resourceARN`; return `ValidationException` when missing or empty.
  - Return embedding vector schema for `amazon.titan-embed*` models (prefix match) instead of text-generation.
  - Use word-boundary matching for profanity to avoid false positives (e.g., "assignment").
  - Serialize non-string hyperparameter values; auto-generate unique deployment names when `modelDeploymentName` is not provided.

<sup>Written for commit 6ef8765f123eb2a693c0681b05e2e623767caa02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

