### PR TITLE
refactor: typed enums for DynamoDB UpdateAction, IAM PolicyScope, ElastiCache engine

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -1371,6 +1371,35 @@ fn evaluate_in_match(
     })
 }
 
+/// One of the four DynamoDB ``UpdateExpression`` action keywords.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpdateAction {
+    Set,
+    Remove,
+    Add,
+    Delete,
+}
+
+impl UpdateAction {
+    /// All four keywords as written on the wire — these double as the search
+    /// terms for ``parse_update_clauses``.
+    const KEYWORDS: &'static [(&'static str, UpdateAction)] = &[
+        ("SET", UpdateAction::Set),
+        ("REMOVE", UpdateAction::Remove),
+        ("ADD", UpdateAction::Add),
+        ("DELETE", UpdateAction::Delete),
+    ];
+
+    fn keyword(self) -> &'static str {
+        match self {
+            UpdateAction::Set => "SET",
+            UpdateAction::Remove => "REMOVE",
+            UpdateAction::Add => "ADD",
+            UpdateAction::Delete => "DELETE",
+        }
+    }
+}
+
 fn apply_update_expression(
     item: &mut HashMap<String, AttributeValue>,
     expr: &str,
@@ -1386,47 +1415,39 @@ fn apply_update_expression(
         ));
     }
     for (action, assignments) in &clauses {
-        match action.to_ascii_uppercase().as_str() {
-            "SET" => {
+        match action {
+            UpdateAction::Set => {
                 for assignment in assignments {
                     apply_set_assignment(item, assignment, expr_attr_names, expr_attr_values)?;
                 }
             }
-            "REMOVE" => {
+            UpdateAction::Remove => {
                 for attr_ref in assignments {
                     let attr = resolve_attr_name(attr_ref.trim(), expr_attr_names);
                     item.remove(&attr);
                 }
             }
-            "ADD" => {
+            UpdateAction::Add => {
                 for assignment in assignments {
                     apply_add_assignment(item, assignment, expr_attr_names, expr_attr_values)?;
                 }
             }
-            "DELETE" => {
+            UpdateAction::Delete => {
                 for assignment in assignments {
                     apply_delete_assignment(item, assignment, expr_attr_names, expr_attr_values)?;
                 }
-            }
-            other => {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    format!("Invalid UpdateExpression: Invalid action: {}", other),
-                ));
             }
         }
     }
     Ok(())
 }
 
-fn parse_update_clauses(expr: &str) -> Vec<(String, Vec<String>)> {
-    let mut clauses: Vec<(String, Vec<String>)> = Vec::new();
+fn parse_update_clauses(expr: &str) -> Vec<(UpdateAction, Vec<String>)> {
+    let mut clauses: Vec<(UpdateAction, Vec<String>)> = Vec::new();
     let upper = expr.to_ascii_uppercase();
-    let keywords = ["SET", "REMOVE", "ADD", "DELETE"];
-    let mut positions: Vec<(usize, &str)> = Vec::new();
+    let mut positions: Vec<(usize, UpdateAction)> = Vec::new();
 
-    for kw in &keywords {
+    for &(kw, action) in UpdateAction::KEYWORDS {
         let mut search_from = 0;
         while let Some(pos) = upper[search_from..].find(kw) {
             let abs_pos = search_from + pos;
@@ -1435,7 +1456,7 @@ fn parse_update_clauses(expr: &str) -> Vec<(String, Vec<String>)> {
             let after_ok =
                 after_pos >= expr.len() || !expr.as_bytes()[after_pos].is_ascii_alphanumeric();
             if before_ok && after_ok {
-                positions.push((abs_pos, kw));
+                positions.push((abs_pos, action));
             }
             search_from = abs_pos + kw.len();
         }
@@ -1443,8 +1464,8 @@ fn parse_update_clauses(expr: &str) -> Vec<(String, Vec<String>)> {
 
     positions.sort_by_key(|(pos, _)| *pos);
 
-    for (i, &(pos, kw)) in positions.iter().enumerate() {
-        let start = pos + kw.len();
+    for (i, &(pos, action)) in positions.iter().enumerate() {
+        let start = pos + action.keyword().len();
         let end = if i + 1 < positions.len() {
             positions[i + 1].0
         } else {
@@ -1452,7 +1473,7 @@ fn parse_update_clauses(expr: &str) -> Vec<(String, Vec<String>)> {
         };
         let content = expr[start..end].trim();
         let assignments: Vec<String> = content.split(',').map(|s| s.trim().to_string()).collect();
-        clauses.push((kw.to_string(), assignments));
+        clauses.push((action, assignments));
     }
 
     clauses
@@ -2394,7 +2415,7 @@ mod tests {
     fn test_parse_update_clauses_set() {
         let clauses = parse_update_clauses("SET #a = :val1, #b = :val2");
         assert_eq!(clauses.len(), 1);
-        assert_eq!(clauses[0].0, "SET");
+        assert_eq!(clauses[0].0, UpdateAction::Set);
         assert_eq!(clauses[0].1.len(), 2);
     }
 
@@ -2402,8 +2423,8 @@ mod tests {
     fn test_parse_update_clauses_set_and_remove() {
         let clauses = parse_update_clauses("SET #a = :val1 REMOVE #b");
         assert_eq!(clauses.len(), 2);
-        assert_eq!(clauses[0].0, "SET");
-        assert_eq!(clauses[1].0, "REMOVE");
+        assert_eq!(clauses[0].0, UpdateAction::Set);
+        assert_eq!(clauses[1].0, UpdateAction::Remove);
     }
 
     #[test]

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -19,6 +19,23 @@ use crate::state::{
 };
 
 const ELASTICACHE_NS: &str = "http://elasticache.amazonaws.com/doc/2015-02-02/";
+
+/// Cache engine wire values. Stored as ``String`` on ``CacheCluster`` etc., but
+/// validated against this list at the wire boundary so a typo can't slip in.
+const ENGINE_REDIS: &str = "redis";
+const ENGINE_VALKEY: &str = "valkey";
+const SUPPORTED_ENGINES: &[&str] = &[ENGINE_REDIS, ENGINE_VALKEY];
+
+fn validate_engine(engine: &str) -> Result<(), AwsServiceError> {
+    if !SUPPORTED_ENGINES.contains(&engine) {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterValue",
+            format!("Invalid value for Engine: {engine}. Supported engines: redis, valkey"),
+        ));
+    }
+    Ok(())
+}
 const SUPPORTED_ACTIONS: &[&str] = &[
     "AddTagsToResource",
     "CreateCacheCluster",
@@ -598,16 +615,14 @@ impl ElastiCacheService {
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let cache_cluster_id = required_param(request, "CacheClusterId")?;
-        let engine = optional_param(request, "Engine").unwrap_or_else(|| "redis".to_string());
-        if engine != "redis" && engine != "valkey" {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                format!("Invalid value for Engine: {engine}. Supported engines: redis, valkey"),
-            ));
-        }
+        let engine = optional_param(request, "Engine").unwrap_or_else(|| ENGINE_REDIS.to_string());
+        validate_engine(&engine)?;
 
-        let default_version = if engine == "valkey" { "8.0" } else { "7.1" };
+        let default_version = if engine == ENGINE_VALKEY {
+            "8.0"
+        } else {
+            "7.1"
+        };
         let engine_version =
             optional_param(request, "EngineVersion").unwrap_or_else(|| default_version.to_string());
         let cache_node_type = optional_param(request, "CacheNodeType")
@@ -846,15 +861,13 @@ impl ElastiCacheService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let replication_group_id = required_param(request, "ReplicationGroupId")?;
         let description = required_param(request, "ReplicationGroupDescription")?;
-        let engine = optional_param(request, "Engine").unwrap_or_else(|| "redis".to_string());
-        if engine != "redis" && engine != "valkey" {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                format!("Invalid value for Engine: {engine}. Supported engines: redis, valkey"),
-            ));
-        }
-        let default_version = if engine == "valkey" { "8.0" } else { "7.1" };
+        let engine = optional_param(request, "Engine").unwrap_or_else(|| ENGINE_REDIS.to_string());
+        validate_engine(&engine)?;
+        let default_version = if engine == ENGINE_VALKEY {
+            "8.0"
+        } else {
+            "7.1"
+        };
         let engine_version =
             optional_param(request, "EngineVersion").unwrap_or_else(|| default_version.to_string());
         let cache_node_type = optional_param(request, "CacheNodeType")
@@ -2438,13 +2451,7 @@ impl ElastiCacheService {
         let engine = required_param(request, "Engine")?;
         let access_string = required_param(request, "AccessString")?;
 
-        if engine != "redis" && engine != "valkey" {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                format!("Invalid value for Engine: {engine}. Supported engines: redis, valkey"),
-            ));
-        }
+        validate_engine(&engine)?;
 
         let no_password_required =
             parse_optional_bool(optional_param(request, "NoPasswordRequired").as_deref())?
@@ -2502,7 +2509,7 @@ impl ElastiCacheService {
             ("no-password".to_string(), 0)
         };
 
-        let minimum_engine_version = if engine == "valkey" {
+        let minimum_engine_version = if engine == ENGINE_VALKEY {
             "8.0".to_string()
         } else {
             "6.0".to_string()
@@ -2632,17 +2639,11 @@ impl ElastiCacheService {
         let user_group_id = required_param(request, "UserGroupId")?;
         let engine = required_param(request, "Engine")?;
 
-        if engine != "redis" && engine != "valkey" {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                format!("Invalid value for Engine: {engine}. Supported engines: redis, valkey"),
-            ));
-        }
+        validate_engine(&engine)?;
 
         let user_ids = parse_member_list(&request.query_params, "UserIds", "member");
 
-        let minimum_engine_version = if engine == "valkey" {
+        let minimum_engine_version = if engine == ENGINE_VALKEY {
             "8.0".to_string()
         } else {
             "6.0".to_string()
@@ -2890,19 +2891,11 @@ fn parse_required_bool(req: &AwsRequest, name: &str) -> Result<bool, AwsServiceE
 }
 
 fn validate_serverless_engine(engine: &str) -> Result<(), AwsServiceError> {
-    if engine == "redis" || engine == "valkey" {
-        Ok(())
-    } else {
-        Err(AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "InvalidParameterValue",
-            format!("Invalid value for Engine: {engine}. Supported engines: redis, valkey"),
-        ))
-    }
+    validate_engine(engine)
 }
 
 fn default_major_engine_version(engine: &str) -> &'static str {
-    if engine == "valkey" {
+    if engine == ENGINE_VALKEY {
         "8.0"
     } else {
         "7.1"
@@ -2921,8 +2914,8 @@ fn default_full_engine_version(
         ));
     }
 
-    if (engine == "redis" && !major_engine_version.starts_with('7'))
-        || (engine == "valkey" && !major_engine_version.starts_with('8'))
+    if (engine == ENGINE_REDIS && !major_engine_version.starts_with('7'))
+        || (engine == ENGINE_VALKEY && !major_engine_version.starts_with('8'))
     {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-iam/src/iam_service/policies.rs
+++ b/crates/fakecloud-iam/src/iam_service/policies.rs
@@ -17,6 +17,28 @@ use fakecloud_aws::xml::xml_escape;
 
 use crate::policy_validation::validate_policy_document;
 
+/// IAM ``ListPolicies`` ``Scope`` filter.
+///
+/// ``All`` (the default) returns both AWS-managed and customer-managed policies,
+/// ``Aws`` returns only AWS-managed, and ``Local`` returns only
+/// customer-managed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PolicyScope {
+    All,
+    Aws,
+    Local,
+}
+
+impl PolicyScope {
+    fn from_query(value: Option<&str>) -> Self {
+        match value {
+            Some("AWS") => Self::Aws,
+            Some("Local") => Self::Local,
+            _ => Self::All,
+        }
+    }
+}
+
 impl IamService {
     pub(super) fn create_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let policy_name = required_param(&req.query_params, "PolicyName")?;
@@ -171,17 +193,15 @@ impl IamService {
 
         let state = self.state.read();
         let path_prefix = req.query_params.get("PathPrefix").cloned();
-        let scope = req.query_params.get("Scope").cloned();
+        let scope = PolicyScope::from_query(req.query_params.get("Scope").map(|s| s.as_str()));
         let mut policies: Vec<IamPolicy> = state.policies.values().cloned().collect();
         if let Some(prefix) = path_prefix {
             policies.retain(|p| p.path.starts_with(&prefix));
         }
-        // If scope is "Local", show only customer-managed
-        // If scope is "AWS", show only AWS-managed (we have none)
-        if let Some(s) = scope {
-            if s == "AWS" {
-                policies.clear();
-            }
+        if matches!(scope, PolicyScope::Aws) {
+            // We don't carry any AWS-managed policies in fakecloud, so an
+            // explicit ``Scope=AWS`` filter returns an empty list.
+            policies.clear();
         }
         let xml = xml_responses::list_policies_response(&policies, &req.request_id);
         Ok(AwsResponse::xml(StatusCode::OK, xml))


### PR DESCRIPTION
## Summary

Three string-match dispatches that genuinely benefit from being typed:

### DynamoDB ``UpdateAction``
``apply_update_expression`` matched on ``action.to_ascii_uppercase().as_str()`` against the four keywords (SET / REMOVE / ADD / DELETE). ``parse_update_clauses`` now produces ``Vec<(UpdateAction, Vec<String>)>`` so the keyword is parsed once at the boundary. The dispatch arm becomes a typed match, the "unknown action" error path goes away (the parser already filters them out), and the four keywords are listed in one place (``UpdateAction::KEYWORDS``).

### IAM ``PolicyScope``
``list_policies`` checked ``if s == "AWS" { policies.clear() }`` against a stringly-typed query parameter. Replaces with a small ``PolicyScope`` enum with ``from_query`` parsing — the All / Aws / Local semantics become explicit and the bare ``"AWS"`` magic string goes away.

### ElastiCache engine constants
``"redis"`` and ``"valkey"`` were scattered across six validation sites and three internal helpers. Replaces them with module constants ``ENGINE_REDIS`` / ``ENGINE_VALKEY`` and a single ``validate_engine`` helper that the four wire-boundary call sites and ``validate_serverless_engine`` all share. Storage stays as ``String`` for now since the wire format is also a string.

## Test plan

- [x] ``cargo build --workspace``
- [x] ``cargo fmt --check``
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``
- [x] ``cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance`` — 1102 passed, 0 failed
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced stringly-typed dispatch with typed enums and shared constants across DynamoDB, IAM, and ElastiCache to make parsing explicit and remove duplicate checks. No behavior change.

- **Refactors**
  - DynamoDB: Added `UpdateAction` enum; `parse_update_clauses` returns `Vec<(UpdateAction, Vec<String>)>`; `apply_update_expression` uses a typed match; centralized keywords via `UpdateAction::KEYWORDS`.
  - IAM: Added `PolicyScope` enum with `from_query`; `list_policies` now uses typed scope (All/Aws/Local) and removes the `"AWS"` magic string.
  - ElastiCache: Introduced `ENGINE_REDIS`, `ENGINE_VALKEY`, and `validate_engine`; all wire-boundary handlers use the shared validator; default version logic now checks against constants.

<sup>Written for commit ada669ab78a0a35b735b67117b5255128b7d147c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

