### PR TITLE
refactor: extract shared Query protocol helpers to fakecloud-core

### DIFF
--- a/crates/fakecloud-core/src/lib.rs
+++ b/crates/fakecloud-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod delivery;
 pub mod dispatch;
 pub mod pagination;
 pub mod protocol;
+pub mod query;
 pub mod registry;
 pub mod service;
 pub mod tags;

--- a/crates/fakecloud-core/src/query.rs
+++ b/crates/fakecloud-core/src/query.rs
@@ -1,0 +1,58 @@
+//! Shared helpers for AWS Query protocol services (SQS, SNS, ElastiCache, RDS, SES v1, IAM).
+
+use http::StatusCode;
+
+use crate::service::{AwsRequest, AwsServiceError};
+
+/// Wrap an action result in the standard AWS Query protocol XML envelope.
+///
+/// Produces the canonical response shape:
+/// ```xml
+/// <?xml version="1.0" encoding="UTF-8"?>
+/// <{Action}Response xmlns="{namespace}">
+///   <{Action}Result>{inner}</{Action}Result>
+///   <ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata>
+/// </{Action}Response>
+/// ```
+pub fn query_response_xml(action: &str, namespace: &str, inner: &str, request_id: &str) -> String {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+         <{action}Response xmlns=\"{namespace}\">\
+         <{action}Result>{inner}</{action}Result>\
+         <ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata>\
+         </{action}Response>"
+    )
+}
+
+/// Produce a Query protocol XML response with only metadata (no result body).
+pub fn query_metadata_only_xml(action: &str, namespace: &str, request_id: &str) -> String {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+         <{action}Response xmlns=\"{namespace}\">\
+         <ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata>\
+         </{action}Response>"
+    )
+}
+
+/// Extract an optional query parameter from an `AwsRequest`.
+///
+/// Returns `None` if the parameter is missing or empty.
+pub fn optional_query_param(req: &AwsRequest, name: &str) -> Option<String> {
+    req.query_params
+        .get(name)
+        .cloned()
+        .filter(|value| !value.is_empty())
+}
+
+/// Extract a required query parameter from an `AwsRequest`.
+///
+/// Returns `MissingParameter` error if the parameter is missing or empty.
+pub fn required_query_param(req: &AwsRequest, name: &str) -> Result<String, AwsServiceError> {
+    optional_query_param(req, name).ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "MissingParameter",
+            format!("The request must contain the parameter {name}."),
+        )
+    })
+}

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -2872,20 +2872,11 @@ impl ElastiCacheService {
 // ---------------------------------------------------------------------------
 
 fn optional_param(req: &AwsRequest, name: &str) -> Option<String> {
-    req.query_params
-        .get(name)
-        .cloned()
-        .filter(|value| !value.is_empty())
+    fakecloud_core::query::optional_query_param(req, name)
 }
 
 fn required_param(req: &AwsRequest, name: &str) -> Result<String, AwsServiceError> {
-    optional_param(req, name).ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "MissingParameter",
-            format!("The request must contain the parameter {name}."),
-        )
-    })
+    fakecloud_core::query::required_query_param(req, name)
 }
 
 fn parse_required_bool(req: &AwsRequest, name: &str) -> Result<bool, AwsServiceError> {
@@ -3229,13 +3220,7 @@ fn filter_engine_versions(
 // ---------------------------------------------------------------------------
 
 fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
-    format!(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-         <{action}Response xmlns=\"{ELASTICACHE_NS}\">\
-         <{action}Result>{inner}</{action}Result>\
-         <ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata>\
-         </{action}Response>"
-    )
+    fakecloud_core::query::query_response_xml(action, ELASTICACHE_NS, inner, request_id)
 }
 
 fn engine_version_xml(v: &CacheEngineVersion) -> String {

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -1800,20 +1800,11 @@ impl RdsService {
 }
 
 fn optional_param(req: &AwsRequest, name: &str) -> Option<String> {
-    req.query_params
-        .get(name)
-        .cloned()
-        .filter(|value| !value.is_empty())
+    fakecloud_core::query::optional_query_param(req, name)
 }
 
 fn required_param(req: &AwsRequest, name: &str) -> Result<String, AwsServiceError> {
-    optional_param(req, name).ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "MissingParameter",
-            format!("The request must contain the parameter {name}."),
-        )
-    })
+    fakecloud_core::query::required_query_param(req, name)
 }
 
 fn required_i32_param(req: &AwsRequest, name: &str) -> Result<i32, AwsServiceError> {
@@ -2149,13 +2140,7 @@ fn filter_orderable_options(
 }
 
 fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
-    format!(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-         <{action}Response xmlns=\"{RDS_NS}\">\
-         <{action}Result>{inner}</{action}Result>\
-         <ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata>\
-         </{action}Response>"
-    )
+    fakecloud_core::query::query_response_xml(action, RDS_NS, inner, request_id)
 }
 
 fn engine_version_xml(version: &EngineVersionInfo) -> String {

--- a/crates/fakecloud-ses/src/v1.rs
+++ b/crates/fakecloud-ses/src/v1.rs
@@ -18,23 +18,12 @@ const SES_NS: &str = "http://ses.amazonaws.com/doc/2010-12-01/";
 
 /// Wrap a v1 action result in the standard SES Query protocol XML envelope.
 fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
-    format!(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-         <{action}Response xmlns=\"{SES_NS}\">\
-         <{action}Result>{inner}</{action}Result>\
-         <ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata>\
-         </{action}Response>"
-    )
+    fakecloud_core::query::query_response_xml(action, SES_NS, inner, request_id)
 }
 
 /// Response with only metadata (no result body).
 fn xml_metadata_only(action: &str, request_id: &str) -> AwsResponse {
-    let xml = format!(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-         <{action}Response xmlns=\"{SES_NS}\">\
-         <ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata>\
-         </{action}Response>"
-    );
+    let xml = fakecloud_core::query::query_metadata_only_xml(action, SES_NS, request_id);
     AwsResponse::xml(StatusCode::OK, xml)
 }
 

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -173,23 +173,14 @@ fn val_as_i64(v: &Value) -> Option<i64> {
 
 use fakecloud_aws::xml::xml_escape;
 
+const SQS_NS: &str = "http://queue.amazonaws.com/doc/2012-11-05/";
+
 fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
-    format!(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-         <{action}Response xmlns=\"http://queue.amazonaws.com/doc/2012-11-05/\">\
-         <{action}Result>{inner}</{action}Result>\
-         <ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata>\
-         </{action}Response>"
-    )
+    fakecloud_core::query::query_response_xml(action, SQS_NS, inner, request_id)
 }
 
 fn xml_metadata_only(action: &str, request_id: &str) -> AwsResponse {
-    let xml = format!(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-         <{action}Response xmlns=\"http://queue.amazonaws.com/doc/2012-11-05/\">\
-         <ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata>\
-         </{action}Response>"
-    );
+    let xml = fakecloud_core::query::query_metadata_only_xml(action, SQS_NS, request_id);
     AwsResponse::xml(StatusCode::OK, xml)
 }
 
