### PR TITLE
refactor(stepfunctions): split run_states into per-state helpers

### DIFF
--- a/crates/fakecloud-stepfunctions/src/choice.rs
+++ b/crates/fakecloud-stepfunctions/src/choice.rs
@@ -19,128 +19,159 @@ pub fn evaluate_choice(state_def: &Value, input: &Value) -> Option<String> {
 
 /// Evaluate a single choice rule (may be compound via And/Or/Not).
 fn evaluate_rule(rule: &Value, input: &Value) -> bool {
-    // Logical operators
-    if let Some(and_rules) = rule["And"].as_array() {
-        return and_rules.iter().all(|r| evaluate_rule(r, input));
-    }
-    if let Some(or_rules) = rule["Or"].as_array() {
-        return or_rules.iter().any(|r| evaluate_rule(r, input));
-    }
-    if rule.get("Not").is_some() {
-        return !evaluate_rule(&rule["Not"], input);
+    if let Some(result) = evaluate_logical(rule, input) {
+        return result;
     }
 
-    // Get the variable value
     let variable = match rule["Variable"].as_str() {
         Some(v) => v,
         None => return false,
     };
     let value = resolve_path(input, variable);
 
-    // Presence/type checks
+    if let Some(result) = evaluate_presence_or_type(rule, input, variable, &value) {
+        return result;
+    }
+    if let Some(result) = evaluate_string_comparison(rule, input, &value) {
+        return result;
+    }
+    if let Some(result) = evaluate_numeric_comparison(rule, input, &value) {
+        return result;
+    }
+    if let Some(result) = evaluate_boolean_comparison(rule, input, &value) {
+        return result;
+    }
+    if let Some(result) = evaluate_timestamp_comparison(rule, &value) {
+        return result;
+    }
+
+    false
+}
+
+fn evaluate_logical(rule: &Value, input: &Value) -> Option<bool> {
+    if let Some(and_rules) = rule["And"].as_array() {
+        return Some(and_rules.iter().all(|r| evaluate_rule(r, input)));
+    }
+    if let Some(or_rules) = rule["Or"].as_array() {
+        return Some(or_rules.iter().any(|r| evaluate_rule(r, input)));
+    }
+    if rule.get("Not").is_some() {
+        return Some(!evaluate_rule(&rule["Not"], input));
+    }
+    None
+}
+
+fn evaluate_presence_or_type(
+    rule: &Value,
+    input: &Value,
+    variable: &str,
+    value: &Value,
+) -> Option<bool> {
     if let Some(expected) = rule.get("IsPresent") {
-        // Check if the field exists in the input (including explicit null).
         // resolve_path returns Value::Null for both missing and null fields,
-        // so we need to check the parent object directly.
+        // so check the parent object directly.
         let is_present = field_exists_in_input(input, variable);
-        return expected.as_bool().unwrap_or(false) == is_present;
+        return Some(expected.as_bool().unwrap_or(false) == is_present);
     }
     if let Some(expected) = rule.get("IsNull") {
-        let is_null = value.is_null();
-        return expected.as_bool().unwrap_or(false) == is_null;
+        return Some(expected.as_bool().unwrap_or(false) == value.is_null());
     }
     if let Some(expected) = rule.get("IsNumeric") {
-        let is_numeric = value.is_number();
-        return expected.as_bool().unwrap_or(false) == is_numeric;
+        return Some(expected.as_bool().unwrap_or(false) == value.is_number());
     }
     if let Some(expected) = rule.get("IsString") {
-        let is_string = value.is_string();
-        return expected.as_bool().unwrap_or(false) == is_string;
+        return Some(expected.as_bool().unwrap_or(false) == value.is_string());
     }
     if let Some(expected) = rule.get("IsBoolean") {
-        let is_boolean = value.is_boolean();
-        return expected.as_bool().unwrap_or(false) == is_boolean;
+        return Some(expected.as_bool().unwrap_or(false) == value.is_boolean());
     }
     if let Some(expected) = rule.get("IsTimestamp") {
         let is_ts = value
             .as_str()
             .map(|s| chrono::DateTime::parse_from_rfc3339(s).is_ok())
             .unwrap_or(false);
-        return expected.as_bool().unwrap_or(false) == is_ts;
+        return Some(expected.as_bool().unwrap_or(false) == is_ts);
     }
+    None
+}
 
-    // String comparisons
+fn evaluate_string_comparison(rule: &Value, input: &Value, value: &Value) -> Option<bool> {
     if let Some(expected) = rule["StringEquals"].as_str() {
-        return value.as_str() == Some(expected);
+        return Some(value.as_str() == Some(expected));
     }
     if let Some(path) = rule["StringEqualsPath"].as_str() {
         let other = resolve_path(input, path);
-        return value.as_str().is_some() && value.as_str() == other.as_str();
+        return Some(value.as_str().is_some() && value.as_str() == other.as_str());
     }
     if let Some(expected) = rule["StringLessThan"].as_str() {
-        return value.as_str().is_some_and(|v| v < expected);
+        return Some(value.as_str().is_some_and(|v| v < expected));
     }
     if let Some(expected) = rule["StringGreaterThan"].as_str() {
-        return value.as_str().is_some_and(|v| v > expected);
+        return Some(value.as_str().is_some_and(|v| v > expected));
     }
     if let Some(expected) = rule["StringLessThanEquals"].as_str() {
-        return value.as_str().is_some_and(|v| v <= expected);
+        return Some(value.as_str().is_some_and(|v| v <= expected));
     }
     if let Some(expected) = rule["StringGreaterThanEquals"].as_str() {
-        return value.as_str().is_some_and(|v| v >= expected);
+        return Some(value.as_str().is_some_and(|v| v >= expected));
     }
     if let Some(pattern) = rule["StringMatches"].as_str() {
-        return value.as_str().is_some_and(|v| string_matches(v, pattern));
+        return Some(value.as_str().is_some_and(|v| string_matches(v, pattern)));
     }
+    None
+}
 
-    // Numeric comparisons
+fn evaluate_numeric_comparison(rule: &Value, input: &Value, value: &Value) -> Option<bool> {
     if let Some(expected) = rule["NumericEquals"].as_f64() {
-        return value.as_f64() == Some(expected);
+        return Some(value.as_f64() == Some(expected));
     }
     if let Some(path) = rule["NumericEqualsPath"].as_str() {
         let other = resolve_path(input, path);
-        return value.as_f64().is_some() && value.as_f64() == other.as_f64();
+        return Some(value.as_f64().is_some() && value.as_f64() == other.as_f64());
     }
     if let Some(expected) = rule["NumericLessThan"].as_f64() {
-        return value.as_f64().is_some_and(|v| v < expected);
+        return Some(value.as_f64().is_some_and(|v| v < expected));
     }
     if let Some(expected) = rule["NumericGreaterThan"].as_f64() {
-        return value.as_f64().is_some_and(|v| v > expected);
+        return Some(value.as_f64().is_some_and(|v| v > expected));
     }
     if let Some(expected) = rule["NumericLessThanEquals"].as_f64() {
-        return value.as_f64().is_some_and(|v| v <= expected);
+        return Some(value.as_f64().is_some_and(|v| v <= expected));
     }
     if let Some(expected) = rule["NumericGreaterThanEquals"].as_f64() {
-        return value.as_f64().is_some_and(|v| v >= expected);
+        return Some(value.as_f64().is_some_and(|v| v >= expected));
     }
+    None
+}
 
-    // Boolean comparisons
+fn evaluate_boolean_comparison(rule: &Value, input: &Value, value: &Value) -> Option<bool> {
     if let Some(expected) = rule["BooleanEquals"].as_bool() {
-        return value.as_bool() == Some(expected);
+        return Some(value.as_bool() == Some(expected));
     }
     if let Some(path) = rule["BooleanEqualsPath"].as_str() {
         let other = resolve_path(input, path);
-        return value.as_bool().is_some() && value.as_bool() == other.as_bool();
+        return Some(value.as_bool().is_some() && value.as_bool() == other.as_bool());
     }
+    None
+}
 
-    // Timestamp comparisons
+fn evaluate_timestamp_comparison(rule: &Value, value: &Value) -> Option<bool> {
     if let Some(expected) = rule["TimestampEquals"].as_str() {
-        return compare_timestamps(&value, expected, |a, b| a == b);
+        return Some(compare_timestamps(value, expected, |a, b| a == b));
     }
     if let Some(expected) = rule["TimestampLessThan"].as_str() {
-        return compare_timestamps(&value, expected, |a, b| a < b);
+        return Some(compare_timestamps(value, expected, |a, b| a < b));
     }
     if let Some(expected) = rule["TimestampGreaterThan"].as_str() {
-        return compare_timestamps(&value, expected, |a, b| a > b);
+        return Some(compare_timestamps(value, expected, |a, b| a > b));
     }
     if let Some(expected) = rule["TimestampLessThanEquals"].as_str() {
-        return compare_timestamps(&value, expected, |a, b| a <= b);
+        return Some(compare_timestamps(value, expected, |a, b| a <= b));
     }
     if let Some(expected) = rule["TimestampGreaterThanEquals"].as_str() {
-        return compare_timestamps(&value, expected, |a, b| a >= b);
+        return Some(compare_timestamps(value, expected, |a, b| a >= b));
     }
-
-    false
+    None
 }
 
 /// Compare two RFC3339 timestamps using the provided comparison function.
@@ -166,72 +197,66 @@ where
 /// Glob-style pattern matching for StringMatches.
 /// Supports `*` (matches any sequence) and `\*` (literal asterisk).
 fn string_matches(value: &str, pattern: &str) -> bool {
-    let mut pattern_chars: Vec<char> = pattern.chars().collect();
-    let value_chars: Vec<char> = value.chars().collect();
+    let compiled = compile_glob_pattern(pattern);
+    glob_dp_match(&value.chars().collect::<Vec<_>>(), &compiled)
+}
 
-    // Preprocess: handle escaped asterisks
-    let mut segments: Vec<PatternSegment> = Vec::new();
-    let mut current = String::new();
+/// Compile a glob pattern into a token vector where `GlobToken::Wildcard`
+/// represents `*` and `GlobToken::Char(c)` represents a literal character
+/// (including escaped `\*`).
+fn compile_glob_pattern(pattern: &str) -> Vec<GlobToken> {
+    let mut out = Vec::new();
+    let chars: Vec<char> = pattern.chars().collect();
     let mut i = 0;
-    while i < pattern_chars.len() {
-        if pattern_chars[i] == '\\' && i + 1 < pattern_chars.len() && pattern_chars[i + 1] == '*' {
-            current.push('*');
+    while i < chars.len() {
+        if chars[i] == '\\' && i + 1 < chars.len() && chars[i + 1] == '*' {
+            out.push(GlobToken::Char('*'));
             i += 2;
-        } else if pattern_chars[i] == '*' {
-            if !current.is_empty() {
-                segments.push(PatternSegment::Literal(current.clone()));
-                current.clear();
-            }
-            segments.push(PatternSegment::Wildcard);
+        } else if chars[i] == '*' {
+            out.push(GlobToken::Wildcard);
             i += 1;
         } else {
-            current.push(pattern_chars[i]);
+            out.push(GlobToken::Char(chars[i]));
             i += 1;
         }
     }
-    if !current.is_empty() {
-        segments.push(PatternSegment::Literal(current));
-    }
+    out
+}
 
-    // Use cleaned-up pattern_chars for matching
-    pattern_chars = Vec::new();
-    for seg in &segments {
-        match seg {
-            PatternSegment::Literal(s) => {
-                for c in s.chars() {
-                    pattern_chars.push(c);
-                }
-            }
-            PatternSegment::Wildcard => {
-                pattern_chars.push('\0'); // sentinel for wildcard
-            }
-        }
-    }
-
-    // DP matching
-    let m = value_chars.len();
-    let n = pattern_chars.len();
+/// Match a compiled glob pattern against a value using dynamic programming.
+fn glob_dp_match(value: &[char], pattern: &[GlobToken]) -> bool {
+    let m = value.len();
+    let n = pattern.len();
     let mut dp = vec![vec![false; n + 1]; m + 1];
     dp[0][0] = true;
 
-    // Handle leading wildcards
     for j in 1..=n {
-        if pattern_chars[j - 1] == '\0' {
+        if matches!(pattern[j - 1], GlobToken::Wildcard) {
             dp[0][j] = dp[0][j - 1];
         }
     }
 
     for i in 1..=m {
         for j in 1..=n {
-            if pattern_chars[j - 1] == '\0' {
-                dp[i][j] = dp[i][j - 1] || dp[i - 1][j];
-            } else if pattern_chars[j - 1] == value_chars[i - 1] {
-                dp[i][j] = dp[i - 1][j - 1];
+            match pattern[j - 1] {
+                GlobToken::Wildcard => {
+                    dp[i][j] = dp[i][j - 1] || dp[i - 1][j];
+                }
+                GlobToken::Char(c) if c == value[i - 1] => {
+                    dp[i][j] = dp[i - 1][j - 1];
+                }
+                GlobToken::Char(_) => {}
             }
         }
     }
 
     dp[m][n]
+}
+
+#[derive(Clone, Copy)]
+enum GlobToken {
+    Char(char),
+    Wildcard,
 }
 
 /// Check if a field referenced by a JsonPath expression actually exists in the input,
@@ -291,11 +316,6 @@ fn field_exists_in_input(root: &Value, path: &str) -> bool {
         }
     }
     false
-}
-
-enum PatternSegment {
-    Literal(String),
-    Wildcard,
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -143,367 +143,458 @@ fn run_states<'a>(
                 "Executing state"
             );
 
-            match state_type.as_str() {
-                "Pass" => {
-                    let entered_event_id = add_event(
-                        shared_state,
-                        execution_arn,
-                        "PassStateEntered",
-                        0,
-                        json!({
-                            "name": current_state,
-                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                        }),
-                    );
-
-                    let result = execute_pass_state(&state_def, &effective_input);
-
-                    add_event(
-                        shared_state,
-                        execution_arn,
-                        "PassStateExited",
-                        entered_event_id,
-                        json!({
-                            "name": current_state,
-                            "output": serde_json::to_string(&result).unwrap_or_default(),
-                        }),
-                    );
-
-                    effective_input = result;
-
-                    match next_state(&state_def) {
-                        NextState::Name(next) => current_state = next,
-                        NextState::End => return Ok(effective_input),
-                        NextState::Error(msg) => {
-                            return Err(("States.Runtime".to_string(), msg));
-                        }
-                    }
-                }
-
-                "Succeed" => {
-                    add_event(
-                        shared_state,
-                        execution_arn,
-                        "SucceedStateEntered",
-                        0,
-                        json!({
-                            "name": current_state,
-                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                        }),
-                    );
-
-                    let input_path = state_def["InputPath"].as_str();
-                    let output_path = state_def["OutputPath"].as_str();
-
-                    let processed = if input_path == Some("null") {
-                        json!({})
-                    } else {
-                        apply_input_path(&effective_input, input_path)
-                    };
-
-                    let output = if output_path == Some("null") {
-                        json!({})
-                    } else {
-                        apply_output_path(&processed, output_path)
-                    };
-
-                    add_event(
-                        shared_state,
-                        execution_arn,
-                        "SucceedStateExited",
-                        0,
-                        json!({
-                            "name": current_state,
-                            "output": serde_json::to_string(&output).unwrap_or_default(),
-                        }),
-                    );
-
-                    return Ok(output);
-                }
-
-                "Fail" => {
-                    let error = state_def["Error"]
-                        .as_str()
-                        .unwrap_or("States.Fail")
-                        .to_string();
-                    let cause = state_def["Cause"].as_str().unwrap_or("").to_string();
-
-                    add_event(
-                        shared_state,
-                        execution_arn,
-                        "FailStateEntered",
-                        0,
-                        json!({
-                            "name": current_state,
-                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                        }),
-                    );
-
-                    return Err((error, cause));
-                }
-
-                "Task" => {
-                    let entered_event_id = add_event(
-                        shared_state,
-                        execution_arn,
-                        "TaskStateEntered",
-                        0,
-                        json!({
-                            "name": current_state,
-                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                        }),
-                    );
-
-                    let result = execute_task_state(
-                        &state_def,
-                        &effective_input,
-                        delivery,
-                        dynamodb_state,
-                        shared_state,
-                        execution_arn,
-                        entered_event_id,
-                    )
-                    .await;
-
-                    match result {
-                        Ok(output) => {
-                            add_event(
-                                shared_state,
-                                execution_arn,
-                                "TaskStateExited",
-                                entered_event_id,
-                                json!({
-                                    "name": current_state,
-                                    "output": serde_json::to_string(&output).unwrap_or_default(),
-                                }),
-                            );
-
-                            effective_input = output;
-
-                            match next_state(&state_def) {
-                                NextState::Name(next) => current_state = next,
-                                NextState::End => return Ok(effective_input),
-                                NextState::Error(msg) => {
-                                    return Err(("States.Runtime".to_string(), msg));
-                                }
-                            }
-                        }
-                        Err((error, cause)) => {
-                            match apply_state_catcher(&state_def, &effective_input, &error, &cause)
-                            {
-                                Some((next, new_input)) => {
-                                    effective_input = new_input;
-                                    current_state = next;
-                                }
-                                None => return Err((error, cause)),
-                            }
-                        }
-                    }
-                }
-
-                "Choice" => {
-                    let entered_event_id = add_event(
-                        shared_state,
-                        execution_arn,
-                        "ChoiceStateEntered",
-                        0,
-                        json!({
-                            "name": current_state,
-                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                        }),
-                    );
-
-                    let input_path = state_def["InputPath"].as_str();
-                    let processed_input = if input_path == Some("null") {
-                        json!({})
-                    } else {
-                        apply_input_path(&effective_input, input_path)
-                    };
-
-                    match evaluate_choice(&state_def, &processed_input) {
-                        Some(next) => {
-                            add_event(
-                                shared_state,
-                                execution_arn,
-                                "ChoiceStateExited",
-                                entered_event_id,
-                                json!({
-                                    "name": current_state,
-                                    "output": serde_json::to_string(&effective_input).unwrap_or_default(),
-                                }),
-                            );
-                            current_state = next;
-                        }
-                        None => {
-                            return Err((
-                                "States.NoChoiceMatched".to_string(),
-                                format!(
-                                    "No choice rule matched and no Default in state '{current_state}'"
-                                ),
-                            ));
-                        }
-                    }
-                }
-
+            let advance = match state_type.as_str() {
+                "Pass" => run_pass_state(
+                    &current_state,
+                    &state_def,
+                    effective_input,
+                    shared_state,
+                    execution_arn,
+                ),
+                "Succeed" => run_succeed_state(
+                    &current_state,
+                    &state_def,
+                    effective_input,
+                    shared_state,
+                    execution_arn,
+                ),
+                "Fail" => run_fail_state(
+                    &current_state,
+                    &state_def,
+                    effective_input,
+                    shared_state,
+                    execution_arn,
+                ),
+                "Choice" => run_choice_state(
+                    &current_state,
+                    &state_def,
+                    effective_input,
+                    shared_state,
+                    execution_arn,
+                ),
                 "Wait" => {
-                    let entered_event_id = add_event(
+                    run_wait_state(
+                        &current_state,
+                        &state_def,
+                        effective_input,
                         shared_state,
                         execution_arn,
-                        "WaitStateEntered",
-                        0,
-                        json!({
-                            "name": current_state,
-                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                        }),
-                    );
-
-                    execute_wait_state(&state_def, &effective_input).await;
-
-                    add_event(
-                        shared_state,
-                        execution_arn,
-                        "WaitStateExited",
-                        entered_event_id,
-                        json!({
-                            "name": current_state,
-                            "output": serde_json::to_string(&effective_input).unwrap_or_default(),
-                        }),
-                    );
-
-                    match next_state(&state_def) {
-                        NextState::Name(next) => current_state = next,
-                        NextState::End => return Ok(effective_input),
-                        NextState::Error(msg) => {
-                            return Err(("States.Runtime".to_string(), msg));
-                        }
-                    }
+                    )
+                    .await
                 }
-
+                "Task" => {
+                    run_task_state(
+                        &current_state,
+                        &state_def,
+                        effective_input,
+                        delivery,
+                        dynamodb_state,
+                        shared_state,
+                        execution_arn,
+                    )
+                    .await
+                }
                 "Parallel" => {
-                    let entered_event_id = add_event(
-                        shared_state,
-                        execution_arn,
-                        "ParallelStateEntered",
-                        0,
-                        json!({
-                            "name": current_state,
-                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                        }),
-                    );
-
-                    let result = execute_parallel_state(
+                    run_parallel_state(
+                        &current_state,
                         &state_def,
-                        &effective_input,
+                        effective_input,
                         delivery,
                         dynamodb_state,
                         shared_state,
                         execution_arn,
                     )
-                    .await;
-
-                    match result {
-                        Ok(output) => {
-                            add_event(
-                                shared_state,
-                                execution_arn,
-                                "ParallelStateExited",
-                                entered_event_id,
-                                json!({
-                                    "name": current_state,
-                                    "output": serde_json::to_string(&output).unwrap_or_default(),
-                                }),
-                            );
-
-                            effective_input = output;
-
-                            match next_state(&state_def) {
-                                NextState::Name(next) => current_state = next,
-                                NextState::End => return Ok(effective_input),
-                                NextState::Error(msg) => {
-                                    return Err(("States.Runtime".to_string(), msg));
-                                }
-                            }
-                        }
-                        Err((error, cause)) => {
-                            match apply_state_catcher(&state_def, &effective_input, &error, &cause)
-                            {
-                                Some((next, new_input)) => {
-                                    effective_input = new_input;
-                                    current_state = next;
-                                }
-                                None => return Err((error, cause)),
-                            }
-                        }
-                    }
+                    .await
                 }
-
                 "Map" => {
-                    let entered_event_id = add_event(
-                        shared_state,
-                        execution_arn,
-                        "MapStateEntered",
-                        0,
-                        json!({
-                            "name": current_state,
-                            "input": serde_json::to_string(&effective_input).unwrap_or_default(),
-                        }),
-                    );
-
-                    let result = execute_map_state(
+                    run_map_state(
+                        &current_state,
                         &state_def,
-                        &effective_input,
+                        effective_input,
                         delivery,
                         dynamodb_state,
                         shared_state,
                         execution_arn,
                     )
-                    .await;
-
-                    match result {
-                        Ok(output) => {
-                            add_event(
-                                shared_state,
-                                execution_arn,
-                                "MapStateExited",
-                                entered_event_id,
-                                json!({
-                                    "name": current_state,
-                                    "output": serde_json::to_string(&output).unwrap_or_default(),
-                                }),
-                            );
-
-                            effective_input = output;
-
-                            match next_state(&state_def) {
-                                NextState::Name(next) => current_state = next,
-                                NextState::End => return Ok(effective_input),
-                                NextState::Error(msg) => {
-                                    return Err(("States.Runtime".to_string(), msg));
-                                }
-                            }
-                        }
-                        Err((error, cause)) => {
-                            match apply_state_catcher(&state_def, &effective_input, &error, &cause)
-                            {
-                                Some((next, new_input)) => {
-                                    effective_input = new_input;
-                                    current_state = next;
-                                }
-                                None => return Err((error, cause)),
-                            }
-                        }
-                    }
+                    .await
                 }
+                other => Advance::Fail(
+                    "States.Runtime".to_string(),
+                    format!("Unsupported state type: '{other}'"),
+                ),
+            };
 
-                other => {
-                    return Err((
-                        "States.Runtime".to_string(),
-                        format!("Unsupported state type: '{other}'"),
-                    ));
+            match advance {
+                Advance::Next(next, new_input) => {
+                    effective_input = new_input;
+                    current_state = next;
                 }
+                Advance::End(output) => return Ok(output),
+                Advance::Fail(error, cause) => return Err((error, cause)),
             }
         }
     })
+}
+
+/// Result of executing a single state in the state machine.
+enum Advance {
+    /// Continue to the given state with the given input.
+    Next(String, Value),
+    /// Terminate the state machine with the given output.
+    End(Value),
+    /// Fail the state machine with the given error and cause.
+    Fail(String, String),
+}
+
+fn advance_from_next(state_def: &Value, input: Value) -> Advance {
+    match next_state(state_def) {
+        NextState::Name(next) => Advance::Next(next, input),
+        NextState::End => Advance::End(input),
+        NextState::Error(msg) => Advance::Fail("States.Runtime".to_string(), msg),
+    }
+}
+
+fn advance_from_error(state_def: &Value, input: &Value, error: String, cause: String) -> Advance {
+    match apply_state_catcher(state_def, input, &error, &cause) {
+        Some((next, new_input)) => Advance::Next(next, new_input),
+        None => Advance::Fail(error, cause),
+    }
+}
+
+fn run_pass_state(
+    name: &str,
+    state_def: &Value,
+    input: Value,
+    shared_state: &SharedStepFunctionsState,
+    execution_arn: &str,
+) -> Advance {
+    let entered_event_id = add_event(
+        shared_state,
+        execution_arn,
+        "PassStateEntered",
+        0,
+        json!({
+            "name": name,
+            "input": serde_json::to_string(&input).unwrap_or_default(),
+        }),
+    );
+
+    let result = execute_pass_state(state_def, &input);
+
+    add_event(
+        shared_state,
+        execution_arn,
+        "PassStateExited",
+        entered_event_id,
+        json!({
+            "name": name,
+            "output": serde_json::to_string(&result).unwrap_or_default(),
+        }),
+    );
+
+    advance_from_next(state_def, result)
+}
+
+fn run_succeed_state(
+    name: &str,
+    state_def: &Value,
+    input: Value,
+    shared_state: &SharedStepFunctionsState,
+    execution_arn: &str,
+) -> Advance {
+    add_event(
+        shared_state,
+        execution_arn,
+        "SucceedStateEntered",
+        0,
+        json!({
+            "name": name,
+            "input": serde_json::to_string(&input).unwrap_or_default(),
+        }),
+    );
+
+    let input_path = state_def["InputPath"].as_str();
+    let output_path = state_def["OutputPath"].as_str();
+
+    let processed = if input_path == Some("null") {
+        json!({})
+    } else {
+        apply_input_path(&input, input_path)
+    };
+
+    let output = if output_path == Some("null") {
+        json!({})
+    } else {
+        apply_output_path(&processed, output_path)
+    };
+
+    add_event(
+        shared_state,
+        execution_arn,
+        "SucceedStateExited",
+        0,
+        json!({
+            "name": name,
+            "output": serde_json::to_string(&output).unwrap_or_default(),
+        }),
+    );
+
+    Advance::End(output)
+}
+
+fn run_fail_state(
+    name: &str,
+    state_def: &Value,
+    input: Value,
+    shared_state: &SharedStepFunctionsState,
+    execution_arn: &str,
+) -> Advance {
+    let error = state_def["Error"]
+        .as_str()
+        .unwrap_or("States.Fail")
+        .to_string();
+    let cause = state_def["Cause"].as_str().unwrap_or("").to_string();
+
+    add_event(
+        shared_state,
+        execution_arn,
+        "FailStateEntered",
+        0,
+        json!({
+            "name": name,
+            "input": serde_json::to_string(&input).unwrap_or_default(),
+        }),
+    );
+
+    Advance::Fail(error, cause)
+}
+
+fn run_choice_state(
+    name: &str,
+    state_def: &Value,
+    input: Value,
+    shared_state: &SharedStepFunctionsState,
+    execution_arn: &str,
+) -> Advance {
+    let entered_event_id = add_event(
+        shared_state,
+        execution_arn,
+        "ChoiceStateEntered",
+        0,
+        json!({
+            "name": name,
+            "input": serde_json::to_string(&input).unwrap_or_default(),
+        }),
+    );
+
+    let input_path = state_def["InputPath"].as_str();
+    let processed_input = if input_path == Some("null") {
+        json!({})
+    } else {
+        apply_input_path(&input, input_path)
+    };
+
+    match evaluate_choice(state_def, &processed_input) {
+        Some(next) => {
+            add_event(
+                shared_state,
+                execution_arn,
+                "ChoiceStateExited",
+                entered_event_id,
+                json!({
+                    "name": name,
+                    "output": serde_json::to_string(&input).unwrap_or_default(),
+                }),
+            );
+            Advance::Next(next, input)
+        }
+        None => Advance::Fail(
+            "States.NoChoiceMatched".to_string(),
+            format!("No choice rule matched and no Default in state '{name}'"),
+        ),
+    }
+}
+
+async fn run_wait_state(
+    name: &str,
+    state_def: &Value,
+    input: Value,
+    shared_state: &SharedStepFunctionsState,
+    execution_arn: &str,
+) -> Advance {
+    let entered_event_id = add_event(
+        shared_state,
+        execution_arn,
+        "WaitStateEntered",
+        0,
+        json!({
+            "name": name,
+            "input": serde_json::to_string(&input).unwrap_or_default(),
+        }),
+    );
+
+    execute_wait_state(state_def, &input).await;
+
+    add_event(
+        shared_state,
+        execution_arn,
+        "WaitStateExited",
+        entered_event_id,
+        json!({
+            "name": name,
+            "output": serde_json::to_string(&input).unwrap_or_default(),
+        }),
+    );
+
+    advance_from_next(state_def, input)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_task_state(
+    name: &str,
+    state_def: &Value,
+    input: Value,
+    delivery: &Option<Arc<DeliveryBus>>,
+    dynamodb_state: &Option<SharedDynamoDbState>,
+    shared_state: &SharedStepFunctionsState,
+    execution_arn: &str,
+) -> Advance {
+    let entered_event_id = add_event(
+        shared_state,
+        execution_arn,
+        "TaskStateEntered",
+        0,
+        json!({
+            "name": name,
+            "input": serde_json::to_string(&input).unwrap_or_default(),
+        }),
+    );
+
+    let result = execute_task_state(
+        state_def,
+        &input,
+        delivery,
+        dynamodb_state,
+        shared_state,
+        execution_arn,
+        entered_event_id,
+    )
+    .await;
+
+    match result {
+        Ok(output) => {
+            add_event(
+                shared_state,
+                execution_arn,
+                "TaskStateExited",
+                entered_event_id,
+                json!({
+                    "name": name,
+                    "output": serde_json::to_string(&output).unwrap_or_default(),
+                }),
+            );
+            advance_from_next(state_def, output)
+        }
+        Err((error, cause)) => advance_from_error(state_def, &input, error, cause),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_parallel_state(
+    name: &str,
+    state_def: &Value,
+    input: Value,
+    delivery: &Option<Arc<DeliveryBus>>,
+    dynamodb_state: &Option<SharedDynamoDbState>,
+    shared_state: &SharedStepFunctionsState,
+    execution_arn: &str,
+) -> Advance {
+    let entered_event_id = add_event(
+        shared_state,
+        execution_arn,
+        "ParallelStateEntered",
+        0,
+        json!({
+            "name": name,
+            "input": serde_json::to_string(&input).unwrap_or_default(),
+        }),
+    );
+
+    let result = execute_parallel_state(
+        state_def,
+        &input,
+        delivery,
+        dynamodb_state,
+        shared_state,
+        execution_arn,
+    )
+    .await;
+
+    match result {
+        Ok(output) => {
+            add_event(
+                shared_state,
+                execution_arn,
+                "ParallelStateExited",
+                entered_event_id,
+                json!({
+                    "name": name,
+                    "output": serde_json::to_string(&output).unwrap_or_default(),
+                }),
+            );
+            advance_from_next(state_def, output)
+        }
+        Err((error, cause)) => advance_from_error(state_def, &input, error, cause),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_map_state(
+    name: &str,
+    state_def: &Value,
+    input: Value,
+    delivery: &Option<Arc<DeliveryBus>>,
+    dynamodb_state: &Option<SharedDynamoDbState>,
+    shared_state: &SharedStepFunctionsState,
+    execution_arn: &str,
+) -> Advance {
+    let entered_event_id = add_event(
+        shared_state,
+        execution_arn,
+        "MapStateEntered",
+        0,
+        json!({
+            "name": name,
+            "input": serde_json::to_string(&input).unwrap_or_default(),
+        }),
+    );
+
+    let result = execute_map_state(
+        state_def,
+        &input,
+        delivery,
+        dynamodb_state,
+        shared_state,
+        execution_arn,
+    )
+    .await;
+
+    match result {
+        Ok(output) => {
+            add_event(
+                shared_state,
+                execution_arn,
+                "MapStateExited",
+                entered_event_id,
+                json!({
+                    "name": name,
+                    "output": serde_json::to_string(&output).unwrap_or_default(),
+                }),
+            );
+            advance_from_next(state_def, output)
+        }
+        Err((error, cause)) => advance_from_error(state_def, &input, error, cause),
+    }
 }
 
 /// Execute a Wait state: pause execution for a specified duration or until a timestamp.


### PR DESCRIPTION
## Summary
- Introduce an `Advance` enum to model state transitions (`Next` / `End` / `Fail`) and extract a per-state helper for each state type (`run_pass_state`, `run_succeed_state`, `run_fail_state`, `run_choice_state`, `run_wait_state`, `run_task_state`, `run_parallel_state`, `run_map_state`). The `run_states` loop is now a ~90-line dispatch match that delegates and funnels results through a single `advance` match at the bottom.
- Factor the shared `next_state` + catcher resolution logic into `advance_from_next` and `advance_from_error` helpers so the per-state helpers stay readable.
- In `choice.rs`, split the ~120-line `evaluate_rule` match ladder into `evaluate_logical`, `evaluate_presence_or_type`, and one helper per scalar type (`evaluate_string_comparison`, `evaluate_numeric_comparison`, `evaluate_boolean_comparison`, `evaluate_timestamp_comparison`). Each returns `Option<bool>` so the top-level call chains short-circuits.
- Split `string_matches` into `compile_glob_pattern` + `glob_dp_match`. The previous implementation built a `PatternSegment` vector only to flatten it back to a `Vec<char>` with a `\0` sentinel; the new compile step emits a typed `GlobToken` sequence directly.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Step Functions interpreter into per-state helpers and introduced an `Advance` enum for transitions. This simplifies `run_states`, centralizes next/catcher handling, and makes the code easier to read and extend.

- **Refactors**
  - `run_states` now dispatches to `run_pass_state`, `run_succeed_state`, `run_fail_state`, `run_choice_state`, `run_wait_state`, `run_task_state`, `run_parallel_state`, `run_map_state`.
  - Added `Advance` enum (`Next`/`End`/`Fail`) with a single final match to handle transitions.
  - Introduced `advance_from_next` and `advance_from_error` to unify next-state and catcher resolution.
  - In `choice.rs`, split `evaluate_rule` into `evaluate_logical`, `evaluate_presence_or_type`, `evaluate_string_comparison`, `evaluate_numeric_comparison`, `evaluate_boolean_comparison`, `evaluate_timestamp_comparison` with `Option<bool>` for short-circuiting.
  - Reworked `StringMatches`: added `compile_glob_pattern` and `glob_dp_match` using `GlobToken` to replace the previous segment build/flatten pass.

<sup>Written for commit dea6084edccf968e5b669310005a7d69ec120982. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

