### PR TITLE
feat(bedrock): fault injection for runtime operations

### DIFF
--- a/crates/fakecloud-bedrock/src/converse.rs
+++ b/crates/fakecloud-bedrock/src/converse.rs
@@ -12,6 +12,11 @@ pub fn converse(
     model_id: &str,
     body: &[u8],
 ) -> Result<AwsResponse, AwsServiceError> {
+    if let Some(fault) = crate::faults::take_matching_fault(state, model_id, "Converse") {
+        crate::faults::record_faulted_invocation(state, model_id, body, &fault);
+        return Err(crate::faults::fault_to_error(&fault));
+    }
+
     let input: Value = serde_json::from_slice(body).unwrap_or_default();
 
     let inference_config = input.get("inferenceConfig");
@@ -108,6 +113,7 @@ pub fn converse(
             input: String::from_utf8_lossy(body).to_string(),
             output: response_str.clone(),
             timestamp: Utc::now(),
+            error: None,
         });
     }
 

--- a/crates/fakecloud-bedrock/src/faults.rs
+++ b/crates/fakecloud-bedrock/src/faults.rs
@@ -1,0 +1,57 @@
+use chrono::Utc;
+use http::StatusCode;
+
+use fakecloud_core::service::AwsServiceError;
+
+use crate::state::{FaultRule, ModelInvocation, SharedBedrockState};
+
+/// Pop the first queued fault rule that matches the given `(model_id, operation)`
+/// pair. Decrements the rule's remaining count; removes the rule when it hits
+/// zero. Returns the rule as it looked *before* decrementing so callers can see
+/// the intended error type/message/status.
+pub fn take_matching_fault(
+    state: &SharedBedrockState,
+    model_id: &str,
+    operation: &str,
+) -> Option<FaultRule> {
+    let mut s = state.write();
+    let idx = s.fault_rules.iter().position(|rule| {
+        rule.model_id
+            .as_deref()
+            .is_none_or(|needle| needle == model_id)
+            && rule
+                .operation
+                .as_deref()
+                .is_none_or(|needle| needle == operation)
+    })?;
+    let snapshot = s.fault_rules[idx].clone();
+    if s.fault_rules[idx].remaining <= 1 {
+        s.fault_rules.remove(idx);
+    } else {
+        s.fault_rules[idx].remaining -= 1;
+    }
+    Some(snapshot)
+}
+
+/// Convert a queued fault rule into an `AwsServiceError` for the caller to return.
+pub fn fault_to_error(fault: &FaultRule) -> AwsServiceError {
+    let status = StatusCode::from_u16(fault.http_status).unwrap_or(StatusCode::BAD_REQUEST);
+    AwsServiceError::aws_error(status, &fault.error_type, &fault.message)
+}
+
+/// Record an invocation that was rejected by an injected fault.
+pub fn record_faulted_invocation(
+    state: &SharedBedrockState,
+    model_id: &str,
+    body: &[u8],
+    fault: &FaultRule,
+) {
+    let mut s = state.write();
+    s.invocations.push(ModelInvocation {
+        model_id: model_id.to_string(),
+        input: String::from_utf8_lossy(body).to_string(),
+        output: String::new(),
+        timestamp: Utc::now(),
+        error: Some(format!("{}: {}", fault.error_type, fault.message)),
+    });
+}

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -22,6 +22,12 @@ pub fn invoke_model(
         ));
     }
 
+    // Fault injection: if a matching rule is queued, record the attempt and fail.
+    if let Some(fault) = crate::faults::take_matching_fault(state, model_id, "InvokeModel") {
+        crate::faults::record_faulted_invocation(state, model_id, body, &fault);
+        return Err(crate::faults::fault_to_error(&fault));
+    }
+
     let input: Value = serde_json::from_slice(body).unwrap_or_default();
 
     let response_body = crate::prompt::resolve_override(state, model_id, body)
@@ -35,6 +41,7 @@ pub fn invoke_model(
             input: String::from_utf8_lossy(body).to_string(),
             output: response_body.clone(),
             timestamp: Utc::now(),
+            error: None,
         });
     }
 

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -8,6 +8,7 @@ pub mod customization;
 
 pub mod enforced_guardrails;
 pub mod evaluation;
