### PR TITLE
refactor: use selective tokio features and fix blocking fs in async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rust-version = "1.94"
 version = "0.8.1"
 
 [workspace.dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
 axum = "0.8"
 hyper = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/fakecloud-lambda/src/runtime.rs
+++ b/crates/fakecloud-lambda/src/runtime.rs
@@ -185,10 +185,15 @@ impl ContainerRuntime {
         let image = runtime_to_image(&func.runtime)
             .ok_or_else(|| RuntimeError::UnsupportedRuntime(func.runtime.clone()))?;
 
-        // Extract ZIP to a temp directory (only needed during container setup)
+        // Extract ZIP to a temp directory (only needed during container setup).
+        // Run in spawn_blocking to avoid blocking the async runtime with fs I/O.
         let code_dir =
             TempDir::new().map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))?;
-        extract_zip(zip_bytes, code_dir.path())?;
+        let zip_bytes = zip_bytes.to_vec();
+        let code_path = code_dir.path().to_path_buf();
+        tokio::task::spawn_blocking(move || extract_zip(&zip_bytes, &code_path))
+            .await
+            .map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))??;
 
         // Step 1: docker create (no volume mounts — works in Docker-in-Docker)
         let mut cmd = tokio::process::Command::new(&self.cli);


### PR DESCRIPTION
## Summary

- Replace `tokio = { features = ["full"] }` with explicit feature set to avoid unnecessary dependencies
- Wrap `extract_zip()` in `spawn_blocking` to avoid blocking the async runtime during Lambda container cold starts

## Test plan

- [x] Full workspace builds cleanly
- [x] `cargo clippy --workspace --all-targets -D warnings` clean
- [x] Lambda `extract_zip` unit test passes
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened `tokio` features to only what's needed and moved ZIP extraction to a blocking task to keep the async runtime responsive during Lambda cold starts.

- **Dependencies**
  - Replaced `tokio = { features = ["full"] }` with explicit features: `macros`, `rt-multi-thread`, `net`, `io-util`, `time`, `signal`, `sync`, `process`, `fs`.

- **Bug Fixes**
  - Wrapped `extract_zip()` in `tokio::task::spawn_blocking` to avoid blocking the async runtime during container setup.

<sup>Written for commit fce066352fd0a65f9c34a721a6fbadb9d2d21c7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

