### PR TITLE
feat(cognito): implement remaining 20 operations for 100% conformance

### DIFF
--- a/crates/fakecloud-cognito/src/service/branding.rs
+++ b/crates/fakecloud-cognito/src/service/branding.rs
@@ -1,0 +1,726 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::json;
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::WebAuthnCredential;
+
+use super::{require_str, CognitoService};
+
+impl CognitoService {
+    // ── Managed Login Branding ────────────────────────────────────────
+
+    pub(super) fn create_managed_login_branding(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let client_id = require_str(&body, "ClientId")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        if !state.user_pool_clients.contains_key(client_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Client {client_id} does not exist."),
+            ));
+        }
+
+        let branding_id = Uuid::new_v4().to_string();
+        let now = Utc::now();
+
+        let use_cognito = body["UseCognitoProvidedValues"].as_bool().unwrap_or(false);
+
+        let mut branding = json!({
+            "ManagedLoginBrandingId": branding_id,
+            "UserPoolId": pool_id,
+            "ClientId": client_id,
+            "UseCognitoProvidedValues": use_cognito,
+            "CreationDate": now.timestamp() as f64,
+            "LastModifiedDate": now.timestamp() as f64,
+        });
+
+        if !body["Settings"].is_null() {
+            branding["Settings"] = body["Settings"].clone();
+        }
+        if !body["Assets"].is_null() {
+            branding["Assets"] = body["Assets"].clone();
+        }
+
+        state
+            .managed_login_brandings
+            .insert(branding_id.clone(), branding.clone());
+
+        Ok(AwsResponse::ok_json(json!({
+            "ManagedLoginBranding": branding
+        })))
+    }
+
+    pub(super) fn delete_managed_login_branding(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let branding_id = require_str(&body, "ManagedLoginBrandingId")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        match state.managed_login_brandings.get(branding_id) {
+            Some(b) if b["UserPoolId"].as_str() == Some(pool_id) => {
+                state.managed_login_brandings.remove(branding_id);
+            }
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Managed login branding {branding_id} does not exist."),
+                ));
+            }
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    pub(super) fn describe_managed_login_branding(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let branding_id = require_str(&body, "ManagedLoginBrandingId")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let return_merged = body["ReturnMergedResources"].as_bool().unwrap_or(false);
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let branding = state
+            .managed_login_brandings
+            .get(branding_id)
+            .filter(|b| b["UserPoolId"].as_str() == Some(pool_id))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Managed login branding {branding_id} does not exist."),
+                )
+            })?;
+
+        let mut result = branding.clone();
+        if return_merged {
+            // For merged resources, just return the same branding (no real merging in fakecloud)
+            result["ReturnMergedResources"] = json!(true);
+        }
+
+        Ok(AwsResponse::ok_json(json!({
+            "ManagedLoginBranding": result
+        })))
+    }
+
+    pub(super) fn describe_managed_login_branding_by_client(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let client_id = require_str(&body, "ClientId")?;
+        let return_merged = body["ReturnMergedResources"].as_bool().unwrap_or(false);
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let branding = state
+            .managed_login_brandings
+            .values()
+            .find(|b| {
+                b["UserPoolId"].as_str() == Some(pool_id)
+                    && b["ClientId"].as_str() == Some(client_id)
+            })
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!(
+                        "No managed login branding found for client {client_id} in pool {pool_id}."
+                    ),
+                )
+            })?;
+
+        let mut result = branding.clone();
+        if return_merged {
+            result["ReturnMergedResources"] = json!(true);
+        }
+
+        Ok(AwsResponse::ok_json(json!({
+            "ManagedLoginBranding": result
+        })))
+    }
+
+    pub(super) fn update_managed_login_branding(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let branding_id = require_str(&body, "ManagedLoginBrandingId")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let branding = state
+            .managed_login_brandings
+            .get_mut(branding_id)
+            .filter(|b| b["UserPoolId"].as_str() == Some(pool_id))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Managed login branding {branding_id} does not exist."),
+                )
+            })?;
+
+        let now = Utc::now();
+        branding["LastModifiedDate"] = json!(now.timestamp() as f64);
+
+        if let Some(use_cognito) = body["UseCognitoProvidedValues"].as_bool() {
+            branding["UseCognitoProvidedValues"] = json!(use_cognito);
+        }
+        if !body["Settings"].is_null() {
+            branding["Settings"] = body["Settings"].clone();
+        }
+        if !body["Assets"].is_null() {
+            branding["Assets"] = body["Assets"].clone();
+        }
+
+        let result = branding.clone();
+
+        Ok(AwsResponse::ok_json(json!({
+            "ManagedLoginBranding": result
+        })))
+    }
+
+    // ── Terms ─────────────────────────────────────────────────────────
+
+    pub(super) fn create_terms(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let terms_name = require_str(&body, "TermsName")?;
+        let client_id = body["ClientId"].as_str().unwrap_or("");
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let terms_id = Uuid::new_v4().to_string();
+        let now = Utc::now();
+
+        let mut terms = json!({
+            "TermsId": terms_id,
+            "UserPoolId": pool_id,
+            "ClientId": client_id,
+            "TermsName": terms_name,
+            "CreationDate": now.timestamp() as f64,
+            "LastModifiedDate": now.timestamp() as f64,
+        });
+
+        if !body["TermsSource"].is_null() {
+            terms["TermsSource"] = body["TermsSource"].clone();
+        }
+        if !body["Enforcement"].is_null() {
+            terms["Enforcement"] = body["Enforcement"].clone();
+        }
+        if !body["Links"].is_null() {
+            terms["Links"] = body["Links"].clone();
+        }
+
+        state.terms.insert(terms_id, terms.clone());
+
+        Ok(AwsResponse::ok_json(json!({
+            "Terms": terms
+        })))
+    }
+
+    pub(super) fn delete_terms(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let terms_id = require_str(&body, "TermsId")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        match state.terms.get(terms_id) {
+            Some(t) if t["UserPoolId"].as_str() == Some(pool_id) => {
+                state.terms.remove(terms_id);
+            }
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Terms {terms_id} does not exist."),
+                ));
+            }
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    pub(super) fn describe_terms(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let terms_id = require_str(&body, "TermsId")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let terms = state
+            .terms
+            .get(terms_id)
+            .filter(|t| t["UserPoolId"].as_str() == Some(pool_id))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Terms {terms_id} does not exist."),
+                )
+            })?;
+
+        Ok(AwsResponse::ok_json(json!({
+            "Terms": terms
+        })))
+    }
+
+    pub(super) fn list_terms(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let max_results = body["MaxResults"].as_i64().unwrap_or(10).clamp(1, 60) as usize;
+        let next_token = body["NextToken"].as_str();
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let mut terms_list: Vec<&serde_json::Value> = state
+            .terms
+            .values()
+            .filter(|t| t["UserPoolId"].as_str() == Some(pool_id))
+            .collect();
+
+        terms_list.sort_by(|a, b| {
+            let a_date = a["CreationDate"].as_f64().unwrap_or(0.0);
+            let b_date = b["CreationDate"].as_f64().unwrap_or(0.0);
+            a_date
+                .partial_cmp(&b_date)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let start = next_token
+            .and_then(|t| {
+                terms_list
+                    .iter()
+                    .position(|term| term["TermsId"].as_str() == Some(t))
+            })
+            .unwrap_or(0);
+
+        let page: Vec<serde_json::Value> = terms_list
+            .iter()
+            .skip(start)
+            .take(max_results)
+            .cloned()
+            .cloned()
+            .collect();
+
+        let has_more = start + max_results < terms_list.len();
+        let mut result = json!({ "Terms": page });
+        if has_more {
+            if let Some(last) = terms_list.get(start + max_results) {
+                if let Some(id) = last["TermsId"].as_str() {
+                    result["NextToken"] = json!(id);
+                }
+            }
+        }
+
+        Ok(AwsResponse::ok_json(result))
+    }
+
+    pub(super) fn update_terms(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let terms_id = require_str(&body, "TermsId")?;
+        let pool_id = require_str(&body, "UserPoolId")?;
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let terms = state
+            .terms
+            .get_mut(terms_id)
+            .filter(|t| t["UserPoolId"].as_str() == Some(pool_id))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Terms {terms_id} does not exist."),
+                )
+            })?;
+
+        let now = Utc::now();
+        terms["LastModifiedDate"] = json!(now.timestamp() as f64);
+
+        if let Some(name) = body["TermsName"].as_str() {
+            terms["TermsName"] = json!(name);
+        }
+        if !body["TermsSource"].is_null() {
+            terms["TermsSource"] = body["TermsSource"].clone();
+        }
+        if !body["Enforcement"].is_null() {
+            terms["Enforcement"] = body["Enforcement"].clone();
+        }
+        if !body["Links"].is_null() {
+            terms["Links"] = body["Links"].clone();
+        }
+
+        let result = terms.clone();
+
+        Ok(AwsResponse::ok_json(json!({
+            "Terms": result
+        })))
+    }
+
+    // ── WebAuthn ──────────────────────────────────────────────────────
+
+    pub(super) fn start_web_authn_registration(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+
+        let state = self.state.read();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+
+        let pool_id = &token_data.user_pool_id;
+        let username = &token_data.username;
+
+        // Validate user exists
+        if !state
+            .users
+            .get(pool_id.as_str())
+            .is_some_and(|u| u.contains_key(username.as_str()))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "User not found.",
+            ));
+        }
+
+        let challenge = Uuid::new_v4().to_string();
+        let user_id = Uuid::new_v4().to_string();
+
+        let credential_creation_options = json!({
+            "rp": {
+                "id": format!("cognito-idp.us-east-1.amazonaws.com/{pool_id}"),
+                "name": "Amazon Cognito"
+            },
+            "user": {
+                "id": user_id,
+                "name": username,
+                "displayName": username
+            },
+            "challenge": challenge,
+            "pubKeyCredParams": [
+                { "type": "public-key", "alg": -7 },
+                { "type": "public-key", "alg": -257 }
+            ],
+            "timeout": 60000,
+            "attestation": "none",
+            "authenticatorSelection": {
+                "userVerification": "preferred",
+                "residentKey": "preferred"
+            }
+        });
+
+        Ok(AwsResponse::ok_json(json!({
+            "CredentialCreationOptions": credential_creation_options
+        })))
+    }
+
+    pub(super) fn complete_web_authn_registration(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+        let credential = &body["Credential"];
+
+        if credential.is_null() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "Credential is required",
+            ));
+        }
+
+        let mut state = self.state.write();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+
+        let pool_id = token_data.user_pool_id.clone();
+        let username = token_data.username.clone();
+
+        // Validate user exists
+        if !state
+            .users
+            .get(pool_id.as_str())
+            .is_some_and(|u| u.contains_key(username.as_str()))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "User not found.",
+            ));
+        }
+
+        let credential_id = credential["id"]
+            .as_str()
+            .unwrap_or(&Uuid::new_v4().to_string())
+            .to_string();
+
+        let friendly_name = credential["clientExtensionResults"]["credProps"]
+            ["authenticatorDisplayName"]
+            .as_str()
+            .map(|s| s.to_string());
+
+        let authenticator_attachment = credential["authenticatorAttachment"]
+            .as_str()
+            .map(|s| s.to_string());
+
+        let authenticator_transport: Vec<String> = credential["response"]["transports"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let now = Utc::now();
+        let cred = WebAuthnCredential {
+            credential_id,
+            friendly_credential_name: friendly_name,
+            relying_party_id: format!("cognito-idp.us-east-1.amazonaws.com/{pool_id}"),
+            authenticator_attachment,
+            authenticator_transport,
+            created_at: now,
+        };
+
+        let key = format!("{pool_id}:{username}");
+        state
+            .webauthn_credentials
+            .entry(key)
+            .or_default()
+            .push(cred);
+
+        Ok(AwsResponse::ok_json(json!({
+            "CredentialId": state
+                .webauthn_credentials
+                .get(&format!("{pool_id}:{username}"))
+                .and_then(|v| v.last())
+                .map(|c| c.credential_id.as_str())
+                .unwrap_or("")
+        })))
+    }
+
+    pub(super) fn delete_web_authn_credential(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+        let credential_id = require_str(&body, "CredentialId")?;
+
+        let mut state = self.state.write();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+
+        let pool_id = token_data.user_pool_id.clone();
+        let username = token_data.username.clone();
+
+        let key = format!("{pool_id}:{username}");
+        let creds = state.webauthn_credentials.get_mut(&key).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Credential {credential_id} does not exist."),
+            )
+        })?;
+
+        let before_len = creds.len();
+        creds.retain(|c| c.credential_id != credential_id);
+
+        if creds.len() == before_len {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("Credential {credential_id} does not exist."),
+            ));
+        }
+
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    pub(super) fn list_web_authn_credentials(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let access_token = require_str(&body, "AccessToken")?;
+        let max_results = body["MaxResults"].as_i64().unwrap_or(10).clamp(1, 60) as usize;
+        let next_token = body["NextToken"].as_str();
+
+        let state = self.state.read();
+
+        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid access token.",
+            )
+        })?;
+
+        let pool_id = &token_data.user_pool_id;
+        let username = &token_data.username;
+
+        let key = format!("{pool_id}:{username}");
+        let all_creds = state.webauthn_credentials.get(&key);
+
+        let creds: &[WebAuthnCredential] = all_creds.map(|v| v.as_slice()).unwrap_or(&[]);
+
+        let start = next_token
+            .and_then(|t| creds.iter().position(|c| c.credential_id == t))
+            .unwrap_or(0);
+
+        let page: Vec<serde_json::Value> = creds
+            .iter()
+            .skip(start)
+            .take(max_results)
+            .map(|c| {
+                let mut obj = json!({
+                    "CredentialId": c.credential_id,
+                    "RelyingPartyId": c.relying_party_id,
+                    "AuthenticatorTransports": c.authenticator_transport,
+                    "CreatedAt": c.created_at.timestamp() as f64,
+                });
+                if let Some(ref name) = c.friendly_credential_name {
+                    obj["FriendlyCredentialName"] = json!(name);
+                }
+                if let Some(ref attachment) = c.authenticator_attachment {
+                    obj["AuthenticatorAttachment"] = json!(attachment);
+                }
+                obj
+            })
+            .collect();
+
+        let has_more = start + max_results < creds.len();
+        let mut result = json!({ "Credentials": page });
+        if has_more {
+            if let Some(c) = creds.get(start + max_results) {
+                result["NextToken"] = json!(c.credential_id);
+            }
+        }
+
+        Ok(AwsResponse::ok_json(result))
+    }
+}

