### PR TITLE
feat(eventbridge): implement real EventBridge → Step Functions delivery

### DIFF
--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -17,6 +17,8 @@ pub struct DeliveryBus {
     lambda_invoker: Option<Arc<dyn LambdaDelivery>>,
     /// Put records to a Kinesis Data Stream by ARN.
     kinesis_sender: Option<Arc<dyn KinesisDelivery>>,
+    /// Start Step Functions executions.
+    stepfunctions_starter: Option<Arc<dyn StepFunctionsDelivery>>,
 }
 
 /// Message attribute for SQS delivery from SNS.
@@ -81,6 +83,13 @@ pub trait KinesisDelivery: Send + Sync {
     fn put_record(&self, stream_arn: &str, data: &str, partition_key: &str);
 }
 
+/// Trait for starting Step Functions executions from cross-service integrations.
+pub trait StepFunctionsDelivery: Send + Sync {
+    /// Start a state machine execution with the given input.
+    /// The state machine is identified by ARN.
+    fn start_execution(&self, state_machine_arn: &str, input: &str);
+}
+
 impl DeliveryBus {
     pub fn new() -> Self {
         Self {
@@ -89,6 +98,7 @@ impl DeliveryBus {
             eventbridge_sender: None,
             lambda_invoker: None,
             kinesis_sender: None,
+            stepfunctions_starter: None,
         }
     }
 
@@ -114,6 +124,11 @@ impl DeliveryBus {
 
     pub fn with_kinesis(mut self, sender: Arc<dyn KinesisDelivery>) -> Self {
         self.kinesis_sender = Some(sender);
+        self
+    }
+
+    pub fn with_stepfunctions(mut self, starter: Arc<dyn StepFunctionsDelivery>) -> Self {
+        self.stepfunctions_starter = Some(starter);
         self
     }
 
@@ -186,6 +201,13 @@ impl DeliveryBus {
     pub fn send_to_kinesis(&self, stream_arn: &str, data: &str, partition_key: &str) {
         if let Some(ref sender) = self.kinesis_sender {
             sender.put_record(stream_arn, data, partition_key);
+        }
+    }
+
+    /// Start a Step Functions execution identified by state machine ARN.
+    pub fn start_stepfunctions_execution(&self, state_machine_arn: &str, input: &str) {
+        if let Some(ref starter) = self.stepfunctions_starter {
+            starter.start_execution(state_machine_arn, input);
         }
     }
 }

--- a/crates/fakecloud-e2e/tests/eventbridge.rs
+++ b/crates/fakecloud-e2e/tests/eventbridge.rs
@@ -1275,3 +1275,87 @@ async fn eb_put_events_delivers_to_kinesis_target() {
     assert_eq!(event["detail-type"], "TestEvent");
     assert_eq!(event["detail"]["key"], "value");
 }
+
+/// Verify EventBridge rule targeting Step Functions actually starts an execution.
+#[tokio::test]
+async fn eb_rule_starts_stepfunctions_execution() {
+    let server = TestServer::start().await;
+    let eb = server.eventbridge_client().await;
+    let sfn = server.sfn_client().await;
+
+    // Create a simple Pass state machine
+    let definition = serde_json::json!({
+        "StartAt": "PassState",
+        "States": {
+            "PassState": {
+                "Type": "Pass",
+                "End": true
+            }
+        }
+    });
+    let sm = sfn
+        .create_state_machine()
+        .name("eb-target-machine")
+        .definition(definition.to_string())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .expect("create state machine");
+    let sm_arn = sm.state_machine_arn();
+
+    // Create EventBridge rule targeting the state machine
+    eb.put_rule()
+        .name("sfn-trigger")
+        .event_pattern(r#"{"source": ["test.sfn"]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    eb.put_targets()
+        .rule("sfn-trigger")
+        .targets(
+            Target::builder()
+                .id("sfn-target")
+                .arn(sm_arn)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Put a matching event
+    eb.put_events()
+        .entries(
+            PutEventsRequestEntry::builder()
+                .source("test.sfn")
+                .detail_type("TriggerExecution")
+                .detail(r#"{"message": "hello from EventBridge"}"#)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Give the async execution a moment to start
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    // Verify execution was started
+    let executions = sfn
+        .list_executions()
+        .state_machine_arn(sm_arn)
+        .send()
+        .await
+        .expect("list executions");
+
+    assert_eq!(
+        executions.executions().len(),
+        1,
+        "expected 1 execution started by EventBridge rule"
+    );
+    let exec = &executions.executions()[0];
+    assert_eq!(
+        exec.status(),
+        &aws_sdk_sfn::types::ExecutionStatus::Succeeded
+    );
+}

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -294,9 +294,9 @@ impl Scheduler {
                 } else if arn.contains(":states:") {
                     tracing::info!(
                         state_machine_arn = %arn,
-                        payload = %event_str,
-                        "Scheduler delivering to Step Functions (stub)"
+                        "Scheduler delivering to Step Functions"
                     );
+                    self.delivery.start_stepfunctions_execution(arn, &event_str);
                     let mut state = self.state.write();
                     state
                         .step_function_executions

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -1988,9 +1988,9 @@ impl EventBridgeService {
                 } else if arn.contains(":states:") {
                     tracing::info!(
                         state_machine_arn = %arn,
-                        payload = %body_str,
-                        "EventBridge delivering to Step Functions (stub)"
+                        "EventBridge delivering to Step Functions"
                     );
+                    self.delivery.start_stepfunctions_execution(arn, &body_str);
                     let mut state = self.state.write();
                     state
                         .step_function_executions
@@ -3180,6 +3180,8 @@ impl EventBridgeService {
                         deliver_to_logs(log_state, target_arn, &body_str, Utc::now());
                     }
                 } else if target_arn.contains(":states:") {
+                    self.delivery
+                        .start_stepfunctions_execution(target_arn, &body_str);
                     let mut state = self.state.write();
                     state
                         .step_function_executions

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -15,6 +15,7 @@ mod dynamodb_streams_lambda_poller;
 mod kinesis_lambda_poller;
 mod lambda_delivery;
 mod sqs_lambda_poller;
+mod stepfunctions_delivery;
 use dynamodb_streams_lambda_poller::DynamoDbStreamsLambdaPoller;
 use kinesis_lambda_poller::KinesisLambdaPoller;
 use sqs_lambda_poller::SqsLambdaPoller;
@@ -222,11 +223,26 @@ async fn main() {
     ));
     let kinesis_delivery_for_eb =
         fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
+
+    // Step Functions delivery (EventBridge/Scheduler can start executions)
+    let sfn_delivery_for_eb: Arc<dyn fakecloud_core::delivery::StepFunctionsDelivery> = {
+        let mut sfn_interpreter_bus = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+        if let Some(ref ld) = lambda_delivery {
+            sfn_interpreter_bus = sfn_interpreter_bus.with_lambda(ld.clone());
+        }
+        Arc::new(stepfunctions_delivery::StepFunctionsDeliveryImpl::new(
+            stepfunctions_state.clone(),
+            Some(Arc::new(sfn_interpreter_bus)),
+            Some(dynamodb_state.clone()),
+        ))
+    };
+
     let delivery_for_eb = Arc::new(
         DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())
             .with_sns(sns_delivery.clone())
-            .with_kinesis(kinesis_delivery_for_eb),
+            .with_kinesis(kinesis_delivery_for_eb)
+            .with_stepfunctions(sfn_delivery_for_eb),
     );
 
     // Step 3: S3 delivery (S3 notifications can push to SQS, SNS, Lambda, and EventBridge)
@@ -450,7 +466,7 @@ async fn main() {
     }
     registry.register(Arc::new(elasticache_service));
     let mut sfn_service = StepFunctionsService::new(stepfunctions_state.clone());
-    {
+    let sfn_delivery_bus = {
         let mut sns_eb_bus = DeliveryBus::new().with_sqs(sqs_delivery.clone());
         if let Some(ref ld) = lambda_delivery {
             sns_eb_bus = sns_eb_bus.with_lambda(ld.clone());
@@ -482,10 +498,11 @@ async fn main() {
         if let Some(ref ld) = lambda_delivery {
             bus = bus.with_lambda(ld.clone());
         }
-        sfn_service = sfn_service
-            .with_delivery(Arc::new(bus))
-            .with_dynamodb(dynamodb_state.clone());
-    }
+        Arc::new(bus)
+    };
+    sfn_service = sfn_service
+        .with_delivery(sfn_delivery_bus.clone())
+        .with_dynamodb(dynamodb_state.clone());
     registry.register(Arc::new(sfn_service));
 
     let mut apigw_service = ApiGatewayV2Service::new(apigatewayv2_state.clone());

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -226,7 +226,22 @@ async fn main() {
 
     // Step Functions delivery (EventBridge/Scheduler can start executions)
     let sfn_delivery_for_eb: Arc<dyn fakecloud_core::delivery::StepFunctionsDelivery> = {
-        let mut sfn_interpreter_bus = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+        // Build a full delivery bus for the SFN interpreter so task states
+        // (SNS Publish, EventBridge PutEvents, etc.) actually deliver.
+        let sns_for_sfn_delivery = Arc::new(fakecloud_sns::delivery::SnsDeliveryImpl::new(
+            sns_state.clone(),
+            Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+        ));
+        let eb_for_sfn_delivery = Arc::new(
+            fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
+                eb_state.clone(),
+                Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+            ),
+        );
+        let mut sfn_interpreter_bus = DeliveryBus::new()
+            .with_sqs(sqs_delivery.clone())
+            .with_sns(sns_for_sfn_delivery)
+            .with_eventbridge(eb_for_sfn_delivery);
         if let Some(ref ld) = lambda_delivery {
             sfn_interpreter_bus = sfn_interpreter_bus.with_lambda(ld.clone());
         }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -228,9 +228,13 @@ async fn main() {
     let sfn_delivery_for_eb: Arc<dyn fakecloud_core::delivery::StepFunctionsDelivery> = {
         // Build a full delivery bus for the SFN interpreter so task states
         // (SNS Publish, EventBridge PutEvents, etc.) actually deliver.
+        let mut sns_fanout_for_sfn = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+        if let Some(ref ld) = lambda_delivery {
+            sns_fanout_for_sfn = sns_fanout_for_sfn.with_lambda(ld.clone());
+        }
         let sns_for_sfn_delivery = Arc::new(fakecloud_sns::delivery::SnsDeliveryImpl::new(
             sns_state.clone(),
-            Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+            Arc::new(sns_fanout_for_sfn),
         ));
         let eb_for_sfn_delivery = Arc::new(
             fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(

--- a/crates/fakecloud-server/src/stepfunctions_delivery.rs
+++ b/crates/fakecloud-server/src/stepfunctions_delivery.rs
@@ -1,0 +1,44 @@
+//! Implements the `StepFunctionsDelivery` trait for real Step Functions execution.
+
+use std::sync::Arc;
+
+use fakecloud_core::delivery::{DeliveryBus, StepFunctionsDelivery};
+use fakecloud_dynamodb::state::SharedDynamoDbState;
+use fakecloud_stepfunctions::state::SharedStepFunctionsState;
+
+/// Starts Step Functions executions from cross-service delivery (EventBridge, Scheduler).
+pub struct StepFunctionsDeliveryImpl {
+    state: SharedStepFunctionsState,
+    delivery: Option<Arc<DeliveryBus>>,
+    dynamodb_state: Option<SharedDynamoDbState>,
+}
+
+impl StepFunctionsDeliveryImpl {
+    pub fn new(
+        state: SharedStepFunctionsState,
+        delivery: Option<Arc<DeliveryBus>>,
+        dynamodb_state: Option<SharedDynamoDbState>,
+    ) -> Self {
+        Self {
+            state,
+            delivery,
+            dynamodb_state,
+        }
+    }
+}
+
+impl StepFunctionsDelivery for StepFunctionsDeliveryImpl {
+    fn start_execution(&self, state_machine_arn: &str, input: &str) {
+        tracing::info!(
+            state_machine_arn,
+            "Step Functions delivery: starting execution"
+        );
+        fakecloud_stepfunctions::service::start_execution_from_delivery(
+            &self.state,
+            &self.delivery,
+            &self.dynamodb_state,
+            state_machine_arn,
+            input,
+        );
+    }
+}

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -841,3 +841,68 @@ fn validate_arn(arn: &str) -> Result<(), AwsServiceError> {
     }
     Ok(())
 }
+
+/// Start a Step Functions execution from a cross-service delivery (e.g. EventBridge).
+///
+/// This is the public entry point used by `StepFunctionsDeliveryImpl` in the server crate.
+/// It mirrors the logic from `StartExecution` but without the AWS request/response wrapper.
+pub fn start_execution_from_delivery(
+    state: &SharedStepFunctionsState,
+    delivery: &Option<Arc<DeliveryBus>>,
+    dynamodb_state: &Option<SharedDynamoDbState>,
+    state_machine_arn: &str,
+    input: &str,
+) {
+    let execution_name = uuid::Uuid::new_v4().to_string();
+
+    let mut st = state.write();
+    let sm = match st.state_machines.get(state_machine_arn) {
+        Some(sm) => sm,
+        None => {
+            tracing::warn!(
+                state_machine_arn,
+                "Step Functions delivery: state machine not found"
+            );
+            return;
+        }
+    };
+
+    let sm_name = sm.name.clone();
+    let definition = sm.definition.clone();
+    let exec_arn = st.execution_arn(&sm_name, &execution_name);
+
+    let now = Utc::now();
+    let execution = Execution {
+        execution_arn: exec_arn.clone(),
+        state_machine_arn: state_machine_arn.to_string(),
+        state_machine_name: sm_name,
+        name: execution_name,
+        status: ExecutionStatus::Running,
+        input: Some(input.to_string()),
+        output: None,
+        start_date: now,
+        stop_date: None,
+        error: None,
+        cause: None,
+        history_events: vec![],
+    };
+
+    st.executions.insert(exec_arn.clone(), execution);
+    drop(st);
+
+    let shared_state = state.clone();
+    let delivery = delivery.clone();
+    let dynamodb_state = dynamodb_state.clone();
+    let input = Some(input.to_string());
+    tokio::spawn(async move {
+        interpreter::execute_state_machine(
+            shared_state,
+            exec_arn,
+            definition,
+            input,
+            delivery,
+            dynamodb_state,
+        )
+        .await;
+    });
+}

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -853,6 +853,15 @@ pub fn start_execution_from_delivery(
     state_machine_arn: &str,
     input: &str,
 ) {
+    // Validate input is valid JSON
+    if serde_json::from_str::<serde_json::Value>(input).is_err() {
+        tracing::warn!(
+            state_machine_arn,
+            "Step Functions delivery: invalid JSON input, skipping execution"
+        );
+        return;
+    }
+
     let execution_name = uuid::Uuid::new_v4().to_string();
 
     let mut st = state.write();


### PR DESCRIPTION
## Summary

- EventBridge rules and Scheduler schedules targeting Step Functions now actually start executions
- Added `StepFunctionsDelivery` trait to the core delivery bus
- Wired up delivery in both EventBridge service and Scheduler code paths
- State machine executions are started with the event payload as input, using the same ASL interpreter

## Test plan

- [x] E2E test: EventBridge rule starts and completes Step Functions execution
- [x] Existing `eb_put_events_stub_targets_no_error` still passes
- [x] `cargo clippy -D warnings` clean
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
EventBridge rules and Scheduler schedules targeting Step Functions now start real executions with the event payload as input. This replaces stubs, runs via the ASL interpreter, and supports SNS, EventBridge, SQS, and Lambda tasks inside those executions.

- **New Features**
  - New `StepFunctionsDelivery` in `fakecloud-core` and `StepFunctionsDeliveryImpl` in `fakecloud-server`.
  - EventBridge and Scheduler now call the delivery bus to start executions.
  - `start_execution_from_delivery` in `fakecloud-stepfunctions`, with a full interpreter delivery bus (SNS, EventBridge, SQS, Lambda) for EB/Scheduler-started runs.
  - E2E test covers EB rule starting and completing an execution; state recording remains for introspection.

- **Bug Fixes**
  - Validate input JSON before starting cross-service executions; reject malformed payloads.
  - Include Lambda in the SNS fanout bus for SFN-triggered runs so SNS→Lambda subscriptions fire during EB-started executions.

<sup>Written for commit 88ea29fdb628a1b1eec69cc26130b052e29e9e68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

