### PR TITLE
refactor: simplify SesState::reset and prefer vec![] in bedrock

### DIFF
--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -604,7 +604,7 @@ impl BedrockService {
     }
 
     fn list_foundation_models(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let mut model_summaries: Vec<Value> = Vec::new();
+        let mut model_summaries: Vec<Value> = vec![];
 
         let by_provider = req.query_params.get("byProvider");
         let by_output_modality = req.query_params.get("byOutputModality");

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -393,37 +393,11 @@ impl SesState {
         }
     }
 
+    /// Reinitialize every field except ``account_id`` / ``region``.
     pub fn reset(&mut self) {
-        self.identities.clear();
-        self.configuration_sets.clear();
-        self.templates.clear();
-        self.sent_emails.clear();
-        self.contact_lists.clear();
-        self.contacts.clear();
-        self.tags.clear();
-        self.suppressed_destinations.clear();
-        self.event_destinations.clear();
-        self.identity_policies.clear();
-        self.custom_verification_email_templates.clear();
-        self.dedicated_ip_pools.clear();
-        self.dedicated_ips.clear();
-        self.multi_region_endpoints.clear();
-        self.account_settings = AccountSettings {
-            sending_enabled: true,
-            dedicated_ip_auto_warmup_enabled: false,
-            suppressed_reasons: Vec::new(),
-            vdm_attributes: None,
-            details: None,
-        };
-        self.import_jobs.clear();
-        self.export_jobs.clear();
-        self.tenants.clear();
-        self.tenant_resource_associations.clear();
-        self.reputation_entities.clear();
-        self.receipt_rule_sets.clear();
-        self.active_receipt_rule_set = None;
-        self.receipt_filters.clear();
-        self.inbound_emails.clear();
+        let account_id = std::mem::take(&mut self.account_id);
+        let region = std::mem::take(&mut self.region);
+        *self = Self::new(&account_id, &region);
     }
 }
 


### PR DESCRIPTION
## Summary

Two small idiom-consistency fixes:

- **``SesState::reset``** open-coded "reinit every field except account_id and region" as a 25-line mirror of ``SesState::new``. Delegates by swapping out ``account_id`` / ``region`` with ``mem::take`` and reassigning ``*self = Self::new(...)``. The reset path can no longer silently drift from ``new`` when new state fields are added.
- **``bedrock::list_foundation_models``** used an explicit ``let mut model_summaries: Vec<Value> = Vec::new();``. Replaced with ``vec![]`` for consistency with the rest of the crate.

Scope note: several other audit-flagged "inconsistent idiom" sites were inspected and intentionally left alone — they turn out to be necessary (lock-scope clones, async-move captures, ``Option<String>`` vs ``String``-with-default semantic distinctions) rather than real inconsistency.

## Test plan

- [x] ``cargo build --workspace``
- [x] ``cargo fmt --check``
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``
- [x] ``cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance`` — 1102 passed, 0 failed
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies `fakecloud-ses` `SesState::reset` by reusing `new`, avoiding field-by-field resets and preventing drift; keeps `account_id` and `region` intact. Also updates `fakecloud-bedrock` `list_foundation_models` to use `vec![]` instead of `Vec::new()` for consistency.

<sup>Written for commit a6278350a876e7a5da56a9993d40afc9904f93c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

