### PR TITLE
fix: address remaining Cubic findings across DynamoDB, ElastiCache, RDS, S3, SDK

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -630,11 +630,41 @@ impl ResourceProvisioner {
             }
         };
 
+        // Parse StreamSpecification from CloudFormation properties
+        let (stream_enabled, stream_view_type) =
+            if let Some(stream_spec) = props.get("StreamSpecification") {
+                let enabled = stream_spec
+                    .get("StreamEnabled")
+                    .and_then(|v| v.as_bool().or_else(|| v.as_str().map(|s| s == "true")))
+                    .unwrap_or(false);
+                let view_type = if enabled {
+                    stream_spec
+                        .get("StreamViewType")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                } else {
+                    None
+                };
+                (enabled, view_type)
+            } else {
+                (false, None)
+            };
+
         let mut state = self.dynamodb_state.write();
         let arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}",
             state.region, state.account_id, table_name
         );
+
+        let stream_arn = if stream_enabled {
+            Some(format!(
+                "{}/stream/{}",
+                arn,
+                Utc::now().format("%Y-%m-%dT%H:%M:%S.%3f")
+            ))
+        } else {
+            None
+        };
 
         let table = DynamoTable {
             name: table_name.to_string(),
@@ -658,9 +688,9 @@ impl ResourceProvisioner {
             kinesis_destinations: Vec::new(),
             contributor_insights_status: "DISABLED".to_string(),
             contributor_insights_counters: HashMap::new(),
-            stream_enabled: false,
-            stream_view_type: None,
-            stream_arn: None,
+            stream_enabled,
+            stream_view_type,
+            stream_arn,
             stream_records: Arc::new(RwLock::new(Vec::new())),
             sse_type: None,
             sse_kms_key_arn: None,

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -633,18 +633,15 @@ impl ResourceProvisioner {
         // Parse StreamSpecification from CloudFormation properties
         let (stream_enabled, stream_view_type) =
             if let Some(stream_spec) = props.get("StreamSpecification") {
+                let view_type = stream_spec
+                    .get("StreamViewType")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 let enabled = stream_spec
                     .get("StreamEnabled")
                     .and_then(|v| v.as_bool().or_else(|| v.as_str().map(|s| s == "true")))
-                    .unwrap_or(false);
-                let view_type = if enabled {
-                    stream_spec
-                        .get("StreamViewType")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                } else {
-                    None
-                };
+                    // If StreamViewType is set, treat streams as enabled even if StreamEnabled is missing
+                    .unwrap_or(view_type.is_some());
                 (enabled, view_type)
             } else {
                 (false, None)

--- a/crates/fakecloud-dynamodb/src/service.rs
+++ b/crates/fakecloud-dynamodb/src/service.rs
@@ -4101,8 +4101,12 @@ fn attribute_size(val: &Value) -> Option<usize> {
         return Some(s.len());
     }
     if let Some(b) = val.get("B").and_then(|v| v.as_str()) {
-        // B is base64-encoded, decode length = raw bytes
-        return Some(b.len()); // approximate with encoded length
+        // B is base64-encoded — return decoded byte count
+        let decoded_len = base64::engine::general_purpose::STANDARD
+            .decode(b)
+            .map(|v| v.len())
+            .unwrap_or(b.len());
+        return Some(decoded_len);
     }
     if let Some(arr) = val.get("SS").and_then(|v| v.as_array()) {
         return Some(arr.len());

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -1170,8 +1170,7 @@ impl ElastiCacheService {
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let global_replication_group_id = required_param(request, "GlobalReplicationGroupId")?;
-        let _retain_primary_replication_group =
-            parse_required_bool(request, "RetainPrimaryReplicationGroup")?;
+        let retain_primary = parse_required_bool(request, "RetainPrimaryReplicationGroup")?;
 
         let mut state = self.state.write();
         let mut group = state
@@ -1186,7 +1185,15 @@ impl ElastiCacheService {
             })?;
 
         for member in &group.members {
-            if let Some(replication_group) = state
+            if !retain_primary && member.role == "PRIMARY" {
+                // Delete the primary replication group when RetainPrimaryReplicationGroup=false
+                if let Some(rg) = state
+                    .replication_groups
+                    .remove(&member.replication_group_id)
+                {
+                    state.tags.remove(&rg.arn);
+                }
+            } else if let Some(replication_group) = state
                 .replication_groups
                 .get_mut(&member.replication_group_id)
             {
@@ -1264,7 +1271,7 @@ impl ElastiCacheService {
         let cache_usage_limits = parse_cache_usage_limits(request)?;
         let security_group_ids =
             parse_query_list_param(request, "SecurityGroupIds", "SecurityGroupId");
-        let subnet_ids = parse_member_list(&request.query_params, "SubnetIds", "SubnetId");
+        let subnet_ids = parse_query_list_param(request, "SubnetIds", "SubnetId");
         let kms_key_id = optional_param(request, "KmsKeyId");
         let user_group_id = optional_param(request, "UserGroupId");
         let snapshot_retention_limit =

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -1185,7 +1185,7 @@ impl ElastiCacheService {
             })?;
 
         for member in &group.members {
-            if !retain_primary && member.role == "PRIMARY" {
+            if !retain_primary && member.role == "primary" {
                 // Delete the primary replication group when RetainPrimaryReplicationGroup=false
                 if let Some(rg) = state
                     .replication_groups

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -190,6 +190,18 @@ impl RdsService {
                     format!("DBInstance {} already exists.", db_instance_identifier),
                 ));
             }
+            // Validate parameter group exists if specified by the caller
+            if let Some(ref pg_name) = db_parameter_group_name {
+                if !pg_name.starts_with("default.") && !state.parameter_groups.contains_key(pg_name)
+                {
+                    state.cancel_instance_creation(&db_instance_identifier);
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "DBParameterGroupNotFound",
+                        format!("DBParameterGroup {} not found.", pg_name),
+                    ));
+                }
+            }
         }
 
         let runtime = self.runtime.as_ref().ok_or_else(|| {

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -192,8 +192,7 @@ impl RdsService {
             }
             // Validate parameter group exists if specified by the caller
             if let Some(ref pg_name) = db_parameter_group_name {
-                if !pg_name.starts_with("default.") && !state.parameter_groups.contains_key(pg_name)
-                {
+                if !state.parameter_groups.contains_key(pg_name) {
                     state.cancel_instance_creation(&db_instance_identifier);
                     return Err(AwsServiceError::aws_error(
                         StatusCode::NOT_FOUND,

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -282,8 +282,8 @@ impl S3Service {
             .buckets
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        // Check if EventBridgeConfiguration is present (any tag, even empty/self-closing)
-        b.eventbridge_enabled = body_str.contains("EventBridgeConfiguration");
+        // Check if EventBridgeConfiguration XML element is present (opening tag or self-closing)
+        b.eventbridge_enabled = body_str.contains("<EventBridgeConfiguration");
         // Auto-generate Id for each configuration element if missing
         let normalized = normalize_notification_ids(&body_str);
         b.notification_config = Some(normalized);

--- a/crates/fakecloud-sdk/src/client.rs
+++ b/crates/fakecloud-sdk/src/client.rs
@@ -534,10 +534,9 @@ impl CognitoClient<'_> {
             .json(req)
             .send()
             .await?;
-        // This endpoint returns 404 for missing users but still has a JSON body
         let status = resp.status().as_u16();
         let body: ConfirmUserResponse = resp.json().await?;
-        if status == 404 {
+        if status >= 400 {
             return Err(Error::Api {
                 status,
                 body: body.error.unwrap_or_default(),

--- a/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
+++ b/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
@@ -54,7 +54,11 @@ impl DynamoDbStreamsLambdaPoller {
             lambda
                 .event_source_mappings
                 .values()
-                .filter(|m| m.enabled && m.event_source_arn.contains(":dynamodb:"))
+                .filter(|m| {
+                    m.enabled
+                        && m.event_source_arn.contains(":dynamodb:")
+                        && m.event_source_arn.contains("/stream/")
+                })
                 .map(|m| {
                     (
                         m.uuid.clone(),


### PR DESCRIPTION
## Summary
- **CloudFormation**: Read `StreamSpecification` when provisioning DynamoDB tables instead of hardcoding `stream_enabled: false`
- **DynamoDB streams poller**: Filter on `/stream/` in ARN to distinguish stream ARNs from table ARNs
- **DynamoDB**: Decode base64 before computing B attribute `size()` (was over-reporting by ~33%)
- **ElastiCache**: Unify `subnet_ids`/`security_group_ids` to use same parser in `create_serverless_cache`
- **ElastiCache**: Implement `RetainPrimaryReplicationGroup=false` behavior in `DeleteGlobalReplicationGroup`
- **SDK**: Fix `confirm_user` to return error on any non-2xx status, not just 404
- **S3**: Check for `<EventBridgeConfiguration` XML element tag instead of raw substring match
- **RDS**: Validate `DBParameterGroupName` exists on `CreateDBInstance`

Addresses unresolved Cubic findings from PRs #232, #265, #203, #204, #171, #234, #217.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] All workspace tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remaining Cubic findings across DynamoDB, ElastiCache, RDS, S3, and SDK. Improves correctness of stream provisioning, attribute sizing, deletion behavior, request parsing, and error handling.

- **Bug Fixes**
  - `fakecloud-cloudformation`: Read DynamoDB `StreamSpecification` and create a stream ARN when enabled; treat `StreamViewType` as enabling streams if `StreamEnabled` is missing.
  - `fakecloud-server` (DynamoDB streams poller): Only consider ARNs with "/stream/" to avoid matching table ARNs.
  - `fakecloud-dynamodb`: Compute `B` attribute size from the decoded base64 bytes.
  - `fakecloud-elasticache`: Parse `SubnetIds` with the same helper as `SecurityGroupIds` in `CreateServerlessCache`; when `RetainPrimaryReplicationGroup=false`, delete the primary replication group (role match uses lowercase "primary") and its tags.
  - `fakecloud-rds`: On `CreateDBInstance`, return `DBParameterGroupNotFound` and cancel creation when `DBParameterGroupName` is unknown, including `default.*` names.
  - `fakecloud-s3`: Detect EventBridge config via the `<EventBridgeConfiguration` XML element.
  - `fakecloud-sdk` (Cognito): `confirm_user` now errors on any non-2xx response.

<sup>Written for commit 0c6016ffe510a0e06d5bf7792d0f98c558a664ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

