### PR TITLE
refactor(cognito): extract user-status wire values into constants

### DIFF
--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod service;
 pub mod state;
 pub mod triggers;
+pub mod user_status;

--- a/crates/fakecloud-cognito/src/service/auth.rs
+++ b/crates/fakecloud-cognito/src/service/auth.rs
@@ -11,6 +11,7 @@ use crate::state::{
     AccessTokenData, AuthEvent, ChallengeResult, RefreshTokenData, SessionData, UserAttribute,
 };
 use crate::triggers::{self, TriggerSource};
+use crate::user_status;
 
 use super::{
     generate_confirmation_code, generate_tokens, parse_user_attributes, require_str,
@@ -224,7 +225,7 @@ impl CognitoService {
             }
 
             // Check if user needs to change password
-            if user.user_status == "FORCE_CHANGE_PASSWORD" {
+            if user.user_status == user_status::FORCE_CHANGE_PASSWORD {
                 let session = Uuid::new_v4().to_string();
                 state.sessions.insert(
                     session.clone(),
@@ -489,7 +490,7 @@ impl CognitoService {
                         ));
                     }
 
-                    if user.user_status == "FORCE_CHANGE_PASSWORD" {
+                    if user.user_status == user_status::FORCE_CHANGE_PASSWORD {
                         let session = Uuid::new_v4().to_string();
                         state.sessions.insert(
                             session.clone(),
@@ -1063,7 +1064,7 @@ impl CognitoService {
 
                 user.password = Some(new_password.to_string());
                 user.temporary_password = None;
-                user.user_status = "CONFIRMED".to_string();
+                user.user_status = user_status::CONFIRMED.to_string();
                 user.user_last_modified_date = Utc::now();
 
                 let sub = user.sub.clone();
@@ -1499,7 +1500,7 @@ impl CognitoService {
                 sub: sub.clone(),
                 attributes,
                 enabled: true,
-                user_status: "UNCONFIRMED".to_string(),
+                user_status: user_status::UNCONFIRMED.to_string(),
                 user_create_date: now,
                 user_last_modified_date: now,
                 password: Some(password.to_string()),
@@ -1562,7 +1563,7 @@ impl CognitoService {
                 .get_mut(&pool_id)
                 .and_then(|users| users.get_mut(username))
             {
-                u.user_status = "CONFIRMED".to_string();
+                u.user_status = user_status::CONFIRMED.to_string();
                 u.user_last_modified_date = Utc::now();
             }
         }
@@ -1614,7 +1615,7 @@ impl CognitoService {
                 )
             })?;
 
-        user.user_status = "CONFIRMED".to_string();
+        user.user_status = user_status::CONFIRMED.to_string();
         user.user_last_modified_date = Utc::now();
 
         let user_attrs = triggers::collect_user_attributes(user);
@@ -1677,7 +1678,7 @@ impl CognitoService {
                 )
             })?;
 
-        user.user_status = "CONFIRMED".to_string();
+        user.user_status = user_status::CONFIRMED.to_string();
         user.user_last_modified_date = Utc::now();
 
         let user_attrs = triggers::collect_user_attributes(user);
@@ -1959,7 +1960,7 @@ impl CognitoService {
         user.password = Some(password.to_string());
         user.temporary_password = None;
         user.confirmation_code = None;
-        user.user_status = "CONFIRMED".to_string();
+        user.user_status = user_status::CONFIRMED.to_string();
         user.user_last_modified_date = Utc::now();
 
         Ok(AwsResponse::ok_json(json!({})))
@@ -1997,7 +1998,7 @@ impl CognitoService {
                 )
             })?;
 
-        user.user_status = "RESET_REQUIRED".to_string();
+        user.user_status = user_status::RESET_REQUIRED.to_string();
         user.confirmation_code = Some(generate_confirmation_code());
         user.user_last_modified_date = Utc::now();
 

--- a/crates/fakecloud-cognito/src/service/users.rs
+++ b/crates/fakecloud-cognito/src/service/users.rs
@@ -9,6 +9,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::UserAttribute;
 use crate::triggers::{self, TriggerSource};
+use crate::user_status;
 
 use super::{
     generate_confirmation_code, matches_filter, parse_filter_expression, parse_string_array,
@@ -87,7 +88,7 @@ impl CognitoService {
                 sub: sub_val,
                 attributes,
                 enabled: true,
-                user_status: "FORCE_CHANGE_PASSWORD".to_string(),
+                user_status: user_status::FORCE_CHANGE_PASSWORD.to_string(),
                 user_create_date: now,
                 user_last_modified_date: now,
                 password: None,
@@ -142,7 +143,7 @@ impl CognitoService {
                             .get_mut(&pool_id_owned)
                             .and_then(|users| users.get_mut(&username_owned))
                         {
-                            u.user_status = "CONFIRMED".to_string();
+                            u.user_status = user_status::CONFIRMED.to_string();
                             u.user_last_modified_date = Utc::now();
                         }
                     }
@@ -642,7 +643,7 @@ impl CognitoService {
         if permanent {
             user.password = Some(password.to_string());
             user.temporary_password = None;
-            user.user_status = "CONFIRMED".to_string();
+            user.user_status = user_status::CONFIRMED.to_string();
         } else {
             user.temporary_password = Some(password.to_string());
         }

--- a/crates/fakecloud-cognito/src/user_status.rs
+++ b/crates/fakecloud-cognito/src/user_status.rs
@@ -1,0 +1,16 @@
+//! Cognito user-status wire values.
+//!
+//! Cognito represents a user's account state as one of a small set of
+//! string literals (``UNCONFIRMED``, ``CONFIRMED``, ``FORCE_CHANGE_PASSWORD``,
+//! etc.) on the wire. We keep them as constants rather than an enum so the
+//! JSON representation stays byte-identical to AWS without serde attributes,
+//! and to make sure the literal is spelled consistently everywhere.
+
+pub const UNCONFIRMED: &str = "UNCONFIRMED";
+pub const CONFIRMED: &str = "CONFIRMED";
+pub const ARCHIVED: &str = "ARCHIVED";
+pub const COMPROMISED: &str = "COMPROMISED";
+pub const UNKNOWN: &str = "UNKNOWN";
+pub const RESET_REQUIRED: &str = "RESET_REQUIRED";
+pub const FORCE_CHANGE_PASSWORD: &str = "FORCE_CHANGE_PASSWORD";
+pub const EXTERNAL_PROVIDER: &str = "EXTERNAL_PROVIDER";


### PR DESCRIPTION
## Summary

Cognito user account states (``UNCONFIRMED``, ``CONFIRMED``, ``FORCE_CHANGE_PASSWORD``, ``RESET_REQUIRED``, etc.) were scattered as bare string literals across ``service/auth.rs``, ``service/users.rs`` and ``service/mod.rs``. The auth state machine has ~20 transition points that set one of these.

Introduces ``crate::user_status`` with a named constant for each wire value. Production call sites now use the constant, which means:
- Typos in status names fail at compile time, not at runtime with a silent wire-format drift.
- Grepping for every place that sets a particular status is one command (``grep 'user_status::FORCE_CHANGE_PASSWORD'``) instead of needing to know the exact string.

Test-only assertions that verify the wire format are left as literals on purpose — those tests want to assert against the exact wire value, not the constant's definition.

Scope note: this PR only const-ifies Cognito user statuses. Other audit-flagged candidates (KMS policy version ``2012-10-17``, ElastiCache statuses ``available``/``primary``, Kinesis stream statuses) were considered but left as literals — they're well-known AWS wire values where a named constant would add import noise without improving readability or catching real bugs.

## Test plan

- [x] ``cargo build --workspace``
- [x] ``cargo fmt --check``
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``
- [x] ``cargo test -p fakecloud-cognito`` — 72 passed, 0 failed
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted Cognito user-status wire values into `crate::user_status` constants to replace scattered string literals and prevent typos. No behavior change; wire JSON stays the same.

- **Refactors**
  - Added `crate::user_status` with constants (e.g., `CONFIRMED`, `UNCONFIRMED`, `FORCE_CHANGE_PASSWORD`, `RESET_REQUIRED`).
  - Replaced literals in `service/auth.rs` and `service/users.rs` with these constants.
  - Kept test assertions as string literals to validate exact wire values.

<sup>Written for commit 6b1e7472a71a54369fc74443280882e97310518b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

