### PR TITLE
Fix DynamoDB DescribeTable warm throughput response

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -666,6 +666,7 @@ impl ResourceProvisioner {
         let table = DynamoTable {
             name: table_name.to_string(),
             arn: arn.clone(),
+            table_id: Uuid::new_v4().to_string().replace('-', ""),
             key_schema,
             attribute_definitions,
             provisioned_throughput,

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -1954,6 +1954,7 @@ fn apply_delete_assignment(
 
 pub(super) struct TableDescriptionInput<'a> {
     pub arn: &'a str,
+    pub table_id: &'a str,
     pub key_schema: &'a [KeySchemaElement],
     pub attribute_definitions: &'a [AttributeDefinition],
     pub provisioned_throughput: &'a ProvisionedThroughput,
@@ -1969,6 +1970,7 @@ pub(super) struct TableDescriptionInput<'a> {
 fn build_table_description_json(input: &TableDescriptionInput<'_>) -> Value {
     let TableDescriptionInput {
         arn,
+        table_id,
         key_schema,
         attribute_definitions,
         provisioned_throughput,
@@ -1997,7 +1999,7 @@ fn build_table_description_json(input: &TableDescriptionInput<'_>) -> Value {
     let mut desc = json!({
         "TableName": table_name,
         "TableArn": arn,
-        "TableId": uuid::Uuid::new_v4().to_string().replace('-', ""),
+        "TableId": table_id,
         "TableStatus": status,
         "KeySchema": ks,
         "AttributeDefinitions": ad,
@@ -2018,6 +2020,18 @@ fn build_table_description_json(input: &TableDescriptionInput<'_>) -> Value {
             "ReadCapacityUnits": 0,
             "WriteCapacityUnits": 0,
             "NumberOfDecreasesToday": 0,
+        });
+    }
+
+    // Terraform's AWS provider now waits on WarmThroughput after CreateTable.
+    // Real AWS returns an ACTIVE warm throughput object for active tables,
+    // including PAY_PER_REQUEST tables. Returning null keeps the provider in a
+    // perpetual "still creating" loop.
+    if status == "ACTIVE" {
+        desc["WarmThroughput"] = json!({
+            "ReadUnitsPerSecond": 0,
+            "WriteUnitsPerSecond": 0,
+            "Status": "ACTIVE",
         });
     }
 
@@ -2087,6 +2101,7 @@ fn build_table_description_json(input: &TableDescriptionInput<'_>) -> Value {
 fn build_table_description(table: &DynamoTable) -> Value {
     let mut desc = build_table_description_json(&TableDescriptionInput {
         arn: &table.arn,
+        table_id: &table.table_id,
         key_schema: &table.key_schema,
         attribute_definitions: &table.attribute_definitions,
         provisioned_throughput: &table.provisioned_throughput,
@@ -2752,6 +2767,48 @@ mod tests {
             }),
         );
         svc.create_table(&req).unwrap();
+    }
+
+    #[test]
+    fn describe_table_returns_stable_table_id_and_active_warm_throughput() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateTable",
+            json!({
+                "TableName": "warm-throughput-table",
+                "KeySchema": [
+                    { "AttributeName": "pk", "KeyType": "HASH" }
+                ],
+                "AttributeDefinitions": [
+                    { "AttributeName": "pk", "AttributeType": "S" }
+                ],
+                "BillingMode": "PAY_PER_REQUEST"
+            }),
+        );
+        let create_resp = svc.create_table(&req).unwrap();
+        let create_body: Value = serde_json::from_slice(&create_resp.body).unwrap();
+        let create_table = &create_body["TableDescription"];
+
+        assert_eq!(create_table["TableStatus"], "ACTIVE");
+        assert_eq!(create_table["WarmThroughput"]["Status"], "ACTIVE");
+        let table_id = create_table["TableId"].as_str().unwrap().to_string();
+        assert!(!table_id.is_empty());
+
+        let describe_req = make_request(
+            "DescribeTable",
+            json!({ "TableName": "warm-throughput-table" }),
+        );
+        let describe_resp = svc.describe_table(&describe_req).unwrap();
+        let describe_body: Value = serde_json::from_slice(&describe_resp.body).unwrap();
+        let described_table = &describe_body["Table"];
+
+        assert_eq!(described_table["TableStatus"], "ACTIVE");
+        assert_eq!(described_table["WarmThroughput"]["Status"], "ACTIVE");
+        assert_eq!(described_table["TableId"], table_id);
+
+        let describe_resp_again = svc.describe_table(&describe_req).unwrap();
+        let describe_body_again: Value = serde_json::from_slice(&describe_resp_again.body).unwrap();
+        assert_eq!(describe_body_again["Table"]["TableId"], table_id);
     }
 
     #[test]

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -154,6 +154,7 @@ impl DynamoDbService {
         let table = DynamoTable {
             name: table_name.clone(),
             arn: arn.clone(),
+            table_id: uuid::Uuid::new_v4().to_string().replace('-', ""),
             key_schema: key_schema.clone(),
             attribute_definitions: attribute_definitions.clone(),
             provisioned_throughput: provisioned_throughput.clone(),
@@ -181,10 +182,12 @@ impl DynamoDbService {
             sse_kms_key_arn,
         };
 
+        let table_id = table.table_id.clone();
         state.tables.insert(table_name, table);
 
         let table_desc = build_table_description_json(&super::TableDescriptionInput {
             arn: &arn,
+            table_id: &table_id,
             key_schema: &key_schema,
             attribute_definitions: &attribute_definitions,
             provisioned_throughput: &provisioned_throughput,
@@ -215,6 +218,7 @@ impl DynamoDbService {
 
         let table_desc = build_table_description_json(&super::TableDescriptionInput {
             arn: &table.arn,
+            table_id: &table.table_id,
             key_schema: &table.key_schema,
             attribute_definitions: &table.attribute_definitions,
             provisioned_throughput: &table.provisioned_throughput,
@@ -337,6 +341,7 @@ impl DynamoDbService {
 
         let table_desc = build_table_description_json(&super::TableDescriptionInput {
             arn: &table.arn,
+            table_id: &table.table_id,
             key_schema: &table.key_schema,
             attribute_definitions: &table.attribute_definitions,
             provisioned_throughput: &table.provisioned_throughput,
@@ -749,6 +754,7 @@ impl DynamoDbService {
         let mut table = DynamoTable {
             name: target_table_name.to_string(),
             arn: arn.clone(),
+            table_id: uuid::Uuid::new_v4().to_string().replace('-', ""),
             key_schema: backup.key_schema.clone(),
             attribute_definitions: backup.attribute_definitions.clone(),
             provisioned_throughput: backup.provisioned_throughput.clone(),
@@ -826,6 +832,7 @@ impl DynamoDbService {
         let mut table = DynamoTable {
             name: target_table_name.to_string(),
             arn: arn.clone(),
+            table_id: uuid::Uuid::new_v4().to_string().replace('-', ""),
             key_schema: source.key_schema.clone(),
             attribute_definitions: source.attribute_definitions.clone(),
             provisioned_throughput: source.provisioned_throughput.clone(),
@@ -1219,6 +1226,7 @@ impl DynamoDbService {
         let mut table = DynamoTable {
             name: table_name.to_string(),
             arn: table_arn.clone(),
+            table_id: uuid::Uuid::new_v4().to_string().replace('-', ""),
             key_schema,
             attribute_definitions,
             provisioned_throughput: ProvisionedThroughput {
@@ -1282,7 +1290,7 @@ impl DynamoDbService {
                 "ImportArn": import_arn,
                 "ImportStatus": "COMPLETED",
                 "TableArn": table_arn,
-                "TableId": uuid::Uuid::new_v4().to_string(),
+                "TableId": table_ref.table_id,
                 "S3BucketSource": {
                     "S3Bucket": s3_bucket
                 },

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -62,6 +62,7 @@ pub struct Projection {
 pub struct DynamoTable {
     pub name: String,
     pub arn: String,
+    pub table_id: String,
     pub key_schema: Vec<KeySchemaElement>,
     pub attribute_definitions: Vec<AttributeDefinition>,
     pub provisioned_throughput: ProvisionedThroughput,

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -86,6 +86,7 @@ mod tests {
         DynamoTable {
             name: "test-table".to_string(),
             arn: "arn:aws:dynamodb:eu-west-1:999999999999:table/test-table".to_string(),
+            table_id: "test-table-id".to_string(),
             key_schema: vec![KeySchemaElement {
                 attribute_name: "pk".to_string(),
                 key_type: "HASH".to_string(),

--- a/crates/fakecloud-dynamodb/src/ttl.rs
+++ b/crates/fakecloud-dynamodb/src/ttl.rs
@@ -74,6 +74,7 @@ mod tests {
         DynamoTable {
             name: name.to_string(),
             arn: format!("arn:aws:dynamodb:us-east-1:123456789012:table/{}", name),
+            table_id: format!("{name}-id"),
             key_schema: vec![KeySchemaElement {
                 attribute_name: "pk".to_string(),
                 key_type: "HASH".to_string(),


### PR DESCRIPTION
## Summary

  Fix DynamoDB table descriptions so Terraform's AWS provider can finish `aws_dynamodb_table` creation against fakecloud.

  This change:
  - returns a stable `TableId` for DynamoDB tables instead of generating a new one on each response
  - includes an `ACTIVE` `WarmThroughput` block in `DescribeTable` responses for active tables
  - stores `table_id` in DynamoDB table state and threads it through create/restore/import paths
  - adds a regression test covering stable `TableId` plus active warm throughput

  ## Why

  Recent Terraform AWS provider versions wait for both:
  - `TableStatus == ACTIVE`
  - `WarmThroughput.Status == ACTIVE`

  Fakecloud already returned `TableStatus: ACTIVE`, but `WarmThroughput` was missing, which caused the provider to stay in the create waiter until timeout.

  ## Validation

  Passed:
  - `cargo test -p fakecloud-dynamodb`
  - direct `boto3` verification of `DescribeTable`
    - stable `TableId` across repeated calls
    - `WarmThroughput.Status == ACTIVE`
  - Terraform repro with only `aws_dynamodb_table`
  - broader Terraform smoke apply/destroy with:
    - `aws_s3_bucket`
    - `aws_dynamodb_table`
    - `aws_iam_role`
    - `aws_ssm_parameter`
    - `aws_sns_topic`

  ## Notes

  This also fixes an unrelated fidelity issue where `TableId` changed across repeated `DescribeTable` calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB `DescribeTable` so Terraform can finish `aws_dynamodb_table` creation against `fakecloud`. Returns a stable `TableId` and an `ACTIVE` `WarmThroughput` for active tables.

- **Bug Fixes**
  - Return a stable `TableId` in `DescribeTable`/create responses; persist `table_id` in state.
  - Generate and thread `table_id` through create/restore/import paths (including CloudFormation provisioner).
  - Include `WarmThroughput` with `Status: ACTIVE` for active tables, including `PAY_PER_REQUEST`.
  - Add a regression test for stable `TableId` and active `WarmThroughput`; update existing tests.

<sup>Written for commit 46057c96e8ea88b81204fef8cf4fb0e62a7f5a01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

