### PR TITLE
refactor(iam): collapse delete_access_key duplicated 404 branches

### DIFF
--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -487,19 +487,19 @@ impl IamService {
             .unwrap_or_else(|| resolve_calling_user(&self.state.read(), &req.account_id));
         let access_key_id = required_param(&req.query_params, "AccessKeyId")?;
         validate_string_length("accessKeyId", &access_key_id, 16, 128)?;
-        let mut state = self.state.write();
 
-        if let Some(keys) = state.access_keys.get_mut(&user_name) {
-            let len_before = keys.len();
-            keys.retain(|k| k.access_key_id != access_key_id);
-            if keys.len() == len_before {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
-                    "NoSuchEntity",
-                    format!("The Access Key with id {access_key_id} cannot be found."),
-                ));
-            }
-        } else {
+        let mut state = self.state.write();
+        let removed = state
+            .access_keys
+            .get_mut(&user_name)
+            .map(|keys| {
+                let len_before = keys.len();
+                keys.retain(|k| k.access_key_id != access_key_id);
+                keys.len() < len_before
+            })
+            .unwrap_or(false);
+
+        if !removed {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",


### PR DESCRIPTION
## Summary
\`delete_access_key\` had two separate \`AwsServiceError::aws_error\` returns with identical \`NoSuchEntity\` messages: one when \`access_keys\` had no entry for the user, another when the entry existed but didn't contain the target id. Collapse to a single \`removed\` flag + one 404 site.

### Audited and judged already-clean
- \`create_user\` (44L): single-purpose function, one validation block, one struct construction, one duplicate check. The \`IamUser\` literal is 14 lines and trivially readable inline.
- \`get_user\` (38L): two-branch function (no UserName → return default user; with name → lookup or 404). Already focused.

These were on the original audit list but case-by-case judgment says they're fine — splitting would move fields around without improving readability.

## Test plan
- [x] \`cargo fmt\`
- [x] \`cargo clippy -p fakecloud-iam --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-iam --lib\` — 73 passed
- [x] \`cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapsed duplicate 404 paths in `delete_access_key` by using a `removed` flag and a single `NoSuchEntity` error when the key isn’t found. This simplifies control flow without changing behavior.

<sup>Written for commit 796df481ce4bf70a16d06c536ddaa8b6a8f2626d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

