### PR TITLE
refactor(server): extract Cli and introspection helpers from main.rs

### DIFF
--- a/crates/fakecloud-server/src/cli.rs
+++ b/crates/fakecloud-server/src/cli.rs
@@ -1,0 +1,40 @@
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "fakecloud")]
+#[command(about = "FakeCloud — local AWS cloud emulator")]
+#[command(version)]
+pub(crate) struct Cli {
+    /// Listen address
+    #[arg(long, default_value = "0.0.0.0:4566", env = "FAKECLOUD_ADDR")]
+    pub addr: String,
+
+    /// AWS region to advertise
+    #[arg(long, default_value = "us-east-1", env = "FAKECLOUD_REGION")]
+    pub region: String,
+
+    /// AWS account ID to use
+    #[arg(long, default_value = "123456789012", env = "FAKECLOUD_ACCOUNT_ID")]
+    pub account_id: String,
+
+    /// Log level (trace, debug, info, warn, error)
+    #[arg(long, default_value = "info", env = "FAKECLOUD_LOG")]
+    pub log_level: String,
+}
+
+impl Cli {
+    /// Derive the public-facing endpoint URL from the configured bind address.
+    /// Wildcard hosts (``0.0.0.0`` / ``[::]``) are rewritten to ``localhost`` so
+    /// the URL is meaningful when handed back to clients.
+    pub fn endpoint_url(&self) -> String {
+        let addr = &self.addr;
+        let port = addr.rsplit(':').next().unwrap_or("4566");
+        let host = addr.rsplit_once(':').map(|(h, _)| h).unwrap_or("0.0.0.0");
+        let host = if host == "0.0.0.0" || host == "[::]" {
+            "localhost"
+        } else {
+            host
+        };
+        format!("http://{host}:{port}")
+    }
+}

