### PR TITLE
refactor(cognito): split handle_auth_challenge_response per challenge

### DIFF
--- a/crates/fakecloud-cognito/src/service/auth.rs
+++ b/crates/fakecloud-cognito/src/service/auth.rs
@@ -982,451 +982,10 @@ impl CognitoService {
         body: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
         match challenge_name {
-            "NEW_PASSWORD_REQUIRED" => {
-                let challenge_responses =
-                    body["ChallengeResponses"].as_object().ok_or_else(|| {
-                        AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "InvalidParameterException",
-                            "ChallengeResponses is required",
-                        )
-                    })?;
-
-                let new_password = challenge_responses
-                    .get("NEW_PASSWORD")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| {
-                        AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "InvalidParameterException",
-                            "NEW_PASSWORD is required in ChallengeResponses",
-                        )
-                    })?;
-
-                let mut state = self.state.write();
-
-                let session_data = state.sessions.remove(session).ok_or_else(|| {
-                    AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "NotAuthorizedException",
-                        "Invalid session.",
-                    )
-                })?;
-
-                if session_data.client_id != client_id {
-                    return Err(AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "NotAuthorizedException",
-                        "Invalid session.",
-                    ));
-                }
-
-                if session_data.challenge_name != "NEW_PASSWORD_REQUIRED" {
-                    return Err(AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "NotAuthorizedException",
-                        "Invalid session.",
-                    ));
-                }
-
-                // Validate password against pool policy (clone to release immutable borrow)
-                let password_policy = state
-                    .user_pools
-                    .get(&session_data.user_pool_id)
-                    .ok_or_else(|| {
-                        AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "ResourceNotFoundException",
-                            "User pool does not exist.",
-                        )
-                    })?
-                    .policies
-                    .password_policy
-                    .clone();
-                validate_password(new_password, &password_policy)?;
-
-                let region = state.region.clone();
-
-                let user = state
-                    .users
-                    .get_mut(&session_data.user_pool_id)
-                    .and_then(|users| users.get_mut(&session_data.username))
-                    .ok_or_else(|| {
-                        AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "UserNotFoundException",
-                            "User does not exist.",
-                        )
-                    })?;
-
-                user.password = Some(new_password.to_string());
-                user.temporary_password = None;
-                user.user_status = user_status::CONFIRMED.to_string();
-                user.user_last_modified_date = Utc::now();
-
-                let sub = user.sub.clone();
-                let username = user.username.clone();
-                let pool_id = session_data.user_pool_id.clone();
-
-                let tokens = generate_tokens(&pool_id, client_id, &sub, &username, &region);
-
-                state.refresh_tokens.insert(
-                    tokens.refresh_token.clone(),
-                    RefreshTokenData {
-                        user_pool_id: pool_id.clone(),
-                        username: username.clone(),
-                        client_id: client_id.to_string(),
-                        issued_at: Utc::now(),
-                    },
-                );
-
-                state.access_tokens.insert(
-                    tokens.access_token.clone(),
-                    AccessTokenData {
-                        user_pool_id: pool_id,
-                        username,
-                        client_id: client_id.to_string(),
-                        issued_at: Utc::now(),
-                    },
-                );
-
-                Ok(AwsResponse::ok_json(json!({
-                    "AuthenticationResult": {
-                        "AccessToken": tokens.access_token,
-                        "IdToken": tokens.id_token,
-                        "RefreshToken": tokens.refresh_token,
-                        "TokenType": "Bearer",
-                        "ExpiresIn": 3600
-                    }
-                })))
-            }
+            "NEW_PASSWORD_REQUIRED" => self.respond_new_password_required(client_id, session, body),
             "CUSTOM_CHALLENGE" => {
-                let challenge_responses =
-                    body["ChallengeResponses"].as_object().ok_or_else(|| {
-                        AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "InvalidParameterException",
-                            "ChallengeResponses is required",
-                        )
-                    })?;
-
-                let answer = challenge_responses
-                    .get("ANSWER")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| {
-                        AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "InvalidParameterException",
-                            "ANSWER is required in ChallengeResponses",
-                        )
-                    })?;
-
-                // Extract session data (remove session to consume it)
-                let (
-                    pool_id,
-                    username,
-                    session_client_id,
-                    mut challenge_results,
-                    challenge_metadata,
-                ) = {
-                    let mut state = self.state.write();
-                    let session_data = state.sessions.remove(session).ok_or_else(|| {
-                        AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "NotAuthorizedException",
-                            "Invalid session.",
-                        )
-                    })?;
-
-                    if session_data.client_id != client_id {
-                        return Err(AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "NotAuthorizedException",
-                            "Invalid session.",
-                        ));
-                    }
-
-                    if session_data.challenge_name != "CUSTOM_CHALLENGE" {
-                        return Err(AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "NotAuthorizedException",
-                            "Invalid session.",
-                        ));
-                    }
-
-                    (
-                        session_data.user_pool_id,
-                        session_data.username,
-                        session_data.client_id,
-                        session_data.challenge_results,
-                        session_data.challenge_metadata,
-                    )
-                };
-
-                // Get user attributes
-                let (user_attrs, region, account_id) = {
-                    let state = self.state.read();
-                    let user = state
-                        .users
-                        .get(&pool_id)
-                        .and_then(|users| users.get(&username))
-                        .ok_or_else(|| {
-                            AwsServiceError::aws_error(
-                                StatusCode::BAD_REQUEST,
-                                "NotAuthorizedException",
-                                "User does not exist.",
-                            )
-                        })?;
-                    let user_attrs = triggers::collect_user_attributes(user);
-                    let region = state.region.clone();
-                    let account_id = state.account_id.clone();
-                    (user_attrs, region, account_id)
-                };
-
-                let ctx = self.delivery_ctx.as_ref().ok_or_else(|| {
-                    AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "InvalidLambdaResponseException",
-                        "No Lambda trigger configured for VerifyAuthChallengeResponse.",
-                    )
-                })?;
-
-                // Invoke VerifyAuthChallengeResponse Lambda
-                let verify_arn = triggers::get_trigger_arn(
-                    &self.state,
-                    &pool_id,
-                    TriggerSource::VerifyAuthChallengeResponseAuthentication,
-                )
-                .ok_or_else(|| {
-                    AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "InvalidLambdaResponseException",
-                        "No Lambda trigger configured for VerifyAuthChallengeResponse.",
-                    )
-                })?;
-
-                let verify_ctx = triggers::AuthChallengeContext {
-                    pool_id: &pool_id,
-                    client_id: Some(&session_client_id),
-                    username: &username,
-                    user_attributes: &user_attrs,
-                    region: &region,
-                    account_id: &account_id,
-                };
-                let verify_event = triggers::build_verify_auth_challenge_event(
-                    &verify_ctx,
-                    answer,
-                    challenge_metadata.as_deref(),
-                );
-
-                let verify_response = triggers::invoke_trigger(ctx, &verify_arn, &verify_event)
+                self.respond_custom_challenge(client_id, session, body)
                     .await
