### PR TITLE
refactor(eventbridge): extract archive_matching_event from put_events

### DIFF
--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -1812,37 +1812,17 @@ impl EventBridgeService {
                 resources: resources.clone(),
             };
 
-            // Archive matching events
-            let archive_keys: Vec<String> = state.archives.keys().cloned().collect();
-            for akey in archive_keys {
-                let (archive_bus, archive_pattern, archive_enabled) = {
-                    let a = &state.archives[&akey];
-                    (
-                        state.resolve_bus_name(&a.event_source_arn),
-                        a.event_pattern.clone(),
-                        a.state == "ENABLED",
-                    )
-                };
-                if archive_bus == event_bus_name && archive_enabled {
-                    // Check if event matches archive's event pattern
-                    let pattern_matches = matches_pattern(
-                        archive_pattern.as_deref(),
-                        &source,
-                        &detail_type,
-                        &detail,
-                        &req.account_id,
-                        &req.region,
-                        &resources,
-                    );
-                    if pattern_matches {
-                        if let Some(archive) = state.archives.get_mut(&akey) {
-                            archive.event_count += 1;
-                            archive.size_bytes += detail.len() as i64;
-                            archive.events.push(event.clone());
-                        }
-                    }
-                }
-            }
+            archive_matching_event(
+                &mut state,
+                &event,
+                &event_bus_name,
+                &source,
+                &detail_type,
+                &detail,
+                &req.account_id,
+                &req.region,
+                &resources,
+            );
 
             state.events.push(event);
 
@@ -3648,6 +3628,54 @@ fn matches_single(pattern_elem: &Value, event_value: &Value) -> bool {
             false
         }
         _ => values_equal(pattern_elem, event_value),
+    }
+}
+
+/// For each archive on `event_bus_name` whose event pattern matches the
+/// event, append a clone of it to the archive's stored events and bump
+/// the archive's counters.
+#[allow(clippy::too_many_arguments)]
+fn archive_matching_event(
+    state: &mut crate::state::EventBridgeState,
+    event: &PutEvent,
+    event_bus_name: &str,
+    source: &str,
+    detail_type: &str,
+    detail: &str,
+    account_id: &str,
+    region: &str,
+    resources: &[String],
+) {
+    let archive_keys: Vec<String> = state.archives.keys().cloned().collect();
+    for akey in archive_keys {
+        let (archive_bus, archive_pattern, archive_enabled) = {
+            let a = &state.archives[&akey];
+            (
+                state.resolve_bus_name(&a.event_source_arn),
+                a.event_pattern.clone(),
+                a.state == "ENABLED",
+            )
+        };
+        if archive_bus != event_bus_name || !archive_enabled {
+            continue;
+        }
+        let pattern_matches = matches_pattern(
+            archive_pattern.as_deref(),
+            source,
+            detail_type,
+            detail,
+            account_id,
+            region,
+            resources,
+        );
+        if !pattern_matches {
+            continue;
+        }
+        if let Some(archive) = state.archives.get_mut(&akey) {
+            archive.event_count += 1;
+            archive.size_bytes += detail.len() as i64;
+            archive.events.push(event.clone());
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
The archive-matching loop inside \`put_events\` was an inline 30-line block: snapshot the archive keys (to release the borrow), per-archive read three fields, run \`matches_pattern\`, then re-acquire the archive mutably to bump counters and append the cloned event. Extract it as \`archive_matching_event\` with the guard-clause shape used elsewhere in the service (\`continue\` on no-match instead of nested \`if let\` pyramids). The per-entry loop in \`put_events\` is now ~80 lines instead of ~110.

## Test plan
- [x] \`cargo fmt\`
- [x] \`cargo clippy -p fakecloud-eventbridge --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-eventbridge --lib\` — 60 passed
- [x] \`cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted archive-matching logic from `put_events` into `archive_matching_event` to simplify the event loop and improve readability. Behavior is unchanged.

- **Refactors**
  - Moved archive matching to `archive_matching_event`.
  - Uses guard clauses and keeps borrow/mutate safe when updating counters and cloning events.
  - Synced with `main` after the `start_replay` split; no functional changes.

<sup>Written for commit 9b4665c8b8c476be8a756c7496780db465691257. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

