### PR TITLE
refactor: standardize ARN construction to use Arn utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "fakecloud-aws",
  "fakecloud-core",
  "flate2",
  "http 1.4.0",
@@ -2491,6 +2492,7 @@ version = "0.8.1"
 dependencies = [
  "async-trait",
  "chrono",
+ "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-dynamodb",
  "http 1.4.0",

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use fakecloud_aws::arn::Arn;
 use parking_lot::RwLock;
 
 pub type SharedElastiCacheState = Arc<RwLock<ElastiCacheState>>;
@@ -498,16 +499,14 @@ fn default_parameter_groups(account_id: &str, region: &str) -> Vec<CacheParamete
             cache_parameter_group_family: "redis7".to_string(),
             description: "Default parameter group for redis7".to_string(),
             is_global: false,
-            arn: format!("arn:aws:elasticache:{region}:{account_id}:parametergroup:default.redis7"),
+            arn: Arn::new("elasticache", region, account_id, "parametergroup:default.redis7").to_string(),
         },
         CacheParameterGroup {
             cache_parameter_group_name: "default.valkey8".to_string(),
             cache_parameter_group_family: "valkey8".to_string(),
             description: "Default parameter group for valkey8".to_string(),
             is_global: false,
-            arn: format!(
-                "arn:aws:elasticache:{region}:{account_id}:parametergroup:default.valkey8"
-            ),
+            arn: Arn::new("elasticache", region, account_id, "parametergroup:default.valkey8").to_string(),
         },
     ]
 }
@@ -518,7 +517,7 @@ fn default_subnet_groups(account_id: &str, region: &str) -> HashMap<String, Cach
         cache_subnet_group_description: "Default CacheSubnetGroup".to_string(),
         vpc_id: "vpc-00000000".to_string(),
         subnet_ids: vec!["subnet-00000000".to_string()],
-        arn: format!("arn:aws:elasticache:{region}:{account_id}:subnetgroup:default"),
+        arn: Arn::new("elasticache", region, account_id, "subnetgroup:default").to_string(),
     };
     let mut map = HashMap::new();
     map.insert("default".to_string(), default_group);
@@ -607,7 +606,7 @@ fn default_users(account_id: &str, region: &str) -> HashMap<String, ElastiCacheU
             status: "active".to_string(),
             authentication_type: "no-password".to_string(),
             password_count: 0,
-            arn: format!("arn:aws:elasticache:{region}:{account_id}:user:default"),
+            arn: Arn::new("elasticache", region, account_id, "user:default").to_string(),
             minimum_engine_version: "6.0".to_string(),
             user_group_ids: Vec::new(),
         },

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -499,14 +499,26 @@ fn default_parameter_groups(account_id: &str, region: &str) -> Vec<CacheParamete
             cache_parameter_group_family: "redis7".to_string(),
             description: "Default parameter group for redis7".to_string(),
             is_global: false,
-            arn: Arn::new("elasticache", region, account_id, "parametergroup:default.redis7").to_string(),
+            arn: Arn::new(
+                "elasticache",
+                region,
+                account_id,
+                "parametergroup:default.redis7",
+            )
+            .to_string(),
         },
         CacheParameterGroup {
             cache_parameter_group_name: "default.valkey8".to_string(),
             cache_parameter_group_family: "valkey8".to_string(),
             description: "Default parameter group for valkey8".to_string(),
             is_global: false,
-            arn: Arn::new("elasticache", region, account_id, "parametergroup:default.valkey8").to_string(),
+            arn: Arn::new(
+                "elasticache",
+                region,
+                account_id,
+                "parametergroup:default.valkey8",
+            )
+            .to_string(),
         },
     ]
 }