--- a/crates/fakecloud-cognito/src/service/config.rs
+++ b/crates/fakecloud-cognito/src/service/config.rs
@@ -1,0 +1,269 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::json;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use super::{require_str, CognitoService};
+
+impl CognitoService {
+    // ── UI Customization ──────────────────────────────────────────────
+
+    pub(super) fn get_ui_customization(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let client_id = body["ClientId"].as_str().unwrap_or("");
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let key = format!("{pool_id}:{client_id}");
+
+        // Try client-specific first, then pool-level, then empty default
+        let customization = state
+            .ui_customizations
+            .get(&key)
+            .or_else(|| {
+                if !client_id.is_empty() {
+                    state.ui_customizations.get(&format!("{pool_id}:"))
+                } else {
+                    None
+                }
+            })
+            .cloned()
+            .unwrap_or_else(|| {
+                json!({
+                    "UserPoolId": pool_id,
+                    "ClientId": if client_id.is_empty() { "ALL" } else { client_id },
+                    "CreationDate": Utc::now().timestamp() as f64,
+                    "LastModifiedDate": Utc::now().timestamp() as f64,
+                })
+            });
+
+        Ok(AwsResponse::ok_json(json!({
+            "UICustomization": customization
+        })))
+    }
+
+    pub(super) fn set_ui_customization(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let client_id = body["ClientId"].as_str().unwrap_or("");
+        let css = body["CSS"].as_str().unwrap_or("");
+        let image_file = body["ImageFile"].as_str();
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let now = Utc::now();
+        let key = format!("{pool_id}:{client_id}");
+
+        let mut customization = json!({
+            "UserPoolId": pool_id,
+            "ClientId": if client_id.is_empty() { "ALL" } else { client_id },
+            "CreationDate": now.timestamp() as f64,
+            "LastModifiedDate": now.timestamp() as f64,
+        });
+
+        if !css.is_empty() {
+            customization["CSS"] = json!(css);
+            customization["CSSVersion"] = json!("20190128");
+        }
+
+        if let Some(img) = image_file {
+            customization["ImageUrl"] = json!(format!(
+                "https://fakecloud-ui.s3.amazonaws.com/{pool_id}/logo.png"
+            ));
+            customization["ImageFile"] = json!(img);
+        }
+
+        state.ui_customizations.insert(key, customization.clone());
+
+        Ok(AwsResponse::ok_json(json!({
+            "UICustomization": customization
+        })))
+    }
+
+    // ── Log Delivery Configuration ────────────────────────────────────
+
+    pub(super) fn get_log_delivery_configuration(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let config = state
+            .log_delivery_configs
+            .get(pool_id)
+            .cloned()
+            .unwrap_or_else(|| {
+                json!({
+                    "UserPoolId": pool_id,
+                    "LogConfigurations": []
+                })
+            });
+
+        Ok(AwsResponse::ok_json(json!({
+            "LogDeliveryConfiguration": config
+        })))
+    }
+
+    pub(super) fn set_log_delivery_configuration(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let log_configs = body["LogConfigurations"].clone();
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let config = json!({
+            "UserPoolId": pool_id,
+            "LogConfigurations": log_configs
+        });
+
+        state
+            .log_delivery_configs
+            .insert(pool_id.to_string(), config.clone());
+
+        Ok(AwsResponse::ok_json(json!({
+            "LogDeliveryConfiguration": config
+        })))
+    }
+
+    // ── Risk Configuration ────────────────────────────────────────────
+
+    pub(super) fn describe_risk_configuration(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let client_id = body["ClientId"].as_str().unwrap_or("");
+
+        let state = self.state.read();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let key = format!("{pool_id}:{client_id}");
+
+        let config = state
+            .risk_configurations
+            .get(&key)
+            .or_else(|| {
+                if !client_id.is_empty() {
+                    state.risk_configurations.get(&format!("{pool_id}:"))
+                } else {
+                    None
+                }
+            })
+            .cloned()
+            .unwrap_or_else(|| {
+                let mut cfg = json!({
+                    "UserPoolId": pool_id,
+                });
+                if !client_id.is_empty() {
+                    cfg["ClientId"] = json!(client_id);
+                }
+                cfg
+            });
+
+        Ok(AwsResponse::ok_json(json!({
+            "RiskConfiguration": config
+        })))
+    }
+
+    pub(super) fn set_risk_configuration(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let pool_id = require_str(&body, "UserPoolId")?;
+        let client_id = body["ClientId"].as_str().unwrap_or("");
+
+        let mut state = self.state.write();
+
+        if !state.user_pools.contains_key(pool_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("User pool {pool_id} does not exist."),
+            ));
+        }
+
+        let key = format!("{pool_id}:{client_id}");
+
+        let mut config = json!({
+            "UserPoolId": pool_id,
+        });
+
+        if !client_id.is_empty() {
+            config["ClientId"] = json!(client_id);
+        }
+
+        // Copy through the risk config fields
+        if !body["CompromisedCredentialsRiskConfiguration"].is_null() {
+            config["CompromisedCredentialsRiskConfiguration"] =
+                body["CompromisedCredentialsRiskConfiguration"].clone();
+        }
+        if !body["AccountTakeoverRiskConfiguration"].is_null() {
+            config["AccountTakeoverRiskConfiguration"] =
+                body["AccountTakeoverRiskConfiguration"].clone();
+        }
+        if !body["RiskExceptionConfiguration"].is_null() {
+            config["RiskExceptionConfiguration"] = body["RiskExceptionConfiguration"].clone();
+        }
+
+        state.risk_configurations.insert(key, config.clone());
+
+        Ok(AwsResponse::ok_json(json!({
+            "RiskConfiguration": config
+        })))
+    }
+}

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1,4 +1,6 @@
 mod auth;
