### PR TITLE
refactor: replace clippy::too_many_arguments allows with config structs

### DIFF
--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -20,59 +20,41 @@ use crate::state::{SharedCloudFormationState, Stack};
 use crate::template;
 use crate::xml_responses;
 
+/// State references for every service CloudFormation can provision resources in.
+pub struct CloudFormationDeps {
+    pub sqs: SharedSqsState,
+    pub sns: SharedSnsState,
+    pub ssm: SharedSsmState,
+    pub iam: SharedIamState,
+    pub s3: SharedS3State,
+    pub eventbridge: SharedEventBridgeState,
+    pub dynamodb: SharedDynamoDbState,
+    pub logs: SharedLogsState,
+    pub delivery: Arc<DeliveryBus>,
+}
+
 pub struct CloudFormationService {
     state: SharedCloudFormationState,
-    sqs_state: SharedSqsState,
-    sns_state: SharedSnsState,
-    ssm_state: SharedSsmState,
-    iam_state: SharedIamState,
-    s3_state: SharedS3State,
-    eventbridge_state: SharedEventBridgeState,
-    dynamodb_state: SharedDynamoDbState,
-    logs_state: SharedLogsState,
-    delivery: Arc<DeliveryBus>,
+    deps: CloudFormationDeps,
 }
 
 impl CloudFormationService {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        state: SharedCloudFormationState,
-        sqs_state: SharedSqsState,
-        sns_state: SharedSnsState,
-        ssm_state: SharedSsmState,
-        iam_state: SharedIamState,
-        s3_state: SharedS3State,
-        eventbridge_state: SharedEventBridgeState,
-        dynamodb_state: SharedDynamoDbState,
-        logs_state: SharedLogsState,
-        delivery: Arc<DeliveryBus>,
-    ) -> Self {
-        Self {
-            state,
-            sqs_state,
-            sns_state,
-            ssm_state,
-            iam_state,
-            s3_state,
-            eventbridge_state,
-            dynamodb_state,
-            logs_state,
-            delivery,
-        }
+    pub fn new(state: SharedCloudFormationState, deps: CloudFormationDeps) -> Self {
+        Self { state, deps }
     }
 
     fn provisioner(&self, stack_id: &str) -> ResourceProvisioner {
         let cf_state = self.state.read();
         ResourceProvisioner {
-            sqs_state: self.sqs_state.clone(),
-            sns_state: self.sns_state.clone(),
-            ssm_state: self.ssm_state.clone(),
-            iam_state: self.iam_state.clone(),
-            s3_state: self.s3_state.clone(),
-            eventbridge_state: self.eventbridge_state.clone(),
-            dynamodb_state: self.dynamodb_state.clone(),
-            logs_state: self.logs_state.clone(),
-            delivery: self.delivery.clone(),
+            sqs_state: self.deps.sqs.clone(),
+            sns_state: self.deps.sns.clone(),
+            ssm_state: self.deps.ssm.clone(),
+            iam_state: self.deps.iam.clone(),
+            s3_state: self.deps.s3.clone(),
+            eventbridge_state: self.deps.eventbridge.clone(),
+            dynamodb_state: self.deps.dynamodb.clone(),
+            logs_state: self.deps.logs.clone(),
+            delivery: self.deps.delivery.clone(),
             account_id: cf_state.account_id.clone(),
             region: cf_state.region.clone(),
             stack_id: stack_id.to_string(),
@@ -306,7 +288,7 @@ impl CloudFormationService {
         }
 
         Self::send_stack_notification(
-            &self.delivery,
+            &self.deps.delivery,
             &notification_arns,
             stack_name,
             &stack_id,
@@ -360,7 +342,7 @@ impl CloudFormationService {
             drop(state);
 
             Self::send_stack_notification(
-                &self.delivery,
+                &self.deps.delivery,
                 &notification_arns,
                 &stack_name_for_notif,
                 &stack_id,
@@ -642,7 +624,7 @@ impl CloudFormationService {
         if update_failed {
             drop(state);
             Self::send_stack_notification(
-                &self.delivery,
+                &self.deps.delivery,
                 &notification_arns,
                 &stack_name_for_notif,
                 &stack_id,
@@ -657,7 +639,7 @@ impl CloudFormationService {
 
         drop(state);
         Self::send_stack_notification(
-            &self.delivery,
+            &self.deps.delivery,
             &notification_arns,
             &stack_name_for_notif,
             &stack_id,
@@ -751,42 +733,42 @@ mod tests {
             "123456789012",
             "us-east-1",
         )));
-        CloudFormationService::new(
-            cf_state,
-            Arc::new(RwLock::new(fakecloud_sqs::state::SqsState::new(
+        let deps = CloudFormationDeps {
+            sqs: Arc::new(RwLock::new(fakecloud_sqs::state::SqsState::new(
                 "123456789012",
                 "us-east-1",
                 "http://localhost:4566",
             ))),
-            Arc::new(RwLock::new(fakecloud_sns::state::SnsState::new(
+            sns: Arc::new(RwLock::new(fakecloud_sns::state::SnsState::new(
                 "123456789012",
                 "us-east-1",
                 "http://localhost:4566",
             ))),
-            Arc::new(RwLock::new(fakecloud_ssm::state::SsmState::new(
+            ssm: Arc::new(RwLock::new(fakecloud_ssm::state::SsmState::new(
                 "123456789012",
                 "us-east-1",
             ))),
-            Arc::new(RwLock::new(fakecloud_iam::state::IamState::new(
+            iam: Arc::new(RwLock::new(fakecloud_iam::state::IamState::new(
                 "123456789012",
             ))),
-            Arc::new(RwLock::new(fakecloud_s3::state::S3State::new(
+            s3: Arc::new(RwLock::new(fakecloud_s3::state::S3State::new(
                 "123456789012",
                 "us-east-1",
             ))),
-            Arc::new(RwLock::new(
+            eventbridge: Arc::new(RwLock::new(
                 fakecloud_eventbridge::state::EventBridgeState::new("123456789012", "us-east-1"),
             )),
-            Arc::new(RwLock::new(fakecloud_dynamodb::state::DynamoDbState::new(
+            dynamodb: Arc::new(RwLock::new(fakecloud_dynamodb::state::DynamoDbState::new(
                 "123456789012",
                 "us-east-1",
             ))),
-            Arc::new(RwLock::new(fakecloud_logs::state::LogsState::new(
+            logs: Arc::new(RwLock::new(fakecloud_logs::state::LogsState::new(
                 "123456789012",
                 "us-east-1",
             ))),
-            Arc::new(DeliveryBus::new()),
-        )
+            delivery: Arc::new(DeliveryBus::new()),
+        };
+        CloudFormationService::new(cf_state, deps)
     }
 
     fn make_request(action: &str, params: HashMap<String, String>) -> AwsRequest {

--- a/crates/fakecloud-cognito/src/service/auth.rs
+++ b/crates/fakecloud-cognito/src/service/auth.rs
@@ -786,15 +786,18 @@ impl CognitoService {
                 let mut challenge_metadata: Option<String> = None;
 
                 if let Some(create_arn) = create_arn {
+                    let create_ctx = triggers::AuthChallengeContext {
+                        pool_id: &pool_id,
+                        client_id: Some(&client_id_owned),
+                        username: &username_owned,
+                        user_attributes: &user_attrs,
+                        region: &region,
+                        account_id: &account_id,
+                    };
                     let create_event = triggers::build_create_auth_challenge_event(
-                        &pool_id,
-                        Some(&client_id_owned),
-                        &username_owned,
-                        &user_attrs,
+                        &create_ctx,
                         &challenge_name,
                         &challenge_results,
-                        &region,
-                        &account_id,
                     );
                     if let Some(create_response) =
                         triggers::invoke_trigger(ctx, &create_arn, &create_event).await
@@ -1207,15 +1210,18 @@ impl CognitoService {
                     )
                 })?;
 
+                let verify_ctx = triggers::AuthChallengeContext {
+                    pool_id: &pool_id,
+                    client_id: Some(&session_client_id),
+                    username: &username,
+                    user_attributes: &user_attrs,
+                    region: &region,
+                    account_id: &account_id,
+                };
                 let verify_event = triggers::build_verify_auth_challenge_event(
-                    &pool_id,
-                    Some(&session_client_id),
-                    &username,
-                    &user_attrs,
+                    &verify_ctx,
                     answer,
                     challenge_metadata.as_deref(),
-                    &region,
-                    &account_id,
                 );
 
                 let verify_response = triggers::invoke_trigger(ctx, &verify_arn, &verify_event)
@@ -1374,15 +1380,18 @@ impl CognitoService {
                 let mut new_challenge_metadata: Option<String> = None;
 
                 if let Some(create_arn) = create_arn {
+                    let create_ctx = triggers::AuthChallengeContext {
+                        pool_id: &pool_id,
+                        client_id: Some(&session_client_id),
+                        username: &username,
+                        user_attributes: &user_attrs,
+                        region: &region,
+                        account_id: &account_id,
+                    };
                     let create_event = triggers::build_create_auth_challenge_event(
-                        &pool_id,
-                        Some(&session_client_id),
-                        &username,
-                        &user_attrs,
+                        &create_ctx,
                         &next_challenge_name,
                         &challenge_results,
-                        &region,
-                        &account_id,
                     );
                     if let Some(create_response) =
                         triggers::invoke_trigger(ctx, &create_arn, &create_event).await

--- a/crates/fakecloud-cognito/src/triggers.rs
+++ b/crates/fakecloud-cognito/src/triggers.rs
@@ -269,24 +269,40 @@ pub fn build_define_auth_challenge_event(
     event
 }
 
+/// Caller/user/pool identity bundled for auth-challenge trigger events.
+pub struct AuthChallengeContext<'a> {
+    pub pool_id: &'a str,
+    pub client_id: Option<&'a str>,
+    pub username: &'a str,
+    pub user_attributes: &'a [UserAttribute],
+    pub region: &'a str,
+    pub account_id: &'a str,
+}
+
+impl<'a> AuthChallengeContext<'a> {
+    fn caller_context(&self) -> Value {
+        json!({
+            "awsSdkVersion": "fakecloud",
+            "clientId": self.client_id.unwrap_or(""),
+            "accountId": self.account_id,
+        })
+    }
+
+    fn user_attrs_value(&self) -> Value {
+        self.user_attributes
+            .iter()
+            .map(|a| (a.name.clone(), Value::String(a.value.clone())))
+            .collect::<serde_json::Map<String, Value>>()
+            .into()
+    }
+}
+
 /// Build a CreateAuthChallenge trigger event.
-#[allow(clippy::too_many_arguments)]
 pub fn build_create_auth_challenge_event(
-    pool_id: &str,
-    client_id: Option<&str>,
-    username: &str,
-    user_attributes: &[UserAttribute],
+    ctx: &AuthChallengeContext<'_>,
     challenge_name: &str,
     challenge_results: &[ChallengeResult],
-    region: &str,
-    account_id: &str,
 ) -> Value {
-    let user_attrs: Value = user_attributes
-        .iter()
-        .map(|a| (a.name.clone(), Value::String(a.value.clone())))
-        .collect::<serde_json::Map<String, Value>>()
-        .into();
-
     let session: Vec<Value> = challenge_results
         .iter()
         .map(|cr| {
@@ -304,16 +320,12 @@ pub fn build_create_auth_challenge_event(
     json!({
         "version": "1",
         "triggerSource": TriggerSource::CreateAuthChallengeAuthentication.as_str(),
-        "region": region,
-        "userPoolId": pool_id,
-        "userName": username,
-        "callerContext": {
-            "awsSdkVersion": "fakecloud",
-            "clientId": client_id.unwrap_or(""),
-            "accountId": account_id,
-        },
+        "region": ctx.region,
+        "userPoolId": ctx.pool_id,
+        "userName": ctx.username,
+        "callerContext": ctx.caller_context(),
         "request": {
-            "userAttributes": user_attrs,
+            "userAttributes": ctx.user_attrs_value(),
             "challengeName": challenge_name,
             "session": session,
         },
@@ -326,36 +338,20 @@ pub fn build_create_auth_challenge_event(
 }
 
 /// Build a VerifyAuthChallengeResponse trigger event.
-#[allow(clippy::too_many_arguments)]
 pub fn build_verify_auth_challenge_event(
-    pool_id: &str,
-    client_id: Option<&str>,
-    username: &str,
-    user_attributes: &[UserAttribute],
+    ctx: &AuthChallengeContext<'_>,
     challenge_answer: &str,
     challenge_metadata: Option<&str>,
-    region: &str,
-    account_id: &str,
 ) -> Value {
-    let user_attrs: Value = user_attributes
-        .iter()
-        .map(|a| (a.name.clone(), Value::String(a.value.clone())))
-        .collect::<serde_json::Map<String, Value>>()
-        .into();
-
     json!({
         "version": "1",
         "triggerSource": TriggerSource::VerifyAuthChallengeResponseAuthentication.as_str(),
-        "region": region,
-        "userPoolId": pool_id,
-        "userName": username,
-        "callerContext": {
-            "awsSdkVersion": "fakecloud",
-            "clientId": client_id.unwrap_or(""),
-            "accountId": account_id,
-        },
+        "region": ctx.region,
+        "userPoolId": ctx.pool_id,
+        "userName": ctx.username,
+        "callerContext": ctx.caller_context(),
         "request": {
-            "userAttributes": user_attrs,
+            "userAttributes": ctx.user_attrs_value(),
             "challengeAnswer": challenge_answer,
             "privateChallengeParameters": {},
             "challengeMetadata": challenge_metadata.unwrap_or(""),
@@ -669,17 +665,16 @@ mod tests {
             name: "email".to_string(),
             value: "user@example.com".to_string(),
         }];
+        let ctx = AuthChallengeContext {
+            pool_id: "us-east-1_abc",
+            client_id: Some("client-id-1"),
+            username: "testuser",
+            user_attributes: &attrs,
+            region: "us-east-1",
+            account_id: "123456789012",
+        };
 
-        let event = build_create_auth_challenge_event(
-            "us-east-1_abc",
-            Some("client-id-1"),
-            "testuser",
-            &attrs,
-            "CUSTOM_CHALLENGE",
-            &[],
-            "us-east-1",
-            "123456789012",
-        );
+        let event = build_create_auth_challenge_event(&ctx, "CUSTOM_CHALLENGE", &[]);
 
         assert_eq!(event["triggerSource"], "CreateAuthChallenge_Authentication");
         assert_eq!(event["request"]["challengeName"], "CUSTOM_CHALLENGE");
@@ -696,17 +691,16 @@ mod tests {
             name: "sub".to_string(),
             value: "abc-123".to_string(),
         }];
+        let ctx = AuthChallengeContext {
+            pool_id: "us-east-1_abc",
+            client_id: Some("client-id-1"),
+            username: "testuser",
+            user_attributes: &attrs,
+            region: "us-east-1",
+            account_id: "123456789012",
+        };
 
-        let event = build_verify_auth_challenge_event(
-            "us-east-1_abc",
-            Some("client-id-1"),
-            "testuser",
-            &attrs,
-            "my-answer",
-            Some("challenge-meta"),
-            "us-east-1",
-            "123456789012",
-        );
+        let event = build_verify_auth_challenge_event(&ctx, "my-answer", Some("challenge-meta"));
 
         assert_eq!(
             event["triggerSource"],

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -1807,20 +1807,34 @@ fn apply_delete_assignment(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-fn build_table_description_json(
-    arn: &str,
-    key_schema: &[KeySchemaElement],
-    attribute_definitions: &[AttributeDefinition],
-    provisioned_throughput: &ProvisionedThroughput,
-    gsi: &[GlobalSecondaryIndex],
-    lsi: &[LocalSecondaryIndex],
-    billing_mode: &str,
-    created_at: chrono::DateTime<chrono::Utc>,
-    item_count: i64,
-    size_bytes: i64,
-    status: &str,
-) -> Value {
+pub(super) struct TableDescriptionInput<'a> {
+    pub arn: &'a str,
+    pub key_schema: &'a [KeySchemaElement],
+    pub attribute_definitions: &'a [AttributeDefinition],
+    pub provisioned_throughput: &'a ProvisionedThroughput,
+    pub gsi: &'a [GlobalSecondaryIndex],
+    pub lsi: &'a [LocalSecondaryIndex],
+    pub billing_mode: &'a str,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub item_count: i64,
+    pub size_bytes: i64,
+    pub status: &'a str,
+}
+
+fn build_table_description_json(input: &TableDescriptionInput<'_>) -> Value {
+    let TableDescriptionInput {
+        arn,
+        key_schema,
+        attribute_definitions,
+        provisioned_throughput,
+        gsi,
+        lsi,
+        billing_mode,
+        created_at,
+        item_count,
+        size_bytes,
+        status,
+    } = *input;
     let table_name = arn.rsplit('/').next().unwrap_or("");
     let creation_timestamp =
         created_at.timestamp() as f64 + created_at.timestamp_subsec_millis() as f64 / 1000.0;
@@ -1926,19 +1940,19 @@ fn build_table_description_json(
 }
 
 fn build_table_description(table: &DynamoTable) -> Value {
-    let mut desc = build_table_description_json(
-        &table.arn,
-        &table.key_schema,
-        &table.attribute_definitions,
-        &table.provisioned_throughput,
-        &table.gsi,
-        &table.lsi,
-        &table.billing_mode,
-        table.created_at,
-        table.item_count,
-        table.size_bytes,
-        &table.status,
-    );
+    let mut desc = build_table_description_json(&TableDescriptionInput {
+        arn: &table.arn,
+        key_schema: &table.key_schema,
+        attribute_definitions: &table.attribute_definitions,
+        provisioned_throughput: &table.provisioned_throughput,
+        gsi: &table.gsi,
+        lsi: &table.lsi,
+        billing_mode: &table.billing_mode,
+        created_at: table.created_at,
+        item_count: table.item_count,
+        size_bytes: table.size_bytes,
+        status: &table.status,
+    });
 
     // Add stream specification if streams are enabled
     if table.stream_enabled {

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -183,19 +183,19 @@ impl DynamoDbService {
 
         state.tables.insert(table_name, table);
 
-        let table_desc = build_table_description_json(
-            &arn,
-            &key_schema,
-            &attribute_definitions,
-            &provisioned_throughput,
-            &gsi,
-            &lsi,
-            &billing_mode,
-            now,
-            0,
-            0,
-            "ACTIVE",
-        );
+        let table_desc = build_table_description_json(&super::TableDescriptionInput {
+            arn: &arn,
+            key_schema: &key_schema,
+            attribute_definitions: &attribute_definitions,
+            provisioned_throughput: &provisioned_throughput,
+            gsi: &gsi,
+            lsi: &lsi,
+            billing_mode: &billing_mode,
+            created_at: now,
+            item_count: 0,
+            size_bytes: 0,
+            status: "ACTIVE",
+        });
 
         Self::ok_json(json!({ "TableDescription": table_desc }))
     }
@@ -213,19 +213,19 @@ impl DynamoDbService {
             )
         })?;
 
-        let table_desc = build_table_description_json(
-            &table.arn,
-            &table.key_schema,
-            &table.attribute_definitions,
-            &table.provisioned_throughput,
-            &table.gsi,
-            &table.lsi,
-            &table.billing_mode,
-            table.created_at,
-            table.item_count,
-            table.size_bytes,
-            "DELETING",
-        );
+        let table_desc = build_table_description_json(&super::TableDescriptionInput {
+            arn: &table.arn,
+            key_schema: &table.key_schema,
+            attribute_definitions: &table.attribute_definitions,
+            provisioned_throughput: &table.provisioned_throughput,
+            gsi: &table.gsi,
+            lsi: &table.lsi,
+            billing_mode: &table.billing_mode,
+            created_at: table.created_at,
+            item_count: table.item_count,
+            size_bytes: table.size_bytes,
+            status: "DELETING",
+        });
 
         Self::ok_json(json!({ "TableDescription": table_desc }))
     }
@@ -335,19 +335,19 @@ impl DynamoDbService {
             }
         }
 
-        let table_desc = build_table_description_json(
-            &table.arn,
-            &table.key_schema,
-            &table.attribute_definitions,
-            &table.provisioned_throughput,
-            &table.gsi,
-            &table.lsi,
-            &table.billing_mode,
-            table.created_at,
-            table.item_count,
-            table.size_bytes,
-            &table.status,
-        );
+        let table_desc = build_table_description_json(&super::TableDescriptionInput {
+            arn: &table.arn,
+            key_schema: &table.key_schema,
+            attribute_definitions: &table.attribute_definitions,
+            provisioned_throughput: &table.provisioned_throughput,
+            gsi: &table.gsi,
+            lsi: &table.lsi,
+            billing_mode: &table.billing_mode,
+            created_at: table.created_at,
+            item_count: table.item_count,
+            size_bytes: table.size_bytes,
+            status: &table.status,
+        });
 
         Self::ok_json(json!({ "TableDescription": table_desc }))
     }

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -271,16 +271,16 @@ impl StsService {
             },
         );
 
-        let xml = xml_responses::assume_role_response(
+        let xml = xml_responses::assume_role_response(&xml_responses::AssumedRoleInfo {
             role_arn,
             role_session_name,
-            &role_id,
-            &account_id,
+            assumed_role_id: &role_id,
+            account_id: &account_id,
             partition,
-            &creds,
-            &expiration,
-            &req.request_id,
-        );
+            creds: &creds,
+            expiration: &expiration,
+            request_id: &req.request_id,
+        });
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 
@@ -377,14 +377,16 @@ impl StsService {
         );
 
         let xml = xml_responses::assume_role_with_web_identity_response(
-            role_arn,
-            role_session_name,
-            &account_id,
-            partition,
-            &creds,
-            &role_id,
-            &expiration,
-            &req.request_id,
+            &xml_responses::AssumedRoleInfo {
+                role_arn,
+                role_session_name,
+                assumed_role_id: &role_id,
+                account_id: &account_id,
+                partition,
+                creds: &creds,
+                expiration: &expiration,
+                request_id: &req.request_id,
+            },
         );
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
@@ -475,16 +477,16 @@ impl StsService {
             },
         );
 
-        let xml = xml_responses::assume_role_with_saml_response(
+        let xml = xml_responses::assume_role_with_saml_response(&xml_responses::AssumedRoleInfo {
             role_arn,
-            &role_session_name,
-            &account_id,
+            role_session_name: &role_session_name,
+            assumed_role_id: &role_id,
+            account_id: &account_id,
             partition,
-            &creds,
-            &role_id,
-            &expiration,
-            &req.request_id,
-        );
+            creds: &creds,
+            expiration: &expiration,
+            request_id: &req.request_id,
+        });
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -582,24 +582,30 @@ impl StsCredentials {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn assume_role_response(
-    role_arn: &str,
-    role_session_name: &str,
-    role_id: &str,
-    account_id: &str,
-    partition: &str,
-    creds: &StsCredentials,
-    expiration: &str,
-    request_id: &str,
-) -> String {
-    // Extract role name from ARN
-    let role_name = role_arn.rsplit('/').next().unwrap_or("unknown");
-    let assumed_role_arn = format!(
-        "arn:{}:sts::{}:assumed-role/{}/{}",
-        partition, account_id, role_name, role_session_name
-    );
+/// Inputs shared by all assume-role variants used to build an STS XML response.
+pub struct AssumedRoleInfo<'a> {
+    pub role_arn: &'a str,
+    pub role_session_name: &'a str,
+    pub assumed_role_id: &'a str,
+    pub account_id: &'a str,
+    pub partition: &'a str,
+    pub creds: &'a StsCredentials,
+    pub expiration: &'a str,
+    pub request_id: &'a str,
+}
 
+impl AssumedRoleInfo<'_> {
+    fn assumed_role_arn(&self) -> String {
+        let role_name = self.role_arn.rsplit('/').next().unwrap_or("unknown");
+        format!(
+            "arn:{}:sts::{}:assumed-role/{}/{}",
+            self.partition, self.account_id, role_name, self.role_session_name
+        )
+    }
+}
+
+pub fn assume_role_response(info: &AssumedRoleInfo<'_>) -> String {
+    let assumed_role_arn = info.assumed_role_arn();
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
@@ -619,32 +625,19 @@ pub fn assume_role_response(
     <RequestId>{request_id}</RequestId>
   </ResponseMetadata>
 </AssumeRoleResponse>"#,
-        access_key_id = creds.access_key_id,
-        secret_access_key = creds.secret_access_key,
-        session_token = creds.session_token,
-        role_id = role_id,
+        access_key_id = info.creds.access_key_id,
+        secret_access_key = info.creds.secret_access_key,
+        session_token = info.creds.session_token,
+        role_id = info.assumed_role_id,
         assumed_role_arn = assumed_role_arn,
-        session = role_session_name,
+        session = info.role_session_name,
+        expiration = info.expiration,
+        request_id = info.request_id,
     )
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn assume_role_with_web_identity_response(
-    role_arn: &str,
-    role_session_name: &str,
-    account_id: &str,
-    partition: &str,
-    creds: &StsCredentials,
-    assumed_role_id: &str,
-    expiration: &str,
-    request_id: &str,
-) -> String {
-    let role_name = role_arn.rsplit('/').next().unwrap_or("unknown");
-    let assumed_role_arn = format!(
-        "arn:{}:sts::{}:assumed-role/{}/{}",
-        partition, account_id, role_name, role_session_name
-    );
-
+pub fn assume_role_with_web_identity_response(info: &AssumedRoleInfo<'_>) -> String {
+    let assumed_role_arn = info.assumed_role_arn();
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
@@ -664,33 +657,19 @@ pub fn assume_role_with_web_identity_response(
     <RequestId>{request_id}</RequestId>
   </ResponseMetadata>
 </AssumeRoleWithWebIdentityResponse>"#,
-        access_key_id = creds.access_key_id,
-        secret_access_key = creds.secret_access_key,
-        session_token = creds.session_token,
-        assumed_role_id = assumed_role_id,
+        access_key_id = info.creds.access_key_id,
+        secret_access_key = info.creds.secret_access_key,
+        session_token = info.creds.session_token,
+        assumed_role_id = info.assumed_role_id,
         assumed_role_arn = assumed_role_arn,
-        session = role_session_name,
-        request_id = request_id,
+        session = info.role_session_name,
+        expiration = info.expiration,
+        request_id = info.request_id,
     )
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn assume_role_with_saml_response(
-    role_arn: &str,
-    role_session_name: &str,
-    account_id: &str,
-    partition: &str,
-    creds: &StsCredentials,
-    assumed_role_id: &str,
-    expiration: &str,
-    request_id: &str,
-) -> String {
-    let role_name = role_arn.rsplit('/').next().unwrap_or("unknown");
-    let assumed_role_arn = format!(
-        "arn:{}:sts::{}:assumed-role/{}/{}",
-        partition, account_id, role_name, role_session_name
-    );
-
+pub fn assume_role_with_saml_response(info: &AssumedRoleInfo<'_>) -> String {
+    let assumed_role_arn = info.assumed_role_arn();
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <AssumeRoleWithSAMLResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
@@ -710,13 +689,14 @@ pub fn assume_role_with_saml_response(
     <RequestId>{request_id}</RequestId>
   </ResponseMetadata>
 </AssumeRoleWithSAMLResponse>"#,
-        access_key_id = creds.access_key_id,
-        secret_access_key = creds.secret_access_key,
-        session_token = creds.session_token,
-        assumed_role_id = assumed_role_id,
+        access_key_id = info.creds.access_key_id,
+        secret_access_key = info.creds.secret_access_key,
+        session_token = info.creds.session_token,
+        assumed_role_id = info.assumed_role_id,
         assumed_role_arn = assumed_role_arn,
-        session = role_session_name,
-        request_id = request_id,
+        session = info.role_session_name,
+        expiration = info.expiration,
+        request_id = info.request_id,
     )
 }
 

--- a/crates/fakecloud-s3/src/logging.rs
+++ b/crates/fakecloud-s3/src/logging.rs
@@ -27,23 +27,35 @@ pub fn parse_logging_config(xml: &str) -> Option<LoggingConfig> {
     })
 }
 
+/// Everything needed to describe a single S3 request for access logging.
+pub struct AccessLogRequest<'a> {
+    pub operation: &'a str,
+    pub key: Option<&'a str>,
+    pub status: u16,
+    pub request_id: &'a str,
+    pub method: &'a str,
+    pub path: &'a str,
+}
+
 /// Generate an S3 access log line in a format similar to AWS.
 ///
 /// See <https://docs.aws.amazon.com/AmazonS3/latest/userguide/LogFormat.html>
-#[allow(clippy::too_many_arguments)]
 pub fn format_access_log_entry(
     bucket_owner: &str,
     bucket: &str,
-    operation: &str,
-    key: Option<&str>,
-    status: u16,
-    request_id: &str,
-    method: &str,
-    path: &str,
+    request: &AccessLogRequest<'_>,
 ) -> String {
     let now = Utc::now();
     let time = now.format("[%d/%b/%Y:%H:%M:%S %z]");
-    let key_str = key.unwrap_or("-");
+    let key_str = request.key.unwrap_or("-");
+    let AccessLogRequest {
+        operation,
+        status,
+        request_id,
+        method,
+        path,
+        ..
+    } = request;
     // Simplified log line matching the AWS format fields
     format!(
         "{bucket_owner} {bucket} {time} 127.0.0.1 arn:aws:iam::000000000000:user/testuser {request_id} REST.{operation} {key_str} \"{method} {path} HTTP/1.1\" {status} - - - - - \"-\" \"FakeCloud/1.0\" - - - - -\n"
@@ -55,16 +67,10 @@ pub fn format_access_log_entry(
 ///
 /// This should be called at the end of the `handle` method so that every S3
 /// operation on a logging-enabled bucket produces a record.
-#[allow(clippy::too_many_arguments)]
 pub fn maybe_write_access_log(
     state: &SharedS3State,
     source_bucket: &str,
-    operation: &str,
-    key: Option<&str>,
-    status: u16,
-    request_id: &str,
-    method: &str,
-    path: &str,
+    request: &AccessLogRequest<'_>,
 ) {
     // Read logging config from the source bucket
     let logging_config_xml = {
@@ -87,16 +93,7 @@ pub fn maybe_write_access_log(
             .unwrap_or_else(|| "unknown".to_string())
     };
 
-    let entry = format_access_log_entry(
-        &bucket_owner,
-        source_bucket,
-        operation,
-        key,
-        status,
-        request_id,
-        method,
-        path,
-    );
+    let entry = format_access_log_entry(&bucket_owner, source_bucket, request);
 
     let now = Utc::now();
     let log_key = format!(
@@ -198,16 +195,15 @@ mod tests {
 
     #[test]
     fn format_log_entry_contains_fields() {
-        let entry = format_access_log_entry(
-            "owner123",
-            "my-bucket",
-            "GET.OBJECT",
-            Some("my-key.txt"),
-            200,
-            "req-abc",
-            "GET",
-            "/my-bucket/my-key.txt",
-        );
+        let request = AccessLogRequest {
+            operation: "GET.OBJECT",
+            key: Some("my-key.txt"),
+            status: 200,
+            request_id: "req-abc",
+            method: "GET",
+            path: "/my-bucket/my-key.txt",
+        };
+        let entry = format_access_log_entry("owner123", "my-bucket", &request);
         assert!(entry.contains("owner123"));
         assert!(entry.contains("my-bucket"));
         assert!(entry.contains("GET.OBJECT"));

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -536,12 +536,14 @@ impl AwsService for S3Service {
             logging::maybe_write_access_log(
                 &self.state,
                 b_name,
-                op,
-                key.as_deref(),
-                status_code,
-                &req.request_id,
-                req.method.as_str(),
-                &req.raw_path,
+                &logging::AccessLogRequest {
+                    operation: op,
+                    key: key.as_deref(),
+                    status: status_code,
+                    request_id: &req.request_id,
+                    method: req.method.as_str(),
+                    path: &req.raw_path,
+                },
             );
         }
 

--- a/crates/fakecloud-s3/src/service/notifications.rs
+++ b/crates/fakecloud-s3/src/service/notifications.rs
@@ -498,19 +498,32 @@ pub(crate) fn event_matches(event_name: &str, filter: &str) -> bool {
     false
 }
 
+/// Everything a reader needs to describe a single S3 object-level event.
+pub(crate) struct ObjectEvent<'a> {
+    pub event_name: &'a str,
+    pub bucket_name: &'a str,
+    pub key: &'a str,
+    pub size: u64,
+    pub etag: &'a str,
+    pub region: &'a str,
+}
+
 /// Deliver S3 event notifications for a bucket operation.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn deliver_notifications(
     delivery: &Arc<DeliveryBus>,
     notification_config: &str,
-    event_name: &str,
-    bucket_name: &str,
-    key: &str,
-    size: u64,
-    etag: &str,
-    region: &str,
+    event: &ObjectEvent<'_>,
     s3_state: Option<&SharedS3State>,
 ) {
+    let ObjectEvent {
+        event_name,
+        bucket_name,
+        key,
+        size,
+        etag,
+        region,
+    } = *event;
+
     let targets = parse_notification_config(notification_config);
     let s3_event_name = format!("s3:{event_name}");
     let message = build_s3_event_notification(event_name, bucket_name, key, size, etag, region);

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -1043,12 +1043,14 @@ impl S3Service {
             deliver_notifications(
                 &self.delivery,
                 config,
-                "ObjectCreated:Put",
-                &bucket_name,
-                &obj_key,
-                obj_size,
-                &obj_etag,
-                &region,
+                &super::notifications::ObjectEvent {
+                    event_name: "ObjectCreated:Put",
+                    bucket_name: &bucket_name,
+                    key: &obj_key,
+                    size: obj_size,
+                    etag: &obj_etag,
+                    region: &region,
+                },
                 Some(&self.state),
             );
         }
@@ -1514,12 +1516,14 @@ impl S3Service {
                 deliver_notifications(
                     &self.delivery,
                     config,
-                    "ObjectRemoved:DeleteMarkerCreated",
-                    &bucket_name,
-                    &obj_key,
-                    0,
-                    "",
-                    &region,
+                    &super::notifications::ObjectEvent {
+                        event_name: "ObjectRemoved:DeleteMarkerCreated",
+                        bucket_name: &bucket_name,
+                        key: &obj_key,
+                        size: 0,
+                        etag: "",
+                        region: &region,
+                    },
                     Some(&self.state),
                 );
             }
@@ -1545,12 +1549,14 @@ impl S3Service {
             deliver_notifications(
                 &self.delivery,
                 config,
-                "ObjectRemoved:Delete",
-                &bucket_name,
-                &obj_key,
-                0,
-                "",
-                &region,
+                &super::notifications::ObjectEvent {
+                    event_name: "ObjectRemoved:Delete",
+                    bucket_name: &bucket_name,
+                    key: &obj_key,
+                    size: 0,
+                    etag: "",
+                    region: &region,
+                },
                 Some(&self.state),
             );
         }
@@ -2172,12 +2178,14 @@ impl S3Service {
             deliver_notifications(
                 &self.delivery,
                 config,
-                "ObjectCreated:Copy",
-                &copy_bucket,
-                &copy_key,
-                copy_size,
-                &copy_etag,
-                &region,
+                &super::notifications::ObjectEvent {
+                    event_name: "ObjectCreated:Copy",
+                    bucket_name: &copy_bucket,
+                    key: &copy_key,
+                    size: copy_size,
+                    etag: &copy_etag,
+                    region: &region,
+                },
                 Some(&self.state),
             );
         }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -378,15 +378,17 @@ async fn main() {
     let mut registry = ServiceRegistry::new();
     registry.register(Arc::new(CloudFormationService::new(
         cloudformation_state,
-        sqs_state.clone(),
-        sns_state.clone(),
-        ssm_state.clone(),
-        iam_state.clone(),
-        s3_state.clone(),
-        eb_state.clone(),
-        dynamodb_state.clone(),
-        logs_state.clone(),
-        delivery_for_cf,
+        fakecloud_cloudformation::service::CloudFormationDeps {
+            sqs: sqs_state.clone(),
+            sns: sns_state.clone(),
+            ssm: ssm_state.clone(),
+            iam: iam_state.clone(),
+            s3: s3_state.clone(),
+            eventbridge: eb_state.clone(),
+            dynamodb: dynamodb_state.clone(),
+            logs: logs_state.clone(),
+            delivery: delivery_for_cf,
+        },
     )));
     registry.register(Arc::new(SqsService::new(sqs_state.clone())));
     let sns_state_for_sfn = sns_state.clone();

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -82,16 +82,17 @@ impl SnsDelivery for SnsDeliveryImpl {
         let lambda_payloads: Vec<(String, String)> = lambda_subscribers
             .iter()
             .map(|(function_arn, subscription_arn)| {
-                let payload = crate::service::build_sns_lambda_event(
-                    &msg_id,
-                    topic_arn,
-                    subscription_arn,
-                    message,
-                    subject,
-                    &empty_attrs,
-                    &now,
-                    &endpoint,
-                );
+                let payload =
+                    crate::service::build_sns_lambda_event(&crate::service::SnsLambdaEventInput {
+                        message_id: &msg_id,
+                        topic_arn,
+                        subscription_arn,
+                        message,
+                        subject,
+                        message_attributes: &empty_attrs,
+                        timestamp: &now,
+                        endpoint: &endpoint,
+                    });
                 (function_arn.clone(), payload)
             })
             .collect();

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -1126,16 +1126,16 @@ impl SnsService {
             let lambda_payloads: Vec<(String, String)> = lambda_subscribers
                 .iter()
                 .map(|(function_arn, subscription_arn)| {
-                    let payload = build_sns_lambda_event(
-                        &msg_id,
-                        &topic_arn,
+                    let payload = build_sns_lambda_event(&SnsLambdaEventInput {
+                        message_id: &msg_id,
+                        topic_arn: &topic_arn,
                         subscription_arn,
-                        &default_message,
-                        subject.as_deref(),
-                        &envelope_attrs,
-                        &now,
-                        &endpoint,
-                    );
+                        message: &default_message,
+                        subject: subject.as_deref(),
+                        message_attributes: &envelope_attrs,
+                        timestamp: &now,
+                        endpoint: &endpoint,
+                    });
                     (function_arn.clone(), payload)
                 })
                 .collect();
@@ -2602,36 +2602,38 @@ impl SnsService {
     }
 }
 
+/// Inputs to `build_sns_lambda_event` — one SNS message delivered to one Lambda subscription.
+pub(crate) struct SnsLambdaEventInput<'a> {
+    pub message_id: &'a str,
+    pub topic_arn: &'a str,
+    pub subscription_arn: &'a str,
+    pub message: &'a str,
+    pub subject: Option<&'a str>,
+    pub message_attributes: &'a serde_json::Map<String, Value>,
+    pub timestamp: &'a chrono::DateTime<Utc>,
+    pub endpoint: &'a str,
+}
+
 /// Build an SNS Lambda event payload (matches real AWS format).
 /// Used by both direct Publish and cross-service delivery.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn build_sns_lambda_event(
-    message_id: &str,
-    topic_arn: &str,
-    subscription_arn: &str,
-    message: &str,
-    subject: Option<&str>,
-    message_attributes: &serde_json::Map<String, Value>,
-    timestamp: &chrono::DateTime<Utc>,
-    endpoint: &str,
-) -> String {
+pub(crate) fn build_sns_lambda_event(input: &SnsLambdaEventInput<'_>) -> String {
     let sns_event = serde_json::json!({
         "Records": [{
             "EventVersion": "1.0",
-            "EventSubscriptionArn": subscription_arn,
+            "EventSubscriptionArn": input.subscription_arn,
             "EventSource": "aws:sns",
             "Sns": {
                 "SignatureVersion": "1",
-                "Timestamp": timestamp.to_rfc3339(),
+                "Timestamp": input.timestamp.to_rfc3339(),
                 "Signature": "FAKE_SIGNATURE",
                 "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
-                "MessageId": message_id,
-                "Message": message,
-                "MessageAttributes": message_attributes,
+                "MessageId": input.message_id,
+                "Message": input.message,
+                "MessageAttributes": input.message_attributes,
                 "Type": "Notification",
-                "UnsubscribeUrl": format!("{}/?Action=Unsubscribe&SubscriptionArn={}", endpoint, subscription_arn),
-                "TopicArn": topic_arn,
-                "Subject": subject.unwrap_or(""),
+                "UnsubscribeUrl": format!("{}/?Action=Unsubscribe&SubscriptionArn={}", input.endpoint, input.subscription_arn),
+                "TopicArn": input.topic_arn,
+                "Subject": input.subject.unwrap_or(""),
             }
         }]
     });
@@ -3601,16 +3603,16 @@ mod tests {
         let topic_arn = "arn:aws:sns:us-east-1:123456789012:my-topic";
         let attrs = serde_json::Map::new();
 
-        let payload = build_sns_lambda_event(
-            "msg-001",
+        let payload = build_sns_lambda_event(&SnsLambdaEventInput {
+            message_id: "msg-001",
             topic_arn,
-            sub_arn,
-            "hello",
-            Some("test subject"),
-            &attrs,
-            &now,
-            "http://localhost:4566",
-        );
+            subscription_arn: sub_arn,
+            message: "hello",
+            subject: Some("test subject"),
+            message_attributes: &attrs,
+            timestamp: &now,
+            endpoint: "http://localhost:4566",
+        });
 
         let parsed: Value = serde_json::from_str(&payload).unwrap();
         let record = &parsed["Records"][0];
@@ -3662,16 +3664,16 @@ mod tests {
         let attrs = serde_json::Map::new();
         let endpoint = "http://custom:9999";
 
-        let payload = build_sns_lambda_event(
-            "msg-003",
-            "arn:aws:sns:us-east-1:123456789012:my-topic",
-            sub_arn,
-            "hello",
-            None,
-            &attrs,
-            &now,
+        let payload = build_sns_lambda_event(&SnsLambdaEventInput {
+            message_id: "msg-003",
+            topic_arn: "arn:aws:sns:us-east-1:123456789012:my-topic",
+            subscription_arn: sub_arn,
+            message: "hello",
+            subject: None,
+            message_attributes: &attrs,
+            timestamp: &now,
             endpoint,
-        );
+        });
 
         let parsed: Value = serde_json::from_str(&payload).unwrap();
         let unsub_url = parsed["Records"][0]["Sns"]["UnsubscribeUrl"]


### PR DESCRIPTION
## Summary

All six ``#[allow(clippy::too_many_arguments)]`` sites in the codebase are replaced with named input structs that group the related parameters:

- ``CloudFormationService::new`` → ``CloudFormationDeps`` (8 sibling-state handles + delivery)
- ``cognito::triggers::build_{create,verify}_auth_challenge_event`` → ``AuthChallengeContext``
- ``iam::xml_responses::assume_role_*`` → ``AssumedRoleInfo``
- ``s3::logging::{format_access_log_entry,maybe_write_access_log}`` → ``AccessLogRequest``
- ``s3::service::notifications::deliver_notifications`` → ``ObjectEvent``
- ``sns::service::build_sns_lambda_event`` → ``SnsLambdaEventInput``
- ``dynamodb::service::build_table_description_json`` → ``TableDescriptionInput``

Every call site now uses labeled fields instead of a long positional list, which makes argument-order mistakes much harder to introduce.

## Test plan

- [x] ``cargo build --workspace``
- [x] ``cargo fmt --check``
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``
- [x] ``cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance`` — 1102 passed, 0 failed
- [x] grep: zero remaining ``#[allow(clippy::too_many_arguments)]`` attributes in ``crates/``
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all remaining clippy “too many arguments” sites with small input structs. This shortens function signatures, makes call sites safer with named fields, and keeps behavior unchanged.

- **Refactors**
  - CloudFormation: `CloudFormationService::new` now takes `CloudFormationDeps`.
  - Cognito triggers: `build_create_auth_challenge_event` and `build_verify_auth_challenge_event` take `AuthChallengeContext`.
  - IAM STS XML: `assume_role_*` responses take `AssumedRoleInfo`.
  - S3 logging: `format_access_log_entry` and `maybe_write_access_log` take `AccessLogRequest`.
  - S3 notifications: `deliver_notifications` takes `ObjectEvent`.
  - SNS: `build_sns_lambda_event` takes `SnsLambdaEventInput`.
  - DynamoDB: `build_table_description_json` takes `TableDescriptionInput`.

- **Migration**
  - Update external call sites to construct the new input structs and pass them by reference.
  - Example: `CloudFormationService::new(state, CloudFormationDeps { ... })`.

<sup>Written for commit a10e4cc38ae610be77a093bf8cdd43bdbe3f79ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

