### PR TITLE
refactor(iam): split long IAM ops in roles, account, and oidc

### DIFF
--- a/crates/fakecloud-iam/src/iam_service/account.rs
+++ b/crates/fakecloud-iam/src/iam_service/account.rs
@@ -4,11 +4,314 @@ use http::StatusCode;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{AccountPasswordPolicy, VirtualMfaDevice};
+use crate::state::{AccountPasswordPolicy, IamState, VirtualMfaDevice};
 
 use super::{empty_response, parse_tags, required_param, tags_xml, url_encode, IamService};
 
 use fakecloud_aws::xml::xml_escape;
+
+/// Build the `<UserDetailList>` body for `GetAccountAuthorizationDetails`.
+/// Each `<member>` carries the user record plus its inline policies, group
+/// memberships, attached managed policies, and tags — exactly the fields
+/// AWS returns in the same call.
+fn build_user_details_xml(state: &IamState) -> String {
+    state
+        .users
+        .values()
+        .map(|u| {
+            let inline_policies: String = state
+                .user_inline_policies
+                .get(&u.user_name)
+                .map(|policies| {
+                    policies
+                        .iter()
+                        .map(|(name, doc)| {
+                            format!(
+                                "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyDocument>{}</PolicyDocument>\n          </member>",
+                                xml_escape(name),
+                                url_encode(doc)
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                })
+                .unwrap_or_default();
+
+            let attached: String = state
+                .user_policies
+                .get(&u.user_name)
+                .map(|arns| {
+                    arns.iter()
+                        .filter_map(|arn| {
+                            state.policies.get(arn).map(|p| {
+                                format!(
+                                    "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyArn>{}</PolicyArn>\n          </member>",
+                                    p.policy_name, p.arn
+                                )
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                })
+                .unwrap_or_default();
+
+            let group_list: String = state
+                .groups
+                .values()
+                .filter(|g| g.members.contains(&u.user_name))
+                .map(|g| format!("          <member>{}</member>", g.group_name))
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let tags_members = tags_xml(&u.tags);
+
+            format!(
+                "      <member>\n        <Path>{}</Path>\n        <UserName>{}</UserName>\n        <UserId>{}</UserId>\n        <Arn>{}</Arn>\n        <CreateDate>{}</CreateDate>\n        <UserPolicyList>\n{inline_policies}\n        </UserPolicyList>\n        <GroupList>\n{group_list}\n        </GroupList>\n        <AttachedManagedPolicies>\n{attached}\n        </AttachedManagedPolicies>\n        <Tags>\n{tags_members}\n        </Tags>\n      </member>",
+                u.path, u.user_name, u.user_id, u.arn, u.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Build the `<RoleDetailList>` body for `GetAccountAuthorizationDetails`.
+/// Each `<member>` carries the role plus its inline policies, attached
+/// managed policies, the instance profiles it lives in, and tags.
+fn build_role_details_xml(state: &IamState) -> String {
+    state
+        .roles
+        .values()
+        .map(|r| {
+            let inline_policies: String = state
+                .role_inline_policies
+                .get(&r.role_name)
+                .map(|policies| {
+                    policies
+                        .iter()
+                        .map(|(name, doc)| {
+                            format!(
+                                "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyDocument>{}</PolicyDocument>\n          </member>",
+                                xml_escape(name),
+                                url_encode(doc)
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                })
+                .unwrap_or_default();
+
+            let attached: String = state
+                .role_policies
+                .get(&r.role_name)
+                .map(|arns| {
+                    arns.iter()
+                        .filter_map(|arn| {
+                            state.policies.get(arn).map(|p| {
+                                format!(
+                                    "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyArn>{}</PolicyArn>\n          </member>",
+                                    p.policy_name, p.arn
+                                )
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                })
+                .unwrap_or_default();
+
+            let instance_profiles: String = state
+                .instance_profiles
+                .values()
+                .filter(|ip| ip.roles.contains(&r.role_name))
+                .map(|ip| {
+                    format!(
+                        "          <member>\n            <InstanceProfileName>{}</InstanceProfileName>\n            <InstanceProfileId>{}</InstanceProfileId>\n            <Arn>{}</Arn>\n            <Path>{}</Path>\n            <CreateDate>{}</CreateDate>\n          </member>",
+                        ip.instance_profile_name, ip.instance_profile_id, ip.arn, ip.path, ip.created_at.format("%Y-%m-%dT%H:%M:%SZ")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let tags_members = tags_xml(&r.tags);
+
+            format!(
+                "      <member>\n        <Path>{}</Path>\n        <RoleName>{}</RoleName>\n        <RoleId>{}</RoleId>\n        <Arn>{}</Arn>\n        <CreateDate>{}</CreateDate>\n        <AssumeRolePolicyDocument>{}</AssumeRolePolicyDocument>\n        <RolePolicyList>\n{inline_policies}\n        </RolePolicyList>\n        <AttachedManagedPolicies>\n{attached}\n        </AttachedManagedPolicies>\n        <InstanceProfileList>\n{instance_profiles}\n        </InstanceProfileList>\n        <Tags>\n{tags_members}\n        </Tags>\n      </member>",
+                r.path, r.role_name, r.role_id, r.arn, r.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
+                url_encode(&r.assume_role_policy_document),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Build the `<GroupDetailList>` body for `GetAccountAuthorizationDetails`.
+/// Each `<member>` carries the group plus its inline policies and attached
+/// managed policies.
+fn build_group_details_xml(state: &IamState) -> String {
+    state
+        .groups
+        .values()
+        .map(|g| {
+            let inline_policies: String = g
+                .inline_policies
+                .iter()
+                .map(|(name, doc)| {
+                    format!(
+                        "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyDocument>{}</PolicyDocument>\n          </member>",
+                        xml_escape(name),
+                        url_encode(doc)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let attached: String = g
+                .attached_policies
+                .iter()
+                .filter_map(|arn| {
+                    state.policies.get(arn).map(|p| {
+                        format!(
+                            "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyArn>{}</PolicyArn>\n          </member>",
+                            p.policy_name, p.arn
+                        )
+                    })
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            format!(
+                "      <member>\n        <Path>{}</Path>\n        <GroupName>{}</GroupName>\n        <GroupId>{}</GroupId>\n        <Arn>{}</Arn>\n        <CreateDate>{}</CreateDate>\n        <GroupPolicyList>\n{inline_policies}\n        </GroupPolicyList>\n        <AttachedManagedPolicies>\n{attached}\n        </AttachedManagedPolicies>\n      </member>",
+                g.path, g.group_name, g.group_id, g.arn, g.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Validate the upper-bound constraints AWS enforces on the password
+/// policy. AWS reports every violating field in a single ValidationError,
+/// so we collect all of them before returning.
+fn validate_password_policy_inputs(req: &AwsRequest) -> Result<(), AwsServiceError> {
+    let min_len: Option<i64> = req
+        .query_params
+        .get("MinimumPasswordLength")
+        .and_then(|v| v.parse().ok());
+    let max_age: Option<i64> = req
+        .query_params
+        .get("MaxPasswordAge")
+        .and_then(|v| v.parse().ok());
+    let reuse_prevention: Option<i64> = req
+        .query_params
+        .get("PasswordReusePrevention")
+        .and_then(|v| v.parse().ok());
+
+    let mut errors = Vec::new();
+    if let Some(v) = min_len {
+        if v > 128 {
+            errors.push(format!("Value \"{v}\" at \"minimumPasswordLength\" failed to satisfy constraint: Member must have value less than or equal to 128"));
+        }
+    }
+    if let Some(v) = reuse_prevention {
+        if v > 24 {
+            errors.push(format!("Value \"{v}\" at \"passwordReusePrevention\" failed to satisfy constraint: Member must have value less than or equal to 24"));
+        }
+    }
+    if let Some(v) = max_age {
+        if v > 1095 {
+            errors.push(format!("Value \"{v}\" at \"maxPasswordAge\" failed to satisfy constraint: Member must have value less than or equal to 1095"));
+        }
+    }
+
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    let n = errors.len();
+    let msg = format!(
+        "{n} validation error{} detected: {}",
+        if n > 1 { "s" } else { "" },
+        errors.join("; ")
+    );
+    Err(AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ValidationError",
+        msg,
+    ))
+}
+
+/// Apply each provided password-policy field onto the policy. Absent
+/// fields keep their existing value (consistent with AWS PATCH-style
+/// semantics on this endpoint).
+fn apply_password_policy_updates(policy: &mut AccountPasswordPolicy, req: &AwsRequest) {
+    if let Some(v) = req
+        .query_params
+        .get("MinimumPasswordLength")
+        .and_then(|v| v.parse().ok())
+    {
+        policy.minimum_password_length = v;
+    }
+    if let Some(v) = req.query_params.get("RequireSymbols") {
+        policy.require_symbols = v == "true";
+    }
+    if let Some(v) = req.query_params.get("RequireNumbers") {
+        policy.require_numbers = v == "true";
+    }
+    if let Some(v) = req.query_params.get("RequireUppercaseCharacters") {
+        policy.require_uppercase_characters = v == "true";
+    }
+    if let Some(v) = req.query_params.get("RequireLowercaseCharacters") {
+        policy.require_lowercase_characters = v == "true";
+    }
+    if let Some(v) = req.query_params.get("AllowUsersToChangePassword") {
+        policy.allow_users_to_change_password = v == "true";
+    }
+    if let Some(v) = req
+        .query_params
+        .get("MaxPasswordAge")
+        .and_then(|v| v.parse().ok())
+    {
+        policy.max_password_age = v;
+    }
+    if let Some(v) = req
+        .query_params
+        .get("PasswordReusePrevention")
+        .and_then(|v| v.parse().ok())
+    {
+        policy.password_reuse_prevention = v;
+    }
+    if let Some(v) = req.query_params.get("HardExpiry") {
+        policy.hard_expiry = v == "true";
+    }
+}
+
+/// Build the `<Policies>` body for `GetAccountAuthorizationDetails`. Each
+/// `<member>` carries the policy plus the full version list (so a caller
+/// can see every revision the policy has had, not just the default).
+fn build_policy_details_xml(state: &IamState) -> String {
+    state
+        .policies
+        .values()
+        .map(|p| {
+            let versions: String = p
+                .versions
+                .iter()
+                .map(|v| {
+                    format!(
+                        "            <member>\n              <VersionId>{}</VersionId>\n              <IsDefaultVersion>{}</IsDefaultVersion>\n              <Document>{}</Document>\n              <CreateDate>{}</CreateDate>\n            </member>",
+                        v.version_id, v.is_default, url_encode(&v.document), v.created_at.format("%Y-%m-%dT%H:%M:%SZ")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            format!(
+                "      <member>\n        <PolicyName>{}</PolicyName>\n        <PolicyId>{}</PolicyId>\n        <Arn>{}</Arn>\n        <Path>{}</Path>\n        <DefaultVersionId>{}</DefaultVersionId>\n        <AttachmentCount>{}</AttachmentCount>\n        <IsAttachable>true</IsAttachable>\n        <CreateDate>{}</CreateDate>\n        <PolicyVersionList>\n{versions}\n        </PolicyVersionList>\n      </member>",
+                p.policy_name, p.policy_id, p.arn, p.path, p.default_version_id,
+                p.attachment_count, p.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 impl IamService {
     pub(super) fn get_account_summary(
@@ -97,195 +400,10 @@ impl IamService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let state = self.state.read();
 
-        // Build user details
-        let user_details: String = state
-            .users
-            .values()
-            .map(|u| {
-                let inline_policies: String = state
-                    .user_inline_policies
-                    .get(&u.user_name)
-                    .map(|policies| {
-                        policies
-                            .iter()
-                            .map(|(name, doc)| {
-                                format!(
-                                    "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyDocument>{}</PolicyDocument>\n          </member>",
-                                    xml_escape(name),
-                                    url_encode(doc)
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    })
-                    .unwrap_or_default();
-
-                let attached: String = state
-                    .user_policies
-                    .get(&u.user_name)
-                    .map(|arns| {
-                        arns.iter()
-                            .filter_map(|arn| {
-                                state.policies.get(arn).map(|p| {
-                                    format!(
-                                        "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyArn>{}</PolicyArn>\n          </member>",
-                                        p.policy_name, p.arn
-                                    )
-                                })
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    })
-                    .unwrap_or_default();
-
-                let group_list: String = state
-                    .groups
-                    .values()
-                    .filter(|g| g.members.contains(&u.user_name))
-                    .map(|g| format!("          <member>{}</member>", g.group_name))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                let tags_members = tags_xml(&u.tags);
-
-                format!(
-                    "      <member>\n        <Path>{}</Path>\n        <UserName>{}</UserName>\n        <UserId>{}</UserId>\n        <Arn>{}</Arn>\n        <CreateDate>{}</CreateDate>\n        <UserPolicyList>\n{inline_policies}\n        </UserPolicyList>\n        <GroupList>\n{group_list}\n        </GroupList>\n        <AttachedManagedPolicies>\n{attached}\n        </AttachedManagedPolicies>\n        <Tags>\n{tags_members}\n        </Tags>\n      </member>",
-                    u.path, u.user_name, u.user_id, u.arn, u.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        // Build role details
-        let role_details: String = state
-            .roles
-            .values()
-            .map(|r| {
-                let inline_policies: String = state
-                    .role_inline_policies
-                    .get(&r.role_name)
-                    .map(|policies| {
-                        policies
-                            .iter()
-                            .map(|(name, doc)| {
-                                format!(
-                                    "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyDocument>{}</PolicyDocument>\n          </member>",
-                                    xml_escape(name),
-                                    url_encode(doc)
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    })
-                    .unwrap_or_default();
-
-                let attached: String = state
-                    .role_policies
-                    .get(&r.role_name)
-                    .map(|arns| {
-                        arns.iter()
-                            .filter_map(|arn| {
-                                state.policies.get(arn).map(|p| {
-                                    format!(
-                                        "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyArn>{}</PolicyArn>\n          </member>",
-                                        p.policy_name, p.arn
-                                    )
-                                })
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    })
-                    .unwrap_or_default();
-
-                let instance_profiles: String = state
-                    .instance_profiles
-                    .values()
-                    .filter(|ip| ip.roles.contains(&r.role_name))
-                    .map(|ip| {
-                        format!(
-                            "          <member>\n            <InstanceProfileName>{}</InstanceProfileName>\n            <InstanceProfileId>{}</InstanceProfileId>\n            <Arn>{}</Arn>\n            <Path>{}</Path>\n            <CreateDate>{}</CreateDate>\n          </member>",
-                            ip.instance_profile_name, ip.instance_profile_id, ip.arn, ip.path, ip.created_at.format("%Y-%m-%dT%H:%M:%SZ")
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                let tags_members = tags_xml(&r.tags);
-
-                format!(
-                    "      <member>\n        <Path>{}</Path>\n        <RoleName>{}</RoleName>\n        <RoleId>{}</RoleId>\n        <Arn>{}</Arn>\n        <CreateDate>{}</CreateDate>\n        <AssumeRolePolicyDocument>{}</AssumeRolePolicyDocument>\n        <RolePolicyList>\n{inline_policies}\n        </RolePolicyList>\n        <AttachedManagedPolicies>\n{attached}\n        </AttachedManagedPolicies>\n        <InstanceProfileList>\n{instance_profiles}\n        </InstanceProfileList>\n        <Tags>\n{tags_members}\n        </Tags>\n      </member>",
-                    r.path, r.role_name, r.role_id, r.arn, r.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
-                    url_encode(&r.assume_role_policy_document),
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        // Build group details
-        let group_details: String = state
-            .groups
-            .values()
-            .map(|g| {
-                let inline_policies: String = g
-                    .inline_policies
-                    .iter()
-                    .map(|(name, doc)| {
-                        format!(
-                            "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyDocument>{}</PolicyDocument>\n          </member>",
-                            xml_escape(name),
-                            url_encode(doc)
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                let attached: String = g
-                    .attached_policies
-                    .iter()
-                    .filter_map(|arn| {
-                        state.policies.get(arn).map(|p| {
-                            format!(
-                                "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyArn>{}</PolicyArn>\n          </member>",
-                                p.policy_name, p.arn
-                            )
-                        })
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                format!(
-                    "      <member>\n        <Path>{}</Path>\n        <GroupName>{}</GroupName>\n        <GroupId>{}</GroupId>\n        <Arn>{}</Arn>\n        <CreateDate>{}</CreateDate>\n        <GroupPolicyList>\n{inline_policies}\n        </GroupPolicyList>\n        <AttachedManagedPolicies>\n{attached}\n        </AttachedManagedPolicies>\n      </member>",
-                    g.path, g.group_name, g.group_id, g.arn, g.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        // Build policy details
-        let policy_details: String = state
-            .policies
-            .values()
-            .map(|p| {
-                let versions: String = p
-                    .versions
-                    .iter()
-                    .map(|v| {
-                        format!(
-                            "            <member>\n              <VersionId>{}</VersionId>\n              <IsDefaultVersion>{}</IsDefaultVersion>\n              <Document>{}</Document>\n              <CreateDate>{}</CreateDate>\n            </member>",
-                            v.version_id, v.is_default, url_encode(&v.document), v.created_at.format("%Y-%m-%dT%H:%M:%SZ")
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                format!(
-                    "      <member>\n        <PolicyName>{}</PolicyName>\n        <PolicyId>{}</PolicyId>\n        <Arn>{}</Arn>\n        <Path>{}</Path>\n        <DefaultVersionId>{}</DefaultVersionId>\n        <AttachmentCount>{}</AttachmentCount>\n        <IsAttachable>true</IsAttachable>\n        <CreateDate>{}</CreateDate>\n        <PolicyVersionList>\n{versions}\n        </PolicyVersionList>\n      </member>",
-                    p.policy_name, p.policy_id, p.arn, p.path, p.default_version_id,
-                    p.attachment_count, p.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let user_details = build_user_details_xml(&state);
+        let role_details = build_role_details_xml(&state);
+        let group_details = build_group_details_xml(&state);
+        let policy_details = build_policy_details_xml(&state);
 
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -375,95 +493,13 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        // Validate constraints
-        let min_len: Option<i64> = req
-            .query_params
-            .get("MinimumPasswordLength")
-            .and_then(|v| v.parse().ok());
-        let max_age: Option<i64> = req
-            .query_params
-            .get("MaxPasswordAge")
-            .and_then(|v| v.parse().ok());
-        let reuse_prevention: Option<i64> = req
-            .query_params
-            .get("PasswordReusePrevention")
-            .and_then(|v| v.parse().ok());
-
-        let mut errors = Vec::new();
-        if let Some(v) = min_len {
-            if v > 128 {
-                errors.push(format!("Value \"{v}\" at \"minimumPasswordLength\" failed to satisfy constraint: Member must have value less than or equal to 128"));
-            }
-        }
-        if let Some(v) = reuse_prevention {
-            if v > 24 {
-                errors.push(format!("Value \"{v}\" at \"passwordReusePrevention\" failed to satisfy constraint: Member must have value less than or equal to 24"));
-            }
-        }
-        if let Some(v) = max_age {
-            if v > 1095 {
-                errors.push(format!("Value \"{v}\" at \"maxPasswordAge\" failed to satisfy constraint: Member must have value less than or equal to 1095"));
-            }
-        }
-        if !errors.is_empty() {
-            let n = errors.len();
-            let msg = format!(
-                "{n} validation error{} detected: {}",
-                if n > 1 { "s" } else { "" },
-                errors.join("; ")
-            );
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationError",
-                msg,
-            ));
-        }
+        validate_password_policy_inputs(req)?;
 
         let mut state = self.state.write();
-
         let policy = state
             .account_password_policy
             .get_or_insert(AccountPasswordPolicy::default());
-
-        if let Some(v) = req
-            .query_params
-            .get("MinimumPasswordLength")
-            .and_then(|v| v.parse().ok())
-        {
-            policy.minimum_password_length = v;
-        }
-        if let Some(v) = req.query_params.get("RequireSymbols") {
-            policy.require_symbols = v == "true";
-        }
-        if let Some(v) = req.query_params.get("RequireNumbers") {
-            policy.require_numbers = v == "true";
-        }
-        if let Some(v) = req.query_params.get("RequireUppercaseCharacters") {
-            policy.require_uppercase_characters = v == "true";
-        }
-        if let Some(v) = req.query_params.get("RequireLowercaseCharacters") {
-            policy.require_lowercase_characters = v == "true";
-        }
-        if let Some(v) = req.query_params.get("AllowUsersToChangePassword") {
-            policy.allow_users_to_change_password = v == "true";
-        }
-        if let Some(v) = req
-            .query_params
-            .get("MaxPasswordAge")
-            .and_then(|v| v.parse().ok())
-        {
-            policy.max_password_age = v;
-        }
-        if let Some(v) = req
-            .query_params
-            .get("PasswordReusePrevention")
-            .and_then(|v| v.parse().ok())
-        {
-            policy.password_reuse_prevention = v;
-        }
-        if let Some(v) = req.query_params.get("HardExpiry") {
-            policy.hard_expiry = v == "true";
-        }
+        apply_password_policy_updates(policy, req);
 
         let xml = empty_response("UpdateAccountPasswordPolicy", &req.request_id);
         Ok(AwsResponse::xml(StatusCode::OK, xml))

--- a/crates/fakecloud-iam/src/iam_service/oidc.rs
+++ b/crates/fakecloud-iam/src/iam_service/oidc.rs
@@ -13,6 +13,79 @@ use super::{
 
 use fakecloud_aws::xml::xml_escape;
 
+/// Validate the URL, thumbprint list, and client ID list for
+/// `CreateOpenIDConnectProvider`. AWS uses two different error styles:
+/// thumbprint count and client ID count violations are surfaced
+/// immediately, while length violations are batched into a single
+/// multi-error ValidationError to match the structure of the real
+/// service.
+fn validate_oidc_provider_input(
+    url: &str,
+    thumbprints: &[String],
+    client_ids: &[String],
+) -> Result<(), AwsServiceError> {
+    let mut validation_errors: Vec<String> = Vec::new();
+
+    if url.len() > 255 {
+        validation_errors.push(
+            "Value at \"url\" failed to satisfy constraint: Member must have length less than or equal to 255".to_string()
+        );
+    }
+
+    if thumbprints.len() > 5 {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationError",
+            "Thumbprint list must contain fewer than 5 entries.".to_string(),
+        ));
+    }
+    if thumbprints.iter().any(|tp| tp.len() != 40) {
+        validation_errors.push(
+            "Value at \"thumbprintList\" failed to satisfy constraint: Member must have length less than or equal to 40; Member must have length greater than or equal to 40".to_string()
+        );
+    }
+
+    if client_ids.len() > 100 {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "LimitExceeded",
+            "Cannot exceed quota for ClientIdsPerOpenIdConnectProvider: 100".to_string(),
+        ));
+    }
+    if client_ids
+        .iter()
+        .any(|cid| cid.len() > 255 || cid.is_empty())
+    {
+        validation_errors.push(
+            "Value at \"clientIDList\" failed to satisfy constraint: Member must have length less than or equal to 255; Member must have length greater than or equal to 1".to_string()
+        );
+    }
+
+    if !validation_errors.is_empty() {
+        let count = validation_errors.len();
+        let msg = format!(
+            "{count} validation error{} detected: {}",
+            if count == 1 { "" } else { "s" },
+            validation_errors.join("; ")
+        );
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationError",
+            msg,
+        ));
+    }
+
+    if !url.starts_with("https://") && !url.starts_with("http://") {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationError",
+            "Invalid Open ID Connect Provider URL".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
 impl IamService {
     pub(super) fn create_saml_provider(
         &self,
@@ -205,74 +278,7 @@ impl IamService {
             i += 1;
         }
 
-        // Collect validation errors for multi-error response
-        let mut validation_errors: Vec<String> = Vec::new();
-
-        // Check URL length (must be <= 255)
-        if url.len() > 255 {
-            validation_errors.push(
-                "Value at \"url\" failed to satisfy constraint: Member must have length less than or equal to 255".to_string()
-            );
-        }
-
-        // Check thumbprint constraints
-        if thumbprints.len() > 5 {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationError",
-                "Thumbprint list must contain fewer than 5 entries.".to_string(),
-            ));
-        }
-        for tp in &thumbprints {
-            if tp.len() != 40 {
-                // AWS always reports both constraints when thumbprint length is wrong
-                validation_errors.push(
-                    "Value at \"thumbprintList\" failed to satisfy constraint: Member must have length less than or equal to 40; Member must have length greater than or equal to 40".to_string()
-                );
-                break;
-            }
-        }
-
-        // Check client ID constraints
-        if client_ids.len() > 100 {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "LimitExceeded",
-                "Cannot exceed quota for ClientIdsPerOpenIdConnectProvider: 100".to_string(),
-            ));
-        }
-        for cid in &client_ids {
-            if cid.len() > 255 || cid.is_empty() {
-                // AWS always reports both constraints when client ID length is wrong
-                validation_errors.push(
-                    "Value at \"clientIDList\" failed to satisfy constraint: Member must have length less than or equal to 255; Member must have length greater than or equal to 1".to_string()
-                );
-                break;
-            }
-        }
-
-        if !validation_errors.is_empty() {
-            let count = validation_errors.len();
-            let msg = format!(
-                "{count} validation error{} detected: {}",
-                if count == 1 { "" } else { "s" },
-                validation_errors.join("; ")
-            );
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationError",
-                msg,
-            ));
-        }
-
-        // Validate URL: must start with http:// or https://
-        if !url.starts_with("https://") && !url.starts_with("http://") {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationError",
-                "Invalid Open ID Connect Provider URL".to_string(),
-            ));
-        }
+        validate_oidc_provider_input(&url, &thumbprints, &client_ids)?;
 
         let mut state = self.state.write();
 

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -4,7 +4,7 @@ use http::StatusCode;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{IamRole, ServiceLinkedRoleDeletion};
+use crate::state::{IamRole, IamState, ServiceLinkedRoleDeletion};
 use crate::xml_responses;
 
 use super::{
@@ -16,6 +16,84 @@ use super::{
 use fakecloud_aws::xml::xml_escape;
 
 use crate::policy_validation::validate_policy_document;
+
+/// Reject deletion of a role that's still attached to instance profiles or
+/// has any kind of policy on it. Mirrors AWS's per-dependency
+/// `DeleteConflict` messages.
+fn ensure_role_can_be_deleted(state: &IamState, role_name: &str) -> Result<(), AwsServiceError> {
+    if state
+        .instance_profiles
+        .values()
+        .any(|ip| ip.roles.contains(&role_name.to_string()))
+    {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "DeleteConflict",
+            "Cannot delete entity, must remove roles from instance profile first.".to_string(),
+        ));
+    }
+
+    if state
+        .role_policies
+        .get(role_name)
+        .is_some_and(|p| !p.is_empty())
+    {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "DeleteConflict",
+            "Cannot delete entity, must detach all policies first.".to_string(),
+        ));
+    }
+
+    if state
+        .role_inline_policies
+        .get(role_name)
+        .is_some_and(|p| !p.is_empty())
+    {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "DeleteConflict",
+            "Cannot delete entity, must delete policies first.".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Compute the service-linked-role name for a given service principal.
+///
+/// AWS has a fixed naming scheme: `AWSServiceRoleFor{Suffix}` (with an
+/// optional `_{custom}` tail) where the suffix is derived from the part
+/// of the service principal before `.amazonaws.com`. A handful of
+/// services have non-derivable casing that we hard-code, and the
+/// `<prefix>.<service>` form (e.g. `custom-resource.application-autoscaling`)
+/// produces a `{Service}_{Prefix}` suffix.
+fn derive_service_linked_role_name(aws_service_name: &str, custom_suffix: Option<&str>) -> String {
+    let service_part = aws_service_name
+        .strip_suffix(".amazonaws.com")
+        .unwrap_or(aws_service_name);
+
+    let role_suffix = match service_part {
+        "autoscaling" => "AutoScaling".to_string(),
+        "elasticbeanstalk" => "ElasticBeanstalk".to_string(),
+        "elasticloadbalancing" => "ElasticLoadBalancing".to_string(),
+        "elasticmapreduce" => "ElasticMapReduce".to_string(),
+        s if s.contains('.') => {
+            let parts: Vec<&str> = s.splitn(2, '.').collect();
+            let prefix = parts[0];
+            let service = parts[1];
+            let service_cased = title_case_service(service);
+            let prefix_cased = title_case_service(prefix);
+            format!("{}_{}", service_cased, prefix_cased)
+        }
+        other => other.to_string(),
+    };
+
+    match custom_suffix {
+        Some(suffix) => format!("AWSServiceRoleFor{}_{}", role_suffix, suffix),
+        None => format!("AWSServiceRoleFor{}", role_suffix),
+    }
+}
 
 impl IamService {
     pub(super) fn create_role(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -118,49 +196,7 @@ impl IamService {
             ));
         }
 
-        // Check if role is in any instance profiles
-        let in_profiles: Vec<String> = state
-            .instance_profiles
-            .values()
-            .filter(|ip| ip.roles.contains(&role_name))
-            .map(|ip| ip.instance_profile_name.clone())
-            .collect();
-
-        if !in_profiles.is_empty() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::CONFLICT,
-                "DeleteConflict",
-                "Cannot delete entity, must remove roles from instance profile first.".to_string(),
-            ));
-        }
-
-        // Check if role has attached managed policies
-        if state
-            .role_policies
-            .get(&role_name)
-            .map(|p| !p.is_empty())
-            .unwrap_or(false)
-        {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::CONFLICT,
-                "DeleteConflict",
-                "Cannot delete entity, must detach all policies first.".to_string(),
-            ));
-        }
-
-        // Check if role has inline policies
-        if state
-            .role_inline_policies
-            .get(&role_name)
-            .map(|p| !p.is_empty())
-            .unwrap_or(false)
-        {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::CONFLICT,
-                "DeleteConflict",
-                "Cannot delete entity, must delete policies first.".to_string(),
-            ));
-        }
+        ensure_role_can_be_deleted(&state, &role_name)?;
 
         state.roles.remove(&role_name);
         state.role_policies.remove(&role_name);
@@ -787,40 +823,8 @@ impl IamService {
 
         let mut state = self.state.write();
 
-        // Derive role name from service name using AWS naming conventions
-        // The service name before .amazonaws.com determines the role suffix
-        let service_part = aws_service_name
-            .strip_suffix(".amazonaws.com")
-            .unwrap_or(&aws_service_name);
-
-        // Known service name mappings (AWS has specific casing rules)
-        let role_suffix = match service_part {
-            "autoscaling" => "AutoScaling".to_string(),
-            "elasticbeanstalk" => "ElasticBeanstalk".to_string(),
-            "elasticloadbalancing" => "ElasticLoadBalancing".to_string(),
-            "elasticmapreduce" => "ElasticMapReduce".to_string(),
-            s if s.contains('.') => {
-                // e.g. "custom-resource.application-autoscaling"
-                // -> suffix is from the part after the dot: "ApplicationAutoScaling"
-                // -> role name has "_CustomResource" appended for the prefix
-                let parts: Vec<&str> = s.splitn(2, '.').collect();
-                let prefix = parts[0]; // "custom-resource"
-                let service = parts[1]; // "application-autoscaling"
-
-                let service_cased = title_case_service(service);
-                let prefix_cased = title_case_service(prefix);
-
-                format!("{}_{}", service_cased, prefix_cased)
-            }
-            other => other.to_string(), // Use as-is for unknown services
-        };
-
-        let role_name = if let Some(suffix) = &custom_suffix {
-            format!("AWSServiceRoleFor{}_{}", role_suffix, suffix)
-        } else {
-            format!("AWSServiceRoleFor{}", role_suffix)
-        };
-
+        let role_name =
+            derive_service_linked_role_name(&aws_service_name, custom_suffix.as_deref());
         let path = format!("/aws-service-role/{}/", aws_service_name);
 
         // AWS uses arrays for Action and Service in SLR trust policies


### PR DESCRIPTION
## Summary

Five long IAM functions had clear logical phases buried in their bodies.

- **\`delete_role\`**: extract \`ensure_role_can_be_deleted\` (instance profile, managed policy, inline policy guards), mirroring the same pattern \`delete_user\` uses. \`delete_role\` drops to a 4-line operation.
- **\`create_service_linked_role\`**: the 30-line role-name derivation match (with hard-coded casing for \`autoscaling\`/\`elasticbeanstalk\`/etc and the \`<prefix>.<service>\` fan-out) becomes \`derive_service_linked_role_name\`. Pure function, easy to test, easy to extend with new principals.
- **\`get_account_authorization_details\`**: the 222-line operation was four parallel XML builders for users, roles, groups, and policies. Move each into \`build_user_details_xml\` / \`build_role_details_xml\` / \`build_group_details_xml\` / \`build_policy_details_xml\`. The operation body is now 'snapshot state, build the four sections, format the envelope.'
- **\`update_account_password_policy\`**: separate \`validate_password_policy_inputs\` (collects every constraint violation into a single multi-error ValidationError) from \`apply_password_policy_updates\` (applies provided fields onto the stored \`AccountPasswordPolicy\`).
- **\`create_oidc_provider\`**: the URL/thumbprint/client-id validation block is now \`validate_oidc_provider_input\` — a pure function that lets the operation body focus on parsing inputs, building the ARN, and inserting the provider.

No behavior change. Same lock semantics, same error wording, same XML output. The OIDC validator switches from a manual \`loop+break\` to \`.iter().any()\` which is the more idiomatic form.

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-iam\` (73 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored IAM operations in `fakecloud-iam` by extracting focused helpers to simplify complex functions and improve testability. No behavior changes; same locks, error messages, and XML outputs.

- **Refactors**
  - delete_role: extracted ensure_role_can_be_deleted (instance profile, managed/inline policy guards).
  - create_service_linked_role: extracted derive_service_linked_role_name (handles casing and prefix.service forms); pure.
  - get_account_authorization_details: split into build_user_details_xml, build_role_details_xml, build_group_details_xml, build_policy_details_xml.
  - update_account_password_policy: added validate_password_policy_inputs and apply_password_policy_updates; aggregates validation errors.
  - create_oidc_provider: added validate_oidc_provider_input; uses iter().any() for checks.

<sup>Written for commit 96fe87aedd7ffaef9e1b1d572216aa91562800c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