+pub mod faults;
 pub mod foundation_model_agreements;
 pub mod guardrails;
 pub mod inference_profiles;

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -1277,6 +1277,19 @@ impl AwsService for BedrockService {
             }
             "InvokeModelWithResponseStream" | "InvokeModelWithBidirectionalStream" => {
                 let model_id = resource_id.unwrap_or_default();
+                if let Some(fault) = crate::faults::take_matching_fault(
+                    &self.state,
+                    &model_id,
+                    "InvokeModelWithResponseStream",
+                ) {
+                    crate::faults::record_faulted_invocation(
+                        &self.state,
+                        &model_id,
+                        &req.body,
+                        &fault,
+                    );
+                    return Err(crate::faults::fault_to_error(&fault));
+                }
                 let response_text =
                     crate::streaming::get_response_text(&self.state, &model_id, &req.body);
                 let body =
@@ -1290,6 +1303,7 @@ impl AwsService for BedrockService {
                         input: String::from_utf8_lossy(&req.body).to_string(),
                         output: response_text,
                         timestamp: chrono::Utc::now(),
+                        error: None,
                     });
                 }
 
@@ -1302,6 +1316,17 @@ impl AwsService for BedrockService {
             }
             "ConverseStream" => {
                 let model_id = resource_id.unwrap_or_default();
+                if let Some(fault) =
+                    crate::faults::take_matching_fault(&self.state, &model_id, "ConverseStream")
+                {
+                    crate::faults::record_faulted_invocation(
+                        &self.state,
+                        &model_id,
+                        &req.body,
+                        &fault,
+                    );
+                    return Err(crate::faults::fault_to_error(&fault));
+                }
                 let response_text =
                     crate::streaming::get_response_text(&self.state, &model_id, &req.body);
                 let body = crate::streaming::build_converse_stream_response(&response_text);
@@ -1314,6 +1339,7 @@ impl AwsService for BedrockService {
                         input: String::from_utf8_lossy(&req.body).to_string(),
                         output: response_text,
                         timestamp: chrono::Utc::now(),
+                        error: None,
                     });
                 }
 

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -28,6 +28,9 @@ pub struct BedrockState {
     /// Prompt-conditional response rules per model ID. Evaluated in order;
     /// the first rule whose `prompt_contains` matches wins.
     pub response_rules: HashMap<String, Vec<ResponseRule>>,
+    /// Queued fault-injection rules. Consumed in order; rules with filters
+    /// only trigger when both `model_id` and `operation` match.
+    pub fault_rules: Vec<FaultRule>,
     /// Async invocations keyed by invocation ARN.
     pub async_invocations: HashMap<String, AsyncInvocation>,
     /// Custom models keyed by model ARN.
@@ -84,6 +87,7 @@ impl BedrockState {
             invocations: Vec::new(),
             custom_responses: HashMap::new(),
             response_rules: HashMap::new(),
+            fault_rules: Vec::new(),
             async_invocations: HashMap::new(),
             custom_models: HashMap::new(),
             custom_model_deployments: HashMap::new(),
@@ -117,6 +121,7 @@ impl BedrockState {
         self.invocations.clear();
         self.custom_responses.clear();
         self.response_rules.clear();
+        self.fault_rules.clear();
         self.async_invocations.clear();
         self.custom_models.clear();
         self.custom_model_deployments.clear();
@@ -229,6 +234,19 @@ pub struct ModelInvocation {
     pub input: String,
     pub output: String,
     pub timestamp: DateTime<Utc>,
+    /// `Some("<errorType>: <message>")` when the call was faulted by an
+    /// injected fault rule; `None` for successful calls.
+    pub error: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct FaultRule {
+    pub error_type: String,
+    pub message: String,
+    pub http_status: u16,
+    pub remaining: u32,
+    pub model_id: Option<String>,
+    pub operation: Option<String>,
 }
 
 #[derive(Clone)]

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -707,197 +707,244 @@ async fn bedrock_simulation_custom_response() {
     assert_eq!(response_body["content"][0]["text"], "Custom test response!");
 }
 
-#[tokio::test]
-async fn bedrock_prompt_conditional_responses() {
-    let server = TestServer::start().await;
-    let runtime_client = server.bedrock_runtime_client().await;
-    let http_client = reqwest::Client::new();
-    let model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+// Fault injection
 
-    let spam_body = serde_json::json!({
-        "id": "msg_spam",
-        "type": "message",
-        "role": "assistant",
-        "content": [{"type": "text", "text": "spam detected"}],
-        "model": model_id,
-        "stop_reason": "end_turn",
-        "usage": {"input_tokens": 5, "output_tokens": 5}
-    });
-    let urgent_body = serde_json::json!({
-        "id": "msg_urgent",
-        "type": "message",
-        "role": "assistant",
-        "content": [{"type": "text", "text": "urgent reply"}],
-        "model": model_id,
-        "stop_reason": "end_turn",
-        "usage": {"input_tokens": 5, "output_tokens": 5}
-    });
+/// Build a Bedrock runtime client that never retries, so fault-injection
+/// tests see the first-attempt error instead of an SDK-automatic retry.
+async fn bedrock_runtime_no_retry(server: &TestServer) -> aws_sdk_bedrockruntime::Client {
+    let base = server.aws_config().await;
+    let cfg = aws_sdk_bedrockruntime::config::Builder::from(&base)
+        .retry_config(aws_sdk_bedrockruntime::config::retry::RetryConfig::disabled())
+        .build();
+    aws_sdk_bedrockruntime::Client::from_conf(cfg)
+}
 
-    let resp = http_client
-        .post(format!(
-            "{}/_fakecloud/bedrock/models/{}/responses",
-            server.endpoint(),
-            model_id
-        ))
-        .json(&serde_json::json!({
-            "rules": [
-                { "promptContains": "spam", "response": spam_body },
-                { "promptContains": "urgent", "response": urgent_body },
-            ]
-        }))
+async fn queue_fault(endpoint: &str, http: &reqwest::Client, body: serde_json::Value) {
+    let resp = http
+        .post(format!("{endpoint}/_fakecloud/bedrock/faults"))
+        .json(&body)
         .send()
         .await
         .unwrap();
     assert!(resp.status().is_success());
+}
 
-    let invoke = |text: &'static str| {
-        let client = runtime_client.clone();
-        async move {
-            let body = serde_json::to_vec(&serde_json::json!({
-                "anthropic_version": "bedrock-2023-05-31",
-                "max_tokens": 10,
-                "messages": [{"role": "user", "content": text}]
-            }))
-            .unwrap();
-            let resp = client
-                .invoke_model()
-                .model_id(model_id)
-                .content_type("application/json")
-                .accept("application/json")
-                .body(Blob::new(body))
-                .send()
-                .await
-                .unwrap();
-            let parsed: serde_json::Value = serde_json::from_slice(resp.body().as_ref()).unwrap();
-            parsed["content"][0]["text"].as_str().unwrap().to_string()
-        }
-    };
-
-    assert_eq!(
-        invoke("please check this spam message").await,
-        "spam detected"
-    );
-    assert_eq!(invoke("urgent issue happening").await, "urgent reply");
-    // Falls through to canned response when no rule matches.
-    assert_eq!(
-        invoke("nothing interesting").await,
-        "This is a test response from the emulated model."
-    );
+async fn invoke_simple(
+    client: &aws_sdk_bedrockruntime::Client,
+    model_id: &str,
+) -> Result<
+    aws_sdk_bedrockruntime::operation::invoke_model::InvokeModelOutput,
+    aws_sdk_bedrockruntime::error::SdkError<
+        aws_sdk_bedrockruntime::operation::invoke_model::InvokeModelError,
+    >,
+> {
+    let body = serde_json::to_vec(&serde_json::json!({
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 10,
+        "messages": [{"role": "user", "content": "hi"}]
+    }))
+    .unwrap();
+    client
+        .invoke_model()
+        .model_id(model_id)
+        .content_type("application/json")
+        .accept("application/json")
+        .body(Blob::new(body))
+        .send()
+        .await
 }
 
 #[tokio::test]
-async fn bedrock_prompt_rules_and_legacy_coexist() {
+async fn bedrock_fault_injection_throttling() {
     let server = TestServer::start().await;
-    let runtime_client = server.bedrock_runtime_client().await;
-    let http_client = reqwest::Client::new();
+    let runtime = bedrock_runtime_no_retry(&server).await;
+    let http = reqwest::Client::new();
     let model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0";
 
-    let rule_body = serde_json::json!({
-        "id": "msg_rule",
-        "type": "message",
-        "role": "assistant",
-        "content": [{"type": "text", "text": "rule matched"}],
-        "model": model_id,
-        "stop_reason": "end_turn",
-        "usage": {"input_tokens": 5, "output_tokens": 5}
-    });
-    let legacy_body = serde_json::json!({
-        "id": "msg_legacy",
-        "type": "message",
-        "role": "assistant",
-        "content": [{"type": "text", "text": "legacy default"}],
-        "model": model_id,
-        "stop_reason": "end_turn",
-        "usage": {"input_tokens": 5, "output_tokens": 5}
-    });
+    queue_fault(
+        server.endpoint(),
+        &http,
+        serde_json::json!({
+            "errorType": "ThrottlingException",
+            "message": "Rate exceeded",
+            "httpStatus": 429,
+            "count": 1
+        }),
+    )
+    .await;
 
-    http_client
-        .post(format!(
-            "{}/_fakecloud/bedrock/models/{}/responses",
-            server.endpoint(),
-            model_id
-        ))
-        .json(&serde_json::json!({
-            "rules": [{ "promptContains": "trigger", "response": rule_body }]
-        }))
-        .send()
-        .await
-        .unwrap();
+    let err = invoke_simple(&runtime, model_id).await.unwrap_err();
+    let service_err = err.into_service_error();
+    assert!(
+        service_err
+            .meta()
+            .code()
+            .unwrap_or("")
+            .contains("ThrottlingException"),
+        "expected ThrottlingException, got: {service_err:?}"
+    );
 
-    http_client
-        .post(format!(
-            "{}/_fakecloud/bedrock/models/{}/response",
-            server.endpoint(),
-            model_id
-        ))
-        .body(serde_json::to_string(&legacy_body).unwrap())
-        .send()
-        .await
-        .unwrap();
-
-    let call = |text: &'static str| {
-        let client = runtime_client.clone();
-        async move {
-            let body = serde_json::to_vec(&serde_json::json!({
-                "anthropic_version": "bedrock-2023-05-31",
-                "max_tokens": 10,
-                "messages": [{"role": "user", "content": text}]
-            }))
-            .unwrap();
-            let resp = client
-                .invoke_model()
-                .model_id(model_id)
-                .content_type("application/json")
-                .accept("application/json")
-                .body(Blob::new(body))
-                .send()
-                .await
-                .unwrap();
-            let parsed: serde_json::Value = serde_json::from_slice(resp.body().as_ref()).unwrap();
-            parsed["content"][0]["text"].as_str().unwrap().to_string()
-        }
-    };
-
-    assert_eq!(call("please trigger me").await, "rule matched");
-    // No rule match — legacy single response applies.
-    assert_eq!(call("nothing").await, "legacy default");
+    // Second call should succeed now that the rule's count is exhausted.
+    invoke_simple(&runtime, model_id).await.unwrap();
 }
 
 #[tokio::test]
-async fn bedrock_prompt_conditional_converse_stream() {
+async fn bedrock_fault_injection_n_calls() {
     let server = TestServer::start().await;
-    let http_client = reqwest::Client::new();
+    let runtime = bedrock_runtime_no_retry(&server).await;
+    let http = reqwest::Client::new();
     let model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0";
 
-    let converse_resp = serde_json::json!({
-        "output": {
-            "message": {
-                "role": "assistant",
-                "content": [{"text": "streamed custom reply"}]
-            }
-        }
-    });
+    queue_fault(
+        server.endpoint(),
+        &http,
+        serde_json::json!({
+            "errorType": "ServiceUnavailableException",
+            "message": "service unavailable",
+            "httpStatus": 503,
+            "count": 3
+        }),
+    )
+    .await;
 
-    http_client
-        .post(format!(
-            "{}/_fakecloud/bedrock/models/{}/responses",
-            server.endpoint(),
-            model_id
-        ))
-        .json(&serde_json::json!({
-            "rules": [{ "promptContains": "hello", "response": converse_resp }]
-        }))
+    for _ in 0..3 {
+        assert!(invoke_simple(&runtime, model_id).await.is_err());
+    }
+    invoke_simple(&runtime, model_id).await.unwrap();
+}
+
+#[tokio::test]
+async fn bedrock_fault_injection_filter_by_model() {
+    let server = TestServer::start().await;
+    let runtime = bedrock_runtime_no_retry(&server).await;
+    let http = reqwest::Client::new();
+    let model_a = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+    let model_b = "amazon.titan-text-express-v1";
+
+    queue_fault(
+        server.endpoint(),
+        &http,
+        serde_json::json!({
+            "errorType": "ValidationException",
+            "message": "bad model",
+            "httpStatus": 400,
+            "count": 5,
+            "modelId": model_a
+        }),
+    )
+    .await;
+
+    // model B is untouched
+    invoke_simple(&runtime, model_b).await.unwrap();
+    // model A faults
+    assert!(invoke_simple(&runtime, model_a).await.is_err());
+}
+
+#[tokio::test]
+async fn bedrock_fault_injection_filter_by_operation() {
+    let server = TestServer::start().await;
+    let runtime = bedrock_runtime_no_retry(&server).await;
+    let http = reqwest::Client::new();
+    let model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+    queue_fault(
+        server.endpoint(),
+        &http,
+        serde_json::json!({
+            "errorType": "ThrottlingException",
+            "message": "throttled",
+            "httpStatus": 429,
+            "count": 10,
+            "operation": "Converse"
+        }),
+    )
+    .await;
+
+    // InvokeModel still works
+    invoke_simple(&runtime, model_id).await.unwrap();
+    // Converse faults
+    let converse_err = runtime
+        .converse()
+        .model_id(model_id)
+        .messages(
+            aws_sdk_bedrockruntime::types::Message::builder()
+                .role(aws_sdk_bedrockruntime::types::ConversationRole::User)
+                .content(aws_sdk_bedrockruntime::types::ContentBlock::Text(
+                    "hi".to_string(),
+                ))
+                .build()
+                .unwrap(),
+        )
         .send()
-        .await
-        .unwrap();
+        .await;
+    assert!(converse_err.is_err(), "converse should have faulted");
+}
+
+#[tokio::test]
+async fn bedrock_fault_injection_history_records_errors() {
+    let server = TestServer::start().await;
+    let runtime = bedrock_runtime_no_retry(&server).await;
+    let http = reqwest::Client::new();
+    let model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+    queue_fault(
+        server.endpoint(),
+        &http,
+        serde_json::json!({
+            "errorType": "ModelTimeoutException",
+            "message": "timeout",
+            "httpStatus": 408,
+            "count": 1
+        }),
+    )
+    .await;
+
+    assert!(invoke_simple(&runtime, model_id).await.is_err());
+
+    let resp: serde_json::Value = reqwest::get(format!(
+        "{}/_fakecloud/bedrock/invocations",
+        server.endpoint()
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+    let invocations = resp["invocations"].as_array().unwrap();
+    assert_eq!(invocations.len(), 1);
+    assert_eq!(invocations[0]["modelId"], model_id);
+    let error = invocations[0]["error"]
+        .as_str()
+        .expect("error field should be populated for faulted call");
+    assert!(error.contains("ModelTimeoutException"));
+    assert!(error.contains("timeout"));
+}
+
+#[tokio::test]
+async fn bedrock_fault_injection_converse_stream() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+    queue_fault(
+        server.endpoint(),
+        &http,
+        serde_json::json!({
+            "errorType": "ModelStreamErrorException",
+            "message": "stream failed",
+            "httpStatus": 500,
+            "count": 1,
+            "operation": "ConverseStream"
+        }),
+    )
+    .await;
 
     let body = serde_json::json!({
         "modelId": model_id,
-        "messages": [
-            {"role": "user", "content": [{"text": "hello there"}]}
-        ]
+        "messages": [{"role": "user", "content": [{"text": "hi"}]}]
     });
-    let resp = http_client
+    let resp = http
         .post(format!(
             "{}/model/{}/converse-stream",
             server.endpoint(),
@@ -912,12 +959,11 @@ async fn bedrock_prompt_conditional_converse_stream() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), 200);
-    let bytes = resp.bytes().await.unwrap();
-    let as_str = String::from_utf8_lossy(&bytes);
+    assert_eq!(resp.status(), 500);
+    let text = resp.text().await.unwrap();
     assert!(
-        as_str.contains("streamed custom reply"),
-        "expected custom text in stream, got: {as_str:?}"
+        text.contains("ModelStreamErrorException"),
+        "expected error in body, got: {text}"
     );
 }
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1484,6 +1484,7 @@ async fn main() {
                                 "input": inv.input,
                                 "output": inv.output,
                                 "timestamp": inv.timestamp.to_rfc3339(),
+                                "error": inv.error,
                             })
                         })
                         .collect();
@@ -1506,70 +1507,101 @@ async fn main() {
                 }
             }),
         )