@@ -2774,14 +2765,14 @@ fn queue_not_found() -> AwsServiceError {
     )
 }
 
-pub fn md5_hex(input: &str) -> String {
+pub(crate) fn md5_hex(input: &str) -> String {
     use md5::Digest;
     let mut hasher = Md5::new();
     hasher.update(input.as_bytes());
     format!("{:032x}", hasher.finalize())
 }
 
-pub fn sha256_hex(input: &str) -> String {
+pub(crate) fn sha256_hex(input: &str) -> String {
     use sha2::Digest;
     let mut hasher = Sha256::new();
     hasher.update(input.as_bytes());


### PR DESCRIPTION
## Summary

- Adds `fakecloud_core::query` module with shared Query protocol XML wrapping (`query_response_xml`, `query_metadata_only_xml`) and param extraction (`optional_query_param`, `required_query_param`)
- Migrates SQS, ElastiCache, RDS, SES v1 to delegate to the shared implementations, eliminating 4 identical `xml_wrap()` copies and 2 identical `optional_param`/`required_param` pairs
- Makes SQS `md5_hex`/`sha256_hex` `pub(crate)` since they're only used within the crate

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes clean
- [x] Existing `xml_wrap_produces_valid_response` test in ElastiCache still passes
- [ ] CI passes
- [ ] Cubic review passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted shared AWS Query protocol helpers into `fakecloud-core` and updated `fakecloud-sqs`, `fakecloud-elasticache`, `fakecloud-rds`, and `fakecloud-ses` (v1) to use them. Removes duplicate XML wrappers and parameter parsing; no behavior change intended.

- **Refactors**
  - Added `fakecloud_core::query::{query_response_xml, query_metadata_only_xml, optional_query_param, required_query_param}`.
  - Replaced per-service `xml_wrap()` and param helpers in the services to delegate to core.
  - Set `fakecloud-sqs` `md5_hex`/`sha256_hex` to `pub(crate)` as they are internal utilities.

- **Migration**
  - If external code used `fakecloud-sqs::md5_hex` or `sha256_hex`, switch to `md5`/`sha2` directly or copy the small helpers.

<sup>Written for commit 7610253ef287f5abe05e98110e9dac5a01e96650. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

