### PR TITLE
refactor(eventbridge): bundle fire_rule context refs into FireRuleContext

### DIFF
--- a/crates/fakecloud-eventbridge/src/simulation.rs
+++ b/crates/fakecloud-eventbridge/src/simulation.rs
@@ -19,20 +19,33 @@ pub struct FiredTarget {
     pub arn: String,
 }
 
+/// Borrowed context passed to `fire_rule` — all the surrounding state
+/// it needs to deliver to the different target protocols. Bundled so
+/// the callers don't have to thread five positional args through.
+pub struct FireRuleContext<'a> {
+    pub state: &'a SharedEventBridgeState,
+    pub delivery: &'a Arc<DeliveryBus>,
+    pub lambda_state: &'a Option<SharedLambdaState>,
+    pub logs_state: &'a Option<SharedLogsState>,
+    pub container_runtime: &'a Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
+}
+
 /// Fire a specific rule by bus name and rule name, delivering to all its
 /// targets regardless of the rule's enabled/disabled state.
 ///
 /// Returns `Ok(targets)` with the list of targets that were delivered to,
 /// or `Err(message)` if the bus or rule doesn't exist.
 pub fn fire_rule(
-    state: &SharedEventBridgeState,
-    delivery: &Arc<DeliveryBus>,
-    lambda_state: &Option<SharedLambdaState>,
-    logs_state: &Option<SharedLogsState>,
-    container_runtime: &Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
+    ctx: &FireRuleContext<'_>,
     bus_name: &str,
     rule_name: &str,
 ) -> Result<Vec<FiredTarget>, String> {
+    let state = ctx.state;
+    let delivery = ctx.delivery;
+    let lambda_state = ctx.lambda_state;
+    let logs_state = ctx.logs_state;
+    let container_runtime = ctx.container_runtime;
+
     let (targets, account_id, region) = {
         let state = state.read();
 
@@ -262,7 +275,14 @@ mod tests {
             }],
         );
 
-        let result = fire_rule(&state, &delivery, &None, &None, &None, "default", "my-rule");
+        let ctx = FireRuleContext {
+            state: &state,
+            delivery: &delivery,
+            lambda_state: &None,
+            logs_state: &None,
+            container_runtime: &None,
+        };
+        let result = fire_rule(&ctx, "default", "my-rule");
         let targets = result.unwrap();
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].target_type, "sqs");
@@ -281,15 +301,14 @@ mod tests {
         let state = make_state();
         let delivery = Arc::new(DeliveryBus::new());
 
-        let result = fire_rule(
-            &state,
-            &delivery,
-            &None,
-            &None,
-            &None,
-            "default",
-            "no-such-rule",
-        );
+        let ctx = FireRuleContext {
+            state: &state,
+            delivery: &delivery,
+            lambda_state: &None,
+            logs_state: &None,
+            container_runtime: &None,
+        };
+        let result = fire_rule(&ctx, "default", "no-such-rule");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("not found"));
     }
@@ -314,15 +333,14 @@ mod tests {
             }],
         );
 
-        let result = fire_rule(
-            &state,
-            &delivery,
-            &None,
-            &None,
-            &None,
-            "default",
-            "disabled-rule",
-        );
+        let ctx = FireRuleContext {
+            state: &state,
+            delivery: &delivery,
+            lambda_state: &None,
+            logs_state: &None,
+            container_runtime: &None,
+        };
+        let result = fire_rule(&ctx, "default", "disabled-rule");
         // Simulation overrides disabled state
         let targets = result.unwrap();
         assert_eq!(targets.len(), 1);

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -957,12 +957,15 @@ async fn main() {
                 move |axum::Json(body): axum::Json<types::FireRuleRequest>| async move {
                     let bus_name = body.bus_name.as_deref().unwrap_or("default");
 
+                    let ctx = fakecloud_eventbridge::simulation::FireRuleContext {
+                        state: &es,
+                        delivery: &delivery,
+                        lambda_state: &lambda_state,
+                        logs_state: &logs_state,
+                        container_runtime: &container_runtime,
+                    };
                     match fakecloud_eventbridge::simulation::fire_rule(
-                        &es,
-                        &delivery,
-                        &lambda_state,
-                        &logs_state,
-                        &container_runtime,
+                        &ctx,
                         bus_name,
                         &body.rule_name,
                     ) {


### PR DESCRIPTION
## Summary
\`fire_rule\` took 7 positional args (state + delivery + lambda_state + logs_state + container_runtime + bus_name + rule_name). Bundle the five that are "where the surrounding services live" into a borrowed \`FireRuleContext<'a>\`; keep \`bus_name\` and \`rule_name\` as regular params since they're the actual lookup keys, not context. Same shape as the SNS \`TopicFanoutContext\` from PR #344.

Updates the three unit tests in \`simulation.rs\` and the server's \`/_fakecloud/eventbridge/fire-rule\` handler in \`main.rs\` to construct the context inline.

## Test plan
- [x] \`cargo fmt\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-eventbridge --lib\` — 60 passed
- [x] \`cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundled the environment args for `fire_rule` into a borrowed `FireRuleContext` to simplify call sites and match the SNS `TopicFanoutContext`. No behavior changes.

- **Refactors**
  - Replaced five positional refs with `FireRuleContext<'a>`; kept `bus_name` and `rule_name` as parameters.
  - Updated unit tests and the server `/_fakecloud/eventbridge/fire-rule` handler to construct the context inline.

<sup>Written for commit b9fc560cba36b692303c9c8c73e3bea6440f4a36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