-        // Bedrock simulation: configure prompt-conditional response rules
+        // Bedrock fault injection: queue / list / clear fault rules
         .route(
-            "/_fakecloud/bedrock/models/{model_id}/responses",
+            "/_fakecloud/bedrock/faults",
             axum::routing::post({
                 let bs = bedrock_state.clone();
-                move |axum::extract::Path(model_id): axum::extract::Path<String>,
-                      axum::Json(body): axum::Json<serde_json::Value>| async move {
-                    let rules_json = body.get("rules").and_then(|r| r.as_array()).cloned();
-                    let Some(rules_json) = rules_json else {
+                move |axum::Json(body): axum::Json<serde_json::Value>| async move {
+                    let error_type = body
+                        .get("errorType")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let message = body
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let http_status_raw =
+                        body.get("httpStatus").and_then(|v| v.as_u64()).unwrap_or(500);
+                    let Ok(http_status) = u16::try_from(http_status_raw) else {
                         return (
                             axum::http::StatusCode::BAD_REQUEST,
                             axum::Json(serde_json::json!({
-                                "error": "body must contain a `rules` array"
+                                "error": "`httpStatus` must fit in a u16"
                             })),
                         );
                     };
-                    let mut parsed = Vec::with_capacity(rules_json.len());
-                    for rule in rules_json {
-                        let prompt_contains = match rule.get("promptContains") {
-                            None | Some(serde_json::Value::Null) => None,
-                            Some(serde_json::Value::String(s)) => Some(s.clone()),
-                            Some(_) => {
-                                return (
-                                    axum::http::StatusCode::BAD_REQUEST,
-                                    axum::Json(serde_json::json!({
-                                        "error": "`promptContains` must be a string when provided"
-                                    })),
-                                );
-                            }
-                        };
-                        let response = match rule.get("response") {
-                            Some(serde_json::Value::String(s)) => s.clone(),
-                            Some(other) => other.to_string(),
-                            None => {
-                                return (
-                                    axum::http::StatusCode::BAD_REQUEST,
-                                    axum::Json(serde_json::json!({
-                                        "error": "each rule must include a `response` field"
-                                    })),
-                                );
-                            }
-                        };
-                        parsed.push(fakecloud_bedrock::state::ResponseRule {
-                            prompt_contains,
-                            response,
-                        });
+                    let count_raw = body.get("count").and_then(|v| v.as_u64()).unwrap_or(1);
+                    let Ok(count) = u32::try_from(count_raw.max(1)) else {
+                        return (
+                            axum::http::StatusCode::BAD_REQUEST,
+                            axum::Json(serde_json::json!({
+                                "error": "`count` must fit in a u32"
+                            })),
+                        );
+                    };
+                    let model_id = body
+                        .get("modelId")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let operation = body
+                        .get("operation")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    if error_type.is_empty() {
+                        return (
+                            axum::http::StatusCode::BAD_REQUEST,
+                            axum::Json(serde_json::json!({
+                                "error": "`errorType` is required"
+                            })),
+                        );
                     }
                     let mut state = bs.write();
-                    state.response_rules.insert(model_id.clone(), parsed);
+                    state
+                        .fault_rules
+                        .push(fakecloud_bedrock::state::FaultRule {
+                            error_type,
+                            message,
+                            http_status,
+                            remaining: count,
+                            model_id,
+                            operation,
+                        });
                     (
                         axum::http::StatusCode::OK,
-                        axum::Json(serde_json::json!({
-                            "status": "ok",
-                            "modelId": model_id
-                        })),
+                        axum::Json(serde_json::json!({ "status": "ok" })),
                     )
+                }
+            })
+            .get({
+                let bs = bedrock_state.clone();
+                move || async move {
+                    let state = bs.read();
+                    let faults: Vec<serde_json::Value> = state
+                        .fault_rules
+                        .iter()
+                        .map(|f| {
+                            serde_json::json!({
+                                "errorType": f.error_type,
+                                "message": f.message,
+                                "httpStatus": f.http_status,
+                                "remaining": f.remaining,
+                                "modelId": f.model_id,
+                                "operation": f.operation,
+                            })
+                        })
+                        .collect();
+                    axum::Json(serde_json::json!({ "faults": faults }))
                 }
             })
             .delete({
                 let bs = bedrock_state.clone();
-                move |axum::extract::Path(model_id): axum::extract::Path<String>| async move {
+                move || async move {
                     let mut state = bs.write();
-                    state.response_rules.remove(&model_id);
-                    axum::Json(serde_json::json!({ "status": "ok", "modelId": model_id }))
+                    state.fault_rules.clear();
+                    axum::Json(serde_json::json!({ "status": "ok" }))
                 }
             }),
         )


### PR DESCRIPTION
## Summary
- Adds queueable fault rules so tests can force Bedrock runtime calls to return \`ThrottlingException\`, \`ModelTimeoutException\`, \`ServiceUnavailableException\`, \`ValidationException\`, \`ModelStreamErrorException\`, etc. Rules carry a \`count\` (next N calls), optional \`modelId\` filter, and optional \`operation\` filter (InvokeModel / Converse / InvokeModelWithResponseStream / ConverseStream).
- Faulted calls are still recorded in invocation history. \`ModelInvocation\` gains an optional \`error\` field, surfaced in \`GET /_fakecloud/bedrock/invocations\` as \`\"error\": \"<Type>: <message>\"\` (null on success).
- New endpoints: \`POST /_fakecloud/bedrock/faults\` (queue), \`GET\` (list), \`DELETE\` (clear all).
- Note: \`ModelStreamErrorException\` on the streaming paths surfaces as a top-level HTTP error rather than a mid-stream event. Fakecloud streams a single chunk so this is a reasonable approximation — callers testing retry/fallback logic see the error either way.

## Test plan
- [x] \`cargo test -p fakecloud-e2e --test bedrock\` — 41 passing, including 6 new fault-injection tests (single-call throttling, next-N-calls, filter-by-model, filter-by-operation, history records faulted calls with error field, ConverseStream fault)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds queueable fault injection to the Bedrock runtime so tests can force AWS-style errors and validate retry/fallback behavior. Rules are managed via `/_fakecloud/bedrock/faults`, and faulted calls are recorded with an `error` field in invocation history.

- **New Features**
  - Rules: `errorType`, `message`, `httpStatus`, `count` (min 1), optional `modelId` and `operation`; consumed in order.
  - Applied to `InvokeModel`, `Converse`, `InvokeModelWithResponseStream`, and `ConverseStream`; streaming faults return a top‑level HTTP error.
  - Endpoints: `POST /_fakecloud/bedrock/faults` (queue), `GET` (list), `DELETE` (clear); validates required `errorType`, and range‑checks `httpStatus` (u16) and `count` (u32) — invalid values return 400.
  - `GET /_fakecloud/bedrock/invocations` now includes `"error"` (string) or `null` for each call.

<sup>Written for commit f053fde6ce0938c9cf8f8b7b823182f133d71b8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