-                    .ok_or_else(|| {
-                        AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "InvalidLambdaResponseException",
-                            "VerifyAuthChallengeResponse Lambda did not return a response.",
-                        )
-                    })?;
-
-                let answer_correct = verify_response["response"]["answerCorrect"]
-                    .as_bool()
-                    .unwrap_or(false);
-
-                // Record this challenge result
-                challenge_results.push(ChallengeResult {
-                    challenge_name: "CUSTOM_CHALLENGE".to_string(),
-                    challenge_result: answer_correct,
-                    challenge_metadata: challenge_metadata.clone(),
-                });
-
-                // Invoke DefineAuthChallenge again with updated session
-                let define_arn = triggers::get_trigger_arn(
-                    &self.state,
-                    &pool_id,
-                    TriggerSource::DefineAuthChallengeAuthentication,
-                )
-                .ok_or_else(|| {
-                    AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "InvalidLambdaResponseException",
-                        "No Lambda trigger configured for DefineAuthChallenge.",
-                    )
-                })?;
-
-                let define_event = triggers::build_define_auth_challenge_event(
-                    &pool_id,
-                    Some(&session_client_id),
-                    &username,
-                    &user_attrs,
-                    &challenge_results,
-                    &region,
-                    &account_id,
-                );
-
-                let define_response = triggers::invoke_trigger(ctx, &define_arn, &define_event)
-                    .await
-                    .ok_or_else(|| {
-                        AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "InvalidLambdaResponseException",
-                            "DefineAuthChallenge Lambda did not return a response.",
-                        )
-                    })?;
-
-                let issue_tokens = define_response["response"]["issueTokens"]
-                    .as_bool()
-                    .unwrap_or(false);
-                let fail_auth = define_response["response"]["failAuthentication"]
-                    .as_bool()
-                    .unwrap_or(false);
-
-                if fail_auth {
-                    let mut state = self.state.write();
-                    state.auth_events.push(AuthEvent {
-                        event_id: Uuid::new_v4().to_string(),
-                        event_type: "SIGN_IN_FAILURE".to_string(),
-                        username: username.clone(),
-                        user_pool_id: pool_id,
-                        client_id: Some(session_client_id),
-                        timestamp: Utc::now(),
-                        success: false,
-                        feedback_value: None,
-                    });
-                    return Err(AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "NotAuthorizedException",
-                        "DefineAuthChallenge Lambda rejected authentication.",
-                    ));
-                }
-
-                if issue_tokens {
-                    // Issue tokens
-                    let mut state = self.state.write();
-                    let user = state
-                        .users
-                        .get(&pool_id)
-                        .and_then(|users| users.get(&username))
-                        .ok_or_else(|| {
-                            AwsServiceError::aws_error(
-                                StatusCode::BAD_REQUEST,
-                                "NotAuthorizedException",
-                                "User does not exist.",
-                            )
-                        })?;
-
-                    let sub = user.sub.clone();
-                    let tokens =
-                        generate_tokens(&pool_id, &session_client_id, &sub, &username, &region);
-
-                    state.refresh_tokens.insert(
-                        tokens.refresh_token.clone(),
-                        RefreshTokenData {
-                            user_pool_id: pool_id.clone(),
-                            username: username.clone(),
-                            client_id: session_client_id.clone(),
-                            issued_at: Utc::now(),
-                        },
-                    );
-                    state.access_tokens.insert(
-                        tokens.access_token.clone(),
-                        AccessTokenData {
-                            user_pool_id: pool_id.clone(),
-                            username: username.clone(),
-                            client_id: session_client_id.clone(),
-                            issued_at: Utc::now(),
-                        },
-                    );
-                    state.auth_events.push(AuthEvent {
-                        event_id: Uuid::new_v4().to_string(),
-                        event_type: "SIGN_IN".to_string(),
-                        username,
-                        user_pool_id: pool_id,
-                        client_id: Some(session_client_id),
-                        timestamp: Utc::now(),
-                        success: true,
-                        feedback_value: None,
-                    });
-
-                    return Ok(AwsResponse::ok_json(json!({
-                        "AuthenticationResult": {
-                            "AccessToken": tokens.access_token,
-                            "IdToken": tokens.id_token,
-                            "RefreshToken": tokens.refresh_token,
-                            "TokenType": "Bearer",
-                            "ExpiresIn": 3600
-                        }
-                    })));
-                }
-
-                // Another challenge round — invoke CreateAuthChallenge
-                let next_challenge_name = define_response["response"]["challengeName"]
-                    .as_str()
-                    .unwrap_or("CUSTOM_CHALLENGE")
-                    .to_string();
-
-                let create_arn = triggers::get_trigger_arn(
-                    &self.state,
-                    &pool_id,
-                    TriggerSource::CreateAuthChallengeAuthentication,
-                );
-
-                let mut public_challenge_params = serde_json::Map::new();
-                let mut new_challenge_metadata: Option<String> = None;
-
-                if let Some(create_arn) = create_arn {
-                    let create_ctx = triggers::AuthChallengeContext {
-                        pool_id: &pool_id,
-                        client_id: Some(&session_client_id),
-                        username: &username,
-                        user_attributes: &user_attrs,
-                        region: &region,
-                        account_id: &account_id,
-                    };
-                    let create_event = triggers::build_create_auth_challenge_event(
-                        &create_ctx,
-                        &next_challenge_name,
-                        &challenge_results,
-                    );
-                    if let Some(create_response) =
-                        triggers::invoke_trigger(ctx, &create_arn, &create_event).await
-                    {
-                        if let Some(params) =
-                            create_response["response"]["publicChallengeParameters"].as_object()
-                        {
-                            public_challenge_params = params.clone();
-                        }
-                        new_challenge_metadata = create_response["response"]["challengeMetadata"]
-                            .as_str()
-                            .map(|s| s.to_string());
-                    }
-                }
-
-                // Store new session
-                let new_session = Uuid::new_v4().to_string();
-                {
-                    let mut state = self.state.write();
-                    state.sessions.insert(
-                        new_session.clone(),
-                        SessionData {
-                            user_pool_id: pool_id,
-                            username: username.clone(),
-                            client_id: session_client_id,
-                            challenge_name: next_challenge_name.clone(),
-                            challenge_results,
-                            challenge_metadata: new_challenge_metadata,
-                        },
-                    );
-                }
-
-                let mut response = json!({
-                    "ChallengeName": next_challenge_name,
-                    "Session": new_session,
-                    "ChallengeParameters": public_challenge_params,
-                });
-                response["ChallengeParameters"]["USERNAME"] = json!(username);
-
-                Ok(AwsResponse::ok_json(response))
             }
             _ => Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1434,6 +993,452 @@ impl CognitoService {
                 format!("Unsupported challenge: {challenge_name}"),
             )),
         }
