### PR TITLE
refactor(cloudformation): extract provision_stack_resources helper

### DIFF
--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -16,9 +16,89 @@ use fakecloud_sqs::state::SharedSqsState;
 use fakecloud_ssm::state::SharedSsmState;
 
 use crate::resource_provisioner::ResourceProvisioner;
-use crate::state::{SharedCloudFormationState, Stack};
+use crate::state::{SharedCloudFormationState, Stack, StackResource};
 use crate::template;
 use crate::xml_responses;
+
+/// Multi-pass provisioning for all resources in a parsed template.
+///
+/// Resources may `Ref` each other in either direction, and JSON object
+/// iteration order isn't stable, so a single forward pass isn't enough
+/// to resolve them. We loop: each pass tries every pending resource, and
+/// any resource whose `Ref` targets are still unknown just stays pending
+/// for the next pass. When no pass makes progress we report the first
+/// pending failure and rollback.
+fn provision_stack_resources(
+    provisioner: &ResourceProvisioner,
+    resource_defs: &[template::ResourceDefinition],
+    template_body: &str,
+    parameters: &HashMap<String, String>,
+) -> Result<Vec<StackResource>, AwsServiceError> {
+    let mut resources = Vec::new();
+    let mut physical_ids: HashMap<String, String> = HashMap::new();
+    let mut pending: Vec<&template::ResourceDefinition> = resource_defs.iter().collect();
+    let max_passes = pending.len() + 1;
+
+    for _ in 0..max_passes {
+        if pending.is_empty() {
+            break;
+        }
+        let mut still_pending = Vec::new();
+        let mut made_progress = false;
+
+        for resource_def in pending {
+            let resolved_def = template::resolve_resource_properties(
+                resource_def,
+                template_body,
+                parameters,
+                &physical_ids,
+            )
+            .map_err(|e| {
+                AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
+            })?;
+
+            match provisioner.create_resource(&resolved_def) {
+                Ok(stack_resource) => {
+                    physical_ids.insert(
+                        stack_resource.logical_id.clone(),
+                        stack_resource.physical_id.clone(),
+                    );
+                    resources.push(stack_resource);
+                    made_progress = true;
+                }
+                Err(_) => still_pending.push(resource_def),
+            }
+        }
+
+        pending = still_pending;
+        if !made_progress && !pending.is_empty() {
+            // No progress — report the first failure and rollback anything
+            // we already created.
+            let resource_def = pending[0];
+            let resolved_def = template::resolve_resource_properties(
+                resource_def,
+                template_body,
+                parameters,
+                &physical_ids,
+            )
+            .unwrap_or_else(|_| resource_def.clone());
+            let err = provisioner.create_resource(&resolved_def).unwrap_err();
+            for r in &resources {
+                let _ = provisioner.delete_resource(r);
+            }
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                format!(
+                    "Failed to create resource {}: {err}",
+                    resource_def.logical_id
+                ),
+            ));
+        }
+    }
+
+    Ok(resources)
+}
 
 /// State references for every service CloudFormation can provision resources in.
 pub struct CloudFormationDeps {
@@ -200,73 +280,8 @@ impl CloudFormationService {
         };
 
         let provisioner = self.provisioner(&stack_id);
-        let mut resources = Vec::new();
-        let mut physical_ids: HashMap<String, String> = HashMap::new();
-
-        // Create resources incrementally, re-resolving Refs with known physical IDs.
-        // Use multi-pass to handle dependency ordering (resources may reference each
-        // other via Ref, and JSON object key order is not guaranteed).
-        let mut pending: Vec<&template::ResourceDefinition> = parsed.resources.iter().collect();
-        let max_passes = pending.len() + 1;
-        for _ in 0..max_passes {
-            if pending.is_empty() {
-                break;
-            }
-            let mut still_pending = Vec::new();
-            let mut made_progress = false;
-
-            for resource_def in pending {
-                let resolved_def = template::resolve_resource_properties(
-                    resource_def,
-                    template_body,
-                    &parameters,
-                    &physical_ids,
-                )
-                .map_err(|e| {
-                    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
-                })?;
-
-                match provisioner.create_resource(&resolved_def) {
-                    Ok(stack_resource) => {
-                        physical_ids.insert(
-                            stack_resource.logical_id.clone(),
-                            stack_resource.physical_id.clone(),
-                        );
-                        resources.push(stack_resource);
-                        made_progress = true;
-                    }
-                    Err(_) => {
-                        still_pending.push(resource_def);
-                    }
-                }
-            }
-
-            pending = still_pending;
-            if !made_progress && !pending.is_empty() {
-                // No progress made — report the first failure
-                let resource_def = pending[0];
-                let resolved_def = template::resolve_resource_properties(
-                    resource_def,
-                    template_body,
-                    &parameters,
-                    &physical_ids,
-                )
-                .unwrap_or_else(|_| resource_def.clone());
-                let err = provisioner.create_resource(&resolved_def).unwrap_err();
-                // Rollback
-                for r in &resources {
-                    let _ = provisioner.delete_resource(r);
-                }
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationError",
-                    format!(
-                        "Failed to create resource {}: {err}",
-                        resource_def.logical_id
-                    ),
-                ));
-            }
-        }
+        let resources =
+            provision_stack_resources(&provisioner, &parsed.resources, template_body, &parameters)?;
 
         let stack = Stack {
             name: stack_name.clone(),


### PR DESCRIPTION
## Summary

\`create_stack\` had a 64-line multi-pass resource-provisioning loop inlined in the middle of its body. The loop handles dependency ordering (\`Ref\` between resources, unstable JSON object iteration) by retrying pending resources across passes, and on stall picks the first pending failure to report along with a rollback.

Move the whole loop into \`provision_stack_resources\` — a pure function over \`(provisioner, &[ResourceDefinition], template_body, &parameters)\` that returns \`Vec<StackResource>\` or a rollback error. \`create_stack\` loses 60 lines and now reads as 'parse → allocate \`stack_id\` → provision → persist stack → notify'.

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-cloudformation\` (17 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the multi-pass resource provisioning loop from `create_stack` into a pure helper `provision_stack_resources` to simplify flow and encapsulate rollback logic. `create_stack` is ~60 lines shorter and now reads: parse → allocate `stack_id` → provision → persist → notify.

- **Refactors**
  - Added `provision_stack_resources(provisioner, &[ResourceDefinition], template_body, &parameters) -> Result<Vec<StackResource>, AwsServiceError>` to handle `Ref` dependencies, unstable JSON key order, and rollback on stall.
  - Updated `create_stack` to call the helper, reducing complexity without changing behavior.

<sup>Written for commit 1f8b9832099916e60771b4943dd575d0fad988fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

