### PR TITLE
fix(cognito): add input validation for CreateUserPool, ListUserPools, DescribeUserPoolDomain

### DIFF
--- a/crates/fakecloud-cognito/src/service/misc.rs
+++ b/crates/fakecloud-cognito/src/service/misc.rs
@@ -10,7 +10,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::state::{CustomDomainConfig, Device, UserImportJob, UserPoolDomain};
 
 use super::{
-    device_to_json, domain_description_to_json, import_job_to_json, require_str, CognitoService,
+    device_to_json, domain_description_to_json, import_job_to_json, require_str,
+    validate_string_length, CognitoService,
 };
 
 impl CognitoService {
@@ -68,6 +69,7 @@ impl CognitoService {
         let body = req.json_body();
 
         let domain = require_str(&body, "Domain")?;
+        validate_string_length(domain, "domain", 1, 63)?;
 
         let state = self.state.read();
 

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -968,6 +968,67 @@ fn validate_password(password: &str, policy: &PasswordPolicy) -> Result<(), AwsS
     Ok(())
 }
 
+/// Validate that a string value is one of the allowed enum values.
+fn validate_enum(value: &str, field: &str, allowed: &[&str]) -> Result<(), AwsServiceError> {
+    if !allowed.contains(&value) {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterException",
+            format!(
+                "1 validation error detected: Value '{}' at '{}' failed to satisfy constraint: Member must satisfy enum value set: [{}]",
+                value, field, allowed.join(", ")
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate string length is within min..=max bounds.
+fn validate_string_length(
+    value: &str,
+    field: &str,
+    min: usize,
+    max: usize,
+) -> Result<(), AwsServiceError> {
+    let len = value.len();
+    if len < min {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterException",
+            format!(
+                "1 validation error detected: Value '{}' at '{}' failed to satisfy constraint: Member must have length greater than or equal to {}",
+                value, field, min
+            ),
+        ));
+    }
+    if len > max {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterException",
+            format!(
+                "1 validation error detected: Value at '{}' failed to satisfy constraint: Member must have length less than or equal to {}",
+                field, max
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate an integer is within min..=max bounds.
+fn validate_range(value: i64, field: &str, min: i64, max: i64) -> Result<(), AwsServiceError> {
+    if value < min || value > max {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterException",
+            format!(
+                "1 validation error detected: Value '{}' at '{}' failed to satisfy constraint: Member must have value between {} and {}",
+                value, field, min, max
+            ),
+        ));
+    }
+    Ok(())
+}
+
 struct TokenSet {
     id_token: String,
     access_token: String,

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -10,7 +10,8 @@ use super::{
     generate_client_id, generate_client_secret, generate_pool_id, parse_account_recovery_setting,
     parse_admin_create_user_config, parse_email_configuration, parse_password_policy,
     parse_schema_attribute, parse_sms_configuration, parse_string_array, parse_tags,
-    parse_token_validity_units, user_pool_client_to_json, user_pool_to_json, CognitoService,
+    parse_token_validity_units, user_pool_client_to_json, user_pool_to_json, validate_enum,
+    validate_range, validate_string_length, CognitoService,
 };
 
 impl CognitoService {
@@ -30,6 +31,36 @@ impl CognitoService {
                     "1 validation error detected: Value at 'poolName' failed to satisfy constraint: Member must not be null",
                 )
             })?;
+
+        validate_string_length(pool_name, "poolName", 1, 128)?;
+
+        if let Some(dp) = body["DeletionProtection"].as_str() {
+            validate_enum(dp, "deletionProtection", &["ACTIVE", "INACTIVE"])?;
+        }
+
+        if let Some(mfa) = body["MfaConfiguration"].as_str() {
+            validate_enum(mfa, "mfaConfiguration", &["OFF", "ON", "OPTIONAL"])?;
+        }
+
+        if let Some(tier) = body["UserPoolTier"].as_str() {
+            validate_enum(tier, "userPoolTier", &["LITE", "ESSENTIALS", "PLUS"])?;
+        }
+
+        if let Some(msg) = body["EmailVerificationMessage"].as_str() {
+            validate_string_length(msg, "emailVerificationMessage", 6, 20000)?;
+        }
+
+        if let Some(subj) = body["EmailVerificationSubject"].as_str() {
+            validate_string_length(subj, "emailVerificationSubject", 1, 140)?;
+        }
+
+        if let Some(msg) = body["SmsAuthenticationMessage"].as_str() {
+            validate_string_length(msg, "smsAuthenticationMessage", 6, 140)?;
+        }
+
+        if let Some(msg) = body["SmsVerificationMessage"].as_str() {
+            validate_string_length(msg, "smsVerificationMessage", 6, 140)?;
+        }
 
         let mut state = self.state.write();
         let pool_id = generate_pool_id(&state.region);
@@ -292,9 +323,22 @@ impl CognitoService {
     pub(super) fn list_user_pools(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
 
-        let max_results = body["MaxResults"].as_i64().unwrap_or(60).clamp(1, 60) as usize;
+        let max_results = body["MaxResults"]
+            .as_i64()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "1 validation error detected: Value at 'maxResults' failed to satisfy constraint: Member must not be null",
+                )
+            })?;
+        validate_range(max_results, "maxResults", 1, 60)?;
+        let max_results = max_results as usize;
 
         let next_token = body["NextToken"].as_str();
+        if let Some(token) = next_token {
+            validate_string_length(token, "nextToken", 1, usize::MAX)?;
+        }
 
         let state = self.state.read();
 


### PR DESCRIPTION
## Summary
- Add validation for enum fields (DeletionProtection, MfaConfiguration, UserPoolTier) in CreateUserPool
- Add string length validation for PoolName, EmailVerificationMessage, EmailVerificationSubject, SmsAuthenticationMessage, SmsVerificationMessage
- Make MaxResults required with range validation (1-60) in ListUserPools, validate NextToken min length
- Add Domain max length validation (63) to DescribeUserPoolDomain
- Add reusable `validate_enum`, `validate_string_length`, `validate_range` helpers

Fixes 17 conformance probe variants. Cognito conformance: 80/80 implemented operations fully passing (was 77/80).

## Test plan
- [x] All 61 handwritten conformance tests pass
- [x] Conformance probes: 3132/4479 variants pass (was 3115), 0 FAIL operations (was 3)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add strict input validation to Cognito’s CreateUserPool, ListUserPools, and DescribeUserPoolDomain so invalid inputs return correct errors. Fixes 17 conformance probe variants; 80/80 operations now fully pass (was 77/80).

- **Bug Fixes**
  - CreateUserPool: validate enums (DeletionProtection, MfaConfiguration, UserPoolTier) and string lengths (PoolName, EmailVerificationMessage, EmailVerificationSubject, SmsAuthenticationMessage, SmsVerificationMessage).
  - ListUserPools: require MaxResults with range 1–60; validate NextToken min length.
  - DescribeUserPoolDomain: enforce Domain max length of 63.
  - Add reusable helpers: `validate_enum`, `validate_string_length`, `validate_range`.

<sup>Written for commit ffe9a9307e31078a4c7d5ab6480592668c2ef419. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