--- a/crates/fakecloud-iam/src/iam_service/oidc.rs
+++ b/crates/fakecloud-iam/src/iam_service/oidc.rs
@@ -24,7 +24,8 @@ impl IamService {
 
         let mut state = self.state.write();
 
-        let arn = Arn::global("iam", &state.account_id, &format!("saml-provider/{name}")).to_string();
+        let arn =
+            Arn::global("iam", &state.account_id, &format!("saml-provider/{name}")).to_string();
 
         let provider = SamlProvider {
             arn: arn.clone(),

--- a/crates/fakecloud-iam/src/iam_service/oidc.rs
+++ b/crates/fakecloud-iam/src/iam_service/oidc.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use http::StatusCode;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{OidcProvider, SamlProvider, ServerCertificate};
@@ -23,7 +24,7 @@ impl IamService {
 
         let mut state = self.state.write();
 
-        let arn = format!("arn:aws:iam::{}:saml-provider/{}", state.account_id, name);
+        let arn = Arn::global("iam", &state.account_id, &format!("saml-provider/{name}")).to_string();
 
         let provider = SamlProvider {
             arn: arn.clone(),

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use http::StatusCode;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -90,7 +91,7 @@ impl IamService {
             None => {
                 let default_user = IamUser {
                     user_id: format!("AIDA{}", generate_id()),
-                    arn: format!("arn:aws:iam::{}:user/default_user", state.account_id),
+                    arn: Arn::global("iam", &state.account_id, "user/default_user").to_string(),
                     user_name: "default_user".to_string(),
                     path: "/".to_string(),
                     created_at: Utc::now(),

--- a/crates/fakecloud-logs/Cargo.toml
+++ b/crates/fakecloud-logs/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 version.workspace = true
 
 [dependencies]
+fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -238,7 +238,13 @@ impl LogsService {
         let region = state_r.region.clone();
         drop(state_r);
 
-        let arn = Arn::new("logs", &region, &account_id, &format!("lookup-table:{lookup_table_name}")).to_string();
+        let arn = Arn::new(
+            "logs",
+            &region,
+            &account_id,
+            &format!("lookup-table:{lookup_table_name}"),
+        )
+        .to_string();
         let now = Utc::now().timestamp_millis();
 
         let table = LookupTable {
@@ -390,7 +396,13 @@ impl LogsService {
         let region = state_r.region.clone();
         drop(state_r);
 
-        let arn = Arn::new("logs", &region, &account_id, &format!("scheduled-query:{name}")).to_string();
+        let arn = Arn::new(
+            "logs",
+            &region,
+            &account_id,
+            &format!("scheduled-query:{name}"),
+        )
+        .to_string();
         let now = Utc::now().timestamp_millis();
 
         let sq = ScheduledQuery {

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -1,6 +1,7 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -237,7 +238,7 @@ impl LogsService {
         let region = state_r.region.clone();
         drop(state_r);
 
-        let arn = format!("arn:aws:logs:{region}:{account_id}:lookup-table:{lookup_table_name}");
+        let arn = Arn::new("logs", &region, &account_id, &format!("lookup-table:{lookup_table_name}")).to_string();
         let now = Utc::now().timestamp_millis();
 
         let table = LookupTable {
@@ -389,7 +390,7 @@ impl LogsService {
         let region = state_r.region.clone();
         drop(state_r);
 
-        let arn = format!("arn:aws:logs:{region}:{account_id}:scheduled-query:{name}");
+        let arn = Arn::new("logs", &region, &account_id, &format!("scheduled-query:{name}")).to_string();
         let now = Utc::now().timestamp_millis();
 
         let sq = ScheduledQuery {

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -446,7 +446,7 @@ pub fn default_parameter_groups(
         let group_name = format!("default.{}", family);
         let group = DbParameterGroup {
             db_parameter_group_name: group_name.clone(),
-            db_parameter_group_arn: format!("arn:aws:rds:{region}:{account_id}:pg:{group_name}"),
+            db_parameter_group_arn: Arn::new("rds", region, account_id, &format!("pg:{group_name}")).to_string(),
             db_parameter_group_family: family.to_string(),
             description: description.to_string(),
             parameters: HashMap::new(),

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -446,7 +446,13 @@ pub fn default_parameter_groups(
         let group_name = format!("default.{}", family);
         let group = DbParameterGroup {
             db_parameter_group_name: group_name.clone(),
-            db_parameter_group_arn: Arn::new("rds", region, account_id, &format!("pg:{group_name}")).to_string(),
+            db_parameter_group_arn: Arn::new(
+                "rds",
+                region,
+                account_id,
+                &format!("pg:{group_name}"),
+            )
+            .to_string(),
             db_parameter_group_family: family.to_string(),
             description: description.to_string(),
             parameters: HashMap::new(),

--- a/crates/fakecloud-stepfunctions/Cargo.toml
+++ b/crates/fakecloud-stepfunctions/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 version.workspace = true
 
 [dependencies]
+fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-dynamodb = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 use serde_json::{json, Value};
 use tracing::{debug, warn};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_dynamodb::state::SharedDynamoDbState;
 
@@ -1399,7 +1400,7 @@ fn queue_url_to_arn(url: &str) -> String {
     if parts.len() >= 2 {
         let queue_name = parts[0];
         let account_id = parts[1];
-        format!("arn:aws:sqs:us-east-1:{account_id}:{queue_name}")
+        Arn::new("sqs", "us-east-1", account_id, queue_name).to_string()
     } else {
         url.to_string()
     }


### PR DESCRIPTION
## Summary

- Replaces inline `format!("arn:aws:...")` strings with `Arn::new()` / `Arn::global()` across 5 crates
- ElastiCache state: 4 default ARNs (param groups, subnet groups, users)
- RDS state: parameter group ARN
- IAM: default user ARN, SAML provider ARN
- CloudWatch Logs: lookup table and scheduled query ARNs
- Step Functions: SQS queue ARN construction
- Adds `fakecloud-aws` dependency to `fakecloud-logs` and `fakecloud-stepfunctions`

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes clean
- [ ] CI passes
- [ ] Cubic review passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized ARN construction using `Arn::new()` and `Arn::global()` for consistency and fewer string bugs across ElastiCache, RDS, IAM, CloudWatch Logs, and Step Functions.

- **Refactors**
  - ElastiCache: parameter groups, subnet groups, users now use `Arn`.
  - RDS: parameter group ARN uses `Arn`.
  - IAM: default user and SAML provider ARNs use `Arn::global()`.
  - CloudWatch Logs: lookup table and scheduled query ARNs use `Arn`.
  - Step Functions: SQS queue ARN built from URL with `Arn`.

- **Dependencies**
  - Add `fakecloud-aws` to `fakecloud-logs` and `fakecloud-stepfunctions`.

<sup>Written for commit dd7bfca6503e74628c4846d80b78a29f5ca83156. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

