### PR TITLE
fix(kinesis): add input validation for CreateStream, DeleteStream, ListStreams

### DIFF
--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -162,18 +162,8 @@ impl KinesisService {
     fn list_streams(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
         let exclusive_start = body["ExclusiveStartStreamName"].as_str();
-        validate_optional_string_length(
-            "ExclusiveStartStreamName",
-            exclusive_start,
-            1,
-            128,
-        )?;
-        validate_optional_string_length(
-            "NextToken",
-            body["NextToken"].as_str(),
-            1,
-            1048576,
-        )?;
+        validate_optional_string_length("ExclusiveStartStreamName", exclusive_start, 1, 128)?;
+        validate_optional_string_length("NextToken", body["NextToken"].as_str(), 1, 1048576)?;
         validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
         let limit = body["Limit"].as_i64().unwrap_or(100);
 

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -6,6 +6,9 @@ use md5::{Digest, Md5};
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_core::validation::{
+    validate_optional_json_range, validate_optional_string_length, validate_string_length,
+};
 
 use crate::state::{KinesisRecord, KinesisShard, KinesisStream, SharedKinesisState};
 
@@ -159,10 +162,20 @@ impl KinesisService {
     fn list_streams(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
         let exclusive_start = body["ExclusiveStartStreamName"].as_str();
-        let limit = body["Limit"].as_i64().unwrap_or(i64::MAX);
-        if limit <= 0 {
-            return Err(invalid_argument("Limit must be greater than zero"));
-        }
+        validate_optional_string_length(
+            "ExclusiveStartStreamName",
+            exclusive_start,
+            1,
+            128,
+        )?;
+        validate_optional_string_length(
+            "NextToken",
+            body["NextToken"].as_str(),
+            1,
+            1048576,
+        )?;
+        validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
+        let limit = body["Limit"].as_i64().unwrap_or(100);
 
         let state = self.state.read();
         let mut names: Vec<String> = state.streams.keys().cloned().collect();
@@ -478,10 +491,12 @@ impl crate::state::KinesisState {
 }
 
 fn require_stream_name(body: &Value) -> Result<&str, AwsServiceError> {
-    body["StreamName"]
+    let name = body["StreamName"]
         .as_str()
         .filter(|value| !value.is_empty())
-        .ok_or_else(|| invalid_argument("StreamName is required"))
+        .ok_or_else(|| invalid_argument("StreamName is required"))?;
+    validate_string_length("StreamName", name, 1, 128)?;
+    Ok(name)
 }
 
 fn resolve_stream_name(
@@ -492,6 +507,7 @@ fn resolve_stream_name(
         .as_str()
         .filter(|value| !value.is_empty())
     {
+        validate_string_length("StreamName", stream_name, 1, 128)?;
         return Ok(stream_name.to_string());
     }
 


### PR DESCRIPTION
## Summary
- Add StreamName length validation (1-128) to `CreateStream` and `DeleteStream`
- Add `ExclusiveStartStreamName` (1-128), `NextToken` (min 1), and `Limit` (1-100) validation to `ListStreams`
- Fixes 6 failing conformance variants, bringing all 14 implemented Kinesis operations to 100% conformance

## Test plan
- [x] `cargo test -p fakecloud-kinesis` — all unit tests pass
- [x] `cargo clippy -p fakecloud-kinesis` — clean
- [x] Conformance probes: all 14 implemented ops now 14/14 fully passing (621/1611 variants)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add strict input validation to Kinesis `CreateStream`, `DeleteStream`, and `ListStreams` to match AWS behavior and prevent invalid requests. Fixes six failing conformance variants and brings all 14 Kinesis ops in `fakecloud-kinesis` to 100% conformance.

- **Bug Fixes**
  - Enforce `StreamName` length 1–128 in `CreateStream`/`DeleteStream` and helpers.
  - Validate `ListStreams` params: `ExclusiveStartStreamName` 1–128, `NextToken` min 1, `Limit` 1–100.
  - Set `ListStreams` default `Limit` to 100.

- **Refactors**
  - Ran `cargo fmt` for code formatting.

<sup>Written for commit 93d8f91db3110ac37c53875d1492a17eee796377. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

