### PR TITLE
feat(bedrock): prompt-conditional response rules

### DIFF
--- a/crates/fakecloud-bedrock/src/converse.rs
+++ b/crates/fakecloud-bedrock/src/converse.rs
@@ -20,18 +20,16 @@ pub fn converse(
         .unwrap_or(u64::MAX);
     let tool_config = input.get("toolConfig");
 
-    let response_text = {
-        let s = state.read();
-        if let Some(custom) = s.custom_responses.get(model_id) {
-            let parsed: Value = serde_json::from_str(custom).unwrap_or_default();
+    let response_text = match crate::prompt::resolve_override(state, model_id, body) {
+        Some(custom) => {
+            let parsed: Value = serde_json::from_str(&custom).unwrap_or_default();
             if let Some(text) = parsed["output"]["message"]["content"][0]["text"].as_str() {
                 text.to_string()
             } else {
-                custom.clone()
+                custom
             }
-        } else {
-            "This is a test response from the emulated model.".to_string()
         }
+        None => "This is a test response from the emulated model.".to_string(),
     };
 
     // Respect maxTokens by truncating (rough approximation: 1 token ~= 4 chars)

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -24,14 +24,8 @@ pub fn invoke_model(
 
     let input: Value = serde_json::from_slice(body).unwrap_or_default();
 
-    let response_body = {
-        let s = state.read();
-        if let Some(custom) = s.custom_responses.get(model_id) {
-            custom.clone()
-        } else {
-            generate_canned_response(model_id, &input)
-        }
-    };
+    let response_body = crate::prompt::resolve_override(state, model_id, body)
+        .unwrap_or_else(|| generate_canned_response(model_id, &input));
 
     // Record invocation for introspection
     {

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -18,6 +18,7 @@ pub mod marketplace;
 pub mod model_copy;
 pub mod model_import;
 pub mod models;
+pub mod prompt;
 pub mod prompt_routers;
 pub mod resource_policies;
 pub mod service;

--- a/crates/fakecloud-bedrock/src/prompt.rs
+++ b/crates/fakecloud-bedrock/src/prompt.rs
@@ -1,0 +1,89 @@
+use serde_json::Value;
+
+use crate::state::{ResponseRule, SharedBedrockState};
+
+/// Extract the user-visible prompt text from a runtime request body.
+///
+/// Handles both InvokeModel (provider-specific shapes) and Converse bodies.
+/// Returns an empty string when nothing recognizable is found, so a rule
+/// with `prompt_contains = ""` matches any call.
+pub fn extract_prompt_text(model_id: &str, body: &[u8]) -> String {
+    let Ok(value): Result<Value, _> = serde_json::from_slice(body) else {
+        return String::new();
+    };
+
+    // Converse shape: top-level `messages` array with `content[].text`,
+    // plus optional `system[].text`.
+    let mut out = String::new();
+    if let Some(system) = value.get("system").and_then(|s| s.as_array()) {
+        for block in system {
+            if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
+                out.push_str(t);
+                out.push(' ');
+            }
+        }
+    }
+    if let Some(messages) = value.get("messages").and_then(|m| m.as_array()) {
+        for msg in messages {
+            match msg.get("content") {
+                // Converse: content is an array of blocks.
+                Some(Value::Array(blocks)) => {
+                    for block in blocks {
+                        if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
+                            out.push_str(t);
+                            out.push(' ');
+                        }
+                    }
+                }
+                // Anthropic InvokeModel: content may be a plain string.
+                Some(Value::String(s)) => {
+                    out.push_str(s);
+                    out.push(' ');
+                }
+                _ => {}
+            }
+        }
+    }
+    if !out.is_empty() {
+        return out.trim_end().to_string();
+    }
+
+    // Provider-specific InvokeModel shapes.
+    if model_id.starts_with("amazon.") {
+        if let Some(t) = value.get("inputText").and_then(|t| t.as_str()) {
+            return t.to_string();
+        }
+    }
+    if let Some(t) = value.get("prompt").and_then(|t| t.as_str()) {
+        return t.to_string();
+    }
+    if let Some(t) = value.get("inputText").and_then(|t| t.as_str()) {
+        return t.to_string();
+    }
+
+    String::new()
+}
+
+/// Return the first rule whose `prompt_contains` filter matches the current prompt.
+/// A rule with `prompt_contains = None` or an empty string matches anything.
+pub fn match_rule<'a>(rules: &'a [ResponseRule], prompt: &str) -> Option<&'a ResponseRule> {
+    rules.iter().find(|rule| match &rule.prompt_contains {
+        None => true,
+        Some(needle) if needle.is_empty() => true,
+        Some(needle) => prompt.contains(needle.as_str()),
+    })
+}
+
+/// Resolve the response body a runtime call should use, applying
+/// rule-based overrides first, then the legacy single-response override.
+/// Returns `None` when neither is configured — caller falls back to canned.
+pub fn resolve_override(state: &SharedBedrockState, model_id: &str, body: &[u8]) -> Option<String> {
+    let prompt = extract_prompt_text(model_id, body);
+    let s = state.read();
+    if let Some(rules) = s.response_rules.get(model_id) {
+        if let Some(rule) = match_rule(rules, &prompt) {
+            return Some(rule.response.clone());
+        }
+    }
+    s.custom_responses.get(model_id).cloned()
+}

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -1277,7 +1277,8 @@ impl AwsService for BedrockService {
             }
             "InvokeModelWithResponseStream" | "InvokeModelWithBidirectionalStream" => {
                 let model_id = resource_id.unwrap_or_default();
-                let response_text = crate::streaming::get_response_text(&self.state, &model_id);
+                let response_text =
+                    crate::streaming::get_response_text(&self.state, &model_id, &req.body);
                 let body =
                     crate::streaming::build_invoke_stream_response(&model_id, &response_text);
 
@@ -1301,7 +1302,8 @@ impl AwsService for BedrockService {
             }
             "ConverseStream" => {
                 let model_id = resource_id.unwrap_or_default();
-                let response_text = crate::streaming::get_response_text(&self.state, &model_id);
+                let response_text =
+                    crate::streaming::get_response_text(&self.state, &model_id, &req.body);
                 let body = crate::streaming::build_converse_stream_response(&response_text);
 
                 // Record invocation

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -25,6 +25,9 @@ pub struct BedrockState {
     pub invocations: Vec<ModelInvocation>,
     /// Custom responses configured per model ID via simulation endpoint.
     pub custom_responses: HashMap<String, String>,
+    /// Prompt-conditional response rules per model ID. Evaluated in order;
+    /// the first rule whose `prompt_contains` matches wins.
+    pub response_rules: HashMap<String, Vec<ResponseRule>>,
     /// Async invocations keyed by invocation ARN.
     pub async_invocations: HashMap<String, AsyncInvocation>,
     /// Custom models keyed by model ARN.
@@ -80,6 +83,7 @@ impl BedrockState {
             logging_config: None,
             invocations: Vec::new(),
             custom_responses: HashMap::new(),
+            response_rules: HashMap::new(),
             async_invocations: HashMap::new(),
             custom_models: HashMap::new(),
             custom_model_deployments: HashMap::new(),
@@ -112,6 +116,7 @@ impl BedrockState {
         self.logging_config = None;
         self.invocations.clear();
         self.custom_responses.clear();
+        self.response_rules.clear();
         self.async_invocations.clear();
         self.custom_models.clear();
         self.custom_model_deployments.clear();
@@ -207,6 +212,15 @@ pub struct LoggingConfig {
     pub text_data_delivery_enabled: bool,
     pub image_data_delivery_enabled: bool,
     pub embedding_data_delivery_enabled: bool,
+}
+
+#[derive(Clone)]
+pub struct ResponseRule {
+    /// Substring to look for in the extracted prompt text. `None` or empty
+    /// matches any prompt.
+    pub prompt_contains: Option<String>,
+    /// Raw response body to return when the rule matches.
+    pub response: String,
 }
 
 #[derive(Clone)]

--- a/crates/fakecloud-bedrock/src/streaming.rs
+++ b/crates/fakecloud-bedrock/src/streaming.rs
@@ -191,23 +191,26 @@ pub fn default_stream_text() -> &'static str {
     "This is a test response from the emulated model."
 }
 
-/// Generate the canned response text, checking for custom overrides
-pub fn get_response_text(state: &crate::state::SharedBedrockState, model_id: &str) -> String {
-    let s = state.read();
-    if let Some(custom) = s.custom_responses.get(model_id) {
-        // Try to extract text from a JSON response
-        if let Ok(parsed) = serde_json::from_str::<Value>(custom) {
-            // Anthropic format
-            if let Some(text) = parsed["content"][0]["text"].as_str() {
-                return text.to_string();
-            }
-            // Converse format
-            if let Some(text) = parsed["output"]["message"]["content"][0]["text"].as_str() {
-                return text.to_string();
-            }
+/// Generate the canned response text, checking for prompt-conditional and
+/// legacy custom overrides for the given call.
+pub fn get_response_text(
+    state: &crate::state::SharedBedrockState,
+    model_id: &str,
+    body: &[u8],
+) -> String {
+    let Some(custom) = crate::prompt::resolve_override(state, model_id, body) else {
+        return default_stream_text().to_string();
+    };
+    // Try to extract text from a JSON response body.
+    if let Ok(parsed) = serde_json::from_str::<Value>(&custom) {
+        // Anthropic format
+        if let Some(text) = parsed["content"][0]["text"].as_str() {
+            return text.to_string();
         }
-        custom.clone()
-    } else {
-        default_stream_text().to_string()
+        // Converse format
+        if let Some(text) = parsed["output"]["message"]["content"][0]["text"].as_str() {
+            return text.to_string();
+        }
     }
+    custom
 }

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -707,6 +707,220 @@ async fn bedrock_simulation_custom_response() {
     assert_eq!(response_body["content"][0]["text"], "Custom test response!");
 }
 
+#[tokio::test]
+async fn bedrock_prompt_conditional_responses() {
+    let server = TestServer::start().await;
+    let runtime_client = server.bedrock_runtime_client().await;
+    let http_client = reqwest::Client::new();
+    let model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+    let spam_body = serde_json::json!({
+        "id": "msg_spam",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "spam detected"}],
+        "model": model_id,
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 5, "output_tokens": 5}
+    });
+    let urgent_body = serde_json::json!({
+        "id": "msg_urgent",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "urgent reply"}],
+        "model": model_id,
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 5, "output_tokens": 5}
+    });
+
+    let resp = http_client
+        .post(format!(
+            "{}/_fakecloud/bedrock/models/{}/responses",
+            server.endpoint(),
+            model_id
+        ))
+        .json(&serde_json::json!({
+            "rules": [
+                { "promptContains": "spam", "response": spam_body },
+                { "promptContains": "urgent", "response": urgent_body },
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    let invoke = |text: &'static str| {
+        let client = runtime_client.clone();
+        async move {
+            let body = serde_json::to_vec(&serde_json::json!({
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 10,
+                "messages": [{"role": "user", "content": text}]
+            }))
+            .unwrap();
+            let resp = client
+                .invoke_model()
+                .model_id(model_id)
+                .content_type("application/json")
+                .accept("application/json")
+                .body(Blob::new(body))
+                .send()
+                .await
+                .unwrap();
+            let parsed: serde_json::Value = serde_json::from_slice(resp.body().as_ref()).unwrap();
+            parsed["content"][0]["text"].as_str().unwrap().to_string()
+        }
+    };
+
+    assert_eq!(
+        invoke("please check this spam message").await,
+        "spam detected"
+    );
+    assert_eq!(invoke("urgent issue happening").await, "urgent reply");
+    // Falls through to canned response when no rule matches.
+    assert_eq!(
+        invoke("nothing interesting").await,
+        "This is a test response from the emulated model."
+    );
+}
+
+#[tokio::test]
+async fn bedrock_prompt_rules_and_legacy_coexist() {
+    let server = TestServer::start().await;
+    let runtime_client = server.bedrock_runtime_client().await;
+    let http_client = reqwest::Client::new();
+    let model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+    let rule_body = serde_json::json!({
+        "id": "msg_rule",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "rule matched"}],
+        "model": model_id,
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 5, "output_tokens": 5}
+    });
+    let legacy_body = serde_json::json!({
+        "id": "msg_legacy",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "legacy default"}],
+        "model": model_id,
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 5, "output_tokens": 5}
+    });
+
+    http_client
+        .post(format!(
+            "{}/_fakecloud/bedrock/models/{}/responses",
+            server.endpoint(),
+            model_id
+        ))
+        .json(&serde_json::json!({
+            "rules": [{ "promptContains": "trigger", "response": rule_body }]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    http_client
+        .post(format!(
+            "{}/_fakecloud/bedrock/models/{}/response",
+            server.endpoint(),
+            model_id
+        ))
+        .body(serde_json::to_string(&legacy_body).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    let call = |text: &'static str| {
+        let client = runtime_client.clone();
+        async move {
+            let body = serde_json::to_vec(&serde_json::json!({
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 10,
+                "messages": [{"role": "user", "content": text}]
+            }))
+            .unwrap();
+            let resp = client
+                .invoke_model()
+                .model_id(model_id)
+                .content_type("application/json")
+                .accept("application/json")
+                .body(Blob::new(body))
+                .send()
+                .await
+                .unwrap();
+            let parsed: serde_json::Value = serde_json::from_slice(resp.body().as_ref()).unwrap();
+            parsed["content"][0]["text"].as_str().unwrap().to_string()
+        }
+    };
+
+    assert_eq!(call("please trigger me").await, "rule matched");
+    // No rule match — legacy single response applies.
+    assert_eq!(call("nothing").await, "legacy default");
+}
+
+#[tokio::test]
+async fn bedrock_prompt_conditional_converse_stream() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+    let converse_resp = serde_json::json!({
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "streamed custom reply"}]
+            }
+        }
+    });
+
+    http_client
+        .post(format!(
+            "{}/_fakecloud/bedrock/models/{}/responses",
+            server.endpoint(),
+            model_id
+        ))
+        .json(&serde_json::json!({
+            "rules": [{ "promptContains": "hello", "response": converse_resp }]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let body = serde_json::json!({
+        "modelId": model_id,
+        "messages": [
+            {"role": "user", "content": [{"text": "hello there"}]}
+        ]
+    });
+    let resp = http_client
+        .post(format!(
+            "{}/model/{}/converse-stream",
+            server.endpoint(),
+            model_id
+        ))
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let bytes = resp.bytes().await.unwrap();
+    let as_str = String::from_utf8_lossy(&bytes);
+    assert!(
+        as_str.contains("streamed custom reply"),
+        "expected custom text in stream, got: {as_str:?}"
+    );
+}
+
 // ApplyGuardrail (Runtime)
 
 #[tokio::test]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1524,10 +1524,18 @@ async fn main() {
                     };
                     let mut parsed = Vec::with_capacity(rules_json.len());
                     for rule in rules_json {
-                        let prompt_contains = rule
-                            .get("promptContains")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
+                        let prompt_contains = match rule.get("promptContains") {
+                            None | Some(serde_json::Value::Null) => None,
+                            Some(serde_json::Value::String(s)) => Some(s.clone()),
+                            Some(_) => {
+                                return (
+                                    axum::http::StatusCode::BAD_REQUEST,
+                                    axum::Json(serde_json::json!({
+                                        "error": "`promptContains` must be a string when provided"
+                                    })),
+                                );
+                            }
+                        };
                         let response = match rule.get("response") {
                             Some(serde_json::Value::String(s)) => s.clone(),
                             Some(other) => other.to_string(),

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1506,6 +1506,65 @@ async fn main() {
                 }
             }),
         )
