### PR TITLE
fix: replace unwraps on user input with proper error handling

### DIFF
--- a/crates/fakecloud-bedrock/src/automated_reasoning.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning.rs
@@ -138,7 +138,11 @@ pub fn update_automated_reasoning_policy(
         )
     })?;
 
-    let policy = s.automated_reasoning_policies.get_mut(&key).unwrap();
+    // SAFETY: key was just validated by find_policy_key above while holding the write lock
+    let policy = s
+        .automated_reasoning_policies
+        .get_mut(&key)
+        .expect("key validated by find_policy_key");
 
     if let Some(name) = body["policyName"].as_str() {
         policy.policy_name = name.to_string();
@@ -196,7 +200,10 @@ pub fn create_automated_reasoning_policy_version(
         )
     })?;
 
-    let policy = s.automated_reasoning_policies.get_mut(&key).unwrap();
+    let policy = s
+        .automated_reasoning_policies
+        .get_mut(&key)
+        .expect("key validated by find_policy_key");
 
     let current: u32 = policy.version.parse().unwrap_or(1);
     let next = current.saturating_add(1);

--- a/crates/fakecloud-bedrock/src/custom_model_deployments.rs
+++ b/crates/fakecloud-bedrock/src/custom_model_deployments.rs
@@ -105,7 +105,10 @@ pub fn update_custom_model_deployment(
 ) -> Result<AwsResponse, AwsServiceError> {
     let mut s = state.write();
     let key = find_deployment_key(&s.custom_model_deployments, deployment_identifier)?;
-    let deployment = s.custom_model_deployments.get_mut(&key).unwrap();
+    let deployment = s
+        .custom_model_deployments
+        .get_mut(&key)
+        .expect("key validated by find_deployment_key");
 
     if let Some(model_arn) = body["modelArn"].as_str() {
         deployment.model_arn = model_arn.to_string();

--- a/crates/fakecloud-bedrock/src/evaluation.rs
+++ b/crates/fakecloud-bedrock/src/evaluation.rs
@@ -128,7 +128,10 @@ pub fn stop_evaluation_job(
 ) -> Result<AwsResponse, AwsServiceError> {
     let mut s = state.write();
     let key = find_job_key(&s.evaluation_jobs, job_identifier)?;
-    let job = s.evaluation_jobs.get_mut(&key).unwrap();
+    let job = s
+        .evaluation_jobs
+        .get_mut(&key)
+        .expect("key validated by find_job_key");
 
     if job.status != "InProgress" {
         return Err(AwsServiceError::aws_error(

--- a/crates/fakecloud-bedrock/src/invocation_jobs.rs
+++ b/crates/fakecloud-bedrock/src/invocation_jobs.rs
@@ -128,7 +128,10 @@ pub fn stop_model_invocation_job(
 ) -> Result<AwsResponse, AwsServiceError> {
     let mut s = state.write();
     let key = find_job_key(&s.model_invocation_jobs, job_identifier)?;
-    let job = s.model_invocation_jobs.get_mut(&key).unwrap();
+    let job = s
+        .model_invocation_jobs
+        .get_mut(&key)
+        .expect("key validated by find_job_key");
 
     if job.status != "InProgress" {
         return Err(AwsServiceError::aws_error(

--- a/crates/fakecloud-bedrock/src/marketplace.rs
+++ b/crates/fakecloud-bedrock/src/marketplace.rs
@@ -165,7 +165,10 @@ pub fn update_marketplace_model_endpoint(
             )
         })?;
 
-    let endpoint = s.marketplace_endpoints.get_mut(&key).unwrap();
+    let endpoint = s
+        .marketplace_endpoints
+        .get_mut(&key)
+        .expect("key validated by find above");
 
     if let Some(config) = body.get("endpointConfig") {
         endpoint.endpoint_config = config.clone();
@@ -237,7 +240,10 @@ pub fn register_marketplace_model_endpoint(
             )
         })?;
 
-    let endpoint = s.marketplace_endpoints.get_mut(&key).unwrap();
+    let endpoint = s
+        .marketplace_endpoints
+        .get_mut(&key)
+        .expect("key validated by find above");
     endpoint.status = "Registered".to_string();
     endpoint.updated_at = Utc::now();
 
@@ -277,7 +283,10 @@ pub fn deregister_marketplace_model_endpoint(
             )
         })?;
 
-    let endpoint = s.marketplace_endpoints.get_mut(&key).unwrap();
+    let endpoint = s
+        .marketplace_endpoints
+        .get_mut(&key)
+        .expect("key validated by find above");
     endpoint.status = "Active".to_string();
     endpoint.updated_at = Utc::now();
 

--- a/crates/fakecloud-bedrock/src/throughput.rs
+++ b/crates/fakecloud-bedrock/src/throughput.rs
@@ -236,7 +236,9 @@ fn find_throughput_mut<'a>(
                 format!("Provisioned model {id_or_arn} not found"),
             )
         })?;
-    Ok(throughputs.get_mut(&key).unwrap())
+    Ok(throughputs
+        .get_mut(&key)
+        .expect("key validated by find above"))
 }
 
 fn throughput_to_json(t: &ProvisionedThroughput) -> Value {

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -106,13 +106,14 @@ impl S3Service {
 
         let mut headers = HeaderMap::new();
         if let Some(algo) = &sse_algorithm {
-            headers.insert("x-amz-server-side-encryption", algo.parse().unwrap());
+            if let Ok(val) = algo.parse() {
+                headers.insert("x-amz-server-side-encryption", val);
+            }
         }
         if let Some(kid) = &sse_kms_key_id {
-            headers.insert(
-                "x-amz-server-side-encryption-aws-kms-key-id",
-                kid.parse().unwrap(),
-            );
+            if let Ok(val) = kid.parse() {
+                headers.insert("x-amz-server-side-encryption-aws-kms-key-id", val);
+            }
         }
 
         let body = format!(

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -532,9 +532,11 @@ impl SnsService {
         // If setting Policy, compact the JSON
         if attr_name == "Policy" {
             if let Ok(parsed) = serde_json::from_str::<Value>(&attr_value) {
-                topic
-                    .attributes
-                    .insert(attr_name, serde_json::to_string(&parsed).unwrap());
+                if let Ok(compact) = serde_json::to_string(&parsed) {
+                    topic.attributes.insert(attr_name, compact);
+                } else {
+                    topic.attributes.insert(attr_name, attr_value);
+                }
             } else {
                 topic.attributes.insert(attr_name, attr_value);
             }

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -763,7 +763,14 @@ fn validate_definition(definition: &str) -> Result<(), AwsServiceError> {
         ));
     }
 
-    let start_at = parsed["StartAt"].as_str().unwrap();
+    let start_at = parsed["StartAt"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidDefinition",
+            "Invalid State Machine Definition: 'MISSING_START_AT' (StartAt field is required)"
+                .to_string(),
+        )
+    })?;
     let states_obj = states.unwrap();
     if !states_obj.contains_key(start_at) {
         return Err(AwsServiceError::aws_error(


### PR DESCRIPTION
## Summary

- **StepFunctions**: `parsed["StartAt"].as_str().unwrap()` on user-provided JSON now returns `InvalidDefinition` error instead of panicking
- **SNS**: `serde_json::to_string().unwrap()` in `SetTopicAttributes` now falls back to original value on serialization failure
- **S3**: `algo.parse().unwrap()` for SSE headers in multipart upload now silently skips invalid header values
- **Bedrock**: 8 bare `.unwrap()` calls after map lookups replaced with `.expect()` documenting the safety invariant (key validated while holding write lock)

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes clean
- [x] `cargo fmt --check` passes clean
- [ ] CI passes
- [ ] Cubic review passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced unwraps on user-controlled input to prevent panics and return clear errors. Documented safety invariants for internal map lookups in `fakecloud-bedrock`.

- **Bug Fixes**
  - `fakecloud-stepfunctions`: Missing StartAt now returns InvalidDefinition instead of panicking.
  - `fakecloud-sns`: `SetTopicAttributes` compacts Policy JSON and falls back to original value if serialization fails.
  - `fakecloud-s3`: Multipart upload ignores invalid SSE header values instead of inserting invalid headers.

- **Refactors**
  - `fakecloud-bedrock`: Replaced bare `.unwrap()` after validated map lookups with `.expect(...)` and comments explaining the invariant.

<sup>Written for commit 8da9dfa23d9f0660b9525681f5d1ccb3bc0d0fb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

