### PR TITLE
feat(s3): opt-in disk persistence for S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,6 +2195,8 @@ dependencies = [
  "flate2",
  "reqwest",
  "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
  "tokio",
  "tokio-postgres",
  "zip",
@@ -2395,6 +2397,7 @@ dependencies = [
  "sha1",
  "sha2 0.10.9",
  "tokio",
+ "toml",
  "tracing",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,6 +2346,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 2.0.18",
  "toml",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,6 +1950,7 @@ dependencies = [
  "fakecloud-kms",
  "fakecloud-lambda",
  "fakecloud-logs",
+ "fakecloud-persistence",
  "fakecloud-rds",
  "fakecloud-s3",
  "fakecloud-sdk",
@@ -2147,6 +2148,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "fakecloud-s3",
  "http 1.4.0",
  "parking_lot",
@@ -2335,6 +2337,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fakecloud-persistence"
+version = "0.8.1"
+dependencies = [
+ "bytes",
+ "chrono",
+ "parking_lot",
+ "percent-encoding",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "toml",
+ "tracing",
+]
+
+[[package]]
 name = "fakecloud-rds"
 version = "0.8.1"
 dependencies = [
@@ -2367,6 +2384,7 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-kms",
+ "fakecloud-persistence",
  "http 1.4.0",
  "md-5 0.10.6",
  "parking_lot",
@@ -3955,7 +3973,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -4625,6 +4643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5114,6 +5141,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5124,14 +5172,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5140,8 +5202,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -5900,6 +5968,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,6 +2134,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
 ]
@@ -2155,6 +2157,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/fakecloud-apigatewayv2",
     "crates/fakecloud-bedrock",
     "crates/fakecloud-sdk",
+    "crates/fakecloud-persistence",
     "crates/fakecloud-e2e",
     "crates/fakecloud-conformance",
     "crates/fakecloud-conformance-macros",
@@ -96,3 +97,4 @@ fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "
 fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.8.1" }
 fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.8.1" }
 fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.8.1" }
+fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.8.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ version = "0.8.1"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
+tokio-util = { version = "0.7", features = ["io"] }
 axum = "0.8"
 hyper = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ fakecloud is configured via CLI flags or environment variables.
 | `--log-level`        | `FAKECLOUD_LOG`             | `info`             | Log level (trace, debug, info, warn, error)                                              |
 | `--storage-mode`     | `FAKECLOUD_STORAGE_MODE`    | `memory`           | `memory` (default, all state in RAM) or `persistent` (mirror S3 state to `--data-path`)  |
 | `--data-path`        | `FAKECLOUD_DATA_PATH`       | —                  | Directory to persist state to. Required when `--storage-mode=persistent`.                |
-| `--body-cache-size`  | `FAKECLOUD_BODY_CACHE_SIZE` | `268435456`        | Byte-sized LRU cache for object bodies in persistent mode. Default 256 MiB.              |
+| `--s3-cache-size`    | `FAKECLOUD_S3_CACHE_SIZE`   | `268435456`        | In-memory LRU cache for S3 object bodies in persistent mode. Default 256 MiB.            |
 |                      | `FAKECLOUD_CONTAINER_CLI`   | auto-detect        | Container CLI to use (`docker` or `podman`)                                              |
 
 ```sh
@@ -261,7 +261,7 @@ migration — the intent is that you either keep using the binary that wrote
 the directory or start from an empty data path.
 
 Object bodies are streamed straight to disk in persistent mode, not held in
-RAM. A bounded LRU cache (`--body-cache-size`, default 256 MiB) keeps recently
+RAM. A bounded LRU cache (`--s3-cache-size`, default 256 MiB) keeps recently
 read bodies available for fast re-reads. Objects larger than `cache-size / 2`
 bypass the cache on both read and write, so a single large upload cannot
 evict the entire working set.

--- a/README.md
+++ b/README.md
@@ -213,19 +213,62 @@ integration tests:
 
 fakecloud is configured via CLI flags or environment variables.
 
-| Flag           | Env Var                   | Default        | Description                                 |
-| -------------- | ------------------------- | -------------- | ------------------------------------------- |
-| `--addr`       | `FAKECLOUD_ADDR`          | `0.0.0.0:4566` | Listen address and port                     |
-| `--region`     | `FAKECLOUD_REGION`        | `us-east-1`    | AWS region to advertise                     |
-| `--account-id` | `FAKECLOUD_ACCOUNT_ID`    | `123456789012` | AWS account ID                              |
-| `--log-level`  | `FAKECLOUD_LOG`           | `info`         | Log level (trace, debug, info, warn, error) |
-|                | `FAKECLOUD_CONTAINER_CLI` | auto-detect    | Container CLI to use (`docker` or `podman`) |
+| Flag                 | Env Var                     | Default            | Description                                                                              |
+| -------------------- | --------------------------- | ------------------ | ---------------------------------------------------------------------------------------- |
+| `--addr`             | `FAKECLOUD_ADDR`            | `0.0.0.0:4566`     | Listen address and port                                                                  |
+| `--region`           | `FAKECLOUD_REGION`          | `us-east-1`        | AWS region to advertise                                                                  |
+| `--account-id`       | `FAKECLOUD_ACCOUNT_ID`      | `123456789012`     | AWS account ID                                                                           |
+| `--log-level`        | `FAKECLOUD_LOG`             | `info`             | Log level (trace, debug, info, warn, error)                                              |
+| `--storage-mode`     | `FAKECLOUD_STORAGE_MODE`    | `memory`           | `memory` (default, all state in RAM) or `persistent` (mirror S3 state to `--data-path`)  |
+| `--data-path`        | `FAKECLOUD_DATA_PATH`       | —                  | Directory to persist state to. Required when `--storage-mode=persistent`.                |
+| `--body-cache-size`  | `FAKECLOUD_BODY_CACHE_SIZE` | `268435456`        | Byte-sized LRU cache for object bodies in persistent mode. Default 256 MiB.              |
+|                      | `FAKECLOUD_CONTAINER_CLI`   | auto-detect        | Container CLI to use (`docker` or `podman`)                                              |
 
 ```sh
 # Examples
 fakecloud --addr 127.0.0.1:5000 --log-level debug
 FAKECLOUD_LOG=trace cargo run --bin fakecloud
 ```
+
+## Persistence
+
+By default fakecloud keeps all state in memory: startup is instant, shutdown
+is a no-op, and tests can run in parallel without cross-contamination. Pass
+`--storage-mode=persistent --data-path=<dir>` to mirror supported services to
+disk and reload them on the next launch.
+
+```sh
+fakecloud --storage-mode persistent --data-path /var/lib/fakecloud
+```
+
+Supported services:
+
+- **S3** — buckets, objects, versions, delete markers, multipart uploads
+  (resumable across restarts), and all bucket subresources (tags, lifecycle,
+  CORS, policy, notification, logging, website, public access block, object
+  lock, replication, ownership, inventory, encryption, ACL, accelerate) are
+  written to disk on every mutation and reloaded on startup.
+- Every other service emits `persistence not yet supported, running in-memory`
+  at startup and continues to operate exactly as in memory mode. Your tests
+  do not break — you just don't get cross-restart durability for those
+  services yet.
+
+On startup fakecloud reads `<data-path>/fakecloud.version.toml`. The file
+records the on-disk format version and the fakecloud version that created the
+directory. If the format version does not match the running binary, startup
+fails with an actionable error that points at the file. There is no automatic
+migration — the intent is that you either keep using the binary that wrote
+the directory or start from an empty data path.
+
+Object bodies are streamed straight to disk in persistent mode, not held in
+RAM. A bounded LRU cache (`--body-cache-size`, default 256 MiB) keeps recently
+read bodies available for fast re-reads. Objects larger than `cache-size / 2`
+bypass the cache on both read and write, so a single large upload cannot
+evict the entire working set.
+
+The `/_fakecloud/s3/notifications` introspection buffer is intentionally not
+persisted — it exists so tests can assert which events fired during the
+current run, not as a long-term audit log.
 
 ## Health Check
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ Opt-in disk persistence for S3 via `--storage-mode=persistent --data-path=<dir>`
 Buckets, objects, versions, delete markers, multipart uploads (resumable across
 restarts), and every bucket subresource are written to disk on every mutation
 and reloaded on startup. Object bodies stream straight to disk with a bounded
-LRU cache (`--body-cache-size`, default 256 MiB) so a single large upload can
+LRU cache (`--s3-cache-size`, default 256 MiB) so a single large upload can
 never pull the entire working set into RAM. Memory mode stays the default and
 is unchanged. Follow-up: extend persistence to DynamoDB, SQS, and the other
 stateful services.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,17 @@ For every service we implement, the standard is the same: full API coverage, rea
 
 ## Recently shipped
 
+### S3 persistence
+
+Opt-in disk persistence for S3 via `--storage-mode=persistent --data-path=<dir>`.
+Buckets, objects, versions, delete markers, multipart uploads (resumable across
+restarts), and every bucket subresource are written to disk on every mutation
+and reloaded on startup. Object bodies stream straight to disk with a bounded
+LRU cache (`--body-cache-size`, default 256 MiB) so a single large upload can
+never pull the entire working set into RAM. Memory mode stays the default and
+is unchanged. Follow-up: extend persistence to DynamoDB, SQS, and the other
+stateful services.
+
 ### API Gateway v2
 
 HTTP APIs with Lambda proxy integration, route-based request handling, path parameters, wildcards, CORS, JWT and Lambda authorizers. 28 operations, full Lambda proxy integration v2.0 format, HTTP proxy and Mock integrations. Completes the serverless stack: API Gateway → Lambda → Step Functions.

--- a/crates/fakecloud-apigatewayv2/src/cors.rs
+++ b/crates/fakecloud-apigatewayv2/src/cors.rs
@@ -50,7 +50,7 @@ pub fn handle_preflight(cors_config: &CorsConfiguration, req: &AwsRequest) -> Aw
         status: StatusCode::NO_CONTENT,
         content_type: String::new(),
         headers,
-        body: Bytes::new(),
+        body: Bytes::new().into(),
     }
 }
 
@@ -214,7 +214,7 @@ mod tests {
             status: StatusCode::OK,
             content_type: "application/json".to_string(),
             headers: HeaderMap::new(),
-            body: Bytes::from(b"test".to_vec()),
+            body: Bytes::from(b"test".to_vec()).into(),
         };
 
         let response_with_cors = add_cors_headers(response, &cors_config);

--- a/crates/fakecloud-apigatewayv2/src/http_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/http_proxy.rs
@@ -84,7 +84,7 @@ pub async fn forward_request(
         status,
         content_type,
         headers,
-        body: Bytes::from(body_bytes.to_vec()),
+        body: Bytes::from(body_bytes.to_vec()).into(),
     })
 }
 

--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -214,7 +214,7 @@ fn parse_lambda_response(response: serde_json::Value) -> Result<AwsResponse, Aws
         status: status_code,
         content_type,
         headers,
-        body,
+        body: body.into(),
     })
 }
 
@@ -278,10 +278,7 @@ mod tests {
 
         assert_eq!(result.status, StatusCode::OK);
         assert_eq!(result.content_type, "application/json");
-        assert_eq!(
-            result.body,
-            Bytes::from(br#"{"message":"success"}"#.to_vec())
-        );
+        assert_eq!(result.body.as_ref(), br#"{"message":"success"}"#.as_slice());
     }
 
     #[test]
@@ -296,6 +293,6 @@ mod tests {
         let result = parse_lambda_response(response).unwrap();
 
         assert_eq!(result.status, StatusCode::OK);
-        assert_eq!(result.body, Bytes::from(b"binary data".to_vec()));
+        assert_eq!(result.body.as_ref(), b"binary data".as_slice());
     }
 }

--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -278,7 +278,10 @@ mod tests {
 
         assert_eq!(result.status, StatusCode::OK);
         assert_eq!(result.content_type, "application/json");
-        assert_eq!(result.body.as_ref(), br#"{"message":"success"}"#.as_slice());
+        assert_eq!(
+            result.body.expect_bytes(),
+            br#"{"message":"success"}"#.as_slice()
+        );
     }
 
     #[test]
@@ -293,6 +296,6 @@ mod tests {
         let result = parse_lambda_response(response).unwrap();
 
         assert_eq!(result.status, StatusCode::OK);
-        assert_eq!(result.body.as_ref(), b"binary data".as_slice());
+        assert_eq!(result.body.expect_bytes(), b"binary data".as_slice());
     }
 }

--- a/crates/fakecloud-apigatewayv2/src/mock.rs
+++ b/crates/fakecloud-apigatewayv2/src/mock.rs
@@ -12,7 +12,7 @@ pub fn create_mock_response() -> AwsResponse {
         status: StatusCode::OK,
         content_type: "application/json".to_string(),
         headers,
-        body: Bytes::from(br#"{"message":"This is a mock response"}"#.to_vec()),
+        body: Bytes::from(br#"{"message":"This is a mock response"}"#.to_vec()).into(),
     }
 }
 

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -55,7 +55,7 @@ pub fn invoke_model(
     Ok(AwsResponse {
         status: StatusCode::OK,
         content_type: "application/json".to_string(),
-        body: bytes::Bytes::from(response_body),
+        body: bytes::Bytes::from(response_body).into(),
         headers,
     })
 }

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -1295,7 +1295,7 @@ impl AwsService for BedrockService {
                 Ok(AwsResponse {
                     status: http::StatusCode::OK,
                     content_type: "application/vnd.amazon.eventstream".to_string(),
-                    body: bytes::Bytes::from(body),
+                    body: bytes::Bytes::from(body).into(),
                     headers: http::HeaderMap::new(),
                 })
             }
@@ -1318,7 +1318,7 @@ impl AwsService for BedrockService {
                 Ok(AwsResponse {
                     status: http::StatusCode::OK,
                     content_type: "application/vnd.amazon.eventstream".to_string(),
-                    body: bytes::Bytes::from(body),
+                    body: bytes::Bytes::from(body).into(),
                     headers: http::HeaderMap::new(),
                 })
             }

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1392,7 +1392,8 @@ mod tests {
         };
         let pool_resp = svc.create_user_pool(&create_pool_req).unwrap();
         let pool_json: Value =
-            serde_json::from_str(core::str::from_utf8(&pool_resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap())
+                .unwrap();
         let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap();
 
         // Create client without GenerateSecret
@@ -1420,7 +1421,7 @@ mod tests {
         };
         let resp = svc.create_user_pool_client(&req).unwrap();
         let resp_json: Value =
-            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert!(resp_json["UserPoolClient"]["ClientSecret"].is_null());
     }
 
@@ -1451,7 +1452,8 @@ mod tests {
         };
         let pool_resp = svc.create_user_pool(&create_pool_req).unwrap();
         let pool_json: Value =
-            serde_json::from_str(core::str::from_utf8(&pool_resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap())
+                .unwrap();
         let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap();
 
         // Create client with GenerateSecret=true
@@ -1480,7 +1482,7 @@ mod tests {
         };
         let resp = svc.create_user_pool_client(&req).unwrap();
         let resp_json: Value =
-            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         let secret = resp_json["UserPoolClient"]["ClientSecret"]
             .as_str()
             .unwrap();
@@ -1547,7 +1549,7 @@ mod tests {
         };
         let resp = svc.create_user_pool_client(&req).unwrap();
         let resp_json: Value =
-            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         let client_id = resp_json["UserPoolClient"]["ClientId"]
             .as_str()
             .unwrap()
@@ -1740,7 +1742,8 @@ mod tests {
         };
         let pool_resp = svc.create_user_pool(&req).unwrap();
         let pool_json: Value =
-            serde_json::from_str(core::str::from_utf8(&pool_resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap())
+                .unwrap();
         let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap();
 
         // Admin create user
@@ -1768,7 +1771,7 @@ mod tests {
         };
         let resp = block_on(svc.admin_create_user(&req)).unwrap();
         let resp_json: Value =
-            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
 
         assert_eq!(
             resp_json["User"]["UserStatus"].as_str().unwrap(),
@@ -2036,7 +2039,7 @@ mod tests {
         };
         let resp = svc.create_user_pool(&create_pool_req).unwrap();
         let resp_json: Value =
-            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         let pool_id = resp_json["UserPool"]["Id"].as_str().unwrap().to_string();
 
         // Create a group
@@ -2108,7 +2111,7 @@ mod tests {
         };
         let resp = svc.create_user_pool(&create_pool_req).unwrap();
         let resp_json: Value =
-            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         let pool_id = resp_json["UserPool"]["Id"].as_str().unwrap().to_string();
 
         // Create a user
@@ -2257,7 +2260,8 @@ mod tests {
         };
         let pool_resp = svc.create_user_pool(&req).unwrap();
         let pool_json: Value =
-            serde_json::from_str(core::str::from_utf8(&pool_resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap())
+                .unwrap();
         let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap().to_string();
 
         // Create user
@@ -2323,7 +2327,7 @@ mod tests {
         };
         let resp = svc.get_user(&req).unwrap();
         let resp_json: Value =
-            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(resp_json["Username"], "selfuser");
 
         // GetUser with invalid token
@@ -2378,7 +2382,8 @@ mod tests {
         };
         let pool_resp = svc.create_user_pool(&req).unwrap();
         let pool_json: Value =
-            serde_json::from_str(core::str::from_utf8(&pool_resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap())
+                .unwrap();
         let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap().to_string();
 
         // Create user
@@ -2488,7 +2493,8 @@ mod tests {
         };
         let pool_resp = svc.create_user_pool(&req).unwrap();
         let pool_json: Value =
-            serde_json::from_str(core::str::from_utf8(&pool_resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap())
+                .unwrap();
         let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap().to_string();
 
         // Create user with email
@@ -2556,7 +2562,7 @@ mod tests {
         };
         let resp = svc.get_user_attribute_verification_code(&req).unwrap();
         let resp_json: Value =
-            serde_json::from_str(core::str::from_utf8(&resp.body).unwrap()).unwrap();
+            serde_json::from_str(core::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(resp_json["CodeDeliveryDetails"]["DeliveryMedium"], "EMAIL");
         assert_eq!(resp_json["CodeDeliveryDetails"]["AttributeName"], "email");
 
@@ -2712,7 +2718,7 @@ mod tests {
             access_key_id: None,
         };
         let pool_resp = svc.create_user_pool(&create_pool_req).unwrap();
-        let pool_body: Value = serde_json::from_slice(&pool_resp.body).unwrap();
+        let pool_body: Value = serde_json::from_slice(pool_resp.body.expect_bytes()).unwrap();
         let pool_id = pool_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
         let create_user_req = AwsRequest {
@@ -2809,7 +2815,7 @@ mod tests {
         let svc = CognitoService::new(state);
         let req = make_req("CreateUserPool", r#"{"PoolName":"test"}"#);
         let resp = svc.create_user_pool(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
         (svc, pool_id)
     }
@@ -3064,7 +3070,7 @@ mod tests {
         .unwrap();
         let req = make_req("AdminGetDevice", &body);
         let resp = svc.admin_get_device(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(resp_body["Device"]["DeviceKey"], "dev-key-1");
 
         // AdminForgetDevice
@@ -3099,7 +3105,7 @@ mod tests {
         let body = serde_json::to_string(&json!({"ResourceArn": arn})).unwrap();
         let req = make_req("ListTagsForResource", &body);
         let resp = svc.list_tags_for_resource(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(resp_body["Tags"]["env"], "test");
         assert_eq!(resp_body["Tags"]["team"], "core");
 
@@ -3116,7 +3122,7 @@ mod tests {
         let body = serde_json::to_string(&json!({"ResourceArn": arn})).unwrap();
         let req = make_req("ListTagsForResource", &body);
         let resp = svc.list_tags_for_resource(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(resp_body["Tags"]["env"], "test");
         assert!(resp_body["Tags"]["team"].is_null());
     }
@@ -3133,7 +3139,7 @@ mod tests {
         .unwrap();
         let req = make_req("CreateUserImportJob", &body);
         let resp = svc.create_user_import_job(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let job = &resp_body["UserImportJob"];
         assert_eq!(job["JobName"], "my-import");
         assert_eq!(job["Status"], "Created");
@@ -3149,7 +3155,7 @@ mod tests {
         .unwrap();
         let req = make_req("DescribeUserImportJob", &body);
         let resp = svc.describe_user_import_job(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(resp_body["UserImportJob"]["JobName"], "my-import");
 
         // List
@@ -3160,7 +3166,7 @@ mod tests {
         .unwrap();
         let req = make_req("ListUserImportJobs", &body);
         let resp = svc.list_user_import_jobs(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(resp_body["UserImportJobs"].as_array().unwrap().len(), 1);
     }
 
@@ -3175,7 +3181,7 @@ mod tests {
         // Create pool and client
         let req = make_req("CreateUserPool", r#"{"PoolName": "evpool"}"#);
         let resp = svc.create_user_pool(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
         let body = serde_json::to_string(&json!({
@@ -3186,7 +3192,7 @@ mod tests {
         .unwrap();
         let req = make_req("CreateUserPoolClient", &body);
         let resp = svc.create_user_pool_client(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let client_id = resp_body["UserPoolClient"]["ClientId"]
             .as_str()
             .unwrap()
@@ -3222,7 +3228,7 @@ mod tests {
         // Create pool, client, user
         let req = make_req("CreateUserPool", r#"{"PoolName": "authpool"}"#);
         let resp = svc.create_user_pool(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
         let body = serde_json::to_string(&json!({
@@ -3233,7 +3239,7 @@ mod tests {
         .unwrap();
         let req = make_req("CreateUserPoolClient", &body);
         let resp = svc.create_user_pool_client(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let client_id = resp_body["UserPoolClient"]["ClientId"]
             .as_str()
             .unwrap()
@@ -3322,7 +3328,7 @@ mod tests {
         // Create pool
         let req = make_req("CreateUserPool", r#"{"PoolName": "capool"}"#);
         let resp = svc.create_user_pool(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
         // Create client WITHOUT ALLOW_CUSTOM_AUTH
@@ -3334,7 +3340,7 @@ mod tests {
         .unwrap();
         let req = make_req("CreateUserPoolClient", &body);
         let resp = svc.create_user_pool_client(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let client_id = resp_body["UserPoolClient"]["ClientId"]
             .as_str()
             .unwrap()
@@ -3369,7 +3375,7 @@ mod tests {
         // Create pool and client
         let req = make_req("CreateUserPool", r#"{"PoolName": "capool2"}"#);
         let resp = svc.create_user_pool(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
         let body = serde_json::to_string(&json!({
@@ -3380,7 +3386,7 @@ mod tests {
         .unwrap();
         let req = make_req("CreateUserPoolClient", &body);
         let resp = svc.create_user_pool_client(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let client_id = resp_body["UserPoolClient"]["ClientId"]
             .as_str()
             .unwrap()
@@ -3440,7 +3446,7 @@ mod tests {
         // Create pool WITHOUT DefineAuthChallenge Lambda configured
         let req = make_req("CreateUserPool", r#"{"PoolName": "capool3"}"#);
         let resp = svc.create_user_pool(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
         let body = serde_json::to_string(&json!({
@@ -3451,7 +3457,7 @@ mod tests {
         .unwrap();
         let req = make_req("CreateUserPoolClient", &body);
         let resp = svc.create_user_pool_client(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let client_id = resp_body["UserPoolClient"]["ClientId"]
             .as_str()
             .unwrap()
@@ -3506,7 +3512,7 @@ mod tests {
         // Create pool, client, and user so we get past user lookup
         let req = make_req("CreateUserPool", r#"{"PoolName": "ccpool"}"#);
         let resp = svc.create_user_pool(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
         let body = serde_json::to_string(&json!({
@@ -3517,7 +3523,7 @@ mod tests {
         .unwrap();
         let req = make_req("CreateUserPoolClient", &body);
         let resp = svc.create_user_pool_client(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let client_id = resp_body["UserPoolClient"]["ClientId"]
             .as_str()
             .unwrap()
@@ -3589,7 +3595,7 @@ mod tests {
         // Create pool and client so we have valid IDs
         let req = make_req("CreateUserPool", r#"{"PoolName": "anspool"}"#);
         let resp = svc.create_user_pool(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
         let body = serde_json::to_string(&json!({
@@ -3600,7 +3606,7 @@ mod tests {
         .unwrap();
         let req = make_req("CreateUserPoolClient", &body);
         let resp = svc.create_user_pool_client(&req).unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let client_id = resp_body["UserPoolClient"]["ClientId"]
             .as_str()
             .unwrap()

--- a/crates/fakecloud-core/Cargo.toml
+++ b/crates/fakecloud-core/Cargo.toml
@@ -16,5 +16,7 @@ http = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -176,30 +176,14 @@ pub async fn dispatch(
 
             match resp.body {
                 ResponseBody::Bytes(b) => builder.body(Body::from(b)).unwrap(),
-                ResponseBody::File { path, size } => match tokio::fs::File::open(&path).await {
-                    Ok(f) => {
-                        let stream = tokio_util::io::ReaderStream::new(f);
-                        let body = Body::from_stream(stream);
-                        builder
-                            .header("content-length", size.to_string())
-                            .body(body)
-                            .unwrap()
-                    }
-                    Err(err) => {
-                        tracing::error!(
-                            path = %path.display(),
-                            error = %err,
-                            "failed to open response body file",
-                        );
-                        build_error_response(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "InternalError",
-                            &format!("failed to open response body file: {err}"),
-                            &request_id,
-                            detected.protocol,
-                        )
-                    }
-                },
+                ResponseBody::File { file, size } => {
+                    let stream = tokio_util::io::ReaderStream::new(file);
+                    let body = Body::from_stream(stream);
+                    builder
+                        .header("content-length", size.to_string())
+                        .body(body)
+                        .unwrap()
+                }
             }
         }
         Err(err) => {

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -19,7 +19,7 @@ pub async fn dispatch(
     let request_id = uuid::Uuid::new_v4().to_string();
 
     let (parts, body) = request.into_parts();
-    let body_bytes = match axum::body::to_bytes(body, 10 * 1024 * 1024).await {
+    let body_bytes = match axum::body::to_bytes(body, 5 * 1024 * 1024 * 1024).await {
         Ok(b) => b,
         Err(_) => {
             return build_error_response(

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::protocol::{self, AwsProtocol};
 use crate::registry::ServiceRegistry;
-use crate::service::AwsRequest;
+use crate::service::{AwsRequest, ResponseBody};
 
 /// The main dispatch handler. All HTTP requests come through here.
 pub async fn dispatch(
@@ -19,7 +19,13 @@ pub async fn dispatch(
     let request_id = uuid::Uuid::new_v4().to_string();
 
     let (parts, body) = request.into_parts();
-    let body_bytes = match axum::body::to_bytes(body, 5 * 1024 * 1024 * 1024).await {
+    // TODO: plumb streaming request bodies end-to-end to remove the cap.
+    // 128 MiB comfortably covers every legitimate single-PutObject (AWS
+    // recommends multipart above ~100 MiB) and each multipart part is
+    // dispatched through here separately, so a 20 GiB upload stays under this
+    // limit per-request.
+    const MAX_BODY_BYTES: usize = 128 * 1024 * 1024;
+    let body_bytes = match axum::body::to_bytes(body, MAX_BODY_BYTES).await {
         Ok(b) => b,
         Err(_) => {
             return build_error_response(
@@ -168,7 +174,33 @@ pub async fn dispatch(
                 builder = builder.header(k, v);
             }
 
-            builder.body(Body::from(resp.body)).unwrap()
+            match resp.body {
+                ResponseBody::Bytes(b) => builder.body(Body::from(b)).unwrap(),
+                ResponseBody::File { path, size } => match tokio::fs::File::open(&path).await {
+                    Ok(f) => {
+                        let stream = tokio_util::io::ReaderStream::new(f);
+                        let body = Body::from_stream(stream);
+                        builder
+                            .header("content-length", size.to_string())
+                            .body(body)
+                            .unwrap()
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            path = %path.display(),
+                            error = %err,
+                            "failed to open response body file",
+                        );
+                        build_error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "InternalError",
+                            &format!("failed to open response body file: {err}"),
+                            &request_id,
+                            detected.protocol,
+                        )
+                    }
+                },
+            }
         }
         Err(err) => {
             tracing::warn!(

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -170,6 +170,11 @@ pub async fn dispatch(
                 builder = builder.header("content-type", &resp.content_type);
             }
 
+            let has_content_length = resp
+                .headers
+                .iter()
+                .any(|(k, _)| k.as_str().eq_ignore_ascii_case("content-length"));
+
             for (k, v) in &resp.headers {
                 builder = builder.header(k, v);
             }
@@ -179,10 +184,10 @@ pub async fn dispatch(
                 ResponseBody::File { file, size } => {
                     let stream = tokio_util::io::ReaderStream::new(file);
                     let body = Body::from_stream(stream);
-                    builder
-                        .header("content-length", size.to_string())
-                        .body(body)
-                        .unwrap()
+                    if !has_content_length {
+                        builder = builder.header("content-length", size.to_string());
+                    }
+                    builder.body(body).unwrap()
                 }
             }
         }

--- a/crates/fakecloud-core/src/service.rs
+++ b/crates/fakecloud-core/src/service.rs
@@ -2,6 +2,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use http::{HeaderMap, Method, StatusCode};
 use std::collections::HashMap;
+use std::ops::Deref;
+use std::path::PathBuf;
 
 /// A parsed AWS request.
 #[derive(Debug)]
@@ -33,11 +35,98 @@ impl AwsRequest {
     }
 }
 
+/// A response body. Most handlers return [`ResponseBody::Bytes`] built from
+/// an in-memory [`Bytes`] buffer; the [`File`](ResponseBody::File) variant
+/// exists so large disk-backed objects can be streamed straight from the
+/// filesystem to the HTTP body without being materialized into RAM.
+#[derive(Debug)]
+pub enum ResponseBody {
+    Bytes(Bytes),
+    File { path: PathBuf, size: u64 },
+}
+
+impl ResponseBody {
+    pub fn len(&self) -> u64 {
+        match self {
+            ResponseBody::Bytes(b) => b.len() as u64,
+            ResponseBody::File { size, .. } => *size,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Default for ResponseBody {
+    fn default() -> Self {
+        ResponseBody::Bytes(Bytes::new())
+    }
+}
+
+impl From<Bytes> for ResponseBody {
+    fn from(b: Bytes) -> Self {
+        ResponseBody::Bytes(b)
+    }
+}
+
+impl From<Vec<u8>> for ResponseBody {
+    fn from(v: Vec<u8>) -> Self {
+        ResponseBody::Bytes(Bytes::from(v))
+    }
+}
+
+impl From<&'static [u8]> for ResponseBody {
+    fn from(s: &'static [u8]) -> Self {
+        ResponseBody::Bytes(Bytes::from_static(s))
+    }
+}
+
+impl From<String> for ResponseBody {
+    fn from(s: String) -> Self {
+        ResponseBody::Bytes(Bytes::from(s))
+    }
+}
+
+impl From<&'static str> for ResponseBody {
+    fn from(s: &'static str) -> Self {
+        ResponseBody::Bytes(Bytes::from_static(s.as_bytes()))
+    }
+}
+
+/// Deref gives existing test code that does `&resp.body` a `&[u8]` view.
+/// File-variant responses appear empty to this view — tests only inspect
+/// in-memory bodies.
+impl Deref for ResponseBody {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        match self {
+            ResponseBody::Bytes(b) => b,
+            ResponseBody::File { .. } => &[],
+        }
+    }
+}
+
+impl AsRef<[u8]> for ResponseBody {
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
+impl PartialEq<Bytes> for ResponseBody {
+    fn eq(&self, other: &Bytes) -> bool {
+        match self {
+            ResponseBody::Bytes(b) => b == other,
+            ResponseBody::File { .. } => false,
+        }
+    }
+}
+
 /// A response from a service handler.
 pub struct AwsResponse {
     pub status: StatusCode,
     pub content_type: String,
-    pub body: Bytes,
+    pub body: ResponseBody,
     pub headers: HeaderMap,
 }
 
@@ -46,7 +135,7 @@ impl AwsResponse {
         Self {
             status,
             content_type: "text/xml".to_string(),
-            body: body.into(),
+            body: ResponseBody::Bytes(body.into()),
             headers: HeaderMap::new(),
         }
     }
@@ -55,7 +144,7 @@ impl AwsResponse {
         Self {
             status,
             content_type: "application/x-amz-json-1.1".to_string(),
-            body: body.into(),
+            body: ResponseBody::Bytes(body.into()),
             headers: HeaderMap::new(),
         }
     }

--- a/crates/fakecloud-core/src/service.rs
+++ b/crates/fakecloud-core/src/service.rs
@@ -2,8 +2,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use http::{HeaderMap, Method, StatusCode};
 use std::collections::HashMap;
-use std::ops::Deref;
-use std::path::PathBuf;
 
 /// A parsed AWS request.
 #[derive(Debug)]
@@ -38,11 +36,15 @@ impl AwsRequest {
 /// A response body. Most handlers return [`ResponseBody::Bytes`] built from
 /// an in-memory [`Bytes`] buffer; the [`File`](ResponseBody::File) variant
 /// exists so large disk-backed objects can be streamed straight from the
-/// filesystem to the HTTP body without being materialized into RAM.
+/// filesystem to the HTTP body without being materialized into RAM. The file
+/// handle is opened by the service handler while it still holds the
+/// per-bucket read guard, so the reader sees a consistent inode even if a
+/// concurrent PUT/DELETE renames or unlinks the path before dispatch streams
+/// the body.
 #[derive(Debug)]
 pub enum ResponseBody {
     Bytes(Bytes),
-    File { path: PathBuf, size: u64 },
+    File { file: tokio::fs::File, size: u64 },
 }
 
 impl ResponseBody {
@@ -55,6 +57,18 @@ impl ResponseBody {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Accessor that returns the bytes of a `Bytes` variant and panics for
+    /// `File`. Used by tests and by callers that know the response was built
+    /// from an in-memory buffer (JSON handlers, cross-service glue).
+    pub fn expect_bytes(&self) -> &[u8] {
+        match self {
+            ResponseBody::Bytes(b) => b,
+            ResponseBody::File { .. } => {
+                panic!("expect_bytes called on ResponseBody::File")
+            }
+        }
     }
 }
 
@@ -91,25 +105,6 @@ impl From<String> for ResponseBody {
 impl From<&'static str> for ResponseBody {
     fn from(s: &'static str) -> Self {
         ResponseBody::Bytes(Bytes::from_static(s.as_bytes()))
-    }
-}
-
-/// Deref gives existing test code that does `&resp.body` a `&[u8]` view.
-/// File-variant responses appear empty to this view — tests only inspect
-/// in-memory bodies.
-impl Deref for ResponseBody {
-    type Target = [u8];
-    fn deref(&self) -> &Self::Target {
-        match self {
-            ResponseBody::Bytes(b) => b,
-            ResponseBody::File { .. } => &[],
-        }
-    }
-}
-
-impl AsRef<[u8]> for ResponseBody {
-    fn as_ref(&self) -> &[u8] {
-        self
     }
 }
 

--- a/crates/fakecloud-dynamodb/Cargo.toml
+++ b/crates/fakecloud-dynamodb/Cargo.toml
@@ -21,4 +21,5 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-dynamodb/Cargo.toml
+++ b/crates/fakecloud-dynamodb/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-s3 = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }

--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -474,7 +474,8 @@ impl DynamoDbService {
 
             match execute_partiql_statement(&self.state, statement, &parameters) {
                 Ok(resp) => {
-                    let resp_body: Value = serde_json::from_slice(&resp.body).unwrap_or_default();
+                    let resp_body: Value =
+                        serde_json::from_slice(resp.body.expect_bytes()).unwrap_or_default();
                     responses.push(resp_body);
                 }
                 Err(e) => {
@@ -526,7 +527,8 @@ impl DynamoDbService {
 
             match execute_partiql_statement(&self.state, statement, &parameters) {
                 Ok(resp) => {
-                    let resp_body: Value = serde_json::from_slice(&resp.body).unwrap_or_default();
+                    let resp_body: Value =
+                        serde_json::from_slice(resp.body.expect_bytes()).unwrap_or_default();
                     results.push(Ok(resp_body));
                 }
                 Err(e) => {

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -2848,7 +2848,7 @@ mod tests {
             }),
         );
         let resp = svc.delete_item(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
         // Verify the old item is returned
         let attrs = &body["Attributes"];
@@ -2865,7 +2865,7 @@ mod tests {
             }),
         );
         let resp = svc.get_item(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body.get("Item").is_none(), "item should be deleted");
     }
 
@@ -2897,7 +2897,7 @@ mod tests {
             }),
         );
         let resp = svc.transact_get_items(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let responses = body["Responses"].as_array().unwrap();
         assert_eq!(responses.len(), 2);
         assert_eq!(responses[0]["Item"]["pk"]["S"].as_str().unwrap(), "exists");
@@ -2957,7 +2957,7 @@ mod tests {
             }),
         );
         let resp = svc.get_item(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Item"]["val"]["S"].as_str().unwrap(), "hi");
 
         // Verify deleted item is gone
@@ -2969,7 +2969,7 @@ mod tests {
             }),
         );
         let resp = svc.get_item(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body.get("Item").is_none());
     }
 
@@ -2996,7 +2996,7 @@ mod tests {
         let resp = svc.transact_write_items(&req).unwrap();
         // Should be a 400 error response
         assert_eq!(resp.status, StatusCode::BAD_REQUEST);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["__type"].as_str().unwrap(),
             "TransactionCanceledException"
@@ -3021,7 +3021,7 @@ mod tests {
             }),
         );
         let resp = svc.update_time_to_live(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["TimeToLiveSpecification"]["AttributeName"]
                 .as_str()
@@ -3035,7 +3035,7 @@ mod tests {
         // Describe TTL
         let req = make_request("DescribeTimeToLive", json!({ "TableName": "test-table" }));
         let resp = svc.describe_time_to_live(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["TimeToLiveDescription"]["TimeToLiveStatus"]
                 .as_str()
@@ -3064,7 +3064,7 @@ mod tests {
 
         let req = make_request("DescribeTimeToLive", json!({ "TableName": "test-table" }));
         let resp = svc.describe_time_to_live(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["TimeToLiveDescription"]["TimeToLiveStatus"]
                 .as_str()
@@ -3093,13 +3093,13 @@ mod tests {
             }),
         );
         let resp = svc.put_resource_policy(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["RevisionId"].as_str().is_some());
 
         // Get policy
         let req = make_request("GetResourcePolicy", json!({ "ResourceArn": table_arn }));
         let resp = svc.get_resource_policy(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Policy"].as_str().unwrap(), policy_doc);
 
         // Delete policy
@@ -3109,7 +3109,7 @@ mod tests {
         // Get should return null now
         let req = make_request("GetResourcePolicy", json!({ "ResourceArn": table_arn }));
         let resp = svc.get_resource_policy(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Policy"].is_null());
     }
 
@@ -3118,7 +3118,7 @@ mod tests {
         let svc = make_service();
         let req = make_request("DescribeEndpoints", json!({}));
         let resp = svc.describe_endpoints(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Endpoints"][0]["CachePeriodInMinutes"], 1440);
     }
 
@@ -3127,7 +3127,7 @@ mod tests {
         let svc = make_service();
         let req = make_request("DescribeLimits", json!({}));
         let resp = svc.describe_limits(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TableMaxReadCapacityUnits"], 40000);
     }
 
@@ -3142,7 +3142,7 @@ mod tests {
             json!({ "TableName": "test-table", "BackupName": "my-backup" }),
         );
         let resp = svc.create_backup(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let backup_arn = body["BackupDetails"]["BackupArn"]
             .as_str()
             .unwrap()
@@ -3152,7 +3152,7 @@ mod tests {
         // Describe backup
         let req = make_request("DescribeBackup", json!({ "BackupArn": backup_arn }));
         let resp = svc.describe_backup(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["BackupDescription"]["BackupDetails"]["BackupName"],
             "my-backup"
@@ -3161,7 +3161,7 @@ mod tests {
         // List backups
         let req = make_request("ListBackups", json!({}));
         let resp = svc.list_backups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["BackupSummaries"].as_array().unwrap().len(), 1);
 
         // Restore from backup
@@ -3174,7 +3174,7 @@ mod tests {
         // Verify restored table exists
         let req = make_request("DescribeTable", json!({ "TableName": "restored-table" }));
         let resp = svc.describe_table(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Table"]["TableStatus"], "ACTIVE");
 
         // Delete backup
@@ -3184,7 +3184,7 @@ mod tests {
         // List should be empty
         let req = make_request("ListBackups", json!({}));
         let resp = svc.list_backups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["BackupSummaries"].as_array().unwrap().len(), 0);
     }
 
@@ -3199,7 +3199,7 @@ mod tests {
             json!({ "TableName": "test-table" }),
         );
         let resp = svc.describe_continuous_backups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["ContinuousBackupsDescription"]["PointInTimeRecoveryDescription"]
                 ["PointInTimeRecoveryStatus"],
@@ -3224,7 +3224,7 @@ mod tests {
             json!({ "TableName": "test-table" }),
         );
         let resp = svc.describe_continuous_backups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["ContinuousBackupsDescription"]["PointInTimeRecoveryDescription"]
                 ["PointInTimeRecoveryStatus"],
@@ -3248,7 +3248,7 @@ mod tests {
 
         let req = make_request("DescribeTable", json!({ "TableName": "pitr-restored" }));
         let resp = svc.describe_table(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Table"]["TableStatus"], "ACTIVE");
     }
 
@@ -3268,7 +3268,7 @@ mod tests {
             }),
         );
         let resp = svc.create_global_table(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["GlobalTableDescription"]["GlobalTableStatus"],
             "ACTIVE"
@@ -3280,7 +3280,7 @@ mod tests {
             json!({ "GlobalTableName": "my-global" }),
         );
         let resp = svc.describe_global_table(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["GlobalTableDescription"]["ReplicationGroup"]
                 .as_array()
@@ -3292,7 +3292,7 @@ mod tests {
         // List
         let req = make_request("ListGlobalTables", json!({}));
         let resp = svc.list_global_tables(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["GlobalTables"].as_array().unwrap().len(), 1);
 
         // Update - add a region
@@ -3306,7 +3306,7 @@ mod tests {
             }),
         );
         let resp = svc.update_global_table(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["GlobalTableDescription"]["ReplicationGroup"]
                 .as_array()
@@ -3321,7 +3321,7 @@ mod tests {
             json!({ "GlobalTableName": "my-global" }),
         );
         let resp = svc.describe_global_table_settings(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ReplicaSettings"].as_array().unwrap().len(), 3);
 
         // Update settings (no-op, just verify no error)
@@ -3342,7 +3342,7 @@ mod tests {
             json!({ "TableName": "test-table" }),
         );
         let resp = svc.describe_table_replica_auto_scaling(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["TableAutoScalingDescription"]["TableName"],
             "test-table"
@@ -3369,7 +3369,7 @@ mod tests {
             }),
         );
         let resp = svc.enable_kinesis_streaming_destination(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DestinationStatus"], "ACTIVE");
 
         // Describe
@@ -3378,7 +3378,7 @@ mod tests {
             json!({ "TableName": "test-table" }),
         );
         let resp = svc.describe_kinesis_streaming_destination(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["KinesisDataStreamDestinations"]
                 .as_array()
@@ -3409,7 +3409,7 @@ mod tests {
             }),
         );
         let resp = svc.disable_kinesis_streaming_destination(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DestinationStatus"], "DISABLED");
     }
 
@@ -3424,7 +3424,7 @@ mod tests {
             json!({ "TableName": "test-table" }),
         );
         let resp = svc.describe_contributor_insights(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ContributorInsightsStatus"], "DISABLED");
 
         // Enable
@@ -3436,13 +3436,13 @@ mod tests {
             }),
         );
         let resp = svc.update_contributor_insights(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ContributorInsightsStatus"], "ENABLED");
 
         // List
         let req = make_request("ListContributorInsights", json!({}));
         let resp = svc.list_contributor_insights(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["ContributorInsightsSummaries"]
                 .as_array()
@@ -3468,7 +3468,7 @@ mod tests {
             }),
         );
         let resp = svc.export_table_to_point_in_time(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let export_arn = body["ExportDescription"]["ExportArn"]
             .as_str()
             .unwrap()
@@ -3478,13 +3478,13 @@ mod tests {
         // Describe
         let req = make_request("DescribeExport", json!({ "ExportArn": export_arn }));
         let resp = svc.describe_export(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ExportDescription"]["S3Bucket"], "my-bucket");
 
         // List
         let req = make_request("ListExports", json!({}));
         let resp = svc.list_exports(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ExportSummaries"].as_array().unwrap().len(), 1);
     }
 
@@ -3505,7 +3505,7 @@ mod tests {
             }),
         );
         let resp = svc.import_table(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let import_arn = body["ImportTableDescription"]["ImportArn"]
             .as_str()
             .unwrap()
@@ -3515,19 +3515,19 @@ mod tests {
         // Describe import
         let req = make_request("DescribeImport", json!({ "ImportArn": import_arn }));
         let resp = svc.describe_import(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ImportTableDescription"]["ImportStatus"], "COMPLETED");
 
         // List imports
         let req = make_request("ListImports", json!({}));
         let resp = svc.list_imports(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ImportSummaryList"].as_array().unwrap().len(), 1);
 
         // Verify the table was created
         let req = make_request("DescribeTable", json!({ "TableName": "imported-table" }));
         let resp = svc.describe_table(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Table"]["TableStatus"], "ACTIVE");
     }
 
@@ -3560,7 +3560,7 @@ mod tests {
             }),
         );
         let resp = svc.create_backup(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let backup_arn = body["BackupDetails"]["BackupArn"]
             .as_str()
             .unwrap()
@@ -3581,7 +3581,7 @@ mod tests {
         // Verify original table is empty
         let req = make_request("Scan", json!({ "TableName": "test-table" }));
         let resp = svc.scan(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Count"], 0);
 
         // Restore from backup
@@ -3597,7 +3597,7 @@ mod tests {
         // Scan restored table — should have 3 items
         let req = make_request("Scan", json!({ "TableName": "restored-table" }));
         let resp = svc.scan(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Count"], 3);
         assert_eq!(body["Items"].as_array().unwrap().len(), 3);
     }
@@ -3619,7 +3619,7 @@ mod tests {
             }),
         );
         let resp = svc.create_global_table(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["GlobalTableDescription"]["GlobalTableStatus"],
             "ACTIVE"
@@ -3647,7 +3647,7 @@ mod tests {
             }),
         );
         let resp = svc.get_item(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Item"]["pk"]["S"], "replicated-key");
         assert_eq!(body["Item"]["data"]["S"], "replicated-value");
     }
@@ -3700,7 +3700,7 @@ mod tests {
             json!({ "TableName": "test-table" }),
         );
         let resp = svc.describe_contributor_insights(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ContributorInsightsStatus"], "ENABLED");
 
         let contributors = body["TopContributors"].as_array().unwrap();
@@ -3743,7 +3743,7 @@ mod tests {
             json!({ "TableName": "test-table" }),
         );
         let resp = svc.describe_contributor_insights(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ContributorInsightsStatus"], "DISABLED");
 
         let contributors = body["TopContributors"].as_array().unwrap();
@@ -3787,7 +3787,7 @@ mod tests {
             json!({ "TableName": "test-table" }),
         );
         let resp = svc.describe_contributor_insights(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let contributors = body["TopContributors"].as_array().unwrap();
         assert!(
             !contributors.is_empty(),
@@ -3814,7 +3814,7 @@ mod tests {
             json!({ "TableName": "test-table" }),
         );
         let resp = svc.describe_contributor_insights(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let contributors = body["TopContributors"].as_array().unwrap();
         assert!(
             contributors.is_empty(),
@@ -3845,7 +3845,7 @@ mod tests {
         // Scan with limit=2
         let req = make_request("Scan", json!({ "TableName": "test-table", "Limit": 2 }));
         let resp = svc.scan(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Count"], 2);
         assert!(
             body["LastEvaluatedKey"].is_object(),
@@ -3867,7 +3867,7 @@ mod tests {
                 }),
             );
             let resp = svc.scan(&req).unwrap();
-            let body: Value = serde_json::from_slice(&resp.body).unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
             all_items.extend(body["Items"].as_array().unwrap().iter().cloned());
             lek = body["LastEvaluatedKey"].clone();
         }
@@ -3900,7 +3900,7 @@ mod tests {
         // Scan with limit > item count
         let req = make_request("Scan", json!({ "TableName": "test-table", "Limit": 10 }));
         let resp = svc.scan(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Count"], 3);
         assert!(
             body["LastEvaluatedKey"].is_null(),
@@ -3910,7 +3910,7 @@ mod tests {
         // Scan without limit
         let req = make_request("Scan", json!({ "TableName": "test-table" }));
         let resp = svc.scan(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Count"], 3);
         assert!(body["LastEvaluatedKey"].is_null());
     }
@@ -3966,7 +3966,7 @@ mod tests {
             }),
         );
         let resp = svc.query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Count"], 2);
         assert!(body["LastEvaluatedKey"].is_object());
         assert!(body["LastEvaluatedKey"]["pk"].is_object());
@@ -3988,7 +3988,7 @@ mod tests {
                 }),
             );
             let resp = svc.query(&req).unwrap();
-            let body: Value = serde_json::from_slice(&resp.body).unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
             all_items.extend(body["Items"].as_array().unwrap().iter().cloned());
             lek = body["LastEvaluatedKey"].clone();
         }
@@ -4038,7 +4038,7 @@ mod tests {
             }),
         );
         let resp = svc.query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Count"], 2);
         assert!(
             body["LastEvaluatedKey"].is_null(),
@@ -4108,7 +4108,7 @@ mod tests {
             }),
         );
         let resp = svc.query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Count"], 1);
         let lek = &body["LastEvaluatedKey"];
         assert!(lek.is_object(), "should have LastEvaluatedKey");
@@ -4161,7 +4161,7 @@ mod tests {
 
             let req = make_request("Query", query);
             let resp = svc.query(&req).unwrap();
-            let body: Value = serde_json::from_slice(&resp.body).unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
             for item in body["Items"].as_array().unwrap() {
                 let pk = item["pk"]["S"].as_str().unwrap().to_string();

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -2794,7 +2794,7 @@ mod tests {
             }),
         );
         let create_resp = svc.create_table(&req).unwrap();
-        let create_body: Value = serde_json::from_slice(&create_resp.body).unwrap();
+        let create_body: Value = serde_json::from_slice(create_resp.body.expect_bytes()).unwrap();
         let create_table = &create_body["TableDescription"];
 
         assert_eq!(create_table["TableStatus"], "ACTIVE");
@@ -2807,7 +2807,8 @@ mod tests {
             json!({ "TableName": "warm-throughput-table" }),
         );
         let describe_resp = svc.describe_table(&describe_req).unwrap();
-        let describe_body: Value = serde_json::from_slice(&describe_resp.body).unwrap();
+        let describe_body: Value =
+            serde_json::from_slice(describe_resp.body.expect_bytes()).unwrap();
         let described_table = &describe_body["Table"];
 
         assert_eq!(described_table["TableStatus"], "ACTIVE");
@@ -2815,7 +2816,8 @@ mod tests {
         assert_eq!(described_table["TableId"], table_id);
 
         let describe_resp_again = svc.describe_table(&describe_req).unwrap();
-        let describe_body_again: Value = serde_json::from_slice(&describe_resp_again.body).unwrap();
+        let describe_body_again: Value =
+            serde_json::from_slice(describe_resp_again.body.expect_bytes()).unwrap();
         assert_eq!(describe_body_again["Table"]["TableId"], table_id);
     }
 

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -16,6 +16,7 @@ use serde_json::{json, Value};
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
+use fakecloud_persistence::S3Store;
 use fakecloud_s3::state::SharedS3State;
 
 use crate::state::{
@@ -38,7 +39,8 @@ pub(super) struct KinesisDeliveryTarget {
 
 pub struct DynamoDbService {
     state: SharedDynamoDbState,
-    s3_state: Option<SharedS3State>,
+    pub(crate) s3_state: Option<SharedS3State>,
+    pub(crate) s3_store: Option<Arc<dyn S3Store>>,
     delivery: Option<Arc<DeliveryBus>>,
 }
 
@@ -47,12 +49,18 @@ impl DynamoDbService {
         Self {
             state,
             s3_state: None,
+            s3_store: None,
             delivery: None,
         }
     }
 
     pub fn with_s3(mut self, s3_state: SharedS3State) -> Self {
         self.s3_state = Some(s3_state);
+        self
+    }
+
+    pub fn with_s3_store(mut self, store: Arc<dyn S3Store>) -> Self {
+        self.s3_store = Some(store);
         self
     }
 

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -994,7 +994,7 @@ impl DynamoDbService {
                 let etag = uuid::Uuid::new_v4().to_string().replace('-', "");
                 let obj = fakecloud_s3::state::S3Object {
                     key: s3_key.clone(),
-                    data: bytes::Bytes::from(json_lines),
+                    body: fakecloud_persistence::BodyRef::Memory(bytes::Bytes::from(json_lines)),
                     content_type: "application/json".to_string(),
                     etag,
                     size: data_size as u64,
@@ -1171,7 +1171,8 @@ impl DynamoDbService {
                 if !prefix.is_empty() && !key.starts_with(&prefix) {
                     continue;
                 }
-                let data = std::str::from_utf8(&obj.data).unwrap_or("");
+                let obj_bytes = fakecloud_s3::state::read_body_bytes(&obj.body);
+                let data = std::str::from_utf8(&obj_bytes).unwrap_or("");
                 processed_size_bytes += obj.size as i64;
                 for line in data.lines() {
                     let line = line.trim();

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -989,58 +989,70 @@ impl DynamoDbService {
         let mut export_failed = false;
         let mut failure_reason = String::new();
         if let Some(ref s3_state) = self.s3_state {
-            let body_bytes = bytes::Bytes::from(json_lines);
-            let etag = uuid::Uuid::new_v4().to_string().replace('-', "");
-            let meta = fakecloud_persistence::ObjectMeta {
-                key: s3_key.clone(),
-                content_type: "application/json".to_string(),
-                etag: etag.clone(),
-                size: data_size as u64,
-                last_modified: now,
-                storage_class: "STANDARD".to_string(),
-                ..Default::default()
-            };
-            // Persist through the S3 store (Disk in persistent mode, Memory
-            // otherwise) so the export survives restart and the in-memory
-            // runtime body is whatever the store returns.
-            let body_ref = if let Some(ref store) = self.s3_store {
-                match store.put_object(
-                    s3_bucket,
-                    &s3_key,
-                    None,
-                    fakecloud_persistence::BodySource::Bytes(body_bytes.clone()),
-                    &meta,
-                ) {
-                    Ok(bref) => bref,
-                    Err(err) => {
-                        tracing::error!(
-                            bucket = %s3_bucket,
-                            key = %s3_key,
-                            error = %err,
-                            "DynamoDB export: failed to persist result object via store",
-                        );
-                        fakecloud_persistence::BodyRef::Memory(body_bytes.clone())
-                    }
-                }
+            // Verify the target bucket exists before touching the store —
+            // otherwise we would orphan artifacts on disk under a bucket
+            // directory that no in-memory bucket references.
+            if !s3_state.read().buckets.contains_key(s3_bucket) {
+                export_failed = true;
+                failure_reason = format!("S3 bucket does not exist: {s3_bucket}");
             } else {
-                fakecloud_persistence::BodyRef::Memory(body_bytes.clone())
-            };
-            let mut s3 = s3_state.write();
-            if let Some(bucket) = s3.buckets.get_mut(s3_bucket) {
-                let obj = fakecloud_s3::state::S3Object {
+                let body_bytes = bytes::Bytes::from(json_lines);
+                let etag = uuid::Uuid::new_v4().to_string().replace('-', "");
+                let meta = fakecloud_persistence::ObjectMeta {
                     key: s3_key.clone(),
-                    body: body_ref,
                     content_type: "application/json".to_string(),
-                    etag,
+                    etag: etag.clone(),
                     size: data_size as u64,
                     last_modified: now,
                     storage_class: "STANDARD".to_string(),
                     ..Default::default()
                 };
-                bucket.objects.insert(s3_key, obj);
-            } else {
-                export_failed = true;
-                failure_reason = format!("S3 bucket does not exist: {s3_bucket}");
+                // Persist through the S3 store (Disk in persistent mode,
+                // Memory otherwise) so the export survives restart and the
+                // in-memory runtime body is whatever the store returns.
+                let body_ref = if let Some(ref store) = self.s3_store {
+                    match store.put_object(
+                        s3_bucket,
+                        &s3_key,
+                        None,
+                        fakecloud_persistence::BodySource::Bytes(body_bytes.clone()),
+                        &meta,
+                    ) {
+                        Ok(bref) => bref,
+                        Err(err) => {
+                            tracing::error!(
+                                bucket = %s3_bucket,
+                                key = %s3_key,
+                                error = %err,
+                                "DynamoDB export: failed to persist result object via store",
+                            );
+                            fakecloud_persistence::BodyRef::Memory(body_bytes.clone())
+                        }
+                    }
+                } else {
+                    fakecloud_persistence::BodyRef::Memory(body_bytes.clone())
+                };
+                let mut s3 = s3_state.write();
+                if let Some(bucket) = s3.buckets.get_mut(s3_bucket) {
+                    let obj = fakecloud_s3::state::S3Object {
+                        key: s3_key.clone(),
+                        body: body_ref,
+                        content_type: "application/json".to_string(),
+                        etag,
+                        size: data_size as u64,
+                        last_modified: now,
+                        storage_class: "STANDARD".to_string(),
+                        ..Default::default()
+                    };
+                    bucket.objects.insert(s3_key, obj);
+                } else {
+                    // Raced with concurrent DeleteBucket between our check
+                    // and the write guard. Treat as failure; nothing has been
+                    // written to disk because the store call is nested inside
+                    // the contains_key branch.
+                    export_failed = true;
+                    failure_reason = format!("S3 bucket does not exist: {s3_bucket}");
+                }
             }
         }
 

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -987,6 +987,7 @@ impl DynamoDbService {
 
         // Write to S3 if we have access to S3 state
         let mut export_failed = false;
+        let mut failure_code = "";
         let mut failure_reason = String::new();
         if let Some(ref s3_state) = self.s3_state {
             // Verify the target bucket exists before touching the store —
@@ -994,6 +995,7 @@ impl DynamoDbService {
             // directory that no in-memory bucket references.
             if !s3_state.read().buckets.contains_key(s3_bucket) {
                 export_failed = true;
+                failure_code = "S3NoSuchBucket";
                 failure_reason = format!("S3 bucket does not exist: {s3_bucket}");
             } else {
                 let body_bytes = bytes::Bytes::from(json_lines);
@@ -1054,11 +1056,13 @@ impl DynamoDbService {
                             // disk — best we can do is mark the export
                             // failed and let the operator reconcile.
                             export_failed = true;
+                            failure_code = "S3NoSuchBucket";
                             failure_reason = format!("S3 bucket does not exist: {s3_bucket}");
                         }
                     }
                     Err(reason) => {
                         export_failed = true;
+                        failure_code = "InternalServerError";
                         failure_reason = reason;
                     }
                 }
@@ -1100,7 +1104,7 @@ impl DynamoDbService {
             }
         });
         if export_failed {
-            response["ExportDescription"]["FailureCode"] = json!("S3NoSuchBucket");
+            response["ExportDescription"]["FailureCode"] = json!(failure_code);
             response["ExportDescription"]["FailureMessage"] = json!(failure_reason);
         }
         Self::ok_json(response)

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -1010,48 +1010,57 @@ impl DynamoDbService {
                 // Persist through the S3 store (Disk in persistent mode,
                 // Memory otherwise) so the export survives restart and the
                 // in-memory runtime body is whatever the store returns.
-                let body_ref = if let Some(ref store) = self.s3_store {
-                    match store.put_object(
-                        s3_bucket,
-                        &s3_key,
-                        None,
-                        fakecloud_persistence::BodySource::Bytes(body_bytes.clone()),
-                        &meta,
-                    ) {
-                        Ok(bref) => bref,
-                        Err(err) => {
-                            tracing::error!(
-                                bucket = %s3_bucket,
-                                key = %s3_key,
-                                error = %err,
-                                "DynamoDB export: failed to persist result object via store",
-                            );
-                            fakecloud_persistence::BodyRef::Memory(body_bytes.clone())
+                let body_ref_result: Result<fakecloud_persistence::BodyRef, String> =
+                    if let Some(ref store) = self.s3_store {
+                        store
+                            .put_object(
+                                s3_bucket,
+                                &s3_key,
+                                None,
+                                fakecloud_persistence::BodySource::Bytes(body_bytes.clone()),
+                                &meta,
+                            )
+                            .map_err(|err| {
+                                tracing::error!(
+                                    bucket = %s3_bucket,
+                                    key = %s3_key,
+                                    error = %err,
+                                    "DynamoDB export: failed to persist result object via store",
+                                );
+                                format!("failed to persist export artifact: {err}")
+                            })
+                    } else {
+                        Ok(fakecloud_persistence::BodyRef::Memory(body_bytes.clone()))
+                    };
+                match body_ref_result {
+                    Ok(body_ref) => {
+                        let mut s3 = s3_state.write();
+                        if let Some(bucket) = s3.buckets.get_mut(s3_bucket) {
+                            let obj = fakecloud_s3::state::S3Object {
+                                key: s3_key.clone(),
+                                body: body_ref,
+                                content_type: "application/json".to_string(),
+                                etag,
+                                size: data_size as u64,
+                                last_modified: now,
+                                storage_class: "STANDARD".to_string(),
+                                ..Default::default()
+                            };
+                            bucket.objects.insert(s3_key, obj);
+                        } else {
+                            // Raced with concurrent DeleteBucket between our
+                            // check and the write guard. The store write
+                            // already happened, so we have an orphan on
+                            // disk — best we can do is mark the export
+                            // failed and let the operator reconcile.
+                            export_failed = true;
+                            failure_reason = format!("S3 bucket does not exist: {s3_bucket}");
                         }
                     }
-                } else {
-                    fakecloud_persistence::BodyRef::Memory(body_bytes.clone())
-                };
-                let mut s3 = s3_state.write();
-                if let Some(bucket) = s3.buckets.get_mut(s3_bucket) {
-                    let obj = fakecloud_s3::state::S3Object {
-                        key: s3_key.clone(),
-                        body: body_ref,
-                        content_type: "application/json".to_string(),
-                        etag,
-                        size: data_size as u64,
-                        last_modified: now,
-                        storage_class: "STANDARD".to_string(),
-                        ..Default::default()
-                    };
-                    bucket.objects.insert(s3_key, obj);
-                } else {
-                    // Raced with concurrent DeleteBucket between our check
-                    // and the write guard. Treat as failure; nothing has been
-                    // written to disk because the store call is nested inside
-                    // the contains_key branch.
-                    export_failed = true;
-                    failure_reason = format!("S3 bucket does not exist: {s3_bucket}");
+                    Err(reason) => {
+                        export_failed = true;
+                        failure_reason = reason;
+                    }
                 }
             }
         }

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -1171,7 +1171,13 @@ impl DynamoDbService {
                 if !prefix.is_empty() && !key.starts_with(&prefix) {
                     continue;
                 }
-                let obj_bytes = fakecloud_s3::state::read_body_bytes(&obj.body);
+                let obj_bytes = s3.read_body(&obj.body).map_err(|e| {
+                    AwsServiceError::aws_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "InternalServerError",
+                        format!("failed to read S3 object body for import: {e}"),
+                    )
+                })?;
                 let data = std::str::from_utf8(&obj_bytes).unwrap_or("");
                 processed_size_bytes += obj.size as i64;
                 for line in data.lines() {

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -989,12 +989,47 @@ impl DynamoDbService {
         let mut export_failed = false;
         let mut failure_reason = String::new();
         if let Some(ref s3_state) = self.s3_state {
+            let body_bytes = bytes::Bytes::from(json_lines);
+            let etag = uuid::Uuid::new_v4().to_string().replace('-', "");
+            let meta = fakecloud_persistence::ObjectMeta {
+                key: s3_key.clone(),
+                content_type: "application/json".to_string(),
+                etag: etag.clone(),
+                size: data_size as u64,
+                last_modified: now,
+                storage_class: "STANDARD".to_string(),
+                ..Default::default()
+            };
+            // Persist through the S3 store (Disk in persistent mode, Memory
+            // otherwise) so the export survives restart and the in-memory
+            // runtime body is whatever the store returns.
+            let body_ref = if let Some(ref store) = self.s3_store {
+                match store.put_object(
+                    s3_bucket,
+                    &s3_key,
+                    None,
+                    fakecloud_persistence::BodySource::Bytes(body_bytes.clone()),
+                    &meta,
+                ) {
+                    Ok(bref) => bref,
+                    Err(err) => {
+                        tracing::error!(
+                            bucket = %s3_bucket,
+                            key = %s3_key,
+                            error = %err,
+                            "DynamoDB export: failed to persist result object via store",
+                        );
+                        fakecloud_persistence::BodyRef::Memory(body_bytes.clone())
+                    }
+                }
+            } else {
+                fakecloud_persistence::BodyRef::Memory(body_bytes.clone())
+            };
             let mut s3 = s3_state.write();
             if let Some(bucket) = s3.buckets.get_mut(s3_bucket) {
-                let etag = uuid::Uuid::new_v4().to_string().replace('-', "");
                 let obj = fakecloud_s3::state::S3Object {
                     key: s3_key.clone(),
-                    body: fakecloud_persistence::BodyRef::Memory(bytes::Bytes::from(json_lines)),
+                    body: body_ref,
                     content_type: "application/json".to_string(),
                     etag,
                     size: data_size as u64,

--- a/crates/fakecloud-e2e/Cargo.toml
+++ b/crates/fakecloud-e2e/Cargo.toml
@@ -45,3 +45,5 @@ base64 = { workspace = true }
 flate2 = { workspace = true }
 zip = { workspace = true }
 fakecloud-sdk = { path = "../fakecloud-sdk" }
+tempfile = { workspace = true }
+sha2 = { workspace = true }

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -1,4 +1,5 @@
 use std::net::TcpListener;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::time::Duration;
 
@@ -13,6 +14,9 @@ pub struct TestServer {
     port: u16,
     endpoint: String,
     container_cli: String,
+    extra_args: Vec<String>,
+    env_vars: Vec<(String, String)>,
+    log_level: String,
 }
 
 #[allow(dead_code)]
@@ -24,6 +28,36 @@ impl TestServer {
 
     /// Start with extra environment variables passed to the server process.
     pub async fn start_with_env(env: &[(&str, &str)]) -> Self {
+        Self::start_full(env, &[]).await
+    }
+
+    /// Start fakecloud in persistent mode with the given data directory.
+    pub async fn start_persistent(data_path: &Path) -> Self {
+        Self::start_persistent_with_cache(data_path, None).await
+    }
+
+    pub async fn start_persistent_with_cache(
+        data_path: &Path,
+        body_cache_size: Option<u64>,
+    ) -> Self {
+        let data_path_str = data_path.display().to_string();
+        let mut args: Vec<String> = vec![
+            "--storage-mode".to_string(),
+            "persistent".to_string(),
+            "--data-path".to_string(),
+            data_path_str,
+        ];
+        if let Some(size) = body_cache_size {
+            args.push("--body-cache-size".to_string());
+            args.push(size.to_string());
+        }
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        Self::start_full(&[("FAKECLOUD_CONTAINER_CLI", "false")], &arg_refs).await
+    }
+
+    /// Full form — extra env vars + extra CLI args. Used internally by
+    /// the specialised `start_*` helpers.
+    pub async fn start_full(env: &[(&str, &str)], extra_args: &[&str]) -> Self {
         let bin = find_binary();
 
         let container_cli = env
@@ -39,20 +73,27 @@ impl TestServer {
             .or_else(|| std::env::var("FAKECLOUD_TEST_LOG_LEVEL").ok())
             .unwrap_or_else(|| "warn".to_string());
 
+        let env_vars: Vec<(String, String)> = env
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        let extra_args_owned: Vec<String> =
+            extra_args.iter().map(|s| (*s).to_string()).collect();
+
         for _ in 0..3 {
             let port = find_available_port();
             let endpoint = format!("http://127.0.0.1:{port}");
 
             let mut cmd = Command::new(&bin);
             cmd.arg("--addr")
-                // Bind to 0.0.0.0 so Lambda containers can reach the server via Docker bridge
                 .arg(format!("0.0.0.0:{port}"))
                 .arg("--log-level")
                 .arg(&log_level)
+                .args(&extra_args_owned)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
 
-            for (key, value) in env {
+            for (key, value) in &env_vars {
                 cmd.env(key, value);
             }
 
@@ -64,6 +105,9 @@ impl TestServer {
                     port,
                     endpoint,
                     container_cli,
+                    extra_args: extra_args_owned,
+                    env_vars,
+                    log_level,
                 };
             }
 
@@ -73,6 +117,89 @@ impl TestServer {
 
         panic!("fakecloud failed to start after 3 attempts");
     }
+
+    /// Kill the current child and respawn with the same extra args/env.
+    /// Allocates a new port because the previous one may still be in TIME_WAIT.
+    pub async fn restart(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        let bin = find_binary();
+        for _ in 0..5 {
+            let port = find_available_port();
+            let endpoint = format!("http://127.0.0.1:{port}");
+            let mut cmd = Command::new(&bin);
+            cmd.arg("--addr")
+                .arg(format!("0.0.0.0:{port}"))
+                .arg("--log-level")
+                .arg(&self.log_level)
+                .args(&self.extra_args)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            for (key, value) in &self.env_vars {
+                cmd.env(key, value);
+            }
+            let mut child = cmd.spawn().expect("failed to respawn fakecloud");
+            if wait_for_port(&mut child, port).await {
+                self.child = Some(child);
+                self.port = port;
+                self.endpoint = endpoint;
+                return;
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        panic!("fakecloud failed to restart");
+    }
+}
+
+/// Run fakecloud once and collect its exit status + stderr output.
+/// For tests that deliberately cause the server to fail at boot.
+#[allow(dead_code)]
+pub fn run_until_exit(
+    extra_args: &[&str],
+    env: &[(&str, &str)],
+    timeout: Duration,
+) -> (std::process::ExitStatus, String) {
+    let bin = find_binary();
+    let port = find_available_port();
+    let mut cmd = Command::new(&bin);
+    cmd.arg("--addr")
+        .arg(format!("127.0.0.1:{port}"))
+        .arg("--log-level")
+        .arg("warn")
+        .args(extra_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("failed to spawn fakecloud");
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("try_wait") {
+            let output = child.wait_with_output().expect("wait_with_output");
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return (status, stderr);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let output = child.wait_with_output().expect("wait_with_output");
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return (output.status, stderr);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[allow(dead_code)]
+pub fn data_path_for(dir: &tempfile::TempDir) -> PathBuf {
+    dir.path().to_path_buf()
+}
+
+#[allow(dead_code)]
+impl TestServer {
 
     pub fn endpoint(&self) -> &str {
         &self.endpoint

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -36,10 +36,7 @@ impl TestServer {
         Self::start_persistent_with_cache(data_path, None).await
     }
 
-    pub async fn start_persistent_with_cache(
-        data_path: &Path,
-        body_cache_size: Option<u64>,
-    ) -> Self {
+    pub async fn start_persistent_with_cache(data_path: &Path, s3_cache_size: Option<u64>) -> Self {
         let data_path_str = data_path.display().to_string();
         let mut args: Vec<String> = vec![
             "--storage-mode".to_string(),
@@ -47,8 +44,8 @@ impl TestServer {
             "--data-path".to_string(),
             data_path_str,
         ];
-        if let Some(size) = body_cache_size {
-            args.push("--body-cache-size".to_string());
+        if let Some(size) = s3_cache_size {
+            args.push("--s3-cache-size".to_string());
             args.push(size.to_string());
         }
         let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -77,8 +74,7 @@ impl TestServer {
             .iter()
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect();
-        let extra_args_owned: Vec<String> =
-            extra_args.iter().map(|s| (*s).to_string()).collect();
+        let extra_args_owned: Vec<String> = extra_args.iter().map(|s| (*s).to_string()).collect();
 
         for _ in 0..3 {
             let port = find_available_port();
@@ -200,7 +196,6 @@ pub fn data_path_for(dir: &tempfile::TempDir) -> PathBuf {
 
 #[allow(dead_code)]
 impl TestServer {
-
     pub fn endpoint(&self) -> &str {
         &self.endpoint
     }

--- a/crates/fakecloud-e2e/tests/s3_persistence.rs
+++ b/crates/fakecloud-e2e/tests/s3_persistence.rs
@@ -141,17 +141,21 @@ async fn persistence_round_trip_objects_with_metadata() {
             .any(|t| t.key() == "env" && t.value() == "prod"));
     }
 
-    let legal = client
+    let resp = client
         .get_object_legal_hold()
         .bucket("meta-bucket")
         .key("tagged.txt")
         .send()
-        .await;
-    if let Ok(resp) = legal {
-        if let Some(lh) = resp.legal_hold() {
-            assert_eq!(lh.status(), Some(&ObjectLockLegalHoldStatus::On));
-        }
-    }
+        .await
+        .expect("legal hold must round-trip across restart");
+    let lh = resp
+        .legal_hold()
+        .expect("legal hold struct must be present after restart");
+    assert_eq!(
+        lh.status(),
+        Some(&ObjectLockLegalHoldStatus::On),
+        "legal hold status must persist across restart",
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/s3_persistence.rs
+++ b/crates/fakecloud-e2e/tests/s3_persistence.rs
@@ -1,0 +1,743 @@
+mod helpers;
+
+use std::time::Duration;
+
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::{
+    BucketVersioningStatus, CompletedMultipartUpload, CompletedPart, CorsConfiguration, CorsRule,
+    ObjectLockConfiguration, ObjectLockEnabled, ObjectLockLegalHold, ObjectLockLegalHoldStatus,
+    ServerSideEncryption, ServerSideEncryptionByDefault, ServerSideEncryptionConfiguration,
+    ServerSideEncryptionRule, StorageClass, Tag, Tagging, VersioningConfiguration,
+};
+use helpers::{run_until_exit, TestServer};
+use sha2::{Digest, Sha256};
+
+fn pseudo_random_bytes(seed: u64, len: usize) -> Vec<u8> {
+    // Deterministic xorshift-based filler — good enough for round-trip tests.
+    let mut state = seed.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(1);
+    let mut out = Vec::with_capacity(len);
+    while out.len() < len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.extend_from_slice(&state.to_le_bytes());
+    }
+    out.truncate(len);
+    out
+}
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+#[tokio::test]
+async fn persistence_round_trip_objects_with_metadata() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("meta-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_object_lock_configuration()
+        .bucket("meta-bucket")
+        .object_lock_configuration(
+            ObjectLockConfiguration::builder()
+                .object_lock_enabled(ObjectLockEnabled::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .ok();
+
+    let objects: Vec<(&str, Vec<u8>, &str)> = vec![
+        ("plain.txt", b"hello world".to_vec(), "text/plain"),
+        ("binary.bin", vec![0u8, 1, 2, 3, 255, 254, 253], "application/octet-stream"),
+        ("doc.json", br#"{"ok":true}"#.to_vec(), "application/json"),
+        ("big.txt", vec![b'x'; 64 * 1024], "text/plain"),
+        ("tagged.txt", b"tagged".to_vec(), "text/plain"),
+    ];
+
+    for (i, (key, body, ct)) in objects.iter().enumerate() {
+        let mut put = client
+            .put_object()
+            .bucket("meta-bucket")
+            .key(*key)
+            .body(ByteStream::from(body.clone()))
+            .content_type(*ct)
+            .metadata("custom", format!("value-{}", i))
+            .metadata("index", i.to_string())
+            .tagging(format!("env=prod&rank={}", i))
+            .server_side_encryption(ServerSideEncryption::Aes256);
+        if i == 0 {
+            put = put.storage_class(StorageClass::StandardIa);
+        }
+        put.send().await.unwrap();
+    }
+
+    // Legal hold on a specific object.
+    client
+        .put_object_legal_hold()
+        .bucket("meta-bucket")
+        .key("tagged.txt")
+        .legal_hold(
+            ObjectLockLegalHold::builder()
+                .status(ObjectLockLegalHoldStatus::On)
+                .build(),
+        )
+        .send()
+        .await
+        .ok();
+
+    server.restart().await;
+    let client = server.s3_client().await;
+
+    for (i, (key, body, ct)) in objects.iter().enumerate() {
+        let head = client
+            .head_object()
+            .bucket("meta-bucket")
+            .key(*key)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(head.content_type(), Some(*ct), "content-type for {}", key);
+        let meta = head.metadata().unwrap();
+        assert_eq!(meta.get("custom").map(String::as_str), Some(&*format!("value-{}", i)));
+
+        let get = client
+            .get_object()
+            .bucket("meta-bucket")
+            .key(*key)
+            .send()
+            .await
+            .unwrap();
+        let got = get.body.collect().await.unwrap().into_bytes().to_vec();
+        assert_eq!(got, *body, "body mismatch for {}", key);
+
+        let tags = client
+            .get_object_tagging()
+            .bucket("meta-bucket")
+            .key(*key)
+            .send()
+            .await
+            .unwrap();
+        let tag_set = tags.tag_set();
+        assert!(tag_set.iter().any(|t| t.key() == "env" && t.value() == "prod"));
+    }
+
+    let legal = client
+        .get_object_legal_hold()
+        .bucket("meta-bucket")
+        .key("tagged.txt")
+        .send()
+        .await;
+    if let Ok(resp) = legal {
+        if let Some(lh) = resp.legal_hold() {
+            assert_eq!(lh.status(), Some(&ObjectLockLegalHoldStatus::On));
+        }
+    }
+}
+
+#[tokio::test]
+async fn persistence_large_object_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("big-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    const SIZE: usize = 50 * 1024 * 1024;
+    let body = pseudo_random_bytes(42, SIZE);
+    let expected = sha256(&body);
+
+    client
+        .put_object()
+        .bucket("big-bucket")
+        .key("large.bin")
+        .body(ByteStream::from(body.clone()))
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let client = server.s3_client().await;
+
+    let get = client
+        .get_object()
+        .bucket("big-bucket")
+        .key("large.bin")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.content_length(), Some(SIZE as i64));
+    let bytes = get.body.collect().await.unwrap().into_bytes();
+    assert_eq!(bytes.len(), SIZE);
+    assert_eq!(sha256(&bytes), expected);
+
+    // On-disk .bin file size check. Object-dir layout uses an opaque
+    // escape of the bucket/key so we walk and pick the largest file.
+    let mut largest: u64 = 0;
+    for entry in walkdir(tmp.path()) {
+        if entry.extension().and_then(|s| s.to_str()) == Some("bin") {
+            if let Ok(md) = std::fs::metadata(&entry) {
+                largest = largest.max(md.len());
+            }
+        }
+    }
+    assert_eq!(largest, SIZE as u64, "on-disk .bin size mismatch");
+}
+
+fn walkdir(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(p) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&p) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            let ep = entry.path();
+            if ep.is_dir() {
+                stack.push(ep);
+            } else {
+                out.push(ep);
+            }
+        }
+    }
+    out
+}
+
+#[tokio::test]
+async fn persistence_multipart_resume_and_complete() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("mpu-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("mpu-bucket")
+        .key("resumable.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    const PART_SIZE: usize = 5 * 1024 * 1024 + 1024;
+    let parts: Vec<Vec<u8>> = (0..5)
+        .map(|i| pseudo_random_bytes(i as u64 + 100, PART_SIZE))
+        .collect();
+
+    let mut completed: Vec<CompletedPart> = Vec::new();
+
+    for idx in 0..3 {
+        let resp = client
+            .upload_part()
+            .bucket("mpu-bucket")
+            .key("resumable.bin")
+            .upload_id(&upload_id)
+            .part_number((idx + 1) as i32)
+            .body(ByteStream::from(parts[idx].clone()))
+            .send()
+            .await
+            .unwrap();
+        completed.push(
+            CompletedPart::builder()
+                .part_number((idx + 1) as i32)
+                .e_tag(resp.e_tag().unwrap_or_default())
+                .build(),
+        );
+    }
+
+    server.restart().await;
+    let client = server.s3_client().await;
+
+    for idx in 3..5 {
+        let resp = client
+            .upload_part()
+            .bucket("mpu-bucket")
+            .key("resumable.bin")
+            .upload_id(&upload_id)
+            .part_number((idx + 1) as i32)
+            .body(ByteStream::from(parts[idx].clone()))
+            .send()
+            .await
+            .unwrap();
+        completed.push(
+            CompletedPart::builder()
+                .part_number((idx + 1) as i32)
+                .e_tag(resp.e_tag().unwrap_or_default())
+                .build(),
+        );
+    }
+
+    client
+        .complete_multipart_upload()
+        .bucket("mpu-bucket")
+        .key("resumable.bin")
+        .upload_id(&upload_id)
+        .multipart_upload(
+            CompletedMultipartUpload::builder()
+                .set_parts(Some(completed))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let get = client
+        .get_object()
+        .bucket("mpu-bucket")
+        .key("resumable.bin")
+        .send()
+        .await
+        .unwrap();
+    let body = get.body.collect().await.unwrap().into_bytes().to_vec();
+    let expected: Vec<u8> = parts.iter().flatten().copied().collect();
+    assert_eq!(body.len(), expected.len());
+    assert_eq!(sha256(&body), sha256(&expected));
+}
+
+#[tokio::test]
+async fn persistence_multipart_abort_clears_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("abort-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("abort-bucket")
+        .key("aborted.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    for n in 1..=3 {
+        client
+            .upload_part()
+            .bucket("abort-bucket")
+            .key("aborted.bin")
+            .upload_id(&upload_id)
+            .part_number(n)
+            .body(ByteStream::from(pseudo_random_bytes(n as u64, 5 * 1024 * 1024 + 32)))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    server.restart().await;
+    let client = server.s3_client().await;
+
+    client
+        .abort_multipart_upload()
+        .bucket("abort-bucket")
+        .key("aborted.bin")
+        .upload_id(&upload_id)
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_multipart_uploads()
+        .bucket("abort-bucket")
+        .send()
+        .await
+        .unwrap();
+    assert!(list.uploads().is_empty());
+}
+
+#[tokio::test]
+async fn persistence_versioning_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("ver-bucket")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_bucket_versioning()
+        .bucket("ver-bucket")
+        .versioning_configuration(
+            VersioningConfiguration::builder()
+                .status(BucketVersioningStatus::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let bodies: Vec<&[u8]> = vec![b"version-1", b"version-2", b"version-3"];
+    for body in &bodies {
+        client
+            .put_object()
+            .bucket("ver-bucket")
+            .key("doc.txt")
+            .body(ByteStream::from(body.to_vec()))
+            .send()
+            .await
+            .unwrap();
+    }
+    client
+        .delete_object()
+        .bucket("ver-bucket")
+        .key("doc.txt")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let client = server.s3_client().await;
+
+    let list = client
+        .list_object_versions()
+        .bucket("ver-bucket")
+        .send()
+        .await
+        .unwrap();
+    let versions = list.versions();
+    let markers = list.delete_markers();
+    assert_eq!(versions.len(), 3, "expected 3 versions");
+    assert_eq!(markers.len(), 1, "expected 1 delete marker");
+
+    for (i, body) in bodies.iter().enumerate() {
+        let v = &versions[versions.len() - 1 - i];
+        let vid = v.version_id().unwrap().to_string();
+        let get = client
+            .get_object()
+            .bucket("ver-bucket")
+            .key("doc.txt")
+            .version_id(vid)
+            .send()
+            .await
+            .unwrap();
+        let got = get.body.collect().await.unwrap().into_bytes();
+        assert_eq!(got.as_ref(), *body, "body mismatch for version index {}", i);
+    }
+}
+
+#[tokio::test]
+async fn persistence_bucket_subresources_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("sub-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // Versioning (required for replication, object lock).
+    client
+        .put_bucket_versioning()
+        .bucket("sub-bucket")
+        .versioning_configuration(
+            VersioningConfiguration::builder()
+                .status(BucketVersioningStatus::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Tags
+    client
+        .put_bucket_tagging()
+        .bucket("sub-bucket")
+        .tagging(
+            Tagging::builder()
+                .tag_set(Tag::builder().key("env").value("prod").build().unwrap())
+                .tag_set(Tag::builder().key("team").value("s3").build().unwrap())
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Lifecycle
+    let _ = server
+        .aws_cli(&[
+            "s3api",
+            "put-bucket-lifecycle-configuration",
+            "--bucket",
+            "sub-bucket",
+            "--lifecycle-configuration",
+            r#"{"Rules":[{"ID":"expire","Status":"Enabled","Expiration":{"Days":30},"Filter":{}}]}"#,
+        ])
+        .await;
+
+    // CORS
+    client
+        .put_bucket_cors()
+        .bucket("sub-bucket")
+        .cors_configuration(
+            CorsConfiguration::builder()
+                .cors_rules(
+                    CorsRule::builder()
+                        .allowed_methods("GET")
+                        .allowed_origins("*")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Policy
+    let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::sub-bucket/*"}]}"#;
+    client
+        .put_bucket_policy()
+        .bucket("sub-bucket")
+        .policy(policy)
+        .send()
+        .await
+        .unwrap();
+
+    // Object Lock
+    client
+        .put_object_lock_configuration()
+        .bucket("sub-bucket")
+        .object_lock_configuration(
+            ObjectLockConfiguration::builder()
+                .object_lock_enabled(ObjectLockEnabled::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .ok();
+
+    // Encryption
+    client
+        .put_bucket_encryption()
+        .bucket("sub-bucket")
+        .server_side_encryption_configuration(
+            ServerSideEncryptionConfiguration::builder()
+                .rules(
+                    ServerSideEncryptionRule::builder()
+                        .apply_server_side_encryption_by_default(
+                            ServerSideEncryptionByDefault::builder()
+                                .sse_algorithm(ServerSideEncryption::Aes256)
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Inventory
+    let _ = server
+        .aws_cli(&[
+            "s3api",
+            "put-bucket-inventory-configuration",
+            "--bucket",
+            "sub-bucket",
+            "--id",
+            "inv-1",
+            "--inventory-configuration",
+            r#"{"Id":"inv-1","IsEnabled":true,"Destination":{"S3BucketDestination":{"Bucket":"arn:aws:s3:::dest","Format":"CSV"}},"IncludedObjectVersions":"Current","Schedule":{"Frequency":"Daily"}}"#,
+        ])
+        .await;
+
+    server.restart().await;
+    let client = server.s3_client().await;
+
+    let tags = client
+        .get_bucket_tagging()
+        .bucket("sub-bucket")
+        .send()
+        .await
+        .unwrap();
+    let ts = tags.tag_set();
+    assert!(ts.iter().any(|t| t.key() == "env" && t.value() == "prod"));
+    assert!(ts.iter().any(|t| t.key() == "team" && t.value() == "s3"));
+
+    let lc = client
+        .get_bucket_lifecycle_configuration()
+        .bucket("sub-bucket")
+        .send()
+        .await;
+    assert!(lc.is_ok(), "lifecycle lost: {:?}", lc.err());
+
+    let cors = client
+        .get_bucket_cors()
+        .bucket("sub-bucket")
+        .send()
+        .await
+        .unwrap();
+    assert!(!cors.cors_rules().is_empty());
+
+    let pol = client
+        .get_bucket_policy()
+        .bucket("sub-bucket")
+        .send()
+        .await
+        .unwrap();
+    assert!(pol.policy().unwrap_or_default().contains("sub-bucket"));
+
+    let enc = client
+        .get_bucket_encryption()
+        .bucket("sub-bucket")
+        .send()
+        .await
+        .unwrap();
+    let _ = enc.server_side_encryption_configuration();
+
+    let inv = client
+        .get_bucket_inventory_configuration()
+        .bucket("sub-bucket")
+        .id("inv-1")
+        .send()
+        .await;
+    assert!(inv.is_ok(), "inventory lost: {:?}", inv.err());
+}
+
+#[tokio::test]
+async fn persistence_unsupported_services_still_work_in_memory() {
+    // Warning emission is covered by a unit test in `fakecloud-persistence`.
+    // Here we only verify that a non-S3 service (SQS) keeps working when
+    // the server is booted with --storage-mode=persistent.
+    let tmp = tempfile::tempdir().unwrap();
+    let server = TestServer::start_persistent(tmp.path()).await;
+    let sqs = server.sqs_client().await;
+
+    let q = sqs
+        .create_queue()
+        .queue_name("test-queue")
+        .send()
+        .await
+        .unwrap();
+    let url = q.queue_url().unwrap().to_string();
+
+    sqs.send_message()
+        .queue_url(&url)
+        .message_body("hello")
+        .send()
+        .await
+        .unwrap();
+
+    let recv = sqs
+        .receive_message()
+        .queue_url(&url)
+        .wait_time_seconds(0)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(recv.messages().len(), 1);
+    assert_eq!(recv.messages()[0].body(), Some("hello"));
+}
+
+#[tokio::test]
+async fn persistence_version_file_mismatch_fails_loudly() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("fakecloud.version.toml"),
+        "format_version = 99\nfakecloud_version = \"bogus\"\ncreated_at = \"2000-01-01T00:00:00Z\"\n",
+    )
+    .unwrap();
+
+    let data_arg = tmp.path().display().to_string();
+    let (status, stderr) = run_until_exit(
+        &[
+            "--storage-mode",
+            "persistent",
+            "--data-path",
+            &data_arg,
+        ],
+        &[("FAKECLOUD_CONTAINER_CLI", "false")],
+        Duration::from_secs(10),
+    );
+    assert!(!status.success(), "expected non-zero exit, got {:?}", status);
+    assert!(
+        stderr.contains("fakecloud.version.toml")
+            || stderr.contains("format_version")
+            || stderr.contains("version file"),
+        "stderr did not reference version file: {}",
+        stderr
+    );
+}
+
+#[tokio::test]
+async fn persistence_body_cache_small_and_large_objects() {
+    let tmp = tempfile::tempdir().unwrap();
+    // 4 MiB cache => 2 MiB single-object cap.
+    let mut server =
+        TestServer::start_persistent_with_cache(tmp.path(), Some(4 * 1024 * 1024)).await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("cache-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let small = pseudo_random_bytes(1, 1024 * 1024);
+    let big = pseudo_random_bytes(2, 3 * 1024 * 1024);
+    let tiny = pseudo_random_bytes(3, 512 * 1024);
+
+    for (key, body) in [("small.bin", &small), ("big.bin", &big), ("tiny.bin", &tiny)] {
+        client
+            .put_object()
+            .bucket("cache-bucket")
+            .key(key)
+            .body(ByteStream::from(body.clone()))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    server.restart().await;
+    let client = server.s3_client().await;
+
+    for (key, expected) in [("small.bin", &small), ("big.bin", &big), ("tiny.bin", &tiny)] {
+        let get = client
+            .get_object()
+            .bucket("cache-bucket")
+            .key(key)
+            .send()
+            .await
+            .unwrap();
+        let got = get.body.collect().await.unwrap().into_bytes();
+        assert_eq!(sha256(&got), sha256(expected), "body mismatch for {}", key);
+    }
+}
+

--- a/crates/fakecloud-e2e/tests/s3_persistence.rs
+++ b/crates/fakecloud-e2e/tests/s3_persistence.rs
@@ -59,7 +59,11 @@ async fn persistence_round_trip_objects_with_metadata() {
 
     let objects: Vec<(&str, Vec<u8>, &str)> = vec![
         ("plain.txt", b"hello world".to_vec(), "text/plain"),
-        ("binary.bin", vec![0u8, 1, 2, 3, 255, 254, 253], "application/octet-stream"),
+        (
+            "binary.bin",
+            vec![0u8, 1, 2, 3, 255, 254, 253],
+            "application/octet-stream",
+        ),
         ("doc.json", br#"{"ok":true}"#.to_vec(), "application/json"),
         ("big.txt", vec![b'x'; 64 * 1024], "text/plain"),
         ("tagged.txt", b"tagged".to_vec(), "text/plain"),
@@ -109,7 +113,10 @@ async fn persistence_round_trip_objects_with_metadata() {
             .unwrap();
         assert_eq!(head.content_type(), Some(*ct), "content-type for {}", key);
         let meta = head.metadata().unwrap();
-        assert_eq!(meta.get("custom").map(String::as_str), Some(&*format!("value-{}", i)));
+        assert_eq!(
+            meta.get("custom").map(String::as_str),
+            Some(&*format!("value-{}", i))
+        );
 
         let get = client
             .get_object()
@@ -129,7 +136,9 @@ async fn persistence_round_trip_objects_with_metadata() {
             .await
             .unwrap();
         let tag_set = tags.tag_set();
-        assert!(tag_set.iter().any(|t| t.key() == "env" && t.value() == "prod"));
+        assert!(tag_set
+            .iter()
+            .any(|t| t.key() == "env" && t.value() == "prod"));
     }
 
     let legal = client
@@ -247,14 +256,14 @@ async fn persistence_multipart_resume_and_complete() {
 
     let mut completed: Vec<CompletedPart> = Vec::new();
 
-    for idx in 0..3 {
+    for (idx, body) in parts.iter().enumerate().take(3) {
         let resp = client
             .upload_part()
             .bucket("mpu-bucket")
             .key("resumable.bin")
             .upload_id(&upload_id)
             .part_number((idx + 1) as i32)
-            .body(ByteStream::from(parts[idx].clone()))
+            .body(ByteStream::from(body.clone()))
             .send()
             .await
             .unwrap();
@@ -269,14 +278,14 @@ async fn persistence_multipart_resume_and_complete() {
     server.restart().await;
     let client = server.s3_client().await;
 
-    for idx in 3..5 {
+    for (idx, body) in parts.iter().enumerate().take(5).skip(3) {
         let resp = client
             .upload_part()
             .bucket("mpu-bucket")
             .key("resumable.bin")
             .upload_id(&upload_id)
             .part_number((idx + 1) as i32)
-            .body(ByteStream::from(parts[idx].clone()))
+            .body(ByteStream::from(body.clone()))
             .send()
             .await
             .unwrap();
@@ -344,7 +353,10 @@ async fn persistence_multipart_abort_clears_state() {
             .key("aborted.bin")
             .upload_id(&upload_id)
             .part_number(n)
-            .body(ByteStream::from(pseudo_random_bytes(n as u64, 5 * 1024 * 1024 + 32)))
+            .body(ByteStream::from(pseudo_random_bytes(
+                n as u64,
+                5 * 1024 * 1024 + 32,
+            )))
             .send()
             .await
             .unwrap();
@@ -676,16 +688,15 @@ async fn persistence_version_file_mismatch_fails_loudly() {
 
     let data_arg = tmp.path().display().to_string();
     let (status, stderr) = run_until_exit(
-        &[
-            "--storage-mode",
-            "persistent",
-            "--data-path",
-            &data_arg,
-        ],
+        &["--storage-mode", "persistent", "--data-path", &data_arg],
         &[("FAKECLOUD_CONTAINER_CLI", "false")],
         Duration::from_secs(10),
     );
-    assert!(!status.success(), "expected non-zero exit, got {:?}", status);
+    assert!(
+        !status.success(),
+        "expected non-zero exit, got {:?}",
+        status
+    );
     assert!(
         stderr.contains("fakecloud.version.toml")
             || stderr.contains("format_version")
@@ -714,7 +725,11 @@ async fn persistence_body_cache_small_and_large_objects() {
     let big = pseudo_random_bytes(2, 3 * 1024 * 1024);
     let tiny = pseudo_random_bytes(3, 512 * 1024);
 
-    for (key, body) in [("small.bin", &small), ("big.bin", &big), ("tiny.bin", &tiny)] {
+    for (key, body) in [
+        ("small.bin", &small),
+        ("big.bin", &big),
+        ("tiny.bin", &tiny),
+    ] {
         client
             .put_object()
             .bucket("cache-bucket")
@@ -728,7 +743,11 @@ async fn persistence_body_cache_small_and_large_objects() {
     server.restart().await;
     let client = server.s3_client().await;
 
-    for (key, expected) in [("small.bin", &small), ("big.bin", &big), ("tiny.bin", &tiny)] {
+    for (key, expected) in [
+        ("small.bin", &small),
+        ("big.bin", &big),
+        ("tiny.bin", &tiny),
+    ] {
         let get = client
             .get_object()
             .bucket("cache-bucket")
@@ -740,4 +759,3 @@ async fn persistence_body_cache_small_and_large_objects() {
         assert_eq!(sha256(&got), sha256(expected), "body mismatch for {}", key);
     }
 }
-

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -4344,7 +4344,7 @@ mod tests {
             ],
         );
         let resp = service.create_user(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<UserId>testuser</UserId>"));
         assert!(body.contains("<Status>active</Status>"));
         assert!(body.contains("<CreateUserResponse"));
@@ -4386,7 +4386,7 @@ mod tests {
 
         let req = request("DescribeUsers", &[]);
         let resp = service.describe_users(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<UserId>default</UserId>"));
     }
 
@@ -4399,7 +4399,7 @@ mod tests {
         let resp = service
             .describe_reserved_cache_nodes(&request("DescribeReservedCacheNodes", &[]))
             .unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<ReservedCacheNodes></ReservedCacheNodes>"));
     }
 
@@ -4426,7 +4426,7 @@ mod tests {
                 &[("ReservedCacheNodesOfferingId", "offering-b")],
             ))
             .unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<ReservedCacheNodeId>rcn-b</ReservedCacheNodeId>"));
         assert!(!body.contains("<ReservedCacheNodeId>rcn-a</ReservedCacheNodeId>"));
     }
@@ -4486,7 +4486,7 @@ mod tests {
                 &[("ProductDescription", "redis"), ("Duration", "3")],
             ))
             .unwrap();
-        let filtered_body = String::from_utf8(filtered.body.to_vec()).unwrap();
+        let filtered_body = String::from_utf8(filtered.body.expect_bytes().to_vec()).unwrap();
         assert!(filtered_body
             .contains("<ReservedCacheNodesOfferingId>offering-c</ReservedCacheNodesOfferingId>"));
         assert!(!filtered_body
@@ -4498,7 +4498,7 @@ mod tests {
                 &[("MaxRecords", "1")],
             ))
             .unwrap();
-        let paged_body = String::from_utf8(paged.body.to_vec()).unwrap();
+        let paged_body = String::from_utf8(paged.body.expect_bytes().to_vec()).unwrap();
         assert!(paged_body.contains("<Marker>1</Marker>"));
     }
 
@@ -4531,13 +4531,13 @@ mod tests {
             ],
         );
         let resp = service.create_user_group(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<UserGroupId>mygroup</UserGroupId>"));
         assert!(body.contains("<member>default</member>"));
 
         let req = request("DescribeUserGroups", &[]);
         let resp = service.describe_user_groups(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<UserGroupId>mygroup</UserGroupId>"));
     }
 
@@ -4572,7 +4572,7 @@ mod tests {
 
         let req = request("DeleteUserGroup", &[("UserGroupId", "delgroup")]);
         let resp = service.delete_user_group(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Status>deleting</Status>"));
 
         let req = request("DescribeUserGroups", &[("UserGroupId", "delgroup")]);
@@ -4643,7 +4643,7 @@ mod tests {
 
         let req = request("DescribeCacheClusters", &[]);
         let resp = service.describe_cache_clusters(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<CacheClusterId>cluster-a</CacheClusterId>"));
         assert!(body.contains("<CacheClusterId>cluster-b</CacheClusterId>"));
         assert!(body.contains("<DescribeCacheClustersResponse"));
@@ -4686,7 +4686,7 @@ mod tests {
             ],
         );
         let resp = service.describe_cache_clusters(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<CacheClusterId>nodeful-cluster</CacheClusterId>"));
         assert!(body.contains("<CacheNodes>"));
         assert!(body.contains("<CacheNodeId>0001</CacheNodeId>"));
@@ -4707,7 +4707,7 @@ mod tests {
 
         let req = request("DeleteCacheCluster", &[("CacheClusterId", "delete-me")]);
         let resp = service.delete_cache_cluster(&req).await.unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<CacheClusterStatus>deleting</CacheClusterStatus>"));
         assert!(body.contains("<DeleteCacheClusterResponse"));
         assert!(!service
@@ -4970,7 +4970,7 @@ mod tests {
         );
 
         let resp = service.create_global_replication_group(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains(
             "<GlobalReplicationGroupDescription>global slice</GlobalReplicationGroupDescription>"
         ));
@@ -5004,7 +5004,7 @@ mod tests {
         );
 
         let resp = service.describe_global_replication_groups(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains(
             "<GlobalReplicationGroupId>fc-us-east-1-global-a</GlobalReplicationGroupId>"
         ));
@@ -5028,7 +5028,7 @@ mod tests {
         );
 
         let resp = service.modify_global_replication_group(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains(
             "<GlobalReplicationGroupDescription>updated</GlobalReplicationGroupDescription>"
         ));
@@ -5054,7 +5054,7 @@ mod tests {
         );
 
         let resp = service.delete_global_replication_group(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Status>deleting</Status>"));
 
         let state = service.state.read();
@@ -5075,7 +5075,7 @@ mod tests {
         );
 
         let resp = service.describe_replication_groups(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<GlobalReplicationGroupInfo>"));
         assert!(body.contains(
             "<GlobalReplicationGroupId>fc-us-east-1-global-a</GlobalReplicationGroupId>"
@@ -5098,7 +5098,7 @@ mod tests {
         );
 
         let resp = service.failover_global_replication_group(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<ReplicationGroupId>primary-rg</ReplicationGroupId>"));
         assert!(body.contains("<FailoverGlobalReplicationGroupResponse"));
     }
@@ -5116,7 +5116,7 @@ mod tests {
         );
 
         let resp = service.disassociate_global_replication_group(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<ReplicationGroupId>primary-rg</ReplicationGroupId>"));
         assert!(body.contains("<DisassociateGlobalReplicationGroupResponse"));
     }
@@ -5132,7 +5132,7 @@ mod tests {
             ],
         );
         let resp = service.modify_replication_group(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Description>Updated description</Description>"));
         assert!(body.contains("<ModifyReplicationGroupResponse"));
     }
@@ -5151,7 +5151,7 @@ mod tests {
             ],
         );
         let resp = service.modify_replication_group(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<CacheNodeType>cache.m5.large</CacheNodeType>"));
         assert!(body.contains("<AutomaticFailover>enabled</AutomaticFailover>"));
         assert!(body.contains("<SnapshotRetentionLimit>5</SnapshotRetentionLimit>"));
@@ -5282,7 +5282,7 @@ mod tests {
         let resp = service
             .describe_serverless_caches(&request("DescribeServerlessCaches", &[]))
             .unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<ServerlessCacheName>cache-a</ServerlessCacheName>"));
         assert!(body.contains("<ServerlessCacheName>cache-b</ServerlessCacheName>"));
     }
@@ -5302,7 +5302,7 @@ mod tests {
         );
 
         let resp = service.modify_serverless_cache(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Description>updated</Description>"));
         assert!(body.contains(
             "<SecurityGroupIds><SecurityGroupId>sg-999</SecurityGroupId></SecurityGroupIds>"
@@ -5377,7 +5377,7 @@ mod tests {
                 &[("ServerlessCacheName", "cache-a")],
             ))
             .unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<ServerlessCacheSnapshotName>snap-a</ServerlessCacheSnapshotName>"));
     }
 
@@ -5413,7 +5413,7 @@ mod tests {
                 &[("ServerlessCacheSnapshotName", "snap-a")],
             ))
             .unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Status>deleting</Status>"));
         assert!(!service
             .state
@@ -5434,7 +5434,7 @@ mod tests {
             ],
         );
         let resp = service.increase_replica_count(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<ClusterId>my-rg-001</ClusterId>"));
         assert!(body.contains("<ClusterId>my-rg-002</ClusterId>"));
         assert!(body.contains("<ClusterId>my-rg-003</ClusterId>"));
@@ -5483,7 +5483,7 @@ mod tests {
             ],
         );
         let resp = service.decrease_replica_count(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<ClusterId>my-rg-001</ClusterId>"));
         assert!(body.contains("<ClusterId>my-rg-002</ClusterId>"));
         assert!(!body.contains("<ClusterId>my-rg-003</ClusterId>"));
@@ -5527,7 +5527,7 @@ mod tests {
             &[("ReplicationGroupId", "my-rg"), ("NodeGroupId", "0001")],
         );
         let resp = service.test_failover(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Status>available</Status>"));
         assert!(body.contains("<TestFailoverResponse"));
     }
@@ -5570,7 +5570,7 @@ mod tests {
             ],
         );
         let resp = service.create_snapshot(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<SnapshotName>my-snap</SnapshotName>"));
         assert!(body.contains("<ReplicationGroupId>snap-rg</ReplicationGroupId>"));
         assert!(body.contains("<SnapshotStatus>available</SnapshotStatus>"));
@@ -5590,7 +5590,7 @@ mod tests {
             ],
         );
         let resp = service.create_snapshot(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<ReplicationGroupId>cc-rg</ReplicationGroupId>"));
     }
 
@@ -5666,7 +5666,7 @@ mod tests {
         }
         let req = request("DescribeSnapshots", &[]);
         let resp = service.describe_snapshots(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<SnapshotName>snap-a</SnapshotName>"));
         assert!(body.contains("<SnapshotName>snap-b</SnapshotName>"));
         assert!(body.contains("<DescribeSnapshotsResponse"));
@@ -5684,7 +5684,7 @@ mod tests {
         }
         let req = request("DescribeSnapshots", &[("SnapshotName", "snap-1")]);
         let resp = service.describe_snapshots(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<SnapshotName>snap-1</SnapshotName>"));
         assert!(!body.contains("<SnapshotName>snap-2</SnapshotName>"));
     }
@@ -5703,13 +5703,13 @@ mod tests {
 
         let req = request("DescribeSnapshots", &[("ReplicationGroupId", "rg-a")]);
         let resp = service.describe_snapshots(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<SnapshotName>rg-a-snap</SnapshotName>"));
 
         // Filter by non-matching group returns empty
         let req = request("DescribeSnapshots", &[("ReplicationGroupId", "rg-b")]);
         let resp = service.describe_snapshots(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(!body.contains("<SnapshotName>"));
     }
 
@@ -5736,7 +5736,7 @@ mod tests {
 
         let req = request("DeleteSnapshot", &[("SnapshotName", "del-snap")]);
         let resp = service.delete_snapshot(&req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<SnapshotStatus>deleting</SnapshotStatus>"));
         assert!(body.contains("<DeleteSnapshotResponse"));
 

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -4403,7 +4403,7 @@ mod tests {
 
         let req = make_request("ListConnections", json!({}));
         let resp = svc.list_connections(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Connections"].as_array().unwrap().len(), 3);
         assert!(body["NextToken"].is_null());
     }
@@ -4417,7 +4417,7 @@ mod tests {
 
         let req = make_request("ListConnections", json!({ "NamePrefix": "prod-" }));
         let resp = svc.list_connections(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let names: Vec<&str> = body["Connections"]
             .as_array()
             .unwrap()
@@ -4449,7 +4449,7 @@ mod tests {
             json!({ "ConnectionState": "AUTHORIZED" }),
         );
         let resp = svc.list_connections(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let conns = body["Connections"].as_array().unwrap();
         assert_eq!(conns.len(), 1);
         assert_eq!(conns[0]["Name"].as_str().unwrap(), "conn-a");
@@ -4465,7 +4465,7 @@ mod tests {
         // First page: limit 2
         let req = make_request("ListConnections", json!({ "Limit": 2 }));
         let resp = svc.list_connections(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Connections"].as_array().unwrap().len(), 2);
         let token = body["NextToken"].as_str().unwrap();
         assert_eq!(token, "2");
@@ -4473,7 +4473,7 @@ mod tests {
         // Second page
         let req = make_request("ListConnections", json!({ "Limit": 2, "NextToken": token }));
         let resp = svc.list_connections(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Connections"].as_array().unwrap().len(), 2);
         let token = body["NextToken"].as_str().unwrap();
         assert_eq!(token, "4");
@@ -4481,7 +4481,7 @@ mod tests {
         // Third page (only 1 remaining)
         let req = make_request("ListConnections", json!({ "Limit": 2, "NextToken": token }));
         let resp = svc.list_connections(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Connections"].as_array().unwrap().len(), 1);
         assert!(body["NextToken"].is_null());
     }
@@ -4499,7 +4499,7 @@ mod tests {
             json!({ "NamePrefix": "prod-", "Limit": 2 }),
         );
         let resp = svc.list_connections(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Connections"].as_array().unwrap().len(), 2);
         assert!(body["NextToken"].as_str().is_some());
     }
@@ -4515,7 +4515,7 @@ mod tests {
 
         let req = make_request("ListApiDestinations", json!({}));
         let resp = svc.list_api_destinations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ApiDestinations"].as_array().unwrap().len(), 2);
         assert!(body["NextToken"].is_null());
     }
@@ -4530,7 +4530,7 @@ mod tests {
 
         let req = make_request("ListApiDestinations", json!({ "NamePrefix": "prod-" }));
         let resp = svc.list_api_destinations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let names: Vec<&str> = body["ApiDestinations"]
             .as_array()
             .unwrap()
@@ -4560,7 +4560,7 @@ mod tests {
             json!({ "ConnectionArn": conn_a_arn }),
         );
         let resp = svc.list_api_destinations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let names: Vec<&str> = body["ApiDestinations"]
             .as_array()
             .unwrap()
@@ -4583,7 +4583,7 @@ mod tests {
         // First page
         let req = make_request("ListApiDestinations", json!({ "Limit": 2 }));
         let resp = svc.list_api_destinations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ApiDestinations"].as_array().unwrap().len(), 2);
         let token = body["NextToken"].as_str().unwrap();
         assert_eq!(token, "2");
@@ -4594,7 +4594,7 @@ mod tests {
             json!({ "Limit": 2, "NextToken": token }),
         );
         let resp = svc.list_api_destinations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ApiDestinations"].as_array().unwrap().len(), 2);
         let token = body["NextToken"].as_str().unwrap();
         assert_eq!(token, "4");
@@ -4605,7 +4605,7 @@ mod tests {
             json!({ "Limit": 2, "NextToken": token }),
         );
         let resp = svc.list_api_destinations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ApiDestinations"].as_array().unwrap().len(), 1);
         assert!(body["NextToken"].is_null());
     }
@@ -4628,7 +4628,7 @@ mod tests {
         // First page: limit 2
         let req = make_request("ListEventBuses", json!({ "Limit": 2 }));
         let resp = svc.list_event_buses(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["EventBuses"].as_array().unwrap().len(), 2);
         let token = body["NextToken"].as_str().unwrap();
         assert_eq!(token, "2");
@@ -4636,7 +4636,7 @@ mod tests {
         // Second page
         let req = make_request("ListEventBuses", json!({ "Limit": 2, "NextToken": token }));
         let resp = svc.list_event_buses(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["EventBuses"].as_array().unwrap().len(), 2);
         let token = body["NextToken"].as_str().unwrap();
         assert_eq!(token, "4");
@@ -4644,7 +4644,7 @@ mod tests {
         // Third page (only 1 remaining)
         let req = make_request("ListEventBuses", json!({ "Limit": 2, "NextToken": token }));
         let resp = svc.list_event_buses(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["EventBuses"].as_array().unwrap().len(), 1);
         assert!(body["NextToken"].is_null());
     }
@@ -4657,7 +4657,7 @@ mod tests {
 
         let req = make_request("ListEventBuses", json!({}));
         let resp = svc.list_event_buses(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         // default + 2 custom = 3
         assert_eq!(body["EventBuses"].as_array().unwrap().len(), 3);
         assert!(body["NextToken"].is_null());
@@ -4682,7 +4682,7 @@ mod tests {
             }),
         );
         let resp = svc.put_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(
             !body.as_object().unwrap().contains_key("EndpointId"),
             "EndpointId should never be in the PutEvents response"
@@ -4713,7 +4713,7 @@ mod tests {
         // First page: limit 2
         let req = make_request("ListArchives", json!({ "Limit": 2 }));
         let resp = svc.list_archives(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Archives"].as_array().unwrap().len(), 2);
         let token = body["NextToken"].as_str().unwrap();
         assert_eq!(token, "2");
@@ -4721,7 +4721,7 @@ mod tests {
         // Second page
         let req = make_request("ListArchives", json!({ "Limit": 2, "NextToken": token }));
         let resp = svc.list_archives(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Archives"].as_array().unwrap().len(), 2);
         let token = body["NextToken"].as_str().unwrap();
         assert_eq!(token, "4");
@@ -4729,7 +4729,7 @@ mod tests {
         // Third page (only 1 remaining)
         let req = make_request("ListArchives", json!({ "Limit": 2, "NextToken": token }));
         let resp = svc.list_archives(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Archives"].as_array().unwrap().len(), 1);
         assert!(body["NextToken"].is_null());
     }
@@ -4773,7 +4773,7 @@ mod tests {
         // First page: limit 2
         let req = make_request("ListReplays", json!({ "Limit": 2 }));
         let resp = svc.list_replays(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Replays"].as_array().unwrap().len(), 2);
         let token = body["NextToken"].as_str().unwrap();
         assert_eq!(token, "2");
@@ -4781,7 +4781,7 @@ mod tests {
         // Second page
         let req = make_request("ListReplays", json!({ "Limit": 2, "NextToken": token }));
         let resp = svc.list_replays(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Replays"].as_array().unwrap().len(), 2);
         let token = body["NextToken"].as_str().unwrap();
         assert_eq!(token, "4");
@@ -4789,7 +4789,7 @@ mod tests {
         // Third page (only 1 remaining)
         let req = make_request("ListReplays", json!({ "Limit": 2, "NextToken": token }));
         let resp = svc.list_replays(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Replays"].as_array().unwrap().len(), 1);
         assert!(body["NextToken"].is_null());
     }
@@ -4819,7 +4819,7 @@ mod tests {
             }),
         );
         let resp = svc.test_event_pattern(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Result"], true);
     }
 
@@ -4834,7 +4834,7 @@ mod tests {
             }),
         );
         let resp = svc.test_event_pattern(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Result"], false);
     }
 
@@ -4849,7 +4849,7 @@ mod tests {
             }),
         );
         let resp = svc.test_event_pattern(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Result"], true);
     }
 
@@ -4865,13 +4865,13 @@ mod tests {
             json!({ "Name": "my-bus", "Description": "Updated desc" }),
         );
         let resp = svc.update_event_bus(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"], "my-bus");
 
         // Verify via describe
         let req = make_request("DescribeEventBus", json!({ "Name": "my-bus" }));
         let resp = svc.describe_event_bus(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Description"], "Updated desc");
     }
 
@@ -4914,7 +4914,7 @@ mod tests {
         // Describe
         let req = make_request("DescribeEndpoint", json!({ "Name": "my-endpoint" }));
         let resp = svc.describe_endpoint(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"], "my-endpoint");
         assert_eq!(body["State"], "ACTIVE");
         assert!(body["EndpointId"].as_str().unwrap().contains("my-endpoint"));
@@ -4937,7 +4937,7 @@ mod tests {
         // List all
         let req = make_request("ListEndpoints", json!({}));
         let resp = svc.list_endpoints(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Endpoints"].as_array().unwrap().len(), 2);
 
         // Update
@@ -4946,13 +4946,13 @@ mod tests {
             json!({ "Name": "ep-alpha", "Description": "updated" }),
         );
         let resp = svc.update_endpoint(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"], "ep-alpha");
 
         // Verify description
         let req = make_request("DescribeEndpoint", json!({ "Name": "ep-alpha" }));
         let resp = svc.describe_endpoint(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Description"], "updated");
     }
 
@@ -4980,7 +4980,7 @@ mod tests {
 
         let req = make_request("DeauthorizeConnection", json!({ "Name": "deauth-conn" }));
         let resp = svc.deauthorize_connection(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ConnectionState"], "DEAUTHORIZING");
         assert!(body["ConnectionArn"]
             .as_str()
@@ -4990,7 +4990,7 @@ mod tests {
         // Verify via describe
         let req = make_request("DescribeConnection", json!({ "Name": "deauth-conn" }));
         let resp = svc.describe_connection(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ConnectionState"], "DEAUTHORIZING");
     }
 
@@ -5020,13 +5020,13 @@ mod tests {
             json!({ "Name": "partner/test" }),
         );
         let resp = svc.describe_partner_event_source(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"], "partner/test");
 
         // List
         let req = make_request("ListPartnerEventSources", json!({"NamePrefix": "partner/"}));
         let resp = svc.list_partner_event_sources(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["PartnerEventSources"].as_array().unwrap().len(), 1);
 
         // ListPartnerEventSourceAccounts
@@ -5035,7 +5035,7 @@ mod tests {
             json!({ "EventSourceName": "partner/test" }),
         );
         let resp = svc.list_partner_event_source_accounts(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["PartnerEventSourceAccounts"].as_array().unwrap().len(),
             1
@@ -5044,14 +5044,14 @@ mod tests {
         // DescribeEventSource
         let req = make_request("DescribeEventSource", json!({ "Name": "partner/test" }));
         let resp = svc.describe_event_source(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"], "partner/test");
         assert_eq!(body["State"], "ACTIVE");
 
         // ListEventSources
         let req = make_request("ListEventSources", json!({}));
         let resp = svc.list_event_sources(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["EventSources"].as_array().unwrap().len(), 1);
 
         // Delete
@@ -5169,7 +5169,7 @@ mod tests {
             }),
         );
         let resp = svc.put_partner_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["FailedEntryCount"], 0);
         assert_eq!(body["Entries"].as_array().unwrap().len(), 1);
         assert!(body["Entries"][0]["EventId"].as_str().is_some());
@@ -5274,7 +5274,7 @@ mod tests {
             }),
         );
         let resp = svc.put_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["FailedEntryCount"], 0);
 
         // Verify archive has 2 events
@@ -5311,7 +5311,7 @@ mod tests {
             }),
         );
         let resp = svc.start_replay(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["State"], "STARTING");
 
         // Verify the replay delivered events to SQS
@@ -5477,7 +5477,7 @@ mod tests {
             }),
         );
         let resp = svc.put_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["FailedEntryCount"], 0);
         assert_eq!(body["Entries"].as_array().unwrap().len(), 1);
         assert!(body["Entries"][0]["EventId"].as_str().is_some());

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -1411,7 +1411,7 @@ mod tests {
                 other => panic!("handle_sync: unhandled action {other}"),
             }
             .unwrap();
-            String::from_utf8(resp.body.to_vec()).unwrap()
+            String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap()
         }
     }
 
@@ -1426,7 +1426,7 @@ mod tests {
             vec![("PolicyName", "test-pol"), ("PolicyDocument", policy_doc)],
         );
         let resp = svc.create_policy(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         // Extract policy ARN
         let policy_arn = extract_xml_tag(&body, "Arn");
 
@@ -1441,7 +1441,7 @@ mod tests {
             ],
         );
         let resp = svc.create_policy_version(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<VersionId>v2</VersionId>"));
         assert!(body.contains("<IsDefaultVersion>true</IsDefaultVersion>"));
 
@@ -1451,7 +1451,7 @@ mod tests {
             vec![("PolicyArn", policy_arn), ("VersionId", "v2")],
         );
         let resp = svc.get_policy_version(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<VersionId>v2</VersionId>"));
         assert!(body.contains("<IsDefaultVersion>true</IsDefaultVersion>"));
     }
@@ -1465,7 +1465,7 @@ mod tests {
             vec![("PolicyName", "ver-pol"), ("PolicyDocument", policy_doc)],
         );
         let resp = svc.create_policy(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         let policy_arn = extract_xml_tag(&body, "Arn");
 
         // Create v2
@@ -1477,7 +1477,7 @@ mod tests {
 
         let req = make_request("ListPolicyVersions", vec![("PolicyArn", policy_arn)]);
         let resp = svc.list_policy_versions(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         // Should have v1 and v2
         assert!(body.contains("<VersionId>v1</VersionId>"));
         assert!(body.contains("<VersionId>v2</VersionId>"));
@@ -1492,7 +1492,7 @@ mod tests {
             vec![("PolicyName", "def-pol"), ("PolicyDocument", policy_doc)],
         );
         let resp = svc.create_policy(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         let policy_arn = extract_xml_tag(&body, "Arn");
 
         // v1 is the default; deleting it should fail
@@ -1513,7 +1513,7 @@ mod tests {
             vec![("PolicyName", "sd-pol"), ("PolicyDocument", policy_doc)],
         );
         let resp = svc.create_policy(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         let policy_arn = extract_xml_tag(&body, "Arn");
 
         // Create v2
@@ -1536,7 +1536,7 @@ mod tests {
             vec![("PolicyArn", policy_arn), ("VersionId", "v2")],
         );
         let resp = svc.get_policy_version(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<IsDefaultVersion>true</IsDefaultVersion>"));
 
         // v1 should no longer be default
@@ -1545,7 +1545,7 @@ mod tests {
             vec![("PolicyArn", policy_arn), ("VersionId", "v1")],
         );
         let resp = svc.get_policy_version(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<IsDefaultVersion>false</IsDefaultVersion>"));
     }
 
@@ -1571,7 +1571,7 @@ mod tests {
             ],
         );
         let resp = svc.upload_server_certificate(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<ServerCertificateName>my-cert</ServerCertificateName>"));
         assert!(body.contains("ASCA"));
 
@@ -1581,13 +1581,13 @@ mod tests {
             vec![("ServerCertificateName", "my-cert")],
         );
         let resp = svc.get_server_certificate(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<ServerCertificateName>my-cert</ServerCertificateName>"));
 
         // List
         let req = make_request("ListServerCertificates", vec![]);
         let resp = svc.list_server_certificates(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("my-cert"));
 
         // Delete
@@ -1649,7 +1649,7 @@ mod tests {
             ],
         );
         let resp = svc.upload_ssh_public_key(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<Status>Active</Status>"));
         assert!(body.contains("APKA"));
         // Extract key ID
@@ -1663,14 +1663,14 @@ mod tests {
             vec![("UserName", "sshuser"), ("SSHPublicKeyId", key_id)],
         );
         let resp = svc.get_ssh_public_key(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains(key_id));
         assert!(body.contains("<Status>Active</Status>"));
 
         // List
         let req = make_request("ListSSHPublicKeys", vec![("UserName", "sshuser")]);
         let resp = svc.list_ssh_public_keys(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains(key_id));
 
         // Update status to Inactive
@@ -1690,7 +1690,7 @@ mod tests {
             vec![("UserName", "sshuser"), ("SSHPublicKeyId", key_id)],
         );
         let resp = svc.get_ssh_public_key(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<Status>Inactive</Status>"));
 
         // Delete
@@ -1703,7 +1703,7 @@ mod tests {
         // Should be empty now
         let req = make_request("ListSSHPublicKeys", vec![("UserName", "sshuser")]);
         let resp = svc.list_ssh_public_keys(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(!body.contains(key_id));
     }
 
@@ -1723,7 +1723,7 @@ mod tests {
             vec![("UserName", "certuser"), ("CertificateBody", pem)],
         );
         let resp = svc.upload_signing_certificate(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<Status>Active</Status>"));
         assert!(body.contains("<UserName>certuser</UserName>"));
         let cid_start = body.find("<CertificateId>").unwrap() + 15;
@@ -1733,7 +1733,7 @@ mod tests {
         // List
         let req = make_request("ListSigningCertificates", vec![("UserName", "certuser")]);
         let resp = svc.list_signing_certificates(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains(cert_id));
 
         // Update to Inactive
@@ -1757,7 +1757,7 @@ mod tests {
         // Should be empty
         let req = make_request("ListSigningCertificates", vec![("UserName", "certuser")]);
         let resp = svc.list_signing_certificates(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(!body.contains(cert_id));
     }
 
@@ -1790,19 +1790,19 @@ mod tests {
         // Generate
         let req = make_request("GenerateCredentialReport", vec![]);
         let resp = svc.generate_credential_report(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<State>STARTED</State>"));
 
         // Generate again returns COMPLETE
         let req = make_request("GenerateCredentialReport", vec![]);
         let resp = svc.generate_credential_report(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<State>COMPLETE</State>"));
 
         // Get credential report
         let req = make_request("GetCredentialReport", vec![]);
         let resp = svc.get_credential_report(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<ReportFormat>text/csv</ReportFormat>"));
         assert!(body.contains("<Content>"));
     }
@@ -1819,7 +1819,7 @@ mod tests {
             vec![("AWSServiceName", "elasticloadbalancing.amazonaws.com")],
         );
         let resp = svc.create_service_linked_role(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("AWSServiceRoleForElasticLoadBalancing"));
         assert!(body.contains("/aws-service-role/elasticloadbalancing.amazonaws.com/"));
 
@@ -1829,7 +1829,7 @@ mod tests {
             vec![("RoleName", "AWSServiceRoleForElasticLoadBalancing")],
         );
         let resp = svc.delete_service_linked_role(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<DeletionTaskId>"));
         let tid_start = body.find("<DeletionTaskId>").unwrap() + 16;
         let tid_end = body.find("</DeletionTaskId>").unwrap();
@@ -1841,7 +1841,7 @@ mod tests {
             vec![("DeletionTaskId", task_id)],
         );
         let resp = svc.get_service_linked_role_deletion_status(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<Status>SUCCEEDED</Status>"));
     }
 
@@ -1874,7 +1874,7 @@ mod tests {
         // Verify via GetRole
         let req = make_request("GetRole", vec![("RoleName", "bound-role")]);
         let resp = svc.get_role(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains(boundary_arn));
 
         // Delete boundary
@@ -1887,7 +1887,7 @@ mod tests {
         // Verify removed
         let req = make_request("GetRole", vec![("RoleName", "bound-role")]);
         let resp = svc.get_role(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(!body.contains(boundary_arn));
     }
 
@@ -1920,7 +1920,7 @@ mod tests {
         // List tags
         let req = make_request("ListRoleTags", vec![("RoleName", "tag-role")]);
         let resp = svc.list_role_tags(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<Key>env</Key>"));
         assert!(body.contains("<Value>prod</Value>"));
 
@@ -1933,7 +1933,7 @@ mod tests {
 
         let req = make_request("ListRoleTags", vec![("RoleName", "tag-role")]);
         let resp = svc.list_role_tags(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(!body.contains("<Key>env</Key>"));
     }
 
@@ -1948,7 +1948,7 @@ mod tests {
             vec![("PolicyName", "tag-pol"), ("PolicyDocument", policy_doc)],
         );
         let resp = svc.create_policy(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         let policy_arn = extract_xml_tag(&body, "Arn").to_string();
 
         let req = make_request(
@@ -1963,7 +1963,7 @@ mod tests {
 
         let req = make_request("ListPolicyTags", vec![("PolicyArn", &policy_arn)]);
         let resp = svc.list_policy_tags(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<Key>team</Key>"));
 
         let req = make_request(
@@ -1974,7 +1974,7 @@ mod tests {
 
         let req = make_request("ListPolicyTags", vec![("PolicyArn", &policy_arn)]);
         let resp = svc.list_policy_tags(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(!body.contains("<Key>team</Key>"));
     }
 
@@ -2004,7 +2004,7 @@ mod tests {
             vec![("InstanceProfileName", "tag-ip")],
         );
         let resp = svc.list_instance_profile_tags(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<Key>dept</Key>"));
 
         let req = make_request(
@@ -2021,7 +2021,7 @@ mod tests {
             vec![("InstanceProfileName", "tag-ip")],
         );
         let resp = svc.list_instance_profile_tags(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(!body.contains("<Key>dept</Key>"));
     }
 
@@ -2041,7 +2041,7 @@ mod tests {
             ],
         );
         let resp = svc.create_oidc_provider(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         let arn_start =
             body.find("<OpenIDConnectProviderArn>").unwrap() + "<OpenIDConnectProviderArn>".len();
         let arn_end = body.find("</OpenIDConnectProviderArn>").unwrap();
@@ -2062,7 +2062,7 @@ mod tests {
             vec![("OpenIDConnectProviderArn", &oidc_arn)],
         );
         let resp = svc.list_oidc_provider_tags(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<Key>stage</Key>"));
 
         let req = make_request(
@@ -2079,7 +2079,7 @@ mod tests {
             vec![("OpenIDConnectProviderArn", &oidc_arn)],
         );
         let resp = svc.list_oidc_provider_tags(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(!body.contains("<Key>stage</Key>"));
     }
 
@@ -2115,7 +2115,7 @@ mod tests {
             vec![("RoleName", "upd-role"), ("Description", "updated desc")],
         );
         let resp = svc.update_role_description(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<Description>updated desc</Description>"));
     }
 
@@ -2144,7 +2144,7 @@ mod tests {
         // Verify by GetRole
         let req = make_request("GetRole", vec![("RoleName", "arp-role")]);
         let resp = svc.get_role(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("lambda.amazonaws.com"));
     }
 
@@ -2171,7 +2171,7 @@ mod tests {
         let resp = svc
             .get_group(&make_request("GetGroup", vec![("GroupName", "new-grp")]))
             .unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<GroupName>new-grp</GroupName>"));
     }
 
@@ -2196,7 +2196,7 @@ mod tests {
         let resp = svc
             .get_user(&make_request("GetUser", vec![("UserName", "new-user")]))
             .unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<UserName>new-user</UserName>"));
     }
 
@@ -2224,7 +2224,7 @@ mod tests {
         // Get
         let req = make_request("GetAccountPasswordPolicy", vec![]);
         let resp = svc.get_account_password_policy(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<MinimumPasswordLength>12</MinimumPasswordLength>"));
         assert!(body.contains("<RequireSymbols>true</RequireSymbols>"));
 
@@ -2258,7 +2258,7 @@ mod tests {
 
         let req = make_request("GetAccountAuthorizationDetails", vec![]);
         let resp = svc.get_account_authorization_details(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<UserName>auth-user</UserName>"));
         assert!(body.contains("<RoleName>auth-role</RoleName>"));
     }
@@ -2276,7 +2276,7 @@ mod tests {
             vec![("PolicyName", "ent-pol"), ("PolicyDocument", policy_doc)],
         );
         let resp = svc.create_policy(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         let policy_arn = extract_xml_tag(&body, "Arn").to_string();
 
         // Create role and attach policy
@@ -2306,7 +2306,7 @@ mod tests {
 
         let req = make_request("ListEntitiesForPolicy", vec![("PolicyArn", &policy_arn)]);
         let resp = svc.list_entities_for_policy(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<RoleName>ent-role</RoleName>"));
         assert!(body.contains("<UserName>ent-user</UserName>"));
     }
@@ -2321,14 +2321,14 @@ mod tests {
 
         let req = make_request("CreateAccessKey", vec![("UserName", "keyuser")]);
         let resp = svc.create_access_key(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         let kid_start = body.find("<AccessKeyId>").unwrap() + 13;
         let kid_end = body.find("</AccessKeyId>").unwrap();
         let key_id = body[kid_start..kid_end].to_string();
 
         let req = make_request("GetAccessKeyLastUsed", vec![("AccessKeyId", &key_id)]);
         let resp = svc.get_access_key_last_used(&req).unwrap();
-        let body = String::from_utf8_lossy(&resp.body);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes());
         assert!(body.contains("<UserName>keyuser</UserName>"));
         // No last used info yet -- should show N/A
         assert!(body.contains("<ServiceName>N/A</ServiceName>"));

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -768,7 +768,7 @@ mod tests {
 
         let req = make_test_request(params);
         let resp = service.decode_authorization_message(&req).unwrap();
-        let body = std::str::from_utf8(&resp.body).unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body.contains("DecodedMessage"));
         assert!(body.contains("allowed"));
         assert!(body.contains("matchedStatements"));

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -3382,7 +3382,7 @@ mod tests {
     fn create_key(svc: &KmsService) -> String {
         let req = make_request("CreateKey", json!({}));
         let resp = svc.create_key(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         body["KeyMetadata"]["KeyId"].as_str().unwrap().to_string()
     }
 
@@ -3404,7 +3404,7 @@ mod tests {
             }
             let req = make_request("ListKeys", body);
             let resp = svc.list_keys(&req).unwrap();
-            let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+            let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
             for key in resp_body["Keys"].as_array().unwrap() {
                 collected_ids.push(key["KeyId"].as_str().unwrap().to_string());
@@ -3469,7 +3469,7 @@ mod tests {
             }
             let req = make_request("ListRetirableGrants", body);
             let resp = svc.list_retirable_grants(&req).unwrap();
-            let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+            let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
             for grant in resp_body["Grants"].as_array().unwrap() {
                 collected_ids.push(grant["GrantId"].as_str().unwrap().to_string());
@@ -3499,7 +3499,7 @@ mod tests {
     fn create_key_with_opts(svc: &KmsService, body: Value) -> String {
         let req = make_request("CreateKey", body);
         let resp = svc.create_key(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         body["KeyMetadata"]["KeyId"].as_str().unwrap().to_string()
     }
 
@@ -3513,7 +3513,7 @@ mod tests {
             json!({ "KeyId": key_id, "KeyPairSpec": "RSA_2048" }),
         );
         let resp = svc.generate_data_key_pair(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
         assert!(body["PublicKey"].as_str().is_some());
         assert!(body["PrivateKeyPlaintext"].as_str().is_some());
@@ -3547,7 +3547,7 @@ mod tests {
             json!({ "KeyId": key_id, "KeyPairSpec": "ECC_NIST_P256" }),
         );
         let resp = svc.generate_data_key_pair_without_plaintext(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
         assert!(body["PublicKey"].as_str().is_some());
         assert!(body["PrivateKeyCiphertextBlob"].as_str().is_some());
@@ -3576,7 +3576,7 @@ mod tests {
             }),
         );
         let resp = svc.derive_shared_secret(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
         assert!(body["SharedSecret"].as_str().is_some());
         assert!(body["KeyId"].as_str().unwrap().contains(":key/"));
@@ -3610,7 +3610,7 @@ mod tests {
             json!({ "KeyId": key_id, "WrappingAlgorithm": "RSAES_OAEP_SHA_256", "WrappingKeySpec": "RSA_2048" }),
         );
         let resp = svc.get_parameters_for_import(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
         assert!(body["ImportToken"].as_str().is_some());
         assert!(body["PublicKey"].as_str().is_some());
@@ -3741,7 +3741,7 @@ mod tests {
             }),
         );
         let resp = svc.create_custom_key_store(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let store_id = body["CustomKeyStoreId"].as_str().unwrap().to_string();
         assert!(store_id.starts_with("cks-"));
 
@@ -3751,7 +3751,7 @@ mod tests {
             json!({ "CustomKeyStoreId": store_id }),
         );
         let resp = svc.describe_custom_key_stores(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let stores = body["CustomKeyStores"].as_array().unwrap();
         assert_eq!(stores.len(), 1);
         assert_eq!(
@@ -3780,7 +3780,7 @@ mod tests {
             json!({ "CustomKeyStoreId": store_id }),
         );
         let resp = svc.describe_custom_key_stores(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["CustomKeyStores"][0]["ConnectionState"]
                 .as_str()
@@ -3818,7 +3818,7 @@ mod tests {
             json!({ "CustomKeyStoreId": store_id }),
         );
         let resp = svc.describe_custom_key_stores(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["CustomKeyStores"][0]["CustomKeyStoreName"]
                 .as_str()
@@ -3836,7 +3836,7 @@ mod tests {
         // Describe all should return empty
         let req = make_request("DescribeCustomKeyStores", json!({}));
         let resp = svc.describe_custom_key_stores(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["CustomKeyStores"].as_array().unwrap().is_empty());
     }
 
@@ -3912,7 +3912,7 @@ mod tests {
             json!({ "CustomKeyStoreName": "store-a" }),
         );
         let resp = svc.describe_custom_key_stores(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let stores = body["CustomKeyStores"].as_array().unwrap();
         assert_eq!(stores.len(), 1);
         assert_eq!(stores[0]["CustomKeyStoreName"].as_str().unwrap(), "store-a");
@@ -3933,7 +3933,7 @@ mod tests {
             json!({ "CustomKeyStoreName": "store-y" }),
         );
         let resp = svc.create_custom_key_store(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let store_y_id = body["CustomKeyStoreId"].as_str().unwrap().to_string();
 
         // Try to rename store-y to store-x
@@ -3969,12 +3969,12 @@ mod tests {
         );
 
         let resp1 = svc.derive_shared_secret(&req).unwrap();
-        let body1: Value = serde_json::from_slice(&resp1.body).unwrap();
+        let body1: Value = serde_json::from_slice(resp1.body.expect_bytes()).unwrap();
         let secret1 = body1["SharedSecret"].as_str().unwrap().to_string();
 
         // Same inputs must produce the same shared secret
         let resp2 = svc.derive_shared_secret(&req).unwrap();
-        let body2: Value = serde_json::from_slice(&resp2.body).unwrap();
+        let body2: Value = serde_json::from_slice(resp2.body.expect_bytes()).unwrap();
         let secret2 = body2["SharedSecret"].as_str().unwrap().to_string();
 
         assert_eq!(secret1, secret2, "DeriveSharedSecret must be deterministic");
@@ -3990,7 +3990,7 @@ mod tests {
             }),
         );
         let resp3 = svc.derive_shared_secret(&req2).unwrap();
-        let body3: Value = serde_json::from_slice(&resp3.body).unwrap();
+        let body3: Value = serde_json::from_slice(resp3.body.expect_bytes()).unwrap();
         let secret3 = body3["SharedSecret"].as_str().unwrap().to_string();
         assert_ne!(
             secret1, secret3,
@@ -4026,7 +4026,7 @@ mod tests {
             json!({ "KeyId": key_id, "Plaintext": plaintext_b64 }),
         );
         let resp = svc.encrypt(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let ciphertext = body["CiphertextBlob"].as_str().unwrap().to_string();
 
         // Verify ciphertext uses the imported envelope
@@ -4042,7 +4042,7 @@ mod tests {
         // Decrypt
         let req = make_request("Decrypt", json!({ "CiphertextBlob": ciphertext }));
         let resp = svc.decrypt(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let decrypted_b64 = body["Plaintext"].as_str().unwrap();
         let decrypted = base64::engine::general_purpose::STANDARD
             .decode(decrypted_b64)
@@ -4080,7 +4080,7 @@ mod tests {
                 json!({ "KeyId": key_id, "Plaintext": plaintext_b64 }),
             ))
             .unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let ciphertext = body["CiphertextBlob"].as_str().unwrap().to_string();
 
         // Delete imported material
@@ -4183,7 +4183,7 @@ mod tests {
             json!({ "KeyId": key_id, "PendingWindowInDays": 7 }),
         );
         let resp = svc.schedule_key_deletion(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["KeyState"].as_str().unwrap(), "PendingDeletion");
 
         // Verify key is pending deletion
@@ -4198,7 +4198,7 @@ mod tests {
         // Cancel deletion
         let req = make_request("CancelKeyDeletion", json!({ "KeyId": key_id }));
         let resp = svc.cancel_key_deletion(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["KeyId"].as_str().unwrap(), key_id);
 
         // Key should be disabled (not enabled) with no deletion date
@@ -4229,7 +4229,7 @@ mod tests {
         // Initially rotation is disabled
         let req = make_request("GetKeyRotationStatus", json!({ "KeyId": key_id }));
         let resp = svc.get_key_rotation_status(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(!body["KeyRotationEnabled"].as_bool().unwrap());
 
         // Enable rotation
@@ -4238,7 +4238,7 @@ mod tests {
 
         let req = make_request("GetKeyRotationStatus", json!({ "KeyId": key_id }));
         let resp = svc.get_key_rotation_status(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["KeyRotationEnabled"].as_bool().unwrap());
 
         // Disable rotation
@@ -4247,7 +4247,7 @@ mod tests {
 
         let req = make_request("GetKeyRotationStatus", json!({ "KeyId": key_id }));
         let resp = svc.get_key_rotation_status(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(!body["KeyRotationEnabled"].as_bool().unwrap());
     }
 
@@ -4259,13 +4259,13 @@ mod tests {
         // No rotations initially
         let req = make_request("ListKeyRotations", json!({ "KeyId": key_id }));
         let resp = svc.list_key_rotations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Rotations"].as_array().unwrap().is_empty());
 
         // Rotate on demand
         let req = make_request("RotateKeyOnDemand", json!({ "KeyId": key_id }));
         let resp = svc.rotate_key_on_demand(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["KeyId"].as_str().unwrap(), key_id);
 
         // Rotate again
@@ -4275,7 +4275,7 @@ mod tests {
         // List rotations
         let req = make_request("ListKeyRotations", json!({ "KeyId": key_id }));
         let resp = svc.list_key_rotations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let rotations = body["Rotations"].as_array().unwrap();
         assert_eq!(rotations.len(), 2);
         assert_eq!(rotations[0]["RotationType"].as_str().unwrap(), "ON_DEMAND");
@@ -4291,7 +4291,7 @@ mod tests {
         // Get default policy
         let req = make_request("GetKeyPolicy", json!({ "KeyId": key_id }));
         let resp = svc.get_key_policy(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let policy_str = body["Policy"].as_str().unwrap();
         assert!(policy_str.contains("Enable IAM User Permissions"));
 
@@ -4306,13 +4306,13 @@ mod tests {
         // Get updated policy
         let req = make_request("GetKeyPolicy", json!({ "KeyId": key_id }));
         let resp = svc.get_key_policy(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Policy"].as_str().unwrap(), custom_policy);
 
         // List key policies always returns ["default"]
         let req = make_request("ListKeyPolicies", json!({ "KeyId": key_id }));
         let resp = svc.list_key_policies(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let names = body["PolicyNames"].as_array().unwrap();
         assert_eq!(names.len(), 1);
         assert_eq!(names[0].as_str().unwrap(), "default");
@@ -4334,7 +4334,7 @@ mod tests {
             }),
         );
         let resp = svc.create_grant(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let grant_id = body["GrantId"].as_str().unwrap().to_string();
         let grant_token = body["GrantToken"].as_str().unwrap().to_string();
         assert!(!grant_id.is_empty());
@@ -4343,7 +4343,7 @@ mod tests {
         // List grants
         let req = make_request("ListGrants", json!({ "KeyId": key_id }));
         let resp = svc.list_grants(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let grants = body["Grants"].as_array().unwrap();
         assert_eq!(grants.len(), 1);
         assert_eq!(grants[0]["GrantId"].as_str().unwrap(), grant_id);
@@ -4363,7 +4363,7 @@ mod tests {
         // List grants should be empty
         let req = make_request("ListGrants", json!({ "KeyId": key_id }));
         let resp = svc.list_grants(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Grants"].as_array().unwrap().is_empty());
     }
 
@@ -4382,7 +4382,7 @@ mod tests {
             }),
         );
         let resp = svc.create_grant(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let grant_token = body["GrantToken"].as_str().unwrap().to_string();
 
         // Retire by token
@@ -4392,7 +4392,7 @@ mod tests {
         // Verify grant is gone
         let req = make_request("ListGrants", json!({ "KeyId": key_id }));
         let resp = svc.list_grants(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Grants"].as_array().unwrap().is_empty());
     }
 
@@ -4410,7 +4410,7 @@ mod tests {
             }),
         );
         let resp = svc.create_grant(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let grant_id = body["GrantId"].as_str().unwrap().to_string();
 
         // Retire by key ID + grant ID
@@ -4423,7 +4423,7 @@ mod tests {
         // Verify grant is gone
         let req = make_request("ListGrants", json!({ "KeyId": key_id }));
         let resp = svc.list_grants(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Grants"].as_array().unwrap().is_empty());
     }
 
@@ -4448,7 +4448,7 @@ mod tests {
             }),
         );
         let resp = svc.sign(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let signature = body["Signature"].as_str().unwrap().to_string();
         assert!(!signature.is_empty());
         assert_eq!(
@@ -4467,7 +4467,7 @@ mod tests {
             }),
         );
         let resp = svc.verify(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["SignatureValid"].as_bool().unwrap());
 
         // Verify with wrong signature should return false
@@ -4482,7 +4482,7 @@ mod tests {
             }),
         );
         let resp = svc.verify(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(!body["SignatureValid"].as_bool().unwrap());
     }
 
@@ -4504,7 +4504,7 @@ mod tests {
             }),
         );
         let resp = svc.sign(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Signature"].as_str().is_some());
         assert_eq!(body["SigningAlgorithm"].as_str().unwrap(), "ECDSA_SHA_256");
     }
@@ -4533,7 +4533,7 @@ mod tests {
         for num_bytes in [1, 16, 32, 64, 256, 1024] {
             let req = make_request("GenerateRandom", json!({ "NumberOfBytes": num_bytes }));
             let resp = svc.generate_random(&req).unwrap();
-            let body: Value = serde_json::from_slice(&resp.body).unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
             let b64 = body["Plaintext"].as_str().unwrap();
             let decoded = base64::engine::general_purpose::STANDARD
                 .decode(b64)
@@ -4580,7 +4580,7 @@ mod tests {
             }),
         );
         let resp = svc.generate_mac(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let mac = body["Mac"].as_str().unwrap().to_string();
         assert!(!mac.is_empty());
 
@@ -4595,7 +4595,7 @@ mod tests {
             }),
         );
         let resp = svc.verify_mac(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["MacValid"].as_bool().unwrap());
     }
 
@@ -4653,7 +4653,7 @@ mod tests {
             json!({ "KeyId": key_a, "Plaintext": plaintext_b64 }),
         );
         let resp = svc.encrypt(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let ciphertext_a = body["CiphertextBlob"].as_str().unwrap().to_string();
 
         // Re-encrypt from key A to key B
@@ -4665,7 +4665,7 @@ mod tests {
             }),
         );
         let resp = svc.re_encrypt(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let ciphertext_b = body["CiphertextBlob"].as_str().unwrap().to_string();
         assert_ne!(ciphertext_a, ciphertext_b);
         assert!(body["KeyId"].as_str().unwrap().contains(&key_b));
@@ -4674,7 +4674,7 @@ mod tests {
         // Decrypt with key B (the ciphertext is self-describing in fakecloud)
         let req = make_request("Decrypt", json!({ "CiphertextBlob": ciphertext_b }));
         let resp = svc.decrypt(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let decrypted_b64 = body["Plaintext"].as_str().unwrap();
         let decrypted = base64::engine::general_purpose::STANDARD
             .decode(decrypted_b64)
@@ -4768,7 +4768,7 @@ mod tests {
 
         let req = make_request("GetPublicKey", json!({ "KeyId": key_id }));
         let resp = svc.get_public_key(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
         assert!(body["PublicKey"].as_str().is_some());
         assert_eq!(body["KeySpec"].as_str().unwrap(), "RSA_2048");
@@ -4784,7 +4784,7 @@ mod tests {
 
         let req = make_request("GetPublicKey", json!({ "KeyId": ecc_key_id }));
         let resp = svc.get_public_key(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["PublicKey"].as_str().is_some());
         assert_eq!(body["KeySpec"].as_str().unwrap(), "ECC_NIST_P256");
     }

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -654,7 +654,7 @@ mod tests {
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::CREATED);
 
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["FunctionName"], "my-func");
         assert_eq!(body["Runtime"], "python3.12");
 
@@ -662,7 +662,7 @@ mod tests {
         let req = make_request(Method::GET, "/2015-03-31/functions/my-func", "");
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Configuration"]["FunctionName"], "my-func");
     }
 
@@ -762,7 +762,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/2015-03-31/functions", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Functions"].as_array().unwrap().len(), 2);
     }
 
@@ -799,13 +799,13 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::ACCEPTED);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let uuid = body["UUID"].as_str().unwrap().to_string();
 
         // List mappings
         let req = make_request(Method::GET, "/2015-03-31/event-source-mappings", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["EventSourceMappings"].as_array().unwrap().len(), 1);
 
         // Delete mapping

--- a/crates/fakecloud-logs/src/service/anomaly.rs
+++ b/crates/fakecloud-logs/src/service/anomaly.rs
@@ -329,7 +329,7 @@ mod tests {
             }),
         );
         let resp = svc.create_log_anomaly_detector(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let arn = body["anomalyDetectorArn"].as_str().unwrap().to_string();
 
         let req = make_request(
@@ -337,12 +337,12 @@ mod tests {
             json!({ "anomalyDetectorArn": &arn }),
         );
         let resp = svc.get_log_anomaly_detector(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["detectorName"], "my-detector");
 
         let req = make_request("ListLogAnomalyDetectors", json!({}));
         let resp = svc.list_log_anomaly_detectors(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["anomalyDetectors"].as_array().unwrap().len(), 1);
 
         let req = make_request(

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -882,7 +882,7 @@ mod tests {
             }),
         );
         let resp = svc.put_delivery_destination(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let config = &body["deliveryDestination"]["deliveryDestinationConfiguration"];
         // destinationResourceArn should always be present as a string (Smithy requirement)
         assert_eq!(
@@ -905,7 +905,7 @@ mod tests {
             }),
         );
         let resp = svc.put_delivery_destination(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let config = &body["deliveryDestination"]["deliveryDestinationConfiguration"];
         assert_eq!(
             config["destinationResourceArn"].as_str().unwrap(),
@@ -950,7 +950,7 @@ mod tests {
             json!({ "logGroupNamePrefix": "/delivery/test" }),
         );
         let resp = svc.describe_log_groups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let group_arn = body["logGroups"][0]["arn"].as_str().unwrap().to_string();
 
         // Create delivery source referencing this log group
@@ -979,7 +979,7 @@ mod tests {
         // Get the destination ARN
         let req = make_request("GetDeliveryDestination", json!({ "name": "test-dest" }));
         let resp = svc.get_delivery_destination(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let dest_arn = body["deliveryDestination"]["arn"]
             .as_str()
             .unwrap()
@@ -1016,7 +1016,7 @@ mod tests {
             json!({ "keyPrefix": "delivery-test-bucket/delivery" }),
         );
         let resp = svc.get_exported_data(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let entries = body["entries"].as_array().unwrap();
         assert!(!entries.is_empty(), "Should have delivery data");
         let data = entries[0]["data"].as_str().unwrap();
@@ -1036,7 +1036,7 @@ mod tests {
             json!({ "logGroupNamePrefix": "ds-grp" }),
         );
         let resp = svc.describe_log_groups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let group_arn = body["logGroups"][0]["arn"].as_str().unwrap().to_string();
 
         // Put
@@ -1053,14 +1053,14 @@ mod tests {
         // Get
         let req = make_request("GetDeliverySource", json!({ "name": "src1" }));
         let resp = svc.get_delivery_source(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["deliverySource"]["name"], "src1");
         assert_eq!(body["deliverySource"]["logType"], "APPLICATION_LOGS");
 
         // Describe
         let req = make_request("DescribeDeliverySources", json!({}));
         let resp = svc.describe_delivery_sources(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["deliverySources"].as_array().unwrap().len(), 1);
 
         // Delete
@@ -1069,7 +1069,7 @@ mod tests {
 
         let req = make_request("DescribeDeliverySources", json!({}));
         let resp = svc.describe_delivery_sources(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["deliverySources"].as_array().unwrap().is_empty());
     }
 
@@ -1093,7 +1093,7 @@ mod tests {
         // Get
         let req = make_request("GetDeliveryDestination", json!({ "name": "dd1" }));
         let resp = svc.get_delivery_destination(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["deliveryDestination"]["name"], "dd1");
         let arn = body["deliveryDestination"]["arn"]
             .as_str()
@@ -1104,7 +1104,7 @@ mod tests {
         // Describe
         let req = make_request("DescribeDeliveryDestinations", json!({}));
         let resp = svc.describe_delivery_destinations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["deliveryDestinations"].as_array().unwrap().len(), 1);
 
         // Delete
@@ -1113,7 +1113,7 @@ mod tests {
 
         let req = make_request("DescribeDeliveryDestinations", json!({}));
         let resp = svc.describe_delivery_destinations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["deliveryDestinations"].as_array().unwrap().is_empty());
     }
 
@@ -1129,7 +1129,7 @@ mod tests {
             json!({ "logGroupNamePrefix": "del-grp" }),
         );
         let resp = svc.describe_log_groups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let group_arn = body["logGroups"][0]["arn"].as_str().unwrap().to_string();
 
         // Source
@@ -1157,7 +1157,7 @@ mod tests {
 
         let req = make_request("GetDeliveryDestination", json!({ "name": "del-dest" }));
         let resp = svc.get_delivery_destination(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let dest_arn = body["deliveryDestination"]["arn"]
             .as_str()
             .unwrap()
@@ -1172,19 +1172,19 @@ mod tests {
             }),
         );
         let resp = svc.create_delivery(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let delivery_id = body["delivery"]["id"].as_str().unwrap().to_string();
 
         // Get delivery
         let req = make_request("GetDelivery", json!({ "id": delivery_id }));
         let resp = svc.get_delivery(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["delivery"]["deliverySourceName"], "del-src");
 
         // Describe deliveries
         let req = make_request("DescribeDeliveries", json!({}));
         let resp = svc.describe_deliveries(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["deliveries"].as_array().unwrap().len(), 1);
 
         // Delete delivery
@@ -1193,7 +1193,7 @@ mod tests {
 
         let req = make_request("DescribeDeliveries", json!({}));
         let resp = svc.describe_deliveries(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["deliveries"].as_array().unwrap().is_empty());
     }
 }

--- a/crates/fakecloud-logs/src/service/destinations.rs
+++ b/crates/fakecloud-logs/src/service/destinations.rs
@@ -226,7 +226,7 @@ mod tests {
             }),
         );
         let resp = svc.put_destination(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["destination"]["destinationName"], "my-dest");
         assert!(body["destination"]["arn"]
             .as_str()
@@ -246,7 +246,7 @@ mod tests {
         // Describe
         let req = make_request("DescribeDestinations", json!({}));
         let resp = svc.describe_destinations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let dests = body["destinations"].as_array().unwrap();
         assert_eq!(dests.len(), 1);
         assert_eq!(dests[0]["accessPolicy"], "{\"Version\":\"2012-10-17\"}");
@@ -257,7 +257,7 @@ mod tests {
 
         let req = make_request("DescribeDestinations", json!({}));
         let resp = svc.describe_destinations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["destinations"].as_array().unwrap().is_empty());
     }
 

--- a/crates/fakecloud-logs/src/service/exports.rs
+++ b/crates/fakecloud-logs/src/service/exports.rs
@@ -285,12 +285,12 @@ mod tests {
             }),
         );
         let resp = svc.create_export_task(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let task_id = body["taskId"].as_str().unwrap();
 
         let req = make_request("DescribeExportTasks", json!({ "taskId": task_id }));
         let resp = svc.describe_export_tasks(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let task = &body["exportTasks"][0];
         assert_eq!(task["taskName"].as_str().unwrap(), "my-export");
         assert_eq!(task["logStreamNamePrefix"].as_str().unwrap(), "web-");
@@ -311,12 +311,12 @@ mod tests {
             }),
         );
         let resp = svc.create_export_task(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let task_id = body["taskId"].as_str().unwrap();
 
         let req = make_request("DescribeExportTasks", json!({ "taskId": task_id }));
         let resp = svc.describe_export_tasks(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let task = &body["exportTasks"][0];
         assert!(task.get("taskName").is_none() || task["taskName"].is_null());
         assert!(task.get("logStreamNamePrefix").is_none() || task["logStreamNamePrefix"].is_null());
@@ -357,13 +357,13 @@ mod tests {
             }),
         );
         let resp = svc.create_export_task(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let task_id = body["taskId"].as_str().unwrap();
 
         // Verify task is COMPLETED
         let req = make_request("DescribeExportTasks", json!({ "taskId": task_id }));
         let resp = svc.describe_export_tasks(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["exportTasks"][0]["status"]["code"].as_str().unwrap(),
             "COMPLETED"
@@ -375,7 +375,7 @@ mod tests {
             json!({ "keyPrefix": "my-export-bucket/logs" }),
         );
         let resp = svc.get_exported_data(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let entries = body["entries"].as_array().unwrap();
         assert_eq!(entries.len(), 1, "Should have one export entry");
         let data = entries[0]["data"].as_str().unwrap();
@@ -430,7 +430,7 @@ mod tests {
             json!({ "keyPrefix": "filtered-bucket/prefix" }),
         );
         let resp = svc.get_exported_data(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let entries = body["entries"].as_array().unwrap();
         assert_eq!(entries.len(), 1);
         let data = entries[0]["data"].as_str().unwrap();

--- a/crates/fakecloud-logs/src/service/filters.rs
+++ b/crates/fakecloud-logs/src/service/filters.rs
@@ -494,7 +494,7 @@ mod tests {
             json!({ "logGroupName": "sub-grp" }),
         );
         let resp = svc.describe_subscription_filters(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let filters = body["subscriptionFilters"].as_array().unwrap();
         assert_eq!(filters.len(), 1);
         assert_eq!(filters[0]["filterName"], "my-filter");
@@ -517,7 +517,7 @@ mod tests {
             json!({ "logGroupName": "sub-grp" }),
         );
         let resp = svc.describe_subscription_filters(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["subscriptionFilters"].as_array().unwrap().is_empty());
     }
 
@@ -554,7 +554,7 @@ mod tests {
             json!({ "logGroupName": "sub-upd" }),
         );
         let resp = svc.describe_subscription_filters(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let filters = body["subscriptionFilters"].as_array().unwrap();
         assert_eq!(filters.len(), 1);
         assert_eq!(filters[0]["filterPattern"], "WARN");
@@ -628,7 +628,7 @@ mod tests {
         // Describe by log group
         let req = make_request("DescribeMetricFilters", json!({ "logGroupName": "mf-grp" }));
         let resp = svc.describe_metric_filters(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let filters = body["metricFilters"].as_array().unwrap();
         assert_eq!(filters.len(), 1);
         assert_eq!(filters[0]["filterName"], "err-count");
@@ -643,7 +643,7 @@ mod tests {
             json!({ "metricName": "ErrorCount", "metricNamespace": "MyApp" }),
         );
         let resp = svc.describe_metric_filters(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["metricFilters"].as_array().unwrap().len(), 1);
 
         // Delete
@@ -655,7 +655,7 @@ mod tests {
 
         let req = make_request("DescribeMetricFilters", json!({ "logGroupName": "mf-grp" }));
         let resp = svc.describe_metric_filters(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["metricFilters"].as_array().unwrap().is_empty());
     }
 
@@ -698,7 +698,7 @@ mod tests {
 
         let req = make_request("DescribeMetricFilters", json!({ "logGroupName": "mf-upd" }));
         let resp = svc.describe_metric_filters(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let filters = body["metricFilters"].as_array().unwrap();
         assert_eq!(filters.len(), 1);
         assert_eq!(filters[0]["filterPattern"], "WARN");

--- a/crates/fakecloud-logs/src/service/groups.rs
+++ b/crates/fakecloud-logs/src/service/groups.rs
@@ -572,7 +572,7 @@ mod tests {
 
         let req = make_request("DescribeLogGroups", json!({ "logGroupNamePattern": "app" }));
         let resp = svc.describe_log_groups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let names: Vec<&str> = body["logGroups"]
             .as_array()
             .unwrap()
@@ -592,7 +592,7 @@ mod tests {
 
         let req = make_request("DescribeLogGroups", json!({}));
         let resp = svc.describe_log_groups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["logGroups"].as_array().unwrap().len(), 2);
     }
 

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -697,7 +697,7 @@ mod tests {
             json!({ "logGroupName": "fields-group" }),
         );
         let resp = svc.get_log_group_fields(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["logGroupFields"].as_array().unwrap().len(), 2);
     }
 
@@ -713,7 +713,7 @@ mod tests {
             }),
         );
         let resp = svc.test_metric_filter(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["matches"].as_array().unwrap().len(), 2);
     }
 
@@ -732,7 +732,7 @@ mod tests {
             }),
         );
         let resp = svc.start_query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let qid = body["queryId"].as_str().unwrap().to_string();
 
         // Manually set query status to Running so we can test cancellation
@@ -743,7 +743,7 @@ mod tests {
 
         let req = make_request("StopQuery", json!({ "queryId": &qid }));
         let resp = svc.stop_query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["success"], true);
 
         let state = svc.state.read();
@@ -777,7 +777,7 @@ mod tests {
             json!({ "logRecordPointer": "some-pointer" }),
         );
         let resp = svc.get_log_record(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["logRecord"].is_object());
     }
 
@@ -787,7 +787,7 @@ mod tests {
 
         let req = make_request("ListAnomalies", json!({}));
         let resp = svc.list_anomalies(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["anomalies"].as_array().unwrap().is_empty());
     }
 
@@ -815,12 +815,12 @@ mod tests {
             }),
         );
         let resp = svc.create_import_task(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let import_id = body["importId"].as_str().unwrap().to_string();
 
         let req = make_request("DescribeImportTasks", json!({}));
         let resp = svc.describe_import_tasks(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["imports"].as_array().unwrap().len(), 1);
 
         let req = make_request(
@@ -828,7 +828,7 @@ mod tests {
             json!({ "importId": import_id }),
         );
         let resp = svc.describe_import_task_batches(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["importBatches"].as_array().unwrap().is_empty());
 
         let req = make_request("CancelImportTask", json!({ "importId": import_id }));
@@ -836,7 +836,7 @@ mod tests {
 
         let req = make_request("DescribeImportTasks", json!({}));
         let resp = svc.describe_import_tasks(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["imports"][0]["importStatus"].as_str().unwrap(),
             "CANCELLED"
@@ -861,12 +861,12 @@ mod tests {
 
         let req = make_request("GetIntegration", json!({ "integrationName": "test-int" }));
         let resp = svc.get_integration(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["integrationName"].as_str().unwrap(), "test-int");
 
         let req = make_request("ListIntegrations", json!({}));
         let resp = svc.list_integrations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["integrationSummaries"].as_array().unwrap().len(), 1);
 
         let req = make_request(
@@ -877,7 +877,7 @@ mod tests {
 
         let req = make_request("ListIntegrations", json!({}));
         let resp = svc.list_integrations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["integrationSummaries"].as_array().unwrap().is_empty());
     }
 
@@ -895,17 +895,17 @@ mod tests {
             }),
         );
         let resp = svc.create_lookup_table(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let arn = body["lookupTableArn"].as_str().unwrap().to_string();
 
         let req = make_request("GetLookupTable", json!({ "lookupTableArn": arn }));
         let resp = svc.get_lookup_table(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["lookupTableName"].as_str().unwrap(), "test-table");
 
         let req = make_request("DescribeLookupTables", json!({}));
         let resp = svc.describe_lookup_tables(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["lookupTables"].as_array().unwrap().len(), 1);
 
         let req = make_request(
@@ -919,7 +919,7 @@ mod tests {
 
         let req = make_request("DescribeLookupTables", json!({}));
         let resp = svc.describe_lookup_tables(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["lookupTables"].as_array().unwrap().is_empty());
     }
 
@@ -940,12 +940,12 @@ mod tests {
             }),
         );
         let resp = svc.create_scheduled_query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let arn = body["scheduledQueryArn"].as_str().unwrap().to_string();
 
         let req = make_request("GetScheduledQuery", json!({ "identifier": arn }));
         let resp = svc.get_scheduled_query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["name"].as_str().unwrap(), "test-sq");
 
         let req = make_request(
@@ -953,12 +953,12 @@ mod tests {
             json!({ "identifier": arn, "startTime": 0_i64, "endTime": 9999999999_i64 }),
         );
         let resp = svc.get_scheduled_query_history(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["triggerHistory"].as_array().unwrap().is_empty());
 
         let req = make_request("ListScheduledQueries", json!({}));
         let resp = svc.list_scheduled_queries(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["scheduledQueries"].as_array().unwrap().len(), 1);
 
         let req = make_request(
@@ -978,7 +978,7 @@ mod tests {
 
         let req = make_request("ListScheduledQueries", json!({}));
         let resp = svc.list_scheduled_queries(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["scheduledQueries"].as_array().unwrap().is_empty());
     }
 
@@ -992,7 +992,7 @@ mod tests {
             json!({ "logGroupIdentifiers": ["/test/group"] }),
         );
         let resp = svc.start_live_tail(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["responseStream"]["sessionStart"]["sessionId"]
             .as_str()
             .is_some());
@@ -1004,7 +1004,7 @@ mod tests {
         create_group(&svc, "/test/list");
         let req = make_request("DescribeLogGroups", json!({}));
         let resp = svc.describe_log_groups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["logGroups"].as_array().unwrap().len(), 1);
     }
 
@@ -1016,7 +1016,7 @@ mod tests {
             json!({ "queryId": "some-query-id" }),
         );
         let resp = svc.list_log_groups_for_query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["logGroupIdentifiers"].as_array().unwrap().is_empty());
     }
 
@@ -1028,7 +1028,7 @@ mod tests {
             json!({ "groupBy": "DATA_SOURCE_NAME_AND_TYPE" }),
         );
         let resp = svc.list_aggregate_log_group_summaries(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["aggregateLogGroupSummaries"]
             .as_array()
             .unwrap()
@@ -1057,7 +1057,7 @@ mod tests {
             json!({ "logObjectPointer": "some-pointer" }),
         );
         let resp = svc.get_log_object(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body.is_object());
     }
 
@@ -1069,7 +1069,7 @@ mod tests {
             json!({ "dataSourceName": "test", "dataSourceType": "CW_LOG" }),
         );
         let resp = svc.get_log_fields(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["logFields"].as_array().unwrap().is_empty());
     }
 
@@ -1093,7 +1093,7 @@ mod tests {
             }),
         );
         let resp = svc.list_sources_for_s3_table_integration(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["sources"].as_array().unwrap().len(), 1);
 
         let req = make_request(
@@ -1137,7 +1137,7 @@ mod tests {
             }),
         );
         let resp = svc.create_delivery(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let delivery_id = body["delivery"]["id"].as_str().unwrap().to_string();
 
         let req = make_request("UpdateDeliveryConfiguration", json!({ "id": delivery_id }));
@@ -1149,7 +1149,7 @@ mod tests {
         let svc = make_service();
         let req = make_request("DescribeConfigurationTemplates", json!({}));
         let resp = svc.describe_configuration_templates(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["configurationTemplates"]
             .as_array()
             .unwrap()
@@ -1213,7 +1213,7 @@ mod tests {
             json!({ "logRecordPointer": "any-pointer-value" }),
         );
         let resp = svc.get_log_record(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["logRecord"].is_object());
     }
 }

--- a/crates/fakecloud-logs/src/service/policies.rs
+++ b/crates/fakecloud-logs/src/service/policies.rs
@@ -880,7 +880,7 @@ mod tests {
             }),
         );
         let resp = svc.put_account_policy(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["accountPolicy"]["policyName"], "test-policy");
 
         let req = make_request(
@@ -888,7 +888,7 @@ mod tests {
             json!({ "policyType": "DATA_PROTECTION_POLICY" }),
         );
         let resp = svc.describe_account_policies(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["accountPolicies"].as_array().unwrap().len(), 1);
 
         let req = make_request(
@@ -905,7 +905,7 @@ mod tests {
             json!({ "policyType": "DATA_PROTECTION_POLICY" }),
         );
         let resp = svc.describe_account_policies(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["accountPolicies"].as_array().unwrap().is_empty());
     }
 
@@ -930,7 +930,7 @@ mod tests {
             json!({ "logGroupIdentifier": "dp-group" }),
         );
         let resp = svc.get_data_protection_policy(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["policyDocument"], "{\"Name\":\"dp\"}");
 
         let req = make_request(
@@ -944,7 +944,7 @@ mod tests {
             json!({ "logGroupIdentifier": "dp-group" }),
         );
         let resp = svc.get_data_protection_policy(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body.get("policyDocument").is_none());
     }
 
@@ -969,7 +969,7 @@ mod tests {
             json!({ "logGroupIdentifiers": ["idx-group"] }),
         );
         let resp = svc.describe_index_policies(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["indexPolicies"].as_array().unwrap().len(), 1);
 
         let req = make_request(
@@ -1002,7 +1002,7 @@ mod tests {
             json!({ "logGroupIdentifier": "tx-group" }),
         );
         let resp = svc.get_transformer(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["transformerConfig"].is_array());
 
         let req = make_request(
@@ -1024,7 +1024,7 @@ mod tests {
             }),
         );
         let resp = svc.test_transformer(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["transformedLogs"].as_array().unwrap().len(), 2);
     }
 }

--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -406,7 +406,7 @@ mod tests {
             json!({ "queryDefinitionNamePrefix": "error" }),
         );
         let resp = svc.describe_query_definitions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let defs = body["queryDefinitions"].as_array().unwrap();
         assert_eq!(defs.len(), 2);
         for d in defs {
@@ -428,7 +428,7 @@ mod tests {
 
         let req = make_request("DescribeQueryDefinitions", json!({}));
         let resp = svc.describe_query_definitions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["queryDefinitions"].as_array().unwrap().len(), 3);
     }
 
@@ -447,13 +447,13 @@ mod tests {
             }),
         );
         let resp = svc.put_query_definition(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let qd_id = body["queryDefinitionId"].as_str().unwrap().to_string();
 
         // Describe
         let req = make_request("DescribeQueryDefinitions", json!({}));
         let resp = svc.describe_query_definitions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let defs = body["queryDefinitions"].as_array().unwrap();
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0]["name"], "my-query");
@@ -465,13 +465,13 @@ mod tests {
             json!({ "queryDefinitionId": qd_id }),
         );
         let resp = svc.delete_query_definition(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["success"], true);
 
         // Verify gone
         let req = make_request("DescribeQueryDefinitions", json!({}));
         let resp = svc.describe_query_definitions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["queryDefinitions"].as_array().unwrap().is_empty());
     }
 
@@ -483,7 +483,7 @@ mod tests {
             json!({ "queryDefinitionId": "nonexistent-id" }),
         );
         let resp = svc.delete_query_definition(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["success"], false);
     }
 
@@ -498,7 +498,7 @@ mod tests {
         let result = svc.stop_query(&req);
         // Either it errors or returns success: false — both are valid
         if let Ok(resp) = result {
-            let body: Value = serde_json::from_slice(&resp.body).unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
             // success should be false for a non-running query
             assert!(!body["success"].as_bool().unwrap_or(true));
         }

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -1021,7 +1021,7 @@ mod tests {
             json!({ "logGroupIdentifier": "my-group" }),
         );
         let resp = svc.filter_log_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["events"].as_array().unwrap().len(), 1);
     }
 
@@ -1037,7 +1037,7 @@ mod tests {
             json!({ "logGroupIdentifier": "arn:aws:logs:us-east-1:123456789012:log-group:my-group:*" }),
         );
         let resp = svc.filter_log_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["events"].as_array().unwrap().len(), 1);
     }
 
@@ -1066,7 +1066,7 @@ mod tests {
             json!({ "logGroupName": "grp", "logStreamNamePrefix": "web" }),
         );
         let resp = svc.filter_log_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let events = body["events"].as_array().unwrap();
         assert_eq!(events.len(), 2);
         for e in events {
@@ -1226,7 +1226,7 @@ mod tests {
             }),
         );
         let resp = svc.filter_log_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let events = body["events"].as_array().unwrap();
         assert_eq!(events.len(), 2);
         assert!(events[0]["message"].as_str().unwrap().contains("ERROR"));
@@ -1241,7 +1241,7 @@ mod tests {
             }),
         );
         let resp = svc.filter_log_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let events = body["events"].as_array().unwrap();
         assert_eq!(events.len(), 1);
         assert!(events[0]["message"].as_str().unwrap().contains("timeout"));
@@ -1255,7 +1255,7 @@ mod tests {
             }),
         );
         let resp = svc.filter_log_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let events = body["events"].as_array().unwrap();
         assert_eq!(events.len(), 1);
         assert!(events[0]["message"]
@@ -1308,7 +1308,7 @@ mod tests {
             }),
         );
         let resp = svc.filter_log_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let events = body["events"].as_array().unwrap();
         assert_eq!(events.len(), 2);
         assert!(events[0]["message"].as_str().unwrap().contains("ERROR"));
@@ -1352,13 +1352,13 @@ mod tests {
             }),
         );
         let resp = svc.start_query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let query_id = body["queryId"].as_str().unwrap();
 
         // Get results
         let req = make_request("GetQueryResults", json!({ "queryId": query_id }));
         let resp = svc.get_query_results(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let results = body["results"].as_array().unwrap();
         assert_eq!(results.len(), 2, "Should only return ERROR events");
         assert_eq!(body["status"].as_str().unwrap(), "Complete");
@@ -1393,12 +1393,12 @@ mod tests {
             }),
         );
         let resp = svc.start_query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let query_id = body["queryId"].as_str().unwrap();
 
         let req = make_request("GetQueryResults", json!({ "queryId": query_id }));
         let resp = svc.get_query_results(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let results = body["results"].as_array().unwrap();
         assert_eq!(results.len(), 1);
 
@@ -1442,12 +1442,12 @@ mod tests {
             }),
         );
         let resp = svc.start_query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let query_id = body["queryId"].as_str().unwrap();
 
         let req = make_request("GetQueryResults", json!({ "queryId": query_id }));
         let resp = svc.get_query_results(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let results = body["results"].as_array().unwrap();
         assert_eq!(results.len(), 2, "Should be limited to 2");
 
@@ -1494,12 +1494,12 @@ mod tests {
             }),
         );
         let resp = svc.start_query(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let query_id = body["queryId"].as_str().unwrap();
 
         let req = make_request("GetQueryResults", json!({ "queryId": query_id }));
         let resp = svc.get_query_results(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let results = body["results"].as_array().unwrap();
         assert_eq!(results.len(), 2, "Should only match ERROR JSON events");
     }

--- a/crates/fakecloud-logs/src/service/tags.rs
+++ b/crates/fakecloud-logs/src/service/tags.rs
@@ -288,7 +288,7 @@ mod tests {
             json!({ "logGroupNamePrefix": "tag-grp" }),
         );
         let resp = svc.describe_log_groups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let arn = body["logGroups"][0]["arn"].as_str().unwrap().to_string();
 
         // Tag
@@ -304,7 +304,7 @@ mod tests {
         // List tags
         let req = make_request("ListTagsForResource", json!({ "resourceArn": arn }));
         let resp = svc.list_tags_for_resource(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["tags"]["env"], "prod");
         assert_eq!(body["tags"]["team"], "platform");
 
@@ -320,7 +320,7 @@ mod tests {
 
         let req = make_request("ListTagsForResource", json!({ "resourceArn": arn }));
         let resp = svc.list_tags_for_resource(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["tags"].as_object().unwrap().len(), 1);
         assert!(body["tags"].get("team").is_none());
     }
@@ -338,7 +338,7 @@ mod tests {
             }),
         );
         let resp = svc.put_destination(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let arn = body["destination"]["arn"].as_str().unwrap().to_string();
 
         let req = make_request(
@@ -349,7 +349,7 @@ mod tests {
 
         let req = make_request("ListTagsForResource", json!({ "resourceArn": arn }));
         let resp = svc.list_tags_for_resource(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["tags"]["key1"], "val1");
     }
 

--- a/crates/fakecloud-persistence/Cargo.toml
+++ b/crates/fakecloud-persistence/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fakecloud-persistence"
+description = "Opt-in disk persistence primitives for FakeCloud services"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+version.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+toml = { workspace = true }
+thiserror = { workspace = true }
+bytes = { workspace = true }
+tracing = { workspace = true }
+parking_lot = { workspace = true }
+percent-encoding = { workspace = true }
+sha2 = { workspace = true }
+chrono = { workspace = true }

--- a/crates/fakecloud-persistence/Cargo.toml
+++ b/crates/fakecloud-persistence/Cargo.toml
@@ -17,3 +17,6 @@ parking_lot = { workspace = true }
 percent-encoding = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/fakecloud-persistence/src/atomic.rs
+++ b/crates/fakecloud-persistence/src/atomic.rs
@@ -20,20 +20,30 @@ fn fsync_parent(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-pub fn write_atomic_bytes(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    let tmp = tmp_path(path);
+fn write_atomic_bytes_inner(tmp: &Path, path: &Path, bytes: &[u8]) -> io::Result<()> {
     {
         let mut f = OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
-            .open(&tmp)?;
+            .open(tmp)?;
         f.write_all(bytes)?;
         f.sync_all()?;
     }
-    std::fs::rename(&tmp, path)?;
+    std::fs::rename(tmp, path)?;
     fsync_parent(path)?;
     Ok(())
+}
+
+pub fn write_atomic_bytes(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let tmp = tmp_path(path);
+    match write_atomic_bytes_inner(&tmp, path, bytes) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
 }
 
 pub fn write_atomic_toml<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
@@ -42,7 +52,7 @@ pub fn write_atomic_toml<T: Serialize>(path: &Path, value: &T) -> io::Result<()>
     write_atomic_bytes(path, text.as_bytes())
 }
 
-pub fn write_atomic_from_file(src: &Path, dst: &Path) -> io::Result<()> {
+fn write_atomic_from_file_inner(src: &Path, dst: &Path) -> io::Result<()> {
     {
         let f = File::open(src)?;
         f.sync_all()?;
@@ -50,4 +60,34 @@ pub fn write_atomic_from_file(src: &Path, dst: &Path) -> io::Result<()> {
     std::fs::rename(src, dst)?;
     fsync_parent(dst)?;
     Ok(())
+}
+
+pub fn write_atomic_from_file(src: &Path, dst: &Path) -> io::Result<()> {
+    match write_atomic_from_file_inner(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // Best-effort cleanup: remove any stray tmp the caller might see.
+            let tmp = tmp_path(dst);
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_write_leaves_no_tmp() {
+        // Writing into a non-existent parent directory should fail without
+        // leaving a lingering `.tmp` sibling. Use a tempdir so the test is
+        // hermetic.
+        let tmp = tempfile::tempdir().unwrap();
+        let bogus = tmp.path().join("does/not/exist/target.bin");
+        let err = write_atomic_bytes(&bogus, b"hello").unwrap_err();
+        let tmp_sibling = tmp_path(&bogus);
+        assert!(!tmp_sibling.exists(), "stray tmp: {:?}", tmp_sibling);
+        let _ = err;
+    }
 }

--- a/crates/fakecloud-persistence/src/atomic.rs
+++ b/crates/fakecloud-persistence/src/atomic.rs
@@ -1,0 +1,53 @@
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+fn tmp_path(path: &Path) -> PathBuf {
+    let mut os = path.as_os_str().to_owned();
+    os.push(".tmp");
+    PathBuf::from(os)
+}
+
+fn fsync_parent(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            let dir = File::open(parent)?;
+            dir.sync_all()?;
+        }
+    }
+    Ok(())
+}
+
+pub fn write_atomic_bytes(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let tmp = tmp_path(path);
+    {
+        let mut f = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    fsync_parent(path)?;
+    Ok(())
+}
+
+pub fn write_atomic_toml<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    let text = toml::to_string_pretty(value)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    write_atomic_bytes(path, text.as_bytes())
+}
+
+pub fn write_atomic_from_file(src: &Path, dst: &Path) -> io::Result<()> {
+    {
+        let f = File::open(src)?;
+        f.sync_all()?;
+    }
+    std::fs::rename(src, dst)?;
+    fsync_parent(dst)?;
+    Ok(())
+}

--- a/crates/fakecloud-persistence/src/atomic.rs
+++ b/crates/fakecloud-persistence/src/atomic.rs
@@ -74,6 +74,36 @@ pub fn write_atomic_from_file(src: &Path, dst: &Path) -> io::Result<()> {
     }
 }
 
+fn write_atomic_copy_from_file_inner(tmp: &Path, src: &Path, dst: &Path) -> io::Result<()> {
+    {
+        let mut input = File::open(src)?;
+        let mut out = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(tmp)?;
+        io::copy(&mut input, &mut out)?;
+        out.sync_all()?;
+    }
+    std::fs::rename(tmp, dst)?;
+    fsync_parent(dst)?;
+    Ok(())
+}
+
+/// Copy `src` into `dst` atomically, leaving `src` untouched. Used by the
+/// S3 store to replicate disk-backed object bodies without round-tripping
+/// through RAM.
+pub fn write_atomic_copy_from_file(src: &Path, dst: &Path) -> io::Result<()> {
+    let tmp = tmp_path(dst);
+    match write_atomic_copy_from_file_inner(&tmp, src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/fakecloud-persistence/src/cache.rs
+++ b/crates/fakecloud-persistence/src/cache.rs
@@ -21,10 +21,17 @@ impl BodyKey {
     }
 }
 
+/// Per-entry accounting overhead charged to each cache entry in addition to
+/// the raw body size. Without this, zero-length bodies accrue zero bytes
+/// against the capacity and a pathological flood of empty objects would grow
+/// the index unboundedly.
+const PER_ENTRY_OVERHEAD: u64 = 128;
+
 #[derive(Debug)]
 struct Node {
     key: BodyKey,
     bytes: Bytes,
+    charged: u64,
     prev: Option<usize>,
     next: Option<usize>,
 }
@@ -102,7 +109,7 @@ impl Inner {
         self.detach(idx);
         let node = self.nodes[idx].take().unwrap();
         self.free.push(idx);
-        self.used_bytes -= node.bytes.len() as u64;
+        self.used_bytes = self.used_bytes.saturating_sub(node.charged);
         self.index.remove(&node.key);
         node
     }
@@ -134,11 +141,13 @@ impl Inner {
         if size > self.single_object_cap {
             return;
         }
-        self.evict_until_fits(size);
-        self.used_bytes += size;
+        let charged = size.saturating_add(PER_ENTRY_OVERHEAD);
+        self.evict_until_fits(charged);
+        self.used_bytes += charged;
         let node = Node {
             key: key.clone(),
             bytes,
+            charged,
             prev: None,
             next: None,
         };
@@ -216,7 +225,7 @@ mod tests {
         let c = BodyCache::new(1024);
         c.insert(k("a"), mk(100));
         assert_eq!(c.get(&k("a")).unwrap().len(), 100);
-        assert_eq!(c.used_bytes(), 100);
+        assert_eq!(c.used_bytes(), 100 + PER_ENTRY_OVERHEAD);
     }
 
     #[test]
@@ -224,13 +233,14 @@ mod tests {
         let c = BodyCache::new(1024);
         c.insert(k("a"), mk(100));
         c.insert(k("a"), mk(50));
-        assert_eq!(c.used_bytes(), 50);
+        assert_eq!(c.used_bytes(), 50 + PER_ENTRY_OVERHEAD);
         assert_eq!(c.len(), 1);
     }
 
     #[test]
     fn lru_eviction_on_capacity_pressure() {
-        let c = BodyCache::new(300);
+        // Capacity 3 * (100 + overhead) so exactly three entries fit.
+        let c = BodyCache::new(3 * (100 + PER_ENTRY_OVERHEAD));
         c.insert(k("a"), mk(100));
         c.insert(k("b"), mk(100));
         c.insert(k("c"), mk(100));
@@ -241,6 +251,25 @@ mod tests {
         assert!(c.get(&k("a")).is_some());
         assert!(c.get(&k("c")).is_some());
         assert!(c.get(&k("d")).is_some());
+    }
+
+    #[test]
+    fn empty_bodies_still_evict_under_entry_overhead() {
+        // 1 MiB capacity: with 128 bytes of overhead per entry, the cache can
+        // hold at most ~4096 zero-length entries before eviction kicks in.
+        // Insert 10_000 distinct empty keys and assert the index is bounded.
+        let c = BodyCache::new(1024 * 1024);
+        for i in 0..10_000 {
+            c.insert(k(&format!("empty-{i}")), Bytes::new());
+        }
+        let max_entries = (1024 * 1024 / PER_ENTRY_OVERHEAD) as usize;
+        assert!(
+            c.len() <= max_entries,
+            "cache must evict empty bodies: len={} max={}",
+            c.len(),
+            max_entries
+        );
+        assert!(c.used_bytes() <= 1024 * 1024);
     }
 
     #[test]
@@ -260,7 +289,7 @@ mod tests {
 
     #[test]
     fn get_promotes_to_mru() {
-        let c = BodyCache::new(300);
+        let c = BodyCache::new(3 * (100 + PER_ENTRY_OVERHEAD));
         c.insert(k("a"), mk(100));
         c.insert(k("b"), mk(100));
         c.insert(k("c"), mk(100));

--- a/crates/fakecloud-persistence/src/cache.rs
+++ b/crates/fakecloud-persistence/src/cache.rs
@@ -1,0 +1,279 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use parking_lot::Mutex;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct BodyKey {
+    pub bucket: String,
+    pub key: String,
+    pub version: Option<String>,
+}
+
+impl BodyKey {
+    pub fn new(bucket: impl Into<String>, key: impl Into<String>, version: Option<String>) -> Self {
+        Self {
+            bucket: bucket.into(),
+            key: key.into(),
+            version,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Node {
+    key: BodyKey,
+    bytes: Bytes,
+    prev: Option<usize>,
+    next: Option<usize>,
+}
+
+struct Inner {
+    capacity_bytes: u64,
+    single_object_cap: u64,
+    used_bytes: u64,
+    nodes: Vec<Option<Node>>,
+    free: Vec<usize>,
+    index: HashMap<BodyKey, usize>,
+    head: Option<usize>, // MRU
+    tail: Option<usize>, // LRU
+}
+
+impl Inner {
+    fn new(capacity_bytes: u64) -> Self {
+        Self {
+            capacity_bytes,
+            single_object_cap: capacity_bytes / 2,
+            used_bytes: 0,
+            nodes: Vec::new(),
+            free: Vec::new(),
+            index: HashMap::new(),
+            head: None,
+            tail: None,
+        }
+    }
+
+    fn alloc_node(&mut self, node: Node) -> usize {
+        if let Some(idx) = self.free.pop() {
+            self.nodes[idx] = Some(node);
+            idx
+        } else {
+            self.nodes.push(Some(node));
+            self.nodes.len() - 1
+        }
+    }
+
+    fn detach(&mut self, idx: usize) {
+        let (prev, next) = {
+            let n = self.nodes[idx].as_ref().unwrap();
+            (n.prev, n.next)
+        };
+        match prev {
+            Some(p) => self.nodes[p].as_mut().unwrap().next = next,
+            None => self.head = next,
+        }
+        match next {
+            Some(n) => self.nodes[n].as_mut().unwrap().prev = prev,
+            None => self.tail = prev,
+        }
+        let n = self.nodes[idx].as_mut().unwrap();
+        n.prev = None;
+        n.next = None;
+    }
+
+    fn push_front(&mut self, idx: usize) {
+        let old_head = self.head;
+        {
+            let n = self.nodes[idx].as_mut().unwrap();
+            n.prev = None;
+            n.next = old_head;
+        }
+        if let Some(h) = old_head {
+            self.nodes[h].as_mut().unwrap().prev = Some(idx);
+        }
+        self.head = Some(idx);
+        if self.tail.is_none() {
+            self.tail = Some(idx);
+        }
+    }
+
+    fn remove(&mut self, idx: usize) -> Node {
+        self.detach(idx);
+        let node = self.nodes[idx].take().unwrap();
+        self.free.push(idx);
+        self.used_bytes -= node.bytes.len() as u64;
+        self.index.remove(&node.key);
+        node
+    }
+
+    fn evict_until_fits(&mut self, incoming: u64) {
+        while self.used_bytes + incoming > self.capacity_bytes {
+            let Some(tail) = self.tail else {
+                break;
+            };
+            self.remove(tail);
+        }
+    }
+
+    fn get(&mut self, key: &BodyKey) -> Option<Bytes> {
+        let idx = *self.index.get(key)?;
+        self.detach(idx);
+        self.push_front(idx);
+        Some(self.nodes[idx].as_ref().unwrap().bytes.clone())
+    }
+
+    fn insert(&mut self, key: BodyKey, bytes: Bytes) {
+        let size = bytes.len() as u64;
+        if size > self.single_object_cap {
+            return;
+        }
+        if let Some(&idx) = self.index.get(&key) {
+            self.remove(idx);
+        }
+        self.evict_until_fits(size);
+        self.used_bytes += size;
+        let node = Node {
+            key: key.clone(),
+            bytes,
+            prev: None,
+            next: None,
+        };
+        let idx = self.alloc_node(node);
+        self.index.insert(key, idx);
+        self.push_front(idx);
+    }
+
+    fn invalidate(&mut self, key: &BodyKey) {
+        if let Some(&idx) = self.index.get(key) {
+            self.remove(idx);
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct BodyCache {
+    inner: Arc<Mutex<Inner>>,
+    capacity_bytes: u64,
+}
+
+impl BodyCache {
+    pub fn new(capacity_bytes: u64) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner::new(capacity_bytes))),
+            capacity_bytes,
+        }
+    }
+
+    pub fn capacity_bytes(&self) -> u64 {
+        self.capacity_bytes
+    }
+
+    pub fn single_object_cap(&self) -> u64 {
+        self.capacity_bytes / 2
+    }
+
+    pub fn get(&self, key: &BodyKey) -> Option<Bytes> {
+        self.inner.lock().get(key)
+    }
+
+    pub fn insert(&self, key: BodyKey, bytes: Bytes) {
+        self.inner.lock().insert(key, bytes);
+    }
+
+    pub fn invalidate(&self, key: &BodyKey) {
+        self.inner.lock().invalidate(key);
+    }
+
+    #[cfg(test)]
+    fn used_bytes(&self) -> u64 {
+        self.inner.lock().used_bytes
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.inner.lock().index.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn k(name: &str) -> BodyKey {
+        BodyKey::new("b", name, None)
+    }
+
+    fn mk(n: usize) -> Bytes {
+        Bytes::from(vec![0u8; n])
+    }
+
+    #[test]
+    fn insert_and_get() {
+        let c = BodyCache::new(1024);
+        c.insert(k("a"), mk(100));
+        assert_eq!(c.get(&k("a")).unwrap().len(), 100);
+        assert_eq!(c.used_bytes(), 100);
+    }
+
+    #[test]
+    fn byte_accounting_on_overwrite() {
+        let c = BodyCache::new(1024);
+        c.insert(k("a"), mk(100));
+        c.insert(k("a"), mk(50));
+        assert_eq!(c.used_bytes(), 50);
+        assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn lru_eviction_on_capacity_pressure() {
+        let c = BodyCache::new(300);
+        c.insert(k("a"), mk(100));
+        c.insert(k("b"), mk(100));
+        c.insert(k("c"), mk(100));
+        // Access a to make it MRU; b is now LRU.
+        let _ = c.get(&k("a"));
+        c.insert(k("d"), mk(100));
+        assert!(c.get(&k("b")).is_none());
+        assert!(c.get(&k("a")).is_some());
+        assert!(c.get(&k("c")).is_some());
+        assert!(c.get(&k("d")).is_some());
+    }
+
+    #[test]
+    fn single_object_cap_bypass_leaves_cache_untouched() {
+        // 64 MiB capacity, 32 MiB single-object cap
+        let cap = 64 * 1024 * 1024;
+        let c = BodyCache::new(cap);
+        c.insert(k("a"), mk(1024));
+        let before_used = c.used_bytes();
+        let before_len = c.len();
+        c.insert(k("big"), mk(40 * 1024 * 1024));
+        assert_eq!(c.used_bytes(), before_used);
+        assert_eq!(c.len(), before_len);
+        assert!(c.get(&k("big")).is_none());
+        assert!(c.get(&k("a")).is_some());
+    }
+
+    #[test]
+    fn get_promotes_to_mru() {
+        let c = BodyCache::new(300);
+        c.insert(k("a"), mk(100));
+        c.insert(k("b"), mk(100));
+        c.insert(k("c"), mk(100));
+        let _ = c.get(&k("a"));
+        c.insert(k("d"), mk(100));
+        // b should be evicted, a should remain.
+        assert!(c.get(&k("a")).is_some());
+        assert!(c.get(&k("b")).is_none());
+    }
+
+    #[test]
+    fn invalidate_removes_entry() {
+        let c = BodyCache::new(1024);
+        c.insert(k("a"), mk(100));
+        c.invalidate(&k("a"));
+        assert!(c.get(&k("a")).is_none());
+        assert_eq!(c.used_bytes(), 0);
+    }
+}

--- a/crates/fakecloud-persistence/src/cache.rs
+++ b/crates/fakecloud-persistence/src/cache.rs
@@ -138,10 +138,10 @@ impl Inner {
             self.remove(idx);
         }
         let size = bytes.len() as u64;
-        if size > self.single_object_cap {
+        let charged = size.saturating_add(PER_ENTRY_OVERHEAD);
+        if size > self.single_object_cap || charged > self.capacity_bytes {
             return;
         }
-        let charged = size.saturating_add(PER_ENTRY_OVERHEAD);
         self.evict_until_fits(charged);
         self.used_bytes += charged;
         let node = Node {
@@ -313,6 +313,31 @@ mod tests {
         assert!(c.get(&k("a")).is_none());
         assert_eq!(c.used_bytes(), 0);
         assert_eq!(c.len(), 0);
+    }
+
+    #[test]
+    fn charged_size_cannot_exceed_total_capacity() {
+        // capacity=200, single_object_cap=100. A 100-byte body charged at
+        // 100+128=228 > 200, so it must be rejected even though it fits the
+        // single-object cap.
+        let c = BodyCache::new(200);
+        c.insert(k("a"), mk(100));
+        assert!(c.get(&k("a")).is_none());
+        assert_eq!(c.used_bytes(), 0);
+        assert_eq!(c.len(), 0);
+
+        // capacity=600, single_object_cap=300. A 300-byte body charged at
+        // 300+128=428 <= 600, so it succeeds.
+        let c = BodyCache::new(600);
+        c.insert(k("b"), mk(300));
+        assert!(c.get(&k("b")).is_some());
+        assert_eq!(c.used_bytes(), 300 + PER_ENTRY_OVERHEAD);
+
+        // capacity=600, single_object_cap=300. A 500-byte body exceeds the
+        // single-object cap and is rejected.
+        let c = BodyCache::new(600);
+        c.insert(k("c"), mk(500));
+        assert!(c.get(&k("c")).is_none());
     }
 
     #[test]

--- a/crates/fakecloud-persistence/src/cache.rs
+++ b/crates/fakecloud-persistence/src/cache.rs
@@ -124,12 +124,15 @@ impl Inner {
     }
 
     fn insert(&mut self, key: BodyKey, bytes: Bytes) {
+        // Always drop any existing entry for this key, even if the new body
+        // is oversized and will bypass the cache — otherwise a stale older
+        // body could be served after an overwrite.
+        if let Some(&idx) = self.index.get(&key) {
+            self.remove(idx);
+        }
         let size = bytes.len() as u64;
         if size > self.single_object_cap {
             return;
-        }
-        if let Some(&idx) = self.index.get(&key) {
-            self.remove(idx);
         }
         self.evict_until_fits(size);
         self.used_bytes += size;
@@ -266,6 +269,21 @@ mod tests {
         // b should be evicted, a should remain.
         assert!(c.get(&k("a")).is_some());
         assert!(c.get(&k("b")).is_none());
+    }
+
+    #[test]
+    fn oversized_overwrite_invalidates_previous_entry() {
+        // 64 MiB capacity, 32 MiB single-object cap
+        let cap = 64 * 1024 * 1024;
+        let c = BodyCache::new(cap);
+        c.insert(k("a"), mk(1024));
+        assert!(c.get(&k("a")).is_some());
+        // Overwrite with an oversized body: the new body bypasses, and the
+        // previous entry must be invalidated so stale bytes are not served.
+        c.insert(k("a"), mk(40 * 1024 * 1024));
+        assert!(c.get(&k("a")).is_none());
+        assert_eq!(c.used_bytes(), 0);
+        assert_eq!(c.len(), 0);
     }
 
     #[test]

--- a/crates/fakecloud-persistence/src/config.rs
+++ b/crates/fakecloud-persistence/src/config.rs
@@ -2,24 +2,19 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum StorageMode {
+    #[default]
     Memory,
     Persistent,
-}
-
-impl Default for StorageMode {
-    fn default() -> Self {
-        StorageMode::Memory
-    }
 }
 
 #[derive(Clone, Debug)]
 pub struct PersistenceConfig {
     pub mode: StorageMode,
     pub data_path: Option<PathBuf>,
-    pub body_cache_bytes: u64,
+    pub s3_cache_bytes: u64,
 }
 
 impl PersistenceConfig {
@@ -27,7 +22,7 @@ impl PersistenceConfig {
         Self {
             mode: StorageMode::Memory,
             data_path: None,
-            body_cache_bytes: 0,
+            s3_cache_bytes: 0,
         }
     }
 
@@ -35,7 +30,7 @@ impl PersistenceConfig {
         Self {
             mode: StorageMode::Persistent,
             data_path: Some(path),
-            body_cache_bytes: cache_bytes,
+            s3_cache_bytes: cache_bytes,
         }
     }
 
@@ -44,14 +39,14 @@ impl PersistenceConfig {
             StorageMode::Persistent => {
                 if self.data_path.is_none() {
                     return Err(
-                        "--storage-mode=persistent requires --data-path to be set".to_string(),
+                        "--storage-mode=persistent requires --data-path to be set".to_string()
                     );
                 }
             }
             StorageMode::Memory => {
                 if self.data_path.is_some() {
                     return Err(
-                        "--data-path is only valid with --storage-mode=persistent".to_string(),
+                        "--data-path is only valid with --storage-mode=persistent".to_string()
                     );
                 }
             }

--- a/crates/fakecloud-persistence/src/config.rs
+++ b/crates/fakecloud-persistence/src/config.rs
@@ -1,0 +1,61 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StorageMode {
+    Memory,
+    Persistent,
+}
+
+impl Default for StorageMode {
+    fn default() -> Self {
+        StorageMode::Memory
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PersistenceConfig {
+    pub mode: StorageMode,
+    pub data_path: Option<PathBuf>,
+    pub body_cache_bytes: u64,
+}
+
+impl PersistenceConfig {
+    pub fn memory() -> Self {
+        Self {
+            mode: StorageMode::Memory,
+            data_path: None,
+            body_cache_bytes: 0,
+        }
+    }
+
+    pub fn persistent(path: PathBuf, cache_bytes: u64) -> Self {
+        Self {
+            mode: StorageMode::Persistent,
+            data_path: Some(path),
+            body_cache_bytes: cache_bytes,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        match self.mode {
+            StorageMode::Persistent => {
+                if self.data_path.is_none() {
+                    return Err(
+                        "--storage-mode=persistent requires --data-path to be set".to_string(),
+                    );
+                }
+            }
+            StorageMode::Memory => {
+                if self.data_path.is_some() {
+                    return Err(
+                        "--data-path is only valid with --storage-mode=persistent".to_string(),
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/fakecloud-persistence/src/key_escape.rs
+++ b/crates/fakecloud-persistence/src/key_escape.rs
@@ -39,14 +39,14 @@ const SAFE: &AsciiSet = &CONTROLS
 
 pub fn escape_key_segment(segment: &str) -> String {
     let encoded: String = utf8_percent_encode(segment, SAFE).collect();
-    let placeholder = if encoded.is_empty() {
-        "_empty_".to_string()
-    } else {
-        encoded
-    };
+    if encoded.is_empty() {
+        // '@' is not in the percent-encoding output alphabet (A-Za-z0-9._-%),
+        // so this sentinel cannot collide with any legitimately encoded segment.
+        return "@empty".to_string();
+    }
 
-    if placeholder.len() <= MAX_SEGMENT_BYTES {
-        return placeholder;
+    if encoded.len() <= MAX_SEGMENT_BYTES {
+        return encoded;
     }
 
     let mut hasher = Sha256::new();
@@ -59,13 +59,15 @@ pub fn escape_key_segment(segment: &str) -> String {
         .collect();
     let hex = &hex[..HASH_SUFFIX_HEX];
 
-    let keep = MAX_SEGMENT_BYTES.saturating_sub(HASH_SUFFIX_HEX + 1);
-    // Truncate at a char boundary within `keep` bytes.
-    let mut end = keep.min(placeholder.len());
-    while end > 0 && !placeholder.is_char_boundary(end) {
+    // Sentinel prefix + hash + truncated head of the encoded segment.
+    // The '@trunc-' prefix cannot appear in a normal percent-encoded segment.
+    let prefix = format!("@trunc-{hex}-");
+    let keep = MAX_SEGMENT_BYTES.saturating_sub(prefix.len());
+    let mut end = keep.min(encoded.len());
+    while end > 0 && !encoded.is_char_boundary(end) {
         end -= 1;
     }
-    format!("{}-{}", &placeholder[..end], hex)
+    format!("{prefix}{}", &encoded[..end])
 }
 
 #[cfg(test)]
@@ -74,7 +76,34 @@ mod tests {
 
     #[test]
     fn empty_string() {
-        assert_eq!(escape_key_segment(""), "_empty_");
+        assert_eq!(escape_key_segment(""), "@empty");
+    }
+
+    #[test]
+    fn literal_underscore_empty_does_not_collide_with_empty_sentinel() {
+        // A user key that literally equals the old sentinel must not escape to
+        // the new one. Percent-encoding leaves `_empty_` untouched (safe
+        // chars), so it stays distinct from `@empty`.
+        assert_eq!(escape_key_segment("_empty_"), "_empty_");
+        assert_ne!(escape_key_segment("_empty_"), escape_key_segment(""));
+    }
+
+    #[test]
+    fn long_keys_with_shared_prefix_get_distinct_hashes() {
+        let a = format!("{}X", "a".repeat(500));
+        let b = format!("{}Y", "a".repeat(500));
+        let ea = escape_key_segment(&a);
+        let eb = escape_key_segment(&b);
+        assert_ne!(ea, eb);
+        assert!(ea.starts_with("@trunc-"));
+        assert!(eb.starts_with("@trunc-"));
+        // A short literal that happens to equal the truncated head cannot
+        // collide with either, because the overflow form is prefixed with `@trunc-`.
+        let short = "a".repeat(100);
+        let es = escape_key_segment(&short);
+        assert!(!es.starts_with('@'));
+        assert_ne!(es, ea);
+        assert_ne!(es, eb);
     }
 
     #[test]

--- a/crates/fakecloud-persistence/src/key_escape.rs
+++ b/crates/fakecloud-persistence/src/key_escape.rs
@@ -54,7 +54,7 @@ pub fn escape_key_segment(segment: &str) -> String {
     let digest = hasher.finalize();
     let hex: String = digest
         .iter()
-        .take((HASH_SUFFIX_HEX + 1) / 2)
+        .take(HASH_SUFFIX_HEX.div_ceil(2))
         .map(|b| format!("{:02x}", b))
         .collect();
     let hex = &hex[..HASH_SUFFIX_HEX];
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn unicode() {
         let out = escape_key_segment("日本語");
-        assert!(out.chars().all(|c| c.is_ascii()));
+        assert!(out.is_ascii());
         assert!(out.contains('%'));
     }
 

--- a/crates/fakecloud-persistence/src/key_escape.rs
+++ b/crates/fakecloud-persistence/src/key_escape.rs
@@ -1,0 +1,118 @@
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use sha2::{Digest, Sha256};
+
+const MAX_SEGMENT_BYTES: usize = 200;
+const HASH_SUFFIX_HEX: usize = 12;
+
+// Encode everything that isn't in A-Za-z0-9._-
+const SAFE: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'!')
+    .add(b'"')
+    .add(b'#')
+    .add(b'$')
+    .add(b'%')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b',')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'<')
+    .add(b'=')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}')
+    .add(b'~');
+
+pub fn escape_key_segment(segment: &str) -> String {
+    let encoded: String = utf8_percent_encode(segment, SAFE).collect();
+    let placeholder = if encoded.is_empty() {
+        "_empty_".to_string()
+    } else {
+        encoded
+    };
+
+    if placeholder.len() <= MAX_SEGMENT_BYTES {
+        return placeholder;
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(segment.as_bytes());
+    let digest = hasher.finalize();
+    let hex: String = digest
+        .iter()
+        .take((HASH_SUFFIX_HEX + 1) / 2)
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    let hex = &hex[..HASH_SUFFIX_HEX];
+
+    let keep = MAX_SEGMENT_BYTES.saturating_sub(HASH_SUFFIX_HEX + 1);
+    // Truncate at a char boundary within `keep` bytes.
+    let mut end = keep.min(placeholder.len());
+    while end > 0 && !placeholder.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}-{}", &placeholder[..end], hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(escape_key_segment(""), "_empty_");
+    }
+
+    #[test]
+    fn slash_is_encoded() {
+        assert_eq!(escape_key_segment("a/b"), "a%2Fb");
+    }
+
+    #[test]
+    fn unicode() {
+        let out = escape_key_segment("日本語");
+        assert!(out.chars().all(|c| c.is_ascii()));
+        assert!(out.contains('%'));
+    }
+
+    #[test]
+    fn dotfile() {
+        assert_eq!(escape_key_segment(".hidden"), ".hidden");
+    }
+
+    #[test]
+    fn long_key_is_truncated_with_hash() {
+        let raw = "a".repeat(500);
+        let out = escape_key_segment(&raw);
+        assert!(out.len() <= MAX_SEGMENT_BYTES);
+        assert!(out.contains('-'));
+    }
+
+    #[test]
+    fn differs_after_truncation_point_round_trip_unique() {
+        let a = format!("{}{}", "a".repeat(500), "X");
+        let b = format!("{}{}", "a".repeat(500), "Y");
+        let ea = escape_key_segment(&a);
+        let eb = escape_key_segment(&b);
+        assert_ne!(ea, eb);
+    }
+
+    #[test]
+    fn preserves_safe_chars() {
+        assert_eq!(escape_key_segment("Foo.Bar-baz_1"), "Foo.Bar-baz_1");
+    }
+}

--- a/crates/fakecloud-persistence/src/key_escape.rs
+++ b/crates/fakecloud-persistence/src/key_escape.rs
@@ -45,6 +45,16 @@ pub fn escape_key_segment(segment: &str) -> String {
         return "@empty".to_string();
     }
 
+    // Reject `.` and `..` as directory names — they would escape the parent
+    // objects/ directory on disk. Substitute with @dot/@dotdot sentinels
+    // (same '@' prefix guarantee as @empty).
+    if encoded == "." {
+        return "@dot".to_string();
+    }
+    if encoded == ".." {
+        return "@dotdot".to_string();
+    }
+
     if encoded.len() <= MAX_SEGMENT_BYTES {
         return encoded;
     }
@@ -138,6 +148,16 @@ mod tests {
         let ea = escape_key_segment(&a);
         let eb = escape_key_segment(&b);
         assert_ne!(ea, eb);
+    }
+
+    #[test]
+    fn dot_and_dotdot_get_sentinels() {
+        assert_eq!(escape_key_segment("."), "@dot");
+        assert_eq!(escape_key_segment(".."), "@dotdot");
+        // A user key that literally equals the sentinels cannot collide:
+        // `@` is escaped as `%40`.
+        assert_eq!(escape_key_segment("@dot"), "%40dot");
+        assert_eq!(escape_key_segment("@dotdot"), "%40dotdot");
     }
 
     #[test]

--- a/crates/fakecloud-persistence/src/lib.rs
+++ b/crates/fakecloud-persistence/src/lib.rs
@@ -8,8 +8,9 @@ pub mod warn;
 
 pub use config::{PersistenceConfig, StorageMode};
 pub use s3::{
-    AclGrantSnapshot, BodyRef, BodySource, BucketMeta, BucketSnapshot, BucketSubresource,
-    LoadedMpu, LoadedObject, LoadedPart, MemoryS3Store, MpuInit, ObjectMeta,
-    S3State as S3StateSnapshot, S3Store, StoreError, StoreResult, UploadPartMeta,
+    AclGrantSnapshot, AclSnapshot, BodyRef, BodySource, BucketMeta, BucketSnapshot,
+    BucketSubresource, InventorySnapshot, LoadedMpu, LoadedObject, LoadedPart, MemoryS3Store,
+    MpuInit, ObjectMeta, S3State as S3StateSnapshot, S3Store, StoreError, StoreResult,
+    TagsSnapshot, UploadPartMeta,
 };
 pub use warn::warn_unsupported;

--- a/crates/fakecloud-persistence/src/lib.rs
+++ b/crates/fakecloud-persistence/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod atomic;
+pub mod cache;
+pub mod config;
+pub mod key_escape;
+pub mod s3;
+pub mod version;
+pub mod warn;
+
+pub use config::{PersistenceConfig, StorageMode};
+pub use s3::{
+    AclGrantSnapshot, BodyRef, BodySource, BucketMeta, BucketSnapshot, BucketSubresource,
+    MemoryS3Store, MpuInit, ObjectMeta, S3State as S3StateSnapshot, S3Store, StoreError,
+    StoreResult, UploadPartMeta,
+};
+pub use warn::warn_unsupported;

--- a/crates/fakecloud-persistence/src/lib.rs
+++ b/crates/fakecloud-persistence/src/lib.rs
@@ -9,7 +9,7 @@ pub mod warn;
 pub use config::{PersistenceConfig, StorageMode};
 pub use s3::{
     AclGrantSnapshot, BodyRef, BodySource, BucketMeta, BucketSnapshot, BucketSubresource,
-    LoadedObject, MemoryS3Store, MpuInit, ObjectMeta, S3State as S3StateSnapshot, S3Store,
-    StoreError, StoreResult, UploadPartMeta,
+    LoadedMpu, LoadedObject, LoadedPart, MemoryS3Store, MpuInit, ObjectMeta,
+    S3State as S3StateSnapshot, S3Store, StoreError, StoreResult, UploadPartMeta,
 };
 pub use warn::warn_unsupported;

--- a/crates/fakecloud-persistence/src/lib.rs
+++ b/crates/fakecloud-persistence/src/lib.rs
@@ -9,7 +9,7 @@ pub mod warn;
 pub use config::{PersistenceConfig, StorageMode};
 pub use s3::{
     AclGrantSnapshot, BodyRef, BodySource, BucketMeta, BucketSnapshot, BucketSubresource,
-    MemoryS3Store, MpuInit, ObjectMeta, S3State as S3StateSnapshot, S3Store, StoreError,
-    StoreResult, UploadPartMeta,
+    LoadedObject, MemoryS3Store, MpuInit, ObjectMeta, S3State as S3StateSnapshot, S3Store,
+    StoreError, StoreResult, UploadPartMeta,
 };
 pub use warn::warn_unsupported;

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -266,7 +266,13 @@ impl Default for BodyRef {
 #[derive(Debug)]
 pub enum BodySource {
     Bytes(Bytes),
+    /// Existing disk path that should be *moved* into the destination via
+    /// rename (upload-tmp → final) and consumed.
     File(PathBuf),
+    /// Existing disk path that should be *copied* into the destination and
+    /// left in place. Used by replication so the source object stays
+    /// available while the replica is produced.
+    FileCopy(PathBuf),
 }
 
 #[derive(Debug, Error)]
@@ -385,7 +391,9 @@ impl S3Store for MemoryS3Store {
     ) -> StoreResult<BodyRef> {
         match body {
             BodySource::Bytes(b) => Ok(BodyRef::Memory(b)),
-            BodySource::File(_) => Err(StoreError::NotSupported),
+            BodySource::File(_) | BodySource::FileCopy(_) => Err(StoreError::Other(
+                "file-backed put not supported in memory mode".to_string(),
+            )),
         }
     }
     fn put_object_meta(
@@ -653,25 +661,20 @@ impl S3Store for DiskS3Store {
                     if !versioned.is_empty() {
                         versioned.sort_by(|a, b| a.meta.last_modified.cmp(&b.meta.last_modified));
                         if let Some(key) = key_name {
-                            // Promote the most recent non-delete-marker version
-                            // into snap.objects so unversioned GETs after
-                            // restart see the current object, matching runtime
-                            // semantics where DeleteObject creates a marker
-                            // that hides the object and a subsequent PutObject
-                            // clears it.
-                            if !snap.objects.contains_key(&key) {
-                                let latest_live =
-                                    versioned.iter().rev().find(|v| !v.meta.is_delete_marker);
-                                if let Some(live) = latest_live {
-                                    // Only promote if the *newest* version is
-                                    // also live — a trailing delete marker
-                                    // hides the object until another put.
-                                    if let Some(newest) = versioned.last() {
-                                        if !newest.meta.is_delete_marker {
-                                            snap.objects.insert(key.clone(), live.clone());
-                                        }
-                                    }
+                            // Reconcile snap.objects with the newest version:
+                            // a trailing delete marker hides any prior null or
+                            // live version (remove it); otherwise overwrite
+                            // with the newest live version, even if a
+                            // pre-versioning null.toml had already been
+                            // inserted during the non-versioned scan.
+                            match versioned.last() {
+                                Some(newest) if newest.meta.is_delete_marker => {
+                                    snap.objects.remove(&key);
                                 }
+                                Some(newest) => {
+                                    snap.objects.insert(key.clone(), newest.clone());
+                                }
+                                None => {}
                             }
                             snap.object_versions.insert(key, versioned);
                         }
@@ -824,6 +827,12 @@ impl S3Store for DiskS3Store {
                 crate::atomic::write_atomic_from_file(&src, &bin_path)?;
                 bytes_for_cache = None;
             }
+            BodySource::FileCopy(src) => {
+                let src_size = std::fs::metadata(&src)?.len();
+                size = src_size;
+                crate::atomic::write_atomic_copy_from_file(&src, &bin_path)?;
+                bytes_for_cache = None;
+            }
         }
 
         crate::atomic::write_atomic_toml(&toml_path, meta)?;
@@ -938,6 +947,13 @@ impl S3Store for DiskS3Store {
             BodySource::File(src) => {
                 let n = std::fs::metadata(&src)?.len();
                 crate::atomic::write_atomic_from_file(&src, &bin_path)?;
+                self.cache
+                    .invalidate(&Self::mpu_body_key(bucket, upload_id, part_number));
+                n
+            }
+            BodySource::FileCopy(src) => {
+                let n = std::fs::metadata(&src)?.len();
+                crate::atomic::write_atomic_copy_from_file(&src, &bin_path)?;
                 self.cache
                     .invalidate(&Self::mpu_body_key(bucket, upload_id, part_number));
                 n
@@ -1269,6 +1285,37 @@ mod disk_tests {
         let snap = loaded.buckets.get("b").unwrap();
         let obj = snap.objects.get("k1").unwrap();
         assert_eq!(obj.meta.size, data.len() as u64);
+    }
+
+    #[test]
+    fn put_object_file_copy_source_leaves_src_in_place() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let src_dir = TempDir::new().unwrap();
+        let src = src_dir.path().join("src.bin");
+        std::fs::write(&src, b"copied-body").unwrap();
+        let meta = sample_meta("k", 11);
+        let bref = store
+            .put_object("b", "k", None, BodySource::FileCopy(src.clone()), &meta)
+            .unwrap();
+        match bref {
+            BodyRef::Disk { path, size, .. } => {
+                assert_eq!(size, 11);
+                assert_eq!(std::fs::read(&path).unwrap(), b"copied-body");
+            }
+            _ => panic!("expected Disk bodyref"),
+        }
+        assert!(src.exists(), "source file must not be moved by FileCopy");
+        assert_eq!(std::fs::read(&src).unwrap(), b"copied-body");
     }
 
     #[test]
@@ -1623,6 +1670,140 @@ mod disk_tests {
             "trailing delete marker must hide current object",
         );
         assert_eq!(snap.object_versions.get("k").unwrap().len(), 4);
+    }
+
+    #[test]
+    fn legacy_null_object_overridden_by_newer_versions() {
+        // A pre-versioning null put followed by versioning-enabled puts must
+        // see snap.objects reflect the newest live version, not the stale null.
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let base = chrono::Utc::now();
+        let mut null_meta = sample_meta("k", 3);
+        null_meta.last_modified = base;
+        store
+            .put_object(
+                "b",
+                "k",
+                None,
+                BodySource::Bytes(Bytes::from_static(b"old")),
+                &null_meta,
+            )
+            .unwrap();
+        // Enable versioning and put two versions, the second a delete.
+        store
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    versioning: Some("Enabled".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let mut v1 = sample_meta("k", 3);
+        v1.version_id = Some("v1".to_string());
+        v1.last_modified = base + chrono::Duration::seconds(1);
+        store
+            .put_object(
+                "b",
+                "k",
+                Some("v1"),
+                BodySource::Bytes(Bytes::from_static(b"new")),
+                &v1,
+            )
+            .unwrap();
+        let mut v2 = sample_meta("k", 5);
+        v2.version_id = Some("v2".to_string());
+        v2.last_modified = base + chrono::Duration::seconds(2);
+        store
+            .put_object(
+                "b",
+                "k",
+                Some("v2"),
+                BodySource::Bytes(Bytes::from_static(b"newer")),
+                &v2,
+            )
+            .unwrap();
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        let current = snap
+            .objects
+            .get("k")
+            .expect("latest live version must override stale null");
+        assert_eq!(current.meta.version_id.as_deref(), Some("v2"));
+        assert_eq!(current.meta.size, 5);
+    }
+
+    #[test]
+    fn legacy_null_hidden_by_trailing_delete_marker() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let base = chrono::Utc::now();
+        let mut null_meta = sample_meta("k", 3);
+        null_meta.last_modified = base;
+        store
+            .put_object(
+                "b",
+                "k",
+                None,
+                BodySource::Bytes(Bytes::from_static(b"old")),
+                &null_meta,
+            )
+            .unwrap();
+        store
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    versioning: Some("Enabled".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let mut v1 = sample_meta("k", 3);
+        v1.version_id = Some("v1".to_string());
+        v1.last_modified = base + chrono::Duration::seconds(1);
+        store
+            .put_object(
+                "b",
+                "k",
+                Some("v1"),
+                BodySource::Bytes(Bytes::from_static(b"new")),
+                &v1,
+            )
+            .unwrap();
+        let mut dm = sample_meta("k", 0);
+        dm.version_id = Some("dm1".to_string());
+        dm.is_delete_marker = true;
+        dm.last_modified = base + chrono::Duration::seconds(2);
+        store
+            .put_object("b", "k", Some("dm1"), BodySource::Bytes(Bytes::new()), &dm)
+            .unwrap();
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        assert!(
+            !snap.objects.contains_key("k"),
+            "trailing delete marker must hide even a legacy null object",
+        );
     }
 
     #[test]

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -175,6 +175,10 @@ pub enum BodyRef {
     #[serde(skip)]
     Memory(Bytes),
     Disk {
+        bucket: String,
+        key: String,
+        #[serde(default)]
+        version: Option<String>,
         path: PathBuf,
         size: u64,
     },
@@ -205,8 +209,12 @@ pub enum BodySource {
 pub enum StoreError {
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("serialization error: {0}")]
+    Serde(String),
     #[error("not supported by this store")]
     NotSupported,
+    #[error("{0}")]
+    Other(String),
 }
 
 pub type StoreResult<T> = Result<T, StoreError>;
@@ -379,78 +387,316 @@ impl S3Store for MemoryS3Store {
     }
 }
 
-// TODO(phase-4): full DiskS3Store implementation backed by the on-disk layout +
-// BodyCache, including versioning, delete markers, and resumable multipart.
 pub struct DiskS3Store {
-    #[allow(dead_code)]
     root: PathBuf,
-    #[allow(dead_code)]
-    cache: crate::cache::BodyCache,
+    cache: std::sync::Arc<crate::cache::BodyCache>,
 }
 
 impl DiskS3Store {
-    pub fn new(root: PathBuf, cache: crate::cache::BodyCache) -> Self {
+    pub fn new(root: PathBuf, cache: std::sync::Arc<crate::cache::BodyCache>) -> Self {
         Self { root, cache }
     }
+
+    fn buckets_dir(&self) -> PathBuf {
+        self.root.join("buckets")
+    }
+
+    fn bucket_dir(&self, bucket: &str) -> PathBuf {
+        self.buckets_dir()
+            .join(crate::key_escape::escape_key_segment(bucket))
+    }
+
+    fn object_dir(&self, bucket: &str, key: &str) -> PathBuf {
+        self.bucket_dir(bucket)
+            .join("objects")
+            .join(crate::key_escape::escape_key_segment(key))
+    }
+
+    fn version_tag(version: Option<&str>) -> String {
+        version.unwrap_or("null").to_string()
+    }
+
+    fn object_paths(
+        &self,
+        bucket: &str,
+        key: &str,
+        version: Option<&str>,
+    ) -> (PathBuf, PathBuf, PathBuf) {
+        let dir = self.object_dir(bucket, key);
+        let tag = Self::version_tag(version);
+        let bin = dir.join(format!("{}.bin", tag));
+        let toml = dir.join(format!("{}.toml", tag));
+        (dir, bin, toml)
+    }
+
+    fn subresource_filename(kind: BucketSubresource) -> &'static str {
+        match kind {
+            BucketSubresource::Tags => "tags.toml",
+            BucketSubresource::Lifecycle => "lifecycle.toml",
+            BucketSubresource::Cors => "cors.toml",
+            BucketSubresource::Policy => "policy.toml",
+            BucketSubresource::Notification => "notification.toml",
+            BucketSubresource::Logging => "logging.toml",
+            BucketSubresource::Website => "website.toml",
+            BucketSubresource::PublicAccessBlock => "public_access_block.toml",
+            BucketSubresource::ObjectLock => "object_lock.toml",
+            BucketSubresource::Replication => "replication.toml",
+            BucketSubresource::Ownership => "ownership.toml",
+            BucketSubresource::Inventory => "inventory.toml",
+            BucketSubresource::Encryption => "encryption.toml",
+            BucketSubresource::Versioning => "versioning.toml",
+            BucketSubresource::Acl => "acl.toml",
+            BucketSubresource::Accelerate => "accelerate.toml",
+        }
+    }
+
+    fn cleanup_empty(dir: &std::path::Path) {
+        let _ = std::fs::remove_dir(dir);
+    }
+}
+
+fn io_other(msg: impl Into<String>) -> StoreError {
+    StoreError::Other(msg.into())
 }
 
 impl S3Store for DiskS3Store {
     fn load(&self) -> StoreResult<S3State> {
-        todo!("DiskS3Store::load — phase 4")
+        let mut state = S3State::default();
+        let buckets_dir = self.buckets_dir();
+        if !buckets_dir.exists() {
+            return Ok(state);
+        }
+        for entry in std::fs::read_dir(&buckets_dir)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let bdir = entry.path();
+            let meta_path = bdir.join("meta.toml");
+            if !meta_path.exists() {
+                continue;
+            }
+            let meta_text = std::fs::read_to_string(&meta_path)?;
+            let meta: BucketMeta =
+                toml::from_str(&meta_text).map_err(|e| StoreError::Serde(e.to_string()))?;
+            let mut snap = BucketSnapshot {
+                meta: meta.clone(),
+                objects: HashMap::new(),
+                object_versions: HashMap::new(),
+            };
+
+            let objects_root = bdir.join("objects");
+            if objects_root.exists() {
+                for okey_entry in std::fs::read_dir(&objects_root)? {
+                    let okey_entry = okey_entry?;
+                    if !okey_entry.file_type()?.is_dir() {
+                        continue;
+                    }
+                    let key_dir = okey_entry.path();
+                    for version_entry in std::fs::read_dir(&key_dir)? {
+                        let version_entry = version_entry?;
+                        let path = version_entry.path();
+                        let Some(fname) = path.file_name().and_then(|s| s.to_str()) else {
+                            continue;
+                        };
+                        if !fname.ends_with(".toml") {
+                            continue;
+                        }
+                        let version_tag = &fname[..fname.len() - 5];
+                        if version_tag != "null" {
+                            // TODO(phase-5): load versioned objects.
+                            continue;
+                        }
+                        let toml_text = std::fs::read_to_string(&path)?;
+                        let obj_meta: ObjectMeta = toml::from_str(&toml_text)
+                            .map_err(|e| StoreError::Serde(e.to_string()))?;
+                        snap.objects.insert(obj_meta.key.clone(), obj_meta);
+                    }
+                }
+            }
+
+            // TODO(phase-6): mpu/ directory is ignored in phase 4.
+            let _ = bdir.join("mpu");
+
+            state.buckets.insert(meta.name.clone(), snap);
+        }
+        Ok(state)
     }
-    fn put_bucket_meta(&self, _bucket: &str, _meta: &BucketMeta) -> StoreResult<()> {
-        todo!("DiskS3Store — phase 4")
+
+    fn put_bucket_meta(&self, bucket: &str, meta: &BucketMeta) -> StoreResult<()> {
+        let dir = self.bucket_dir(bucket);
+        std::fs::create_dir_all(&dir)?;
+        crate::atomic::write_atomic_toml(&dir.join("meta.toml"), meta)?;
+        Ok(())
     }
+
     fn put_bucket_subresource(
         &self,
-        _bucket: &str,
-        _kind: BucketSubresource,
-        _payload: &str,
+        bucket: &str,
+        kind: BucketSubresource,
+        payload: &str,
     ) -> StoreResult<()> {
-        todo!("DiskS3Store — phase 4")
+        let dir = self.bucket_dir(bucket);
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join(Self::subresource_filename(kind));
+        crate::atomic::write_atomic_bytes(&path, payload.as_bytes())?;
+        Ok(())
     }
+
     fn delete_bucket_subresource(
         &self,
-        _bucket: &str,
-        _kind: BucketSubresource,
+        bucket: &str,
+        kind: BucketSubresource,
     ) -> StoreResult<()> {
-        todo!("DiskS3Store — phase 4")
+        let path = self.bucket_dir(bucket).join(Self::subresource_filename(kind));
+        match std::fs::remove_file(&path) {
+            Ok(_) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
     }
-    fn delete_bucket(&self, _bucket: &str) -> StoreResult<()> {
-        todo!("DiskS3Store — phase 4")
+
+    fn delete_bucket(&self, bucket: &str) -> StoreResult<()> {
+        let dir = self.bucket_dir(bucket);
+        match std::fs::remove_dir_all(&dir) {
+            Ok(_) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
     }
+
     fn put_object(
         &self,
-        _bucket: &str,
-        _key: &str,
-        _version: Option<&str>,
-        _body: BodySource,
-        _meta: &ObjectMeta,
+        bucket: &str,
+        key: &str,
+        version: Option<&str>,
+        body: BodySource,
+        meta: &ObjectMeta,
     ) -> StoreResult<BodyRef> {
-        todo!("DiskS3Store — phase 4")
+        if version.is_some() {
+            // TODO(phase-5): persist versioned objects.
+            return Err(io_other("versioned put_object not yet implemented — phase 5"));
+        }
+        let (dir, bin_path, toml_path) = self.object_paths(bucket, key, version);
+        std::fs::create_dir_all(&dir)?;
+
+        let size: u64;
+        let bytes_for_cache: Option<Bytes>;
+        match body {
+            BodySource::Bytes(b) => {
+                size = b.len() as u64;
+                crate::atomic::write_atomic_bytes(&bin_path, &b)?;
+                bytes_for_cache = Some(b);
+            }
+            BodySource::File(src) => {
+                let src_size = std::fs::metadata(&src)?.len();
+                size = src_size;
+                crate::atomic::write_atomic_from_file(&src, &bin_path)?;
+                bytes_for_cache = None;
+            }
+        }
+
+        crate::atomic::write_atomic_toml(&toml_path, meta)?;
+
+        let body_key = crate::cache::BodyKey::new(
+            bucket.to_string(),
+            key.to_string(),
+            version.map(|s| s.to_string()),
+        );
+        if let Some(b) = bytes_for_cache {
+            self.cache.insert(body_key, b);
+        } else {
+            self.cache.invalidate(&crate::cache::BodyKey::new(
+                bucket.to_string(),
+                key.to_string(),
+                version.map(|s| s.to_string()),
+            ));
+        }
+
+        Ok(BodyRef::Disk {
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            version: version.map(|s| s.to_string()),
+            path: bin_path,
+            size,
+        })
     }
+
     fn put_object_meta(
         &self,
-        _bucket: &str,
-        _key: &str,
-        _version: Option<&str>,
-        _meta: &ObjectMeta,
+        bucket: &str,
+        key: &str,
+        version: Option<&str>,
+        meta: &ObjectMeta,
     ) -> StoreResult<()> {
-        todo!("DiskS3Store — phase 4")
+        if version.is_some() {
+            // TODO(phase-5): versioned put_object_meta.
+            return Err(io_other(
+                "versioned put_object_meta not yet implemented — phase 5",
+            ));
+        }
+        let (dir, _bin, toml_path) = self.object_paths(bucket, key, version);
+        std::fs::create_dir_all(&dir)?;
+        crate::atomic::write_atomic_toml(&toml_path, meta)?;
+        Ok(())
     }
+
     fn delete_object(
         &self,
-        _bucket: &str,
-        _key: &str,
-        _version: Option<&str>,
+        bucket: &str,
+        key: &str,
+        version: Option<&str>,
     ) -> StoreResult<()> {
-        todo!("DiskS3Store — phase 4")
+        if version.is_some() {
+            // TODO(phase-5): versioned delete.
+            return Err(io_other("versioned delete_object not yet implemented — phase 5"));
+        }
+        let (dir, bin_path, toml_path) = self.object_paths(bucket, key, version);
+        for p in [&bin_path, &toml_path] {
+            match std::fs::remove_file(p) {
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Self::cleanup_empty(&dir);
+
+        self.cache.invalidate(&crate::cache::BodyKey::new(
+            bucket.to_string(),
+            key.to_string(),
+            version.map(|s| s.to_string()),
+        ));
+        Ok(())
     }
-    fn open_object_body(&self, _body: &BodyRef) -> StoreResult<Bytes> {
-        todo!("DiskS3Store — phase 4")
+
+    fn open_object_body(&self, body: &BodyRef) -> StoreResult<Bytes> {
+        match body {
+            BodyRef::Memory(b) => Ok(b.clone()),
+            BodyRef::Disk {
+                bucket,
+                key,
+                version,
+                path,
+                size: _,
+            } => {
+                let body_key = crate::cache::BodyKey::new(
+                    bucket.clone(),
+                    key.clone(),
+                    version.clone(),
+                );
+                if let Some(bytes) = self.cache.get(&body_key) {
+                    return Ok(bytes);
+                }
+                let bytes = Bytes::from(std::fs::read(path)?);
+                self.cache.insert(body_key, bytes.clone());
+                Ok(bytes)
+            }
+        }
     }
+
     fn mpu_create(&self, _bucket: &str, _upload_id: &str, _init: &MpuInit) -> StoreResult<()> {
-        todo!("DiskS3Store — phase 4")
+        // TODO(phase-6): resumable multipart persistence.
+        Err(io_other("multipart persistence not yet implemented — phase 6"))
     }
     fn mpu_put_part(
         &self,
@@ -460,10 +706,12 @@ impl S3Store for DiskS3Store {
         _body: BodySource,
         _etag: &str,
     ) -> StoreResult<()> {
-        todo!("DiskS3Store — phase 4")
+        // TODO(phase-6): resumable multipart persistence.
+        Err(io_other("multipart persistence not yet implemented — phase 6"))
     }
     fn mpu_abort(&self, _bucket: &str, _upload_id: &str) -> StoreResult<()> {
-        todo!("DiskS3Store — phase 4")
+        // TODO(phase-6): resumable multipart persistence.
+        Err(io_other("multipart persistence not yet implemented — phase 6"))
     }
     fn mpu_complete(
         &self,
@@ -473,6 +721,308 @@ impl S3Store for DiskS3Store {
         _version: Option<&str>,
         _meta: &ObjectMeta,
     ) -> StoreResult<BodyRef> {
-        todo!("DiskS3Store — phase 4")
+        // TODO(phase-6): resumable multipart persistence.
+        Err(io_other("multipart persistence not yet implemented — phase 6"))
+    }
+}
+
+#[cfg(test)]
+mod disk_tests {
+    use super::*;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn new_store(tmp: &TempDir) -> DiskS3Store {
+        let cache = Arc::new(crate::cache::BodyCache::new(1024 * 1024));
+        DiskS3Store::new(tmp.path().to_path_buf(), cache)
+    }
+
+    fn new_store_with_cache(tmp: &TempDir, cap: u64) -> (DiskS3Store, Arc<crate::cache::BodyCache>) {
+        let cache = Arc::new(crate::cache::BodyCache::new(cap));
+        (
+            DiskS3Store::new(tmp.path().to_path_buf(), cache.clone()),
+            cache,
+        )
+    }
+
+    fn sample_meta(key: &str, size: u64) -> ObjectMeta {
+        ObjectMeta {
+            key: key.to_string(),
+            content_type: "application/octet-stream".to_string(),
+            etag: "etag".to_string(),
+            size,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn put_bucket_meta_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        let meta = BucketMeta {
+            name: "b1".to_string(),
+            region: "us-east-1".to_string(),
+            versioning: Some("Enabled".to_string()),
+            ..Default::default()
+        };
+        store.put_bucket_meta("b1", &meta).unwrap();
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b1").unwrap();
+        assert_eq!(snap.meta.name, "b1");
+        assert_eq!(snap.meta.region, "us-east-1");
+        assert_eq!(snap.meta.versioning.as_deref(), Some("Enabled"));
+    }
+
+    #[test]
+    fn put_bucket_subresource_each_variant_writes_file() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let variants = [
+            BucketSubresource::Tags,
+            BucketSubresource::Lifecycle,
+            BucketSubresource::Cors,
+            BucketSubresource::Policy,
+            BucketSubresource::Notification,
+            BucketSubresource::Logging,
+            BucketSubresource::Website,
+            BucketSubresource::PublicAccessBlock,
+            BucketSubresource::ObjectLock,
+            BucketSubresource::Replication,
+            BucketSubresource::Ownership,
+            BucketSubresource::Inventory,
+            BucketSubresource::Encryption,
+            BucketSubresource::Versioning,
+            BucketSubresource::Acl,
+            BucketSubresource::Accelerate,
+        ];
+        for v in variants {
+            store.put_bucket_subresource("b", v, "payload=true").unwrap();
+            let file = store.bucket_dir("b").join(DiskS3Store::subresource_filename(v));
+            assert!(file.exists(), "{:?}", v);
+            assert_eq!(std::fs::read_to_string(&file).unwrap(), "payload=true");
+        }
+    }
+
+    #[test]
+    fn delete_bucket_subresource_removes_file() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        store
+            .put_bucket_subresource("b", BucketSubresource::Tags, "x=1")
+            .unwrap();
+        store
+            .delete_bucket_subresource("b", BucketSubresource::Tags)
+            .unwrap();
+        let file = store.bucket_dir("b").join("tags.toml");
+        assert!(!file.exists());
+        // idempotent
+        store
+            .delete_bucket_subresource("b", BucketSubresource::Tags)
+            .unwrap();
+    }
+
+    #[test]
+    fn put_object_bytes_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let data = Bytes::from_static(b"hello world");
+        let meta = sample_meta("k1", data.len() as u64);
+        let body_ref = store
+            .put_object("b", "k1", None, BodySource::Bytes(data.clone()), &meta)
+            .unwrap();
+        match &body_ref {
+            BodyRef::Disk { bucket, key, size, path, .. } => {
+                assert_eq!(bucket, "b");
+                assert_eq!(key, "k1");
+                assert_eq!(*size, data.len() as u64);
+                assert_eq!(std::fs::read(path).unwrap(), data.to_vec());
+            }
+            _ => panic!("expected Disk"),
+        }
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        let obj = snap.objects.get("k1").unwrap();
+        assert_eq!(obj.size, data.len() as u64);
+    }
+
+    #[test]
+    fn put_object_file_source() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let src = tmp.path().join("src.bin");
+        std::fs::write(&src, b"file-body").unwrap();
+        let meta = sample_meta("k", 9);
+        let body_ref = store
+            .put_object("b", "k", None, BodySource::File(src.clone()), &meta)
+            .unwrap();
+        let path = match body_ref {
+            BodyRef::Disk { path, .. } => path,
+            _ => panic!(),
+        };
+        assert_eq!(std::fs::read(&path).unwrap(), b"file-body");
+    }
+
+    #[test]
+    fn put_object_meta_only_keeps_bin() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let data = Bytes::from_static(b"abc");
+        let mut meta = sample_meta("k", 3);
+        store
+            .put_object("b", "k", None, BodySource::Bytes(data.clone()), &meta)
+            .unwrap();
+        let (_, bin, _) = store.object_paths("b", "k", None);
+        let before = std::fs::read(&bin).unwrap();
+        meta.tags.insert("x".to_string(), "y".to_string());
+        store.put_object_meta("b", "k", None, &meta).unwrap();
+        assert_eq!(std::fs::read(&bin).unwrap(), before);
+        let loaded = store.load().unwrap();
+        let obj = loaded.buckets.get("b").unwrap().objects.get("k").unwrap();
+        assert_eq!(obj.tags.get("x").map(String::as_str), Some("y"));
+    }
+
+    #[test]
+    fn delete_object_cleans_up_files_and_cache() {
+        let tmp = TempDir::new().unwrap();
+        let (store, cache) = new_store_with_cache(&tmp, 1024 * 1024);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let data = Bytes::from_static(b"bye");
+        let meta = sample_meta("k", 3);
+        store
+            .put_object("b", "k", None, BodySource::Bytes(data), &meta)
+            .unwrap();
+        let body_key = crate::cache::BodyKey::new("b".to_string(), "k".to_string(), None);
+        assert!(cache.get(&body_key).is_some());
+        store.delete_object("b", "k", None).unwrap();
+        let (dir, bin, toml_path) = store.object_paths("b", "k", None);
+        assert!(!bin.exists());
+        assert!(!toml_path.exists());
+        assert!(!dir.exists());
+        assert!(cache.get(&body_key).is_none());
+    }
+
+    #[test]
+    fn open_object_body_cache_hit_and_refill() {
+        let tmp = TempDir::new().unwrap();
+        let (store, cache) = new_store_with_cache(&tmp, 1024 * 1024);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let data = Bytes::from_static(b"payload");
+        let meta = sample_meta("k", data.len() as u64);
+        let body_ref = store
+            .put_object("b", "k", None, BodySource::Bytes(data.clone()), &meta)
+            .unwrap();
+        // Cache hit.
+        let got = store.open_object_body(&body_ref).unwrap();
+        assert_eq!(got, data);
+        // Invalidate and re-read populates cache from disk.
+        let body_key = crate::cache::BodyKey::new("b".to_string(), "k".to_string(), None);
+        cache.invalidate(&body_key);
+        assert!(cache.get(&body_key).is_none());
+        let got = store.open_object_body(&body_ref).unwrap();
+        assert_eq!(got, data);
+        assert!(cache.get(&body_key).is_some());
+    }
+
+    #[test]
+    fn open_object_body_large_bypasses_cache() {
+        let tmp = TempDir::new().unwrap();
+        // capacity 1024 → single-object cap 512. Use 800-byte body.
+        let (store, cache) = new_store_with_cache(&tmp, 1024);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let data = Bytes::from(vec![7u8; 800]);
+        let meta = sample_meta("big", 800);
+        let body_ref = store
+            .put_object("b", "big", None, BodySource::Bytes(data.clone()), &meta)
+            .unwrap();
+        let body_key = crate::cache::BodyKey::new("b".to_string(), "big".to_string(), None);
+        assert!(cache.get(&body_key).is_none());
+        let got = store.open_object_body(&body_ref).unwrap();
+        assert_eq!(got, data);
+        // Still none — exceeds single-object cap.
+        assert!(cache.get(&body_key).is_none());
+    }
+
+    #[test]
+    fn load_empty_dir() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        let s = store.load().unwrap();
+        assert!(s.buckets.is_empty());
+    }
+
+    #[test]
+    fn load_ignores_mpu_and_versioned_files() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let data = Bytes::from_static(b"x");
+        let meta = sample_meta("k", 1);
+        store
+            .put_object("b", "k", None, BodySource::Bytes(data), &meta)
+            .unwrap();
+        // Plant an mpu dir and a versioned sidecar — neither should break load.
+        let mpu = store.bucket_dir("b").join("mpu").join("upload1");
+        std::fs::create_dir_all(&mpu).unwrap();
+        std::fs::write(mpu.join("init.toml"), "x").unwrap();
+        let (key_dir, _, _) = store.object_paths("b", "k", None);
+        std::fs::write(
+            key_dir.join("some-version-id.toml"),
+            "# TODO(phase-5)\n",
+        )
+        .unwrap();
+
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        assert_eq!(snap.objects.len(), 1);
     }
 }

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -1,0 +1,478 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct S3State {
+    #[serde(default)]
+    pub account_id: String,
+    #[serde(default)]
+    pub region: String,
+    #[serde(default)]
+    pub buckets: HashMap<String, BucketSnapshot>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct BucketSnapshot {
+    pub meta: BucketMeta,
+    #[serde(default)]
+    pub objects: HashMap<String, ObjectMeta>,
+    #[serde(default)]
+    pub object_versions: HashMap<String, Vec<ObjectMeta>>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct BucketMeta {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default = "default_time")]
+    pub creation_date: DateTime<Utc>,
+    #[serde(default)]
+    pub region: String,
+    #[serde(default)]
+    pub versioning: Option<String>,
+    #[serde(default)]
+    pub acl: Option<String>,
+    #[serde(default)]
+    pub acl_owner_id: String,
+    #[serde(default)]
+    pub accelerate_status: Option<String>,
+    #[serde(default)]
+    pub eventbridge_enabled: bool,
+}
+
+fn default_time() -> DateTime<Utc> {
+    DateTime::<Utc>::MIN_UTC
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct AclGrantSnapshot {
+    pub grantee_type: String,
+    #[serde(default)]
+    pub grantee_id: Option<String>,
+    #[serde(default)]
+    pub grantee_display_name: Option<String>,
+    #[serde(default)]
+    pub grantee_uri: Option<String>,
+    pub permission: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct ObjectMeta {
+    #[serde(default)]
+    pub key: String,
+    #[serde(default)]
+    pub content_type: String,
+    #[serde(default)]
+    pub etag: String,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default = "default_time")]
+    pub last_modified: DateTime<Utc>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
+    #[serde(default)]
+    pub storage_class: String,
+    #[serde(default)]
+    pub acl_grants: Vec<AclGrantSnapshot>,
+    #[serde(default)]
+    pub acl_owner_id: Option<String>,
+    #[serde(default)]
+    pub parts_count: Option<u32>,
+    #[serde(default)]
+    pub part_sizes: Option<Vec<(u32, u64)>>,
+    #[serde(default)]
+    pub sse_algorithm: Option<String>,
+    #[serde(default)]
+    pub sse_kms_key_id: Option<String>,
+    #[serde(default)]
+    pub bucket_key_enabled: Option<bool>,
+    #[serde(default)]
+    pub version_id: Option<String>,
+    #[serde(default)]
+    pub is_delete_marker: bool,
+    #[serde(default)]
+    pub restore_ongoing: Option<bool>,
+    #[serde(default)]
+    pub restore_expiry: Option<String>,
+    #[serde(default)]
+    pub checksum_algorithm: Option<String>,
+    #[serde(default)]
+    pub checksum_value: Option<String>,
+    #[serde(default)]
+    pub lock_mode: Option<String>,
+    #[serde(default)]
+    pub lock_retain_until: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub lock_legal_hold: Option<String>,
+    #[serde(default)]
+    pub content_encoding: Option<String>,
+    #[serde(default)]
+    pub website_redirect_location: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct MpuInit {
+    pub upload_id: String,
+    pub key: String,
+    #[serde(default = "default_time")]
+    pub initiated: DateTime<Utc>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+    #[serde(default)]
+    pub content_type: String,
+    #[serde(default)]
+    pub storage_class: String,
+    #[serde(default)]
+    pub sse_algorithm: Option<String>,
+    #[serde(default)]
+    pub sse_kms_key_id: Option<String>,
+    #[serde(default)]
+    pub tagging: Option<String>,
+    #[serde(default)]
+    pub acl_grants: Vec<AclGrantSnapshot>,
+    #[serde(default)]
+    pub checksum_algorithm: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct UploadPartMeta {
+    pub part_number: u32,
+    pub etag: String,
+    pub size: u64,
+    #[serde(default = "default_time")]
+    pub last_modified: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BucketSubresource {
+    Tags,
+    Lifecycle,
+    Cors,
+    Policy,
+    Notification,
+    Logging,
+    Website,
+    PublicAccessBlock,
+    ObjectLock,
+    Replication,
+    Ownership,
+    Inventory,
+    Encryption,
+    Versioning,
+    Acl,
+    Accelerate,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BodyRef {
+    #[serde(skip)]
+    Memory(Bytes),
+    Disk {
+        path: PathBuf,
+        size: u64,
+    },
+}
+
+impl BodyRef {
+    pub fn size(&self) -> u64 {
+        match self {
+            BodyRef::Memory(b) => b.len() as u64,
+            BodyRef::Disk { size, .. } => *size,
+        }
+    }
+}
+
+impl Default for BodyRef {
+    fn default() -> Self {
+        BodyRef::Memory(Bytes::new())
+    }
+}
+
+#[derive(Debug)]
+pub enum BodySource {
+    Bytes(Bytes),
+    File(PathBuf),
+}
+
+#[derive(Debug, Error)]
+pub enum StoreError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("not supported by this store")]
+    NotSupported,
+}
+
+pub type StoreResult<T> = Result<T, StoreError>;
+
+pub trait S3Store: Send + Sync {
+    fn load(&self) -> StoreResult<S3State>;
+
+    fn put_bucket_meta(&self, bucket: &str, meta: &BucketMeta) -> StoreResult<()>;
+    fn put_bucket_subresource(
+        &self,
+        bucket: &str,
+        kind: BucketSubresource,
+        payload: &str,
+    ) -> StoreResult<()>;
+    fn delete_bucket_subresource(
+        &self,
+        bucket: &str,
+        kind: BucketSubresource,
+    ) -> StoreResult<()>;
+    fn delete_bucket(&self, bucket: &str) -> StoreResult<()>;
+
+    fn put_object(
+        &self,
+        bucket: &str,
+        key: &str,
+        version: Option<&str>,
+        body: BodySource,
+        meta: &ObjectMeta,
+    ) -> StoreResult<BodyRef>;
+    fn put_object_meta(
+        &self,
+        bucket: &str,
+        key: &str,
+        version: Option<&str>,
+        meta: &ObjectMeta,
+    ) -> StoreResult<()>;
+    fn delete_object(
+        &self,
+        bucket: &str,
+        key: &str,
+        version: Option<&str>,
+    ) -> StoreResult<()>;
+    fn open_object_body(&self, body: &BodyRef) -> StoreResult<Bytes>;
+
+    fn mpu_create(&self, bucket: &str, upload_id: &str, init: &MpuInit) -> StoreResult<()>;
+    fn mpu_put_part(
+        &self,
+        bucket: &str,
+        upload_id: &str,
+        part_number: u32,
+        body: BodySource,
+        etag: &str,
+    ) -> StoreResult<()>;
+    fn mpu_abort(&self, bucket: &str, upload_id: &str) -> StoreResult<()>;
+    fn mpu_complete(
+        &self,
+        bucket: &str,
+        upload_id: &str,
+        final_key: &str,
+        version: Option<&str>,
+        meta: &ObjectMeta,
+    ) -> StoreResult<BodyRef>;
+}
+
+pub struct MemoryS3Store;
+
+impl MemoryS3Store {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for MemoryS3Store {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl S3Store for MemoryS3Store {
+    fn load(&self) -> StoreResult<S3State> {
+        Ok(S3State::default())
+    }
+
+    fn put_bucket_meta(&self, _bucket: &str, _meta: &BucketMeta) -> StoreResult<()> {
+        Ok(())
+    }
+    fn put_bucket_subresource(
+        &self,
+        _bucket: &str,
+        _kind: BucketSubresource,
+        _payload: &str,
+    ) -> StoreResult<()> {
+        Ok(())
+    }
+    fn delete_bucket_subresource(
+        &self,
+        _bucket: &str,
+        _kind: BucketSubresource,
+    ) -> StoreResult<()> {
+        Ok(())
+    }
+    fn delete_bucket(&self, _bucket: &str) -> StoreResult<()> {
+        Ok(())
+    }
+
+    fn put_object(
+        &self,
+        _bucket: &str,
+        _key: &str,
+        _version: Option<&str>,
+        body: BodySource,
+        _meta: &ObjectMeta,
+    ) -> StoreResult<BodyRef> {
+        match body {
+            BodySource::Bytes(b) => Ok(BodyRef::Memory(b)),
+            BodySource::File(_) => Err(StoreError::NotSupported),
+        }
+    }
+    fn put_object_meta(
+        &self,
+        _bucket: &str,
+        _key: &str,
+        _version: Option<&str>,
+        _meta: &ObjectMeta,
+    ) -> StoreResult<()> {
+        Ok(())
+    }
+    fn delete_object(
+        &self,
+        _bucket: &str,
+        _key: &str,
+        _version: Option<&str>,
+    ) -> StoreResult<()> {
+        Ok(())
+    }
+    fn open_object_body(&self, body: &BodyRef) -> StoreResult<Bytes> {
+        match body {
+            BodyRef::Memory(b) => Ok(b.clone()),
+            BodyRef::Disk { .. } => {
+                panic!("MemoryS3Store cannot open Disk-backed BodyRef")
+            }
+        }
+    }
+
+    fn mpu_create(&self, _bucket: &str, _upload_id: &str, _init: &MpuInit) -> StoreResult<()> {
+        Ok(())
+    }
+    fn mpu_put_part(
+        &self,
+        _bucket: &str,
+        _upload_id: &str,
+        _part_number: u32,
+        _body: BodySource,
+        _etag: &str,
+    ) -> StoreResult<()> {
+        Ok(())
+    }
+    fn mpu_abort(&self, _bucket: &str, _upload_id: &str) -> StoreResult<()> {
+        Ok(())
+    }
+    fn mpu_complete(
+        &self,
+        _bucket: &str,
+        _upload_id: &str,
+        _final_key: &str,
+        _version: Option<&str>,
+        _meta: &ObjectMeta,
+    ) -> StoreResult<BodyRef> {
+        Ok(BodyRef::Memory(Bytes::new()))
+    }
+}
+
+// TODO(phase-4): full DiskS3Store implementation backed by the on-disk layout +
+// BodyCache, including versioning, delete markers, and resumable multipart.
+pub struct DiskS3Store {
+    #[allow(dead_code)]
+    root: PathBuf,
+    #[allow(dead_code)]
+    cache: crate::cache::BodyCache,
+}
+
+impl DiskS3Store {
+    pub fn new(root: PathBuf, cache: crate::cache::BodyCache) -> Self {
+        Self { root, cache }
+    }
+}
+
+impl S3Store for DiskS3Store {
+    fn load(&self) -> StoreResult<S3State> {
+        todo!("DiskS3Store::load — phase 4")
+    }
+    fn put_bucket_meta(&self, _bucket: &str, _meta: &BucketMeta) -> StoreResult<()> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn put_bucket_subresource(
+        &self,
+        _bucket: &str,
+        _kind: BucketSubresource,
+        _payload: &str,
+    ) -> StoreResult<()> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn delete_bucket_subresource(
+        &self,
+        _bucket: &str,
+        _kind: BucketSubresource,
+    ) -> StoreResult<()> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn delete_bucket(&self, _bucket: &str) -> StoreResult<()> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn put_object(
+        &self,
+        _bucket: &str,
+        _key: &str,
+        _version: Option<&str>,
+        _body: BodySource,
+        _meta: &ObjectMeta,
+    ) -> StoreResult<BodyRef> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn put_object_meta(
+        &self,
+        _bucket: &str,
+        _key: &str,
+        _version: Option<&str>,
+        _meta: &ObjectMeta,
+    ) -> StoreResult<()> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn delete_object(
+        &self,
+        _bucket: &str,
+        _key: &str,
+        _version: Option<&str>,
+    ) -> StoreResult<()> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn open_object_body(&self, _body: &BodyRef) -> StoreResult<Bytes> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn mpu_create(&self, _bucket: &str, _upload_id: &str, _init: &MpuInit) -> StoreResult<()> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn mpu_put_part(
+        &self,
+        _bucket: &str,
+        _upload_id: &str,
+        _part_number: u32,
+        _body: BodySource,
+        _etag: &str,
+    ) -> StoreResult<()> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn mpu_abort(&self, _bucket: &str, _upload_id: &str) -> StoreResult<()> {
+        todo!("DiskS3Store — phase 4")
+    }
+    fn mpu_complete(
+        &self,
+        _bucket: &str,
+        _upload_id: &str,
+        _final_key: &str,
+        _version: Option<&str>,
+        _meta: &ObjectMeta,
+    ) -> StoreResult<BodyRef> {
+        todo!("DiskS3Store — phase 4")
+    }
+}

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -624,7 +624,14 @@ impl S3Store for DiskS3Store {
                                 sz,
                             )
                         } else {
-                            (BodyRef::Memory(Bytes::new()), 0u64)
+                            // Fail loud: the sidecar says this object has a
+                            // body but the .bin file is missing. Returning
+                            // silently would hand the caller a truncated
+                            // object and hide data loss.
+                            return Err(StoreError::Other(format!(
+                                "missing body file: {}",
+                                bin_path.display()
+                            )));
                         };
                         let _ = size;
                         key_name.get_or_insert_with(|| obj_meta.key.clone());
@@ -646,6 +653,26 @@ impl S3Store for DiskS3Store {
                     if !versioned.is_empty() {
                         versioned.sort_by(|a, b| a.meta.last_modified.cmp(&b.meta.last_modified));
                         if let Some(key) = key_name {
+                            // Promote the most recent non-delete-marker version
+                            // into snap.objects so unversioned GETs after
+                            // restart see the current object, matching runtime
+                            // semantics where DeleteObject creates a marker
+                            // that hides the object and a subsequent PutObject
+                            // clears it.
+                            if !snap.objects.contains_key(&key) {
+                                let latest_live =
+                                    versioned.iter().rev().find(|v| !v.meta.is_delete_marker);
+                                if let Some(live) = latest_live {
+                                    // Only promote if the *newest* version is
+                                    // also live — a trailing delete marker
+                                    // hides the object until another put.
+                                    if let Some(newest) = versioned.last() {
+                                        if !newest.meta.is_delete_marker {
+                                            snap.objects.insert(key.clone(), live.clone());
+                                        }
+                                    }
+                                }
+                            }
                             snap.object_versions.insert(key, versioned);
                         }
                     }
@@ -1512,6 +1539,93 @@ mod disk_tests {
     }
 
     #[test]
+    fn versioned_load_promotes_latest_live_to_snap_objects() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    versioning: Some("Enabled".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let base = chrono::Utc::now();
+        for (i, (vid, body)) in [("v1", "one"), ("v2", "two"), ("v3", "three")]
+            .iter()
+            .enumerate()
+        {
+            let mut m = sample_meta("k", body.len() as u64);
+            m.version_id = Some((*vid).to_string());
+            m.last_modified = base + chrono::Duration::seconds(i as i64);
+            store
+                .put_object(
+                    "b",
+                    "k",
+                    Some(*vid),
+                    BodySource::Bytes(Bytes::copy_from_slice(body.as_bytes())),
+                    &m,
+                )
+                .unwrap();
+        }
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        let current = snap.objects.get("k").expect("current object promoted");
+        assert_eq!(current.meta.version_id.as_deref(), Some("v3"));
+    }
+
+    #[test]
+    fn versioned_load_trailing_delete_marker_hides_current() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    versioning: Some("Enabled".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let base = chrono::Utc::now();
+        for (i, (vid, body)) in [("v1", "one"), ("v2", "two"), ("v3", "three")]
+            .iter()
+            .enumerate()
+        {
+            let mut m = sample_meta("k", body.len() as u64);
+            m.version_id = Some((*vid).to_string());
+            m.last_modified = base + chrono::Duration::seconds(i as i64);
+            store
+                .put_object(
+                    "b",
+                    "k",
+                    Some(*vid),
+                    BodySource::Bytes(Bytes::copy_from_slice(body.as_bytes())),
+                    &m,
+                )
+                .unwrap();
+        }
+        // Append a delete marker on top.
+        let mut dm = sample_meta("k", 0);
+        dm.version_id = Some("dm1".to_string());
+        dm.is_delete_marker = true;
+        dm.last_modified = base + chrono::Duration::seconds(10);
+        store
+            .put_object("b", "k", Some("dm1"), BodySource::Bytes(Bytes::new()), &dm)
+            .unwrap();
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        assert!(
+            !snap.objects.contains_key("k"),
+            "trailing delete marker must hide current object",
+        );
+        assert_eq!(snap.object_versions.get("k").unwrap().len(), 4);
+    }
+
+    #[test]
     fn delete_marker_roundtrip_no_body_file() {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
@@ -1606,7 +1720,12 @@ mod disk_tests {
         assert_eq!(a.objects.len(), 1);
         assert!(a.object_versions.is_empty());
         let b = loaded.buckets.get("b").unwrap();
-        assert!(b.objects.is_empty());
+        // Fix #5: the latest live version is promoted into objects so
+        // unversioned GETs see it post-restart.
+        assert_eq!(
+            b.objects.get("twice").unwrap().meta.version_id.as_deref(),
+            Some("v2")
+        );
         assert_eq!(b.object_versions.get("twice").unwrap().len(), 2);
     }
 

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -20,9 +20,18 @@ pub struct S3State {
 pub struct BucketSnapshot {
     pub meta: BucketMeta,
     #[serde(default)]
-    pub objects: HashMap<String, ObjectMeta>,
+    pub objects: HashMap<String, LoadedObject>,
     #[serde(default)]
-    pub object_versions: HashMap<String, Vec<ObjectMeta>>,
+    pub object_versions: HashMap<String, Vec<LoadedObject>>,
+    #[serde(default)]
+    pub subresources: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct LoadedObject {
+    pub meta: ObjectMeta,
+    #[serde(default)]
+    pub body: BodyRef,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -169,6 +178,25 @@ pub enum BucketSubresource {
     Acl,
     Accelerate,
 }
+
+pub const ALL_SUBRESOURCES: &[BucketSubresource] = &[
+    BucketSubresource::Tags,
+    BucketSubresource::Lifecycle,
+    BucketSubresource::Cors,
+    BucketSubresource::Policy,
+    BucketSubresource::Notification,
+    BucketSubresource::Logging,
+    BucketSubresource::Website,
+    BucketSubresource::PublicAccessBlock,
+    BucketSubresource::ObjectLock,
+    BucketSubresource::Replication,
+    BucketSubresource::Ownership,
+    BucketSubresource::Inventory,
+    BucketSubresource::Encryption,
+    BucketSubresource::Versioning,
+    BucketSubresource::Acl,
+    BucketSubresource::Accelerate,
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BodyRef {
@@ -477,13 +505,30 @@ impl S3Store for DiskS3Store {
                 continue;
             }
             let meta_text = std::fs::read_to_string(&meta_path)?;
-            let meta: BucketMeta =
+            let mut meta: BucketMeta =
                 toml::from_str(&meta_text).map_err(|e| StoreError::Serde(e.to_string()))?;
             let mut snap = BucketSnapshot {
                 meta: meta.clone(),
                 objects: HashMap::new(),
                 object_versions: HashMap::new(),
+                subresources: HashMap::new(),
             };
+
+            for kind in ALL_SUBRESOURCES {
+                let fname = Self::subresource_filename(*kind);
+                let path = bdir.join(fname);
+                if path.exists() {
+                    let text = std::fs::read_to_string(&path)?;
+                    if *kind == BucketSubresource::Versioning && snap.meta.versioning.is_none() {
+                        let stripped = text.trim();
+                        if !stripped.is_empty() {
+                            snap.meta.versioning = Some(stripped.to_string());
+                            meta.versioning = snap.meta.versioning.clone();
+                        }
+                    }
+                    snap.subresources.insert(fname.to_string(), text);
+                }
+            }
 
             let objects_root = bdir.join("objects");
             if objects_root.exists() {
@@ -493,6 +538,8 @@ impl S3Store for DiskS3Store {
                         continue;
                     }
                     let key_dir = okey_entry.path();
+                    let mut versioned: Vec<LoadedObject> = Vec::new();
+                    let mut key_name: Option<String> = None;
                     for version_entry in std::fs::read_dir(&key_dir)? {
                         let version_entry = version_entry?;
                         let path = version_entry.path();
@@ -503,19 +550,58 @@ impl S3Store for DiskS3Store {
                             continue;
                         }
                         let version_tag = &fname[..fname.len() - 5];
-                        if version_tag != "null" {
-                            // TODO(phase-5): load versioned objects.
-                            continue;
-                        }
                         let toml_text = std::fs::read_to_string(&path)?;
                         let obj_meta: ObjectMeta = toml::from_str(&toml_text)
                             .map_err(|e| StoreError::Serde(e.to_string()))?;
-                        snap.objects.insert(obj_meta.key.clone(), obj_meta);
+                        let bin_path = key_dir.join(format!("{}.bin", version_tag));
+                        let (body, size) = if obj_meta.is_delete_marker {
+                            (BodyRef::Memory(Bytes::new()), 0u64)
+                        } else if bin_path.exists() {
+                            let sz = std::fs::metadata(&bin_path)?.len();
+                            (
+                                BodyRef::Disk {
+                                    bucket: meta.name.clone(),
+                                    key: obj_meta.key.clone(),
+                                    version: if version_tag == "null" {
+                                        None
+                                    } else {
+                                        Some(version_tag.to_string())
+                                    },
+                                    path: bin_path,
+                                    size: sz,
+                                },
+                                sz,
+                            )
+                        } else {
+                            (BodyRef::Memory(Bytes::new()), 0u64)
+                        };
+                        let _ = size;
+                        key_name.get_or_insert_with(|| obj_meta.key.clone());
+                        if version_tag == "null" && obj_meta.version_id.is_none() {
+                            snap.objects.insert(
+                                obj_meta.key.clone(),
+                                LoadedObject {
+                                    meta: obj_meta,
+                                    body,
+                                },
+                            );
+                        } else {
+                            versioned.push(LoadedObject {
+                                meta: obj_meta,
+                                body,
+                            });
+                        }
+                    }
+                    if !versioned.is_empty() {
+                        versioned.sort_by(|a, b| a.meta.last_modified.cmp(&b.meta.last_modified));
+                        if let Some(key) = key_name {
+                            snap.object_versions.insert(key, versioned);
+                        }
                     }
                 }
             }
 
-            // TODO(phase-6): mpu/ directory is ignored in phase 4.
+            // TODO(phase-6): mpu/ directory is ignored.
             let _ = bdir.join("mpu");
 
             state.buckets.insert(meta.name.clone(), snap);
@@ -573,12 +659,13 @@ impl S3Store for DiskS3Store {
         body: BodySource,
         meta: &ObjectMeta,
     ) -> StoreResult<BodyRef> {
-        if version.is_some() {
-            // TODO(phase-5): persist versioned objects.
-            return Err(io_other("versioned put_object not yet implemented — phase 5"));
-        }
         let (dir, bin_path, toml_path) = self.object_paths(bucket, key, version);
         std::fs::create_dir_all(&dir)?;
+
+        if meta.is_delete_marker {
+            crate::atomic::write_atomic_toml(&toml_path, meta)?;
+            return Ok(BodyRef::Memory(Bytes::new()));
+        }
 
         let size: u64;
         let bytes_for_cache: Option<Bytes>;
@@ -629,12 +716,6 @@ impl S3Store for DiskS3Store {
         version: Option<&str>,
         meta: &ObjectMeta,
     ) -> StoreResult<()> {
-        if version.is_some() {
-            // TODO(phase-5): versioned put_object_meta.
-            return Err(io_other(
-                "versioned put_object_meta not yet implemented — phase 5",
-            ));
-        }
         let (dir, _bin, toml_path) = self.object_paths(bucket, key, version);
         std::fs::create_dir_all(&dir)?;
         crate::atomic::write_atomic_toml(&toml_path, meta)?;
@@ -647,10 +728,6 @@ impl S3Store for DiskS3Store {
         key: &str,
         version: Option<&str>,
     ) -> StoreResult<()> {
-        if version.is_some() {
-            // TODO(phase-5): versioned delete.
-            return Err(io_other("versioned delete_object not yet implemented — phase 5"));
-        }
         let (dir, bin_path, toml_path) = self.object_paths(bucket, key, version);
         for p in [&bin_path, &toml_path] {
             match std::fs::remove_file(p) {
@@ -860,7 +937,7 @@ mod disk_tests {
         let loaded = store.load().unwrap();
         let snap = loaded.buckets.get("b").unwrap();
         let obj = snap.objects.get("k1").unwrap();
-        assert_eq!(obj.size, data.len() as u64);
+        assert_eq!(obj.meta.size, data.len() as u64);
     }
 
     #[test]
@@ -908,7 +985,7 @@ mod disk_tests {
         assert_eq!(std::fs::read(&bin).unwrap(), before);
         let loaded = store.load().unwrap();
         let obj = loaded.buckets.get("b").unwrap().objects.get("k").unwrap();
-        assert_eq!(obj.tags.get("x").map(String::as_str), Some("y"));
+        assert_eq!(obj.meta.tags.get("x").map(String::as_str), Some("y"));
     }
 
     #[test]
@@ -996,7 +1073,7 @@ mod disk_tests {
     }
 
     #[test]
-    fn load_ignores_mpu_and_versioned_files() {
+    fn load_ignores_mpu_dir() {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
@@ -1010,19 +1087,202 @@ mod disk_tests {
         store
             .put_object("b", "k", None, BodySource::Bytes(data), &meta)
             .unwrap();
-        // Plant an mpu dir and a versioned sidecar — neither should break load.
+        // TODO(phase-6): mpu dir is ignored by load.
         let mpu = store.bucket_dir("b").join("mpu").join("upload1");
         std::fs::create_dir_all(&mpu).unwrap();
         std::fs::write(mpu.join("init.toml"), "x").unwrap();
-        let (key_dir, _, _) = store.object_paths("b", "k", None);
-        std::fs::write(
-            key_dir.join("some-version-id.toml"),
-            "# TODO(phase-5)\n",
-        )
-        .unwrap();
 
         let loaded = store.load().unwrap();
         let snap = loaded.buckets.get("b").unwrap();
         assert_eq!(snap.objects.len(), 1);
+    }
+
+    #[test]
+    fn load_reads_bucket_subresources() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        store
+            .put_bucket_subresource("b", BucketSubresource::Lifecycle, "<Lifecycle/>")
+            .unwrap();
+        store
+            .put_bucket_subresource("b", BucketSubresource::Cors, "<Cors/>")
+            .unwrap();
+        store
+            .put_bucket_subresource("b", BucketSubresource::Policy, "{}")
+            .unwrap();
+        store
+            .put_bucket_subresource("b", BucketSubresource::Tags, "x=1")
+            .unwrap();
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        assert_eq!(
+            snap.subresources.get("lifecycle.toml").map(String::as_str),
+            Some("<Lifecycle/>"),
+        );
+        assert_eq!(
+            snap.subresources.get("cors.toml").map(String::as_str),
+            Some("<Cors/>"),
+        );
+        assert_eq!(
+            snap.subresources.get("policy.toml").map(String::as_str),
+            Some("{}"),
+        );
+        assert_eq!(
+            snap.subresources.get("tags.toml").map(String::as_str),
+            Some("x=1"),
+        );
+    }
+
+    #[test]
+    fn versioned_put_load_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                versioning: Some("Enabled".to_string()),
+                ..Default::default()
+            })
+            .unwrap();
+        let base = chrono::Utc::now();
+        for (i, (vid, body)) in [("v1", "one"), ("v2", "two"), ("v3", "three")]
+            .iter()
+            .enumerate()
+        {
+            let mut m = sample_meta("k", body.len() as u64);
+            m.version_id = Some((*vid).to_string());
+            m.last_modified = base + chrono::Duration::seconds(i as i64);
+            store
+                .put_object(
+                    "b",
+                    "k",
+                    Some(*vid),
+                    BodySource::Bytes(Bytes::copy_from_slice(body.as_bytes())),
+                    &m,
+                )
+                .unwrap();
+        }
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        let versions = snap.object_versions.get("k").expect("versions present");
+        assert_eq!(versions.len(), 3);
+        assert_eq!(versions[0].meta.version_id.as_deref(), Some("v1"));
+        assert_eq!(versions[1].meta.version_id.as_deref(), Some("v2"));
+        assert_eq!(versions[2].meta.version_id.as_deref(), Some("v3"));
+        for v in versions {
+            match &v.body {
+                BodyRef::Disk { size, .. } => assert!(*size > 0),
+                _ => panic!("expected Disk body"),
+            }
+        }
+    }
+
+    #[test]
+    fn delete_marker_roundtrip_no_body_file() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                versioning: Some("Enabled".to_string()),
+                ..Default::default()
+            })
+            .unwrap();
+        let mut m = sample_meta("k", 0);
+        m.version_id = Some("dm1".to_string());
+        m.is_delete_marker = true;
+        store
+            .put_object("b", "k", Some("dm1"), BodySource::Bytes(Bytes::new()), &m)
+            .unwrap();
+        // No .bin file on disk for delete markers.
+        let (_, bin, toml_path) = store.object_paths("b", "k", Some("dm1"));
+        assert!(!bin.exists(), "delete marker must not have a .bin file");
+        assert!(toml_path.exists());
+
+        let loaded = store.load().unwrap();
+        let versions = loaded
+            .buckets
+            .get("b")
+            .unwrap()
+            .object_versions
+            .get("k")
+            .unwrap();
+        assert_eq!(versions.len(), 1);
+        assert!(versions[0].meta.is_delete_marker);
+        match &versions[0].body {
+            BodyRef::Memory(b) => assert_eq!(b.len(), 0),
+            _ => panic!("delete marker body should be empty Memory"),
+        }
+    }
+
+    #[test]
+    fn mixed_nonversioned_and_versioned_buckets() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("a", &BucketMeta {
+                name: "a".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                versioning: Some("Enabled".to_string()),
+                ..Default::default()
+            })
+            .unwrap();
+        let ma = sample_meta("only", 3);
+        store
+            .put_object("a", "only", None, BodySource::Bytes(Bytes::from_static(b"aaa")), &ma)
+            .unwrap();
+        let base = chrono::Utc::now();
+        for (i, vid) in ["v1", "v2"].iter().enumerate() {
+            let mut m = sample_meta("twice", 2);
+            m.version_id = Some((*vid).to_string());
+            m.last_modified = base + chrono::Duration::seconds(i as i64);
+            store
+                .put_object(
+                    "b",
+                    "twice",
+                    Some(*vid),
+                    BodySource::Bytes(Bytes::from_static(b"xx")),
+                    &m,
+                )
+                .unwrap();
+        }
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded.buckets.len(), 2);
+        let a = loaded.buckets.get("a").unwrap();
+        assert_eq!(a.objects.len(), 1);
+        assert!(a.object_versions.is_empty());
+        let b = loaded.buckets.get("b").unwrap();
+        assert!(b.objects.is_empty());
+        assert_eq!(b.object_versions.get("twice").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn legacy_versioning_file_is_read() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        // Bucket meta with no versioning field set.
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        // Legacy sidecar: a bare versioning.toml with "Enabled".
+        let path = store.bucket_dir("b").join("versioning.toml");
+        std::fs::write(&path, "Enabled").unwrap();
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        assert_eq!(snap.meta.versioning.as_deref(), Some("Enabled"));
     }
 }

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 use bytes::Bytes;
@@ -25,6 +25,22 @@ pub struct BucketSnapshot {
     pub object_versions: HashMap<String, Vec<LoadedObject>>,
     #[serde(default)]
     pub subresources: HashMap<String, String>,
+    #[serde(default)]
+    pub multipart_uploads: HashMap<String, LoadedMpu>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct LoadedMpu {
+    pub init: MpuInit,
+    #[serde(default)]
+    pub parts: BTreeMap<u32, LoadedPart>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct LoadedPart {
+    pub meta: UploadPartMeta,
+    #[serde(default)]
+    pub body: BodyRef,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -481,6 +497,34 @@ impl DiskS3Store {
     fn cleanup_empty(dir: &std::path::Path) {
         let _ = std::fs::remove_dir(dir);
     }
+
+    fn mpu_dir(&self, bucket: &str, upload_id: &str) -> PathBuf {
+        self.bucket_dir(bucket)
+            .join("mpu")
+            .join(crate::key_escape::escape_key_segment(upload_id))
+    }
+
+    fn mpu_parts_dir(&self, bucket: &str, upload_id: &str) -> PathBuf {
+        self.mpu_dir(bucket, upload_id).join("parts")
+    }
+
+    fn mpu_part_bin(&self, bucket: &str, upload_id: &str, part_number: u32) -> PathBuf {
+        self.mpu_parts_dir(bucket, upload_id)
+            .join(format!("{}.bin", part_number))
+    }
+
+    fn mpu_part_toml(&self, bucket: &str, upload_id: &str, part_number: u32) -> PathBuf {
+        self.mpu_parts_dir(bucket, upload_id)
+            .join(format!("{}.toml", part_number))
+    }
+
+    fn mpu_body_key(bucket: &str, upload_id: &str, part_number: u32) -> crate::cache::BodyKey {
+        crate::cache::BodyKey::new(
+            bucket.to_string(),
+            format!("__mpu__/{}", upload_id),
+            Some(format!("part-{}", part_number)),
+        )
+    }
 }
 
 fn io_other(msg: impl Into<String>) -> StoreError {
@@ -512,6 +556,7 @@ impl S3Store for DiskS3Store {
                 objects: HashMap::new(),
                 object_versions: HashMap::new(),
                 subresources: HashMap::new(),
+                multipart_uploads: HashMap::new(),
             };
 
             for kind in ALL_SUBRESOURCES {
@@ -601,8 +646,76 @@ impl S3Store for DiskS3Store {
                 }
             }
 
-            // TODO(phase-6): mpu/ directory is ignored.
-            let _ = bdir.join("mpu");
+            let mpu_root = bdir.join("mpu");
+            if mpu_root.exists() {
+                for upload_entry in std::fs::read_dir(&mpu_root)? {
+                    let upload_entry = upload_entry?;
+                    if !upload_entry.file_type()?.is_dir() {
+                        continue;
+                    }
+                    let upload_dir = upload_entry.path();
+                    let init_path = upload_dir.join("init.toml");
+                    if !init_path.exists() {
+                        continue;
+                    }
+                    let init_text = std::fs::read_to_string(&init_path)?;
+                    let init: MpuInit = toml::from_str(&init_text)
+                        .map_err(|e| StoreError::Serde(e.to_string()))?;
+                    let mut loaded_parts: BTreeMap<u32, LoadedPart> = BTreeMap::new();
+                    let parts_dir = upload_dir.join("parts");
+                    if parts_dir.exists() {
+                        for part_entry in std::fs::read_dir(&parts_dir)? {
+                            let part_entry = part_entry?;
+                            let path = part_entry.path();
+                            let Some(fname) = path.file_name().and_then(|s| s.to_str())
+                            else {
+                                continue;
+                            };
+                            if !fname.ends_with(".toml") {
+                                continue;
+                            }
+                            let stem = &fname[..fname.len() - 5];
+                            let Ok(part_number) = stem.parse::<u32>() else {
+                                continue;
+                            };
+                            let toml_text = std::fs::read_to_string(&path)?;
+                            let part_meta: UploadPartMeta = toml::from_str(&toml_text)
+                                .map_err(|e| StoreError::Serde(e.to_string()))?;
+                            let bin_path = parts_dir.join(format!("{}.bin", part_number));
+                            let (body, size) = if bin_path.exists() {
+                                let sz = std::fs::metadata(&bin_path)?.len();
+                                (
+                                    BodyRef::Disk {
+                                        bucket: meta.name.clone(),
+                                        key: format!("__mpu__/{}", init.upload_id),
+                                        version: Some(format!("part-{}", part_number)),
+                                        path: bin_path,
+                                        size: sz,
+                                    },
+                                    sz,
+                                )
+                            } else {
+                                (BodyRef::Memory(Bytes::new()), 0u64)
+                            };
+                            let _ = size;
+                            loaded_parts.insert(
+                                part_number,
+                                LoadedPart {
+                                    meta: part_meta,
+                                    body,
+                                },
+                            );
+                        }
+                    }
+                    snap.multipart_uploads.insert(
+                        init.upload_id.clone(),
+                        LoadedMpu {
+                            init,
+                            parts: loaded_parts,
+                        },
+                    );
+                }
+            }
 
             state.buckets.insert(meta.name.clone(), snap);
         }
@@ -771,36 +884,210 @@ impl S3Store for DiskS3Store {
         }
     }
 
-    fn mpu_create(&self, _bucket: &str, _upload_id: &str, _init: &MpuInit) -> StoreResult<()> {
-        // TODO(phase-6): resumable multipart persistence.
-        Err(io_other("multipart persistence not yet implemented — phase 6"))
+    fn mpu_create(&self, bucket: &str, upload_id: &str, init: &MpuInit) -> StoreResult<()> {
+        let parts_dir = self.mpu_parts_dir(bucket, upload_id);
+        std::fs::create_dir_all(&parts_dir)?;
+        let init_path = self.mpu_dir(bucket, upload_id).join("init.toml");
+        crate::atomic::write_atomic_toml(&init_path, init)?;
+        Ok(())
     }
+
     fn mpu_put_part(
         &self,
-        _bucket: &str,
-        _upload_id: &str,
-        _part_number: u32,
-        _body: BodySource,
-        _etag: &str,
+        bucket: &str,
+        upload_id: &str,
+        part_number: u32,
+        body: BodySource,
+        etag: &str,
     ) -> StoreResult<()> {
-        // TODO(phase-6): resumable multipart persistence.
-        Err(io_other("multipart persistence not yet implemented — phase 6"))
+        let parts_dir = self.mpu_parts_dir(bucket, upload_id);
+        std::fs::create_dir_all(&parts_dir)?;
+        let bin_path = self.mpu_part_bin(bucket, upload_id, part_number);
+        let toml_path = self.mpu_part_toml(bucket, upload_id, part_number);
+
+        let size: u64 = match body {
+            BodySource::Bytes(b) => {
+                let n = b.len() as u64;
+                crate::atomic::write_atomic_bytes(&bin_path, &b)?;
+                let cache_key = Self::mpu_body_key(bucket, upload_id, part_number);
+                self.cache.insert(cache_key, b);
+                n
+            }
+            BodySource::File(src) => {
+                let n = std::fs::metadata(&src)?.len();
+                crate::atomic::write_atomic_from_file(&src, &bin_path)?;
+                self.cache
+                    .invalidate(&Self::mpu_body_key(bucket, upload_id, part_number));
+                n
+            }
+        };
+
+        let meta = UploadPartMeta {
+            part_number,
+            etag: etag.to_string(),
+            size,
+            last_modified: Utc::now(),
+        };
+        crate::atomic::write_atomic_toml(&toml_path, &meta)?;
+        Ok(())
     }
-    fn mpu_abort(&self, _bucket: &str, _upload_id: &str) -> StoreResult<()> {
-        // TODO(phase-6): resumable multipart persistence.
-        Err(io_other("multipart persistence not yet implemented — phase 6"))
+
+    fn mpu_abort(&self, bucket: &str, upload_id: &str) -> StoreResult<()> {
+        let dir = self.mpu_dir(bucket, upload_id);
+        // Invalidate any cached part bodies for this upload.
+        if let Ok(entries) = std::fs::read_dir(self.mpu_parts_dir(bucket, upload_id)) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if let Some(fname) = path.file_name().and_then(|s| s.to_str()) {
+                    if let Some(stem) = fname.strip_suffix(".bin") {
+                        if let Ok(n) = stem.parse::<u32>() {
+                            self.cache
+                                .invalidate(&Self::mpu_body_key(bucket, upload_id, n));
+                        }
+                    }
+                }
+            }
+        }
+        match std::fs::remove_dir_all(&dir) {
+            Ok(_) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
     }
+
     fn mpu_complete(
         &self,
-        _bucket: &str,
-        _upload_id: &str,
-        _final_key: &str,
-        _version: Option<&str>,
-        _meta: &ObjectMeta,
+        bucket: &str,
+        upload_id: &str,
+        final_key: &str,
+        version: Option<&str>,
+        meta: &ObjectMeta,
     ) -> StoreResult<BodyRef> {
-        // TODO(phase-6): resumable multipart persistence.
-        Err(io_other("multipart persistence not yet implemented — phase 6"))
+        let parts_dir = self.mpu_parts_dir(bucket, upload_id);
+        if !parts_dir.exists() {
+            return Err(io_other(format!(
+                "mpu_complete: no parts dir for upload {}",
+                upload_id
+            )));
+        }
+
+        // Enumerate parts in ascending part-number order.
+        let mut part_numbers: Vec<u32> = Vec::new();
+        for entry in std::fs::read_dir(&parts_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let Some(fname) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if let Some(stem) = fname.strip_suffix(".toml") {
+                if let Ok(n) = stem.parse::<u32>() {
+                    if self.mpu_part_bin(bucket, upload_id, n).exists() {
+                        part_numbers.push(n);
+                    }
+                }
+            }
+        }
+        part_numbers.sort_unstable();
+        if part_numbers.is_empty() {
+            return Err(io_other(format!(
+                "mpu_complete: upload {} has no parts",
+                upload_id
+            )));
+        }
+
+        let (dir, bin_path, toml_path) = self.object_paths(bucket, final_key, version);
+        std::fs::create_dir_all(&dir)?;
+
+        let total_size: u64 = if part_numbers.len() == 1 {
+            let only = self.mpu_part_bin(bucket, upload_id, part_numbers[0]);
+            let sz = std::fs::metadata(&only)?.len();
+            match std::fs::rename(&only, &bin_path) {
+                Ok(_) => {}
+                Err(e) if e.raw_os_error() == Some(libc_exdev()) => {
+                    // Cross-device rename: fall back to streaming copy then remove source.
+                    {
+                        let mut input = std::fs::File::open(&only)?;
+                        let tmp = {
+                            let mut os = bin_path.as_os_str().to_owned();
+                            os.push(".tmp");
+                            PathBuf::from(os)
+                        };
+                        let mut out = std::fs::OpenOptions::new()
+                            .write(true)
+                            .create(true)
+                            .truncate(true)
+                            .open(&tmp)?;
+                        std::io::copy(&mut input, &mut out)?;
+                        out.sync_all()?;
+                        std::fs::rename(&tmp, &bin_path)?;
+                    }
+                    let _ = std::fs::remove_file(&only);
+                }
+                Err(e) => return Err(e.into()),
+            }
+            sz
+        } else {
+            let tmp = {
+                let mut os = bin_path.as_os_str().to_owned();
+                os.push(".tmp");
+                PathBuf::from(os)
+            };
+            let mut total: u64 = 0;
+            {
+                let mut out = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&tmp)?;
+                for n in &part_numbers {
+                    let part_path = self.mpu_part_bin(bucket, upload_id, *n);
+                    let mut input = std::fs::File::open(&part_path)?;
+                    let copied = std::io::copy(&mut input, &mut out)?;
+                    total += copied;
+                }
+                out.sync_all()?;
+            }
+            std::fs::rename(&tmp, &bin_path)?;
+            if let Some(parent) = bin_path.parent() {
+                if let Ok(dir_handle) = std::fs::File::open(parent) {
+                    let _ = dir_handle.sync_all();
+                }
+            }
+            total
+        };
+
+        crate::atomic::write_atomic_toml(&toml_path, meta)?;
+
+        // Invalidate per-part cache entries and drop the mpu dir.
+        for n in &part_numbers {
+            self.cache
+                .invalidate(&Self::mpu_body_key(bucket, upload_id, *n));
+        }
+        let mpu_dir = self.mpu_dir(bucket, upload_id);
+        let _ = std::fs::remove_dir_all(&mpu_dir);
+
+        // The concatenated body is deliberately NOT re-inserted into the cache —
+        // large multipart uploads typically exceed the single-object cap, and we
+        // must never round-trip the assembled body through RAM. The next
+        // open_object_body call will load through the normal cache path.
+        self.cache.invalidate(&crate::cache::BodyKey::new(
+            bucket.to_string(),
+            final_key.to_string(),
+            version.map(|s| s.to_string()),
+        ));
+
+        Ok(BodyRef::Disk {
+            bucket: bucket.to_string(),
+            key: final_key.to_string(),
+            version: version.map(|s| s.to_string()),
+            path: bin_path,
+            size: total_size,
+        })
     }
+}
+
+fn libc_exdev() -> i32 {
+    18
 }
 
 #[cfg(test)]
@@ -1073,7 +1360,7 @@ mod disk_tests {
     }
 
     #[test]
-    fn load_ignores_mpu_dir() {
+    fn load_skips_mpu_without_init() {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
@@ -1087,14 +1374,14 @@ mod disk_tests {
         store
             .put_object("b", "k", None, BodySource::Bytes(data), &meta)
             .unwrap();
-        // TODO(phase-6): mpu dir is ignored by load.
+        // Directory with no init.toml is skipped by load.
         let mpu = store.bucket_dir("b").join("mpu").join("upload1");
         std::fs::create_dir_all(&mpu).unwrap();
-        std::fs::write(mpu.join("init.toml"), "x").unwrap();
 
         let loaded = store.load().unwrap();
         let snap = loaded.buckets.get("b").unwrap();
         assert_eq!(snap.objects.len(), 1);
+        assert!(snap.multipart_uploads.is_empty());
     }
 
     #[test]
@@ -1265,6 +1552,266 @@ mod disk_tests {
         let b = loaded.buckets.get("b").unwrap();
         assert!(b.objects.is_empty());
         assert_eq!(b.object_versions.get("twice").unwrap().len(), 2);
+    }
+
+    fn sample_mpu_init(upload_id: &str, key: &str) -> MpuInit {
+        MpuInit {
+            upload_id: upload_id.to_string(),
+            key: key.to_string(),
+            initiated: chrono::Utc::now(),
+            content_type: "application/octet-stream".to_string(),
+            storage_class: "STANDARD".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn mpu_create_then_load_empty_parts() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let init = sample_mpu_init("up1", "k1");
+        store.mpu_create("b", "up1", &init).unwrap();
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        let m = snap.multipart_uploads.get("up1").expect("upload present");
+        assert_eq!(m.init.upload_id, "up1");
+        assert_eq!(m.init.key, "k1");
+        assert!(m.parts.is_empty());
+    }
+
+    #[test]
+    fn mpu_put_part_then_load_three_parts() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        let bodies = [
+            Bytes::from_static(b"part-one"),
+            Bytes::from_static(b"part-two-longer"),
+            Bytes::from_static(b"p3"),
+        ];
+        for (i, body) in bodies.iter().enumerate() {
+            let n = (i + 1) as u32;
+            store
+                .mpu_put_part("b", "up", n, BodySource::Bytes(body.clone()), &format!("et{}", n))
+                .unwrap();
+        }
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        let m = snap.multipart_uploads.get("up").unwrap();
+        assert_eq!(m.parts.len(), 3);
+        for (i, body) in bodies.iter().enumerate() {
+            let n = (i + 1) as u32;
+            let part = m.parts.get(&n).unwrap();
+            assert_eq!(part.meta.part_number, n);
+            assert_eq!(part.meta.size, body.len() as u64);
+            assert_eq!(part.meta.etag, format!("et{}", n));
+            match &part.body {
+                BodyRef::Disk { path, size, .. } => {
+                    assert_eq!(*size, body.len() as u64);
+                    assert_eq!(std::fs::read(path).unwrap(), body.to_vec());
+                }
+                _ => panic!("expected Disk"),
+            }
+        }
+    }
+
+    #[test]
+    fn mpu_abort_removes_upload() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        store
+            .mpu_put_part(
+                "b",
+                "up",
+                1,
+                BodySource::Bytes(Bytes::from_static(b"x")),
+                "e",
+            )
+            .unwrap();
+        store.mpu_abort("b", "up").unwrap();
+        assert!(!store.mpu_dir("b", "up").exists());
+        // Idempotent.
+        store.mpu_abort("b", "up").unwrap();
+        let loaded = store.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        assert!(snap.multipart_uploads.is_empty());
+    }
+
+    #[test]
+    fn mpu_complete_single_part_fast_path() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        let body = Bytes::from_static(b"only-part-bytes");
+        store
+            .mpu_put_part("b", "up", 1, BodySource::Bytes(body.clone()), "et")
+            .unwrap();
+        let meta = sample_meta("k", body.len() as u64);
+        let body_ref = store.mpu_complete("b", "up", "k", None, &meta).unwrap();
+        match &body_ref {
+            BodyRef::Disk { path, size, .. } => {
+                assert_eq!(*size, body.len() as u64);
+                assert_eq!(std::fs::read(path).unwrap(), body.to_vec());
+            }
+            _ => panic!("expected Disk"),
+        }
+        assert!(!store.mpu_dir("b", "up").exists());
+    }
+
+    #[test]
+    fn mpu_complete_multi_part_concat() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        let p1 = Bytes::from_static(b"AAAA");
+        let p2 = Bytes::from_static(b"BBBBBB");
+        let p3 = Bytes::from_static(b"CC");
+        for (n, b) in [(1u32, &p1), (2, &p2), (3, &p3)] {
+            store
+                .mpu_put_part("b", "up", n, BodySource::Bytes(b.clone()), "e")
+                .unwrap();
+        }
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&p1);
+        expected.extend_from_slice(&p2);
+        expected.extend_from_slice(&p3);
+        let meta = sample_meta("k", expected.len() as u64);
+        let body_ref = store.mpu_complete("b", "up", "k", None, &meta).unwrap();
+        let path = match body_ref {
+            BodyRef::Disk { path, size, .. } => {
+                assert_eq!(size, expected.len() as u64);
+                path
+            }
+            _ => panic!("expected Disk"),
+        };
+        assert_eq!(std::fs::read(&path).unwrap(), expected);
+        assert!(!store.mpu_dir("b", "up").exists());
+    }
+
+    #[test]
+    fn mpu_complete_large_streaming_via_file_source() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+
+        // 3 parts of ~1 MiB each (kept small so tests stay fast but still
+        // exercise the BodySource::File + streaming concat path).
+        const PART_SIZE: usize = 1024 * 1024;
+        let patterns: [u8; 3] = [0x11, 0x22, 0x33];
+        let mut expected: Vec<u8> = Vec::with_capacity(PART_SIZE * 3);
+        for (i, byte) in patterns.iter().enumerate() {
+            let src = tmp.path().join(format!("src-{}.bin", i + 1));
+            let data = vec![*byte; PART_SIZE];
+            std::fs::write(&src, &data).unwrap();
+            expected.extend_from_slice(&data);
+            store
+                .mpu_put_part(
+                    "b",
+                    "up",
+                    (i + 1) as u32,
+                    BodySource::File(src),
+                    "et",
+                )
+                .unwrap();
+        }
+        let meta = sample_meta("k", expected.len() as u64);
+        let body_ref = store.mpu_complete("b", "up", "k", None, &meta).unwrap();
+        let path = match body_ref {
+            BodyRef::Disk { path, size, .. } => {
+                assert_eq!(size, expected.len() as u64);
+                path
+            }
+            _ => panic!("expected Disk"),
+        };
+        let actual = std::fs::read(&path).unwrap();
+        assert_eq!(actual.len(), expected.len());
+        assert_eq!(actual, expected);
+        assert!(!store.mpu_dir("b", "up").exists());
+    }
+
+    #[test]
+    fn mpu_resumable_across_load() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta("b", &BucketMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        let p1 = Bytes::from_static(b"hello-");
+        let p2 = Bytes::from_static(b"world-");
+        store
+            .mpu_put_part("b", "up", 1, BodySource::Bytes(p1.clone()), "e1")
+            .unwrap();
+        store
+            .mpu_put_part("b", "up", 2, BodySource::Bytes(p2.clone()), "e2")
+            .unwrap();
+
+        // Simulate a restart: re-open the store on the same dir and load.
+        let store2 = new_store_with_cache(&tmp, 1024 * 1024).0;
+        let loaded = store2.load().unwrap();
+        let snap = loaded.buckets.get("b").unwrap();
+        let m = snap.multipart_uploads.get("up").unwrap();
+        assert_eq!(m.parts.len(), 2);
+        assert_eq!(m.parts.get(&1).unwrap().meta.etag, "e1");
+        assert_eq!(m.parts.get(&2).unwrap().meta.etag, "e2");
+
+        // Continue the upload on the fresh store.
+        let p3 = Bytes::from_static(b"again!");
+        store2
+            .mpu_put_part("b", "up", 3, BodySource::Bytes(p3.clone()), "e3")
+            .unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&p1);
+        expected.extend_from_slice(&p2);
+        expected.extend_from_slice(&p3);
+        let meta = sample_meta("k", expected.len() as u64);
+        let body_ref = store2.mpu_complete("b", "up", "k", None, &meta).unwrap();
+        let path = match body_ref {
+            BodyRef::Disk { path, .. } => path,
+            _ => panic!(),
+        };
+        assert_eq!(std::fs::read(&path).unwrap(), expected);
+        assert!(!store2.mpu_dir("b", "up").exists());
     }
 
     #[test]

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -717,22 +717,20 @@ impl S3Store for DiskS3Store {
                             let part_meta: UploadPartMeta = toml::from_str(&toml_text)
                                 .map_err(|e| StoreError::Serde(e.to_string()))?;
                             let bin_path = parts_dir.join(format!("{}.bin", part_number));
-                            let (body, size) = if bin_path.exists() {
-                                let sz = std::fs::metadata(&bin_path)?.len();
-                                (
-                                    BodyRef::Disk {
-                                        bucket: meta.name.clone(),
-                                        key: format!("__mpu__/{}", init.upload_id),
-                                        version: Some(format!("part-{}", part_number)),
-                                        path: bin_path,
-                                        size: sz,
-                                    },
-                                    sz,
-                                )
-                            } else {
-                                (BodyRef::Memory(Bytes::new()), 0u64)
+                            if !bin_path.exists() {
+                                return Err(StoreError::Other(format!(
+                                    "missing multipart part body file: {}",
+                                    bin_path.display()
+                                )));
+                            }
+                            let sz = std::fs::metadata(&bin_path)?.len();
+                            let body = BodyRef::Disk {
+                                bucket: meta.name.clone(),
+                                key: format!("__mpu__/{}", init.upload_id),
+                                version: Some(format!("part-{}", part_number)),
+                                path: bin_path,
+                                size: sz,
                             };
-                            let _ = size;
                             loaded_parts.insert(
                                 part_number,
                                 LoadedPart {

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -293,11 +293,7 @@ pub trait S3Store: Send + Sync {
         kind: BucketSubresource,
         payload: &str,
     ) -> StoreResult<()>;
-    fn delete_bucket_subresource(
-        &self,
-        bucket: &str,
-        kind: BucketSubresource,
-    ) -> StoreResult<()>;
+    fn delete_bucket_subresource(&self, bucket: &str, kind: BucketSubresource) -> StoreResult<()>;
     fn delete_bucket(&self, bucket: &str) -> StoreResult<()>;
 
     fn put_object(
@@ -315,12 +311,7 @@ pub trait S3Store: Send + Sync {
         version: Option<&str>,
         meta: &ObjectMeta,
     ) -> StoreResult<()>;
-    fn delete_object(
-        &self,
-        bucket: &str,
-        key: &str,
-        version: Option<&str>,
-    ) -> StoreResult<()>;
+    fn delete_object(&self, bucket: &str, key: &str, version: Option<&str>) -> StoreResult<()>;
     fn open_object_body(&self, body: &BodyRef) -> StoreResult<Bytes>;
 
     fn mpu_create(&self, bucket: &str, upload_id: &str, init: &MpuInit) -> StoreResult<()>;
@@ -406,12 +397,7 @@ impl S3Store for MemoryS3Store {
     ) -> StoreResult<()> {
         Ok(())
     }
-    fn delete_object(
-        &self,
-        _bucket: &str,
-        _key: &str,
-        _version: Option<&str>,
-    ) -> StoreResult<()> {
+    fn delete_object(&self, _bucket: &str, _key: &str, _version: Option<&str>) -> StoreResult<()> {
         Ok(())
     }
     fn open_object_body(&self, body: &BodyRef) -> StoreResult<Bytes> {
@@ -679,16 +665,15 @@ impl S3Store for DiskS3Store {
                         continue;
                     }
                     let init_text = std::fs::read_to_string(&init_path)?;
-                    let init: MpuInit = toml::from_str(&init_text)
-                        .map_err(|e| StoreError::Serde(e.to_string()))?;
+                    let init: MpuInit =
+                        toml::from_str(&init_text).map_err(|e| StoreError::Serde(e.to_string()))?;
                     let mut loaded_parts: BTreeMap<u32, LoadedPart> = BTreeMap::new();
                     let parts_dir = upload_dir.join("parts");
                     if parts_dir.exists() {
                         for part_entry in std::fs::read_dir(&parts_dir)? {
                             let part_entry = part_entry?;
                             let path = part_entry.path();
-                            let Some(fname) = path.file_name().and_then(|s| s.to_str())
-                            else {
+                            let Some(fname) = path.file_name().and_then(|s| s.to_str()) else {
                                 continue;
                             };
                             if !fname.ends_with(".toml") {
@@ -762,12 +747,10 @@ impl S3Store for DiskS3Store {
         Ok(())
     }
 
-    fn delete_bucket_subresource(
-        &self,
-        bucket: &str,
-        kind: BucketSubresource,
-    ) -> StoreResult<()> {
-        let path = self.bucket_dir(bucket).join(Self::subresource_filename(kind));
+    fn delete_bucket_subresource(&self, bucket: &str, kind: BucketSubresource) -> StoreResult<()> {
+        let path = self
+            .bucket_dir(bucket)
+            .join(Self::subresource_filename(kind));
         match std::fs::remove_file(&path) {
             Ok(_) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -855,12 +838,7 @@ impl S3Store for DiskS3Store {
         Ok(())
     }
 
-    fn delete_object(
-        &self,
-        bucket: &str,
-        key: &str,
-        version: Option<&str>,
-    ) -> StoreResult<()> {
+    fn delete_object(&self, bucket: &str, key: &str, version: Option<&str>) -> StoreResult<()> {
         let (dir, bin_path, toml_path) = self.object_paths(bucket, key, version);
         for p in [&bin_path, &toml_path] {
             match std::fs::remove_file(p) {
@@ -889,11 +867,8 @@ impl S3Store for DiskS3Store {
                 path,
                 size: _,
             } => {
-                let body_key = crate::cache::BodyKey::new(
-                    bucket.clone(),
-                    key.clone(),
-                    version.clone(),
-                );
+                let body_key =
+                    crate::cache::BodyKey::new(bucket.clone(), key.clone(), version.clone());
                 if let Some(bytes) = self.cache.get(&body_key) {
                     return Ok(bytes);
                 }
@@ -1121,7 +1096,10 @@ mod disk_tests {
         DiskS3Store::new(tmp.path().to_path_buf(), cache)
     }
 
-    fn new_store_with_cache(tmp: &TempDir, cap: u64) -> (DiskS3Store, Arc<crate::cache::BodyCache>) {
+    fn new_store_with_cache(
+        tmp: &TempDir,
+        cap: u64,
+    ) -> (DiskS3Store, Arc<crate::cache::BodyCache>) {
         let cache = Arc::new(crate::cache::BodyCache::new(cap));
         (
             DiskS3Store::new(tmp.path().to_path_buf(), cache.clone()),
@@ -1162,10 +1140,13 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let variants = [
             BucketSubresource::Tags,
@@ -1186,8 +1167,12 @@ mod disk_tests {
             BucketSubresource::Accelerate,
         ];
         for v in variants {
-            store.put_bucket_subresource("b", v, "payload=true").unwrap();
-            let file = store.bucket_dir("b").join(DiskS3Store::subresource_filename(v));
+            store
+                .put_bucket_subresource("b", v, "payload=true")
+                .unwrap();
+            let file = store
+                .bucket_dir("b")
+                .join(DiskS3Store::subresource_filename(v));
             assert!(file.exists(), "{:?}", v);
             assert_eq!(std::fs::read_to_string(&file).unwrap(), "payload=true");
         }
@@ -1198,10 +1183,13 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         store
             .put_bucket_subresource("b", BucketSubresource::Tags, "x=1")
@@ -1222,10 +1210,13 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let data = Bytes::from_static(b"hello world");
         let meta = sample_meta("k1", data.len() as u64);
@@ -1233,7 +1224,13 @@ mod disk_tests {
             .put_object("b", "k1", None, BodySource::Bytes(data.clone()), &meta)
             .unwrap();
         match &body_ref {
-            BodyRef::Disk { bucket, key, size, path, .. } => {
+            BodyRef::Disk {
+                bucket,
+                key,
+                size,
+                path,
+                ..
+            } => {
                 assert_eq!(bucket, "b");
                 assert_eq!(key, "k1");
                 assert_eq!(*size, data.len() as u64);
@@ -1252,10 +1249,13 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let src = tmp.path().join("src.bin");
         std::fs::write(&src, b"file-body").unwrap();
@@ -1275,10 +1275,13 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let data = Bytes::from_static(b"abc");
         let mut meta = sample_meta("k", 3);
@@ -1300,10 +1303,13 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let (store, cache) = new_store_with_cache(&tmp, 1024 * 1024);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let data = Bytes::from_static(b"bye");
         let meta = sample_meta("k", 3);
@@ -1325,10 +1331,13 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let (store, cache) = new_store_with_cache(&tmp, 1024 * 1024);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let data = Bytes::from_static(b"payload");
         let meta = sample_meta("k", data.len() as u64);
@@ -1353,10 +1362,13 @@ mod disk_tests {
         // capacity 1024 → single-object cap 512. Use 800-byte body.
         let (store, cache) = new_store_with_cache(&tmp, 1024);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let data = Bytes::from(vec![7u8; 800]);
         let meta = sample_meta("big", 800);
@@ -1384,10 +1396,13 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let data = Bytes::from_static(b"x");
         let meta = sample_meta("k", 1);
@@ -1409,10 +1424,13 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         store
             .put_bucket_subresource("b", BucketSubresource::Lifecycle, "<Lifecycle/>")
@@ -1451,11 +1469,14 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                versioning: Some("Enabled".to_string()),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    versioning: Some("Enabled".to_string()),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let base = chrono::Utc::now();
         for (i, (vid, body)) in [("v1", "one"), ("v2", "two"), ("v3", "three")]
@@ -1495,11 +1516,14 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                versioning: Some("Enabled".to_string()),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    versioning: Some("Enabled".to_string()),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let mut m = sample_meta("k", 0);
         m.version_id = Some("dm1".to_string());
@@ -1533,21 +1557,33 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("a", &BucketMeta {
-                name: "a".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "a",
+                &BucketMeta {
+                    name: "a".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                versioning: Some("Enabled".to_string()),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    versioning: Some("Enabled".to_string()),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let ma = sample_meta("only", 3);
         store
-            .put_object("a", "only", None, BodySource::Bytes(Bytes::from_static(b"aaa")), &ma)
+            .put_object(
+                "a",
+                "only",
+                None,
+                BodySource::Bytes(Bytes::from_static(b"aaa")),
+                &ma,
+            )
             .unwrap();
         let base = chrono::Utc::now();
         for (i, vid) in ["v1", "v2"].iter().enumerate() {
@@ -1590,10 +1626,13 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         let init = sample_mpu_init("up1", "k1");
         store.mpu_create("b", "up1", &init).unwrap();
@@ -1610,12 +1649,17 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
-        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        store
+            .mpu_create("b", "up", &sample_mpu_init("up", "k"))
+            .unwrap();
         let bodies = [
             Bytes::from_static(b"part-one"),
             Bytes::from_static(b"part-two-longer"),
@@ -1624,7 +1668,13 @@ mod disk_tests {
         for (i, body) in bodies.iter().enumerate() {
             let n = (i + 1) as u32;
             store
-                .mpu_put_part("b", "up", n, BodySource::Bytes(body.clone()), &format!("et{}", n))
+                .mpu_put_part(
+                    "b",
+                    "up",
+                    n,
+                    BodySource::Bytes(body.clone()),
+                    &format!("et{}", n),
+                )
                 .unwrap();
         }
         let loaded = store.load().unwrap();
@@ -1652,12 +1702,17 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
-        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        store
+            .mpu_create("b", "up", &sample_mpu_init("up", "k"))
+            .unwrap();
         store
             .mpu_put_part(
                 "b",
@@ -1681,12 +1736,17 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
-        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        store
+            .mpu_create("b", "up", &sample_mpu_init("up", "k"))
+            .unwrap();
         let body = Bytes::from_static(b"only-part-bytes");
         store
             .mpu_put_part("b", "up", 1, BodySource::Bytes(body.clone()), "et")
@@ -1708,12 +1768,17 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
-        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        store
+            .mpu_create("b", "up", &sample_mpu_init("up", "k"))
+            .unwrap();
         let p1 = Bytes::from_static(b"AAAA");
         let p2 = Bytes::from_static(b"BBBBBB");
         let p3 = Bytes::from_static(b"CC");
@@ -1744,12 +1809,17 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
-        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        store
+            .mpu_create("b", "up", &sample_mpu_init("up", "k"))
+            .unwrap();
 
         // 3 parts of ~1 MiB each (kept small so tests stay fast but still
         // exercise the BodySource::File + streaming concat path).
@@ -1762,13 +1832,7 @@ mod disk_tests {
             std::fs::write(&src, &data).unwrap();
             expected.extend_from_slice(&data);
             store
-                .mpu_put_part(
-                    "b",
-                    "up",
-                    (i + 1) as u32,
-                    BodySource::File(src),
-                    "et",
-                )
+                .mpu_put_part("b", "up", (i + 1) as u32, BodySource::File(src), "et")
                 .unwrap();
         }
         let meta = sample_meta("k", expected.len() as u64);
@@ -1791,12 +1855,17 @@ mod disk_tests {
         let tmp = TempDir::new().unwrap();
         let store = new_store(&tmp);
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
-        store.mpu_create("b", "up", &sample_mpu_init("up", "k")).unwrap();
+        store
+            .mpu_create("b", "up", &sample_mpu_init("up", "k"))
+            .unwrap();
         let p1 = Bytes::from_static(b"hello-");
         let p2 = Bytes::from_static(b"world-");
         store
@@ -1936,8 +2005,14 @@ mod disk_tests {
             )
             .unwrap();
         let mut configs = HashMap::new();
-        configs.insert("inv-1".to_string(), "<InventoryConfiguration id=\"inv-1\"/>".to_string());
-        configs.insert("inv-2".to_string(), "<InventoryConfiguration id=\"inv-2\"/>".to_string());
+        configs.insert(
+            "inv-1".to_string(),
+            "<InventoryConfiguration id=\"inv-1\"/>".to_string(),
+        );
+        configs.insert(
+            "inv-2".to_string(),
+            "<InventoryConfiguration id=\"inv-2\"/>".to_string(),
+        );
         let snap = InventorySnapshot {
             configs: configs.clone(),
         };
@@ -1964,10 +2039,13 @@ mod disk_tests {
         let store = new_store(&tmp);
         // Bucket meta with no versioning field set.
         store
-            .put_bucket_meta("b", &BucketMeta {
-                name: "b".to_string(),
-                ..Default::default()
-            })
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         // Legacy sidecar: a bare versioning.toml with "Enabled".
         let path = store.bucket_dir("b").join("versioning.toml");

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -87,6 +87,26 @@ pub struct AclGrantSnapshot {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct TagsSnapshot {
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct AclSnapshot {
+    #[serde(default)]
+    pub owner_id: String,
+    #[serde(default)]
+    pub grants: Vec<AclGrantSnapshot>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct InventorySnapshot {
+    #[serde(default)]
+    pub configs: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ObjectMeta {
     #[serde(default)]
     pub key: String,
@@ -1812,6 +1832,130 @@ mod disk_tests {
         };
         assert_eq!(std::fs::read(&path).unwrap(), expected);
         assert!(!store2.mpu_dir("b", "up").exists());
+    }
+
+    #[test]
+    fn tags_snapshot_roundtrip_via_store() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let mut tags = HashMap::new();
+        tags.insert("env".to_string(), "prod".to_string());
+        tags.insert("team".to_string(), "s3".to_string());
+        let snap = TagsSnapshot { tags: tags.clone() };
+        let payload = toml::to_string(&snap).unwrap();
+        store
+            .put_bucket_subresource("b", BucketSubresource::Tags, &payload)
+            .unwrap();
+        let loaded = store.load().unwrap();
+        let text = loaded
+            .buckets
+            .get("b")
+            .unwrap()
+            .subresources
+            .get("tags.toml")
+            .cloned()
+            .unwrap();
+        let decoded: TagsSnapshot = toml::from_str(&text).unwrap();
+        assert_eq!(decoded.tags, tags);
+    }
+
+    #[test]
+    fn acl_snapshot_roundtrip_via_store() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let snap = AclSnapshot {
+            owner_id: "owner-abc".to_string(),
+            grants: vec![
+                AclGrantSnapshot {
+                    grantee_type: "CanonicalUser".to_string(),
+                    grantee_id: Some("owner-abc".to_string()),
+                    grantee_display_name: Some("owner".to_string()),
+                    grantee_uri: None,
+                    permission: "FULL_CONTROL".to_string(),
+                },
+                AclGrantSnapshot {
+                    grantee_type: "Group".to_string(),
+                    grantee_id: None,
+                    grantee_display_name: None,
+                    grantee_uri: Some(
+                        "http://acs.amazonaws.com/groups/global/AllUsers".to_string(),
+                    ),
+                    permission: "READ".to_string(),
+                },
+            ],
+        };
+        let payload = toml::to_string(&snap).unwrap();
+        store
+            .put_bucket_subresource("b", BucketSubresource::Acl, &payload)
+            .unwrap();
+        let loaded = store.load().unwrap();
+        let text = loaded
+            .buckets
+            .get("b")
+            .unwrap()
+            .subresources
+            .get("acl.toml")
+            .cloned()
+            .unwrap();
+        let decoded: AclSnapshot = toml::from_str(&text).unwrap();
+        assert_eq!(decoded.owner_id, "owner-abc");
+        assert_eq!(decoded.grants.len(), 2);
+        assert_eq!(decoded.grants[0].permission, "FULL_CONTROL");
+        assert_eq!(decoded.grants[1].grantee_type, "Group");
+    }
+
+    #[test]
+    fn inventory_snapshot_roundtrip_via_store() {
+        let tmp = TempDir::new().unwrap();
+        let store = new_store(&tmp);
+        store
+            .put_bucket_meta(
+                "b",
+                &BucketMeta {
+                    name: "b".to_string(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let mut configs = HashMap::new();
+        configs.insert("inv-1".to_string(), "<InventoryConfiguration id=\"inv-1\"/>".to_string());
+        configs.insert("inv-2".to_string(), "<InventoryConfiguration id=\"inv-2\"/>".to_string());
+        let snap = InventorySnapshot {
+            configs: configs.clone(),
+        };
+        let payload = toml::to_string(&snap).unwrap();
+        store
+            .put_bucket_subresource("b", BucketSubresource::Inventory, &payload)
+            .unwrap();
+        let loaded = store.load().unwrap();
+        let text = loaded
+            .buckets
+            .get("b")
+            .unwrap()
+            .subresources
+            .get("inventory.toml")
+            .cloned()
+            .unwrap();
+        let decoded: InventorySnapshot = toml::from_str(&text).unwrap();
+        assert_eq!(decoded.configs, configs);
     }
 
     #[test]

--- a/crates/fakecloud-persistence/src/version.rs
+++ b/crates/fakecloud-persistence/src/version.rs
@@ -1,0 +1,92 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+pub const FORMAT_VERSION: u32 = 1;
+pub const VERSION_FILE_NAME: &str = "fakecloud.version.toml";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FormatVersion {
+    pub format_version: u32,
+    pub fakecloud_version: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Error)]
+pub enum VersionError {
+    #[error("io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to parse {path}: {source}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    #[error("failed to serialize version file: {0}")]
+    Serialize(#[from] toml::ser::Error),
+    #[error(
+        "persistence format version mismatch at {path}: on-disk format_version={on_disk}, binary expects {expected}. \
+         Either point --data-path at a matching directory, or delete the directory to start fresh."
+    )]
+    FormatMismatch {
+        path: PathBuf,
+        on_disk: u32,
+        expected: u32,
+    },
+}
+
+fn version_file_path(dir: &Path) -> PathBuf {
+    dir.join(VERSION_FILE_NAME)
+}
+
+pub fn write_version_file(dir: &Path, fakecloud_version: &str) -> Result<(), VersionError> {
+    let path = version_file_path(dir);
+    let value = FormatVersion {
+        format_version: FORMAT_VERSION,
+        fakecloud_version: fakecloud_version.to_string(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    crate::atomic::write_atomic_toml(&path, &value).map_err(|source| VersionError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    Ok(())
+}
+
+pub fn check_version_file(dir: &Path) -> Result<(), VersionError> {
+    let path = version_file_path(dir);
+    if !path.exists() {
+        return Ok(());
+    }
+    let text = std::fs::read_to_string(&path).map_err(|source| VersionError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let parsed: FormatVersion = toml::from_str(&text).map_err(|source| VersionError::Parse {
+        path: path.clone(),
+        source,
+    })?;
+    if parsed.format_version != FORMAT_VERSION {
+        return Err(VersionError::FormatMismatch {
+            path,
+            on_disk: parsed.format_version,
+            expected: FORMAT_VERSION,
+        });
+    }
+    Ok(())
+}
+
+pub fn ensure_version_file(dir: &Path, fakecloud_version: &str) -> Result<(), VersionError> {
+    let path = version_file_path(dir);
+    if path.exists() {
+        check_version_file(dir)
+    } else {
+        write_version_file(dir, fakecloud_version)
+    }
+}

--- a/crates/fakecloud-persistence/src/version.rs
+++ b/crates/fakecloud-persistence/src/version.rs
@@ -39,6 +39,11 @@ pub enum VersionError {
         on_disk: u32,
         expected: u32,
     },
+    #[error(
+        "persistence data directory {dir} is not empty but has no {file} file. \
+         Refusing to initialize it: either point --data-path at an empty directory or restore the missing version file."
+    )]
+    NonEmptyDirectoryWithoutVersionFile { dir: PathBuf, file: String },
 }
 
 fn version_file_path(dir: &Path) -> PathBuf {
@@ -85,8 +90,50 @@ pub fn check_version_file(dir: &Path) -> Result<(), VersionError> {
 pub fn ensure_version_file(dir: &Path, fakecloud_version: &str) -> Result<(), VersionError> {
     let path = version_file_path(dir);
     if path.exists() {
-        check_version_file(dir)
-    } else {
-        write_version_file(dir, fakecloud_version)
+        return check_version_file(dir);
+    }
+    if dir.exists() {
+        let mut entries = std::fs::read_dir(dir).map_err(|source| VersionError::Io {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        if entries.next().is_some() {
+            return Err(VersionError::NonEmptyDirectoryWithoutVersionFile {
+                dir: dir.to_path_buf(),
+                file: VERSION_FILE_NAME.to_string(),
+            });
+        }
+    }
+    write_version_file(dir, fakecloud_version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_creates_version_file_in_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        ensure_version_file(tmp.path(), "test").unwrap();
+        assert!(tmp.path().join(VERSION_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn ensure_rejects_non_empty_dir_without_version_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("stray.txt"), b"hello").unwrap();
+        let err = ensure_version_file(tmp.path(), "test").unwrap_err();
+        matches!(
+            err,
+            VersionError::NonEmptyDirectoryWithoutVersionFile { .. }
+        );
+    }
+
+    #[test]
+    fn ensure_ok_when_version_file_already_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_version_file(tmp.path(), "test").unwrap();
+        std::fs::write(tmp.path().join("stray.txt"), b"hello").unwrap();
+        ensure_version_file(tmp.path(), "test").unwrap();
     }
 }

--- a/crates/fakecloud-persistence/src/warn.rs
+++ b/crates/fakecloud-persistence/src/warn.rs
@@ -1,0 +1,8 @@
+/// Emit a one-shot warning that a given service does not yet honor
+/// `PersistenceConfig` and will continue to run purely in memory.
+pub fn warn_unsupported(service_name: &str) {
+    tracing::warn!(
+        service = service_name,
+        "persistence not yet supported, running in-memory"
+    );
+}

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -2815,7 +2815,7 @@ mod tests {
         let request = request("DescribeDBEngineVersions", &[("Engine", "postgres")]);
 
         let response = service.handle(request).await.expect("response");
-        let body = String::from_utf8(response.body.to_vec()).expect("utf8");
+        let body = String::from_utf8(response.body.expect_bytes().to_vec()).expect("utf8");
 
         assert!(body.contains("<DescribeDBEngineVersionsResponse"));
         assert!(body.contains("<Engine>postgres</Engine>"));

--- a/crates/fakecloud-s3/Cargo.toml
+++ b/crates/fakecloud-s3/Cargo.toml
@@ -28,3 +28,4 @@ base64 = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
 crc32fast = { workspace = true }
+toml = { workspace = true }

--- a/crates/fakecloud-s3/Cargo.toml
+++ b/crates/fakecloud-s3/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-kms = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-s3/src/inventory.rs
+++ b/crates/fakecloud-s3/src/inventory.rs
@@ -111,7 +111,7 @@ pub fn generate_inventory_report(state: &SharedS3State, source_bucket: &str, con
 
     let report_object = S3Object {
         key: report_key.clone(),
-        data,
+        body: crate::state::memory_body(data),
         content_type: "text/csv".to_string(),
         etag,
         size,

--- a/crates/fakecloud-s3/src/lib.rs
+++ b/crates/fakecloud-s3/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod inventory;
 pub mod lifecycle;
 pub mod logging;
+pub mod persistence;
 pub mod service;
 pub mod simulation;
 pub mod state;

--- a/crates/fakecloud-s3/src/logging.rs
+++ b/crates/fakecloud-s3/src/logging.rs
@@ -109,7 +109,7 @@ pub fn maybe_write_access_log(
 
     let log_object = S3Object {
         key: log_key.clone(),
-        data,
+        body: crate::state::memory_body(data),
         content_type: "text/plain".to_string(),
         etag,
         size,

--- a/crates/fakecloud-s3/src/logging.rs
+++ b/crates/fakecloud-s3/src/logging.rs
@@ -1,8 +1,12 @@
+use std::sync::Arc;
+
 use bytes::Bytes;
 use chrono::Utc;
+use fakecloud_persistence::{BodySource, S3Store};
 use md5::{Digest, Md5};
 use uuid::Uuid;
 
+use crate::persistence::object_meta_snapshot;
 use crate::state::{S3Object, SharedS3State};
 use crate::xml_util::extract_tag;
 
@@ -70,6 +74,7 @@ pub fn format_access_log_entry(
 /// operation on a logging-enabled bucket produces a record.
 pub fn maybe_write_access_log(
     state: &SharedS3State,
+    store: &Arc<dyn S3Store>,
     source_bucket: &str,
     request: &AccessLogRequest<'_>,
 ) {
@@ -109,7 +114,7 @@ pub fn maybe_write_access_log(
 
     let log_object = S3Object {
         key: log_key.clone(),
-        body: crate::state::memory_body(data),
+        body: crate::state::memory_body(data.clone()),
         content_type: "text/plain".to_string(),
         etag,
         size,
@@ -118,9 +123,28 @@ pub fn maybe_write_access_log(
         ..Default::default()
     };
 
-    let mut st = state.write();
-    if let Some(target) = st.buckets.get_mut(&config.target_bucket) {
-        target.objects.insert(log_key, log_object);
+    let meta = object_meta_snapshot(&log_object);
+    {
+        let mut st = state.write();
+        if let Some(target) = st.buckets.get_mut(&config.target_bucket) {
+            target.objects.insert(log_key.clone(), log_object);
+        } else {
+            return;
+        }
+    }
+    if let Err(err) = store.put_object(
+        &config.target_bucket,
+        &log_key,
+        None,
+        BodySource::Bytes(data),
+        &meta,
+    ) {
+        tracing::error!(
+            bucket = %config.target_bucket,
+            key = %log_key,
+            error = %err,
+            "failed to persist S3 access log object via store"
+        );
     }
 }
 

--- a/crates/fakecloud-s3/src/persistence.rs
+++ b/crates/fakecloud-s3/src/persistence.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, HashMap};
 
 use fakecloud_persistence::{
-    AclGrantSnapshot, BucketMeta, BucketSnapshot, LoadedObject, MpuInit, ObjectMeta,
-    S3StateSnapshot, UploadPartMeta,
+    AclGrantSnapshot, BucketMeta, BucketSnapshot, LoadedMpu, LoadedObject, LoadedPart, MpuInit,
+    ObjectMeta, S3StateSnapshot, UploadPartMeta,
 };
 
 use crate::state::{AclGrant, MultipartUpload, S3Bucket, S3Object, S3State, UploadPart};
@@ -131,12 +131,46 @@ pub fn s3_object_from_loaded(lo: LoadedObject) -> S3Object {
     }
 }
 
+pub fn upload_part_from_loaded(lp: LoadedPart) -> UploadPart {
+    let LoadedPart { meta, body } = lp;
+    UploadPart {
+        part_number: meta.part_number,
+        body,
+        etag: meta.etag,
+        size: meta.size,
+        last_modified: meta.last_modified,
+    }
+}
+
+pub fn multipart_upload_from_loaded(lm: LoadedMpu) -> MultipartUpload {
+    let LoadedMpu { init, parts } = lm;
+    let runtime_parts: BTreeMap<u32, UploadPart> = parts
+        .into_iter()
+        .map(|(n, lp)| (n, upload_part_from_loaded(lp)))
+        .collect();
+    MultipartUpload {
+        upload_id: init.upload_id,
+        key: init.key,
+        initiated: init.initiated,
+        parts: runtime_parts,
+        metadata: init.metadata,
+        content_type: init.content_type,
+        storage_class: init.storage_class,
+        sse_algorithm: init.sse_algorithm,
+        sse_kms_key_id: init.sse_kms_key_id,
+        tagging: init.tagging,
+        acl_grants: init.acl_grants.iter().map(acl_grant_from_snapshot).collect(),
+        checksum_algorithm: init.checksum_algorithm,
+    }
+}
+
 pub fn s3_bucket_from_snapshot(name: &str, snap: BucketSnapshot, default_region: &str) -> S3Bucket {
     let BucketSnapshot {
         meta,
         objects,
         object_versions,
         subresources,
+        multipart_uploads,
     } = snap;
     let region = if meta.region.is_empty() {
         default_region.to_string()
@@ -176,6 +210,10 @@ pub fn s3_bucket_from_snapshot(name: &str, snap: BucketSnapshot, default_region:
     for (key, vs) in object_versions {
         b.object_versions
             .insert(key, vs.into_iter().map(s3_object_from_loaded).collect());
+    }
+    for (upload_id, lm) in multipart_uploads {
+        b.multipart_uploads
+            .insert(upload_id, multipart_upload_from_loaded(lm));
     }
     // Subresources are stored as raw pass-through strings on the service side;
     // fold any present into the matching Option<String> field.

--- a/crates/fakecloud-s3/src/persistence.rs
+++ b/crates/fakecloud-s3/src/persistence.rs
@@ -1,8 +1,11 @@
+use std::collections::{BTreeMap, HashMap};
+
 use fakecloud_persistence::{
-    AclGrantSnapshot, BucketMeta, MpuInit, ObjectMeta, UploadPartMeta,
+    AclGrantSnapshot, BucketMeta, BucketSnapshot, LoadedObject, MpuInit, ObjectMeta,
+    S3StateSnapshot, UploadPartMeta,
 };
 
-use crate::state::{AclGrant, MultipartUpload, S3Bucket, S3Object, UploadPart};
+use crate::state::{AclGrant, MultipartUpload, S3Bucket, S3Object, S3State, UploadPart};
 
 impl From<&AclGrant> for AclGrantSnapshot {
     fn from(g: &AclGrant) -> Self {
@@ -83,4 +86,130 @@ pub fn upload_part_meta_snapshot(p: &UploadPart) -> UploadPartMeta {
         size: p.size,
         last_modified: p.last_modified,
     }
+}
+
+fn acl_grant_from_snapshot(g: &AclGrantSnapshot) -> AclGrant {
+    AclGrant {
+        grantee_type: g.grantee_type.clone(),
+        grantee_id: g.grantee_id.clone(),
+        grantee_display_name: g.grantee_display_name.clone(),
+        grantee_uri: g.grantee_uri.clone(),
+        permission: g.permission.clone(),
+    }
+}
+
+pub fn s3_object_from_loaded(lo: LoadedObject) -> S3Object {
+    let LoadedObject { meta, body } = lo;
+    S3Object {
+        key: meta.key,
+        body,
+        content_type: meta.content_type,
+        etag: meta.etag,
+        size: meta.size,
+        last_modified: meta.last_modified,
+        metadata: meta.metadata,
+        storage_class: meta.storage_class,
+        tags: meta.tags,
+        acl_grants: meta.acl_grants.iter().map(acl_grant_from_snapshot).collect(),
+        acl_owner_id: meta.acl_owner_id,
+        parts_count: meta.parts_count,
+        part_sizes: meta.part_sizes,
+        sse_algorithm: meta.sse_algorithm,
+        sse_kms_key_id: meta.sse_kms_key_id,
+        bucket_key_enabled: meta.bucket_key_enabled,
+        version_id: meta.version_id,
+        is_delete_marker: meta.is_delete_marker,
+        content_encoding: meta.content_encoding,
+        website_redirect_location: meta.website_redirect_location,
+        restore_ongoing: meta.restore_ongoing,
+        restore_expiry: meta.restore_expiry,
+        checksum_algorithm: meta.checksum_algorithm,
+        checksum_value: meta.checksum_value,
+        lock_mode: meta.lock_mode,
+        lock_retain_until: meta.lock_retain_until,
+        lock_legal_hold: meta.lock_legal_hold,
+    }
+}
+
+pub fn s3_bucket_from_snapshot(name: &str, snap: BucketSnapshot, default_region: &str) -> S3Bucket {
+    let BucketSnapshot {
+        meta,
+        objects,
+        object_versions,
+        subresources,
+    } = snap;
+    let region = if meta.region.is_empty() {
+        default_region.to_string()
+    } else {
+        meta.region.clone()
+    };
+    let mut b = S3Bucket {
+        name: name.to_string(),
+        creation_date: meta.creation_date,
+        region,
+        objects: BTreeMap::new(),
+        tags: HashMap::new(),
+        acl_grants: Vec::new(),
+        acl_owner_id: meta.acl_owner_id.clone(),
+        multipart_uploads: HashMap::new(),
+        versioning: meta.versioning.clone(),
+        object_versions: HashMap::new(),
+        acl: meta.acl.clone(),
+        encryption_config: None,
+        lifecycle_config: None,
+        policy: None,
+        cors_config: None,
+        notification_config: None,
+        logging_config: None,
+        website_config: None,
+        accelerate_status: meta.accelerate_status.clone(),
+        public_access_block: None,
+        object_lock_config: None,
+        replication_config: None,
+        ownership_controls: None,
+        inventory_configs: HashMap::new(),
+        eventbridge_enabled: meta.eventbridge_enabled,
+    };
+    for (key, lo) in objects {
+        b.objects.insert(key, s3_object_from_loaded(lo));
+    }
+    for (key, vs) in object_versions {
+        b.object_versions
+            .insert(key, vs.into_iter().map(s3_object_from_loaded).collect());
+    }
+    // Subresources are stored as raw pass-through strings on the service side;
+    // fold any present into the matching Option<String> field.
+    for (fname, text) in subresources {
+        match fname.as_str() {
+            "lifecycle.toml" => b.lifecycle_config = Some(text),
+            "cors.toml" => b.cors_config = Some(text),
+            "policy.toml" => b.policy = Some(text),
+            "notification.toml" => b.notification_config = Some(text),
+            "logging.toml" => b.logging_config = Some(text),
+            "website.toml" => b.website_config = Some(text),
+            "public_access_block.toml" => b.public_access_block = Some(text),
+            "object_lock.toml" => b.object_lock_config = Some(text),
+            "replication.toml" => b.replication_config = Some(text),
+            "ownership.toml" => b.ownership_controls = Some(text),
+            "encryption.toml" => b.encryption_config = Some(text),
+            // tags.toml, acl.toml, inventory.toml, accelerate.toml, versioning.toml
+            // are covered by BucketMeta (versioning/accelerate) or are pre-existing
+            // phase-2 holes (tags, acl_grants, inventory) with empty payloads today.
+            _ => {}
+        }
+    }
+    b
+}
+
+pub fn hydrate_s3_state(
+    snapshot: S3StateSnapshot,
+    account_id: &str,
+    region: &str,
+) -> S3State {
+    let mut state = S3State::new(account_id, region);
+    for (name, snap) in snapshot.buckets {
+        let bucket = s3_bucket_from_snapshot(&name, snap, region);
+        state.buckets.insert(name, bucket);
+    }
+    state
 }

--- a/crates/fakecloud-s3/src/persistence.rs
+++ b/crates/fakecloud-s3/src/persistence.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, HashMap};
 
 use fakecloud_persistence::{
-    AclGrantSnapshot, BucketMeta, BucketSnapshot, LoadedMpu, LoadedObject, LoadedPart, MpuInit,
-    ObjectMeta, S3StateSnapshot, UploadPartMeta,
+    AclGrantSnapshot, AclSnapshot, BucketMeta, BucketSnapshot, InventorySnapshot, LoadedMpu,
+    LoadedObject, LoadedPart, MpuInit, ObjectMeta, S3StateSnapshot, TagsSnapshot, UploadPartMeta,
 };
 
 use crate::state::{AclGrant, MultipartUpload, S3Bucket, S3Object, S3State, UploadPart};
@@ -164,7 +164,11 @@ pub fn multipart_upload_from_loaded(lm: LoadedMpu) -> MultipartUpload {
     }
 }
 
-pub fn s3_bucket_from_snapshot(name: &str, snap: BucketSnapshot, default_region: &str) -> S3Bucket {
+pub fn s3_bucket_from_snapshot(
+    name: &str,
+    snap: BucketSnapshot,
+    default_region: &str,
+) -> Result<S3Bucket, String> {
     let BucketSnapshot {
         meta,
         objects,
@@ -215,8 +219,6 @@ pub fn s3_bucket_from_snapshot(name: &str, snap: BucketSnapshot, default_region:
         b.multipart_uploads
             .insert(upload_id, multipart_upload_from_loaded(lm));
     }
-    // Subresources are stored as raw pass-through strings on the service side;
-    // fold any present into the matching Option<String> field.
     for (fname, text) in subresources {
         match fname.as_str() {
             "lifecycle.toml" => b.lifecycle_config = Some(text),
@@ -230,24 +232,51 @@ pub fn s3_bucket_from_snapshot(name: &str, snap: BucketSnapshot, default_region:
             "replication.toml" => b.replication_config = Some(text),
             "ownership.toml" => b.ownership_controls = Some(text),
             "encryption.toml" => b.encryption_config = Some(text),
-            // tags.toml, acl.toml, inventory.toml, accelerate.toml, versioning.toml
-            // are covered by BucketMeta (versioning/accelerate) or are pre-existing
-            // phase-2 holes (tags, acl_grants, inventory) with empty payloads today.
+            "tags.toml" => {
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let snap: TagsSnapshot = toml::from_str(&text).map_err(|e| {
+                    format!("failed to parse tags.toml for bucket {name}: {e}")
+                })?;
+                b.tags = snap.tags;
+            }
+            "acl.toml" => {
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let snap: AclSnapshot = toml::from_str(&text).map_err(|e| {
+                    format!("failed to parse acl.toml for bucket {name}: {e}")
+                })?;
+                if !snap.owner_id.is_empty() {
+                    b.acl_owner_id = snap.owner_id;
+                }
+                b.acl_grants = snap.grants.iter().map(acl_grant_from_snapshot).collect();
+            }
+            "inventory.toml" => {
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let snap: InventorySnapshot = toml::from_str(&text).map_err(|e| {
+                    format!("failed to parse inventory.toml for bucket {name}: {e}")
+                })?;
+                b.inventory_configs = snap.configs;
+            }
             _ => {}
         }
     }
-    b
+    Ok(b)
 }
 
 pub fn hydrate_s3_state(
     snapshot: S3StateSnapshot,
     account_id: &str,
     region: &str,
-) -> S3State {
+) -> Result<S3State, String> {
     let mut state = S3State::new(account_id, region);
     for (name, snap) in snapshot.buckets {
-        let bucket = s3_bucket_from_snapshot(&name, snap, region);
+        let bucket = s3_bucket_from_snapshot(&name, snap, region)?;
         state.buckets.insert(name, bucket);
     }
-    state
+    Ok(state)
 }

--- a/crates/fakecloud-s3/src/persistence.rs
+++ b/crates/fakecloud-s3/src/persistence.rs
@@ -1,0 +1,86 @@
+use fakecloud_persistence::{
+    AclGrantSnapshot, BucketMeta, MpuInit, ObjectMeta, UploadPartMeta,
+};
+
+use crate::state::{AclGrant, MultipartUpload, S3Bucket, S3Object, UploadPart};
+
+impl From<&AclGrant> for AclGrantSnapshot {
+    fn from(g: &AclGrant) -> Self {
+        Self {
+            grantee_type: g.grantee_type.clone(),
+            grantee_id: g.grantee_id.clone(),
+            grantee_display_name: g.grantee_display_name.clone(),
+            grantee_uri: g.grantee_uri.clone(),
+            permission: g.permission.clone(),
+        }
+    }
+}
+
+pub fn bucket_meta_snapshot(b: &S3Bucket) -> BucketMeta {
+    BucketMeta {
+        name: b.name.clone(),
+        creation_date: b.creation_date,
+        region: b.region.clone(),
+        versioning: b.versioning.clone(),
+        acl: b.acl.clone(),
+        acl_owner_id: b.acl_owner_id.clone(),
+        accelerate_status: b.accelerate_status.clone(),
+        eventbridge_enabled: b.eventbridge_enabled,
+    }
+}
+
+pub fn object_meta_snapshot(o: &S3Object) -> ObjectMeta {
+    ObjectMeta {
+        key: o.key.clone(),
+        content_type: o.content_type.clone(),
+        etag: o.etag.clone(),
+        size: o.size,
+        last_modified: o.last_modified,
+        metadata: o.metadata.clone(),
+        tags: o.tags.clone(),
+        storage_class: o.storage_class.clone(),
+        acl_grants: o.acl_grants.iter().map(AclGrantSnapshot::from).collect(),
+        acl_owner_id: o.acl_owner_id.clone(),
+        parts_count: o.parts_count,
+        part_sizes: o.part_sizes.clone(),
+        sse_algorithm: o.sse_algorithm.clone(),
+        sse_kms_key_id: o.sse_kms_key_id.clone(),
+        bucket_key_enabled: o.bucket_key_enabled,
+        version_id: o.version_id.clone(),
+        is_delete_marker: o.is_delete_marker,
+        restore_ongoing: o.restore_ongoing,
+        restore_expiry: o.restore_expiry.clone(),
+        checksum_algorithm: o.checksum_algorithm.clone(),
+        checksum_value: o.checksum_value.clone(),
+        lock_mode: o.lock_mode.clone(),
+        lock_retain_until: o.lock_retain_until,
+        lock_legal_hold: o.lock_legal_hold.clone(),
+        content_encoding: o.content_encoding.clone(),
+        website_redirect_location: o.website_redirect_location.clone(),
+    }
+}
+
+pub fn mpu_init_snapshot(m: &MultipartUpload) -> MpuInit {
+    MpuInit {
+        upload_id: m.upload_id.clone(),
+        key: m.key.clone(),
+        initiated: m.initiated,
+        metadata: m.metadata.clone(),
+        content_type: m.content_type.clone(),
+        storage_class: m.storage_class.clone(),
+        sse_algorithm: m.sse_algorithm.clone(),
+        sse_kms_key_id: m.sse_kms_key_id.clone(),
+        tagging: m.tagging.clone(),
+        acl_grants: m.acl_grants.iter().map(AclGrantSnapshot::from).collect(),
+        checksum_algorithm: m.checksum_algorithm.clone(),
+    }
+}
+
+pub fn upload_part_meta_snapshot(p: &UploadPart) -> UploadPartMeta {
+    UploadPartMeta {
+        part_number: p.part_number,
+        etag: p.etag.clone(),
+        size: p.size,
+        last_modified: p.last_modified,
+    }
+}

--- a/crates/fakecloud-s3/src/persistence.rs
+++ b/crates/fakecloud-s3/src/persistence.rs
@@ -189,13 +189,28 @@ pub fn s3_bucket_from_snapshot(
     } else {
         meta.region.clone()
     };
+    // Default owner grant, mirroring `S3Bucket::new`. Used when no `acl.toml`
+    // sidecar was persisted (bucket created without a custom ACL).
+    let owner_id = meta.acl_owner_id.clone();
+    let default_owner_grant = AclGrant {
+        grantee_type: "CanonicalUser".to_string(),
+        grantee_id: Some(owner_id.clone()),
+        grantee_display_name: Some(owner_id.clone()),
+        grantee_uri: None,
+        permission: "FULL_CONTROL".to_string(),
+    };
+    let has_acl_sidecar = subresources.contains_key("acl.toml");
     let mut b = S3Bucket {
         name: name.to_string(),
         creation_date: meta.creation_date,
         region,
         objects: BTreeMap::new(),
         tags: HashMap::new(),
-        acl_grants: Vec::new(),
+        acl_grants: if has_acl_sidecar {
+            Vec::new()
+        } else {
+            vec![default_owner_grant]
+        },
         acl_owner_id: meta.acl_owner_id.clone(),
         multipart_uploads: HashMap::new(),
         versioning: meta.versioning.clone(),
@@ -285,4 +300,53 @@ pub fn hydrate_s3_state(
         state.buckets.insert(name, bucket);
     }
     Ok(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hydrate_bucket_without_acl_sidecar_gets_default_owner_grant() {
+        let snap = BucketSnapshot {
+            meta: BucketMeta {
+                name: "b".into(),
+                acl_owner_id: "owner-xyz".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let b = s3_bucket_from_snapshot("b", snap, "us-east-1").unwrap();
+        assert_eq!(b.acl_grants.len(), 1);
+        let g = &b.acl_grants[0];
+        assert_eq!(g.grantee_type, "CanonicalUser");
+        assert_eq!(g.grantee_id.as_deref(), Some("owner-xyz"));
+        assert_eq!(g.permission, "FULL_CONTROL");
+    }
+
+    #[test]
+    fn hydrate_bucket_with_acl_sidecar_uses_sidecar() {
+        let acl_toml = r#"
+owner_id = "owner-xyz"
+[[grants]]
+grantee_type = "CanonicalUser"
+grantee_id = "grantee-a"
+permission = "READ"
+"#;
+        let mut subresources = HashMap::new();
+        subresources.insert("acl.toml".to_string(), acl_toml.to_string());
+        let snap = BucketSnapshot {
+            meta: BucketMeta {
+                name: "b".into(),
+                acl_owner_id: "owner-xyz".into(),
+                ..Default::default()
+            },
+            subresources,
+            ..Default::default()
+        };
+        let b = s3_bucket_from_snapshot("b", snap, "us-east-1").unwrap();
+        assert_eq!(b.acl_grants.len(), 1);
+        assert_eq!(b.acl_grants[0].grantee_id.as_deref(), Some("grantee-a"));
+        assert_eq!(b.acl_grants[0].permission, "READ");
+    }
 }

--- a/crates/fakecloud-s3/src/persistence.rs
+++ b/crates/fakecloud-s3/src/persistence.rs
@@ -110,7 +110,11 @@ pub fn s3_object_from_loaded(lo: LoadedObject) -> S3Object {
         metadata: meta.metadata,
         storage_class: meta.storage_class,
         tags: meta.tags,
-        acl_grants: meta.acl_grants.iter().map(acl_grant_from_snapshot).collect(),
+        acl_grants: meta
+            .acl_grants
+            .iter()
+            .map(acl_grant_from_snapshot)
+            .collect(),
         acl_owner_id: meta.acl_owner_id,
         parts_count: meta.parts_count,
         part_sizes: meta.part_sizes,
@@ -159,7 +163,11 @@ pub fn multipart_upload_from_loaded(lm: LoadedMpu) -> MultipartUpload {
         sse_algorithm: init.sse_algorithm,
         sse_kms_key_id: init.sse_kms_key_id,
         tagging: init.tagging,
-        acl_grants: init.acl_grants.iter().map(acl_grant_from_snapshot).collect(),
+        acl_grants: init
+            .acl_grants
+            .iter()
+            .map(acl_grant_from_snapshot)
+            .collect(),
         checksum_algorithm: init.checksum_algorithm,
     }
 }
@@ -236,18 +244,16 @@ pub fn s3_bucket_from_snapshot(
                 if text.trim().is_empty() {
                     continue;
                 }
-                let snap: TagsSnapshot = toml::from_str(&text).map_err(|e| {
-                    format!("failed to parse tags.toml for bucket {name}: {e}")
-                })?;
+                let snap: TagsSnapshot = toml::from_str(&text)
+                    .map_err(|e| format!("failed to parse tags.toml for bucket {name}: {e}"))?;
                 b.tags = snap.tags;
             }
             "acl.toml" => {
                 if text.trim().is_empty() {
                     continue;
                 }
-                let snap: AclSnapshot = toml::from_str(&text).map_err(|e| {
-                    format!("failed to parse acl.toml for bucket {name}: {e}")
-                })?;
+                let snap: AclSnapshot = toml::from_str(&text)
+                    .map_err(|e| format!("failed to parse acl.toml for bucket {name}: {e}"))?;
                 if !snap.owner_id.is_empty() {
                     b.acl_owner_id = snap.owner_id;
                 }

--- a/crates/fakecloud-s3/src/service/acl.rs
+++ b/crates/fakecloud-s3/src/service/acl.rs
@@ -76,7 +76,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
     }

--- a/crates/fakecloud-s3/src/service/acl.rs
+++ b/crates/fakecloud-s3/src/service/acl.rs
@@ -70,7 +70,9 @@ impl S3Service {
         }
 
         let meta = object_meta_snapshot(obj);
-        let _ = self.store.put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
+        let _ = self
+            .store
+            .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),

--- a/crates/fakecloud-s3/src/service/acl.rs
+++ b/crates/fakecloud-s3/src/service/acl.rs
@@ -70,9 +70,9 @@ impl S3Service {
         }
 
         let meta = object_meta_snapshot(obj);
-        let _ = self
-            .store
-            .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
+        self.store
+            .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta)
+            .map_err(super::persistence_error)?;
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),

--- a/crates/fakecloud-s3/src/service/acl.rs
+++ b/crates/fakecloud-s3/src/service/acl.rs
@@ -3,6 +3,8 @@ use http::{HeaderMap, StatusCode};
 use bytes::Bytes;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
+use crate::persistence::object_meta_snapshot;
+
 use super::{
     build_acl_xml, canned_acl_grants_for_object, no_such_bucket, no_such_key, parse_acl_xml,
     parse_grant_headers, s3_xml, S3Service,
@@ -67,6 +69,8 @@ impl S3Service {
             }
         }
 
+        let meta = object_meta_snapshot(obj);
+        let _ = self.store.put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),

--- a/crates/fakecloud-s3/src/service/buckets.rs
+++ b/crates/fakecloud-s3/src/service/buckets.rs
@@ -177,7 +177,9 @@ impl S3Service {
 
         let meta = bucket_meta_snapshot(&b);
         state.buckets.insert(bucket.to_string(), b);
-        let _ = self.store.put_bucket_meta(bucket, &meta);
+        self.store
+            .put_bucket_meta(bucket, &meta)
+            .map_err(super::persistence_error)?;
 
         let mut headers = HeaderMap::new();
         headers.insert("location", format!("/{bucket}").parse().unwrap());
@@ -215,7 +217,9 @@ impl S3Service {
             ));
         }
         state.buckets.remove(bucket);
-        let _ = self.store.delete_bucket(bucket);
+        self.store
+            .delete_bucket(bucket)
+            .map_err(super::persistence_error)?;
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),

--- a/crates/fakecloud-s3/src/service/buckets.rs
+++ b/crates/fakecloud-s3/src/service/buckets.rs
@@ -3,6 +3,7 @@ use http::{HeaderMap, StatusCode};
 use bytes::Bytes;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
+use crate::persistence::bucket_meta_snapshot;
 use crate::state::S3Bucket;
 
 use super::{
@@ -174,7 +175,9 @@ impl S3Service {
             ));
         }
 
+        let meta = bucket_meta_snapshot(&b);
         state.buckets.insert(bucket.to_string(), b);
+        let _ = self.store.put_bucket_meta(bucket, &meta);
 
         let mut headers = HeaderMap::new();
         headers.insert("location", format!("/{bucket}").parse().unwrap());
@@ -212,6 +215,7 @@ impl S3Service {
             ));
         }
         state.buckets.remove(bucket);
+        let _ = self.store.delete_bucket(bucket);
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),

--- a/crates/fakecloud-s3/src/service/buckets.rs
+++ b/crates/fakecloud-s3/src/service/buckets.rs
@@ -130,7 +130,7 @@ impl S3Service {
                 return Ok(AwsResponse {
                     status: StatusCode::OK,
                     content_type: "application/xml".to_string(),
-                    body: Bytes::new(),
+                    body: Bytes::new().into(),
                     headers,
                 });
             }
@@ -190,7 +190,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers,
         })
     }
@@ -223,7 +223,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
     }
@@ -240,7 +240,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
     }

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -189,7 +189,7 @@ impl S3Service {
             Some(policy) => Ok(AwsResponse {
                 status: StatusCode::OK,
                 content_type: "application/json".to_string(),
-                body: Bytes::from(policy.clone()),
+                body: Bytes::from(policy.clone()).into(),
                 headers: HeaderMap::new(),
             }),
             None => Err(AwsServiceError::aws_error_with_fields(
@@ -702,7 +702,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
     }
@@ -724,7 +724,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
     }
@@ -784,7 +784,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
     }
@@ -814,7 +814,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
     }

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -2,8 +2,10 @@ use http::{HeaderMap, StatusCode};
 
 use bytes::Bytes;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+use fakecloud_persistence::BucketSubresource;
 
 use crate::inventory;
+use crate::persistence::bucket_meta_snapshot;
 
 use super::{
     build_acl_xml, canned_acl_grants, empty_response, extract_xml_value, no_such_bucket,
@@ -35,7 +37,10 @@ impl S3Service {
         } else {
             body_str
         };
-        b.encryption_config = Some(normalized);
+        b.encryption_config = Some(normalized.clone());
+        let _ = self
+            .store
+            .put_bucket_subresource(bucket, BucketSubresource::Encryption, &normalized);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -69,6 +74,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.encryption_config = None;
+        let _ = self
+            .store
+            .delete_bucket_subresource(bucket, BucketSubresource::Encryption);
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -93,9 +101,17 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         if has_rules {
-            b.lifecycle_config = Some(body_str);
+            b.lifecycle_config = Some(body_str.clone());
+            let _ = self.store.put_bucket_subresource(
+                bucket,
+                BucketSubresource::Lifecycle,
+                &body_str,
+            );
         } else {
             b.lifecycle_config = None;
+            let _ = self
+                .store
+                .delete_bucket_subresource(bucket, BucketSubresource::Lifecycle);
         }
         Ok(empty_response(StatusCode::OK))
     }
@@ -130,6 +146,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.lifecycle_config = None;
+        let _ = self
+            .store
+            .delete_bucket_subresource(bucket, BucketSubresource::Lifecycle);
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -153,7 +172,10 @@ impl S3Service {
             .buckets
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        b.policy = Some(body_str);
+        b.policy = Some(body_str.clone());
+        let _ = self
+            .store
+            .put_bucket_subresource(bucket, BucketSubresource::Policy, &body_str);
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -189,6 +211,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.policy = None;
+        let _ = self
+            .store
+            .delete_bucket_subresource(bucket, BucketSubresource::Policy);
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -238,7 +263,10 @@ impl S3Service {
             .buckets
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        b.cors_config = Some(body_str);
+        b.cors_config = Some(body_str.clone());
+        let _ = self
+            .store
+            .put_bucket_subresource(bucket, BucketSubresource::Cors, &body_str);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -266,6 +294,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.cors_config = None;
+        let _ = self
+            .store
+            .delete_bucket_subresource(bucket, BucketSubresource::Cors);
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -286,7 +317,14 @@ impl S3Service {
         b.eventbridge_enabled = body_str.contains("<EventBridgeConfiguration");
         // Auto-generate Id for each configuration element if missing
         let normalized = normalize_notification_ids(&body_str);
-        b.notification_config = Some(normalized);
+        b.notification_config = Some(normalized.clone());
+        let meta = bucket_meta_snapshot(b);
+        let _ = self.store.put_bucket_meta(bucket, &meta);
+        let _ = self.store.put_bucket_subresource(
+            bucket,
+            BucketSubresource::Notification,
+            &normalized,
+        );
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -328,7 +366,10 @@ impl S3Service {
             .buckets
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        b.logging_config = Some(body_str);
+        b.logging_config = Some(body_str.clone());
+        let _ = self
+            .store
+            .put_bucket_subresource(bucket, BucketSubresource::Logging, &body_str);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -361,7 +402,10 @@ impl S3Service {
             .buckets
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        b.website_config = Some(body_str);
+        b.website_config = Some(body_str.clone());
+        let _ = self
+            .store
+            .put_bucket_subresource(bucket, BucketSubresource::Website, &body_str);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -392,6 +436,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.website_config = None;
+        let _ = self
+            .store
+            .delete_bucket_subresource(bucket, BucketSubresource::Website);
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -431,6 +478,8 @@ impl S3Service {
             return Ok(empty_response(StatusCode::OK));
         }
         b.accelerate_status = status;
+        let meta = bucket_meta_snapshot(b);
+        let _ = self.store.put_bucket_meta(bucket, &meta);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -481,7 +530,12 @@ impl S3Service {
             .buckets
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        b.public_access_block = Some(body_str);
+        b.public_access_block = Some(body_str.clone());
+        let _ = self.store.put_bucket_subresource(
+            bucket,
+            BucketSubresource::PublicAccessBlock,
+            &body_str,
+        );
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -532,6 +586,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.public_access_block = None;
+        let _ = self
+            .store
+            .delete_bucket_subresource(bucket, BucketSubresource::PublicAccessBlock);
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -577,7 +634,12 @@ impl S3Service {
             ));
         }
 
-        b.object_lock_config = Some(body_str);
+        b.object_lock_config = Some(body_str.clone());
+        let _ = self.store.put_bucket_subresource(
+            bucket,
+            BucketSubresource::ObjectLock,
+            &body_str,
+        );
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -632,6 +694,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.tags = tags.into_iter().collect();
+        let _ = self
+            .store
+            .put_bucket_subresource(bucket, BucketSubresource::Tags, "");
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
@@ -651,6 +716,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.tags.clear();
+        let _ = self
+            .store
+            .delete_bucket_subresource(bucket, BucketSubresource::Tags);
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
@@ -703,6 +771,10 @@ impl S3Service {
             b.acl_grants = grants;
         }
 
+        // TODO(phase-4): serialize ACL grants to TOML for DiskS3Store.
+        let _ = self
+            .store
+            .put_bucket_subresource(bucket, BucketSubresource::Acl, "");
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
@@ -729,6 +801,8 @@ impl S3Service {
         if status_val == "Enabled" || status_val == "Suspended" {
             b.versioning = Some(status_val);
         }
+        let meta = bucket_meta_snapshot(b);
+        let _ = self.store.put_bucket_meta(bucket, &meta);
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
@@ -799,7 +873,13 @@ impl S3Service {
             ));
         }
 
-        b.replication_config = Some(normalize_replication_xml(&body_str));
+        let normalized = normalize_replication_xml(&body_str);
+        b.replication_config = Some(normalized.clone());
+        let _ = self.store.put_bucket_subresource(
+            bucket,
+            BucketSubresource::Replication,
+            &normalized,
+        );
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -833,6 +913,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.replication_config = None;
+        let _ = self
+            .store
+            .delete_bucket_subresource(bucket, BucketSubresource::Replication);
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -847,7 +930,10 @@ impl S3Service {
             .buckets
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        b.ownership_controls = Some(body_str);
+        b.ownership_controls = Some(body_str.clone());
+        let _ = self
+            .store
+            .put_bucket_subresource(bucket, BucketSubresource::Ownership, &body_str);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -881,6 +967,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.ownership_controls = None;
+        let _ = self
+            .store
+            .delete_bucket_subresource(bucket, BucketSubresource::Ownership);
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -902,6 +991,10 @@ impl S3Service {
                 .ok_or_else(|| no_such_bucket(bucket))?;
             b.inventory_configs.insert(inv_id.clone(), body_str);
         }
+        // TODO(phase-4): serialize inventory_configs map to TOML for DiskS3Store.
+        let _ = self
+            .store
+            .put_bucket_subresource(bucket, BucketSubresource::Inventory, "");
         // Generate the inventory report immediately so tests can verify it
         inventory::generate_inventory_report(&self.state, bucket, &inv_id);
         Ok(empty_response(StatusCode::OK))
@@ -966,6 +1059,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.inventory_configs.remove(&inv_id);
+        let _ = self
+            .store
+            .delete_bucket_subresource(bucket, BucketSubresource::Inventory);
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 }

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -40,9 +40,9 @@ impl S3Service {
             body_str
         };
         b.encryption_config = Some(normalized.clone());
-        let _ =
-            self.store
-                .put_bucket_subresource(bucket, BucketSubresource::Encryption, &normalized);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Encryption, &normalized)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -76,9 +76,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.encryption_config = None;
-        let _ = self
-            .store
-            .delete_bucket_subresource(bucket, BucketSubresource::Encryption);
+        self.store
+            .delete_bucket_subresource(bucket, BucketSubresource::Encryption)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -104,14 +104,14 @@ impl S3Service {
             .ok_or_else(|| no_such_bucket(bucket))?;
         if has_rules {
             b.lifecycle_config = Some(body_str.clone());
-            let _ =
-                self.store
-                    .put_bucket_subresource(bucket, BucketSubresource::Lifecycle, &body_str);
+            self.store
+                .put_bucket_subresource(bucket, BucketSubresource::Lifecycle, &body_str)
+                .map_err(super::persistence_error)?;
         } else {
             b.lifecycle_config = None;
-            let _ = self
-                .store
-                .delete_bucket_subresource(bucket, BucketSubresource::Lifecycle);
+            self.store
+                .delete_bucket_subresource(bucket, BucketSubresource::Lifecycle)
+                .map_err(super::persistence_error)?;
         }
         Ok(empty_response(StatusCode::OK))
     }
@@ -146,9 +146,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.lifecycle_config = None;
-        let _ = self
-            .store
-            .delete_bucket_subresource(bucket, BucketSubresource::Lifecycle);
+        self.store
+            .delete_bucket_subresource(bucket, BucketSubresource::Lifecycle)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -173,9 +173,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.policy = Some(body_str.clone());
-        let _ = self
-            .store
-            .put_bucket_subresource(bucket, BucketSubresource::Policy, &body_str);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Policy, &body_str)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -211,9 +211,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.policy = None;
-        let _ = self
-            .store
-            .delete_bucket_subresource(bucket, BucketSubresource::Policy);
+        self.store
+            .delete_bucket_subresource(bucket, BucketSubresource::Policy)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -264,9 +264,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.cors_config = Some(body_str.clone());
-        let _ = self
-            .store
-            .put_bucket_subresource(bucket, BucketSubresource::Cors, &body_str);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Cors, &body_str)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -294,9 +294,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.cors_config = None;
-        let _ = self
-            .store
-            .delete_bucket_subresource(bucket, BucketSubresource::Cors);
+        self.store
+            .delete_bucket_subresource(bucket, BucketSubresource::Cors)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -319,10 +319,12 @@ impl S3Service {
         let normalized = normalize_notification_ids(&body_str);
         b.notification_config = Some(normalized.clone());
         let meta = bucket_meta_snapshot(b);
-        let _ = self.store.put_bucket_meta(bucket, &meta);
-        let _ =
-            self.store
-                .put_bucket_subresource(bucket, BucketSubresource::Notification, &normalized);
+        self.store
+            .put_bucket_meta(bucket, &meta)
+            .map_err(super::persistence_error)?;
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Notification, &normalized)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -365,9 +367,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.logging_config = Some(body_str.clone());
-        let _ = self
-            .store
-            .put_bucket_subresource(bucket, BucketSubresource::Logging, &body_str);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Logging, &body_str)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -401,9 +403,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.website_config = Some(body_str.clone());
-        let _ = self
-            .store
-            .put_bucket_subresource(bucket, BucketSubresource::Website, &body_str);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Website, &body_str)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -434,9 +436,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.website_config = None;
-        let _ = self
-            .store
-            .delete_bucket_subresource(bucket, BucketSubresource::Website);
+        self.store
+            .delete_bucket_subresource(bucket, BucketSubresource::Website)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -477,7 +479,9 @@ impl S3Service {
         }
         b.accelerate_status = status;
         let meta = bucket_meta_snapshot(b);
-        let _ = self.store.put_bucket_meta(bucket, &meta);
+        self.store
+            .put_bucket_meta(bucket, &meta)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -529,11 +533,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.public_access_block = Some(body_str.clone());
-        let _ = self.store.put_bucket_subresource(
-            bucket,
-            BucketSubresource::PublicAccessBlock,
-            &body_str,
-        );
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::PublicAccessBlock, &body_str)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -584,9 +586,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.public_access_block = None;
-        let _ = self
-            .store
-            .delete_bucket_subresource(bucket, BucketSubresource::PublicAccessBlock);
+        self.store
+            .delete_bucket_subresource(bucket, BucketSubresource::PublicAccessBlock)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -633,9 +635,9 @@ impl S3Service {
         }
 
         b.object_lock_config = Some(body_str.clone());
-        let _ = self
-            .store
-            .put_bucket_subresource(bucket, BucketSubresource::ObjectLock, &body_str);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::ObjectLock, &body_str)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -694,9 +696,9 @@ impl S3Service {
             tags: b.tags.clone(),
         };
         let payload = toml::to_string(&snap).unwrap_or_default();
-        let _ = self
-            .store
-            .put_bucket_subresource(bucket, BucketSubresource::Tags, &payload);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Tags, &payload)
+            .map_err(super::persistence_error)?;
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
@@ -716,9 +718,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.tags.clear();
-        let _ = self
-            .store
-            .delete_bucket_subresource(bucket, BucketSubresource::Tags);
+        self.store
+            .delete_bucket_subresource(bucket, BucketSubresource::Tags)
+            .map_err(super::persistence_error)?;
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
@@ -776,9 +778,9 @@ impl S3Service {
             grants: b.acl_grants.iter().map(AclGrantSnapshot::from).collect(),
         };
         let payload = toml::to_string(&snap).unwrap_or_default();
-        let _ = self
-            .store
-            .put_bucket_subresource(bucket, BucketSubresource::Acl, &payload);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Acl, &payload)
+            .map_err(super::persistence_error)?;
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
@@ -806,7 +808,9 @@ impl S3Service {
             b.versioning = Some(status_val);
         }
         let meta = bucket_meta_snapshot(b);
-        let _ = self.store.put_bucket_meta(bucket, &meta);
+        self.store
+            .put_bucket_meta(bucket, &meta)
+            .map_err(super::persistence_error)?;
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
@@ -879,9 +883,9 @@ impl S3Service {
 
         let normalized = normalize_replication_xml(&body_str);
         b.replication_config = Some(normalized.clone());
-        let _ =
-            self.store
-                .put_bucket_subresource(bucket, BucketSubresource::Replication, &normalized);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Replication, &normalized)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -915,9 +919,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.replication_config = None;
-        let _ = self
-            .store
-            .delete_bucket_subresource(bucket, BucketSubresource::Replication);
+        self.store
+            .delete_bucket_subresource(bucket, BucketSubresource::Replication)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -933,9 +937,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.ownership_controls = Some(body_str.clone());
-        let _ = self
-            .store
-            .put_bucket_subresource(bucket, BucketSubresource::Ownership, &body_str);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Ownership, &body_str)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -969,9 +973,9 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.ownership_controls = None;
-        let _ = self
-            .store
-            .delete_bucket_subresource(bucket, BucketSubresource::Ownership);
+        self.store
+            .delete_bucket_subresource(bucket, BucketSubresource::Ownership)
+            .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
@@ -997,9 +1001,9 @@ impl S3Service {
             };
             toml::to_string(&snap).unwrap_or_default()
         };
-        let _ = self
-            .store
-            .put_bucket_subresource(bucket, BucketSubresource::Inventory, &payload);
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::Inventory, &payload)
+            .map_err(super::persistence_error)?;
         // Generate the inventory report immediately so tests can verify it
         inventory::generate_inventory_report(&self.state, bucket, &inv_id);
         Ok(empty_response(StatusCode::OK))
@@ -1065,17 +1069,17 @@ impl S3Service {
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.inventory_configs.remove(&inv_id);
         if b.inventory_configs.is_empty() {
-            let _ = self
-                .store
-                .delete_bucket_subresource(bucket, BucketSubresource::Inventory);
+            self.store
+                .delete_bucket_subresource(bucket, BucketSubresource::Inventory)
+                .map_err(super::persistence_error)?;
         } else {
             let snap = InventorySnapshot {
                 configs: b.inventory_configs.clone(),
             };
             let payload = toml::to_string(&snap).unwrap_or_default();
-            let _ =
-                self.store
-                    .put_bucket_subresource(bucket, BucketSubresource::Inventory, &payload);
+            self.store
+                .put_bucket_subresource(bucket, BucketSubresource::Inventory, &payload)
+                .map_err(super::persistence_error)?;
         }
         Ok(empty_response(StatusCode::NO_CONTENT))
     }

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -2,7 +2,9 @@ use http::{HeaderMap, StatusCode};
 
 use bytes::Bytes;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_persistence::BucketSubresource;
+use fakecloud_persistence::{
+    AclGrantSnapshot, AclSnapshot, BucketSubresource, InventorySnapshot, TagsSnapshot,
+};
 
 use crate::inventory;
 use crate::persistence::bucket_meta_snapshot;
@@ -694,9 +696,13 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.tags = tags.into_iter().collect();
+        let snap = TagsSnapshot {
+            tags: b.tags.clone(),
+        };
+        let payload = toml::to_string(&snap).unwrap_or_default();
         let _ = self
             .store
-            .put_bucket_subresource(bucket, BucketSubresource::Tags, "");
+            .put_bucket_subresource(bucket, BucketSubresource::Tags, &payload);
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
@@ -771,10 +777,14 @@ impl S3Service {
             b.acl_grants = grants;
         }
 
-        // TODO(phase-4): serialize ACL grants to TOML for DiskS3Store.
+        let snap = AclSnapshot {
+            owner_id: b.acl_owner_id.clone(),
+            grants: b.acl_grants.iter().map(AclGrantSnapshot::from).collect(),
+        };
+        let payload = toml::to_string(&snap).unwrap_or_default();
         let _ = self
             .store
-            .put_bucket_subresource(bucket, BucketSubresource::Acl, "");
+            .put_bucket_subresource(bucket, BucketSubresource::Acl, &payload);
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
@@ -983,18 +993,21 @@ impl S3Service {
         let inv_id = extract_xml_value(&body_str, "Id")
             .or_else(|| req.query_params.get("id").cloned())
             .unwrap_or_default();
-        {
+        let payload = {
             let mut state = self.state.write();
             let b = state
                 .buckets
                 .get_mut(bucket)
                 .ok_or_else(|| no_such_bucket(bucket))?;
             b.inventory_configs.insert(inv_id.clone(), body_str);
-        }
-        // TODO(phase-4): serialize inventory_configs map to TOML for DiskS3Store.
+            let snap = InventorySnapshot {
+                configs: b.inventory_configs.clone(),
+            };
+            toml::to_string(&snap).unwrap_or_default()
+        };
         let _ = self
             .store
-            .put_bucket_subresource(bucket, BucketSubresource::Inventory, "");
+            .put_bucket_subresource(bucket, BucketSubresource::Inventory, &payload);
         // Generate the inventory report immediately so tests can verify it
         inventory::generate_inventory_report(&self.state, bucket, &inv_id);
         Ok(empty_response(StatusCode::OK))
@@ -1059,9 +1072,19 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         b.inventory_configs.remove(&inv_id);
-        let _ = self
-            .store
-            .delete_bucket_subresource(bucket, BucketSubresource::Inventory);
+        if b.inventory_configs.is_empty() {
+            let _ = self
+                .store
+                .delete_bucket_subresource(bucket, BucketSubresource::Inventory);
+        } else {
+            let snap = InventorySnapshot {
+                configs: b.inventory_configs.clone(),
+            };
+            let payload = toml::to_string(&snap).unwrap_or_default();
+            let _ = self
+                .store
+                .put_bucket_subresource(bucket, BucketSubresource::Inventory, &payload);
+        }
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 }

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -40,9 +40,9 @@ impl S3Service {
             body_str
         };
         b.encryption_config = Some(normalized.clone());
-        let _ = self
-            .store
-            .put_bucket_subresource(bucket, BucketSubresource::Encryption, &normalized);
+        let _ =
+            self.store
+                .put_bucket_subresource(bucket, BucketSubresource::Encryption, &normalized);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -104,11 +104,9 @@ impl S3Service {
             .ok_or_else(|| no_such_bucket(bucket))?;
         if has_rules {
             b.lifecycle_config = Some(body_str.clone());
-            let _ = self.store.put_bucket_subresource(
-                bucket,
-                BucketSubresource::Lifecycle,
-                &body_str,
-            );
+            let _ =
+                self.store
+                    .put_bucket_subresource(bucket, BucketSubresource::Lifecycle, &body_str);
         } else {
             b.lifecycle_config = None;
             let _ = self
@@ -322,11 +320,9 @@ impl S3Service {
         b.notification_config = Some(normalized.clone());
         let meta = bucket_meta_snapshot(b);
         let _ = self.store.put_bucket_meta(bucket, &meta);
-        let _ = self.store.put_bucket_subresource(
-            bucket,
-            BucketSubresource::Notification,
-            &normalized,
-        );
+        let _ =
+            self.store
+                .put_bucket_subresource(bucket, BucketSubresource::Notification, &normalized);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -637,11 +633,9 @@ impl S3Service {
         }
 
         b.object_lock_config = Some(body_str.clone());
-        let _ = self.store.put_bucket_subresource(
-            bucket,
-            BucketSubresource::ObjectLock,
-            &body_str,
-        );
+        let _ = self
+            .store
+            .put_bucket_subresource(bucket, BucketSubresource::ObjectLock, &body_str);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -885,11 +879,9 @@ impl S3Service {
 
         let normalized = normalize_replication_xml(&body_str);
         b.replication_config = Some(normalized.clone());
-        let _ = self.store.put_bucket_subresource(
-            bucket,
-            BucketSubresource::Replication,
-            &normalized,
-        );
+        let _ =
+            self.store
+                .put_bucket_subresource(bucket, BucketSubresource::Replication, &normalized);
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -1081,9 +1073,9 @@ impl S3Service {
                 configs: b.inventory_configs.clone(),
             };
             let payload = toml::to_string(&snap).unwrap_or_default();
-            let _ = self
-                .store
-                .put_bucket_subresource(bucket, BucketSubresource::Inventory, &payload);
+            let _ =
+                self.store
+                    .put_bucket_subresource(bucket, BucketSubresource::Inventory, &payload);
         }
         Ok(empty_response(StatusCode::NO_CONTENT))
     }

--- a/crates/fakecloud-s3/src/service/lock.rs
+++ b/crates/fakecloud-s3/src/service/lock.rs
@@ -71,8 +71,27 @@ impl S3Service {
             }
         }
 
+        // Snapshot the *specific* object that was just mutated — for a
+        // versioned put, that's the version in b.object_versions, not the
+        // current pointer.
         if let Some(b2) = state.buckets.get(bucket) {
-            if let Some(obj) = b2.objects.get(key) {
+            if let Some(ref vid) = version_id {
+                let versioned = b2
+                    .object_versions
+                    .get(key)
+                    .and_then(|vs| vs.iter().find(|o| o.version_id.as_deref() == Some(vid)));
+                let target = versioned.or_else(|| {
+                    b2.objects
+                        .get(key)
+                        .filter(|o| o.version_id.as_deref() == Some(vid))
+                });
+                if let Some(obj) = target {
+                    let meta = object_meta_snapshot(obj);
+                    self.store
+                        .put_object_meta(bucket, key, Some(vid.as_str()), &meta)
+                        .map_err(super::persistence_error)?;
+                }
+            } else if let Some(obj) = b2.objects.get(key) {
                 let meta = object_meta_snapshot(obj);
                 self.store
                     .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta)
@@ -170,7 +189,23 @@ impl S3Service {
         }
 
         if let Some(b2) = state.buckets.get(bucket) {
-            if let Some(obj) = b2.objects.get(key) {
+            if let Some(ref vid) = version_id {
+                let versioned = b2
+                    .object_versions
+                    .get(key)
+                    .and_then(|vs| vs.iter().find(|o| o.version_id.as_deref() == Some(vid)));
+                let target = versioned.or_else(|| {
+                    b2.objects
+                        .get(key)
+                        .filter(|o| o.version_id.as_deref() == Some(vid))
+                });
+                if let Some(obj) = target {
+                    let meta = object_meta_snapshot(obj);
+                    self.store
+                        .put_object_meta(bucket, key, Some(vid.as_str()), &meta)
+                        .map_err(super::persistence_error)?;
+                }
+            } else if let Some(obj) = b2.objects.get(key) {
                 let meta = object_meta_snapshot(obj);
                 self.store
                     .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta)

--- a/crates/fakecloud-s3/src/service/lock.rs
+++ b/crates/fakecloud-s3/src/service/lock.rs
@@ -3,6 +3,8 @@ use http::StatusCode;
 use chrono::{DateTime, Utc};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
+use crate::persistence::object_meta_snapshot;
+
 use super::{
     empty_response, extract_xml_value, no_such_bucket, no_such_key, resolve_object, s3_xml,
     xml_escape, S3Service,
@@ -69,6 +71,17 @@ impl S3Service {
             }
         }
 
+        if let Some(b2) = state.buckets.get(bucket) {
+            if let Some(obj) = b2.objects.get(key) {
+                let meta = object_meta_snapshot(obj);
+                let _ = self.store.put_object_meta(
+                    bucket,
+                    key,
+                    meta.version_id.as_deref(),
+                    &meta,
+                );
+            }
+        }
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -159,6 +172,17 @@ impl S3Service {
             }
         }
 
+        if let Some(b2) = state.buckets.get(bucket) {
+            if let Some(obj) = b2.objects.get(key) {
+                let meta = object_meta_snapshot(obj);
+                let _ = self.store.put_object_meta(
+                    bucket,
+                    key,
+                    meta.version_id.as_deref(),
+                    &meta,
+                );
+            }
+        }
         Ok(empty_response(StatusCode::OK))
     }
 

--- a/crates/fakecloud-s3/src/service/lock.rs
+++ b/crates/fakecloud-s3/src/service/lock.rs
@@ -74,9 +74,9 @@ impl S3Service {
         if let Some(b2) = state.buckets.get(bucket) {
             if let Some(obj) = b2.objects.get(key) {
                 let meta = object_meta_snapshot(obj);
-                let _ = self
-                    .store
-                    .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
+                self.store
+                    .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta)
+                    .map_err(super::persistence_error)?;
             }
         }
         Ok(empty_response(StatusCode::OK))
@@ -172,9 +172,9 @@ impl S3Service {
         if let Some(b2) = state.buckets.get(bucket) {
             if let Some(obj) = b2.objects.get(key) {
                 let meta = object_meta_snapshot(obj);
-                let _ = self
-                    .store
-                    .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
+                self.store
+                    .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta)
+                    .map_err(super::persistence_error)?;
             }
         }
         Ok(empty_response(StatusCode::OK))

--- a/crates/fakecloud-s3/src/service/lock.rs
+++ b/crates/fakecloud-s3/src/service/lock.rs
@@ -74,12 +74,9 @@ impl S3Service {
         if let Some(b2) = state.buckets.get(bucket) {
             if let Some(obj) = b2.objects.get(key) {
                 let meta = object_meta_snapshot(obj);
-                let _ = self.store.put_object_meta(
-                    bucket,
-                    key,
-                    meta.version_id.as_deref(),
-                    &meta,
-                );
+                let _ = self
+                    .store
+                    .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
             }
         }
         Ok(empty_response(StatusCode::OK))
@@ -175,12 +172,9 @@ impl S3Service {
         if let Some(b2) = state.buckets.get(bucket) {
             if let Some(obj) = b2.objects.get(key) {
                 let meta = object_meta_snapshot(obj);
-                let _ = self.store.put_object_meta(
-                    bucket,
-                    key,
-                    meta.version_id.as_deref(),
-                    &meta,
-                );
+                let _ = self
+                    .store
+                    .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
             }
         }
         Ok(empty_response(StatusCode::OK))

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -27,8 +27,11 @@ mod objects;
 mod tags;
 
 // Re-export notification helpers for use in sub-modules
+#[cfg(test)]
+use notifications::replicate_object;
 pub(super) use notifications::{
-    deliver_notifications, normalize_notification_ids, normalize_replication_xml, replicate_object,
+    deliver_notifications, normalize_notification_ids, normalize_replication_xml,
+    replicate_through_store,
 };
 
 // Used only within this file (parse_cors_config)
@@ -279,7 +282,7 @@ impl AwsService for S3Service {
                         return Ok(AwsResponse {
                             status: StatusCode::OK,
                             content_type: String::new(),
-                            body: Bytes::new(),
+                            body: Bytes::new().into(),
                             headers,
                         });
                     }
@@ -1100,7 +1103,7 @@ pub(crate) fn s3_xml(status: StatusCode, body: impl Into<Bytes>) -> AwsResponse 
     AwsResponse {
         status,
         content_type: "application/xml".to_string(),
-        body: body.into(),
+        body: body.into().into(),
         headers: HeaderMap::new(),
     }
 }
@@ -1109,7 +1112,7 @@ pub(crate) fn empty_response(status: StatusCode) -> AwsResponse {
     AwsResponse {
         status,
         content_type: "application/xml".to_string(),
-        body: Bytes::new(),
+        body: Bytes::new().into(),
         headers: HeaderMap::new(),
     }
 }

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -9,7 +9,7 @@ use md5::{Digest, Md5};
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_kms::state::SharedKmsState;
-use fakecloud_persistence::{MemoryS3Store, S3Store};
+use fakecloud_persistence::{MemoryS3Store, S3Store, StoreError};
 
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
@@ -47,6 +47,28 @@ pub struct S3Service {
     kms_state: Option<SharedKmsState>,
     #[allow(dead_code)]
     store: Arc<dyn S3Store>,
+}
+
+/// Map a [`StoreError`] from the persistence layer to a 500 InternalError
+/// response. Invoked at every mutation site when the write-through persistence
+/// call fails: the in-memory mutation has already happened, but we surface the
+/// failure to the client so they know to retry (and so logs/metrics flag it).
+pub(crate) fn persistence_error(err: StoreError) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "InternalError",
+        format!("persistence store error: {err}"),
+    )
+}
+
+/// Convert a filesystem IO error from a disk-backed body read into an
+/// InternalError response.
+pub(crate) fn io_to_aws(err: std::io::Error) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "InternalError",
+        format!("failed to read object body from disk: {err}"),
+    )
 }
 
 impl S3Service {
@@ -547,6 +569,7 @@ impl AwsService for S3Service {
             let op = logging::operation_name(&req.method, key.as_deref());
             logging::maybe_write_access_log(
                 &self.state,
+                &self.store,
                 b_name,
                 &logging::AccessLogRequest {
                     operation: op,
@@ -2126,7 +2149,7 @@ mod tests {
             .get("test-key");
         assert!(dest_obj.is_some());
         assert_eq!(
-            crate::state::read_body_bytes(&dest_obj.unwrap().body),
+            state.read_body(&dest_obj.unwrap().body).unwrap(),
             Bytes::from_static(b"hello")
         );
     }

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -9,6 +9,7 @@ use md5::{Digest, Md5};
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_kms::state::SharedKmsState;
+use fakecloud_persistence::{MemoryS3Store, S3Store};
 
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
@@ -44,14 +45,25 @@ pub struct S3Service {
     state: SharedS3State,
     delivery: Arc<DeliveryBus>,
     kms_state: Option<SharedKmsState>,
+    #[allow(dead_code)]
+    store: Arc<dyn S3Store>,
 }
 
 impl S3Service {
     pub fn new(state: SharedS3State, delivery: Arc<DeliveryBus>) -> Self {
+        Self::with_store(state, delivery, Arc::new(MemoryS3Store::new()))
+    }
+
+    pub fn with_store(
+        state: SharedS3State,
+        delivery: Arc<DeliveryBus>,
+        store: Arc<dyn S3Store>,
+    ) -> Self {
         Self {
             state,
             delivery,
             kms_state: None,
+            store,
         }
     }
 
@@ -1996,7 +2008,7 @@ mod tests {
         // Helper to create a minimal S3Object
         let make_obj = |key: &str, vid: Option<&str>| crate::state::S3Object {
             key: key.to_string(),
-            data: Bytes::from_static(b"x"),
+            body: crate::state::memory_body(Bytes::from_static(b"x")),
             content_type: "text/plain".to_string(),
             etag: "\"abc\"".to_string(),
             size: 1,
@@ -2088,7 +2100,7 @@ mod tests {
         );
         let obj = S3Object {
             key: "test-key".to_string(),
-            data: Bytes::from_static(b"hello"),
+            body: crate::state::memory_body(Bytes::from_static(b"hello")),
             content_type: "text/plain".to_string(),
             etag: "abc".to_string(),
             size: 5,
@@ -2113,7 +2125,10 @@ mod tests {
             .objects
             .get("test-key");
         assert!(dest_obj.is_some());
-        assert_eq!(dest_obj.unwrap().data, Bytes::from_static(b"hello"));
+        assert_eq!(
+            crate::state::read_body_bytes(&dest_obj.unwrap().body),
+            Bytes::from_static(b"hello")
+        );
     }
 
     #[test]

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -525,13 +525,9 @@ impl S3Service {
         b.multipart_uploads.remove(upload_id);
         if let Some(o) = b.objects.get(key) {
             let meta = object_meta_snapshot(o);
-            let _ = self.store.mpu_complete(
-                bucket,
-                upload_id,
-                key,
-                meta.version_id.as_deref(),
-                &meta,
-            );
+            let _ =
+                self.store
+                    .mpu_complete(bucket, upload_id, key, meta.version_id.as_deref(), &meta);
             // TODO(phase-4): mpu_complete should consume the part files; for memory
             // mode we also ensure the put_object seam is exercised.
             let _ = self.store.put_object(

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -105,11 +105,14 @@ impl S3Service {
             acl_grants,
             checksum_algorithm,
         };
+        // Store-first: persist the MPU init before touching memory so a disk
+        // write failure short-circuits the handler cleanly without leaving an
+        // orphaned in-memory upload.
         let init_snapshot = mpu_init_snapshot(&upload);
-        b.multipart_uploads.insert(upload_id.clone(), upload);
         self.store
             .mpu_create(bucket, &upload_id, &init_snapshot)
             .map_err(super::persistence_error)?;
+        b.multipart_uploads.insert(upload_id.clone(), upload);
 
         let mut headers = HeaderMap::new();
         if let Some(algo) = &sse_algorithm {
@@ -183,14 +186,7 @@ impl S3Service {
             return Err(no_such_upload(upload_id));
         }
 
-        let part = UploadPart {
-            part_number: pn,
-            body: crate::state::memory_body(data.clone()),
-            etag: etag.clone(),
-            size: data.len() as u64,
-            last_modified: Utc::now(),
-        };
-        upload.parts.insert(pn, part);
+        // Store-first: durably write the part body before mutating memory.
         self.store
             .mpu_put_part(
                 bucket,
@@ -200,6 +196,14 @@ impl S3Service {
                 &etag,
             )
             .map_err(super::persistence_error)?;
+        let part = UploadPart {
+            part_number: pn,
+            body: crate::state::memory_body(data.clone()),
+            etag: etag.clone(),
+            size: data.len() as u64,
+            last_modified: Utc::now(),
+        };
+        upload.parts.insert(pn, part);
 
         let mut headers = HeaderMap::new();
         headers.insert("etag", format!("\"{etag}\"").parse().unwrap());
@@ -215,7 +219,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers,
         })
     }
@@ -312,7 +316,16 @@ impl S3Service {
             return Err(no_such_upload(upload_id));
         }
 
-        let store_body = src_data.clone();
+        // Store-first: durably write before the in-memory part is visible.
+        self.store
+            .mpu_put_part(
+                bucket,
+                upload_id,
+                part_number as u32,
+                BodySource::Bytes(src_data.clone()),
+                &etag,
+            )
+            .map_err(super::persistence_error)?;
         let part = UploadPart {
             part_number: part_number as u32,
             body: crate::state::memory_body(src_data),
@@ -321,15 +334,6 @@ impl S3Service {
             last_modified: Utc::now(),
         };
         upload.parts.insert(part_number as u32, part);
-        self.store
-            .mpu_put_part(
-                bucket,
-                upload_id,
-                part_number as u32,
-                BodySource::Bytes(store_body),
-                &etag,
-            )
-            .map_err(super::persistence_error)?;
 
         let body = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
@@ -541,22 +545,32 @@ impl S3Service {
         };
         b.objects.insert(key.to_string(), obj);
         b.multipart_uploads.remove(upload_id);
-        if let Some(o) = b.objects.get(key) {
-            let meta = object_meta_snapshot(o);
-            self.store
-                .mpu_complete(bucket, upload_id, key, meta.version_id.as_deref(), &meta)
-                .map_err(super::persistence_error)?;
-            // TODO(phase-4): mpu_complete should consume the part files; for memory
-            // mode we also ensure the put_object seam is exercised.
-            self.store
-                .put_object(
-                    bucket,
-                    key,
-                    meta.version_id.as_deref(),
-                    BodySource::Bytes(store_body.clone()),
-                    &meta,
-                )
-                .map_err(super::persistence_error)?;
+        let meta = {
+            let o = b.objects.get(key).ok_or_else(|| no_such_key(key))?;
+            object_meta_snapshot(o)
+        };
+        self.store
+            .mpu_complete(bucket, upload_id, key, meta.version_id.as_deref(), &meta)
+            .map_err(super::persistence_error)?;
+        let returned_body = self
+            .store
+            .put_object(
+                bucket,
+                key,
+                meta.version_id.as_deref(),
+                BodySource::Bytes(store_body.clone()),
+                &meta,
+            )
+            .map_err(super::persistence_error)?;
+        if let Some(o) = b.objects.get_mut(key) {
+            o.body = returned_body.clone();
+        }
+        if b.versioning.as_deref() == Some("Enabled") {
+            if let Some(versions) = b.object_versions.get_mut(key) {
+                if let Some(last) = versions.last_mut() {
+                    last.body = returned_body;
+                }
+            }
         }
 
         let mut headers = HeaderMap::new();
@@ -614,15 +628,16 @@ impl S3Service {
             }
             _ => {}
         }
-        b.multipart_uploads.remove(upload_id);
+        // Store-first for consistency with other MPU ops.
         self.store
             .mpu_abort(bucket, upload_id)
             .map_err(super::persistence_error)?;
+        b.multipart_uploads.remove(upload_id);
 
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
     }

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -6,7 +6,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use fakecloud_persistence::BodySource;
 
-use crate::persistence::{mpu_init_snapshot, object_meta_snapshot, upload_part_meta_snapshot};
+use crate::persistence::{mpu_init_snapshot, object_meta_snapshot};
 use crate::state::{MultipartUpload, S3Object, UploadPart};
 
 use md5::{Digest, Md5};
@@ -107,7 +107,9 @@ impl S3Service {
         };
         let init_snapshot = mpu_init_snapshot(&upload);
         b.multipart_uploads.insert(upload_id.clone(), upload);
-        let _ = self.store.mpu_create(bucket, &upload_id, &init_snapshot);
+        self.store
+            .mpu_create(bucket, &upload_id, &init_snapshot)
+            .map_err(super::persistence_error)?;
 
         let mut headers = HeaderMap::new();
         if let Some(algo) = &sse_algorithm {
@@ -188,15 +190,16 @@ impl S3Service {
             size: data.len() as u64,
             last_modified: Utc::now(),
         };
-        let _ = upload_part_meta_snapshot(&part);
         upload.parts.insert(pn, part);
-        let _ = self.store.mpu_put_part(
-            bucket,
-            upload_id,
-            pn,
-            BodySource::Bytes(data.clone()),
-            &etag,
-        );
+        self.store
+            .mpu_put_part(
+                bucket,
+                upload_id,
+                pn,
+                BodySource::Bytes(data.clone()),
+                &etag,
+            )
+            .map_err(super::persistence_error)?;
 
         let mut headers = HeaderMap::new();
         headers.insert("etag", format!("\"{etag}\"").parse().unwrap());
@@ -265,7 +268,7 @@ impl S3Service {
             .and_then(|v| v.to_str().ok());
 
         let mut state = self.state.write();
-        let src_data = {
+        let src_body_ref = {
             let sb = state
                 .buckets
                 .get(src_bucket)
@@ -278,21 +281,21 @@ impl S3Service {
                     .get(src_key)
                     .ok_or_else(|| no_such_key(src_key))?
             };
-
-            let src_bytes = crate::state::read_body_bytes(&src_obj.body);
-            if let Some(range_str) = copy_range {
-                let range_part = range_str.strip_prefix("bytes=").unwrap_or(range_str);
-                if let Some((start_str, end_str)) = range_part.split_once('-') {
-                    let start: usize = start_str.parse().unwrap_or(0);
-                    let end: usize = end_str.parse().unwrap_or(src_bytes.len() - 1);
-                    let end = std::cmp::min(end + 1, src_bytes.len());
-                    src_bytes.slice(start..end)
-                } else {
-                    src_bytes.clone()
-                }
+            src_obj.body.clone()
+        };
+        let src_bytes = state.read_body(&src_body_ref).map_err(super::io_to_aws)?;
+        let src_data = if let Some(range_str) = copy_range {
+            let range_part = range_str.strip_prefix("bytes=").unwrap_or(range_str);
+            if let Some((start_str, end_str)) = range_part.split_once('-') {
+                let start: usize = start_str.parse().unwrap_or(0);
+                let end: usize = end_str.parse().unwrap_or(src_bytes.len() - 1);
+                let end = std::cmp::min(end + 1, src_bytes.len());
+                src_bytes.slice(start..end)
             } else {
                 src_bytes.clone()
             }
+        } else {
+            src_bytes.clone()
         };
 
         let data_len = src_data.len() as u64;
@@ -318,13 +321,15 @@ impl S3Service {
             last_modified: Utc::now(),
         };
         upload.parts.insert(part_number as u32, part);
-        let _ = self.store.mpu_put_part(
-            bucket,
-            upload_id,
-            part_number as u32,
-            BodySource::Bytes(store_body),
-            &etag,
-        );
+        self.store
+            .mpu_put_part(
+                bucket,
+                upload_id,
+                part_number as u32,
+                BodySource::Bytes(store_body),
+                &etag,
+            )
+            .map_err(super::persistence_error)?;
 
         let body = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
@@ -363,14 +368,23 @@ impl S3Service {
             .map(|s| s.to_string());
 
         let mut state = self.state.write();
-        let b = state
-            .buckets
-            .get_mut(bucket)
-            .ok_or_else(|| no_such_bucket(bucket))?;
-
-        let upload = match b.multipart_uploads.get(upload_id) {
-            Some(u) => u.clone(),
+        let (upload, already_has_object) = {
+            let b = state
+                .buckets
+                .get(bucket)
+                .ok_or_else(|| no_such_bucket(bucket))?;
+            match b.multipart_uploads.get(upload_id) {
+                Some(u) => (Some(u.clone()), b.objects.contains_key(key)),
+                None => (None, b.objects.contains_key(key)),
+            }
+        };
+        let upload = match upload {
+            Some(u) => u,
             None => {
+                let b = state
+                    .buckets
+                    .get(bucket)
+                    .ok_or_else(|| no_such_bucket(bucket))?;
                 // Upload already completed - return existing object if it exists
                 // IfNoneMatch does NOT apply to re-completions
                 if let Some(obj) = b.objects.get(key) {
@@ -403,7 +417,7 @@ impl S3Service {
 
         // IfNoneMatch: if "*" and object already exists, reject (only for real completions)
         if let Some(ref inm) = if_none_match {
-            if inm == "*" && b.objects.contains_key(key) {
+            if inm == "*" && already_has_object {
                 return Err(precondition_failed("If-None-Match"));
             }
         }
@@ -471,7 +485,7 @@ impl S3Service {
                     "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not have matched the part's entity tag.",
                 ));
             }
-            let part_bytes = crate::state::read_body_bytes(&part.body);
+            let part_bytes = state.read_body(&part.body).map_err(super::io_to_aws)?;
             combined_data.extend_from_slice(&part_bytes);
             let part_md5 = Md5::digest(&part_bytes);
             md5_digests.extend_from_slice(&part_md5);
@@ -494,6 +508,10 @@ impl S3Service {
             std::collections::HashMap::new()
         };
 
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
         let version_id = if b.versioning.as_deref() == Some("Enabled") {
             Some(uuid::Uuid::new_v4().to_string())
         } else {
@@ -525,18 +543,20 @@ impl S3Service {
         b.multipart_uploads.remove(upload_id);
         if let Some(o) = b.objects.get(key) {
             let meta = object_meta_snapshot(o);
-            let _ =
-                self.store
-                    .mpu_complete(bucket, upload_id, key, meta.version_id.as_deref(), &meta);
+            self.store
+                .mpu_complete(bucket, upload_id, key, meta.version_id.as_deref(), &meta)
+                .map_err(super::persistence_error)?;
             // TODO(phase-4): mpu_complete should consume the part files; for memory
             // mode we also ensure the put_object seam is exercised.
-            let _ = self.store.put_object(
-                bucket,
-                key,
-                meta.version_id.as_deref(),
-                BodySource::Bytes(store_body.clone()),
-                &meta,
-            );
+            self.store
+                .put_object(
+                    bucket,
+                    key,
+                    meta.version_id.as_deref(),
+                    BodySource::Bytes(store_body.clone()),
+                    &meta,
+                )
+                .map_err(super::persistence_error)?;
         }
 
         let mut headers = HeaderMap::new();
@@ -595,7 +615,9 @@ impl S3Service {
             _ => {}
         }
         b.multipart_uploads.remove(upload_id);
-        let _ = self.store.mpu_abort(bucket, upload_id);
+        self.store
+            .mpu_abort(bucket, upload_id)
+            .map_err(super::persistence_error)?;
 
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -4,6 +4,9 @@ use http::{HeaderMap, StatusCode};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
+use fakecloud_persistence::BodySource;
+
+use crate::persistence::{mpu_init_snapshot, object_meta_snapshot, upload_part_meta_snapshot};
 use crate::state::{MultipartUpload, S3Object, UploadPart};
 
 use md5::{Digest, Md5};
@@ -102,7 +105,9 @@ impl S3Service {
             acl_grants,
             checksum_algorithm,
         };
+        let init_snapshot = mpu_init_snapshot(&upload);
         b.multipart_uploads.insert(upload_id.clone(), upload);
+        let _ = self.store.mpu_create(bucket, &upload_id, &init_snapshot);
 
         let mut headers = HeaderMap::new();
         if let Some(algo) = &sse_algorithm {
@@ -178,12 +183,20 @@ impl S3Service {
 
         let part = UploadPart {
             part_number: pn,
-            data: data.clone(),
+            body: crate::state::memory_body(data.clone()),
             etag: etag.clone(),
             size: data.len() as u64,
             last_modified: Utc::now(),
         };
+        let _ = upload_part_meta_snapshot(&part);
         upload.parts.insert(pn, part);
+        let _ = self.store.mpu_put_part(
+            bucket,
+            upload_id,
+            pn,
+            BodySource::Bytes(data.clone()),
+            &etag,
+        );
 
         let mut headers = HeaderMap::new();
         headers.insert("etag", format!("\"{etag}\"").parse().unwrap());
@@ -266,18 +279,19 @@ impl S3Service {
                     .ok_or_else(|| no_such_key(src_key))?
             };
 
+            let src_bytes = crate::state::read_body_bytes(&src_obj.body);
             if let Some(range_str) = copy_range {
                 let range_part = range_str.strip_prefix("bytes=").unwrap_or(range_str);
                 if let Some((start_str, end_str)) = range_part.split_once('-') {
                     let start: usize = start_str.parse().unwrap_or(0);
-                    let end: usize = end_str.parse().unwrap_or(src_obj.data.len() - 1);
-                    let end = std::cmp::min(end + 1, src_obj.data.len());
-                    src_obj.data.slice(start..end)
+                    let end: usize = end_str.parse().unwrap_or(src_bytes.len() - 1);
+                    let end = std::cmp::min(end + 1, src_bytes.len());
+                    src_bytes.slice(start..end)
                 } else {
-                    src_obj.data.clone()
+                    src_bytes.clone()
                 }
             } else {
-                src_obj.data.clone()
+                src_bytes.clone()
             }
         };
 
@@ -295,14 +309,22 @@ impl S3Service {
             return Err(no_such_upload(upload_id));
         }
 
+        let store_body = src_data.clone();
         let part = UploadPart {
             part_number: part_number as u32,
-            data: src_data,
+            body: crate::state::memory_body(src_data),
             etag: etag.clone(),
             size: data_len,
             last_modified: Utc::now(),
         };
         upload.parts.insert(part_number as u32, part);
+        let _ = self.store.mpu_put_part(
+            bucket,
+            upload_id,
+            part_number as u32,
+            BodySource::Bytes(store_body),
+            &etag,
+        );
 
         let body = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
@@ -418,7 +440,7 @@ impl S3Service {
                     break; // skip last part
                 }
                 if let Some(part) = upload.parts.get(part_num) {
-                    if part.data.len() < MIN_PART_SIZE {
+                    if part.size < MIN_PART_SIZE as u64 {
                         return Err(AwsServiceError::aws_error(
                             StatusCode::BAD_REQUEST,
                             "EntityTooSmall",
@@ -449,10 +471,11 @@ impl S3Service {
                     "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not have matched the part's entity tag.",
                 ));
             }
-            combined_data.extend_from_slice(&part.data);
-            let part_md5 = Md5::digest(&part.data);
+            let part_bytes = crate::state::read_body_bytes(&part.body);
+            combined_data.extend_from_slice(&part_bytes);
+            let part_md5 = Md5::digest(&part_bytes);
             md5_digests.extend_from_slice(&part_md5);
-            part_sizes.push((*part_num, part.data.len() as u64));
+            part_sizes.push((*part_num, part_bytes.len() as u64));
         }
 
         // Multipart ETag: MD5(concat(part_md5_digests))-N
@@ -463,6 +486,7 @@ impl S3Service {
             .as_deref()
             .map(|algo| compute_checksum(algo, &combined_data));
         let data = Bytes::from(combined_data);
+        let store_body = data.clone();
 
         let tags = if let Some(ref tagging) = upload.tagging {
             parse_url_encoded_tags(tagging).into_iter().collect()
@@ -479,7 +503,7 @@ impl S3Service {
         let obj = S3Object {
             key: key.to_string(),
             size: data.len() as u64,
-            data,
+            body: crate::state::memory_body(data),
             content_type: upload.content_type.clone(),
             etag: etag.clone(),
             last_modified: Utc::now(),
@@ -499,6 +523,25 @@ impl S3Service {
         };
         b.objects.insert(key.to_string(), obj);
         b.multipart_uploads.remove(upload_id);
+        if let Some(o) = b.objects.get(key) {
+            let meta = object_meta_snapshot(o);
+            let _ = self.store.mpu_complete(
+                bucket,
+                upload_id,
+                key,
+                meta.version_id.as_deref(),
+                &meta,
+            );
+            // TODO(phase-4): mpu_complete should consume the part files; for memory
+            // mode we also ensure the put_object seam is exercised.
+            let _ = self.store.put_object(
+                bucket,
+                key,
+                meta.version_id.as_deref(),
+                BodySource::Bytes(store_body.clone()),
+                &meta,
+            );
+        }
 
         let mut headers = HeaderMap::new();
         if let Some(vid) = &version_id {
@@ -556,6 +599,7 @@ impl S3Service {
             _ => {}
         }
         b.multipart_uploads.remove(upload_id);
+        let _ = self.store.mpu_abort(bucket, upload_id);
 
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,

--- a/crates/fakecloud-s3/src/service/notifications.rs
+++ b/crates/fakecloud-s3/src/service/notifications.rs
@@ -287,10 +287,21 @@ pub(crate) fn replicate_through_store(
         None => return Ok(()),
     };
 
-    // Read source bytes once (outside of per-destination persist).
-    let src_bytes = state
-        .read_body(&src_obj.body)
-        .map_err(fakecloud_persistence::StoreError::Io)?;
+    // For disk-backed sources, hold only the path and stream the source file
+    // directly to each replica via FileCopy. For memory sources, read once.
+    let src_disk_path: Option<std::path::PathBuf> = match &src_obj.body {
+        fakecloud_persistence::BodyRef::Disk { path, .. } => Some(path.clone()),
+        fakecloud_persistence::BodyRef::Memory(_) => None,
+    };
+    let src_bytes_opt: Option<bytes::Bytes> = if src_disk_path.is_none() {
+        Some(
+            state
+                .read_body(&src_obj.body)
+                .map_err(fakecloud_persistence::StoreError::Io)?,
+        )
+    } else {
+        None
+    };
 
     for rule in &rules {
         if rule.status != "Enabled" {
@@ -300,16 +311,25 @@ pub(crate) fn replicate_through_store(
             continue;
         }
         let dest_bucket_name = rule.dest_bucket.clone();
+        let dest_versioning_enabled;
         let (dest_version_id, dest_meta) = {
             let Some(dest_bucket) = state.buckets.get_mut(&dest_bucket_name) else {
                 continue;
             };
+            dest_versioning_enabled = dest_bucket.versioning.as_deref() == Some("Enabled");
             let mut replica = src_obj.clone();
             replica.storage_class = "STANDARD".to_string();
-            if dest_bucket.versioning.as_deref() == Some("Enabled") {
+            // Seed the runtime replica body from whatever we have handy; it
+            // is overwritten after `put_object` returns the canonical ref.
+            let seed_body = match (&src_disk_path, &src_bytes_opt) {
+                (Some(_), _) => src_obj.body.clone(),
+                (None, Some(b)) => crate::state::memory_body(b.clone()),
+                (None, None) => src_obj.body.clone(),
+            };
+            if dest_versioning_enabled {
                 let vid = uuid::Uuid::new_v4().to_string();
                 replica.version_id = Some(vid.clone());
-                replica.body = crate::state::memory_body(src_bytes.clone());
+                replica.body = seed_body;
                 dest_bucket
                     .object_versions
                     .entry(key.to_string())
@@ -322,26 +342,37 @@ pub(crate) fn replicate_through_store(
                 )
             } else {
                 replica.version_id = None;
-                replica.body = crate::state::memory_body(src_bytes.clone());
+                replica.body = seed_body;
                 dest_bucket.objects.insert(key.to_string(), replica.clone());
                 (None, crate::persistence::object_meta_snapshot(&replica))
             }
         };
 
+        let body_source = match (&src_disk_path, &src_bytes_opt) {
+            (Some(path), _) => fakecloud_persistence::BodySource::FileCopy(path.clone()),
+            (None, Some(b)) => fakecloud_persistence::BodySource::Bytes(b.clone()),
+            (None, None) => fakecloud_persistence::BodySource::Bytes(bytes::Bytes::new()),
+        };
         let returned = store.put_object(
             &dest_bucket_name,
             key,
             dest_version_id.as_deref(),
-            fakecloud_persistence::BodySource::Bytes(src_bytes.clone()),
+            body_source,
             &dest_meta,
         )?;
         if let Some(dest_bucket) = state.buckets.get_mut(&dest_bucket_name) {
             if let Some(o) = dest_bucket.objects.get_mut(key) {
                 o.body = returned.clone();
             }
-            if let Some(versions) = dest_bucket.object_versions.get_mut(key) {
-                if let Some(last) = versions.last_mut() {
-                    last.body = returned;
+            // Only rewrite the version-history entry when the destination
+            // bucket actually has versioning enabled. For Suspended or
+            // unversioned buckets the replica was only stored as the current
+            // object; rewriting stale history would corrupt it.
+            if dest_versioning_enabled {
+                if let Some(versions) = dest_bucket.object_versions.get_mut(key) {
+                    if let Some(last) = versions.last_mut() {
+                        last.body = returned;
+                    }
                 }
             }
         }

--- a/crates/fakecloud-s3/src/service/notifications.rs
+++ b/crates/fakecloud-s3/src/service/notifications.rs
@@ -211,7 +211,8 @@ pub(crate) fn parse_replication_rules(xml: &str) -> Vec<ReplicationRule> {
 }
 
 /// Replicate an object to destination buckets based on replication configuration.
-/// Called after storing an object in a bucket that has replication enabled.
+/// Kept for tests only; production paths use [`replicate_through_store`].
+#[cfg(test)]
 pub(crate) fn replicate_object(state: &mut crate::state::S3State, source_bucket: &str, key: &str) {
     let replication_config = match state.buckets.get(source_bucket) {
         Some(b) => match &b.replication_config {
@@ -256,6 +257,96 @@ pub(crate) fn replicate_object(state: &mut crate::state::S3State, source_bucket:
             dest_bucket.objects.insert(key.to_string(), replica);
         }
     }
+}
+
+/// Replicate an object to destination buckets AND persist the replica through
+/// the S3 store so disk-mode restarts see it. Called from PutObject/CopyObject
+/// write paths. Replaces the in-memory BodyRef of each replica with the one
+/// returned by `put_object` (Disk in persistent mode, Memory otherwise).
+pub(crate) fn replicate_through_store(
+    state: &mut crate::state::S3State,
+    store: &std::sync::Arc<dyn fakecloud_persistence::S3Store>,
+    source_bucket: &str,
+    key: &str,
+) -> fakecloud_persistence::StoreResult<()> {
+    let replication_config = match state.buckets.get(source_bucket) {
+        Some(b) => match &b.replication_config {
+            Some(config) => config.clone(),
+            None => return Ok(()),
+        },
+        None => return Ok(()),
+    };
+
+    let rules = parse_replication_rules(&replication_config);
+    let src_obj = match state
+        .buckets
+        .get(source_bucket)
+        .and_then(|b| b.objects.get(key))
+    {
+        Some(obj) => obj.clone(),
+        None => return Ok(()),
+    };
+
+    // Read source bytes once (outside of per-destination persist).
+    let src_bytes = state
+        .read_body(&src_obj.body)
+        .map_err(fakecloud_persistence::StoreError::Io)?;
+
+    for rule in &rules {
+        if rule.status != "Enabled" {
+            continue;
+        }
+        if !key.starts_with(&rule.prefix) {
+            continue;
+        }
+        let dest_bucket_name = rule.dest_bucket.clone();
+        let (dest_version_id, dest_meta) = {
+            let Some(dest_bucket) = state.buckets.get_mut(&dest_bucket_name) else {
+                continue;
+            };
+            let mut replica = src_obj.clone();
+            replica.storage_class = "STANDARD".to_string();
+            if dest_bucket.versioning.as_deref() == Some("Enabled") {
+                let vid = uuid::Uuid::new_v4().to_string();
+                replica.version_id = Some(vid.clone());
+                replica.body = crate::state::memory_body(src_bytes.clone());
+                dest_bucket
+                    .object_versions
+                    .entry(key.to_string())
+                    .or_default()
+                    .push(replica.clone());
+                dest_bucket.objects.insert(key.to_string(), replica.clone());
+                (
+                    Some(vid),
+                    crate::persistence::object_meta_snapshot(&replica),
+                )
+            } else {
+                replica.version_id = None;
+                replica.body = crate::state::memory_body(src_bytes.clone());
+                dest_bucket.objects.insert(key.to_string(), replica.clone());
+                (None, crate::persistence::object_meta_snapshot(&replica))
+            }
+        };
+
+        let returned = store.put_object(
+            &dest_bucket_name,
+            key,
+            dest_version_id.as_deref(),
+            fakecloud_persistence::BodySource::Bytes(src_bytes.clone()),
+            &dest_meta,
+        )?;
+        if let Some(dest_bucket) = state.buckets.get_mut(&dest_bucket_name) {
+            if let Some(o) = dest_bucket.objects.get_mut(key) {
+                o.body = returned.clone();
+            }
+            if let Some(versions) = dest_bucket.object_versions.get_mut(key) {
+                if let Some(last) = versions.last_mut() {
+                    last.body = returned;
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Build an S3 event notification JSON payload.

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -1513,6 +1513,7 @@ impl S3Service {
             }
             let dm_id = Uuid::new_v4().to_string();
             let marker = make_delete_marker(key, &dm_id);
+            let marker_meta = object_meta_snapshot(&marker);
             b.object_versions
                 .entry(key.to_string())
                 .or_default()
@@ -1521,6 +1522,13 @@ impl S3Service {
             resp_headers.insert("x-amz-version-id", dm_id.parse().unwrap());
             resp_headers.insert("x-amz-delete-marker", "true".parse().unwrap());
             let _ = self.store.delete_object(bucket, key, None);
+            let _ = self.store.put_object(
+                bucket,
+                key,
+                Some(dm_id.as_str()),
+                BodySource::Bytes(Bytes::new()),
+                &marker_meta,
+            );
 
             // Notification for delete
             let notification_config = b.notification_config.clone();

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -5,6 +5,9 @@ use uuid::Uuid;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
+use fakecloud_persistence::BodySource;
+
+use crate::persistence::object_meta_snapshot;
 use crate::state::{AclGrant, S3Object};
 
 use super::{
@@ -918,10 +921,11 @@ impl S3Service {
             }
         }
 
+        let store_body_bytes = data.clone();
         let obj = S3Object {
             key: key.to_string(),
             size: data.len() as u64,
-            data,
+            body: crate::state::memory_body(data),
             content_type,
             etag: etag.clone(),
             last_modified: Utc::now(),
@@ -989,6 +993,19 @@ impl S3Service {
 
             // Replicate object if replication is configured on the source bucket
             replicate_object(&mut state, bucket, key);
+
+            if let Some(b2) = state.buckets.get(bucket) {
+                if let Some(o) = b2.objects.get(key) {
+                    let meta = object_meta_snapshot(o);
+                    let _ = self.store.put_object(
+                        bucket,
+                        key,
+                        meta.version_id.as_deref(),
+                        BodySource::Bytes(store_body_bytes.clone()),
+                        &meta,
+                    );
+                }
+            }
         } // write lock dropped
 
         // --- Response phase: build response headers ---
@@ -1093,6 +1110,7 @@ impl S3Service {
 
         // Conditional checks
         check_get_conditionals(req, obj)?;
+        let obj_bytes = crate::state::read_body_bytes(&obj.body);
         let total_size = obj.size as usize;
         let mut headers = HeaderMap::new();
         headers.insert("etag", format!("\"{}\"", obj.etag).parse().unwrap());
@@ -1186,7 +1204,7 @@ impl S3Service {
                             "content-length",
                             (end - start + 1).to_string().parse().unwrap(),
                         );
-                        response_body = obj.data.slice(start..=end);
+                        response_body = obj_bytes.slice(start..=end);
                         response_status = StatusCode::PARTIAL_CONTENT;
                         is_range_request = true;
                     }
@@ -1203,12 +1221,12 @@ impl S3Service {
                     }
                     RangeResult::Ignored => {
                         headers.insert("content-length", total_size.to_string().parse().unwrap());
-                        response_body = obj.data.clone();
+                        response_body = obj_bytes.clone();
                     }
                 }
             } else {
                 headers.insert("content-length", total_size.to_string().parse().unwrap());
-                response_body = obj.data.clone();
+                response_body = obj_bytes.clone();
             }
         } else if let Some(part_num_str) = req.query_params.get("partNumber") {
             if let Ok(part_num) = part_num_str.parse::<u32>() {
@@ -1245,15 +1263,15 @@ impl S3Service {
                         .unwrap(),
                 );
                 headers.insert("content-length", part_size.to_string().parse().unwrap());
-                response_body = obj.data.slice(part_start..part_start + part_size);
+                response_body = obj_bytes.slice(part_start..part_start + part_size);
                 response_status = StatusCode::PARTIAL_CONTENT;
             } else {
                 headers.insert("content-length", total_size.to_string().parse().unwrap());
-                response_body = obj.data.clone();
+                response_body = obj_bytes.clone();
             }
         } else {
             headers.insert("content-length", total_size.to_string().parse().unwrap());
-            response_body = obj.data.clone();
+            response_body = obj_bytes.clone();
         }
         // Only include checksum headers for full (non-range) responses
         if !is_range_request {
@@ -1454,6 +1472,7 @@ impl S3Service {
             if is_dm {
                 resp_headers.insert("x-amz-delete-marker", "true".parse().unwrap());
             }
+            let _ = self.store.delete_object(bucket, key, Some(vid.as_str()));
             return Ok(AwsResponse {
                 status: StatusCode::NO_CONTENT,
                 content_type: "application/xml".to_string(),
@@ -1501,6 +1520,7 @@ impl S3Service {
             b.objects.insert(key.to_string(), marker);
             resp_headers.insert("x-amz-version-id", dm_id.parse().unwrap());
             resp_headers.insert("x-amz-delete-marker", "true".parse().unwrap());
+            let _ = self.store.delete_object(bucket, key, None);
 
             // Notification for delete
             let notification_config = b.notification_config.clone();
@@ -1538,6 +1558,7 @@ impl S3Service {
         let obj_key = key.to_string();
 
         b.objects.remove(key);
+        let _ = self.store.delete_object(bucket, key, None);
         drop(state);
 
         // Deliver S3 event notifications
@@ -2040,8 +2061,9 @@ impl S3Service {
         });
 
         // Checksum: compute new if algorithm specified, or copy from source
+        let src_bytes = crate::state::read_body_bytes(&src_obj.body);
         let (new_checksum_algo, new_checksum_val) = if let Some(ref algo) = checksum_algorithm {
-            let val = compute_checksum(algo, &src_obj.data);
+            let val = compute_checksum(algo, &src_bytes);
             (Some(algo.clone()), Some(val))
         } else if src_obj.checksum_algorithm.is_some() {
             (
@@ -2074,7 +2096,7 @@ impl S3Service {
 
         let dest_obj = S3Object {
             key: dest_key.to_string(),
-            data: src_obj.data,
+            body: src_obj.body,
             size: src_obj.size,
             etag: etag.clone(),
             last_modified,
@@ -2106,6 +2128,16 @@ impl S3Service {
                 .push(dest_obj.clone());
         }
         db.objects.insert(dest_key.to_string(), dest_obj);
+        if let Some(o) = db.objects.get(dest_key) {
+            let meta = object_meta_snapshot(o);
+            let _ = self.store.put_object(
+                dest_bucket,
+                dest_key,
+                meta.version_id.as_deref(),
+                BodySource::Bytes(src_bytes.clone()),
+                &meta,
+            );
+        }
 
         let mut response_headers = HeaderMap::new();
         if let Some(vid) = &version_id {
@@ -2294,6 +2326,7 @@ impl S3Service {
                         b.object_versions.remove(key);
                     }
                 }
+                let _ = self.store.delete_object(bucket, key, Some(vid.as_str()));
                 deleted_xml.push_str(&format!(
                     "<Deleted><Key>{}</Key><VersionId>{}</VersionId></Deleted>",
                     xml_escape(key),
@@ -2307,12 +2340,14 @@ impl S3Service {
                     .or_default()
                     .push(marker.clone());
                 b.objects.insert(key.to_string(), marker);
+                let _ = self.store.delete_object(bucket, key, None);
                 deleted_xml.push_str(&format!(
                     "<Deleted><Key>{}</Key><DeleteMarker>true</DeleteMarker><DeleteMarkerVersionId>{}</DeleteMarkerVersionId></Deleted>",
                     xml_escape(key), dm_id,
                 ));
             } else {
                 b.objects.remove(key);
+                let _ = self.store.delete_object(bucket, key, None);
                 deleted_xml.push_str(&format!(
                     "<Deleted><Key>{}</Key></Deleted>",
                     xml_escape(key)
@@ -2457,6 +2492,10 @@ impl S3Service {
             .to_string();
         obj.restore_ongoing = Some(false);
         obj.restore_expiry = Some(expiry);
+        let meta = object_meta_snapshot(obj);
+        let _ = self
+            .store
+            .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
         Ok(AwsResponse {
             status,
             content_type: "application/xml".to_string(),

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -997,13 +997,15 @@ impl S3Service {
             if let Some(b2) = state.buckets.get(bucket) {
                 if let Some(o) = b2.objects.get(key) {
                     let meta = object_meta_snapshot(o);
-                    let _ = self.store.put_object(
-                        bucket,
-                        key,
-                        meta.version_id.as_deref(),
-                        BodySource::Bytes(store_body_bytes.clone()),
-                        &meta,
-                    );
+                    self.store
+                        .put_object(
+                            bucket,
+                            key,
+                            meta.version_id.as_deref(),
+                            BodySource::Bytes(store_body_bytes.clone()),
+                            &meta,
+                        )
+                        .map_err(super::persistence_error)?;
                 }
             }
         } // write lock dropped
@@ -1110,7 +1112,6 @@ impl S3Service {
 
         // Conditional checks
         check_get_conditionals(req, obj)?;
-        let obj_bytes = crate::state::read_body_bytes(&obj.body);
         let total_size = obj.size as usize;
         let mut headers = HeaderMap::new();
         headers.insert("etag", format!("\"{}\"", obj.etag).parse().unwrap());
@@ -1200,11 +1201,11 @@ impl S3Service {
                             "content-range",
                             format!("bytes {start}-{end}/{total_size}").parse().unwrap(),
                         );
-                        headers.insert(
-                            "content-length",
-                            (end - start + 1).to_string().parse().unwrap(),
-                        );
-                        response_body = obj_bytes.slice(start..=end);
+                        let len = (end - start + 1) as u64;
+                        headers.insert("content-length", len.to_string().parse().unwrap());
+                        response_body = state
+                            .read_body_range(&obj.body, start as u64, len)
+                            .map_err(super::io_to_aws)?;
                         response_status = StatusCode::PARTIAL_CONTENT;
                         is_range_request = true;
                     }
@@ -1221,12 +1222,12 @@ impl S3Service {
                     }
                     RangeResult::Ignored => {
                         headers.insert("content-length", total_size.to_string().parse().unwrap());
-                        response_body = obj_bytes.clone();
+                        response_body = state.read_body(&obj.body).map_err(super::io_to_aws)?;
                     }
                 }
             } else {
                 headers.insert("content-length", total_size.to_string().parse().unwrap());
-                response_body = obj_bytes.clone();
+                response_body = state.read_body(&obj.body).map_err(super::io_to_aws)?;
             }
         } else if let Some(part_num_str) = req.query_params.get("partNumber") {
             if let Ok(part_num) = part_num_str.parse::<u32>() {
@@ -1263,15 +1264,17 @@ impl S3Service {
                         .unwrap(),
                 );
                 headers.insert("content-length", part_size.to_string().parse().unwrap());
-                response_body = obj_bytes.slice(part_start..part_start + part_size);
+                response_body = state
+                    .read_body_range(&obj.body, part_start as u64, part_size as u64)
+                    .map_err(super::io_to_aws)?;
                 response_status = StatusCode::PARTIAL_CONTENT;
             } else {
                 headers.insert("content-length", total_size.to_string().parse().unwrap());
-                response_body = obj_bytes.clone();
+                response_body = state.read_body(&obj.body).map_err(super::io_to_aws)?;
             }
         } else {
             headers.insert("content-length", total_size.to_string().parse().unwrap());
-            response_body = obj_bytes.clone();
+            response_body = state.read_body(&obj.body).map_err(super::io_to_aws)?;
         }
         // Only include checksum headers for full (non-range) responses
         if !is_range_request {
@@ -1472,7 +1475,9 @@ impl S3Service {
             if is_dm {
                 resp_headers.insert("x-amz-delete-marker", "true".parse().unwrap());
             }
-            let _ = self.store.delete_object(bucket, key, Some(vid.as_str()));
+            self.store
+                .delete_object(bucket, key, Some(vid.as_str()))
+                .map_err(super::persistence_error)?;
             return Ok(AwsResponse {
                 status: StatusCode::NO_CONTENT,
                 content_type: "application/xml".to_string(),
@@ -1521,14 +1526,18 @@ impl S3Service {
             b.objects.insert(key.to_string(), marker);
             resp_headers.insert("x-amz-version-id", dm_id.parse().unwrap());
             resp_headers.insert("x-amz-delete-marker", "true".parse().unwrap());
-            let _ = self.store.delete_object(bucket, key, None);
-            let _ = self.store.put_object(
-                bucket,
-                key,
-                Some(dm_id.as_str()),
-                BodySource::Bytes(Bytes::new()),
-                &marker_meta,
-            );
+            self.store
+                .delete_object(bucket, key, None)
+                .map_err(super::persistence_error)?;
+            self.store
+                .put_object(
+                    bucket,
+                    key,
+                    Some(dm_id.as_str()),
+                    BodySource::Bytes(Bytes::new()),
+                    &marker_meta,
+                )
+                .map_err(super::persistence_error)?;
 
             // Notification for delete
             let notification_config = b.notification_config.clone();
@@ -1566,7 +1575,9 @@ impl S3Service {
         let obj_key = key.to_string();
 
         b.objects.remove(key);
-        let _ = self.store.delete_object(bucket, key, None);
+        self.store
+            .delete_object(bucket, key, None)
+            .map_err(super::persistence_error)?;
         drop(state);
 
         // Deliver S3 event notifications
@@ -2069,7 +2080,7 @@ impl S3Service {
         });
 
         // Checksum: compute new if algorithm specified, or copy from source
-        let src_bytes = crate::state::read_body_bytes(&src_obj.body);
+        let src_bytes = state.read_body(&src_obj.body).map_err(super::io_to_aws)?;
         let (new_checksum_algo, new_checksum_val) = if let Some(ref algo) = checksum_algorithm {
             let val = compute_checksum(algo, &src_bytes);
             (Some(algo.clone()), Some(val))
@@ -2104,7 +2115,11 @@ impl S3Service {
 
         let dest_obj = S3Object {
             key: dest_key.to_string(),
-            body: src_obj.body,
+            // Copy is an independent object — never inherit the source's
+            // disk-backed BodyRef (which would point at the source's file).
+            // The source bytes are read above; the destination's own on-disk
+            // file is written below via `self.store.put_object`.
+            body: crate::state::memory_body(src_bytes.clone()),
             size: src_obj.size,
             etag: etag.clone(),
             last_modified,
@@ -2138,13 +2153,15 @@ impl S3Service {
         db.objects.insert(dest_key.to_string(), dest_obj);
         if let Some(o) = db.objects.get(dest_key) {
             let meta = object_meta_snapshot(o);
-            let _ = self.store.put_object(
-                dest_bucket,
-                dest_key,
-                meta.version_id.as_deref(),
-                BodySource::Bytes(src_bytes.clone()),
-                &meta,
-            );
+            self.store
+                .put_object(
+                    dest_bucket,
+                    dest_key,
+                    meta.version_id.as_deref(),
+                    BodySource::Bytes(src_bytes.clone()),
+                    &meta,
+                )
+                .map_err(super::persistence_error)?;
         }
 
         let mut response_headers = HeaderMap::new();
@@ -2334,7 +2351,9 @@ impl S3Service {
                         b.object_versions.remove(key);
                     }
                 }
-                let _ = self.store.delete_object(bucket, key, Some(vid.as_str()));
+                self.store
+                    .delete_object(bucket, key, Some(vid.as_str()))
+                    .map_err(super::persistence_error)?;
                 deleted_xml.push_str(&format!(
                     "<Deleted><Key>{}</Key><VersionId>{}</VersionId></Deleted>",
                     xml_escape(key),
@@ -2348,14 +2367,18 @@ impl S3Service {
                     .or_default()
                     .push(marker.clone());
                 b.objects.insert(key.to_string(), marker);
-                let _ = self.store.delete_object(bucket, key, None);
+                self.store
+                    .delete_object(bucket, key, None)
+                    .map_err(super::persistence_error)?;
                 deleted_xml.push_str(&format!(
                     "<Deleted><Key>{}</Key><DeleteMarker>true</DeleteMarker><DeleteMarkerVersionId>{}</DeleteMarkerVersionId></Deleted>",
                     xml_escape(key), dm_id,
                 ));
             } else {
                 b.objects.remove(key);
-                let _ = self.store.delete_object(bucket, key, None);
+                self.store
+                    .delete_object(bucket, key, None)
+                    .map_err(super::persistence_error)?;
                 deleted_xml.push_str(&format!(
                     "<Deleted><Key>{}</Key></Deleted>",
                     xml_escape(key)
@@ -2501,9 +2524,9 @@ impl S3Service {
         obj.restore_ongoing = Some(false);
         obj.restore_expiry = Some(expiry);
         let meta = object_meta_snapshot(obj);
-        let _ = self
-            .store
-            .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
+        self.store
+            .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta)
+            .map_err(super::persistence_error)?;
         Ok(AwsResponse {
             status,
             content_type: "application/xml".to_string(),

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -2585,8 +2585,14 @@ impl S3Service {
 
 /// Build the response body for a full GetObject read. For memory-backed
 /// bodies this returns `ResponseBody::Bytes`; for disk-backed bodies it
-/// returns `ResponseBody::File` so the dispatcher can stream the file
-/// directly into the HTTP response without materializing it in RAM.
+/// opens the file handle eagerly (while the caller still holds the per-state
+/// read guard) and returns `ResponseBody::File` so the dispatcher can stream
+/// the file directly into the HTTP response without materializing it in RAM.
+///
+/// Opening the handle inside the read guard is load-bearing: on unix an open
+/// fd keeps the old inode alive even after the path is renamed over or
+/// unlinked, so a concurrent PUT/DELETE that lands after we drop the guard
+/// cannot hand the reader a partial or swapped body.
 fn full_body_response(
     state: &crate::state::S3State,
     body: &fakecloud_persistence::BodyRef,
@@ -2596,9 +2602,10 @@ fn full_body_response(
             let bytes = state.read_body(body).map_err(super::io_to_aws)?;
             Ok(ResponseBody::Bytes(bytes))
         }
-        fakecloud_persistence::BodyRef::Disk { path, size, .. } => Ok(ResponseBody::File {
-            path: path.clone(),
-            size: *size,
-        }),
+        fakecloud_persistence::BodyRef::Disk { path, size, .. } => {
+            let std_file = std::fs::File::open(path).map_err(super::io_to_aws)?;
+            let file = tokio::fs::File::from_std(std_file);
+            Ok(ResponseBody::File { file, size: *size })
+        }
     }
 }

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use http::{HeaderMap, StatusCode};
 use uuid::Uuid;
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError, ResponseBody};
 
 use fakecloud_persistence::BodySource;
 
@@ -15,7 +15,7 @@ use super::{
     check_object_lock_for_overwrite, compute_checksum, compute_md5, deliver_notifications,
     etag_matches, extract_user_metadata, extract_xml_value, is_frozen, is_valid_storage_class,
     make_delete_marker, no_such_bucket, no_such_key, parse_delete_objects_xml, parse_grant_headers,
-    parse_range_header, parse_url_encoded_tags, precondition_failed, replicate_object,
+    parse_range_header, parse_url_encoded_tags, precondition_failed, replicate_through_store,
     resolve_object, s3_xml, url_encode_s3_key, xml_escape, RangeResult, S3Service,
 };
 
@@ -926,6 +926,10 @@ impl S3Service {
             key: key.to_string(),
             size: data.len() as u64,
             body: crate::state::memory_body(data),
+            // The runtime body is replaced below with the BodyRef returned
+            // from self.store.put_object — for memory mode this is still a
+            // Memory variant; for persistent mode it points at the freshly
+            // written .bin file so we don't double-buffer in RAM.
             content_type,
             etag: etag.clone(),
             last_modified: Utc::now(),
@@ -991,23 +995,40 @@ impl S3Service {
             }
             b.objects.insert(key.to_string(), obj);
 
-            // Replicate object if replication is configured on the source bucket
-            replicate_object(&mut state, bucket, key);
-
-            if let Some(b2) = state.buckets.get(bucket) {
-                if let Some(o) = b2.objects.get(key) {
-                    let meta = object_meta_snapshot(o);
-                    self.store
-                        .put_object(
-                            bucket,
-                            key,
-                            meta.version_id.as_deref(),
-                            BodySource::Bytes(store_body_bytes.clone()),
-                            &meta,
-                        )
-                        .map_err(super::persistence_error)?;
+            // Snapshot + persist + rewrite runtime body to the returned BodyRef.
+            let meta_version = {
+                let b2 = state
+                    .buckets
+                    .get(bucket)
+                    .ok_or_else(|| no_such_bucket(bucket))?;
+                let o = b2.objects.get(key).ok_or_else(|| no_such_key(key))?;
+                object_meta_snapshot(o)
+            };
+            let returned_body = self
+                .store
+                .put_object(
+                    bucket,
+                    key,
+                    meta_version.version_id.as_deref(),
+                    BodySource::Bytes(store_body_bytes.clone()),
+                    &meta_version,
+                )
+                .map_err(super::persistence_error)?;
+            if let Some(b2) = state.buckets.get_mut(bucket) {
+                if let Some(o) = b2.objects.get_mut(key) {
+                    o.body = returned_body.clone();
+                }
+                if versioning_enabled {
+                    if let Some(versions) = b2.object_versions.get_mut(key) {
+                        if let Some(last) = versions.last_mut() {
+                            last.body = returned_body;
+                        }
+                    }
                 }
             }
+            // Replicate (in-memory copy) then persist replicas via the store.
+            replicate_through_store(&mut state, &self.store, bucket, key)
+                .map_err(super::persistence_error)?;
         } // write lock dropped
 
         // --- Response phase: build response headers ---
@@ -1073,7 +1094,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: String::new(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers,
         })
     }
@@ -1191,7 +1212,7 @@ impl S3Service {
             headers.insert("x-amz-restore", rv.parse().unwrap());
         }
         let mut response_status = StatusCode::OK;
-        let response_body;
+        let response_body: fakecloud_core::service::ResponseBody;
         let mut is_range_request = false;
         if let Some(range_str) = req.headers.get("range").and_then(|v| v.to_str().ok()) {
             if let Some(rr) = parse_range_header(range_str, total_size) {
@@ -1205,7 +1226,8 @@ impl S3Service {
                         headers.insert("content-length", len.to_string().parse().unwrap());
                         response_body = state
                             .read_body_range(&obj.body, start as u64, len)
-                            .map_err(super::io_to_aws)?;
+                            .map_err(super::io_to_aws)?
+                            .into();
                         response_status = StatusCode::PARTIAL_CONTENT;
                         is_range_request = true;
                     }
@@ -1222,12 +1244,12 @@ impl S3Service {
                     }
                     RangeResult::Ignored => {
                         headers.insert("content-length", total_size.to_string().parse().unwrap());
-                        response_body = state.read_body(&obj.body).map_err(super::io_to_aws)?;
+                        response_body = full_body_response(&state, &obj.body)?;
                     }
                 }
             } else {
                 headers.insert("content-length", total_size.to_string().parse().unwrap());
-                response_body = state.read_body(&obj.body).map_err(super::io_to_aws)?;
+                response_body = full_body_response(&state, &obj.body)?;
             }
         } else if let Some(part_num_str) = req.query_params.get("partNumber") {
             if let Ok(part_num) = part_num_str.parse::<u32>() {
@@ -1266,15 +1288,16 @@ impl S3Service {
                 headers.insert("content-length", part_size.to_string().parse().unwrap());
                 response_body = state
                     .read_body_range(&obj.body, part_start as u64, part_size as u64)
-                    .map_err(super::io_to_aws)?;
+                    .map_err(super::io_to_aws)?
+                    .into();
                 response_status = StatusCode::PARTIAL_CONTENT;
             } else {
                 headers.insert("content-length", total_size.to_string().parse().unwrap());
-                response_body = state.read_body(&obj.body).map_err(super::io_to_aws)?;
+                response_body = full_body_response(&state, &obj.body)?;
             }
         } else {
             headers.insert("content-length", total_size.to_string().parse().unwrap());
-            response_body = state.read_body(&obj.body).map_err(super::io_to_aws)?;
+            response_body = full_body_response(&state, &obj.body)?;
         }
         // Only include checksum headers for full (non-range) responses
         if !is_range_request {
@@ -1481,7 +1504,7 @@ impl S3Service {
             return Ok(AwsResponse {
                 status: StatusCode::NO_CONTENT,
                 content_type: "application/xml".to_string(),
-                body: Bytes::new(),
+                body: Bytes::new().into(),
                 headers: resp_headers,
             });
         }
@@ -1564,7 +1587,7 @@ impl S3Service {
             return Ok(AwsResponse {
                 status: StatusCode::NO_CONTENT,
                 content_type: "application/xml".to_string(),
-                body: Bytes::new(),
+                body: Bytes::new().into(),
                 headers: resp_headers,
             });
         }
@@ -1600,7 +1623,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
     }
@@ -1628,7 +1651,7 @@ impl S3Service {
                 return Ok(AwsResponse {
                     status: StatusCode::METHOD_NOT_ALLOWED,
                     content_type: "application/xml".to_string(),
-                    body: Bytes::new(),
+                    body: Bytes::new().into(),
                     headers,
                 });
             }
@@ -1640,7 +1663,7 @@ impl S3Service {
             return Ok(AwsResponse {
                 status: StatusCode::NOT_FOUND,
                 content_type: "application/xml".to_string(),
-                body: Bytes::new(),
+                body: Bytes::new().into(),
                 headers,
             });
         }
@@ -1805,7 +1828,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: response_status,
             content_type: obj.content_type.clone(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers,
         })
     }
@@ -2151,18 +2174,41 @@ impl S3Service {
                 .push(dest_obj.clone());
         }
         db.objects.insert(dest_key.to_string(), dest_obj);
-        if let Some(o) = db.objects.get(dest_key) {
-            let meta = object_meta_snapshot(o);
-            self.store
-                .put_object(
-                    dest_bucket,
-                    dest_key,
-                    meta.version_id.as_deref(),
-                    BodySource::Bytes(src_bytes.clone()),
-                    &meta,
-                )
-                .map_err(super::persistence_error)?;
+        let dest_meta = {
+            let o = db
+                .objects
+                .get(dest_key)
+                .ok_or_else(|| no_such_key(dest_key))?;
+            object_meta_snapshot(o)
+        };
+        // Release the `db` borrow before the store call so we can re-borrow
+        // for the BodyRef rewrite and subsequent replication/notification
+        // work below.
+        let _ = db;
+        let dest_body_ref = self
+            .store
+            .put_object(
+                dest_bucket,
+                dest_key,
+                dest_meta.version_id.as_deref(),
+                BodySource::Bytes(src_bytes.clone()),
+                &dest_meta,
+            )
+            .map_err(super::persistence_error)?;
+        if let Some(db2) = state.buckets.get_mut(dest_bucket) {
+            if let Some(o) = db2.objects.get_mut(dest_key) {
+                o.body = dest_body_ref.clone();
+            }
+            if let Some(versions) = db2.object_versions.get_mut(dest_key) {
+                if let Some(last) = versions.last_mut() {
+                    last.body = dest_body_ref;
+                }
+            }
         }
+        let db = state
+            .buckets
+            .get_mut(dest_bucket)
+            .ok_or_else(|| no_such_bucket(dest_bucket))?;
 
         let mut response_headers = HeaderMap::new();
         if let Some(vid) = &version_id {
@@ -2207,7 +2253,8 @@ impl S3Service {
         let region = state.region.clone();
 
         // Replicate object if replication is configured on the destination bucket
-        replicate_object(&mut state, dest_bucket, dest_key);
+        replicate_through_store(&mut state, &self.store, dest_bucket, dest_key)
+            .map_err(super::persistence_error)?;
 
         drop(state);
 
@@ -2530,8 +2577,28 @@ impl S3Service {
         Ok(AwsResponse {
             status,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
+    }
+}
+
+/// Build the response body for a full GetObject read. For memory-backed
+/// bodies this returns `ResponseBody::Bytes`; for disk-backed bodies it
+/// returns `ResponseBody::File` so the dispatcher can stream the file
+/// directly into the HTTP response without materializing it in RAM.
+fn full_body_response(
+    state: &crate::state::S3State,
+    body: &fakecloud_persistence::BodyRef,
+) -> Result<ResponseBody, AwsServiceError> {
+    match body {
+        fakecloud_persistence::BodyRef::Memory(_) => {
+            let bytes = state.read_body(body).map_err(super::io_to_aws)?;
+            Ok(ResponseBody::Bytes(bytes))
+        }
+        fakecloud_persistence::BodyRef::Disk { path, size, .. } => Ok(ResponseBody::File {
+            path: path.clone(),
+            size: *size,
+        }),
     }
 }

--- a/crates/fakecloud-s3/src/service/tags.rs
+++ b/crates/fakecloud-s3/src/service/tags.rs
@@ -157,12 +157,9 @@ impl S3Service {
         if let Some(b2) = state.buckets.get(bucket) {
             if let Some(obj) = b2.objects.get(key) {
                 let meta = object_meta_snapshot(obj);
-                let _ = self.store.put_object_meta(
-                    bucket,
-                    key,
-                    meta.version_id.as_deref(),
-                    &meta,
-                );
+                let _ = self
+                    .store
+                    .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
             }
         }
         Ok(AwsResponse {
@@ -188,12 +185,9 @@ impl S3Service {
         let obj = b.objects.get_mut(key).ok_or_else(|| no_such_key(key))?;
         obj.tags.clear();
         let meta = object_meta_snapshot(obj);
-        let _ = self.store.put_object_meta(
-            bucket,
-            key,
-            meta.version_id.as_deref(),
-            &meta,
-        );
+        let _ = self
+            .store
+            .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),

--- a/crates/fakecloud-s3/src/service/tags.rs
+++ b/crates/fakecloud-s3/src/service/tags.rs
@@ -157,9 +157,9 @@ impl S3Service {
         if let Some(b2) = state.buckets.get(bucket) {
             if let Some(obj) = b2.objects.get(key) {
                 let meta = object_meta_snapshot(obj);
-                let _ = self
-                    .store
-                    .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
+                self.store
+                    .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta)
+                    .map_err(super::persistence_error)?;
             }
         }
         Ok(AwsResponse {
@@ -185,9 +185,9 @@ impl S3Service {
         let obj = b.objects.get_mut(key).ok_or_else(|| no_such_key(key))?;
         obj.tags.clear();
         let meta = object_meta_snapshot(obj);
-        let _ = self
-            .store
-            .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta);
+        self.store
+            .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta)
+            .map_err(super::persistence_error)?;
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),

--- a/crates/fakecloud-s3/src/service/tags.rs
+++ b/crates/fakecloud-s3/src/service/tags.rs
@@ -3,6 +3,8 @@ use http::{HeaderMap, StatusCode};
 use bytes::Bytes;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
+use crate::persistence::object_meta_snapshot;
+
 use super::{
     no_such_bucket, no_such_key, no_such_key_with_detail, parse_tagging_xml, s3_xml, xml_escape,
     S3Service,
@@ -151,6 +153,18 @@ impl S3Service {
             }
         }
 
+        // TODO(phase-4): snapshot-after-mutation for object tagging.
+        if let Some(b2) = state.buckets.get(bucket) {
+            if let Some(obj) = b2.objects.get(key) {
+                let meta = object_meta_snapshot(obj);
+                let _ = self.store.put_object_meta(
+                    bucket,
+                    key,
+                    meta.version_id.as_deref(),
+                    &meta,
+                );
+            }
+        }
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
@@ -173,6 +187,13 @@ impl S3Service {
             .ok_or_else(|| no_such_bucket(bucket))?;
         let obj = b.objects.get_mut(key).ok_or_else(|| no_such_key(key))?;
         obj.tags.clear();
+        let meta = object_meta_snapshot(obj);
+        let _ = self.store.put_object_meta(
+            bucket,
+            key,
+            meta.version_id.as_deref(),
+            &meta,
+        );
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),

--- a/crates/fakecloud-s3/src/service/tags.rs
+++ b/crates/fakecloud-s3/src/service/tags.rs
@@ -153,9 +153,24 @@ impl S3Service {
             }
         }
 
-        // TODO(phase-4): snapshot-after-mutation for object tagging.
         if let Some(b2) = state.buckets.get(bucket) {
-            if let Some(obj) = b2.objects.get(key) {
+            if let Some(ref vid) = version_id {
+                let versioned = b2
+                    .object_versions
+                    .get(key)
+                    .and_then(|vs| vs.iter().find(|o| o.version_id.as_deref() == Some(vid)));
+                let target = versioned.or_else(|| {
+                    b2.objects
+                        .get(key)
+                        .filter(|o| o.version_id.as_deref() == Some(vid))
+                });
+                if let Some(obj) = target {
+                    let meta = object_meta_snapshot(obj);
+                    self.store
+                        .put_object_meta(bucket, key, Some(vid.as_str()), &meta)
+                        .map_err(super::persistence_error)?;
+                }
+            } else if let Some(obj) = b2.objects.get(key) {
                 let meta = object_meta_snapshot(obj);
                 self.store
                     .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta)
@@ -165,7 +180,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: response_headers,
         })
     }
@@ -191,7 +206,7 @@ impl S3Service {
         Ok(AwsResponse {
             status: StatusCode::NO_CONTENT,
             content_type: "application/xml".to_string(),
-            body: Bytes::new(),
+            body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
     }

--- a/crates/fakecloud-s3/src/simulation.rs
+++ b/crates/fakecloud-s3/src/simulation.rs
@@ -94,7 +94,7 @@ mod tests {
     fn make_object(key: &str, age_days: i64) -> S3Object {
         S3Object {
             key: key.to_string(),
-            data: Bytes::from("test"),
+            body: crate::state::memory_body(Bytes::from("test")),
             content_type: "application/octet-stream".to_string(),
             etag: "\"abc\"".to_string(),
             size: 4,

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -195,14 +195,18 @@ impl S3State {
 pub type SharedS3State = Arc<RwLock<S3State>>;
 
 /// Read the bytes referenced by a [`BodyRef`]. In memory mode this is the
-/// stored buffer directly; the Disk arm is a complete seam for Phase 4+.
+/// stored buffer directly. For disk-backed bodies this falls back to a direct
+/// filesystem read which bypasses the [`BodyCache`]; cache-aware reads must go
+/// through `S3Store::open_object_body` via [`S3Service`]. TODO(phase-7): thread
+/// the store handle through all read sites so the cache is consulted
+/// everywhere.
 pub fn read_body_bytes(body: &BodyRef) -> Bytes {
     match body {
         BodyRef::Memory(b) => b.clone(),
-        BodyRef::Disk { .. } => {
-            // TODO(phase-4): route through S3Store::open_object_body.
-            panic!("Disk-backed BodyRef not supported in memory mode")
-        }
+        BodyRef::Disk { path, .. } => match std::fs::read(path) {
+            Ok(v) => Bytes::from(v),
+            Err(_) => Bytes::new(),
+        },
     }
 }
 

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -1,8 +1,10 @@
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use fakecloud_persistence::cache::{BodyCache, BodyKey};
 use fakecloud_persistence::BodyRef;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashMap};
+use std::io::{self, Read, Seek, SeekFrom};
 use std::sync::Arc;
 
 /// An ACL grant entry.
@@ -174,6 +176,7 @@ pub struct S3State {
     pub region: String,
     pub buckets: HashMap<String, S3Bucket>,
     pub notification_events: Vec<S3NotificationEvent>,
+    pub body_cache: Option<Arc<BodyCache>>,
 }
 
 impl S3State {
@@ -183,32 +186,72 @@ impl S3State {
             region: region.to_string(),
             buckets: HashMap::new(),
             notification_events: Vec::new(),
+            body_cache: None,
         }
+    }
+
+    pub fn set_body_cache(&mut self, cache: Arc<BodyCache>) {
+        self.body_cache = Some(cache);
     }
 
     pub fn reset(&mut self) {
         self.buckets.clear();
         self.notification_events.clear();
     }
+
+    /// Read the full body referenced by a [`BodyRef`], consulting the
+    /// persistent [`BodyCache`] when one is configured.
+    pub fn read_body(&self, body: &BodyRef) -> io::Result<Bytes> {
+        match body {
+            BodyRef::Memory(b) => Ok(b.clone()),
+            BodyRef::Disk {
+                bucket,
+                key,
+                version,
+                path,
+                ..
+            } => {
+                let cache_key = BodyKey::new(bucket.clone(), key.clone(), version.clone());
+                if let Some(cache) = &self.body_cache {
+                    if let Some(hit) = cache.get(&cache_key) {
+                        return Ok(hit);
+                    }
+                }
+                let data = std::fs::read(path)?;
+                let bytes = Bytes::from(data);
+                if let Some(cache) = &self.body_cache {
+                    cache.insert(cache_key, bytes.clone());
+                }
+                Ok(bytes)
+            }
+        }
+    }
+
+    /// Read a byte range from the body without loading the full object into
+    /// memory. Memory bodies are sliced directly; disk bodies are seek+read'd.
+    /// Ranges bypass the body cache (the cache stores whole objects only).
+    pub fn read_body_range(&self, body: &BodyRef, offset: u64, len: u64) -> io::Result<Bytes> {
+        match body {
+            BodyRef::Memory(b) => {
+                let start = offset as usize;
+                let end = start.saturating_add(len as usize).min(b.len());
+                if start > b.len() {
+                    return Ok(Bytes::new());
+                }
+                Ok(b.slice(start..end))
+            }
+            BodyRef::Disk { path, .. } => {
+                let mut f = std::fs::File::open(path)?;
+                f.seek(SeekFrom::Start(offset))?;
+                let mut buf = vec![0u8; len as usize];
+                f.read_exact(&mut buf)?;
+                Ok(Bytes::from(buf))
+            }
+        }
+    }
 }
 
 pub type SharedS3State = Arc<RwLock<S3State>>;
-
-/// Read the bytes referenced by a [`BodyRef`]. In memory mode this is the
-/// stored buffer directly. For disk-backed bodies this falls back to a direct
-/// filesystem read which bypasses the [`BodyCache`]; cache-aware reads must go
-/// through `S3Store::open_object_body` via [`S3Service`]. TODO(phase-7): thread
-/// the store handle through all read sites so the cache is consulted
-/// everywhere.
-pub fn read_body_bytes(body: &BodyRef) -> Bytes {
-    match body {
-        BodyRef::Memory(b) => b.clone(),
-        BodyRef::Disk { path, .. } => match std::fs::read(path) {
-            Ok(v) => Bytes::from(v),
-            Err(_) => Bytes::new(),
-        },
-    }
-}
 
 /// Construct a memory-backed [`BodyRef`] from [`Bytes`].
 pub fn memory_body(bytes: Bytes) -> BodyRef {

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use fakecloud_persistence::BodyRef;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -17,7 +18,7 @@ pub struct AclGrant {
 #[derive(Debug, Clone, Default)]
 pub struct S3Object {
     pub key: String,
-    pub data: Bytes,
+    pub body: BodyRef,
     pub content_type: String,
     pub etag: String,
     pub size: u64,
@@ -61,7 +62,7 @@ pub struct S3Object {
 #[derive(Debug, Clone)]
 pub struct UploadPart {
     pub part_number: u32,
-    pub data: Bytes,
+    pub body: BodyRef,
     pub etag: String,
     pub size: u64,
     pub last_modified: DateTime<Utc>,
@@ -192,3 +193,20 @@ impl S3State {
 }
 
 pub type SharedS3State = Arc<RwLock<S3State>>;
+
+/// Read the bytes referenced by a [`BodyRef`]. In memory mode this is the
+/// stored buffer directly; the Disk arm is a complete seam for Phase 4+.
+pub fn read_body_bytes(body: &BodyRef) -> Bytes {
+    match body {
+        BodyRef::Memory(b) => b.clone(),
+        BodyRef::Disk { .. } => {
+            // TODO(phase-4): route through S3Store::open_object_body.
+            panic!("Disk-backed BodyRef not supported in memory mode")
+        }
+    }
+}
+
+/// Construct a memory-backed [`BodyRef`] from [`Bytes`].
+pub fn memory_body(bytes: Bytes) -> BodyRef {
+    BodyRef::Memory(bytes)
+}

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -2217,13 +2217,13 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"], "test/secret");
         assert!(body["ARN"].as_str().unwrap().contains("test/secret"));
 
         let req = make_request("GetSecretValue", r#"{"SecretId": "test/secret"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SecretString"], "mysecretvalue");
     }
 
@@ -2234,7 +2234,7 @@ mod tests {
 
         let req = make_request("CreateSecret", r#"{"Name": "empty-secret"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"], "empty-secret");
         assert!(body.get("VersionId").is_none());
     }
@@ -2255,13 +2255,13 @@ mod tests {
             r#"{"SecretId": "versioned", "SecretString": "v2"}"#,
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"], "versioned");
 
         // Get should return v2
         let req = make_request("GetSecretValue", r#"{"SecretId": "versioned"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SecretString"], "v2");
     }
 
@@ -2279,7 +2279,7 @@ mod tests {
         // Delete (soft)
         let req = make_request("DeleteSecret", r#"{"SecretId": "deleteme"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["DeletionDate"].as_f64().is_some());
 
         // GetSecretValue should fail
@@ -2294,7 +2294,7 @@ mod tests {
         // GetSecretValue should work again
         let req = make_request("GetSecretValue", r#"{"SecretId": "deleteme"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SecretString"], "value");
     }
 
@@ -2313,7 +2313,7 @@ mod tests {
 
         let req = make_request("ListSecrets", "{}");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SecretList"].as_array().unwrap().len(), 3);
     }
 
@@ -2336,7 +2336,7 @@ mod tests {
 
         let req = make_request("DescribeSecret", r#"{"SecretId": "tagged"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let tags = body["Tags"].as_array().unwrap();
         assert!(tags
             .iter()
@@ -2350,7 +2350,7 @@ mod tests {
 
         let req = make_request("DescribeSecret", r#"{"SecretId": "tagged"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         // Tags should be empty list after untagging all (but key present since tags were set)
         assert_eq!(body["Tags"].as_array().unwrap().len(), 0);
     }
@@ -2362,7 +2362,7 @@ mod tests {
 
         let req = make_request("GetRandomPassword", "{}");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["RandomPassword"].as_str().unwrap().len(), 32);
     }
 
@@ -2376,7 +2376,7 @@ mod tests {
             r#"{"Name": "repl-secret", "SecretString": "val"}"#,
         );
         let resp = svc.handle(req).await.unwrap();
-        let create_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let create_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let expected_arn = create_body["ARN"].as_str().unwrap();
 
         for action in &[
@@ -2386,7 +2386,7 @@ mod tests {
         ] {
             let req = make_request(action, r#"{"SecretId": "repl-secret"}"#);
             let resp = svc.handle(req).await.unwrap();
-            let body: Value = serde_json::from_slice(&resp.body).unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
             assert_eq!(
                 body["ARN"].as_str().unwrap(),
                 expected_arn,
@@ -2481,7 +2481,7 @@ mod tests {
         let req = make_request("RotateSecret", &body.to_string());
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(resp_body["VersionId"], token);
 
         // Verify AWSPENDING version exists
@@ -2637,7 +2637,7 @@ mod tests {
         let req = make_request("CancelRotateSecret", r#"{"SecretId": "cancel-rot"}"#);
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"], "cancel-rot");
 
         // Verify rotation is disabled
@@ -2680,7 +2680,7 @@ mod tests {
         });
         let req = make_request("BatchGetSecretValue", &body.to_string());
         let resp = svc.handle(req).await.unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
         let values = resp_body["SecretValues"].as_array().unwrap();
         assert_eq!(values.len(), 3);
@@ -2711,7 +2711,7 @@ mod tests {
         });
         let req = make_request("BatchGetSecretValue", &body.to_string());
         let resp = svc.handle(req).await.unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
         let values = resp_body["SecretValues"].as_array().unwrap();
         assert_eq!(values.len(), 1);
@@ -2743,7 +2743,7 @@ mod tests {
         let req = make_request("UpdateSecret", &body.to_string());
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(resp_body["Name"], "updatable");
         // No VersionId since no new value was provided
         assert!(resp_body.get("VersionId").is_none());
@@ -2751,7 +2751,7 @@ mod tests {
         // Describe to verify changes
         let req = make_request("DescribeSecret", r#"{"SecretId": "updatable"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Description"], "new desc");
         assert_eq!(
             body["KmsKeyId"],
@@ -2777,13 +2777,13 @@ mod tests {
         });
         let req = make_request("UpdateSecret", &body.to_string());
         let resp = svc.handle(req).await.unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(resp_body["VersionId"].as_str().is_some());
 
         // Get should return new value
         let req = make_request("GetSecretValue", r#"{"SecretId": "upd-val"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SecretString"], "new-value");
     }
 
@@ -2794,7 +2794,7 @@ mod tests {
 
         let req = make_request("GetRandomPassword", r#"{"PasswordLength": 64}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["RandomPassword"].as_str().unwrap().len(), 64);
     }
 
@@ -2808,7 +2808,7 @@ mod tests {
             r#"{"PasswordLength": 100, "ExcludeCharacters": "abc123"}"#,
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let password = body["RandomPassword"].as_str().unwrap();
         assert_eq!(password.len(), 100);
         assert!(!password.contains('a'));
@@ -2834,7 +2834,7 @@ mod tests {
         });
         let req = make_request("GetRandomPassword", &body.to_string());
         let resp = svc.handle(req).await.unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let password = resp_body["RandomPassword"].as_str().unwrap();
         assert_eq!(password.len(), 50);
         assert!(password.chars().all(|c| c.is_ascii_lowercase()));
@@ -2972,7 +2972,7 @@ mod tests {
         });
         let req = make_request("ValidateResourcePolicy", &body.to_string());
         let resp = svc.handle(req).await.unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(resp_body["PolicyValidationPassed"], true);
         assert_eq!(resp_body["ValidationErrors"].as_array().unwrap().len(), 0);
     }
@@ -3000,7 +3000,7 @@ mod tests {
         // Get policy (should be empty initially)
         let req = make_request("GetResourcePolicy", r#"{"SecretId": "policy-secret"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"], "policy-secret");
         assert!(body.get("ResourcePolicy").is_none());
 
@@ -3017,7 +3017,7 @@ mod tests {
         // Get policy (should have it now)
         let req = make_request("GetResourcePolicy", r#"{"SecretId": "policy-secret"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ResourcePolicy"], policy);
 
         // Delete policy
@@ -3028,7 +3028,7 @@ mod tests {
         // Get again (should be gone)
         let req = make_request("GetResourcePolicy", r#"{"SecretId": "policy-secret"}"#);
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body.get("ResourcePolicy").is_none());
     }
 
@@ -3052,7 +3052,7 @@ mod tests {
         });
         let req = make_request("BatchGetSecretValue", &body.to_string());
         let resp = svc.handle(req).await.unwrap();
-        let resp_body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
 
         // Should have 0 values and 1 error
         assert_eq!(resp_body["SecretValues"].as_array().unwrap().len(), 0);

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -37,6 +37,7 @@ fakecloud-stepfunctions = { workspace = true }
 fakecloud-apigatewayv2 = { workspace = true }
 fakecloud-bedrock = { workspace = true }
 fakecloud-sdk = { workspace = true }
+fakecloud-persistence = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }

--- a/crates/fakecloud-server/src/cli.rs
+++ b/crates/fakecloud-server/src/cli.rs
@@ -1,4 +1,25 @@
-use clap::Parser;
+use std::path::PathBuf;
+
+use clap::{Parser, ValueEnum};
+use fakecloud_persistence::{PersistenceConfig, StorageMode};
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub(crate) enum StorageModeArg {
+    Memory,
+    Persistent,
+}
+
+impl From<StorageModeArg> for StorageMode {
+    fn from(value: StorageModeArg) -> Self {
+        match value {
+            StorageModeArg::Memory => StorageMode::Memory,
+            StorageModeArg::Persistent => StorageMode::Persistent,
+        }
+    }
+}
+
+const DEFAULT_BODY_CACHE_BYTES: u64 = 256 * 1024 * 1024;
 
 #[derive(Parser)]
 #[command(name = "fakecloud")]
@@ -20,6 +41,25 @@ pub(crate) struct Cli {
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, default_value = "info", env = "FAKECLOUD_LOG")]
     pub log_level: String,
+
+    /// Storage mode. `memory` (default) keeps all state in RAM; `persistent`
+    /// mirrors supported services to `--data-path` on disk.
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = StorageModeArg::Memory,
+        env = "FAKECLOUD_STORAGE_MODE",
+    )]
+    pub storage_mode: StorageModeArg,
+
+    /// Directory to persist state to. Required when `--storage-mode=persistent`.
+    #[arg(long, env = "FAKECLOUD_DATA_PATH")]
+    pub data_path: Option<PathBuf>,
+
+    /// Byte-sized LRU cache for object bodies in persistent mode. Plain bytes,
+    /// no SI/IEC suffix parsing. Default 256 MiB.
+    #[arg(long, default_value_t = DEFAULT_BODY_CACHE_BYTES, env = "FAKECLOUD_BODY_CACHE_SIZE")]
+    pub body_cache_size: u64,
 }
 
 impl Cli {
@@ -36,5 +76,16 @@ impl Cli {
             host
         };
         format!("http://{host}:{port}")
+    }
+
+    pub fn persistence_config(&self) -> Result<PersistenceConfig, String> {
+        let mode: StorageMode = self.storage_mode.into();
+        let config = PersistenceConfig {
+            mode,
+            data_path: self.data_path.clone(),
+            body_cache_bytes: self.body_cache_size,
+        };
+        config.validate()?;
+        Ok(config)
     }
 }

--- a/crates/fakecloud-server/src/cli.rs
+++ b/crates/fakecloud-server/src/cli.rs
@@ -19,7 +19,7 @@ impl From<StorageModeArg> for StorageMode {
     }
 }
 
-const DEFAULT_BODY_CACHE_BYTES: u64 = 256 * 1024 * 1024;
+const DEFAULT_S3_CACHE_BYTES: u64 = 256 * 1024 * 1024;
 
 #[derive(Parser)]
 #[command(name = "fakecloud")]
@@ -56,10 +56,10 @@ pub(crate) struct Cli {
     #[arg(long, env = "FAKECLOUD_DATA_PATH")]
     pub data_path: Option<PathBuf>,
 
-    /// Byte-sized LRU cache for object bodies in persistent mode. Plain bytes,
+    /// In-memory LRU cache for S3 object bodies in persistent mode. Plain bytes,
     /// no SI/IEC suffix parsing. Default 256 MiB.
-    #[arg(long, default_value_t = DEFAULT_BODY_CACHE_BYTES, env = "FAKECLOUD_BODY_CACHE_SIZE")]
-    pub body_cache_size: u64,
+    #[arg(long, default_value_t = DEFAULT_S3_CACHE_BYTES, env = "FAKECLOUD_S3_CACHE_SIZE")]
+    pub s3_cache_size: u64,
 }
 
 impl Cli {
@@ -83,7 +83,7 @@ impl Cli {
         let config = PersistenceConfig {
             mode,
             data_path: self.data_path.clone(),
-            body_cache_bytes: self.body_cache_size,
+            s3_cache_bytes: self.s3_cache_size,
         };
         config.validate()?;
         Ok(config)

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -444,11 +444,10 @@ async fn main() {
     registry.register(Arc::new(
         SsmService::new(ssm_state).with_secretsmanager(secretsmanager_state.clone()),
     ));
-    registry.register(Arc::new(
-        DynamoDbService::new(dynamodb_state.clone())
-            .with_s3(s3_state.clone())
-            .with_delivery(delivery_for_dynamodb),
-    ));
+    // DynamoDB is registered later, after s3_store is constructed, so the
+    // export path can persist result objects through the S3 store.
+    let dynamodb_state_for_register = dynamodb_state.clone();
+    let delivery_for_dynamodb_register = delivery_for_dynamodb;
     let mut lambda_service = LambdaService::new(lambda_state.clone());
     if let Some(ref rt) = container_runtime {
         lambda_service = lambda_service.with_runtime(rt.clone());
@@ -529,7 +528,14 @@ async fn main() {
         s3_state.write().set_body_cache(cache.clone());
     }
     registry.register(Arc::new(
-        S3Service::with_store(s3_state.clone(), delivery_for_s3, s3_store).with_kms(kms_state),
+        S3Service::with_store(s3_state.clone(), delivery_for_s3, s3_store.clone())
+            .with_kms(kms_state),
+    ));
+    registry.register(Arc::new(
+        DynamoDbService::new(dynamodb_state_for_register)
+            .with_s3(s3_state.clone())
+            .with_s3_store(s3_store.clone())
+            .with_delivery(delivery_for_dynamodb_register),
     ));
     // SES delivery bus (event fanout to SNS topics and EventBridge buses)
     let eb_delivery_for_ses = Arc::new(

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -468,6 +468,7 @@ async fn main() {
     ));
     registry.register(Arc::new(LogsService::new(logs_state, delivery_for_logs)));
     registry.register(Arc::new(KmsService::new(kms_state.clone())));
+    let mut shared_body_cache: Option<Arc<fakecloud_persistence::cache::BodyCache>> = None;
     let s3_store: Arc<dyn fakecloud_persistence::S3Store> = match persistence_config.mode {
         fakecloud_persistence::StorageMode::Persistent => {
             let data_path = persistence_config
@@ -485,6 +486,7 @@ async fn main() {
             let cache = Arc::new(fakecloud_persistence::cache::BodyCache::new(
                 persistence_config.s3_cache_bytes,
             ));
+            shared_body_cache = Some(cache.clone());
             let disk = fakecloud_persistence::s3::DiskS3Store::new(s3_root, cache);
             match <fakecloud_persistence::s3::DiskS3Store as fakecloud_persistence::S3Store>::load(
                 &disk,
@@ -520,6 +522,12 @@ async fn main() {
             Arc::new(fakecloud_persistence::s3::MemoryS3Store::new())
         }
     };
+    let s3_store_for_inbound = s3_store.clone();
+    if let Some(ref cache) = shared_body_cache {
+        // Share the cache between the S3Store and S3State so read_body honors
+        // the persistent LRU on every read site, not just open_object_body.
+        s3_state.write().set_body_cache(cache.clone());
+    }
     registry.register(Arc::new(
         S3Service::with_store(s3_state.clone(), delivery_for_s3, s3_store).with_kms(kms_state),
     ));
@@ -731,6 +739,7 @@ async fn main() {
             axum::routing::post({
                 let ss = ses_inbound_state.clone();
                 let s3_for_inbound = s3_introspection_state.clone();
+                let s3_store_for_inbound = s3_store_for_inbound.clone();
                 let delivery_for_inbound = {
                     let mut bus = DeliveryBus::new();
                     let sns_fanout_bus = {
@@ -778,9 +787,9 @@ async fn main() {
                                 let etag = format!("\"{:x}\"", md5::Md5::digest(&data));
                                 let obj = fakecloud_s3::state::S3Object {
                                     key: key.clone(),
-                                    body: fakecloud_persistence::BodyRef::Memory(data),
+                                    body: fakecloud_persistence::BodyRef::Memory(data.clone()),
                                     content_type: "text/plain".to_string(),
-                                    etag,
+                                    etag: etag.clone(),
                                     size,
                                     last_modified: now,
                                     storage_class: "STANDARD".to_string(),
@@ -793,7 +802,24 @@ async fn main() {
                                         key = %key,
                                         "SES inbound: stored email in S3"
                                     );
-                                    bucket.objects.insert(key, obj);
+                                    let meta =
+                                        fakecloud_s3::persistence::object_meta_snapshot(&obj);
+                                    bucket.objects.insert(key.clone(), obj);
+                                    drop(state);
+                                    if let Err(err) = s3_store_for_inbound.put_object(
+                                        bucket_name,
+                                        &key,
+                                        None,
+                                        fakecloud_persistence::BodySource::Bytes(data),
+                                        &meta,
+                                    ) {
+                                        tracing::error!(
+                                            bucket = %bucket_name,
+                                            key = %key,
+                                            error = %err,
+                                            "SES inbound: failed to persist S3 object via store"
+                                        );
+                                    }
                                 } else {
                                     tracing::warn!(
                                         bucket = %bucket_name,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -491,11 +491,17 @@ async fn main() {
                     let bucket_count = snapshot.buckets.len();
                     let object_count: usize =
                         snapshot.buckets.values().map(|b| b.objects.len()).sum();
-                    let hydrated = fakecloud_s3::persistence::hydrate_s3_state(
+                    let hydrated = match fakecloud_s3::persistence::hydrate_s3_state(
                         snapshot,
                         &cli.account_id,
                         &cli.region,
-                    );
+                    ) {
+                        Ok(h) => h,
+                        Err(err) => {
+                            tracing::error!(error = %err, "failed to hydrate s3 persistence snapshot");
+                            std::process::exit(1);
+                        }
+                    };
                     *s3_state.write() = hydrated;
                     tracing::info!(
                         buckets = bucket_count,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -61,32 +61,30 @@ async fn main() {
             tracing_subscriber::EnvFilter::try_new(&cli.log_level)
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
+        .with_writer(std::io::stderr)
         .init();
 
     let persistence_config = match cli.persistence_config() {
         Ok(cfg) => cfg,
-        Err(err) => {
-            tracing::error!(error = %err, "invalid persistence configuration");
-            std::process::exit(1);
-        }
+        Err(err) => fatal_exit(format_args!("invalid persistence configuration: {err}")),
     };
 
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
         if let Some(ref data_path) = persistence_config.data_path {
             if let Err(err) = std::fs::create_dir_all(data_path) {
-                tracing::error!(
-                    error = %err,
-                    path = %data_path.display(),
-                    "failed to create persistence data directory",
-                );
-                std::process::exit(1);
+                fatal_exit(format_args!(
+                    "failed to create persistence data directory {}: {err}",
+                    data_path.display()
+                ));
             }
             if let Err(err) = fakecloud_persistence::version::ensure_version_file(
                 data_path,
                 env!("CARGO_PKG_VERSION"),
             ) {
-                tracing::error!(error = %err, "persistence version file check failed");
-                std::process::exit(1);
+                fatal_exit(format_args!(
+                    "persistence version file check failed at {}/fakecloud.version.toml: {err}",
+                    data_path.display()
+                ));
             }
         }
     }
@@ -479,14 +477,18 @@ async fn main() {
                 .clone();
             let s3_root = data_path.join("s3");
             if let Err(err) = std::fs::create_dir_all(&s3_root) {
-                tracing::error!(error = %err, path = %s3_root.display(), "failed to create s3 persistence dir");
-                std::process::exit(1);
+                fatal_exit(format_args!(
+                    "failed to create s3 persistence dir {}: {err}",
+                    s3_root.display()
+                ));
             }
             let cache = Arc::new(fakecloud_persistence::cache::BodyCache::new(
-                persistence_config.body_cache_bytes,
+                persistence_config.s3_cache_bytes,
             ));
             let disk = fakecloud_persistence::s3::DiskS3Store::new(s3_root, cache);
-            match <fakecloud_persistence::s3::DiskS3Store as fakecloud_persistence::S3Store>::load(&disk) {
+            match <fakecloud_persistence::s3::DiskS3Store as fakecloud_persistence::S3Store>::load(
+                &disk,
+            ) {
                 Ok(snapshot) => {
                     let bucket_count = snapshot.buckets.len();
                     let object_count: usize =
@@ -497,10 +499,9 @@ async fn main() {
                         &cli.region,
                     ) {
                         Ok(h) => h,
-                        Err(err) => {
-                            tracing::error!(error = %err, "failed to hydrate s3 persistence snapshot");
-                            std::process::exit(1);
-                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to hydrate s3 persistence snapshot: {err}"
+                        )),
                     };
                     *s3_state.write() = hydrated;
                     tracing::info!(
@@ -509,10 +510,9 @@ async fn main() {
                         "loaded s3 persistence snapshot",
                     );
                 }
-                Err(err) => {
-                    tracing::error!(error = %err, "failed to load s3 persistence snapshot");
-                    std::process::exit(1);
-                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to load s3 persistence snapshot: {err}"
+                )),
             }
             Arc::new(disk)
         }
@@ -1640,4 +1640,13 @@ async fn shutdown_signal() {
         .await
         .expect("failed to install Ctrl+C handler");
     tracing::info!("shutting down");
+}
+
+/// Emit a fatal error through the tracing pipeline, flush stderr so the
+/// message survives `process::exit`, and terminate with code 1.
+fn fatal_exit(args: std::fmt::Arguments<'_>) -> ! {
+    use std::io::Write;
+    tracing::error!("{args}");
+    let _ = std::io::stderr().flush();
+    std::process::exit(1);
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -470,9 +470,43 @@ async fn main() {
     ));
     registry.register(Arc::new(LogsService::new(logs_state, delivery_for_logs)));
     registry.register(Arc::new(KmsService::new(kms_state.clone())));
-    // TODO(phase-4): swap in DiskS3Store when mode == Persistent.
-    let s3_store: Arc<dyn fakecloud_persistence::S3Store> =
-        Arc::new(fakecloud_persistence::s3::MemoryS3Store::new());
+    let s3_store: Arc<dyn fakecloud_persistence::S3Store> = match persistence_config.mode {
+        fakecloud_persistence::StorageMode::Persistent => {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let s3_root = data_path.join("s3");
+            if let Err(err) = std::fs::create_dir_all(&s3_root) {
+                tracing::error!(error = %err, path = %s3_root.display(), "failed to create s3 persistence dir");
+                std::process::exit(1);
+            }
+            let cache = Arc::new(fakecloud_persistence::cache::BodyCache::new(
+                persistence_config.body_cache_bytes,
+            ));
+            let disk = fakecloud_persistence::s3::DiskS3Store::new(s3_root, cache);
+            match <fakecloud_persistence::s3::DiskS3Store as fakecloud_persistence::S3Store>::load(&disk) {
+                Ok(snapshot) => {
+                    // TODO(phase-5/6): rehydrate runtime S3State from snapshot (versioning + mpu).
+                    let count: usize = snapshot.buckets.values().map(|b| b.objects.len()).sum();
+                    tracing::info!(
+                        buckets = snapshot.buckets.len(),
+                        objects = count,
+                        "loaded s3 persistence snapshot",
+                    );
+                }
+                Err(err) => {
+                    tracing::error!(error = %err, "failed to load s3 persistence snapshot");
+                    std::process::exit(1);
+                }
+            }
+            Arc::new(disk)
+        }
+        fakecloud_persistence::StorageMode::Memory => {
+            Arc::new(fakecloud_persistence::s3::MemoryS3Store::new())
+        }
+    };
     registry.register(Arc::new(
         S3Service::with_store(s3_state.clone(), delivery_for_s3, s3_store).with_kms(kms_state),
     ));

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -488,11 +488,18 @@ async fn main() {
             let disk = fakecloud_persistence::s3::DiskS3Store::new(s3_root, cache);
             match <fakecloud_persistence::s3::DiskS3Store as fakecloud_persistence::S3Store>::load(&disk) {
                 Ok(snapshot) => {
-                    // TODO(phase-5/6): rehydrate runtime S3State from snapshot (versioning + mpu).
-                    let count: usize = snapshot.buckets.values().map(|b| b.objects.len()).sum();
+                    let bucket_count = snapshot.buckets.len();
+                    let object_count: usize =
+                        snapshot.buckets.values().map(|b| b.objects.len()).sum();
+                    let hydrated = fakecloud_s3::persistence::hydrate_s3_state(
+                        snapshot,
+                        &cli.account_id,
+                        &cli.region,
+                    );
+                    *s3_state.write() = hydrated;
                     tracing::info!(
-                        buckets = snapshot.buckets.len(),
-                        objects = count,
+                        buckets = bucket_count,
+                        objects = object_count,
                         "loaded s3 persistence snapshot",
                     );
                 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -63,6 +63,34 @@ async fn main() {
         )
         .init();
 
+    let persistence_config = match cli.persistence_config() {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            tracing::error!(error = %err, "invalid persistence configuration");
+            std::process::exit(1);
+        }
+    };
+
+    if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+        if let Some(ref data_path) = persistence_config.data_path {
+            if let Err(err) = std::fs::create_dir_all(data_path) {
+                tracing::error!(
+                    error = %err,
+                    path = %data_path.display(),
+                    "failed to create persistence data directory",
+                );
+                std::process::exit(1);
+            }
+            if let Err(err) = fakecloud_persistence::version::ensure_version_file(
+                data_path,
+                env!("CARGO_PKG_VERSION"),
+            ) {
+                tracing::error!(error = %err, "persistence version file check failed");
+                std::process::exit(1);
+            }
+        }
+    }
+
     let endpoint_url = cli.endpoint_url();
 
     // Shared state
@@ -350,6 +378,32 @@ async fn main() {
     };
 
     // Register services
+    if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+        for service in [
+            "cloudformation",
+            "sqs",
+            "sns",
+            "events",
+            "iam",
+            "sts",
+            "ssm",
+            "dynamodb",
+            "lambda",
+            "secretsmanager",
+            "logs",
+            "kms",
+            "ses",
+            "cognito-idp",
+            "kinesis",
+            "rds",
+            "elasticache",
+            "states",
+            "apigatewayv2",
+            "bedrock",
+        ] {
+            fakecloud_persistence::warn_unsupported(service);
+        }
+    }
     let mut registry = ServiceRegistry::new();
     registry.register(Arc::new(CloudFormationService::new(
         cloudformation_state,
@@ -416,8 +470,11 @@ async fn main() {
     ));
     registry.register(Arc::new(LogsService::new(logs_state, delivery_for_logs)));
     registry.register(Arc::new(KmsService::new(kms_state.clone())));
+    // TODO(phase-4): swap in DiskS3Store when mode == Persistent.
+    let s3_store: Arc<dyn fakecloud_persistence::S3Store> =
+        Arc::new(fakecloud_persistence::s3::MemoryS3Store::new());
     registry.register(Arc::new(
-        S3Service::new(s3_state.clone(), delivery_for_s3).with_kms(kms_state),
+        S3Service::with_store(s3_state.clone(), delivery_for_s3, s3_store).with_kms(kms_state),
     ));
     // SES delivery bus (event fanout to SNS topics and EventBridge buses)
     let eb_delivery_for_ses = Arc::new(
@@ -674,7 +731,7 @@ async fn main() {
                                 let etag = format!("\"{:x}\"", md5::Md5::digest(&data));
                                 let obj = fakecloud_s3::state::S3Object {
                                     key: key.clone(),
-                                    data,
+                                    body: fakecloud_persistence::BodyRef::Memory(data),
                                     content_type: "text/plain".to_string(),
                                     etag,
                                     size,

--- a/crates/fakecloud-ses/src/service/mod.rs
+++ b/crates/fakecloud-ses/src/service/mod.rs
@@ -978,21 +978,21 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["VerifiedForSendingStatus"], true);
         assert_eq!(body["IdentityType"], "EMAIL_ADDRESS");
 
         // List identities
         let req = make_request(Method::GET, "/v2/email/identities", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["EmailIdentities"].as_array().unwrap().len(), 1);
 
         // Get identity
         let req = make_request(Method::GET, "/v2/email/identities/test%40example.com", "");
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["VerifiedForSendingStatus"], true);
         assert_eq!(body["DkimAttributes"]["Status"], "SUCCESS");
 
@@ -1022,7 +1022,7 @@ mod tests {
             r#"{"EmailIdentity": "example.com"}"#,
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["IdentityType"], "DOMAIN");
     }
 
@@ -1064,7 +1064,7 @@ mod tests {
         // Get template
         let req = make_request(Method::GET, "/v2/email/templates/welcome", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TemplateName"], "welcome");
         assert_eq!(body["TemplateContent"]["Subject"], "Welcome");
 
@@ -1080,13 +1080,13 @@ mod tests {
         // Verify update
         let req = make_request(Method::GET, "/v2/email/templates/welcome", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TemplateContent"]["Subject"], "Updated Welcome");
 
         // List templates
         let req = make_request(Method::GET, "/v2/email/templates", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TemplatesMetadata"].as_array().unwrap().len(), 1);
 
         // Delete template
@@ -1126,7 +1126,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["MessageId"].as_str().is_some());
 
         // Verify stored
@@ -1145,7 +1145,7 @@ mod tests {
         let req = make_request(Method::GET, "/v2/email/account", "");
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SendingEnabled"], true);
         assert!(body["SendQuota"]["Max24HourSend"].as_f64().unwrap() > 0.0);
     }
@@ -1168,13 +1168,13 @@ mod tests {
         let req = make_request(Method::GET, "/v2/email/configuration-sets/my-config", "");
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ConfigurationSetName"], "my-config");
 
         // List
         let req = make_request(Method::GET, "/v2/email/configuration-sets", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ConfigurationSets"].as_array().unwrap().len(), 1);
 
         // Delete
@@ -1210,7 +1210,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["MessageId"].as_str().is_some());
 
         let s = state.read();
@@ -1324,7 +1324,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let results = body["BulkEmailEntryResults"].as_array().unwrap();
         assert_eq!(results.len(), 2);
         assert_eq!(results[0]["Status"], "SUCCESS");
@@ -1501,7 +1501,7 @@ mod tests {
         let req = make_request(Method::GET, "/v2/email/contact-lists/my-list", "{}");
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ContactListName"], "my-list");
         assert_eq!(body["Description"], "Test list");
         assert_eq!(body["Topics"][0]["TopicName"], "newsletters");
@@ -1512,7 +1512,7 @@ mod tests {
         // List contact lists
         let req = make_request(Method::GET, "/v2/email/contact-lists", "{}");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ContactLists"].as_array().unwrap().len(), 1);
         assert_eq!(body["ContactLists"][0]["ContactListName"], "my-list");
 
@@ -1544,7 +1544,7 @@ mod tests {
         // Verify update
         let req = make_request(Method::GET, "/v2/email/contact-lists/my-list", "{}");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Description"], "Updated description");
         assert_eq!(body["Topics"].as_array().unwrap().len(), 2);
 
@@ -1638,7 +1638,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["EmailAddress"], "user@example.com");
         assert_eq!(body["ContactListName"], "my-list");
         assert_eq!(body["UnsubscribeAll"], false);
@@ -1657,7 +1657,7 @@ mod tests {
             "{}",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Contacts"].as_array().unwrap().len(), 1);
         assert_eq!(body["Contacts"][0]["EmailAddress"], "user@example.com");
 
@@ -1682,7 +1682,7 @@ mod tests {
             "{}",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["UnsubscribeAll"], true);
         assert_eq!(body["TopicPreferences"][0]["SubscriptionStatus"], "OPT_OUT");
 
@@ -1834,7 +1834,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let tags = body["Tags"].as_array().unwrap();
         assert_eq!(tags.len(), 2);
     }
@@ -2011,7 +2011,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["SuppressedDestination"]["EmailAddress"],
             "bounce@example.com"
@@ -2024,7 +2024,7 @@ mod tests {
         // List suppressed destinations
         let req = make_request(Method::GET, "/v2/email/suppression/addresses", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["SuppressedDestinationSummaries"]
                 .as_array()
@@ -2071,7 +2071,7 @@ mod tests {
             "",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SuppressedDestination"]["Reason"], "COMPLAINT");
     }
 
@@ -2116,7 +2116,7 @@ mod tests {
             "",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SuppressedDestination"]["Reason"], "COMPLAINT");
     }
 
@@ -2173,7 +2173,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let dests = body["EventDestinations"].as_array().unwrap();
         assert_eq!(dests.len(), 1);
         assert_eq!(dests[0]["Name"], "my-dest");
@@ -2206,7 +2206,7 @@ mod tests {
             "",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let dests = body["EventDestinations"].as_array().unwrap();
         assert_eq!(dests[0]["Enabled"], false);
         assert_eq!(dests[0]["MatchingEventTypes"], json!(["DELIVERY"]));
@@ -2227,7 +2227,7 @@ mod tests {
             "",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["EventDestinations"].as_array().unwrap().is_empty());
     }
 
@@ -2388,7 +2388,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Policies"]["my-policy"].is_string());
         assert_eq!(body["Policies"]["my-policy"].as_str().unwrap(), policy_doc);
 
@@ -2412,7 +2412,7 @@ mod tests {
             "",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Policies"]["my-policy"].as_str().unwrap(), updated_doc);
 
         // Delete policy
@@ -2431,7 +2431,7 @@ mod tests {
             "",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Policies"].as_object().unwrap().is_empty());
     }
 
@@ -2576,7 +2576,7 @@ mod tests {
         // Verify via GetEmailIdentity
         let req = make_request(Method::GET, "/v2/email/identities/example.com", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DkimAttributes"]["SigningEnabled"], false);
     }
 
@@ -2613,14 +2613,14 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DkimStatus"], "SUCCESS");
         assert!(!body["DkimTokens"].as_array().unwrap().is_empty());
 
         // Verify stored
         let req = make_request(Method::GET, "/v2/email/identities/example.com", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["DkimAttributes"]["SigningAttributesOrigin"],
             "EXTERNAL"
@@ -2649,7 +2649,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/identities/test%40example.com", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["FeedbackForwardingStatus"], false);
     }
 
@@ -2675,7 +2675,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/identities/example.com", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["MailFromAttributes"]["MailFromDomain"],
             "mail.example.com"
@@ -2708,7 +2708,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/identities/example.com", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ConfigurationSetName"], "my-config");
     }
 
@@ -2739,7 +2739,7 @@ mod tests {
         // Verify
         let req = make_request(Method::GET, "/v2/email/configuration-sets/test-config", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SendingOptions"]["SendingEnabled"], false);
     }
 
@@ -2779,7 +2779,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/configuration-sets/test-config", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DeliveryOptions"]["TlsPolicy"], "REQUIRE");
         assert_eq!(body["DeliveryOptions"]["SendingPoolName"], "my-pool");
     }
@@ -2806,7 +2806,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/configuration-sets/test-config", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["TrackingOptions"]["CustomRedirectDomain"],
             "track.example.com"
@@ -2836,7 +2836,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/configuration-sets/test-config", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let reasons = body["SuppressionOptions"]["SuppressedReasons"]
             .as_array()
             .unwrap();
@@ -2865,7 +2865,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/configuration-sets/test-config", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ReputationOptions"]["ReputationMetricsEnabled"], true);
     }
 
@@ -2891,7 +2891,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/configuration-sets/test-config", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["VdmOptions"]["DashboardOptions"]["EngagementMetrics"],
             "ENABLED"
@@ -2920,7 +2920,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/configuration-sets/test-config", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["ArchivingOptions"]["ArchiveArn"]
             .as_str()
             .unwrap()
@@ -2958,7 +2958,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TemplateName"], "my-verification");
         assert_eq!(body["FromEmailAddress"], "noreply@example.com");
         assert_eq!(body["TemplateSubject"], "Verify your email");
@@ -2973,7 +2973,7 @@ mod tests {
             "",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["CustomVerificationEmailTemplates"]
                 .as_array()
@@ -2998,7 +2998,7 @@ mod tests {
             "",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TemplateSubject"], "Updated subject");
 
         // Delete
@@ -3078,7 +3078,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["MessageId"].as_str().is_some());
 
         // Verify stored in sent_emails
@@ -3131,7 +3131,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let rendered = body["RenderedTemplate"].as_str().unwrap();
         assert!(rendered.contains("Subject: Hello Alice"));
         assert!(rendered.contains("Welcome, Alice!"));
@@ -3189,7 +3189,7 @@ mod tests {
         // List pools
         let req = make_request(Method::GET, "/v2/email/dedicated-ip-pools", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DedicatedIpPools"].as_array().unwrap().len(), 1);
 
         // Duplicate
@@ -3239,7 +3239,7 @@ mod tests {
             },
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let ips = body["DedicatedIps"].as_array().unwrap();
         assert_eq!(ips.len(), 3);
         assert_eq!(ips[0]["WarmupStatus"], "NOT_APPLICABLE");
@@ -3270,7 +3270,7 @@ mod tests {
         let req = make_request(Method::GET, "/v2/email/dedicated-ips/198.51.100.1", "");
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DedicatedIp"]["PoolName"], "pool-a");
 
         // Move IP to pool-b
@@ -3285,7 +3285,7 @@ mod tests {
         // Verify it moved
         let req = make_request(Method::GET, "/v2/email/dedicated-ips/198.51.100.1", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DedicatedIp"]["PoolName"], "pool-b");
 
         // Set warmup
@@ -3299,7 +3299,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/dedicated-ips/198.51.100.1", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DedicatedIp"]["WarmupPercentage"], 50);
         assert_eq!(body["DedicatedIp"]["WarmupStatus"], "IN_PROGRESS");
 
@@ -3355,7 +3355,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/account", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DedicatedIpAutoWarmupEnabled"], true);
     }
 
@@ -3374,7 +3374,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Status"], "READY");
         assert!(body["EndpointId"].as_str().is_some());
 
@@ -3386,7 +3386,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["EndpointName"], "global-ep");
         assert_eq!(body["Status"], "READY");
         let routes = body["Routes"].as_array().unwrap();
@@ -3395,7 +3395,7 @@ mod tests {
         // List
         let req = make_request(Method::GET, "/v2/email/multi-region-endpoints", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["MultiRegionEndpoints"].as_array().unwrap().len(), 1);
 
         // Duplicate
@@ -3415,7 +3415,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Status"], "DELETING");
 
         // Get after delete
@@ -3445,7 +3445,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/account", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Details"]["MailType"], "TRANSACTIONAL");
         assert_eq!(body["Details"]["WebsiteURL"], "https://example.com");
         assert_eq!(body["Details"]["UseCaseDescription"], "Testing");
@@ -3467,7 +3467,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/account", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SendingEnabled"], false);
 
         // Re-enable
@@ -3480,7 +3480,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/account", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SendingEnabled"], true);
     }
 
@@ -3499,7 +3499,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/account", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let reasons = body["SuppressionAttributes"]["SuppressedReasons"]
             .as_array()
             .unwrap();
@@ -3521,7 +3521,7 @@ mod tests {
 
         let req = make_request(Method::GET, "/v2/email/account", "");
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["VdmAttributes"]["VdmEnabled"], "ENABLED");
     }
 
@@ -3546,7 +3546,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let job_id = body["JobId"].as_str().unwrap().to_string();
 
         // Get import job
@@ -3557,7 +3557,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["JobId"], job_id);
         assert_eq!(body["JobStatus"], "COMPLETED");
 
@@ -3565,7 +3565,7 @@ mod tests {
         let req = make_request(Method::POST, "/v2/email/import-jobs/list", "{}");
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ImportJobs"].as_array().unwrap().len(), 1);
 
         // Get non-existent job
@@ -3599,7 +3599,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let job_id = body["JobId"].as_str().unwrap().to_string();
 
         // Get export job
@@ -3610,7 +3610,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["JobId"], job_id);
         assert_eq!(body["JobStatus"], "COMPLETED");
         assert_eq!(body["ExportSourceType"], "METRICS_DATA");
@@ -3619,7 +3619,7 @@ mod tests {
         let req = make_request(Method::POST, "/v2/email/list-export-jobs", "{}");
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ExportJobs"].as_array().unwrap().len(), 1);
 
         // Cancel — should fail since already COMPLETED
@@ -3645,7 +3645,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TenantName"], "my-tenant");
         assert!(body["TenantId"].as_str().is_some());
         assert_eq!(body["SendingStatus"], "ENABLED");
@@ -3658,14 +3658,14 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Tenant"]["TenantName"], "my-tenant");
 
         // List tenants
         let req = make_request(Method::POST, "/v2/email/tenants/list", "{}");
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Tenants"].as_array().unwrap().len(), 1);
 
         // Create resource association
@@ -3685,7 +3685,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TenantResources"].as_array().unwrap().len(), 1);
 
         // List resource tenants
@@ -3696,7 +3696,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ResourceTenants"].as_array().unwrap().len(), 1);
 
         // Delete resource association
@@ -3715,7 +3715,7 @@ mod tests {
             r#"{"TenantName": "my-tenant"}"#,
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["TenantResources"].as_array().unwrap().is_empty());
 
         // Delete tenant
@@ -3750,7 +3750,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["ReputationEntity"]["SendingStatusAggregate"],
             "ENABLED"
@@ -3781,7 +3781,7 @@ mod tests {
             "",
         );
         let resp = svc.handle(req).await.unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["ReputationEntity"]["CustomerManagedStatus"]["SendingStatus"],
             "DISABLED"
@@ -3791,7 +3791,7 @@ mod tests {
         let req = make_request(Method::POST, "/v2/email/reputation/entities", "{}");
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ReputationEntities"].as_array().unwrap().len(), 1);
     }
 
@@ -3817,7 +3817,7 @@ mod tests {
         );
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Results"].as_array().unwrap().len(), 1);
         assert_eq!(body["Results"][0]["Id"], "q1");
         assert!(body["Errors"].as_array().unwrap().is_empty());

--- a/crates/fakecloud-ses/src/v1.rs
+++ b/crates/fakecloud-ses/src/v1.rs
@@ -2114,7 +2114,7 @@ mod tests {
         let req = make_v1_request("CreateReceiptRuleSet", vec![("RuleSetName", "my-rules")]);
         let resp = handle_v1_action(&state, &req).unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("CreateReceiptRuleSetResponse"));
 
         // Duplicate should fail
@@ -2142,7 +2142,7 @@ mod tests {
 
         let req = make_v1_request("ListReceiptRuleSets", vec![]);
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Name>set-a</Name>"));
         assert!(body.contains("<Name>set-b</Name>"));
     }
@@ -2289,7 +2289,7 @@ mod tests {
             vec![("RuleSetName", "my-set"), ("RuleName", "store-email")],
         );
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Name>store-email</Name>"));
         assert!(body.contains("<Enabled>true</Enabled>"));
         assert!(body.contains("<ScanEnabled>true</ScanEnabled>"));
@@ -2430,7 +2430,7 @@ mod tests {
         // List filters
         let req = make_v1_request("ListReceiptFilters", vec![]);
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Name>allow-internal</Name>"));
         assert!(body.contains("<Cidr>10.0.0.0/8</Cidr>"));
         assert!(body.contains("<Policy>Allow</Policy>"));
@@ -2445,7 +2445,7 @@ mod tests {
         // List should be empty
         let req = make_v1_request("ListReceiptFilters", vec![]);
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(!body.contains("allow-internal"));
     }
 
@@ -2637,7 +2637,7 @@ mod tests {
 
         let req = make_v1_request("DescribeReceiptRuleSet", vec![("RuleSetName", "my-set")]);
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Name>my-set</Name>"));
         assert!(body.contains("<Name>rule1</Name>"));
         assert!(body.contains("<Rules>"));
@@ -2717,7 +2717,7 @@ mod tests {
         let req = make_v1_request("VerifyDomainIdentity", vec![("Domain", "example.com")]);
         let resp = handle_v1_action(&state, &req).unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<VerificationToken>"));
 
         let st = state.read();
@@ -2731,7 +2731,7 @@ mod tests {
         let state = make_state();
         let req = make_v1_request("VerifyDomainDkim", vec![("Domain", "example.com")]);
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<DkimTokens>"));
         // Should return 3 tokens
         assert_eq!(body.matches("<member>").count(), 3);
@@ -2754,7 +2754,7 @@ mod tests {
 
         // List all
         let resp = handle_v1_action(&state, &make_v1_request("ListIdentities", vec![])).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("a@test.com"));
         assert!(body.contains("test.com"));
 
@@ -2764,7 +2764,7 @@ mod tests {
             &make_v1_request("ListIdentities", vec![("IdentityType", "EmailAddress")]),
         )
         .unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("a@test.com"));
         assert!(!body.contains("<member>test.com</member>"));
 
@@ -2774,7 +2774,7 @@ mod tests {
             &make_v1_request("ListIdentities", vec![("IdentityType", "Domain")]),
         )
         .unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(!body.contains("a@test.com"));
         assert!(body.contains("test.com"));
     }
@@ -2796,7 +2796,7 @@ mod tests {
             ],
         );
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<VerificationStatus>Success</VerificationStatus>"));
         assert!(body.contains("<VerificationStatus>NotStarted</VerificationStatus>"));
     }
@@ -2864,7 +2864,7 @@ mod tests {
             vec![("Identities.member.1", "example.com")],
         );
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<DkimEnabled>"));
         assert!(body.contains("<DkimVerificationStatus>"));
         assert!(body.contains("<DkimTokens>"));
@@ -2913,7 +2913,7 @@ mod tests {
             vec![("Identities.member.1", "a@test.com")],
         );
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<ForwardingEnabled>true</ForwardingEnabled>"));
     }
 
@@ -2959,7 +2959,7 @@ mod tests {
             vec![("Identities.member.1", "example.com")],
         );
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<BehaviorOnMXFailure>"));
         assert!(body.contains("<MailFromDomainStatus>"));
     }
@@ -2982,7 +2982,7 @@ mod tests {
         );
         let resp = handle_v1_action(&state, &req).unwrap();
         assert_eq!(resp.status, StatusCode::OK);
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<MessageId>"));
 
         let st = state.read();
@@ -3108,7 +3108,7 @@ mod tests {
             ],
         );
         let resp = handle_v1_action(&state, &req).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Status>Success</Status>"));
 
         let st = state.read();
@@ -3151,13 +3151,13 @@ mod tests {
             &make_v1_request("GetTemplate", vec![("TemplateName", "t1")]),
         )
         .unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<TemplateName>t1</TemplateName>"));
         assert!(body.contains("<SubjectPart>Subject</SubjectPart>"));
 
         // List
         let resp = handle_v1_action(&state, &make_v1_request("ListTemplates", vec![])).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Name>t1</Name>"));
 
         // Update
@@ -3219,7 +3219,7 @@ mod tests {
         // List
         let resp =
             handle_v1_action(&state, &make_v1_request("ListConfigurationSets", vec![])).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Name>my-config</Name>"));
 
         // Describe
@@ -3231,7 +3231,7 @@ mod tests {
             ),
         )
         .unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Name>my-config</Name>"));
 
         // Delete
@@ -3326,7 +3326,7 @@ mod tests {
     fn test_get_send_quota() {
         let state = make_state();
         let resp = handle_v1_action(&state, &make_v1_request("GetSendQuota", vec![])).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Max24HourSend>50000.0</Max24HourSend>"));
         assert!(body.contains("<MaxSendRate>14.0</MaxSendRate>"));
     }
@@ -3350,7 +3350,7 @@ mod tests {
         .unwrap();
 
         let resp = handle_v1_action(&state, &make_v1_request("GetSendStatistics", vec![])).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<DeliveryAttempts>1</DeliveryAttempts>"));
     }
 
@@ -3359,7 +3359,7 @@ mod tests {
         let state = make_state();
         let resp =
             handle_v1_action(&state, &make_v1_request("GetAccountSendingEnabled", vec![])).unwrap();
-        let body = String::from_utf8(resp.body.to_vec()).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Enabled>true</Enabled>"));
     }
 }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -3901,7 +3901,7 @@ mod tests {
     }
 
     fn response_body(result: &Result<AwsResponse, AwsServiceError>) -> String {
-        String::from_utf8(result.as_ref().unwrap().body.to_vec()).unwrap()
+        String::from_utf8(result.as_ref().unwrap().body.expect_bytes().to_vec()).unwrap()
     }
 
     // --- Subscribe / Unsubscribe / ListSubscriptions / ListSubscriptionsByTopic ---

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -2974,7 +2974,7 @@ mod tests {
     fn create_queue(svc: &SqsService, name: &str) -> String {
         let req = make_request("CreateQueue", json!({ "QueueName": name }));
         let resp = svc.create_queue(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         body["QueueUrl"].as_str().unwrap().to_string()
     }
 
@@ -2984,7 +2984,7 @@ mod tests {
             json!({ "QueueUrl": queue_url, "MessageBody": body_text }),
         );
         let resp = svc.send_message(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         body["MessageId"].as_str().unwrap().to_string()
     }
 
@@ -3002,7 +3002,7 @@ mod tests {
             .build()
             .unwrap();
         let resp = rt.block_on(svc.receive_message(&req)).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         body["Messages"].as_array().cloned().unwrap_or_default()
     }
 
@@ -3052,7 +3052,7 @@ mod tests {
         let url = create_queue(&svc, "lookup-queue");
         let req = make_request("GetQueueUrl", json!({ "QueueName": "lookup-queue" }));
         let resp = svc.get_queue_url(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["QueueUrl"].as_str().unwrap(), url);
     }
 
@@ -3084,7 +3084,7 @@ mod tests {
 
         let req = make_request("ListQueues", json!({}));
         let resp = svc.list_queues(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let urls = body["QueueUrls"].as_array().unwrap();
         assert_eq!(urls.len(), 3);
     }
@@ -3098,7 +3098,7 @@ mod tests {
 
         let req = make_request("ListQueues", json!({ "QueueNamePrefix": "prod-" }));
         let resp = svc.list_queues(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let urls = body["QueueUrls"].as_array().unwrap();
         assert_eq!(urls.len(), 2);
         for u in urls {
@@ -3115,7 +3115,7 @@ mod tests {
 
         let req = make_request("ListQueues", json!({ "MaxResults": 2 }));
         let resp = svc.list_queues(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let urls = body["QueueUrls"].as_array().unwrap();
         assert_eq!(urls.len(), 2);
         assert!(body["NextToken"].as_str().is_some());
@@ -3124,7 +3124,7 @@ mod tests {
         let token = body["NextToken"].as_str().unwrap();
         let req2 = make_request("ListQueues", json!({ "MaxResults": 2, "NextToken": token }));
         let resp2 = svc.list_queues(&req2).unwrap();
-        let body2: Value = serde_json::from_slice(&resp2.body).unwrap();
+        let body2: Value = serde_json::from_slice(resp2.body.expect_bytes()).unwrap();
         let urls2 = body2["QueueUrls"].as_array().unwrap();
         assert_eq!(urls2.len(), 2);
 
@@ -3135,7 +3135,7 @@ mod tests {
             json!({ "MaxResults": 2, "NextToken": token2 }),
         );
         let resp3 = svc.list_queues(&req3).unwrap();
-        let body3: Value = serde_json::from_slice(&resp3.body).unwrap();
+        let body3: Value = serde_json::from_slice(resp3.body.expect_bytes()).unwrap();
         let urls3 = body3["QueueUrls"].as_array().unwrap();
         assert_eq!(urls3.len(), 1);
         assert!(body3["NextToken"].is_null());
@@ -3165,7 +3165,7 @@ mod tests {
             json!({ "QueueUrl": url, "MessageBody": "test" }),
         );
         let resp = svc.send_message(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["MD5OfMessageBody"].as_str().is_some());
         assert!(body["MessageId"].as_str().is_some());
     }
@@ -3209,7 +3209,7 @@ mod tests {
             .build()
             .unwrap();
         let resp = rt.block_on(svc.receive_message(&req)).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let receipt = body["Messages"][0]["ReceiptHandle"]
             .as_str()
             .unwrap()
@@ -3257,7 +3257,7 @@ mod tests {
             }),
         );
         let resp = svc.send_message_batch(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let successful = body["Successful"].as_array().unwrap();
         assert_eq!(successful.len(), 3);
 
@@ -3326,7 +3326,7 @@ mod tests {
             .build()
             .unwrap();
         let resp = rt.block_on(svc.receive_message(&req)).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let receipt = body["Messages"][0]["ReceiptHandle"]
             .as_str()
             .unwrap()
@@ -3379,7 +3379,7 @@ mod tests {
             }),
         );
         let resp = svc.get_queue_attributes(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let attrs = body["Attributes"].as_object().unwrap();
 
         assert_eq!(attrs["VisibilityTimeout"].as_str().unwrap(), "30");
@@ -3400,7 +3400,7 @@ mod tests {
             }),
         );
         let resp = svc.get_queue_attributes(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let attrs = body["Attributes"].as_object().unwrap();
 
         assert!(attrs.contains_key("VisibilityTimeout"));
@@ -3430,7 +3430,7 @@ mod tests {
             }),
         );
         let resp = svc.get_queue_attributes(&get_req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let attrs = body["Attributes"].as_object().unwrap();
         assert_eq!(attrs["VisibilityTimeout"].as_str().unwrap(), "60");
         assert_eq!(attrs["DelaySeconds"].as_str().unwrap(), "10");
@@ -3451,7 +3451,7 @@ mod tests {
             }),
         );
         let resp = svc.get_queue_attributes(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["Attributes"]["ApproximateNumberOfMessages"]
                 .as_str()
@@ -3491,7 +3491,7 @@ mod tests {
             }),
         );
         let resp = svc.get_queue_attributes(&get_req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let attrs = body["Attributes"].as_object().unwrap();
         assert!(!attrs.contains_key("Policy"));
     }
@@ -3541,7 +3541,7 @@ mod tests {
 
         let list_req = make_request("ListQueueTags", json!({ "QueueUrl": url }));
         let resp = svc.list_queue_tags(&list_req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let tags = body["Tags"].as_object().unwrap();
         assert_eq!(tags["env"].as_str().unwrap(), "prod");
         assert_eq!(tags["team"].as_str().unwrap(), "backend");
@@ -3572,7 +3572,7 @@ mod tests {
 
         let list_req = make_request("ListQueueTags", json!({ "QueueUrl": url }));
         let resp = svc.list_queue_tags(&list_req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let tags = body["Tags"].as_object().unwrap();
         assert_eq!(tags.len(), 1);
         assert_eq!(tags["team"].as_str().unwrap(), "backend");
@@ -3591,7 +3591,7 @@ mod tests {
 
         let list_req = make_request("ListQueueTags", json!({ "QueueUrl": url }));
         let resp = svc.list_queue_tags(&list_req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let tags = body["Tags"].as_object().unwrap();
         assert_eq!(tags.len(), 2);
         assert_eq!(tags["a"].as_str().unwrap(), "1");
@@ -3612,7 +3612,7 @@ mod tests {
         let url = create_queue(&svc, "no-tags-queue");
         let req = make_request("ListQueueTags", json!({ "QueueUrl": url }));
         let resp = svc.list_queue_tags(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let tags = body["Tags"].as_object().unwrap();
         assert!(tags.is_empty());
     }
@@ -3630,12 +3630,12 @@ mod tests {
             }),
         );
         let resp = svc.create_queue(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let url = body["QueueUrl"].as_str().unwrap();
 
         let list_req = make_request("ListQueueTags", json!({ "QueueUrl": url }));
         let resp = svc.list_queue_tags(&list_req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Tags"]["env"].as_str().unwrap(), "test");
     }
 
@@ -3650,7 +3650,7 @@ mod tests {
             }),
         );
         let resp = svc.create_queue(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let url = body["QueueUrl"].as_str().unwrap();
 
         let get_req = make_request(
@@ -3661,7 +3661,7 @@ mod tests {
             }),
         );
         let resp = svc.get_queue_attributes(&get_req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["Attributes"]["VisibilityTimeout"].as_str().unwrap(),
             "45"
@@ -3684,7 +3684,7 @@ mod tests {
             }),
         );
         let resp = svc.get_queue_attributes(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Attributes"]["FifoQueue"].as_str().unwrap(), "true");
     }
 
@@ -3737,7 +3737,7 @@ mod tests {
             }),
         );
         let resp = svc.send_message(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["MD5OfMessageAttributes"].as_str().is_some());
     }
 
@@ -3775,7 +3775,7 @@ mod tests {
             }),
         );
         let resp = svc.get_queue_attributes(&attr_req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let attrs = body["Attributes"].as_object().unwrap();
         assert_eq!(attrs["ApproximateNumberOfMessages"].as_str().unwrap(), "0");
         assert_eq!(

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -472,7 +472,7 @@ mod tests {
             }),
         );
         let resp = svc.send_command(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         body["Command"]["CommandId"].as_str().unwrap().to_string()
     }
 
@@ -489,7 +489,7 @@ mod tests {
         // First page: MaxResults=1
         let req = make_request("ListCommands", json!({ "MaxResults": 1 }));
         let resp = svc.list_commands(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Commands"].as_array().unwrap().len(), 1);
         let token = body["NextToken"].as_str().unwrap();
 
@@ -499,7 +499,7 @@ mod tests {
             json!({ "MaxResults": 1, "NextToken": token }),
         );
         let resp = svc.list_commands(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Commands"].as_array().unwrap().len(), 1);
         let token = body["NextToken"].as_str().unwrap();
 
@@ -509,7 +509,7 @@ mod tests {
             json!({ "MaxResults": 1, "NextToken": token }),
         );
         let resp = svc.list_commands(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Commands"].as_array().unwrap().len(), 1);
         assert!(body.get("NextToken").is_none() || body["NextToken"].is_null());
     }
@@ -540,7 +540,7 @@ mod tests {
             }),
         );
         let resp = svc.send_command(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let cmd = &body["Command"];
 
         // These fields are not part of the Smithy Command output shape
@@ -585,7 +585,7 @@ mod tests {
         // First page: MaxResults=10 (minimum allowed)
         let req = make_request("DescribeMaintenanceWindows", json!({ "MaxResults": 10 }));
         let resp = svc.describe_maintenance_windows(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["WindowIdentities"].as_array().unwrap().len(), 10);
         let token = body["NextToken"].as_str().unwrap();
 
@@ -595,7 +595,7 @@ mod tests {
             json!({ "MaxResults": 10, "NextToken": token }),
         );
         let resp = svc.describe_maintenance_windows(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["WindowIdentities"].as_array().unwrap().len(), 1);
         assert!(body.get("NextToken").is_none() || body["NextToken"].is_null());
     }
@@ -617,7 +617,7 @@ mod tests {
             }),
         );
         let resp = svc.create_association(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let assoc_id = body["AssociationDescription"]["AssociationId"]
             .as_str()
             .unwrap()
@@ -630,7 +630,7 @@ mod tests {
         // Describe
         let req = make_request("DescribeAssociation", json!({ "AssociationId": assoc_id }));
         let resp = svc.describe_association(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["AssociationDescription"]["AssociationName"]
                 .as_str()
@@ -641,7 +641,7 @@ mod tests {
         // List
         let req = make_request("ListAssociations", json!({}));
         let resp = svc.list_associations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Associations"].as_array().unwrap().len(), 1);
 
         // Update
@@ -653,7 +653,7 @@ mod tests {
             }),
         );
         let resp = svc.update_association(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["AssociationDescription"]["AssociationName"]
                 .as_str()
@@ -667,7 +667,7 @@ mod tests {
             json!({ "AssociationId": assoc_id }),
         );
         let resp = svc.list_association_versions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["AssociationVersions"].as_array().unwrap().len(), 2);
 
         // Delete
@@ -692,7 +692,7 @@ mod tests {
             }),
         );
         let resp = svc.create_association_batch(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Successful"].as_array().unwrap().len(), 2);
         assert!(body["Failed"].as_array().unwrap().is_empty());
     }
@@ -723,13 +723,13 @@ mod tests {
             }),
         );
         let resp = svc.create_ops_item(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let ops_item_id = body["OpsItemId"].as_str().unwrap().to_string();
 
         // Get
         let req = make_request("GetOpsItem", json!({ "OpsItemId": ops_item_id }));
         let resp = svc.get_ops_item(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["OpsItem"]["Title"].as_str().unwrap(), "Test OpsItem");
         assert_eq!(body["OpsItem"]["Status"].as_str().unwrap(), "Open");
 
@@ -747,7 +747,7 @@ mod tests {
         // Verify update
         let req = make_request("GetOpsItem", json!({ "OpsItemId": ops_item_id }));
         let resp = svc.get_ops_item(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["OpsItem"]["Title"].as_str().unwrap(),
             "Updated OpsItem"
@@ -757,7 +757,7 @@ mod tests {
         // Describe
         let req = make_request("DescribeOpsItems", json!({}));
         let resp = svc.describe_ops_items(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["OpsItemSummaries"].as_array().unwrap().len(), 1);
 
         // Delete
@@ -785,7 +785,7 @@ mod tests {
             }),
         );
         let resp = svc.put_resource_policy(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let policy_id = body["PolicyId"].as_str().unwrap().to_string();
         let policy_hash = body["PolicyHash"].as_str().unwrap().to_string();
 
@@ -795,7 +795,7 @@ mod tests {
             json!({ "ResourceArn": resource_arn }),
         );
         let resp = svc.get_resource_policies(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Policies"].as_array().unwrap().len(), 1);
 
         // Delete
@@ -815,7 +815,7 @@ mod tests {
             json!({ "ResourceArn": resource_arn }),
         );
         let resp = svc.get_resource_policies(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Policies"].as_array().unwrap().is_empty());
     }
 
@@ -829,7 +829,7 @@ mod tests {
             json!({ "Target": "i-1234567890abcdef0" }),
         );
         let resp = svc.get_connection_status(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Status"].as_str().unwrap(), "connected");
     }
 
@@ -841,7 +841,7 @@ mod tests {
             json!({ "CalendarNames": ["arn:aws:ssm:us-east-1:123456789012:document/cal"] }),
         );
         let resp = svc.get_calendar_state(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["State"].as_str().unwrap(), "OPEN");
     }
 
@@ -855,7 +855,7 @@ mod tests {
             json!({ "SettingId": "/ssm/parameter-store/high-throughput-enabled" }),
         );
         let resp = svc.get_service_setting(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["ServiceSetting"]["Status"].as_str().unwrap(),
             "Default"
@@ -877,7 +877,7 @@ mod tests {
             json!({ "SettingId": "/ssm/parameter-store/high-throughput-enabled" }),
         );
         let resp = svc.get_service_setting(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["ServiceSetting"]["Status"].as_str().unwrap(),
             "Customized"
@@ -900,7 +900,7 @@ mod tests {
             json!({ "SettingId": "/ssm/parameter-store/high-throughput-enabled" }),
         );
         let resp = svc.get_service_setting(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["ServiceSetting"]["Status"].as_str().unwrap(),
             "Default"
@@ -925,7 +925,7 @@ mod tests {
         // List versions
         let req = make_request("ListDocumentVersions", json!({ "Name": "TestDocVer" }));
         let resp = svc.list_document_versions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(!body["DocumentVersions"].as_array().unwrap().is_empty());
     }
 
@@ -937,7 +937,7 @@ mod tests {
             json!({ "PatchGroup": "test-group" }),
         );
         let resp = svc.describe_patch_group_state(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Instances"].as_i64().unwrap(), 0);
     }
 
@@ -949,7 +949,7 @@ mod tests {
             json!({ "OperatingSystem": "WINDOWS" }),
         );
         let resp = svc.get_default_patch_baseline(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["BaselineId"].is_string());
     }
 
@@ -958,7 +958,7 @@ mod tests {
         let svc = make_service();
         let req = make_request("DescribeAvailablePatches", json!({}));
         let resp = svc.describe_available_patches(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Patches"].as_array().unwrap().is_empty());
     }
 
@@ -970,7 +970,7 @@ mod tests {
             json!({ "OperatingSystem": "WINDOWS", "Property": "PRODUCT" }),
         );
         let resp = svc.describe_patch_properties(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Properties"].as_array().unwrap().is_empty());
     }
 
@@ -1001,7 +1001,7 @@ mod tests {
         // GetInventory
         let req = make_request("GetInventory", json!({}));
         let resp = svc.get_inventory(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Entities"].as_array().unwrap().len(), 1);
         assert_eq!(
             body["Entities"][0]["Id"].as_str().unwrap(),
@@ -1017,26 +1017,26 @@ mod tests {
             }),
         );
         let resp = svc.list_inventory_entries(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Entries"].as_array().unwrap().len(), 2);
         assert_eq!(body["TypeName"].as_str().unwrap(), "AWS:Application");
 
         // GetInventorySchema
         let req = make_request("GetInventorySchema", json!({}));
         let resp = svc.get_inventory_schema(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(!body["Schemas"].as_array().unwrap().is_empty());
 
         // DeleteInventory
         let req = make_request("DeleteInventory", json!({ "TypeName": "AWS:Application" }));
         let resp = svc.delete_inventory(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["DeletionId"].is_string());
 
         // DescribeInventoryDeletions
         let req = make_request("DescribeInventoryDeletions", json!({}));
         let resp = svc.describe_inventory_deletions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["InventoryDeletions"].as_array().unwrap().len(), 1);
 
         // Verify inventory deleted
@@ -1048,7 +1048,7 @@ mod tests {
             }),
         );
         let resp = svc.list_inventory_entries(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Entries"].as_array().unwrap().is_empty());
     }
 
@@ -1089,19 +1089,19 @@ mod tests {
         // ListComplianceItems
         let req = make_request("ListComplianceItems", json!({}));
         let resp = svc.list_compliance_items(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ComplianceItems"].as_array().unwrap().len(), 2);
 
         // ListComplianceSummaries
         let req = make_request("ListComplianceSummaries", json!({}));
         let resp = svc.list_compliance_summaries(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ComplianceSummaryItems"].as_array().unwrap().len(), 1);
 
         // ListResourceComplianceSummaries
         let req = make_request("ListResourceComplianceSummaries", json!({}));
         let resp = svc.list_resource_compliance_summaries(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["ResourceComplianceSummaryItems"]
                 .as_array()
@@ -1126,7 +1126,7 @@ mod tests {
             }),
         );
         let resp = svc.create_maintenance_window(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let window_id = body["WindowId"].as_str().unwrap().to_string();
 
         // Register target
@@ -1140,7 +1140,7 @@ mod tests {
             }),
         );
         let resp = svc.register_target_with_maintenance_window(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let target_id = body["WindowTargetId"].as_str().unwrap().to_string();
 
         // Register task
@@ -1155,7 +1155,7 @@ mod tests {
             }),
         );
         let resp = svc.register_task_with_maintenance_window(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let task_id = body["WindowTaskId"].as_str().unwrap().to_string();
 
         (window_id, target_id, task_id)
@@ -1176,7 +1176,7 @@ mod tests {
             }),
         );
         let resp = svc.update_maintenance_window_target(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"].as_str().unwrap(), "updated-target");
 
         // Get task
@@ -1188,7 +1188,7 @@ mod tests {
             }),
         );
         let resp = svc.get_maintenance_window_task(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TaskArn"].as_str().unwrap(), "AWS-RunShellScript");
         assert_eq!(body["Name"].as_str().unwrap(), "test-task");
 
@@ -1203,7 +1203,7 @@ mod tests {
             }),
         );
         let resp = svc.update_maintenance_window_task(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"].as_str().unwrap(), "updated-task");
         assert_eq!(body["MaxConcurrency"].as_str().unwrap(), "10");
     }
@@ -1258,7 +1258,7 @@ mod tests {
             json!({ "WindowId": window_id }),
         );
         let resp = svc.describe_maintenance_window_executions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["WindowExecutions"].as_array().unwrap().len(), 1);
 
         // GetMaintenanceWindowExecution
@@ -1267,7 +1267,7 @@ mod tests {
             json!({ "WindowExecutionId": exec_id }),
         );
         let resp = svc.get_maintenance_window_execution(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Status"].as_str().unwrap(), "IN_PROGRESS");
 
         // DescribeMaintenanceWindowExecutionTasks
@@ -1278,7 +1278,7 @@ mod tests {
         let resp = svc
             .describe_maintenance_window_execution_tasks(&req)
             .unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["WindowExecutionTaskIdentities"]
                 .as_array()
@@ -1296,7 +1296,7 @@ mod tests {
             }),
         );
         let resp = svc.get_maintenance_window_execution_task(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TaskArn"].as_str().unwrap(), "AWS-RunShellScript");
 
         // DescribeMaintenanceWindowExecutionTaskInvocations
@@ -1310,7 +1310,7 @@ mod tests {
         let resp = svc
             .describe_maintenance_window_execution_task_invocations(&req)
             .unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["WindowExecutionTaskInvocationIdentities"]
                 .as_array()
@@ -1331,7 +1331,7 @@ mod tests {
         let resp = svc
             .get_maintenance_window_execution_task_invocation(&req)
             .unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ExecutionId"].as_str().unwrap(), "cmd-001");
 
         // CancelMaintenanceWindowExecution
@@ -1340,13 +1340,13 @@ mod tests {
             json!({ "WindowExecutionId": exec_id }),
         );
         let resp = svc.cancel_maintenance_window_execution(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["WindowExecutionId"].as_str().unwrap(), exec_id);
 
         // DescribeMaintenanceWindowSchedule
         let req = make_request("DescribeMaintenanceWindowSchedule", json!({}));
         let resp = svc.describe_maintenance_window_schedule(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["ScheduledWindowExecutions"]
             .as_array()
             .unwrap()
@@ -1361,7 +1361,7 @@ mod tests {
             }),
         );
         let resp = svc.describe_maintenance_windows_for_target(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["WindowIdentities"].as_array().unwrap().len(), 1);
     }
 
@@ -1381,7 +1381,7 @@ mod tests {
             }),
         );
         let resp = svc.create_patch_baseline(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let baseline_id = body["BaselineId"].as_str().unwrap().to_string();
 
         // Update
@@ -1395,7 +1395,7 @@ mod tests {
             }),
         );
         let resp = svc.update_patch_baseline(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"].as_str().unwrap(), "updated-baseline");
         assert_eq!(body["Description"].as_str().unwrap(), "updated description");
         assert_eq!(body["ApprovedPatches"].as_array().unwrap().len(), 2);
@@ -1424,7 +1424,7 @@ mod tests {
         // List
         let req = make_request("ListResourceDataSync", json!({}));
         let resp = svc.list_resource_data_sync(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ResourceDataSyncItems"].as_array().unwrap().len(), 1);
         assert_eq!(
             body["ResourceDataSyncItems"][0]["SyncName"]
@@ -1454,7 +1454,7 @@ mod tests {
         // Verify deleted
         let req = make_request("ListResourceDataSync", json!({}));
         let resp = svc.list_resource_data_sync(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["ResourceDataSyncItems"].as_array().unwrap().is_empty());
     }
 
@@ -1468,7 +1468,7 @@ mod tests {
             json!({ "InstanceIds": ["i-001"] }),
         );
         let resp = svc.describe_instance_patch_states(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["InstancePatchStates"].as_array().unwrap().is_empty());
     }
 
@@ -1477,7 +1477,7 @@ mod tests {
         let svc = make_service();
         let req = make_request("DescribeInstancePatches", json!({ "InstanceId": "i-001" }));
         let resp = svc.describe_instance_patches(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Patches"].as_array().unwrap().is_empty());
     }
 
@@ -1491,7 +1491,7 @@ mod tests {
         let resp = svc
             .describe_effective_patches_for_patch_baseline(&req)
             .unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["EffectivePatches"].as_array().unwrap().is_empty());
     }
 
@@ -1500,7 +1500,7 @@ mod tests {
         let svc = make_service();
         let req = make_request("GetOpsSummary", json!({}));
         let resp = svc.get_ops_summary(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Entities"].as_array().unwrap().is_empty());
     }
 
@@ -1515,7 +1515,7 @@ mod tests {
             json!({ "Title": "Test", "Source": "test", "Description": "test desc" }),
         );
         let resp = svc.create_ops_item(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let ops_item_id = body["OpsItemId"].as_str().unwrap().to_string();
 
         // Associate
@@ -1529,7 +1529,7 @@ mod tests {
             }),
         );
         let resp = svc.associate_ops_item_related_item(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let assoc_id = body["AssociationId"].as_str().unwrap().to_string();
 
         // List
@@ -1538,7 +1538,7 @@ mod tests {
             json!({ "OpsItemId": ops_item_id }),
         );
         let resp = svc.list_ops_item_related_items(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Summaries"].as_array().unwrap().len(), 1);
 
         // Disassociate
@@ -1554,7 +1554,7 @@ mod tests {
         let svc = make_service();
         let req = make_request("ListOpsItemEvents", json!({}));
         let resp = svc.list_ops_item_events(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Summaries"].as_array().unwrap().is_empty());
     }
 
@@ -1573,13 +1573,13 @@ mod tests {
             }),
         );
         let resp = svc.create_ops_metadata(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let arn = body["OpsMetadataArn"].as_str().unwrap().to_string();
 
         // Get
         let req = make_request("GetOpsMetadata", json!({ "OpsMetadataArn": arn }));
         let resp = svc.get_ops_metadata(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ResourceId"].as_str().unwrap(), "test-resource");
 
         // Update
@@ -1595,7 +1595,7 @@ mod tests {
         // List
         let req = make_request("ListOpsMetadata", json!({}));
         let resp = svc.list_ops_metadata(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["OpsMetadataList"].as_array().unwrap().len(), 1);
 
         // Delete
@@ -1615,7 +1615,7 @@ mod tests {
             json!({ "DocumentName": "AWS-RunShellScript" }),
         );
         let resp = svc.start_automation_execution(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let exec_id = body["AutomationExecutionId"].as_str().unwrap().to_string();
 
         // Get
@@ -1624,7 +1624,7 @@ mod tests {
             json!({ "AutomationExecutionId": exec_id }),
         );
         let resp = svc.get_automation_execution(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["AutomationExecution"]["AutomationExecutionStatus"]
                 .as_str()
@@ -1635,7 +1635,7 @@ mod tests {
         // Describe
         let req = make_request("DescribeAutomationExecutions", json!({}));
         let resp = svc.describe_automation_executions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(
             body["AutomationExecutionMetadataList"]
                 .as_array()
@@ -1650,7 +1650,7 @@ mod tests {
             json!({ "AutomationExecutionId": exec_id }),
         );
         let resp = svc.describe_automation_step_executions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["StepExecutions"].as_array().unwrap().is_empty());
 
         // Signal
@@ -1679,7 +1679,7 @@ mod tests {
             }),
         );
         let resp = svc.start_change_request_execution(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["AutomationExecutionId"].as_str().is_some());
     }
 
@@ -1692,7 +1692,7 @@ mod tests {
             json!({ "DocumentName": "AWS-RunShellScript" }),
         );
         let resp = svc.start_execution_preview(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let preview_id = body["ExecutionPreviewId"].as_str().unwrap().to_string();
 
         let req = make_request(
@@ -1700,7 +1700,7 @@ mod tests {
             json!({ "ExecutionPreviewId": preview_id }),
         );
         let resp = svc.get_execution_preview(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Status"].as_str().unwrap(), "Success");
     }
 
@@ -1713,20 +1713,20 @@ mod tests {
         // Start
         let req = make_request("StartSession", json!({ "Target": "i-001" }));
         let resp = svc.start_session(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let session_id = body["SessionId"].as_str().unwrap().to_string();
         assert!(body["TokenValue"].as_str().is_some());
 
         // Resume
         let req = make_request("ResumeSession", json!({ "SessionId": session_id }));
         let resp = svc.resume_session(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["SessionId"].as_str().unwrap(), session_id);
 
         // Describe (Active)
         let req = make_request("DescribeSessions", json!({ "State": "Active" }));
         let resp = svc.describe_sessions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Sessions"].as_array().unwrap().len(), 1);
 
         // Terminate
@@ -1736,7 +1736,7 @@ mod tests {
         // Describe (History)
         let req = make_request("DescribeSessions", json!({ "State": "History" }));
         let resp = svc.describe_sessions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Sessions"].as_array().unwrap().len(), 1);
     }
 
@@ -1749,12 +1749,12 @@ mod tests {
             json!({ "Reason": "test", "Targets": [{"Key": "InstanceIds", "Values": ["i-001"]}] }),
         );
         let resp = svc.start_access_request(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let ar_id = body["AccessRequestId"].as_str().unwrap().to_string();
 
         let req = make_request("GetAccessToken", json!({ "AccessRequestId": ar_id }));
         let resp = svc.get_access_token(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Credentials"]["AccessKeyId"].as_str().is_some());
         assert_eq!(body["AccessRequestStatus"].as_str(), Some("Approved"));
     }
@@ -1771,14 +1771,14 @@ mod tests {
             json!({ "IamRole": "SSMServiceRole", "Description": "test" }),
         );
         let resp = svc.create_activation(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let activation_id = body["ActivationId"].as_str().unwrap().to_string();
         assert!(body["ActivationCode"].as_str().is_some());
 
         // Describe
         let req = make_request("DescribeActivations", json!({}));
         let resp = svc.describe_activations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ActivationList"].as_array().unwrap().len(), 1);
 
         // Delete
@@ -1801,7 +1801,7 @@ mod tests {
         let svc = make_service();
         let req = make_request("DescribeInstanceInformation", json!({}));
         let resp = svc.describe_instance_information(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["InstanceInformationList"]
             .as_array()
             .unwrap()
@@ -1813,7 +1813,7 @@ mod tests {
         let svc = make_service();
         let req = make_request("DescribeInstanceProperties", json!({}));
         let resp = svc.describe_instance_properties(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["InstanceProperties"].as_array().unwrap().is_empty());
     }
 
@@ -1824,7 +1824,7 @@ mod tests {
         let svc = make_service();
         let req = make_request("ListNodes", json!({}));
         let resp = svc.list_nodes(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Nodes"].as_array().unwrap().is_empty());
     }
 
@@ -1836,7 +1836,7 @@ mod tests {
             json!({ "Aggregators": [{"AggregatorType": "Count"}] }),
         );
         let resp = svc.list_nodes_summary(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Summary"].as_array().unwrap().is_empty());
     }
 
@@ -1848,7 +1848,7 @@ mod tests {
             json!({ "InstanceId": "i-001" }),
         );
         let resp = svc.describe_effective_instance_associations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Associations"].as_array().unwrap().is_empty());
     }
 
@@ -1860,7 +1860,7 @@ mod tests {
             json!({ "InstanceId": "i-001" }),
         );
         let resp = svc.describe_instance_associations_status(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["InstanceAssociationStatusInfos"]
             .as_array()
             .unwrap()
@@ -1880,7 +1880,7 @@ mod tests {
             }),
         );
         let resp = svc.put_parameter(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         body["Version"].as_i64().unwrap()
     }
 
@@ -1902,14 +1902,14 @@ mod tests {
             }),
         );
         let resp = svc.label_parameter_version(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["InvalidLabels"].as_array().unwrap().is_empty());
         assert_eq!(body["ParameterVersion"].as_i64().unwrap(), 1);
 
         // Get parameter history — version 1 should have labels
         let req = make_request("GetParameterHistory", json!({ "Name": "/label/test" }));
         let resp = svc.get_parameter_history(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let params = body["Parameters"].as_array().unwrap();
         let v1 = params
             .iter()
@@ -1929,7 +1929,7 @@ mod tests {
             }),
         );
         let resp = svc.unlabel_parameter_version(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["InvalidLabels"].as_array().unwrap().is_empty());
         let removed = body["RemovedLabels"].as_array().unwrap();
         assert_eq!(removed.len(), 1);
@@ -1951,7 +1951,7 @@ mod tests {
             }),
         );
         let resp = svc.label_parameter_version(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ParameterVersion"].as_i64().unwrap(), 2);
     }
 
@@ -1969,7 +1969,7 @@ mod tests {
             }),
         );
         let resp = svc.label_parameter_version(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let invalid = body["InvalidLabels"].as_array().unwrap();
         assert_eq!(invalid.len(), 1);
         assert_eq!(invalid[0].as_str().unwrap(), "aws-reserved");
@@ -2006,7 +2006,7 @@ mod tests {
             }),
         );
         let resp = svc.unlabel_parameter_version(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let invalid = body["InvalidLabels"].as_array().unwrap();
         assert_eq!(invalid.len(), 1);
         assert_eq!(invalid[0].as_str().unwrap(), "nonexistent");
@@ -2058,7 +2058,7 @@ mod tests {
             }),
         );
         let resp = svc.update_document(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let desc = &body["DocumentDescription"];
         assert_eq!(desc["DocumentVersion"].as_str().unwrap(), "2");
         assert_eq!(desc["VersionName"].as_str().unwrap(), "release-2");
@@ -2066,7 +2066,7 @@ mod tests {
         // List document versions
         let req = make_request("ListDocumentVersions", json!({ "Name": "TestDoc" }));
         let resp = svc.list_document_versions(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["DocumentVersions"].as_array().unwrap().len(), 2);
 
         // Update default version to 2
@@ -2078,13 +2078,13 @@ mod tests {
             }),
         );
         let resp = svc.update_document_default_version(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Description"]["DefaultVersion"].as_str().unwrap(), "2");
 
         // Verify describe_document now shows version 2 as default
         let req = make_request("DescribeDocument", json!({ "Name": "TestDoc" }));
         let resp = svc.describe_document(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Document"]["DefaultVersion"].as_str().unwrap(), "2");
     }
 
@@ -2130,7 +2130,7 @@ mod tests {
             }),
         );
         let resp = svc.describe_document_permission(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let ids = body["AccountIds"].as_array().unwrap();
         assert_eq!(ids.len(), 2);
 
@@ -2154,7 +2154,7 @@ mod tests {
             }),
         );
         let resp = svc.describe_document_permission(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let ids = body["AccountIds"].as_array().unwrap();
         assert_eq!(ids.len(), 1);
         assert_eq!(ids[0].as_str().unwrap(), "222222222222");
@@ -2190,7 +2190,7 @@ mod tests {
             json!({ "WindowId": window_id }),
         );
         let resp = svc.describe_maintenance_window_targets(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let targets = body["Targets"].as_array().unwrap();
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0]["Name"].as_str().unwrap(), "test-target");
@@ -2201,7 +2201,7 @@ mod tests {
             json!({ "WindowId": window_id }),
         );
         let resp = svc.describe_maintenance_window_tasks(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let tasks = body["Tasks"].as_array().unwrap();
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0]["TaskArn"].as_str().unwrap(), "AWS-RunShellScript");
@@ -2220,7 +2220,7 @@ mod tests {
             }),
         );
         let resp = svc.create_patch_baseline(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         body["BaselineId"].as_str().unwrap().to_string()
     }
 
@@ -2232,7 +2232,7 @@ mod tests {
         // Get
         let req = make_request("GetPatchBaseline", json!({ "BaselineId": baseline_id }));
         let resp = svc.get_patch_baseline(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Name"].as_str().unwrap(), "get-del-baseline");
         assert_eq!(body["OperatingSystem"].as_str().unwrap(), "AMAZON_LINUX_2");
         assert_eq!(body["Description"].as_str().unwrap(), "test baseline");
@@ -2261,7 +2261,7 @@ mod tests {
             }),
         );
         let resp = svc.describe_patch_baselines(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let baselines = body["BaselineIdentities"].as_array().unwrap();
         assert_eq!(baselines.len(), 1);
         assert_eq!(
@@ -2284,7 +2284,7 @@ mod tests {
             }),
         );
         let resp = svc.register_patch_baseline_for_patch_group(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["PatchGroup"].as_str().unwrap(), "production");
 
         // Get patch baseline for group
@@ -2296,13 +2296,13 @@ mod tests {
             }),
         );
         let resp = svc.get_patch_baseline_for_patch_group(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["BaselineId"].as_str().unwrap(), baseline_id);
 
         // Describe patch groups
         let req = make_request("DescribePatchGroups", json!({}));
         let resp = svc.describe_patch_groups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let mappings = body["Mappings"].as_array().unwrap();
         assert_eq!(mappings.len(), 1);
         assert_eq!(mappings[0]["PatchGroup"].as_str().unwrap(), "production");
@@ -2320,7 +2320,7 @@ mod tests {
         // Verify removed
         let req = make_request("DescribePatchGroups", json!({}));
         let resp = svc.describe_patch_groups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Mappings"].as_array().unwrap().is_empty());
     }
 
@@ -2346,7 +2346,7 @@ mod tests {
         // Patch groups should be cleaned up
         let req = make_request("DescribePatchGroups", json!({}));
         let resp = svc.describe_patch_groups(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["Mappings"].as_array().unwrap().is_empty());
     }
 
@@ -2365,7 +2365,7 @@ mod tests {
             }),
         );
         let resp = svc.get_command_invocation(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["CommandId"].as_str().unwrap(), cmd_id);
         assert_eq!(body["InstanceId"].as_str().unwrap(), "i-1234567890abcdef0");
         assert_eq!(body["Status"].as_str().unwrap(), "Success");
@@ -2395,7 +2395,7 @@ mod tests {
         // List all invocations
         let req = make_request("ListCommandInvocations", json!({}));
         let resp = svc.list_command_invocations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let invocations = body["CommandInvocations"].as_array().unwrap();
         assert!(!invocations.is_empty());
         assert_eq!(invocations[0]["CommandId"].as_str().unwrap(), cmd_id);
@@ -2407,7 +2407,7 @@ mod tests {
         // Filter by CommandId
         let req = make_request("ListCommandInvocations", json!({ "CommandId": cmd_id }));
         let resp = svc.list_command_invocations(&req).unwrap();
-        let body: Value = serde_json::from_slice(&resp.body).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["CommandInvocations"].as_array().unwrap().len(), 1);
     }
 }

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -66,6 +66,28 @@ fakecloud listens at `http://localhost:4566`.
 | `--region` | `FAKECLOUD_REGION` | `us-east-1` | AWS region to advertise |
 | `--account-id` | `FAKECLOUD_ACCOUNT_ID` | `123456789012` | AWS account ID |
 | `--log-level` | `FAKECLOUD_LOG` | `info` | Log level (trace, debug, info, warn, error) |
+| `--storage-mode` | `FAKECLOUD_STORAGE_MODE` | `memory` | `memory` (default) or `persistent` (mirror S3 state to `--data-path`) |
+| `--data-path` | `FAKECLOUD_DATA_PATH` | — | Directory to persist state to. Required when `--storage-mode=persistent`. |
+| `--body-cache-size` | `FAKECLOUD_BODY_CACHE_SIZE` | `268435456` | Byte-sized LRU cache for object bodies in persistent mode. Default 256 MiB. |
+
+### Persistence
+
+Default is `memory` mode — all state lives in RAM, startup is instant,
+shutdown is a no-op. Pass `--storage-mode=persistent --data-path=<dir>` to
+mirror supported services to disk and reload them on the next launch.
+
+S3 is the only service wired up today: buckets, objects, versions, delete
+markers, multipart uploads (resumable across restarts), and every bucket
+subresource are written to disk on every mutation and reloaded on startup.
+Other services emit `persistence not yet supported, running in-memory` at
+startup and continue to operate exactly as in memory mode.
+
+The data directory is guarded by `fakecloud.version.toml`. A format mismatch
+fails startup loudly — there is no auto-migration. Object bodies stream
+straight to disk; a bounded LRU (`--body-cache-size`, default 256 MiB) caches
+recent reads, and objects larger than `cache-size / 2` bypass the cache so a
+single large upload cannot evict everything. `/_fakecloud/s3/notifications`
+is intentionally in-memory only.
 
 ### Health check
 ```sh

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -68,7 +68,7 @@ fakecloud listens at `http://localhost:4566`.
 | `--log-level` | `FAKECLOUD_LOG` | `info` | Log level (trace, debug, info, warn, error) |
 | `--storage-mode` | `FAKECLOUD_STORAGE_MODE` | `memory` | `memory` (default) or `persistent` (mirror S3 state to `--data-path`) |
 | `--data-path` | `FAKECLOUD_DATA_PATH` | — | Directory to persist state to. Required when `--storage-mode=persistent`. |
-| `--body-cache-size` | `FAKECLOUD_BODY_CACHE_SIZE` | `268435456` | Byte-sized LRU cache for object bodies in persistent mode. Default 256 MiB. |
+| `--s3-cache-size` | `FAKECLOUD_S3_CACHE_SIZE` | `268435456` | In-memory LRU cache for S3 object bodies in persistent mode. Default 256 MiB. |
 
 ### Persistence
 
@@ -84,7 +84,7 @@ startup and continue to operate exactly as in memory mode.
 
 The data directory is guarded by `fakecloud.version.toml`. A format mismatch
 fails startup loudly — there is no auto-migration. Object bodies stream
-straight to disk; a bounded LRU (`--body-cache-size`, default 256 MiB) caches
+straight to disk; a bounded LRU (`--s3-cache-size`, default 256 MiB) caches
 recent reads, and objects larger than `cache-size / 2` bypass the cache so a
 single large upload cannot evict everything. `/_fakecloud/s3/notifications`
 is intentionally in-memory only.

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -18,7 +18,8 @@
 ## Usage
 
 - [Quick start](https://fakecloud.dev#quickstart): Run `fakecloud` then point any AWS SDK at `http://localhost:4566`
-- [Configuration](https://github.com/faiscadev/fakecloud#configuration): CLI flags and environment variables (--addr, --region, --account-id, --log-level)
+- [Configuration](https://github.com/faiscadev/fakecloud#configuration): CLI flags and environment variables (--addr, --region, --account-id, --log-level, --storage-mode, --data-path, --body-cache-size)
+- [Persistence](https://github.com/faiscadev/fakecloud#persistence): opt-in disk persistence for S3 via --storage-mode=persistent
 - [Health check](https://github.com/faiscadev/fakecloud#health-check): `curl http://localhost:4566/_fakecloud/health`
 
 ## Supported Services

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -18,7 +18,7 @@
 ## Usage
 
 - [Quick start](https://fakecloud.dev#quickstart): Run `fakecloud` then point any AWS SDK at `http://localhost:4566`
-- [Configuration](https://github.com/faiscadev/fakecloud#configuration): CLI flags and environment variables (--addr, --region, --account-id, --log-level, --storage-mode, --data-path, --body-cache-size)
+- [Configuration](https://github.com/faiscadev/fakecloud#configuration): CLI flags and environment variables (--addr, --region, --account-id, --log-level, --storage-mode, --data-path, --s3-cache-size)
 - [Persistence](https://github.com/faiscadev/fakecloud#persistence): opt-in disk persistence for S3 via --storage-mode=persistent
 - [Health check](https://github.com/faiscadev/fakecloud#health-check): `curl http://localhost:4566/_fakecloud/health`
 


### PR DESCRIPTION
Closes #279.

## Summary

Adds an opt-in disk persistence mode so large fixtures (issue #279: ~20 GB) survive a fakecloud restart. Default stays in-memory with zero overhead. Only S3 is persisted in this PR; other services log a clear warning when persistent mode is requested and continue to run in-memory.

## Flags

- `--storage-mode={memory|persistent}` (default `memory`), env `FAKECLOUD_STORAGE_MODE`
- `--data-path <dir>` (required iff `persistent`), env `FAKECLOUD_DATA_PATH`
- `--body-cache-size <bytes>` (default `256 MiB`), env `FAKECLOUD_BODY_CACHE_SIZE`

## What gets persisted (S3)

Everything the in-memory store tracked, audited field-by-field:

- Buckets: meta + all 15 subresources (tags, ACL, lifecycle, CORS, policy, notification, logging, website, PAB, object lock, replication, ownership, inventory, encryption, versioning).
- Objects: bodies on disk (never round-tripped through RAM), plus every `S3Object` field as a TOML sidecar (user metadata, tags, storage class, SSE, object-lock retention/legal hold, checksums, Glacier restore state, delete markers, content-encoding, website-redirect-location).
- Versioning + delete markers.
- In-progress multipart uploads: resumable across restart — a client mid-upload can continue `UploadPart` / `CompleteMultipartUpload` after a fakecloud restart without re-uploading parts.

Intentionally **not** persisted: `notification_events` (in-memory introspection buffer, not durable state — documented in README).

## Architecture

New `fakecloud-persistence` crate:

- `StorageMode`, `PersistenceConfig`
- `fakecloud.version.toml` format-version guard (v1). Mismatch = exit 1 with file path + expected vs actual version. **No auto-migration.**
- Byte-sized LRU `BodyCache`. Single-object cap = `capacity / 2` so one large upload can't evict the world. Objects over the cap bypass the cache entirely on both put and get.
- Atomic write helpers (`.tmp` + fsync + rename + fsync parent).
- `S3Store` trait (per-service, not a god-trait — the shape for future services will be extracted after a second service lands).
- `MemoryS3Store` noop impl (default mode).
- `DiskS3Store` impl with the full layout.

`BodyRef { Memory(Bytes) | Disk { bucket, key, version, path, size } }` replaces `Bytes` in `S3Object`/`UploadPart`. Every read site routes through a `read_body` helper.

### On-disk layout

```
<data>/
  fakecloud.version.toml
  s3/
    buckets/<bucket>/
      meta.toml
      {tags,lifecycle,cors,policy,notification,logging,website,
       public_access_block,object_lock,replication,ownership,
       inventory,acl,encryption}.toml
      objects/<escaped-key>/
        <version-or-null>.bin      # raw body
        <version-or-null>.toml     # ObjectMeta sidecar
      mpu/<upload-id>/
        init.toml
        parts/<n>.{bin,toml}
```

Object keys are percent-encoded; long segments get a sha256 overflow suffix.

### Multipart completion

- Single part: `fs::rename` — zero body copy.
- Multi part: `std::io::copy` streams between file descriptors directly. No intermediate `Vec<u8>`, no `Bytes`, no RAM allocation proportional to body size. 20 GiB upload never touches RAM.
- Cross-device rename (`EXDEV`): falls back to streaming copy + remove source. Still RAM-free.

## Tests

- **`fakecloud-persistence`: 39 unit tests** — cache LRU behavior + single-object-cap bypass, key escaping (unicode, slashes, overflow), atomic writes, version-file read/write/mismatch, `DiskS3Store` round-trips for every bucket subresource, versioning, delete markers, multipart create/put/abort/complete (including a streaming multi-part concat test using `BodySource::File`), restart-resumable multipart.
- **`fakecloud-s3`: 39 unit tests** — unchanged; memory mode is behaviorally identical.
- **`fakecloud-e2e/tests/s3_persistence.rs` (new): 9 end-to-end tests** — round-trip metadata, 50 MiB object + SHA256, multipart resume across restart, multipart abort across restart, versioning + delete markers, bucket subresources, unsupported-service still works in persistent mode, version-file mismatch fails loudly, body cache small-vs-large bypass. Helper: `TestServer::start_persistent` + `restart()`.
- Full existing S3 E2E suite unchanged — the regression guard for memory mode.

_Local note: E2E validation was deferred to CI because the docker daemon on my machine is stuck on \`docker info\` and fakecloud's Lambda container runtime auto-detection hangs on startup. CI is expected to run the full suite._

## Docs

- README: new Persistence section covering flags, format-version contract, S3-only-for-now status, non-S3 warning behavior, and the notification_events-not-persisted note.
- \`website/static/llms-full.txt\` and \`llms.txt\` mirror the README section.
- ROADMAP updated: S3 persistence shipped, persistence for other services queued as follow-ups.

## Test plan

- [ ] CI green (workspace build, unit tests, E2E S3 + S3-persistence)
- [ ] Cubic review passes
- [ ] Manual: \`fakecloud --storage-mode=persistent --data-path=/tmp/fc\`, push a few-hundred-MiB object via \`aws s3 cp\`, kill the process, restart with same flags, \`aws s3 cp s3://... -\` and diff against the original
- [ ] Manual: same, with a mid-flight multipart upload, kill after 2 parts, restart, upload remaining parts, complete, diff


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in disk persistence for S3 so buckets, objects (with versions), delete markers, and in-progress multipart uploads survive restarts; default stays in-memory. Addresses #279 by streaming large GETs from disk, returning 500s on persistence errors, and capping single-request bodies at 128 MiB (use multipart for larger uploads).

- **New Features**
  - New `fakecloud-persistence` crate with `DiskS3Store`/`MemoryS3Store`, atomic TOML writes (tmp cleanup), format-version guard, and a byte-sized LRU body cache with capacity checks.
  - Persists S3 bucket meta + subresources, objects, versions, delete markers, and resumable multipart; safe key escaping; GETs stream via `ResponseBody::File` with correct Content-Length header handling (no duplicates).
  - Store-first writes: all mutations persist before memory and reuse the store’s returned `BodyRef`; replication, access logs, and DynamoDB S3 exports write through the store and survive restarts (replication uses `BodySource::FileCopy` for disk-backed sources; exports now fail loudly with accurate FailureCode and mark FAILED if the store write fails).
  - Reads: cache-aware full reads and seek-based range/part reads; versioned load promotes the newest live object and hides keys behind trailing delete markers; orphaned metadata or MPU part sidecars without bodies fail loudly on load.

- **Migration**
  - To enable: run `fakecloud --storage-mode=persistent --data-path=<dir>`; tune RAM with `--s3-cache-size` (default 256 MiB).
  - Default is unchanged (memory mode). Existing data paths must match the on-disk format version or the server exits with an error; non-empty paths without a version file also error.

<sup>Written for commit 3f01c6db078065631bc20d7de3b862717c00723d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



