### PR TITLE
docs: fix conformance numbers, add known limitations and security note

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ tests; they are an extra layer, not the whole story.
 | ElastiCache         | 44 operations, Redis and Valkey via Docker         | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | Bedrock             | 111 operations (control plane + runtime)           | Not available                                                                  |
 
+> Performance numbers measured on Apple M1: startup via `time fakecloud`, memory via `ps -o rss` after startup, binary size via `ls -lh`.
+
 ## First-party SDKs
 
 fakecloud now ships SDKs for the introspection and simulation API, so your tests
@@ -191,7 +193,7 @@ integration tests:
 
 - **SNS -> SQS/Lambda/HTTP**: Fan-out delivery to all subscription types
 - **S3 -> SNS/SQS/Lambda/EventBridge**: Bucket notifications on object create/delete
-- **EventBridge -> SNS/SQS/Lambda/Logs/Kinesis/HTTP**: Rules deliver to targets on schedule or event match, including API Destinations
+- **EventBridge -> SNS/SQS/Lambda/Logs/Kinesis/StepFunctions/HTTP**: Rules deliver to targets on schedule or event match, including API Destinations
 - **SQS -> Lambda**: Event source mapping polls and invokes
 - **Kinesis -> Lambda**: Event source mapping polls shards and invokes
 - **DynamoDB Streams -> Lambda**: Event source mapping polls stream records and invokes
@@ -375,12 +377,21 @@ Contributions are welcome.
 **fakecloud is** a free, open-source local AWS emulator for integration testing and
 local development. For every service it implements, the goal is 100% behavioral
 parity with real AWS — verified by 34,000+ automated conformance test variants
-against official AWS Smithy models across all API operations. 19 services,
-100% conformance.
+against official AWS Smithy models across all API operations. 16 of 18 tested
+services at 100% conformance (Cognito and Kinesis in progress).
 
 **fakecloud is not** a production-ready cloud replacement. It's not designed to
 be scalable or to handle production workloads. It's for testing — making sure
 your code works correctly before it hits the real cloud.
+
+**Known limitations:**
+
+- SNS email/SMS delivery: messages are recorded for introspection but not actually sent (no SMTP/SMS gateway). Use the `/_fakecloud/sns/messages` endpoint to verify delivery in tests.
+- CloudWatch Logs anomaly detection: anomaly detectors are fully managed (CRUD), but no anomaly analysis runs. `ListAnomalies` returns empty.
+
+**Docker socket:** Lambda, RDS, and ElastiCache require a Docker socket mount (`/var/run/docker.sock`) to run real containers. This grants the fakecloud process the ability to manage Docker containers on the host. Only use in development/testing environments.
+
+**License (AGPL-3.0):** Using fakecloud as a dev/test tool has zero AGPL implications for your application. The AGPL copyleft clause only applies if you modify and redistribute fakecloud itself as a network service.
 
 ## Use with AI Coding Tools
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -142,7 +142,7 @@
           <tr><td>Startup time</td><td class="check">~500ms</td><td class="cross">~3s</td></tr>
           <tr><td>Idle memory</td><td class="check">~10 MiB</td><td class="cross">~150 MiB</td></tr>
           <tr><td>Install size</td><td class="check">~19 MB binary</td><td class="cross">~1 GB Docker image</td></tr>
-          <tr><td>AWS services</td><td>21</td><td>30+</td></tr>
+          <tr><td>AWS services</td><td>22</td><td>30+</td></tr>
           <tr><td>Test assertion SDKs</td><td class="check">TypeScript, Python, Go, Rust</td><td>Python, Java</td></tr>
           <tr><td>Cognito User Pools</td><td class="check">80 operations</td><td class="cross">Paid only</td></tr>
           <tr><td>SES v2</td><td class="check">97 operations</td><td class="cross">Paid only</td></tr>


### PR DESCRIPTION
## Summary

- Fix conformance claim: 16/18 services at 100% (was incorrectly stated as 19)
- Add performance measurement methodology after comparison table
- Document known limitations (SNS email/SMS stubs, CloudWatch Logs anomaly detection)
- Add Docker socket security note for Lambda/RDS/ElastiCache container features
- Add AGPL license clarification for dev/test usage
- Fix website service count (21 → 22)
- Add StepFunctions to EventBridge cross-service target list

## Test plan

- [x] No code changes, docs only
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the conformance claim and tightens docs for accuracy and security. Adds performance measurement notes, known limitations, and small corrections to targets and service counts.

- **Docs**
  - Correct conformance stats to 16/18 tested services; update website service count to 22.
  - Add performance measurement methodology under the comparison table.
  - Document known limitations: SNS email/SMS stubs; CloudWatch Logs anomaly detection not executed.
  - Add Docker socket security note for Lambda/RDS/ElastiCache containers and clarify AGPL-3.0 usage for dev/test.
  - Include StepFunctions in the EventBridge cross-service target list.

<sup>Written for commit 216bd3e869daae89cfe9aec4d5a84fd330a3c81f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

