### PR TITLE
refactor: trim unnecessary clones in kms, dynamodb, and lambda

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -87,30 +87,24 @@ impl DynamoDbService {
             }
 
             // Capture kinesis delivery info (delivered after lock release)
-            let kinesis_info = if table
-                .kinesis_destinations
-                .iter()
-                .any(|d| d.destination_status == "ACTIVE")
-            {
-                Some((
-                    table.clone(),
+            let kinesis_info = DynamoDbService::kinesis_target(table).map(|target| {
+                (
+                    target,
                     event_name.to_string(),
                     key,
                     old_item_for_stream,
                     Some(item.clone()),
-                ))
-            } else {
-                None
-            };
+                )
+            });
 
             (old_item_for_return, kinesis_info)
         };
         // --- Write lock released, build response ---
 
         // Deliver to Kinesis destinations outside the lock
-        if let Some((table, event_name, keys, old_image, new_image)) = kinesis_info {
+        if let Some((target, event_name, keys, old_image, new_image)) = kinesis_info {
             self.deliver_to_kinesis_destinations(
-                &table,
+                &target,
                 &event_name,
                 &keys,
                 old_image.as_ref(),
@@ -235,12 +229,8 @@ impl DynamoDbService {
                 }
 
                 // Capture kinesis delivery info
-                if table
-                    .kinesis_destinations
-                    .iter()
-                    .any(|d| d.destination_status == "ACTIVE")
-                {
-                    kinesis_info = Some((table.clone(), key.clone(), Some(old_item)));
+                if let Some(target) = DynamoDbService::kinesis_target(table) {
+                    kinesis_info = Some((target, key.clone(), Some(old_item)));
                 }
 
                 table.items.remove(idx);
@@ -267,8 +257,14 @@ impl DynamoDbService {
         };
 
         // Deliver to Kinesis destinations outside the lock
-        if let Some((table, keys, old_image)) = kinesis_info {
-            self.deliver_to_kinesis_destinations(&table, "REMOVE", &keys, old_image.as_ref(), None);
+        if let Some((target, keys, old_image)) = kinesis_info {
+            self.deliver_to_kinesis_destinations(
+                &target,
+                "REMOVE",
+                &keys,
+                old_image.as_ref(),
+                None,
+            );
         }
 
         Self::ok_json(result)
@@ -363,21 +359,15 @@ impl DynamoDbService {
         }
 
         // Capture kinesis delivery info
-        let kinesis_info = if table
-            .kinesis_destinations
-            .iter()
-            .any(|d| d.destination_status == "ACTIVE")
-        {
-            Some((
-                table.clone(),
+        let kinesis_info = DynamoDbService::kinesis_target(table).map(|target| {
+            (
+                target,
                 event_name.to_string(),
                 key.clone(),
                 old_item_for_stream,
                 Some(new_item_for_stream),
-            ))
-        } else {
-            None
-        };
+            )
+        });
 
         table.recalculate_stats();
 
@@ -385,9 +375,9 @@ impl DynamoDbService {
         drop(state);
 
         // Deliver to Kinesis destinations outside the lock
-        if let Some((tbl, ev, keys, old_image, new_image)) = kinesis_info {
+        if let Some((target, ev, keys, old_image, new_image)) = kinesis_info {
             self.deliver_to_kinesis_destinations(
-                &tbl,
+                &target,
                 &ev,
                 &keys,
                 old_image.as_ref(),

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -20,9 +20,21 @@ use fakecloud_s3::state::SharedS3State;
 
 use crate::state::{
     attribute_type_and_value, AttributeDefinition, AttributeValue, DynamoTable,
-    GlobalSecondaryIndex, KeySchemaElement, LocalSecondaryIndex, Projection, ProvisionedThroughput,
-    SharedDynamoDbState,
+    GlobalSecondaryIndex, KeySchemaElement, KinesisDestination, LocalSecondaryIndex, Projection,
+    ProvisionedThroughput, SharedDynamoDbState,
 };
+
+/// Minimal subset of a ``DynamoTable`` that Kinesis streaming delivery needs.
+///
+/// A table can carry megabytes of items; cloning the whole table just to
+/// release the write lock and deliver one change record is extremely wasteful.
+/// Extracting only the fields the delivery path actually reads (destinations,
+/// arn, name) keeps the clone small.
+pub(super) struct KinesisDeliveryTarget {
+    pub destinations: Vec<KinesisDestination>,
+    pub arn: String,
+    pub name: String,
+}
 
 pub struct DynamoDbService {
     state: SharedDynamoDbState,
@@ -49,10 +61,26 @@ impl DynamoDbService {
         self
     }
 
+    fn kinesis_target(table: &DynamoTable) -> Option<KinesisDeliveryTarget> {
+        if table
+            .kinesis_destinations
+            .iter()
+            .any(|d| d.destination_status == "ACTIVE")
+        {
+            Some(KinesisDeliveryTarget {
+                destinations: table.kinesis_destinations.clone(),
+                arn: table.arn.clone(),
+                name: table.name.clone(),
+            })
+        } else {
+            None
+        }
+    }
+
     /// Deliver a change record to all active Kinesis streaming destinations for a table.
-    fn deliver_to_kinesis_destinations(
+    pub(super) fn deliver_to_kinesis_destinations(
         &self,
-        table: &DynamoTable,
+        target: &KinesisDeliveryTarget,
         event_name: &str,
         keys: &HashMap<String, AttributeValue>,
         old_image: Option<&HashMap<String, AttributeValue>>,
@@ -63,8 +91,8 @@ impl DynamoDbService {
             None => return,
         };
 
-        let active_destinations: Vec<_> = table
-            .kinesis_destinations
+        let active_destinations: Vec<_> = target
+            .destinations
             .iter()
             .filter(|d| d.destination_status == "ACTIVE")
             .collect();
@@ -78,15 +106,15 @@ impl DynamoDbService {
             "eventName": event_name,
             "eventVersion": "1.1",
             "eventSource": "aws:dynamodb",
-            "awsRegion": table.arn.split(':').nth(3).unwrap_or("us-east-1"),
+            "awsRegion": target.arn.split(':').nth(3).unwrap_or("us-east-1"),
             "dynamodb": {
                 "Keys": keys,
                 "SequenceNumber": chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0).to_string(),
                 "SizeBytes": serde_json::to_string(keys).map(|s| s.len()).unwrap_or(0),
                 "StreamViewType": "NEW_AND_OLD_IMAGES",
             },
-            "eventSourceARN": &table.arn,
-            "tableName": &table.name,
+            "eventSourceARN": &target.arn,
+            "tableName": &target.name,
         });
 
         if let Some(old) = old_image {

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -746,14 +746,13 @@ impl DynamoDbService {
             state.region, state.account_id, target_table_name
         );
 
-        let restored_items = backup.items.clone();
         let mut table = DynamoTable {
             name: target_table_name.to_string(),
             arn: arn.clone(),
             key_schema: backup.key_schema.clone(),
             attribute_definitions: backup.attribute_definitions.clone(),
             provisioned_throughput: backup.provisioned_throughput.clone(),
-            items: restored_items,
+            items: backup.items.clone(),
             gsi: Vec::new(),
             lsi: Vec::new(),
             tags: HashMap::new(),

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -2338,89 +2338,67 @@ impl KmsService {
 
         let mut state = self.state.write();
 
-        // Clone all needed data from source key first to avoid borrow issues
-        let source_key = state.keys.get(&resolved).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "KMSInternalException",
-                "Key state became inconsistent",
-            )
-        })?;
-        let source_key_id = source_key.key_id.clone();
-        let source_arn = source_key.arn.clone();
-        let source_creation_date = source_key.creation_date;
-        let source_description = source_key.description.clone();
-        let source_enabled = source_key.enabled;
-        let source_key_usage = source_key.key_usage.clone();
-        let source_key_spec = source_key.key_spec.clone();
-        let source_key_manager = source_key.key_manager.clone();
-        let source_key_state = source_key.key_state.clone();
-        let source_origin = source_key.origin.clone();
-        let source_tags = source_key.tags.clone();
-        let source_policy = source_key.policy.clone();
-        let source_signing_algorithms = source_key.signing_algorithms.clone();
-        let source_encryption_algorithms = source_key.encryption_algorithms.clone();
-        let source_mac_algorithms = source_key.mac_algorithms.clone();
+        // Clone the source key once and drop the borrow — the replica reuses
+        // every field except the region-dependent ones.
+        let source_key = state
+            .keys
+            .get(&resolved)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "KMSInternalException",
+                    "Key state became inconsistent",
+                )
+            })?
+            .clone();
         let account_id = state.account_id.clone();
         let source_region = state.region.clone();
 
         let replica_arn = format!(
             "arn:aws:kms:{}:{}:key/{}",
-            replica_region, account_id, source_key_id
+            replica_region, account_id, source_key.key_id
         );
 
         let metadata = json!({
-            "KeyId": source_key_id,
+            "KeyId": source_key.key_id,
             "Arn": replica_arn,
             "AWSAccountId": account_id,
-            "CreationDate": source_creation_date,
-            "Description": source_description,
-            "Enabled": source_enabled,
-            "KeyUsage": source_key_usage,
-            "KeySpec": source_key_spec,
-            "CustomerMasterKeySpec": source_key_spec,
-            "KeyManager": source_key_manager,
-            "KeyState": source_key_state,
-            "Origin": source_origin,
+            "CreationDate": source_key.creation_date,
+            "Description": source_key.description,
+            "Enabled": source_key.enabled,
+            "KeyUsage": source_key.key_usage,
+            "KeySpec": source_key.key_spec,
+            "CustomerMasterKeySpec": source_key.key_spec,
+            "KeyManager": source_key.key_manager,
+            "KeyState": source_key.key_state,
+            "Origin": source_key.origin,
             "MultiRegion": true,
             "MultiRegionConfiguration": {
                 "MultiRegionKeyType": "REPLICA",
                 "PrimaryKey": {
-                    "Arn": source_arn,
+                    "Arn": source_key.arn,
                     "Region": source_region,
                 },
                 "ReplicaKeys": [],
             },
         });
 
+        let replica_storage_key = format!("{}:{}", replica_region, source_key.key_id);
+        let source_policy = source_key.policy.clone();
         let replica_key = KmsKey {
-            key_id: source_key_id.clone(),
             arn: replica_arn,
-            creation_date: source_creation_date,
-            description: source_description,
-            enabled: source_enabled,
-            key_usage: source_key_usage,
-            key_spec: source_key_spec,
-            key_manager: source_key_manager,
-            key_state: source_key_state,
             deletion_date: None,
-            tags: source_tags,
-            policy: source_policy.clone(),
             key_rotation_enabled: false,
-            origin: source_origin,
             multi_region: true,
             rotations: Vec::new(),
-            signing_algorithms: source_signing_algorithms,
-            encryption_algorithms: source_encryption_algorithms,
-            mac_algorithms: source_mac_algorithms,
             custom_key_store_id: None,
             imported_key_material: false,
             imported_material_bytes: None,
             private_key_seed: rand_bytes(32),
             primary_region: None,
+            ..source_key
         };
 
-        let replica_storage_key = format!("{}:{}", replica_region, source_key_id);
         state.keys.insert(replica_storage_key, replica_key);
 
         Ok(AwsResponse::json(

--- a/crates/fakecloud-kms/src/state.rs
+++ b/crates/fakecloud-kms/src/state.rs
@@ -34,6 +34,7 @@ impl KmsState {
     }
 }
 
+#[derive(Clone)]
 pub struct KmsKey {
     pub key_id: String,
     pub arn: String,
@@ -82,6 +83,7 @@ pub struct KmsGrant {
     pub creation_date: f64,
 }
 
+#[derive(Clone)]
 pub struct KeyRotation {
     pub key_id: String,
     pub rotation_date: f64,

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -52,37 +52,37 @@ impl LambdaService {
             return None;
         }
 
-        match (req.method.clone(), segs.len()) {
+        match (&req.method, segs.len()) {
             // /2015-03-31/functions
-            (Method::POST, 2) if segs[1] == "functions" => Some(("CreateFunction", None)),
-            (Method::GET, 2) if segs[1] == "functions" => Some(("ListFunctions", None)),
+            (&Method::POST, 2) if segs[1] == "functions" => Some(("CreateFunction", None)),
+            (&Method::GET, 2) if segs[1] == "functions" => Some(("ListFunctions", None)),
             // /2015-03-31/functions/{name}
-            (Method::GET, 3) if segs[1] == "functions" => {
+            (&Method::GET, 3) if segs[1] == "functions" => {
                 Some(("GetFunction", Some(segs[2].clone())))
             }
-            (Method::DELETE, 3) if segs[1] == "functions" => {
+            (&Method::DELETE, 3) if segs[1] == "functions" => {
                 Some(("DeleteFunction", Some(segs[2].clone())))
             }
             // /2015-03-31/functions/{name}/invocations
-            (Method::POST, 4) if segs[1] == "functions" && segs[3] == "invocations" => {
+            (&Method::POST, 4) if segs[1] == "functions" && segs[3] == "invocations" => {
                 Some(("Invoke", Some(segs[2].clone())))
             }
             // /2015-03-31/functions/{name}/versions
-            (Method::POST, 4) if segs[1] == "functions" && segs[3] == "versions" => {
+            (&Method::POST, 4) if segs[1] == "functions" && segs[3] == "versions" => {
                 Some(("PublishVersion", Some(segs[2].clone())))
             }
             // /2015-03-31/event-source-mappings
-            (Method::POST, 2) if segs[1] == "event-source-mappings" => {
+            (&Method::POST, 2) if segs[1] == "event-source-mappings" => {
                 Some(("CreateEventSourceMapping", None))
             }
-            (Method::GET, 2) if segs[1] == "event-source-mappings" => {
+            (&Method::GET, 2) if segs[1] == "event-source-mappings" => {
                 Some(("ListEventSourceMappings", None))
             }
             // /2015-03-31/event-source-mappings/{uuid}
-            (Method::GET, 3) if segs[1] == "event-source-mappings" => {
+            (&Method::GET, 3) if segs[1] == "event-source-mappings" => {
                 Some(("GetEventSourceMapping", Some(segs[2].clone())))
             }
-            (Method::DELETE, 3) if segs[1] == "event-source-mappings" => {
+            (&Method::DELETE, 3) if segs[1] == "event-source-mappings" => {
                 Some(("DeleteEventSourceMapping", Some(segs[2].clone())))
             }
             _ => None,


### PR DESCRIPTION
## Summary

Three audit-flagged over-clone sites:

### ``fakecloud-kms::replicate_key``
Used to clone sixteen individual fields out of the source ``KmsKey`` *"to avoid borrow issues"* — the comment was literally on the line. Now derives ``Clone`` on ``KmsKey`` / ``KeyRotation``, clones the source once, and uses struct update syntax to reuse every field except the five region-dependent ones. Same replica key, ~30 fewer lines of field shuffling, one clone instead of sixteen.

### ``fakecloud-dynamodb::items``
Cloned the entire ``DynamoTable`` three times (put_item / delete_item / update_item) just to pass a handle into ``deliver_to_kinesis_destinations`` after dropping the write lock. Cloning the whole table clones every item too — potentially megabytes of user data — just to deliver one change record to Kinesis. Introduces a ``KinesisDeliveryTarget`` bundle with only the three fields delivery actually reads (destinations, arn, name) and clones that instead.

### ``fakecloud-lambda::resolve_action``
``match req.method.clone()`` → ``match &req.method`` with ``&Method::POST`` patterns.

Also inlines a redundant ``restored_items`` intermediate in ``restore_table_from_backup``.

## Test plan

- [x] ``cargo build --workspace``
- [x] ``cargo fmt --check``
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``
- [x] ``cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance`` — 1102 passed, 0 failed
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed over-cloning in `fakecloud-kms`, `fakecloud-dynamodb`, and `fakecloud-lambda` to cut allocations and avoid copying large data. No behavior change.

- **Refactors**
  - KMS: `replicate_key` clones `KmsKey` once (derive `Clone` on `KmsKey`/`KeyRotation`) and uses struct update; removes per-field clones.
  - DynamoDB: Introduced `KinesisDeliveryTarget` (destinations, arn, name) to avoid cloning entire `DynamoTable` for streaming; `deliver_to_kinesis_destinations` now takes this lightweight target.
  - Lambda: Match on `&req.method` instead of cloning `Method`.
  - DynamoDB: Inlined redundant `restored_items` in backup restore.

<sup>Written for commit 0f4ba1b9c24e38cda9d55d12adb6554e203f7934. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