+    }
+
+    fn respond_new_password_required(
+        &self,
+        client_id: &str,
+        session: &str,
+        body: &Value,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let challenge_responses = body["ChallengeResponses"].as_object().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "ChallengeResponses is required",
+            )
+        })?;
+
+        let new_password = challenge_responses
+            .get("NEW_PASSWORD")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "NEW_PASSWORD is required in ChallengeResponses",
+                )
+            })?;
+
+        let mut state = self.state.write();
+
+        let session_data = state.sessions.remove(session).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid session.",
+            )
+        })?;
+
+        if session_data.client_id != client_id
+            || session_data.challenge_name != "NEW_PASSWORD_REQUIRED"
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Invalid session.",
+            ));
+        }
+
+        let password_policy = state
+            .user_pools
+            .get(&session_data.user_pool_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    "User pool does not exist.",
+                )
+            })?
+            .policies
+            .password_policy
+            .clone();
+        validate_password(new_password, &password_policy)?;
+
+        let region = state.region.clone();
+
+        let user = state
+            .users
+            .get_mut(&session_data.user_pool_id)
+            .and_then(|users| users.get_mut(&session_data.username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "UserNotFoundException",
+                    "User does not exist.",
+                )
+            })?;
+
+        user.password = Some(new_password.to_string());
+        user.temporary_password = None;
+        user.user_status = user_status::CONFIRMED.to_string();
+        user.user_last_modified_date = Utc::now();
+
+        let sub = user.sub.clone();
+        let username = user.username.clone();
+        let pool_id = session_data.user_pool_id.clone();
+
+        let tokens = generate_tokens(&pool_id, client_id, &sub, &username, &region);
+
+        state.refresh_tokens.insert(
+            tokens.refresh_token.clone(),
+            RefreshTokenData {
+                user_pool_id: pool_id.clone(),
+                username: username.clone(),
+                client_id: client_id.to_string(),
+                issued_at: Utc::now(),
+            },
+        );
+
+        state.access_tokens.insert(
+            tokens.access_token.clone(),
+            AccessTokenData {
+                user_pool_id: pool_id,
+                username,
+                client_id: client_id.to_string(),
+                issued_at: Utc::now(),
+            },
+        );
+
+        Ok(AwsResponse::ok_json(json!({
+            "AuthenticationResult": {
+                "AccessToken": tokens.access_token,
+                "IdToken": tokens.id_token,
+                "RefreshToken": tokens.refresh_token,
+                "TokenType": "Bearer",
+                "ExpiresIn": 3600
+            }
+        })))
+    }
+
+    async fn respond_custom_challenge(
+        &self,
+        client_id: &str,
+        session: &str,
+        body: &Value,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let challenge_responses = body["ChallengeResponses"].as_object().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "ChallengeResponses is required",
+            )
+        })?;
+
+        let answer = challenge_responses
+            .get("ANSWER")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "ANSWER is required in ChallengeResponses",
+                )
+            })?;
+
+        let (pool_id, username, session_client_id, mut challenge_results, challenge_metadata) = {
+            let mut state = self.state.write();
+            let session_data = state.sessions.remove(session).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid session.",
+                )
+            })?;
+
+            if session_data.client_id != client_id
+                || session_data.challenge_name != "CUSTOM_CHALLENGE"
+            {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid session.",
+                ));
+            }
+
+            (
+                session_data.user_pool_id,
+                session_data.username,
+                session_data.client_id,
+                session_data.challenge_results,
+                session_data.challenge_metadata,
+            )
+        };
+
+        let (user_attrs, region, account_id) = {
+            let state = self.state.read();
+            let user = state
+                .users
+                .get(&pool_id)
+                .and_then(|users| users.get(&username))
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "NotAuthorizedException",
+                        "User does not exist.",
+                    )
+                })?;
+            let user_attrs = triggers::collect_user_attributes(user);
+            let region = state.region.clone();
+            let account_id = state.account_id.clone();
+            (user_attrs, region, account_id)
+        };
+
+        let ctx = self.delivery_ctx.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidLambdaResponseException",
+                "No Lambda trigger configured for VerifyAuthChallengeResponse.",
+            )
+        })?;
+
+        let verify_arn = triggers::get_trigger_arn(
+            &self.state,
+            &pool_id,
+            TriggerSource::VerifyAuthChallengeResponseAuthentication,
+        )
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidLambdaResponseException",
+                "No Lambda trigger configured for VerifyAuthChallengeResponse.",
+            )
+        })?;
+
+        let verify_ctx = triggers::AuthChallengeContext {
+            pool_id: &pool_id,
+            client_id: Some(&session_client_id),
+            username: &username,
+            user_attributes: &user_attrs,
+            region: &region,
+            account_id: &account_id,
+        };
+        let verify_event = triggers::build_verify_auth_challenge_event(
+            &verify_ctx,
+            answer,
+            challenge_metadata.as_deref(),
+        );
+
+        let verify_response = triggers::invoke_trigger(ctx, &verify_arn, &verify_event)
+            .await
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidLambdaResponseException",
+                    "VerifyAuthChallengeResponse Lambda did not return a response.",
+                )
+            })?;
+
+        let answer_correct = verify_response["response"]["answerCorrect"]
+            .as_bool()
+            .unwrap_or(false);
+
+        challenge_results.push(ChallengeResult {
+            challenge_name: "CUSTOM_CHALLENGE".to_string(),
+            challenge_result: answer_correct,
+            challenge_metadata: challenge_metadata.clone(),
+        });
+
+        let define_arn = triggers::get_trigger_arn(
+            &self.state,
+            &pool_id,
+            TriggerSource::DefineAuthChallengeAuthentication,
+        )
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidLambdaResponseException",
+                "No Lambda trigger configured for DefineAuthChallenge.",
+            )
+        })?;
+
+        let define_event = triggers::build_define_auth_challenge_event(
+            &pool_id,
+            Some(&session_client_id),
+            &username,
+            &user_attrs,
+            &challenge_results,
+            &region,
+            &account_id,
+        );
+
+        let define_response = triggers::invoke_trigger(ctx, &define_arn, &define_event)
+            .await
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidLambdaResponseException",
+                    "DefineAuthChallenge Lambda did not return a response.",
+                )
+            })?;
+
+        let issue_tokens = define_response["response"]["issueTokens"]
+            .as_bool()
+            .unwrap_or(false);
+        let fail_auth = define_response["response"]["failAuthentication"]
+            .as_bool()
+            .unwrap_or(false);
+
+        if fail_auth {
+            let mut state = self.state.write();
+            state.auth_events.push(AuthEvent {
+                event_id: Uuid::new_v4().to_string(),
+                event_type: "SIGN_IN_FAILURE".to_string(),
+                username,
+                user_pool_id: pool_id,
+                client_id: Some(session_client_id),
+                timestamp: Utc::now(),
+                success: false,
+                feedback_value: None,
+            });
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "DefineAuthChallenge Lambda rejected authentication.",
+            ));
+        }
+
+        if issue_tokens {
+            return self.custom_challenge_issue_tokens(
+                &pool_id,
+                &session_client_id,
+                &username,
+                &region,
+            );
+        }
+
+        let next_challenge_name = define_response["response"]["challengeName"]
+            .as_str()
+            .unwrap_or("CUSTOM_CHALLENGE")
+            .to_string();
+
+        let create_arn = triggers::get_trigger_arn(
+            &self.state,
+            &pool_id,
+            TriggerSource::CreateAuthChallengeAuthentication,
+        );
+
+        let mut public_challenge_params = serde_json::Map::new();
+        let mut new_challenge_metadata: Option<String> = None;
+
+        if let Some(create_arn) = create_arn {
+            let create_ctx = triggers::AuthChallengeContext {
+                pool_id: &pool_id,
+                client_id: Some(&session_client_id),
+                username: &username,
+                user_attributes: &user_attrs,
+                region: &region,
+                account_id: &account_id,
+            };
+            let create_event = triggers::build_create_auth_challenge_event(
+                &create_ctx,
+                &next_challenge_name,
+                &challenge_results,
+            );
+            if let Some(create_response) =
+                triggers::invoke_trigger(ctx, &create_arn, &create_event).await
+            {
+                if let Some(params) =
+                    create_response["response"]["publicChallengeParameters"].as_object()
+                {
+                    public_challenge_params = params.clone();
+                }
+                new_challenge_metadata = create_response["response"]["challengeMetadata"]
+                    .as_str()
+                    .map(|s| s.to_string());
+            }
+        }
+
+        let new_session = Uuid::new_v4().to_string();
+        {
+            let mut state = self.state.write();
+            state.sessions.insert(
+                new_session.clone(),
+                SessionData {
+                    user_pool_id: pool_id,
+                    username: username.clone(),
+                    client_id: session_client_id,
+                    challenge_name: next_challenge_name.clone(),
+                    challenge_results,
+                    challenge_metadata: new_challenge_metadata,
+                },
+            );
+        }
+
+        let mut response = json!({
+            "ChallengeName": next_challenge_name,
+            "Session": new_session,
+            "ChallengeParameters": public_challenge_params,
+        });
+        response["ChallengeParameters"]["USERNAME"] = json!(username);
+
+        Ok(AwsResponse::ok_json(response))
+    }
+
+    /// Mint and persist tokens for a CUSTOM_CHALLENGE round whose final
+    /// DefineAuthChallenge response set `issueTokens: true`. Mirrors the
+    /// success-path bookkeeping that USER_PASSWORD_AUTH does.
+    fn custom_challenge_issue_tokens(
+        &self,
+        pool_id: &str,
+        client_id: &str,
+        username: &str,
+        region: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let mut state = self.state.write();
+        let user = state
+            .users
+            .get(pool_id)
+            .and_then(|users| users.get(username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "User does not exist.",
+                )
+            })?;
+
+        let sub = user.sub.clone();
+        let tokens = generate_tokens(pool_id, client_id, &sub, username, region);
+
+        state.refresh_tokens.insert(
+            tokens.refresh_token.clone(),
+            RefreshTokenData {
+                user_pool_id: pool_id.to_string(),
+                username: username.to_string(),
+                client_id: client_id.to_string(),
+                issued_at: Utc::now(),
+            },
+        );
+        state.access_tokens.insert(
+            tokens.access_token.clone(),
+            AccessTokenData {
+                user_pool_id: pool_id.to_string(),
+                username: username.to_string(),
+                client_id: client_id.to_string(),
+                issued_at: Utc::now(),
+            },
+        );
+        state.auth_events.push(AuthEvent {
+            event_id: Uuid::new_v4().to_string(),
+            event_type: "SIGN_IN".to_string(),
+            username: username.to_string(),
+            user_pool_id: pool_id.to_string(),
+            client_id: Some(client_id.to_string()),
+            timestamp: Utc::now(),
+            success: true,
+            feedback_value: None,
+        });
+
+        Ok(AwsResponse::ok_json(json!({
+            "AuthenticationResult": {
+                "AccessToken": tokens.access_token,
+                "IdToken": tokens.id_token,
+                "RefreshToken": tokens.refresh_token,
+                "TokenType": "Bearer",
+                "ExpiresIn": 3600
+            }
+        })))
     }
 
     pub(super) async fn sign_up(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {


### PR DESCRIPTION
## Summary

The 460-line \`handle_auth_challenge_response\` inlined two arms whose control flow had nothing in common. \`NEW_PASSWORD_REQUIRED\` is a single write-locked sequence (validate session, validate new password against the pool's password policy, swap the user's password, mint tokens). \`CUSTOM_CHALLENGE\` is a Lambda choreography (consume session, snapshot user attrs under a read lock, run \`VerifyAuthChallengeResponse\`, then \`DefineAuthChallenge\`, then either fail / issue tokens / kick off \`CreateAuthChallenge\` for the next round).

Extract each into its own helper:

- \`respond_new_password_required\`: synchronous, no Lambda triggers, so it sheds the \`async\` modifier.
- \`respond_custom_challenge\`: keeps the async path. The token-issuance branch is its own \`custom_challenge_issue_tokens\` helper since it reproduces the same write-lock bookkeeping (refresh + access token insertion, \`AuthEvent\` push) used elsewhere on a successful sign-in.

Two duplicate session-validity checks (\`client_id\` mismatch / \`challenge_name\` mismatch each had their own if-block) collapse into a single combined check per arm. Lock scopes, side-effect ordering, and error wording are preserved exactly.

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-cognito\` (72 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the 460-line Cognito `handle_auth_challenge_response` into per-challenge helpers for clarity and safer lock handling. Behavior is unchanged; session validation, token minting, and Lambda flow remain the same.

- **Refactors**
  - Extracted `respond_new_password_required` (sync) and `respond_custom_challenge` (async).
  - Added `custom_challenge_issue_tokens` to centralize token issuance on custom challenge success.
  - Consolidated session validity checks; preserved lock scopes, side effects, and error wording.

<sup>Written for commit 0332c25ebcb78d05562c7fe7dfa0e6f8334e824a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

