### PR TITLE
feat(kinesis): implement Tags v2 and Resource Policy operations

### DIFF
--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -520,10 +520,7 @@ impl KinesisService {
         Ok(AwsResponse::ok_json(json!({})))
     }
 
-    fn list_tags_for_resource(
-        &self,
-        request: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
+    fn list_tags_for_resource(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
         validate_stream_id(&body)?;
         let resource_arn = require_resource_arn(&body)?;
@@ -580,10 +577,7 @@ impl KinesisService {
         Ok(AwsResponse::ok_json(json!({})))
     }
 
-    fn delete_resource_policy(
-        &self,
-        request: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
+    fn delete_resource_policy(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
         validate_stream_id(&body)?;
         let resource_arn = require_resource_arn(&body)?;

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -6,24 +6,31 @@ use md5::{Digest, Md5};
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_core::validation::validate_optional_string_length;
 
 use crate::state::{KinesisRecord, KinesisShard, KinesisStream, SharedKinesisState};
 
 const SUPPORTED_ACTIONS: &[&str] = &[
     "CreateStream",
+    "DecreaseStreamRetentionPeriod",
+    "DeleteResourcePolicy",
+    "DeleteStream",
     "DescribeStream",
     "DescribeStreamSummary",
-    "ListStreams",
-    "DeleteStream",
     "GetRecords",
+    "GetResourcePolicy",
     "GetShardIterator",
+    "IncreaseStreamRetentionPeriod",
+    "ListStreams",
+    "ListTagsForResource",
+    "ListTagsForStream",
+    "AddTagsToStream",
     "PutRecord",
     "PutRecords",
-    "AddTagsToStream",
-    "ListTagsForStream",
+    "PutResourcePolicy",
     "RemoveTagsFromStream",
-    "IncreaseStreamRetentionPeriod",
-    "DecreaseStreamRetentionPeriod",
+    "TagResource",
+    "UntagResource",
 ];
 
 pub struct KinesisService {
@@ -58,6 +65,12 @@ impl AwsService for KinesisService {
             "RemoveTagsFromStream" => self.remove_tags_from_stream(&request),
             "IncreaseStreamRetentionPeriod" => self.increase_stream_retention_period(&request),
             "DecreaseStreamRetentionPeriod" => self.decrease_stream_retention_period(&request),
+            "TagResource" => self.tag_resource(&request),
+            "UntagResource" => self.untag_resource(&request),
+            "ListTagsForResource" => self.list_tags_for_resource(&request),
+            "GetResourcePolicy" => self.get_resource_policy(&request),
+            "PutResourcePolicy" => self.put_resource_policy(&request),
+            "DeleteResourcePolicy" => self.delete_resource_policy(&request),
             _ => Err(AwsServiceError::action_not_implemented(
                 self.service_name(),
                 &request.action,
@@ -466,6 +479,123 @@ impl KinesisService {
         stream.retention_period_hours = hours as i32;
         Ok(AwsResponse::ok_json(json!({})))
     }
+
+    fn tag_resource(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        validate_stream_id(&body)?;
+        let resource_arn = require_resource_arn(&body)?;
+        let tags = body["Tags"]
+            .as_object()
+            .ok_or_else(|| invalid_argument("Tags must be a map"))?;
+
+        let mut state = self.state.write();
+        let stream_name = state
+            .stream_name_from_arn(resource_arn)
+            .ok_or_else(|| resource_not_found_arn(resource_arn))?;
+        let stream = state.streams.get_mut(&stream_name).unwrap();
+        for (key, value) in tags {
+            if let Some(value) = value.as_str() {
+                stream.tags.insert(key.clone(), value.to_string());
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn untag_resource(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        validate_stream_id(&body)?;
+        let resource_arn = require_resource_arn(&body)?;
+        let tag_keys = body["TagKeys"]
+            .as_array()
+            .ok_or_else(|| invalid_argument("TagKeys must be a list"))?;
+
+        let mut state = self.state.write();
+        let stream_name = state
+            .stream_name_from_arn(resource_arn)
+            .ok_or_else(|| resource_not_found_arn(resource_arn))?;
+        let stream = state.streams.get_mut(&stream_name).unwrap();
+        for key in tag_keys.iter().filter_map(|v| v.as_str()) {
+            stream.tags.remove(key);
+        }
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn list_tags_for_resource(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        validate_stream_id(&body)?;
+        let resource_arn = require_resource_arn(&body)?;
+
+        let state = self.state.read();
+        let stream_name = state
+            .stream_name_from_arn(resource_arn)
+            .ok_or_else(|| resource_not_found_arn(resource_arn))?;
+        let stream = state.streams.get(&stream_name).unwrap();
+        let tags: Vec<Value> = stream
+            .tags
+            .iter()
+            .map(|(key, value)| json!({ "Key": key, "Value": value }))
+            .collect();
+
+        Ok(AwsResponse::ok_json(json!({ "Tags": tags })))
+    }
+
+    fn get_resource_policy(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        validate_stream_id(&body)?;
+        let resource_arn = require_resource_arn(&body)?;
+
+        let state = self.state.read();
+        // Verify the stream exists
+        state
+            .stream_name_from_arn(resource_arn)
+            .ok_or_else(|| resource_not_found_arn(resource_arn))?;
+        let policy = state
+            .resource_policies
+            .get(resource_arn)
+            .cloned()
+            .unwrap_or_default();
+
+        Ok(AwsResponse::ok_json(json!({ "Policy": policy })))
+    }
+
+    fn put_resource_policy(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        validate_stream_id(&body)?;
+        let resource_arn = require_resource_arn(&body)?;
+        let policy = body["Policy"]
+            .as_str()
+            .ok_or_else(|| invalid_argument("Policy is required"))?;
+
+        let mut state = self.state.write();
+        state
+            .stream_name_from_arn(resource_arn)
+            .ok_or_else(|| resource_not_found_arn(resource_arn))?;
+        state
+            .resource_policies
+            .insert(resource_arn.to_string(), policy.to_string());
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn delete_resource_policy(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        validate_stream_id(&body)?;
+        let resource_arn = require_resource_arn(&body)?;
+
+        let mut state = self.state.write();
+        state
+            .stream_name_from_arn(resource_arn)
+            .ok_or_else(|| resource_not_found_arn(resource_arn))?;
+        state.resource_policies.remove(resource_arn);
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
 }
 
 impl crate::state::KinesisState {
@@ -635,6 +765,25 @@ fn find_record_index_by_sequence_number(
         .iter()
         .position(|record| record.sequence_number == sequence_number)
         .ok_or_else(|| invalid_argument("StartingSequenceNumber is invalid"))
+}
+
+fn validate_stream_id(body: &Value) -> Result<(), AwsServiceError> {
+    validate_optional_string_length("StreamId", body["StreamId"].as_str(), 1, 24)
+}
+
+fn require_resource_arn(body: &Value) -> Result<&str, AwsServiceError> {
+    body["ResourceARN"]
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| invalid_argument("ResourceARN is required"))
+}
+
+fn resource_not_found_arn(arn: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ResourceNotFoundException",
+        format!("Resource {arn} not found."),
+    )
 }
 
 fn invalid_argument(message: impl Into<String>) -> AwsServiceError {

--- a/crates/fakecloud-kinesis/src/state.rs
+++ b/crates/fakecloud-kinesis/src/state.rs
@@ -13,6 +13,7 @@ pub struct KinesisState {
     pub streams: HashMap<String, KinesisStream>,
     pub iterators: HashMap<String, ShardIteratorLease>,
     pub lambda_checkpoints: HashMap<String, usize>,
+    pub resource_policies: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -62,6 +63,7 @@ impl KinesisState {
             streams: HashMap::new(),
             iterators: HashMap::new(),
             lambda_checkpoints: HashMap::new(),
+            resource_policies: HashMap::new(),
         }
     }
 
@@ -69,6 +71,16 @@ impl KinesisState {
         self.streams.clear();
         self.iterators.clear();
         self.lambda_checkpoints.clear();
+        self.resource_policies.clear();
+    }
+
+    /// Look up a stream by its ARN (e.g. `arn:aws:kinesis:us-east-1:123456789012:stream/my-stream`).
+    /// Returns the stream name if found.
+    pub fn stream_name_from_arn(&self, arn: &str) -> Option<String> {
+        arn.rsplit('/')
+            .next()
+            .filter(|name| self.streams.contains_key(*name))
+            .map(|name| name.to_string())
     }
 
     pub fn stream_arn(&self, stream_name: &str) -> String {


### PR DESCRIPTION
## Summary
- Implement 6 new Kinesis operations: TagResource, UntagResource, ListTagsForResource, GetResourcePolicy, PutResourcePolicy, DeleteResourcePolicy
- Add ARN-based stream lookup and StreamId validation
- All 6 operations pass conformance at 100% (202/202 variants)

## Test plan
- [x] `cargo clippy -p fakecloud-kinesis` — clean
- [x] Conformance probes: all 6 new ops fully passing
- [x] Kinesis conformance now at 50.7% (817/1611), up from 38.2%

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Kinesis Tags v2 and Resource Policy operations to `fakecloud-kinesis`. Enables ARN-based tagging and simple policy CRUD.

- **New Features**
  - Tags v2: `TagResource`, `UntagResource`, `ListTagsForResource` (ARN-based).
  - Resource policies: `GetResourcePolicy`, `PutResourcePolicy`, `DeleteResourcePolicy`.
  - Add `resource_policies` storage and `stream_name_from_arn` helper.
  - Validate `StreamId` length (1–24).
  - Conformance: new ops at 100% (202/202); overall Kinesis now 50.7% (817/1611).

- **Refactors**
  - Run `cargo fmt` for code formatting.

<sup>Written for commit 6850c6c054b437344e973ef5b92ef2f28d612be1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

