### PR TITLE
test(harness): wait for an HTTP response, not a bare TCP connect

### DIFF
--- a/crates/fakecloud-conformance/tests/helpers/mod.rs
+++ b/crates/fakecloud-conformance/tests/helpers/mod.rs
@@ -193,13 +193,28 @@ fn find_binary() -> String {
 }
 
 async fn wait_for_port(child: &mut Child, port: u16) -> bool {
+    // Two-stage readiness: (1) TCP connect succeeds, (2) an HTTP request
+    // actually reaches an axum handler. A successful TCP connect only
+    // proves the kernel accepted SYNs into fakecloud's listen queue — it
+    // does not prove axum has reached `serve().await` and installed the
+    // request handlers. Tests that hit the server immediately after a
+    // bare TCP connect occasionally saw ConnectionRefused / EOF mid-flight.
     let addr = format!("127.0.0.1:{port}");
+    let health_url = format!("http://127.0.0.1:{port}/");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(500))
+        .build()
+        .expect("build reqwest client");
+
     for _ in 0..300 {
-        if std::net::TcpStream::connect(&addr).is_ok() {
-            return true;
-        }
         if child.try_wait().ok().flatten().is_some() {
             return false;
+        }
+        if std::net::TcpStream::connect(&addr).is_ok() {
+            // Any HTTP response (including 4xx) proves axum is serving.
+            if client.get(&health_url).send().await.is_ok() {
+                return true;
+            }
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -327,16 +327,28 @@ fn cli_available(cli: &str) -> bool {
 }
 
 async fn wait_for_port(child: &mut Child, port: u16) -> bool {
+    // Two-stage readiness: (1) TCP connect succeeds, (2) an HTTP request
+    // actually reaches an axum handler. A bare TCP connect only proves
+    // the kernel accepted SYNs into fakecloud's listen queue — it does
+    // not prove axum has reached `serve().await` and installed request
+    // handlers. Tests that hit the server immediately after a bare TCP
+    // connect occasionally saw ConnectionRefused / EOF mid-flight.
     let loopback = format!("127.0.0.1:{port}");
     let wildcard = format!("0.0.0.0:{port}");
+    let health_url = format!("http://127.0.0.1:{port}/");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(500))
+        .build()
+        .expect("build reqwest client");
+
     for _ in 0..300 {
-        if std::net::TcpStream::connect(&loopback).is_ok()
-            || std::net::TcpStream::connect(&wildcard).is_ok()
-        {
-            return true;
-        }
         if child.try_wait().ok().flatten().is_some() {
             return false;
+        }
+        let tcp_ok = std::net::TcpStream::connect(&loopback).is_ok()
+            || std::net::TcpStream::connect(&wildcard).is_ok();
+        if tcp_ok && client.get(&health_url).send().await.is_ok() {
+            return true;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }


### PR DESCRIPTION
## Summary
Both test harnesses (\`crates/fakecloud-e2e/tests/helpers/mod.rs\` and \`crates/fakecloud-conformance/tests/helpers/mod.rs\`) spawn fakecloud as a child process and gate \`TestServer::start\` on a \`wait_for_port\` loop that only checks \`TcpStream::connect\`. A successful TCP connect proves fakecloud's listener socket is in the kernel accept queue, **but not** that axum has reached \`serve().await\` and installed the request handlers. Tests that issued a real HTTP call immediately after the TCP probe occasionally raced that window and saw \`ConnectionRefused\` / early EOF — prior sessions blamed this on flakes across RDS, IAM OIDC, Bedrock, KMS, and SES and just re-ran the workflow instead of investigating.

Fix: two-stage readiness probe.
1. Wait for \`TcpStream::connect\` to succeed (SYN accepted into the listen queue).
2. Issue a reqwest \`GET /\` and require any HTTP response — including 404s from unmatched routes, which is what fakecloud's root path returns. That's the guarantee the AWS SDK clients actually need.

\`reqwest\` is already a dev-dependency in both crates, so this is zero new cost.

## Test plan
- [x] Both harnesses build with \`cargo build -p fakecloud-e2e --tests\` / \`-p fakecloud-conformance --tests\`.
- [x] CI will exercise the new probe on every check; prior-session flakes across RDS/IAM/Bedrock/KMS/SES should stop recurring under this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the e2e and conformance test harnesses wait for a real HTTP response before running tests. This ensures `axum` is serving and eliminates ConnectionRefused/early-EOF flakes in CI.

- **Bug Fixes**
  - Replaced bare TCP probe with two-stage readiness: TCP connect, then `reqwest` GET to `http://127.0.0.1:{port}/`; any HTTP status (including 404) counts as ready.
  - Added 500ms per-request timeout; kept 100ms retry loop (~30s total) and early exit if the child process exits.

<sup>Written for commit 6c41896ffffa15345b085b637a680bc5071a70b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