+        // Bedrock simulation: configure prompt-conditional response rules
+        .route(
+            "/_fakecloud/bedrock/models/{model_id}/responses",
+            axum::routing::post({
+                let bs = bedrock_state.clone();
+                move |axum::extract::Path(model_id): axum::extract::Path<String>,
+                      axum::Json(body): axum::Json<serde_json::Value>| async move {
+                    let rules_json = body.get("rules").and_then(|r| r.as_array()).cloned();
+                    let Some(rules_json) = rules_json else {
+                        return (
+                            axum::http::StatusCode::BAD_REQUEST,
+                            axum::Json(serde_json::json!({
+                                "error": "body must contain a `rules` array"
+                            })),
+                        );
+                    };
+                    let mut parsed = Vec::with_capacity(rules_json.len());
+                    for rule in rules_json {
+                        let prompt_contains = rule
+                            .get("promptContains")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        let response = match rule.get("response") {
+                            Some(serde_json::Value::String(s)) => s.clone(),
+                            Some(other) => other.to_string(),
+                            None => {
+                                return (
+                                    axum::http::StatusCode::BAD_REQUEST,
+                                    axum::Json(serde_json::json!({
+                                        "error": "each rule must include a `response` field"
+                                    })),
+                                );
+                            }
+                        };
+                        parsed.push(fakecloud_bedrock::state::ResponseRule {
+                            prompt_contains,
+                            response,
+                        });
+                    }
+                    let mut state = bs.write();
+                    state.response_rules.insert(model_id.clone(), parsed);
+                    (
+                        axum::http::StatusCode::OK,
+                        axum::Json(serde_json::json!({
+                            "status": "ok",
+                            "modelId": model_id
+                        })),
+                    )
+                }
+            })
+            .delete({
+                let bs = bedrock_state.clone();
+                move |axum::extract::Path(model_id): axum::extract::Path<String>| async move {
+                    let mut state = bs.write();
+                    state.response_rules.remove(&model_id);
+                    axum::Json(serde_json::json!({ "status": "ok", "modelId": model_id }))
+                }
+            }),
+        )
         .fallback(dispatch::dispatch)
         .layer(Extension(Arc::new(registry)))
         .layer(Extension(Arc::new(config)))