--- a/crates/fakecloud-server/src/introspection.rs
+++ b/crates/fakecloud-server/src/introspection.rs
@@ -1,0 +1,140 @@
+//! Helpers that translate raw service state into the public introspection
+//! response types from ``fakecloud-sdk``.
+//!
+//! These mappings exist so the ``GET /_fakecloud/...`` introspection endpoints
+//! can hand back stable structs without leaking secrets (e.g. RDS master
+//! passwords) or runtime-internal fields.
+
+use fakecloud_sdk::types;
+
+pub(crate) fn rds_instance_response(
+    instance: &fakecloud_rds::state::DbInstance,
+) -> types::RdsInstance {
+    types::RdsInstance {
+        db_instance_identifier: instance.db_instance_identifier.clone(),
+        db_instance_arn: instance.db_instance_arn.clone(),
+        db_instance_class: instance.db_instance_class.clone(),
+        engine: instance.engine.clone(),
+        engine_version: instance.engine_version.clone(),
+        db_instance_status: instance.db_instance_status.clone(),
+        master_username: instance.master_username.clone(),
+        db_name: instance.db_name.clone(),
+        endpoint_address: instance.endpoint_address.clone(),
+        port: instance.port,
+        allocated_storage: instance.allocated_storage,
+        publicly_accessible: instance.publicly_accessible,
+        deletion_protection: instance.deletion_protection,
+        created_at: instance.created_at.to_rfc3339(),
+        dbi_resource_id: instance.dbi_resource_id.clone(),
+        container_id: instance.container_id.clone(),
+        host_port: instance.host_port,
+        tags: instance
+            .tags
+            .iter()
+            .map(|tag| types::RdsTag {
+                key: tag.key.clone(),
+                value: tag.value.clone(),
+            })
+            .collect(),
+    }
+}
+
+pub(crate) fn elasticache_cluster_response(
+    cluster: &fakecloud_elasticache::state::CacheCluster,
+) -> types::ElastiCacheCluster {
+    types::ElastiCacheCluster {
+        cache_cluster_id: cluster.cache_cluster_id.clone(),
+        cache_cluster_status: cluster.cache_cluster_status.clone(),
+        engine: cluster.engine.clone(),
+        engine_version: cluster.engine_version.clone(),
+        cache_node_type: cluster.cache_node_type.clone(),
+        num_cache_nodes: cluster.num_cache_nodes,
+        replication_group_id: cluster.replication_group_id.clone(),
+        port: Some(cluster.endpoint_port as i32),
+        host_port: Some(cluster.host_port),
+        container_id: Some(cluster.container_id.clone()),
+    }
+}
+
+pub(crate) fn elasticache_replication_group_response(
+    group: &fakecloud_elasticache::state::ReplicationGroup,
+) -> types::ElastiCacheReplicationGroupIntrospection {
+    types::ElastiCacheReplicationGroupIntrospection {
+        replication_group_id: group.replication_group_id.clone(),
+        status: group.status.clone(),
+        description: group.description.clone(),
+        member_clusters: group.member_clusters.clone(),
+        automatic_failover: group.automatic_failover_enabled,
+        multi_az: group.automatic_failover_enabled,
+        engine: group.engine.clone(),
+        engine_version: group.engine_version.clone(),
+        cache_node_type: group.cache_node_type.clone(),
+        num_cache_clusters: group.num_cache_clusters,
+    }
+}
+
+pub(crate) fn elasticache_serverless_cache_response(
+    cache: &fakecloud_elasticache::state::ServerlessCache,
+) -> types::ElastiCacheServerlessCacheIntrospection {
+    types::ElastiCacheServerlessCacheIntrospection {
+        serverless_cache_name: cache.serverless_cache_name.clone(),
+        status: cache.status.clone(),
+        engine: cache.engine.clone(),
+        engine_version: cache.full_engine_version.clone(),
+        cache_node_type: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use fakecloud_rds::state::DbInstance;
+
+    use super::rds_instance_response;
+
+    #[test]
+    fn rds_instance_response_omits_password_but_keeps_runtime_metadata() {
+        let created_at = Utc::now();
+        let instance = DbInstance {
+            db_instance_identifier: "db-1".to_string(),
+            db_instance_arn: "arn:aws:rds:us-east-1:123456789012:db:db-1".to_string(),
+            db_instance_class: "db.t3.micro".to_string(),
+            engine: "postgres".to_string(),
+            engine_version: "16.3".to_string(),
+            db_instance_status: "available".to_string(),
+            master_username: "admin".to_string(),
+            db_name: Some("appdb".to_string()),
+            endpoint_address: "127.0.0.1".to_string(),
+            port: 15432,
+            allocated_storage: 20,
+            publicly_accessible: true,
+            deletion_protection: false,
+            created_at,
+            dbi_resource_id: "db-test".to_string(),
+            master_user_password: "secret123".to_string(),
+            container_id: "container-id".to_string(),
+            host_port: 15432,
+            tags: vec![fakecloud_rds::state::RdsTag {
+                key: "env".to_string(),
+                value: "test".to_string(),
+            }],
+            read_replica_source_db_instance_identifier: None,
+            read_replica_db_instance_identifiers: Vec::new(),
+            vpc_security_group_ids: Vec::new(),
+            db_parameter_group_name: None,
+            backup_retention_period: 1,
+            preferred_backup_window: "03:00-04:00".to_string(),
+            latest_restorable_time: Some(created_at),
+            option_group_name: None,
+            multi_az: false,
+            pending_modified_values: None,
+        };
+
+        let response = rds_instance_response(&instance);
+
+        assert_eq!(response.db_instance_identifier, "db-1");
+        assert_eq!(response.container_id, "container-id");
+        assert_eq!(response.host_port, 15432);
+        assert_eq!(response.tags.len(), 1);
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -12,13 +12,20 @@ use fakecloud_core::dispatch::{self, DispatchConfig};
 use fakecloud_core::registry::ServiceRegistry;
 use fakecloud_sdk::types;
 
+mod cli;
 mod dynamodb_streams_lambda_poller;
+mod introspection;
 mod kinesis_lambda_poller;
 mod lambda_delivery;
 mod reset;
 mod sqs_lambda_poller;
 mod stepfunctions_delivery;
+use cli::Cli;
 use dynamodb_streams_lambda_poller::DynamoDbStreamsLambdaPoller;
+use introspection::{
+    elasticache_cluster_response, elasticache_replication_group_response,
+    elasticache_serverless_cache_response, rds_instance_response,
+};
 use kinesis_lambda_poller::KinesisLambdaPoller;
 use reset::ResetState;
 use sqs_lambda_poller::SqsLambdaPoller;
@@ -45,28 +52,6 @@ use fakecloud_sqs::service::SqsService;
 use fakecloud_ssm::service::SsmService;
 use fakecloud_stepfunctions::service::StepFunctionsService;
 
-#[derive(Parser)]
-#[command(name = "fakecloud")]
-#[command(about = "FakeCloud — local AWS cloud emulator")]
-#[command(version)]
-struct Cli {
-    /// Listen address
-    #[arg(long, default_value = "0.0.0.0:4566", env = "FAKECLOUD_ADDR")]
-    addr: String,
-
-    /// AWS region to advertise
-    #[arg(long, default_value = "us-east-1", env = "FAKECLOUD_REGION")]
-    region: String,
-
-    /// AWS account ID to use
-    #[arg(long, default_value = "123456789012", env = "FAKECLOUD_ACCOUNT_ID")]
-    account_id: String,
-
-    /// Log level (trace, debug, info, warn, error)
-    #[arg(long, default_value = "info", env = "FAKECLOUD_LOG")]
-    log_level: String,
-}
-
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
@@ -78,19 +63,7 @@ async fn main() {
         )
         .init();
 
-    // Derive endpoint URL from the configured bind address.
-    // Use rsplit to handle IPv6 addresses (e.g., "[::1]:4566").
-    let endpoint_url = {
-        let addr = &cli.addr;
-        let port = addr.rsplit(':').next().unwrap_or("4566");
-        let host = addr.rsplit_once(':').map(|(h, _)| h).unwrap_or("0.0.0.0");
-        let host = if host == "0.0.0.0" || host == "[::]" {
-            "localhost"
-        } else {
-            host
-        };
-        format!("http://{host}:{port}")
-    };
+    let endpoint_url = cli.endpoint_url();
 
     // Shared state
     let iam_state = Arc::new(parking_lot::RwLock::new(
@@ -1560,134 +1533,4 @@ async fn shutdown_signal() {
         .await
         .expect("failed to install Ctrl+C handler");
     tracing::info!("shutting down");
-}
-
-fn rds_instance_response(instance: &fakecloud_rds::state::DbInstance) -> types::RdsInstance {
-    types::RdsInstance {
-        db_instance_identifier: instance.db_instance_identifier.clone(),
-        db_instance_arn: instance.db_instance_arn.clone(),
-        db_instance_class: instance.db_instance_class.clone(),
-        engine: instance.engine.clone(),
-        engine_version: instance.engine_version.clone(),
-        db_instance_status: instance.db_instance_status.clone(),
-        master_username: instance.master_username.clone(),
-        db_name: instance.db_name.clone(),
-        endpoint_address: instance.endpoint_address.clone(),
-        port: instance.port,
-        allocated_storage: instance.allocated_storage,
-        publicly_accessible: instance.publicly_accessible,
-        deletion_protection: instance.deletion_protection,
-        created_at: instance.created_at.to_rfc3339(),
-        dbi_resource_id: instance.dbi_resource_id.clone(),
-        container_id: instance.container_id.clone(),
-        host_port: instance.host_port,
-        tags: instance
-            .tags
-            .iter()
-            .map(|tag| types::RdsTag {
-                key: tag.key.clone(),
-                value: tag.value.clone(),
-            })
-            .collect(),
-    }
-}
-
-fn elasticache_cluster_response(
-    cluster: &fakecloud_elasticache::state::CacheCluster,
-) -> types::ElastiCacheCluster {
-    types::ElastiCacheCluster {
-        cache_cluster_id: cluster.cache_cluster_id.clone(),
-        cache_cluster_status: cluster.cache_cluster_status.clone(),
-        engine: cluster.engine.clone(),
-        engine_version: cluster.engine_version.clone(),
-        cache_node_type: cluster.cache_node_type.clone(),
-        num_cache_nodes: cluster.num_cache_nodes,
-        replication_group_id: cluster.replication_group_id.clone(),
-        port: Some(cluster.endpoint_port as i32),
-        host_port: Some(cluster.host_port),
-        container_id: Some(cluster.container_id.clone()),
-    }
-}
-
-fn elasticache_replication_group_response(
-    group: &fakecloud_elasticache::state::ReplicationGroup,
-) -> types::ElastiCacheReplicationGroupIntrospection {
-    types::ElastiCacheReplicationGroupIntrospection {
-        replication_group_id: group.replication_group_id.clone(),
-        status: group.status.clone(),
-        description: group.description.clone(),
-        member_clusters: group.member_clusters.clone(),
-        automatic_failover: group.automatic_failover_enabled,
-        multi_az: group.automatic_failover_enabled,
-        engine: group.engine.clone(),
-        engine_version: group.engine_version.clone(),
-        cache_node_type: group.cache_node_type.clone(),
-        num_cache_clusters: group.num_cache_clusters,
-    }
-}
-
-fn elasticache_serverless_cache_response(
-    cache: &fakecloud_elasticache::state::ServerlessCache,
-) -> types::ElastiCacheServerlessCacheIntrospection {
-    types::ElastiCacheServerlessCacheIntrospection {
-        serverless_cache_name: cache.serverless_cache_name.clone(),
-        status: cache.status.clone(),
-        engine: cache.engine.clone(),
-        engine_version: cache.full_engine_version.clone(),
-        cache_node_type: None,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use chrono::Utc;
-    use fakecloud_rds::state::DbInstance;
-
-    use super::rds_instance_response;
-
-    #[test]
-    fn rds_instance_response_omits_password_but_keeps_runtime_metadata() {
-        let created_at = Utc::now();
-        let instance = DbInstance {
-            db_instance_identifier: "db-1".to_string(),
-            db_instance_arn: "arn:aws:rds:us-east-1:123456789012:db:db-1".to_string(),
-            db_instance_class: "db.t3.micro".to_string(),
-            engine: "postgres".to_string(),
-            engine_version: "16.3".to_string(),
-            db_instance_status: "available".to_string(),
-            master_username: "admin".to_string(),
-            db_name: Some("appdb".to_string()),
-            endpoint_address: "127.0.0.1".to_string(),
-            port: 15432,
-            allocated_storage: 20,
-            publicly_accessible: true,
-            deletion_protection: false,
-            created_at,
-            dbi_resource_id: "db-test".to_string(),
-            master_user_password: "secret123".to_string(),
-            container_id: "container-id".to_string(),
-            host_port: 15432,
-            tags: vec![fakecloud_rds::state::RdsTag {
-                key: "env".to_string(),
-                value: "test".to_string(),
-            }],
-            read_replica_source_db_instance_identifier: None,
-            read_replica_db_instance_identifiers: Vec::new(),
-            vpc_security_group_ids: Vec::new(),
-            db_parameter_group_name: None,
-            backup_retention_period: 1,
-            preferred_backup_window: "03:00-04:00".to_string(),
-            latest_restorable_time: Some(created_at),
-            option_group_name: None,
-            multi_az: false,
-            pending_modified_values: None,
-        };
-
-        let response = rds_instance_response(&instance);
-
-        assert_eq!(response.db_instance_identifier, "db-1");
-        assert_eq!(response.container_id, "container-id");
-        assert_eq!(response.host_port, 15432);
-        assert_eq!(response.tags.len(), 1);
-    }
 }


### PR DESCRIPTION
## Summary

- Extract the `Cli` struct (clap parser) from `crates/fakecloud-server/src/main.rs` into a new `crates/fakecloud-server/src/cli.rs`.
- Add a small `Cli::endpoint_url()` method that derives the public URL from the configured bind address (rewriting wildcard hosts `0.0.0.0` / `[::]` to `localhost` so the URL is meaningful when handed back to clients). main.rs no longer needs to do this string surgery inline.
- Extract the four introspection response builders (`rds_instance_response`, `elasticache_cluster_response`, `elasticache_replication_group_response`, `elasticache_serverless_cache_response`) into a new `crates/fakecloud-server/src/introspection.rs`. These translate raw service state into the public SDK types and exist explicitly so the `GET /_fakecloud/...` endpoints don't leak runtime-internal fields like RDS master passwords.
- The existing `rds_instance_response_omits_password_but_keeps_runtime_metadata` test moves with the helper.
- main.rs shrinks by 165 lines and now contains only the bind / orchestration / shutdown logic.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance`
- [x] `cargo build -p fakecloud`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split server startup by moving the CLI parser and introspection builders out of `main.rs`, keeping startup orchestration focused. Added `Cli::endpoint_url()` to derive a client-facing URL (rewrites `0.0.0.0`/`[::]` to `localhost`).

- **Refactors**
  - New `crates/fakecloud-server/src/cli.rs`: defines `Cli` (via `clap`) and `endpoint_url()`.
  - New `crates/fakecloud-server/src/introspection.rs`: response builders for RDS/ElastiCache map runtime state to `fakecloud-sdk` types without secrets; includes the password-redaction test.
  - `main.rs` now imports these helpers and focuses on bind/setup; reduced by ~165 lines.

<sup>Written for commit b32db67c5bd13bf365d6703f4e3108510b863712. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