+mod branding;
+mod config;
 mod groups;
 mod identity_providers;
 mod legacy;
@@ -158,6 +160,28 @@ impl AwsService for CognitoService {
             "UpdateAuthEventFeedback" => self.update_auth_event_feedback(&req),
             "StartUserImportJob" => self.start_user_import_job(&req),
             "StopUserImportJob" => self.stop_user_import_job(&req),
+            "GetUICustomization" => self.get_ui_customization(&req),
+            "SetUICustomization" => self.set_ui_customization(&req),
+            "GetLogDeliveryConfiguration" => self.get_log_delivery_configuration(&req),
+            "SetLogDeliveryConfiguration" => self.set_log_delivery_configuration(&req),
+            "DescribeRiskConfiguration" => self.describe_risk_configuration(&req),
+            "SetRiskConfiguration" => self.set_risk_configuration(&req),
+            "CreateManagedLoginBranding" => self.create_managed_login_branding(&req),
+            "DeleteManagedLoginBranding" => self.delete_managed_login_branding(&req),
+            "DescribeManagedLoginBranding" => self.describe_managed_login_branding(&req),
+            "DescribeManagedLoginBrandingByClient" => {
+                self.describe_managed_login_branding_by_client(&req)
+            }
+            "UpdateManagedLoginBranding" => self.update_managed_login_branding(&req),
+            "CreateTerms" => self.create_terms(&req),
+            "DeleteTerms" => self.delete_terms(&req),
+            "DescribeTerms" => self.describe_terms(&req),
+            "ListTerms" => self.list_terms(&req),
+            "UpdateTerms" => self.update_terms(&req),
+            "StartWebAuthnRegistration" => self.start_web_authn_registration(&req),
+            "CompleteWebAuthnRegistration" => self.complete_web_authn_registration(&req),
+            "DeleteWebAuthnCredential" => self.delete_web_authn_credential(&req),
+            "ListWebAuthnCredentials" => self.list_web_authn_credentials(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "cognito-idp",
                 &req.action,
@@ -269,6 +293,26 @@ impl AwsService for CognitoService {
             "UpdateAuthEventFeedback",
             "StartUserImportJob",
             "StopUserImportJob",
+            "GetUICustomization",
+            "SetUICustomization",
+            "GetLogDeliveryConfiguration",
+            "SetLogDeliveryConfiguration",
+            "DescribeRiskConfiguration",
+            "SetRiskConfiguration",
+            "CreateManagedLoginBranding",
+            "DeleteManagedLoginBranding",
+            "DescribeManagedLoginBranding",
+            "DescribeManagedLoginBrandingByClient",
+            "UpdateManagedLoginBranding",
+            "CreateTerms",
+            "DeleteTerms",
+            "DescribeTerms",
+            "ListTerms",
+            "UpdateTerms",
+            "StartWebAuthnRegistration",
+            "CompleteWebAuthnRegistration",
+            "DeleteWebAuthnCredential",
+            "ListWebAuthnCredentials",
         ]
     }
 }

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -36,6 +36,18 @@ pub struct CognitoState {
     pub import_jobs: HashMap<String, HashMap<String, UserImportJob>>,
     /// Auth events for introspection
     pub auth_events: Vec<AuthEvent>,
+    /// (pool_id, client_id|"") -> UICustomization JSON
+    pub ui_customizations: HashMap<String, serde_json::Value>,
+    /// pool_id -> LogDeliveryConfiguration JSON
+    pub log_delivery_configs: HashMap<String, serde_json::Value>,
+    /// (pool_id, client_id|"") -> RiskConfiguration JSON
+    pub risk_configurations: HashMap<String, serde_json::Value>,
+    /// branding_id -> ManagedLoginBranding JSON
+    pub managed_login_brandings: HashMap<String, serde_json::Value>,
+    /// terms_id -> Terms JSON
+    pub terms: HashMap<String, serde_json::Value>,
+    /// (pool_id:username) -> WebAuthn credentials
+    pub webauthn_credentials: HashMap<String, Vec<WebAuthnCredential>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -48,6 +60,16 @@ pub struct AuthEvent {
     pub timestamp: DateTime<Utc>,
     pub success: bool,
     pub feedback_value: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebAuthnCredential {
+    pub credential_id: String,
+    pub friendly_credential_name: Option<String>,
+    pub relying_party_id: String,
+    pub authenticator_attachment: Option<String>,
+    pub authenticator_transport: Vec<String>,
+    pub created_at: DateTime<Utc>,
 }
 
 /// Linked external provider for a user
@@ -77,6 +99,12 @@ impl CognitoState {
             tags: HashMap::new(),
             import_jobs: HashMap::new(),
             auth_events: Vec::new(),
+            ui_customizations: HashMap::new(),
+            log_delivery_configs: HashMap::new(),
+            risk_configurations: HashMap::new(),
+            managed_login_brandings: HashMap::new(),
+            terms: HashMap::new(),
+            webauthn_credentials: HashMap::new(),
         }
     }
 
@@ -95,6 +123,12 @@ impl CognitoState {
         self.tags.clear();
         self.import_jobs.clear();
         self.auth_events.clear();
+        self.ui_customizations.clear();
+        self.log_delivery_configs.clear();
+        self.risk_configurations.clear();
+        self.managed_login_brandings.clear();
+        self.terms.clear();
+        self.webauthn_credentials.clear();
     }
 }
 

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -3494,3 +3494,981 @@ async fn cognito_get_signing_certificate() {
         .unwrap();
     assert!(resp.certificate().is_some());
 }