### PR DESCRIPTION
## Summary
- Adds per-model response rules so a single test can return different Bedrock responses for different prompts against the same model (spam-classifier branches, refusal retries, etc.).
- New \`POST /_fakecloud/bedrock/models/{model_id}/responses\` (replace rule list) and \`DELETE\` (clear). Rules are evaluated rules-first, then legacy single \`/response\` override, then canned — existing endpoint is untouched.
- Shared prompt-extraction helper covers Anthropic/Titan/Meta/Cohere/Mistral InvokeModel bodies and Converse bodies, plumbed through invoke, converse, and the streaming paths.

## Test plan
- [x] \`cargo test -p fakecloud-e2e --test bedrock\` — 38 passing, including 3 new tests:
  - \`bedrock_prompt_conditional_responses\` — two rules against one model, distinct responses, fallthrough to canned when nothing matches
  - \`bedrock_prompt_rules_and_legacy_coexist\` — rules take precedence, legacy kicks in when no rule matches
  - \`bedrock_prompt_conditional_converse_stream\` — ConverseStream emits the matched rule's text
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add prompt-conditional response rules so tests can return different responses for different prompts on the same model across InvokeModel, Converse, and streaming. Rule order: first matching `promptContains`, then legacy `/_fakecloud/bedrock/models/{model_id}/response`, then canned default.

- **New Features**
  - Add `POST /_fakecloud/bedrock/models/{model_id}/responses` (replace rules) and `DELETE` (clear); legacy `/_fakecloud/bedrock/models/{model_id}/response` is unchanged.
  - Prompt extraction covers Anthropic, Titan, Meta, Cohere, and Mistral InvokeModel bodies, plus Converse; all paths use it to resolve overrides before falling back to canned text.
  - E2E tests cover rule selection, coexistence with legacy, and ConverseStream output.

- **Bug Fixes**
  - Reject non-string `promptContains` in rule config with 400 and an error message to prevent unintended catch-all rules.

<sup>Written for commit 8dc41315127156adb14251b7a10b92b9b120bf49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

