### PR TITLE
feat(ses): implement real SES inbound receipt rule action execution

### DIFF
--- a/crates/fakecloud-e2e/tests/ses_receipt_rules.rs
+++ b/crates/fakecloud-e2e/tests/ses_receipt_rules.rs
@@ -518,3 +518,263 @@ async fn test_update_receipt_rule() {
     assert!(!rule.enabled());
     assert_eq!(rule.actions().len(), 1);
 }
+
+#[tokio::test]
+async fn test_inbound_email_s3_action_stores_object() {
+    let server = TestServer::start().await;
+    let ses_client = server.ses_client().await;
+    let s3_client = server.s3_client().await;
+    let http_client = reqwest::Client::new();
+
+    // Create the S3 bucket first
+    s3_client
+        .create_bucket()
+        .bucket("inbound-emails")
+        .send()
+        .await
+        .expect("create bucket");
+
+    // Set up receipt rule with S3 action
+    ses_client
+        .create_receipt_rule_set()
+        .rule_set_name("s3-test")
+        .send()
+        .await
+        .unwrap();
+
+    let rule = aws_sdk_ses::types::ReceiptRule::builder()
+        .name("store-to-s3")
+        .enabled(true)
+        .actions(
+            aws_sdk_ses::types::ReceiptAction::builder()
+                .s3_action(
+                    aws_sdk_ses::types::S3Action::builder()
+                        .bucket_name("inbound-emails")
+                        .object_key_prefix("inbox/")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .build()
+        .unwrap();
+    ses_client
+        .create_receipt_rule()
+        .rule_set_name("s3-test")
+        .rule(rule)
+        .send()
+        .await
+        .unwrap();
+
+    ses_client
+        .set_active_receipt_rule_set()
+        .rule_set_name("s3-test")
+        .send()
+        .await
+        .unwrap();
+
+    // Send inbound email
+    let resp = http_client
+        .post(format!("{}/_fakecloud/ses/inbound", server.endpoint()))
+        .json(&serde_json::json!({
+            "from": "sender@example.com",
+            "to": ["recipient@example.com"],
+            "subject": "Test S3 Action",
+            "body": "Email body for S3 storage"
+        }))
+        .send()
+        .await
+        .expect("post inbound email");
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let message_id = body["messageId"].as_str().unwrap();
+
+    // Verify object was stored in S3
+    let key = format!("inbox/{message_id}");
+    let obj = s3_client
+        .get_object()
+        .bucket("inbound-emails")
+        .key(&key)
+        .send()
+        .await
+        .expect("get object from S3");
+
+    let data = obj.body.collect().await.unwrap().into_bytes();
+    assert_eq!(
+        std::str::from_utf8(&data).unwrap(),
+        "Email body for S3 storage"
+    );
+}
+
+#[tokio::test]
+async fn test_inbound_email_sns_action_publishes_message() {
+    let server = TestServer::start().await;
+    let ses_client = server.ses_client().await;
+    let sns_client = server.sns_client().await;
+    let sqs_client = server.sqs_client().await;
+    let http_client = reqwest::Client::new();
+
+    // Create SNS topic and SQS queue, subscribe queue to topic
+    let topic = sns_client
+        .create_topic()
+        .name("ses-notifications")
+        .send()
+        .await
+        .expect("create topic");
+    let topic_arn = topic.topic_arn().unwrap();
+
+    let queue = sqs_client
+        .create_queue()
+        .queue_name("ses-queue")
+        .send()
+        .await
+        .expect("create queue");
+    let queue_url = queue.queue_url().unwrap();
+
+    // Get queue ARN
+    let attrs = sqs_client
+        .get_queue_attributes()
+        .queue_url(queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = attrs
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap();
+
+    sns_client
+        .subscribe()
+        .topic_arn(topic_arn)
+        .protocol("sqs")
+        .endpoint(queue_arn)
+        .send()
+        .await
+        .expect("subscribe");
+
+    // Set up receipt rule with SNS action
+    ses_client
+        .create_receipt_rule_set()
+        .rule_set_name("sns-test")
+        .send()
+        .await
+        .unwrap();
+
+    let rule = aws_sdk_ses::types::ReceiptRule::builder()
+        .name("notify-sns")
+        .enabled(true)
+        .actions(
+            aws_sdk_ses::types::ReceiptAction::builder()
+                .sns_action(
+                    aws_sdk_ses::types::SnsAction::builder()
+                        .topic_arn(topic_arn)
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .build()
+        .unwrap();
+    ses_client
+        .create_receipt_rule()
+        .rule_set_name("sns-test")
+        .rule(rule)
+        .send()
+        .await
+        .unwrap();
+
+    ses_client
+        .set_active_receipt_rule_set()
+        .rule_set_name("sns-test")
+        .send()
+        .await
+        .unwrap();
+
+    // First verify direct SNS->SQS fanout works
+    sns_client
+        .publish()
+        .topic_arn(topic_arn)
+        .message("direct-test")
+        .send()
+        .await
+        .expect("direct publish");
+    let direct = sqs_client
+        .receive_message()
+        .queue_url(queue_url)
+        .max_number_of_messages(1)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        direct.messages().len(),
+        1,
+        "direct SNS->SQS fanout should work"
+    );
+
+    // Purge queue for the real test
+    sqs_client
+        .purge_queue()
+        .queue_url(queue_url)
+        .send()
+        .await
+        .unwrap();
+
+    // Send inbound email
+    let resp = http_client
+        .post(format!("{}/_fakecloud/ses/inbound", server.endpoint()))
+        .json(&serde_json::json!({
+            "from": "sender@example.com",
+            "to": ["recipient@example.com"],
+            "subject": "Test SNS Action",
+            "body": "Email body for SNS"
+        }))
+        .send()
+        .await
+        .expect("post inbound email");
+
+    assert_eq!(resp.status(), 200);
+    let inbound_body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        inbound_body["actionsExecuted"][0]["actionType"], "SNS",
+        "SNS action should be in executed list"
+    );
+
+    // Check that the SNS message was published via introspection
+    let sns_msgs_resp = http_client
+        .get(format!("{}/_fakecloud/sns/messages", server.endpoint()))
+        .send()
+        .await
+        .unwrap();
+    let sns_msgs: serde_json::Value = sns_msgs_resp.json().await.unwrap();
+    let msg_count = sns_msgs["messages"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
+    // Should be 2: 1 from direct publish + 1 from inbound
+    assert!(
+        msg_count >= 2,
+        "expected at least 2 SNS messages (direct + inbound), got {msg_count}"
+    );
+
+    // Check that a message was delivered to SQS via SNS
+    let messages = sqs_client
+        .receive_message()
+        .queue_url(queue_url)
+        .max_number_of_messages(1)
+        .send()
+        .await
+        .expect("receive message");
+
+    let msgs = messages.messages();
+    assert_eq!(msgs.len(), 1, "expected 1 message in SQS from SNS fanout");
+    let msg_body = msgs[0].body().unwrap();
+    // The message body is an SNS notification envelope containing the SES notification
+    let sns_envelope: serde_json::Value = serde_json::from_str(msg_body).unwrap();
+    let ses_notification: serde_json::Value =
+        serde_json::from_str(sns_envelope["Message"].as_str().unwrap()).unwrap();
+    assert_eq!(ses_notification["notificationType"], "Received");
+    assert_eq!(ses_notification["mail"]["source"], "sender@example.com");
+}

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -39,8 +39,11 @@ fakecloud-bedrock = { workspace = true }
 fakecloud-sdk = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }
+bytes = { workspace = true }
 chrono = { workspace = true }
+md-5 = { workspace = true }
 parking_lot = { workspace = true }
+uuid = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use axum::extract::Extension;
 use axum::Router;
 use clap::Parser;
+use md5::Digest;
 use tokio::net::TcpListener;
 use tower_http::trace::TraceLayer;
 
@@ -612,6 +613,28 @@ async fn main() {
             "/_fakecloud/ses/inbound",
             axum::routing::post({
                 let ss = ses_inbound_state.clone();
+                let s3_for_inbound = s3_introspection_state.clone();
+                let delivery_for_inbound = {
+                    let mut bus = DeliveryBus::new();
+                    let sns_fanout_bus = {
+                        let mut b = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+                        if let Some(ref ld) = lambda_delivery {
+                            b = b.with_lambda(ld.clone());
+                        }
+                        Arc::new(b)
+                    };
+                    let sns_for_inbound = Arc::new(
+                        fakecloud_sns::delivery::SnsDeliveryImpl::new(
+                            sns_introspection_state.clone(),
+                            sns_fanout_bus,
+                        ),
+                    );
+                    bus = bus.with_sns(sns_for_inbound);
+                    if let Some(ref ld) = lambda_delivery {
+                        bus = bus.with_lambda(ld.clone());
+                    }
+                    Arc::new(bus)
+                };
                 move |axum::Json(body): axum::Json<types::InboundEmailRequest>| async move {
                     let (message_id, matched_rules, actions) =
                         fakecloud_ses::v1::evaluate_inbound_email(
@@ -621,6 +644,155 @@ async fn main() {
                             &body.subject,
                             &body.body,
                         );
+
+                    // Execute actions for real
+                    for (_rule, action) in &actions {
+                        match action {
+                            fakecloud_ses::state::ReceiptAction::S3 {
+                                bucket_name,
+                                object_key_prefix,
+                                ..
+                            } => {
+                                let prefix = object_key_prefix.as_deref().unwrap_or("");
+                                let key = format!("{prefix}{message_id}");
+                                let now = chrono::Utc::now();
+                                let data = bytes::Bytes::from(body.body.clone());
+                                let size = data.len() as u64;
+                                let etag = format!("\"{:x}\"", md5::Md5::digest(&data));
+                                let obj = fakecloud_s3::state::S3Object {
+                                    key: key.clone(),
+                                    data,
+                                    content_type: "text/plain".to_string(),
+                                    etag,
+                                    size,
+                                    last_modified: now,
+                                    metadata: std::collections::HashMap::new(),
+                                    storage_class: "STANDARD".to_string(),
+                                    tags: std::collections::HashMap::new(),
+                                    acl_grants: Vec::new(),
+                                    acl_owner_id: None,
+                                    parts_count: None,
+                                    part_sizes: None,
+                                    sse_algorithm: None,
+                                    sse_kms_key_id: None,
+                                    bucket_key_enabled: None,
+                                    version_id: None,
+                                    is_delete_marker: false,
+                                    content_encoding: None,
+                                    website_redirect_location: None,
+                                    restore_ongoing: None,
+                                    restore_expiry: None,
+                                    checksum_algorithm: None,
+                                    checksum_value: None,
+                                    lock_mode: None,
+                                    lock_retain_until: None,
+                                    lock_legal_hold: None,
+                                };
+                                let mut state = s3_for_inbound.write();
+                                if let Some(bucket) = state.buckets.get_mut(bucket_name) {
+                                    tracing::info!(
+                                        bucket = %bucket_name,
+                                        key = %key,
+                                        "SES inbound: stored email in S3"
+                                    );
+                                    bucket.objects.insert(key, obj);
+                                } else {
+                                    tracing::warn!(
+                                        bucket = %bucket_name,
+                                        "SES inbound: S3 bucket not found, skipping S3 action"
+                                    );
+                                }
+                            }
+                            fakecloud_ses::state::ReceiptAction::Sns { topic_arn, .. } => {
+                                let notification = serde_json::json!({
+                                    "notificationType": "Received",
+                                    "mail": {
+                                        "messageId": message_id,
+                                        "source": body.from,
+                                        "destination": body.to,
+                                        "commonHeaders": {
+                                            "from": [&body.from],
+                                            "to": &body.to,
+                                            "subject": &body.subject,
+                                        }
+                                    },
+                                    "content": &body.body,
+                                });
+                                tracing::info!(
+                                    topic_arn = %topic_arn,
+                                    "SES inbound: publishing to SNS"
+                                );
+                                delivery_for_inbound.publish_to_sns(
+                                    topic_arn,
+                                    &notification.to_string(),
+                                    Some(&body.subject),
+                                );
+                            }
+                            fakecloud_ses::state::ReceiptAction::Lambda {
+                                function_arn,
+                                invocation_type,
+                                ..
+                            } => {
+                                let ses_event = serde_json::json!({
+                                    "Records": [{
+                                        "eventSource": "aws:ses",
+                                        "eventVersion": "1.0",
+                                        "ses": {
+                                            "mail": {
+                                                "messageId": message_id,
+                                                "source": body.from,
+                                                "destination": body.to,
+                                                "commonHeaders": {
+                                                    "from": [&body.from],
+                                                    "to": &body.to,
+                                                    "subject": &body.subject,
+                                                }
+                                            },
+                                            "receipt": {
+                                                "recipients": &body.to,
+                                                "action": {
+                                                    "type": "Lambda",
+                                                    "functionArn": function_arn,
+                                                    "invocationType": invocation_type.as_deref().unwrap_or("Event"),
+                                                }
+                                            }
+                                        }
+                                    }]
+                                });
+                                let payload = ses_event.to_string();
+                                let delivery = delivery_for_inbound.clone();
+                                let function_arn = function_arn.clone();
+                                tracing::info!(
+                                    function_arn = %function_arn,
+                                    "SES inbound: invoking Lambda"
+                                );
+                                tokio::spawn(async move {
+                                    match delivery.invoke_lambda(&function_arn, &payload).await {
+                                        Some(Ok(_)) => {
+                                            tracing::info!(
+                                                function_arn = %function_arn,
+                                                "SES inbound: Lambda invocation succeeded"
+                                            );
+                                        }
+                                        Some(Err(e)) => {
+                                            tracing::error!(
+                                                function_arn = %function_arn,
+                                                error = %e,
+                                                "SES inbound: Lambda invocation failed"
+                                            );
+                                        }
+                                        None => {
+                                            tracing::warn!(
+                                                "SES inbound: no container runtime available for Lambda invocation"
+                                            );
+                                        }
+                                    }
+                                });
+                            }
+                            // Bounce, AddHeader, Stop are metadata-only — no cross-service delivery
+                            _ => {}
+                        }
+                    }
 
                     let actions_executed = actions
                         .iter()


### PR DESCRIPTION
## Summary

- The `/_fakecloud/ses/inbound` endpoint now actually executes receipt rule actions instead of just evaluating them
- **S3 actions**: stores the email body as an object in the specified bucket with the configured key prefix
- **SNS actions**: publishes an SES Received notification to the specified topic, with full fan-out to SQS/Lambda subscribers
- **Lambda actions**: invokes the specified function with an SES event payload matching the real AWS format

## Test plan

- [x] E2E test: S3 action stores object in bucket with correct key and content
- [x] E2E test: SNS action publishes notification that fans out to SQS subscriber
- [x] All 11 existing SES receipt rule tests still pass
- [x] `cargo clippy -D warnings` clean
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/_fakecloud/ses/inbound` execute SES receipt rule actions for real, enabling cross-service delivery. S3, SNS, and Lambda actions now run and mirror AWS behavior via the DeliveryBus.

- **New Features**
  - Executes receipt rule actions in `/_fakecloud/ses/inbound`.
  - S3 actions: store email body in the target bucket with the key prefix and message ID.
  - SNS actions: publish a "Received" SES notification to the topic with fan-out to SQS/Lambda.
  - Lambda actions: invoke the target function with a real SES event payload.
  - Integrated with the existing DeliveryBus for SNS/SQS/Lambda wiring.

- **Dependencies**
  - Add `bytes`, `md-5`, and `uuid` to `fakecloud-server`.

<sup>Written for commit 28e42a0ddbb5280456dfbe77acb229380c2a2c56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