+
+// ---------------------------------------------------------------------------
+// UI Customization
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "SetUICustomization", checksum = "27bc4b26")]
+#[tokio::test]
+async fn cognito_set_ui_customization() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("ui-custom-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let resp = client
+        .set_ui_customization()
+        .user_pool_id(&pool_id)
+        .css("body { background: red; }")
+        .send()
+        .await
+        .unwrap();
+    let ui = resp.ui_customization().unwrap();
+    assert_eq!(ui.user_pool_id().unwrap(), pool_id);
+    assert_eq!(ui.css().unwrap(), "body { background: red; }");
+}
+
+#[test_action("cognito-idp", "GetUICustomization", checksum = "807d92dc")]
+#[tokio::test]
+async fn cognito_get_ui_customization() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("ui-get-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Set first
+    client
+        .set_ui_customization()
+        .user_pool_id(&pool_id)
+        .css(".header { color: blue; }")
+        .send()
+        .await
+        .unwrap();
+
+    // Get
+    let resp = client
+        .get_ui_customization()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .unwrap();
+    let ui = resp.ui_customization().unwrap();
+    assert_eq!(ui.user_pool_id().unwrap(), pool_id);
+    assert_eq!(ui.css().unwrap(), ".header { color: blue; }");
+}
+
+// ---------------------------------------------------------------------------
+// Log Delivery Configuration
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "SetLogDeliveryConfiguration", checksum = "8a6a037d")]
+#[tokio::test]
+async fn cognito_set_log_delivery_configuration() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("log-config-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let log_config = aws_sdk_cognitoidentityprovider::types::LogConfigurationType::builder()
+        .log_level(aws_sdk_cognitoidentityprovider::types::LogLevel::Error)
+        .event_source(aws_sdk_cognitoidentityprovider::types::EventSourceName::UserNotification)
+        .build()
+        .unwrap();
+
+    let resp = client
+        .set_log_delivery_configuration()
+        .user_pool_id(&pool_id)
+        .log_configurations(log_config)
+        .send()
+        .await
+        .unwrap();
+    let cfg = resp.log_delivery_configuration().unwrap();
+    assert_eq!(cfg.user_pool_id(), &pool_id);
+    assert!(!cfg.log_configurations().is_empty());
+}
+
+#[test_action("cognito-idp", "GetLogDeliveryConfiguration", checksum = "37aab735")]
+#[tokio::test]
+async fn cognito_get_log_delivery_configuration() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("log-get-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Get before set (should return empty)
+    let resp = client
+        .get_log_delivery_configuration()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .unwrap();
+    let cfg = resp.log_delivery_configuration().unwrap();
+    assert_eq!(cfg.user_pool_id(), &pool_id);
+
+    // Set and get again
+    let log_config = aws_sdk_cognitoidentityprovider::types::LogConfigurationType::builder()
+        .log_level(aws_sdk_cognitoidentityprovider::types::LogLevel::Error)
+        .event_source(aws_sdk_cognitoidentityprovider::types::EventSourceName::UserNotification)
+        .build()
+        .unwrap();
+
+    client
+        .set_log_delivery_configuration()
+        .user_pool_id(&pool_id)
+        .log_configurations(log_config)
+        .send()
+        .await
+        .unwrap();
+
+    let resp2 = client
+        .get_log_delivery_configuration()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .unwrap();
+    let cfg2 = resp2.log_delivery_configuration().unwrap();
+    assert!(!cfg2.log_configurations().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Risk Configuration
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "SetRiskConfiguration", checksum = "f74ed3fe")]
+#[tokio::test]
+async fn cognito_set_risk_configuration() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("risk-config-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let risk_exception =
+        aws_sdk_cognitoidentityprovider::types::RiskExceptionConfigurationType::builder()
+            .blocked_ip_range_list("192.168.1.0/24")
+            .build();
+
+    let resp = client
+        .set_risk_configuration()
+        .user_pool_id(&pool_id)
+        .risk_exception_configuration(risk_exception)
+        .send()
+        .await
+        .unwrap();
+    let cfg = resp.risk_configuration().unwrap();
+    assert_eq!(cfg.user_pool_id().unwrap(), pool_id);
+}
+
+#[test_action("cognito-idp", "DescribeRiskConfiguration", checksum = "da8ca179")]
+#[tokio::test]
+async fn cognito_describe_risk_configuration() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("risk-describe-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Describe before set (should return default)
+    let resp = client
+        .describe_risk_configuration()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .unwrap();
+    let cfg = resp.risk_configuration().unwrap();
+    assert_eq!(cfg.user_pool_id().unwrap(), pool_id);
+
+    // Set and describe again
+    let risk_exception =
+        aws_sdk_cognitoidentityprovider::types::RiskExceptionConfigurationType::builder()
+            .blocked_ip_range_list("10.0.0.0/8")
+            .build();
+
+    client
+        .set_risk_configuration()
+        .user_pool_id(&pool_id)
+        .risk_exception_configuration(risk_exception)
+        .send()
+        .await
+        .unwrap();
+
+    let resp2 = client
+        .describe_risk_configuration()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .unwrap();
+    let cfg2 = resp2.risk_configuration().unwrap();
+    assert!(cfg2.risk_exception_configuration().is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Managed Login Branding
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "CreateManagedLoginBranding", checksum = "cb913f30")]
+#[tokio::test]
+async fn cognito_create_managed_login_branding() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("branding-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("branding-client")
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    let resp = client
+        .create_managed_login_branding()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .use_cognito_provided_values(true)
+        .send()
+        .await
+        .unwrap();
+    let branding = resp.managed_login_branding().unwrap();
+    assert!(!branding.managed_login_branding_id().unwrap().is_empty());
+    assert_eq!(branding.user_pool_id().unwrap(), pool_id);
+}
+
+#[test_action("cognito-idp", "DescribeManagedLoginBranding", checksum = "078abe45")]
+#[tokio::test]
+async fn cognito_describe_managed_login_branding() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("branding-describe-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("branding-desc-client")
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    let created = client
+        .create_managed_login_branding()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .use_cognito_provided_values(true)
+        .send()
+        .await
+        .unwrap();
+    let branding_id = created
+        .managed_login_branding()
+        .unwrap()
+        .managed_login_branding_id()
+        .unwrap()
+        .to_string();
+
+    let resp = client
+        .describe_managed_login_branding()
+        .user_pool_id(&pool_id)
+        .managed_login_branding_id(&branding_id)
+        .send()
+        .await
+        .unwrap();
+    let b = resp.managed_login_branding().unwrap();
+    assert_eq!(b.managed_login_branding_id().unwrap(), branding_id);
+    assert_eq!(b.user_pool_id().unwrap(), pool_id);
+}
+
+#[test_action(
+    "cognito-idp",
+    "DescribeManagedLoginBrandingByClient",
+    checksum = "1614d8e7"
+)]
+#[tokio::test]
+async fn cognito_describe_managed_login_branding_by_client() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("branding-by-client-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("branding-by-client")
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .create_managed_login_branding()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .use_cognito_provided_values(true)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_managed_login_branding_by_client()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .send()
+        .await
+        .unwrap();
+    let b = resp.managed_login_branding().unwrap();
+    assert_eq!(b.user_pool_id().unwrap(), pool_id);
+}
+
+#[test_action("cognito-idp", "UpdateManagedLoginBranding", checksum = "efc1e7bb")]
+#[tokio::test]
+async fn cognito_update_managed_login_branding() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("branding-update-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("branding-upd-client")
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    let created = client
+        .create_managed_login_branding()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .use_cognito_provided_values(true)
+        .send()
+        .await
+        .unwrap();
+    let branding_id = created
+        .managed_login_branding()
+        .unwrap()
+        .managed_login_branding_id()
+        .unwrap()
+        .to_string();
+
+    let resp = client
+        .update_managed_login_branding()
+        .user_pool_id(&pool_id)
+        .managed_login_branding_id(&branding_id)
+        .use_cognito_provided_values(false)
+        .send()
+        .await
+        .unwrap();
+    let b = resp.managed_login_branding().unwrap();
+    assert_eq!(b.managed_login_branding_id().unwrap(), branding_id);
+}
+
+#[test_action("cognito-idp", "DeleteManagedLoginBranding", checksum = "7f018306")]
+#[tokio::test]
+async fn cognito_delete_managed_login_branding() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("branding-delete-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("branding-del-client")
+        .send()
+        .await
+        .unwrap();
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    let created = client
+        .create_managed_login_branding()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .use_cognito_provided_values(true)
+        .send()
+        .await
+        .unwrap();
+    let branding_id = created
+        .managed_login_branding()
+        .unwrap()
+        .managed_login_branding_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .delete_managed_login_branding()
+        .user_pool_id(&pool_id)
+        .managed_login_branding_id(&branding_id)
+        .send()
+        .await
+        .unwrap();
+
+    // Should fail to describe after delete
+    let err = client
+        .describe_managed_login_branding()
+        .user_pool_id(&pool_id)
+        .managed_login_branding_id(&branding_id)
+        .send()
+        .await;
+    assert!(err.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Terms
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "CreateTerms", checksum = "b7975c85")]
+#[tokio::test]
+async fn cognito_create_terms() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let endpoint = server.endpoint();
+
+    // First create a pool via SDK
+    let client = server.cognito_client().await;
+    let pool = client
+        .create_user_pool()
+        .pool_name("terms-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.CreateTerms",
+        )
+        .json(&serde_json::json!({
+            "UserPoolId": pool_id,
+            "TermsName": "test-terms"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(!body["Terms"]["TermsId"].as_str().unwrap().is_empty());
+    assert_eq!(body["Terms"]["UserPoolId"].as_str().unwrap(), pool_id);
+    assert_eq!(body["Terms"]["TermsName"].as_str().unwrap(), "test-terms");
+}
+
+#[test_action("cognito-idp", "DescribeTerms", checksum = "a01327c5")]
+#[tokio::test]
+async fn cognito_describe_terms() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let endpoint = server.endpoint();
+
+    let client = server.cognito_client().await;
+    let pool = client
+        .create_user_pool()
+        .pool_name("terms-desc-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create terms
+    let create_resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.CreateTerms",
+        )
+        .json(&serde_json::json!({
+            "UserPoolId": pool_id,
+            "TermsName": "desc-terms"
+        }))
+        .send()
+        .await
+        .unwrap();
+    let create_body: serde_json::Value = create_resp.json().await.unwrap();
+    let terms_id = create_body["Terms"]["TermsId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Describe
+    let resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.DescribeTerms",
+        )
+        .json(&serde_json::json!({
+            "UserPoolId": pool_id,
+            "TermsId": terms_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["Terms"]["TermsId"].as_str().unwrap(), terms_id);
+    assert_eq!(body["Terms"]["TermsName"].as_str().unwrap(), "desc-terms");
+}
+
+#[test_action("cognito-idp", "ListTerms", checksum = "86783ac4")]
+#[tokio::test]
+async fn cognito_list_terms() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let endpoint = server.endpoint();
+
+    let client = server.cognito_client().await;
+    let pool = client
+        .create_user_pool()
+        .pool_name("terms-list-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create two terms
+    for name in &["terms-a", "terms-b"] {
+        http.post(endpoint)
+            .header("Content-Type", "application/x-amz-json-1.1")
+            .header(
+                "X-Amz-Target",
+                "AWSCognitoIdentityProviderService.CreateTerms",
+            )
+            .json(&serde_json::json!({
+                "UserPoolId": pool_id,
+                "TermsName": name
+            }))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.ListTerms",
+        )
+        .json(&serde_json::json!({
+            "UserPoolId": pool_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let terms = body["Terms"].as_array().unwrap();
+    assert_eq!(terms.len(), 2);
+}
+
+#[test_action("cognito-idp", "UpdateTerms", checksum = "fa5f729e")]
+#[tokio::test]
+async fn cognito_update_terms() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let endpoint = server.endpoint();
+
+    let client = server.cognito_client().await;
+    let pool = client
+        .create_user_pool()
+        .pool_name("terms-update-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create
+    let create_resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.CreateTerms",
+        )
+        .json(&serde_json::json!({
+            "UserPoolId": pool_id,
+            "TermsName": "old-name"
+        }))
+        .send()
+        .await
+        .unwrap();
+    let create_body: serde_json::Value = create_resp.json().await.unwrap();
+    let terms_id = create_body["Terms"]["TermsId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Update
+    let resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.UpdateTerms",
+        )
+        .json(&serde_json::json!({
+            "UserPoolId": pool_id,
+            "TermsId": terms_id,
+            "TermsName": "new-name"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["Terms"]["TermsName"].as_str().unwrap(), "new-name");
+}
+
+#[test_action("cognito-idp", "DeleteTerms", checksum = "85c898a8")]
+#[tokio::test]
+async fn cognito_delete_terms() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let endpoint = server.endpoint();
+
+    let client = server.cognito_client().await;
+    let pool = client
+        .create_user_pool()
+        .pool_name("terms-delete-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    // Create
+    let create_resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.CreateTerms",
+        )
+        .json(&serde_json::json!({
+            "UserPoolId": pool_id,
+            "TermsName": "delete-me"
+        }))
+        .send()
+        .await
+        .unwrap();
+    let create_body: serde_json::Value = create_resp.json().await.unwrap();
+    let terms_id = create_body["Terms"]["TermsId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Delete
+    let resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.DeleteTerms",
+        )
+        .json(&serde_json::json!({
+            "UserPoolId": pool_id,
+            "TermsId": terms_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Describe should fail
+    let err_resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.DescribeTerms",
+        )
+        .json(&serde_json::json!({
+            "UserPoolId": pool_id,
+            "TermsId": terms_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(err_resp.status(), 400);
+}
+
+// ---------------------------------------------------------------------------
+// WebAuthn
+// ---------------------------------------------------------------------------
+
+#[test_action("cognito-idp", "StartWebAuthnRegistration", checksum = "372f550e")]
+#[tokio::test]
+async fn cognito_start_web_authn_registration() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let endpoint = server.endpoint();
+    let client = server.cognito_client().await;
+    let (_pool_id, _client_id, access_token) =
+        setup_authenticated_user(&client, "webauthn-start-pool").await;
+
+    let resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.StartWebAuthnRegistration",
+        )
+        .json(&serde_json::json!({
+            "AccessToken": access_token
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["CredentialCreationOptions"]["challenge"]
+        .as_str()
+        .is_some());
+    assert!(body["CredentialCreationOptions"]["rp"].is_object());
+    assert!(body["CredentialCreationOptions"]["user"].is_object());
+}
+
+#[test_action("cognito-idp", "CompleteWebAuthnRegistration", checksum = "f18b9292")]
+#[tokio::test]
+async fn cognito_complete_web_authn_registration() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let endpoint = server.endpoint();
+    let client = server.cognito_client().await;
+    let (_pool_id, _client_id, access_token) =
+        setup_authenticated_user(&client, "webauthn-complete-pool").await;
+
+    let resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.CompleteWebAuthnRegistration",
+        )
+        .json(&serde_json::json!({
+            "AccessToken": access_token,
+            "Credential": {
+                "id": "cred-123",
+                "type": "public-key",
+                "authenticatorAttachment": "platform",
+                "response": {
+                    "clientDataJSON": "eyJ0ZXN0IjogdHJ1ZX0",
+                    "attestationObject": "o2NmbXRkbm9uZQ",
+                    "transports": ["internal"]
+                },
+                "clientExtensionResults": {}
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[test_action("cognito-idp", "ListWebAuthnCredentials", checksum = "e93ad619")]
+#[tokio::test]
+async fn cognito_list_web_authn_credentials() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let endpoint = server.endpoint();
+    let client = server.cognito_client().await;
+    let (_pool_id, _client_id, access_token) =
+        setup_authenticated_user(&client, "webauthn-list-pool").await;
+
+    // Register a credential first
+    http.post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.CompleteWebAuthnRegistration",
+        )
+        .json(&serde_json::json!({
+            "AccessToken": access_token,
+            "Credential": {
+                "id": "list-cred-1",
+                "type": "public-key",
+                "response": {
+                    "clientDataJSON": "eyJ0ZXN0IjogdHJ1ZX0",
+                    "attestationObject": "o2NmbXRkbm9uZQ",
+                    "transports": ["usb"]
+                },
+                "clientExtensionResults": {}
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.ListWebAuthnCredentials",
+        )
+        .json(&serde_json::json!({
+            "AccessToken": access_token
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let creds = body["Credentials"].as_array().unwrap();
+    assert!(!creds.is_empty());
+    assert_eq!(creds[0]["CredentialId"].as_str().unwrap(), "list-cred-1");
+}
+
+#[test_action("cognito-idp", "DeleteWebAuthnCredential", checksum = "271bbdea")]
+#[tokio::test]
+async fn cognito_delete_web_authn_credential() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let endpoint = server.endpoint();
+    let client = server.cognito_client().await;
+    let (_pool_id, _client_id, access_token) =
+        setup_authenticated_user(&client, "webauthn-delete-pool").await;
+
+    // Register a credential
+    http.post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.CompleteWebAuthnRegistration",
+        )
+        .json(&serde_json::json!({
+            "AccessToken": access_token,
+            "Credential": {
+                "id": "del-cred-1",
+                "type": "public-key",
+                "response": {
+                    "clientDataJSON": "eyJ0ZXN0IjogdHJ1ZX0",
+                    "attestationObject": "o2NmbXRkbm9uZQ",
+                    "transports": ["ble"]
+                },
+                "clientExtensionResults": {}
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Delete
+    let resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.DeleteWebAuthnCredential",
+        )
+        .json(&serde_json::json!({
+            "AccessToken": access_token,
+            "CredentialId": "del-cred-1"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // List should be empty
+    let list_resp = http
+        .post(endpoint)
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.ListWebAuthnCredentials",
+        )
+        .json(&serde_json::json!({
+            "AccessToken": access_token
+        }))
+        .send()
+        .await
+        .unwrap();
+    let list_body: serde_json::Value = list_resp.json().await.unwrap();
+    assert!(list_body["Credentials"].as_array().unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary
Implements all remaining Cognito User Pools operations to achieve 100% conformance:

- **UI Customization**: Get/SetUICustomization, Get/SetLogDeliveryConfiguration, Describe/SetRiskConfiguration (6 ops)
- **Managed Login Branding**: Create/Delete/Describe/DescribeByClient/Update (5 ops)
- **Terms of Service**: Create/Delete/Describe/List/Update (5 ops)
- **WebAuthn**: Start/CompleteRegistration, Delete/ListCredentials (4 ops)

**Cognito conformance: 122/122 operations (100%), 4479/4479 variants (100%)**

## Test plan
- [x] All 94 handwritten conformance tests pass
- [x] Conformance probes: 4479/4479 variants pass (100%)
- [x] Zero clippy warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the remaining Cognito User Pools operations in `fakecloud-cognito`, completing feature coverage. Conformance is now 122/122 operations and 4479/4479 variants (100%).

- New Features
  - UI Customization: GetUICustomization, SetUICustomization
  - Log Delivery: GetLogDeliveryConfiguration, SetLogDeliveryConfiguration
  - Risk Configuration: DescribeRiskConfiguration, SetRiskConfiguration
  - Managed Login Branding: Create/Delete/Describe/DescribeByClient/Update
  - Terms of Service: Create/Delete/Describe/List/Update
  - WebAuthn: Start/CompleteRegistration, Delete/ListCredentials

<sup>Written for commit 986ba6879c915bb4b551d294aeeb4d085a64ea63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

