### PR TITLE
refactor(ssm): extract CreatePatchBaselineInput and CreateAssociationInput

### DIFF
--- a/crates/fakecloud-ssm/src/service/associations.rs
+++ b/crates/fakecloud-ssm/src/service/associations.rs
@@ -14,156 +14,52 @@ use super::{missing, SsmService};
 
 impl SsmService {
     pub(super) fn create_association_inner(&self, body: &Value) -> Result<Value, AwsServiceError> {
-        validate_optional_string_length(
-            "AssociationDispatchAssumeRole",
-            body["AssociationDispatchAssumeRole"].as_str(),
-            1,
-            512,
-        )?;
-        validate_optional_string_length(
-            "AutomationTargetParameterName",
-            body["AutomationTargetParameterName"].as_str(),
-            1,
-            50,
-        )?;
-        validate_optional_string_length(
-            "ScheduleExpression",
-            body["ScheduleExpression"].as_str(),
-            1,
-            256,
-        )?;
-        validate_optional_string_length("MaxConcurrency", body["MaxConcurrency"].as_str(), 1, 7)?;
-        validate_optional_string_length("MaxErrors", body["MaxErrors"].as_str(), 1, 7)?;
-        validate_optional_enum(
-            "ComplianceSeverity",
-            body["ComplianceSeverity"].as_str(),
-            &["Critical", "High", "Medium", "Low", "Unspecified"],
-        )?;
-        validate_optional_enum(
-            "SyncCompliance",
-            body["SyncCompliance"].as_str(),
-            &["Auto", "Manual"],
-        )?;
-        validate_optional_range_i64("Duration", body["Duration"].as_i64(), 1, 24)?;
-        validate_optional_range_i64("ScheduleOffset", body["ScheduleOffset"].as_i64(), 1, 6)?;
-
-        let name = body["Name"]
-            .as_str()
-            .ok_or_else(|| missing("Name"))?
-            .to_string();
-
-        let targets: Vec<serde_json::Value> =
-            body["Targets"].as_array().cloned().unwrap_or_default();
-        let instance_id = body["InstanceId"].as_str().map(|s| s.to_string());
-
-        // Must have either Targets or InstanceId
-        if targets.is_empty() && instance_id.is_none() {
-            // Accept it anyway like AWS does for document-only associations
-        }
-
-        let schedule_expression = body["ScheduleExpression"].as_str().map(|s| s.to_string());
-        let parameters: HashMap<String, Vec<String>> = body["Parameters"]
-            .as_object()
-            .map(|obj| {
-                obj.iter()
-                    .map(|(k, v)| {
-                        let vals = v
-                            .as_array()
-                            .map(|a| {
-                                a.iter()
-                                    .filter_map(|x| x.as_str().map(|s| s.to_string()))
-                                    .collect()
-                            })
-                            .unwrap_or_default();
-                        (k.clone(), vals)
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-        let association_name = body["AssociationName"].as_str().map(|s| s.to_string());
-        let document_version = body["DocumentVersion"].as_str().map(|s| s.to_string());
-        let output_location = body.get("OutputLocation").filter(|v| !v.is_null()).cloned();
-        let automation_target_parameter_name = body["AutomationTargetParameterName"]
-            .as_str()
-            .map(|s| s.to_string());
-        let max_errors = body["MaxErrors"].as_str().map(|s| s.to_string());
-        let max_concurrency = body["MaxConcurrency"].as_str().map(|s| s.to_string());
-        let compliance_severity = body["ComplianceSeverity"].as_str().map(|s| s.to_string());
-        let sync_compliance = body["SyncCompliance"].as_str().map(|s| s.to_string());
-        let apply_only_at_cron_interval =
-            body["ApplyOnlyAtCronInterval"].as_bool().unwrap_or(false);
-        let calendar_names: Vec<String> = body["CalendarNames"]
-            .as_array()
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect()
-            })
-            .unwrap_or_default();
-        let target_locations: Vec<serde_json::Value> = body["TargetLocations"]
-            .as_array()
-            .cloned()
-            .unwrap_or_default();
-        let schedule_offset = body["ScheduleOffset"].as_i64();
-        let target_maps: Vec<serde_json::Value> =
-            body["TargetMaps"].as_array().cloned().unwrap_or_default();
-        let tags: HashMap<String, String> = body["Tags"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|t| {
-                        let k = t["Key"].as_str()?;
-                        let v = t["Value"].as_str()?;
-                        Some((k.to_string(), v.to_string()))
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+        let input = CreateAssociationInput::from_body(body)?;
 
         let now = Utc::now();
         let association_id = uuid::Uuid::new_v4().to_string();
 
         let version = SsmAssociationVersion {
             version: 1,
-            name: name.clone(),
-            targets: targets.clone(),
-            schedule_expression: schedule_expression.clone(),
-            parameters: parameters.clone(),
-            document_version: document_version.clone(),
+            name: input.name.clone(),
+            targets: input.targets.clone(),
+            schedule_expression: input.schedule_expression.clone(),
+            parameters: input.parameters.clone(),
+            document_version: input.document_version.clone(),
             created_date: now,
-            association_name: association_name.clone(),
-            max_errors: max_errors.clone(),
-            max_concurrency: max_concurrency.clone(),
-            compliance_severity: compliance_severity.clone(),
+            association_name: input.association_name.clone(),
+            max_errors: input.max_errors.clone(),
+            max_concurrency: input.max_concurrency.clone(),
+            compliance_severity: input.compliance_severity.clone(),
         };
 
         let assoc = SsmAssociation {
             association_id: association_id.clone(),
-            name: name.clone(),
-            targets: targets.clone(),
-            schedule_expression,
-            parameters,
-            association_name: association_name.clone(),
-            document_version,
-            output_location,
-            automation_target_parameter_name,
-            max_errors,
-            max_concurrency,
-            compliance_severity,
-            sync_compliance,
-            apply_only_at_cron_interval,
-            calendar_names,
-            target_locations,
-            schedule_offset,
-            target_maps,
-            tags,
+            name: input.name,
+            targets: input.targets,
+            schedule_expression: input.schedule_expression,
+            parameters: input.parameters,
+            association_name: input.association_name,
+            document_version: input.document_version,
+            output_location: input.output_location,
+            automation_target_parameter_name: input.automation_target_parameter_name,
+            max_errors: input.max_errors,
+            max_concurrency: input.max_concurrency,
+            compliance_severity: input.compliance_severity,
+            sync_compliance: input.sync_compliance,
+            apply_only_at_cron_interval: input.apply_only_at_cron_interval,
+            calendar_names: input.calendar_names,
+            target_locations: input.target_locations,
+            schedule_offset: input.schedule_offset,
+            target_maps: input.target_maps,
+            tags: input.tags,
             status: "Pending".to_string(),
             status_date: now,
             overview: json!({"Status": "Pending", "DetailedStatus": "Creating", "AssociationStatusAggregatedCount": {}}),
             created_date: now,
             last_update_association_date: now,
             last_execution_date: None,
-            instance_id,
+            instance_id: input.instance_id,
             versions: vec![version],
         };
 
@@ -651,6 +547,139 @@ impl SsmService {
         Ok(AwsResponse::ok_json(
             json!({ "InstanceAssociationStatusInfos": statuses }),
         ))
+    }
+}
+
+/// Parsed + validated inputs for `CreateAssociation`.
+struct CreateAssociationInput {
+    name: String,
+    targets: Vec<Value>,
+    instance_id: Option<String>,
+    schedule_expression: Option<String>,
+    parameters: HashMap<String, Vec<String>>,
+    association_name: Option<String>,
+    document_version: Option<String>,
+    output_location: Option<Value>,
+    automation_target_parameter_name: Option<String>,
+    max_errors: Option<String>,
+    max_concurrency: Option<String>,
+    compliance_severity: Option<String>,
+    sync_compliance: Option<String>,
+    apply_only_at_cron_interval: bool,
+    calendar_names: Vec<String>,
+    target_locations: Vec<Value>,
+    schedule_offset: Option<i64>,
+    target_maps: Vec<Value>,
+    tags: HashMap<String, String>,
+}
+
+impl CreateAssociationInput {
+    fn from_body(body: &Value) -> Result<Self, AwsServiceError> {
+        validate_optional_string_length(
+            "AssociationDispatchAssumeRole",
+            body["AssociationDispatchAssumeRole"].as_str(),
+            1,
+            512,
+        )?;
+        validate_optional_string_length(
+            "AutomationTargetParameterName",
+            body["AutomationTargetParameterName"].as_str(),
+            1,
+            50,
+        )?;
+        validate_optional_string_length(
+            "ScheduleExpression",
+            body["ScheduleExpression"].as_str(),
+            1,
+            256,
+        )?;
+        validate_optional_string_length("MaxConcurrency", body["MaxConcurrency"].as_str(), 1, 7)?;
+        validate_optional_string_length("MaxErrors", body["MaxErrors"].as_str(), 1, 7)?;
+        validate_optional_enum(
+            "ComplianceSeverity",
+            body["ComplianceSeverity"].as_str(),
+            &["Critical", "High", "Medium", "Low", "Unspecified"],
+        )?;
+        validate_optional_enum(
+            "SyncCompliance",
+            body["SyncCompliance"].as_str(),
+            &["Auto", "Manual"],
+        )?;
+        validate_optional_range_i64("Duration", body["Duration"].as_i64(), 1, 24)?;
+        validate_optional_range_i64("ScheduleOffset", body["ScheduleOffset"].as_i64(), 1, 6)?;
+
+        let name = body["Name"]
+            .as_str()
+            .ok_or_else(|| missing("Name"))?
+            .to_string();
+
+        let parameters: HashMap<String, Vec<String>> = body["Parameters"]
+            .as_object()
+            .map(|obj| {
+                obj.iter()
+                    .map(|(k, v)| {
+                        let vals = v
+                            .as_array()
+                            .map(|a| {
+                                a.iter()
+                                    .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        (k.clone(), vals)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let calendar_names: Vec<String> = body["CalendarNames"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let tags: HashMap<String, String> = body["Tags"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let k = t["Key"].as_str()?;
+                        let v = t["Value"].as_str()?;
+                        Some((k.to_string(), v.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(Self {
+            name,
+            targets: body["Targets"].as_array().cloned().unwrap_or_default(),
+            instance_id: body["InstanceId"].as_str().map(|s| s.to_string()),
+            schedule_expression: body["ScheduleExpression"].as_str().map(|s| s.to_string()),
+            parameters,
+            association_name: body["AssociationName"].as_str().map(|s| s.to_string()),
+            document_version: body["DocumentVersion"].as_str().map(|s| s.to_string()),
+            output_location: body.get("OutputLocation").filter(|v| !v.is_null()).cloned(),
+            automation_target_parameter_name: body["AutomationTargetParameterName"]
+                .as_str()
+                .map(|s| s.to_string()),
+            max_errors: body["MaxErrors"].as_str().map(|s| s.to_string()),
+            max_concurrency: body["MaxConcurrency"].as_str().map(|s| s.to_string()),
+            compliance_severity: body["ComplianceSeverity"].as_str().map(|s| s.to_string()),
+            sync_compliance: body["SyncCompliance"].as_str().map(|s| s.to_string()),
+            apply_only_at_cron_interval: body["ApplyOnlyAtCronInterval"].as_bool().unwrap_or(false),
+            calendar_names,
+            target_locations: body["TargetLocations"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default(),
+            schedule_offset: body["ScheduleOffset"].as_i64(),
+            target_maps: body["TargetMaps"].as_array().cloned().unwrap_or_default(),
+            tags,
+        })
     }
 }
 

--- a/crates/fakecloud-ssm/src/service/patches.rs
+++ b/crates/fakecloud-ssm/src/service/patches.rs
@@ -16,115 +16,12 @@ impl SsmService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = req.json_body();
-        let name = body["Name"]
-            .as_str()
-            .ok_or_else(|| missing("Name"))?
-            .to_string();
-        validate_string_length("Name", &name, 3, 128)?;
-        validate_optional_enum(
-            "OperatingSystem",
-            body["OperatingSystem"].as_str(),
-            &[
-                "WINDOWS",
-                "AMAZON_LINUX",
-                "AMAZON_LINUX_2",
-                "AMAZON_LINUX_2022",
-                "UBUNTU",
-                "REDHAT_ENTERPRISE_LINUX",
-                "SUSE",
-                "CENTOS",
-                "ORACLE_LINUX",
-                "DEBIAN",
-                "MACOS",
-                "RASPBIAN",
-                "ROCKY_LINUX",
-                "ALMA_LINUX",
-                "AMAZON_LINUX_2023",
-            ],
-        )?;
-        let operating_system = body["OperatingSystem"]
-            .as_str()
-            .unwrap_or("WINDOWS")
-            .to_string();
-        validate_optional_string_length("Description", body["Description"].as_str(), 1, 1024)?;
-        validate_optional_enum(
-            "ApprovedPatchesComplianceLevel",
-            body["ApprovedPatchesComplianceLevel"].as_str(),
-            &[
-                "CRITICAL",
-                "HIGH",
-                "MEDIUM",
-                "LOW",
-                "INFORMATIONAL",
-                "UNSPECIFIED",
-            ],
-        )?;
-        validate_optional_enum(
-            "RejectedPatchesAction",
-            body["RejectedPatchesAction"].as_str(),
-            &["ALLOW_AS_DEPENDENCY", "BLOCK"],
-        )?;
-        validate_optional_enum(
-            "AvailableSecurityUpdatesComplianceStatus",
-            body["AvailableSecurityUpdatesComplianceStatus"].as_str(),
-            &["COMPLIANT", "NON_COMPLIANT"],
-        )?;
-        validate_optional_string_length("ClientToken", body["ClientToken"].as_str(), 1, 64)?;
-        let description = body["Description"].as_str().map(|s| s.to_string());
-        let approval_rules = body.get("ApprovalRules").cloned();
-        let approved_patches: Vec<String> = body["ApprovedPatches"]
-            .as_array()
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect()
-            })
-            .unwrap_or_default();
-        let rejected_patches: Vec<String> = body["RejectedPatches"]
-            .as_array()
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect()
-            })
-            .unwrap_or_default();
-        let approved_patches_compliance_level = body["ApprovedPatchesComplianceLevel"]
-            .as_str()
-            .unwrap_or("UNSPECIFIED")
-            .to_string();
-        let rejected_patches_action = body["RejectedPatchesAction"]
-            .as_str()
-            .unwrap_or("ALLOW_AS_DEPENDENCY")
-            .to_string();
-        let global_filters = body.get("GlobalFilters").cloned();
-        let sources: Vec<Value> = body["Sources"].as_array().cloned().unwrap_or_default();
-        let approved_patches_enable_non_security = body["ApprovedPatchesEnableNonSecurity"]
-            .as_bool()
-            .unwrap_or(false);
-        let tags: HashMap<String, String> = body["Tags"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|t| {
-                        let k = t["Key"].as_str()?;
-                        let v = t["Value"].as_str()?;
-                        Some((k.to_string(), v.to_string()))
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let available_security_updates_compliance_status = body
-            ["AvailableSecurityUpdatesComplianceStatus"]
-            .as_str()
-            .map(|s| s.to_string());
-        let client_token = body["ClientToken"].as_str().map(|s| s.to_string());
+        let input = CreatePatchBaselineInput::from_body(&req.json_body())?;
 
         let mut state = self.state.write();
 
         // Idempotency: if a baseline with the same ClientToken already exists, return it
-        if let Some(ref token) = client_token {
+        if let Some(ref token) = input.client_token {
             if let Some(existing) = state
                 .patch_baselines
                 .values()
@@ -141,20 +38,21 @@ impl SsmService {
 
         let pb = PatchBaseline {
             id: baseline_id.clone(),
-            name,
-            operating_system,
-            description,
-            approval_rules,
-            approved_patches,
-            rejected_patches,
-            tags,
-            approved_patches_compliance_level,
-            rejected_patches_action,
-            global_filters,
-            sources,
-            approved_patches_enable_non_security,
-            available_security_updates_compliance_status,
-            client_token,
+            name: input.name,
+            operating_system: input.operating_system,
+            description: input.description,
+            approval_rules: input.approval_rules,
+            approved_patches: input.approved_patches,
+            rejected_patches: input.rejected_patches,
+            tags: input.tags,
+            approved_patches_compliance_level: input.approved_patches_compliance_level,
+            rejected_patches_action: input.rejected_patches_action,
+            global_filters: input.global_filters,
+            sources: input.sources,
+            approved_patches_enable_non_security: input.approved_patches_enable_non_security,
+            available_security_updates_compliance_status: input
+                .available_security_updates_compliance_status,
+            client_token: input.client_token,
         };
 
         state.patch_baselines.insert(baseline_id.clone(), pb);
@@ -842,6 +740,139 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 100)?;
         Ok(AwsResponse::ok_json(json!({ "Patches": [] })))
+    }
+}
+
+/// Parsed + validated inputs for `CreatePatchBaseline`.
+struct CreatePatchBaselineInput {
+    name: String,
+    operating_system: String,
+    description: Option<String>,
+    approval_rules: Option<Value>,
+    approved_patches: Vec<String>,
+    rejected_patches: Vec<String>,
+    approved_patches_compliance_level: String,
+    rejected_patches_action: String,
+    global_filters: Option<Value>,
+    sources: Vec<Value>,
+    approved_patches_enable_non_security: bool,
+    available_security_updates_compliance_status: Option<String>,
+    client_token: Option<String>,
+    tags: HashMap<String, String>,
+}
+
+impl CreatePatchBaselineInput {
+    fn from_body(body: &Value) -> Result<Self, AwsServiceError> {
+        let name = body["Name"]
+            .as_str()
+            .ok_or_else(|| missing("Name"))?
+            .to_string();
+        validate_string_length("Name", &name, 3, 128)?;
+        validate_optional_enum(
+            "OperatingSystem",
+            body["OperatingSystem"].as_str(),
+            &[
+                "WINDOWS",
+                "AMAZON_LINUX",
+                "AMAZON_LINUX_2",
+                "AMAZON_LINUX_2022",
+                "UBUNTU",
+                "REDHAT_ENTERPRISE_LINUX",
+                "SUSE",
+                "CENTOS",
+                "ORACLE_LINUX",
+                "DEBIAN",
+                "MACOS",
+                "RASPBIAN",
+                "ROCKY_LINUX",
+                "ALMA_LINUX",
+                "AMAZON_LINUX_2023",
+            ],
+        )?;
+        validate_optional_string_length("Description", body["Description"].as_str(), 1, 1024)?;
+        validate_optional_enum(
+            "ApprovedPatchesComplianceLevel",
+            body["ApprovedPatchesComplianceLevel"].as_str(),
+            &[
+                "CRITICAL",
+                "HIGH",
+                "MEDIUM",
+                "LOW",
+                "INFORMATIONAL",
+                "UNSPECIFIED",
+            ],
+        )?;
+        validate_optional_enum(
+            "RejectedPatchesAction",
+            body["RejectedPatchesAction"].as_str(),
+            &["ALLOW_AS_DEPENDENCY", "BLOCK"],
+        )?;
+        validate_optional_enum(
+            "AvailableSecurityUpdatesComplianceStatus",
+            body["AvailableSecurityUpdatesComplianceStatus"].as_str(),
+            &["COMPLIANT", "NON_COMPLIANT"],
+        )?;
+        validate_optional_string_length("ClientToken", body["ClientToken"].as_str(), 1, 64)?;
+
+        let approved_patches: Vec<String> = body["ApprovedPatches"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let rejected_patches: Vec<String> = body["RejectedPatches"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let tags: HashMap<String, String> = body["Tags"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let k = t["Key"].as_str()?;
+                        let v = t["Value"].as_str()?;
+                        Some((k.to_string(), v.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(Self {
+            name,
+            operating_system: body["OperatingSystem"]
+                .as_str()
+                .unwrap_or("WINDOWS")
+                .to_string(),
+            description: body["Description"].as_str().map(|s| s.to_string()),
+            approval_rules: body.get("ApprovalRules").cloned(),
+            approved_patches,
+            rejected_patches,
+            approved_patches_compliance_level: body["ApprovedPatchesComplianceLevel"]
+                .as_str()
+                .unwrap_or("UNSPECIFIED")
+                .to_string(),
+            rejected_patches_action: body["RejectedPatchesAction"]
+                .as_str()
+                .unwrap_or("ALLOW_AS_DEPENDENCY")
+                .to_string(),
+            global_filters: body.get("GlobalFilters").cloned(),
+            sources: body["Sources"].as_array().cloned().unwrap_or_default(),
+            approved_patches_enable_non_security: body["ApprovedPatchesEnableNonSecurity"]
+                .as_bool()
+                .unwrap_or(false),
+            available_security_updates_compliance_status: body
+                ["AvailableSecurityUpdatesComplianceStatus"]
+                .as_str()
+                .map(|s| s.to_string()),
+            client_token: body["ClientToken"].as_str().map(|s| s.to_string()),
+            tags,
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

The two longest functions in the SSM sub-modules were `create_patch_baseline` (~150 lines) and `create_association_inner` (~162 lines). Both were dominated by body parsing, field validation, and field extraction — with the actual state mutation only in the last 30-40 lines.

This extracts dedicated `*Input` structs with `from_body()` constructors, leaving each function focused on idempotency, ID generation, and struct assembly. Same pattern as PRs #324/#328/#338/#355/#356.

## Test plan
- [x] `cargo clippy -p fakecloud-ssm --all-targets -- -D warnings`
- [x] `cargo test -p fakecloud-ssm` (60 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored SSM create flows by extracting `CreatePatchBaselineInput` and `CreateAssociationInput` with `from_body()` parsing and validation. This simplifies `create_patch_baseline` and `create_association_inner` and keeps them focused on idempotency and state updates.

- **Refactors**
  - Moved body parsing, field extraction, and validation into `CreatePatchBaselineInput::from_body` and `CreateAssociationInput::from_body`.
  - Shortened the two longest functions and improved readability and testability.
  - Preserved behavior, defaults, and validation logic (no functional changes).

<sup>Written for commit 7289b60540ab0aaf87aa9a2437cd3e19c4c975be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

