### PR TITLE
fix(dynamodb): paren-aware comma split in parse_update_clauses

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -1548,7 +1548,13 @@ fn parse_update_clauses(expr: &str) -> Vec<(UpdateAction, Vec<String>)> {
             expr.len()
         };
         let content = expr[start..end].trim();
-        let assignments: Vec<String> = content.split(',').map(|s| s.trim().to_string()).collect();
+        // Use a paren-aware split so that function-call arguments such as
+        // `list_append(#a, :b)` are kept as a single assignment rather than
+        // being torn apart at the inner comma.
+        let assignments: Vec<String> = split_on_top_level_keyword(content, ",")
+            .into_iter()
+            .map(|s| s.trim().to_string())
+            .collect();
         clauses.push((action, assignments));
     }
 
@@ -2574,6 +2580,36 @@ mod tests {
         assert_eq!(clauses.len(), 2);
         assert_eq!(clauses[0].0, UpdateAction::Set);
         assert_eq!(clauses[1].0, UpdateAction::Remove);
+    }
+
+    #[test]
+    fn test_parse_update_clauses_list_append_single_assignment() {
+        // Before fix: naive comma split tore list_append(#0, :0) at the
+        // inner comma, producing two bogus assignments instead of one.
+        let clauses = parse_update_clauses("SET #0 = list_append(#0, :0)");
+        assert_eq!(clauses.len(), 1);
+        assert_eq!(clauses[0].0, UpdateAction::Set);
+        assert_eq!(
+            clauses[0].1.len(),
+            1,
+            "list_append(a, b) must be kept as a single assignment, not split at the inner comma"
+        );
+    }
+
+    #[test]
+    fn test_parse_update_clauses_list_append_mixed_with_plain_set() {
+        // list_append assignment followed by a plain SET — the comma between
+        // the two assignments must still split them, while the comma inside
+        // the list_append call must not.
+        let clauses =
+            parse_update_clauses("SET #0 = list_append(#0, :new), #1 = :other");
+        assert_eq!(clauses.len(), 1);
+        assert_eq!(clauses[0].0, UpdateAction::Set);
+        assert_eq!(
+            clauses[0].1.len(),
+            2,
+            "two SET assignments: one list_append and one plain"
+        );
     }
 
     #[test]
@@ -4642,6 +4678,111 @@ mod tests {
             .unwrap();
         assert_eq!(tags[0].get("S").and_then(|s| s.as_str()), Some("red"));
         assert_eq!(tags[1].get("S").and_then(|s| s.as_str()), Some("green"));
+    }
+
+    #[test]
+    fn test_list_append_into_empty_list() {
+        // Regression: UpdateItem with `SET #0 = list_append(#0, :0)` where
+        // the attribute already exists as an empty list silently no-oped.
+        // Root cause: parse_update_clauses split `list_append(#0, :0)` at
+        // the inner comma, so apply_set_list_append received a truncated
+        // `rest` with no closing ')' and returned early without writing.
+        let mut item = HashMap::new();
+        item.insert("files".to_string(), json!({"L": []}));
+
+        let names = cond_names(&[("#0", "files")]);
+        let mut values = HashMap::new();
+        values.insert(
+            ":0".to_string(),
+            json!({"L": [{"M": {"field": {"S": "value"}}}]}),
+        );
+
+        apply_update_expression(
+            &mut item,
+            "SET #0 = list_append(#0, :0)",
+            &names,
+            &values,
+        )
+        .unwrap();
+
+        let list = item
+            .get("files")
+            .and_then(|v| v.get("L"))
+            .and_then(|v| v.as_array())
+            .expect("files should be an L-typed attribute");
+        assert_eq!(list.len(), 1, "one element should have been appended");
+    }
+
+    #[test]
+    fn test_list_append_into_nonempty_list() {
+        // Verifies the same fix works when the existing list already has elements.
+        let mut item = HashMap::new();
+        item.insert(
+            "files".to_string(),
+            json!({"L": [{"M": {"field": {"S": "existing"}}}]}),
+        );
+
+        let names = cond_names(&[("#0", "files")]);
+        let mut values = HashMap::new();
+        values.insert(
+            ":0".to_string(),
+            json!({"L": [{"M": {"field": {"S": "new"}}}]}),
+        );
+
+        apply_update_expression(
+            &mut item,
+            "SET #0 = list_append(#0, :0)",
+            &names,
+            &values,
+        )
+        .unwrap();
+
+        let list = item
+            .get("files")
+            .and_then(|v| v.get("L"))
+            .and_then(|v| v.as_array())
+            .expect("files should be an L-typed attribute");
+        assert_eq!(list.len(), 2, "existing element plus one new element");
+    }
+
+    #[test]
+    fn test_list_append_combined_with_plain_set() {
+        // Verifies that a mixed expression like
+        // `SET #a = list_append(#a, :v), #b = :other` correctly applies
+        // both assignments after the paren-aware comma split fix.
+        let mut item = HashMap::new();
+        item.insert("logs".to_string(), json!({"L": []}));
+        item.insert("count".to_string(), json!({"N": "0"}));
+
+        let names = cond_names(&[("#a", "logs"), ("#b", "count")]);
+        let mut values = HashMap::new();
+        values.insert(
+            ":v".to_string(),
+            json!({"L": [{"S": "entry"}]}),
+        );
+        values.insert(":other".to_string(), json!({"N": "1"}));
+
+        apply_update_expression(
+            &mut item,
+            "SET #a = list_append(#a, :v), #b = :other",
+            &names,
+            &values,
+        )
+        .unwrap();
+
+        let list = item
+            .get("logs")
+            .and_then(|v| v.get("L"))
+            .and_then(|v| v.as_array())
+            .expect("logs should be an L-typed attribute");
+        assert_eq!(list.len(), 1, "one log entry appended");
+
+        let count = item
+            .get("count")
+            .and_then(|v| v.get("N"))
+            .and_then(|v| v.as_str())
+            .expect("count should be an N-typed attribute");
+        assert_eq!(count, "1", "count updated to 1");
     }
 
     #[test]

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -2601,8 +2601,7 @@ mod tests {
         // list_append assignment followed by a plain SET — the comma between
         // the two assignments must still split them, while the comma inside
         // the list_append call must not.
-        let clauses =
-            parse_update_clauses("SET #0 = list_append(#0, :new), #1 = :other");
+        let clauses = parse_update_clauses("SET #0 = list_append(#0, :new), #1 = :other");
         assert_eq!(clauses.len(), 1);
         assert_eq!(clauses[0].0, UpdateAction::Set);
         assert_eq!(
@@ -4697,13 +4696,8 @@ mod tests {
             json!({"L": [{"M": {"field": {"S": "value"}}}]}),
         );
 
-        apply_update_expression(
-            &mut item,
-            "SET #0 = list_append(#0, :0)",
-            &names,
-            &values,
-        )
-        .unwrap();
+        apply_update_expression(&mut item, "SET #0 = list_append(#0, :0)", &names, &values)
+            .unwrap();
 
         let list = item
             .get("files")
@@ -4729,13 +4723,8 @@ mod tests {
             json!({"L": [{"M": {"field": {"S": "new"}}}]}),
         );
 
-        apply_update_expression(
-            &mut item,
-            "SET #0 = list_append(#0, :0)",
-            &names,
-            &values,
-        )
-        .unwrap();
+        apply_update_expression(&mut item, "SET #0 = list_append(#0, :0)", &names, &values)
+            .unwrap();
 
         let list = item
             .get("files")
@@ -4756,10 +4745,7 @@ mod tests {
 
         let names = cond_names(&[("#a", "logs"), ("#b", "count")]);
         let mut values = HashMap::new();
-        values.insert(
-            ":v".to_string(),
-            json!({"L": [{"S": "entry"}]}),
-        );
+        values.insert(":v".to_string(), json!({"L": [{"S": "entry"}]}));
         values.insert(":other".to_string(), json!({"N": "1"}));
 
         apply_update_expression(


### PR DESCRIPTION
> Heads up — this PR was written by an AI agent (Claude Code) under my direction. I don't write Rust day-to-day, so I can't speak to the idiom-level quality of the diff off the top of my head. The test coverage and reasoning should stand on their own; happy to revise anything that doesn't fit the project's style.

## Summary

`UpdateItem` with a `list_append` expression silently no-oped:

```
SET #0 = list_append(#0, :0)
```

The item's target attribute was left unchanged even though the call returned no error, and the attribute already existed as an empty list (so `if_not_exists` was not the issue). Confirmed broken in v0.7.1 and v0.9.0 against real DynamoDB.

### Root cause

`parse_update_clauses` split each action clause's content on every comma naively:

```rust
let assignments = content.split(',').map(...).collect();
```

The expression `#0 = list_append(#0, :0)` was torn apart at the comma *inside* the function call, producing two bogus tokens:

1. `#0 = list_append(#0` — sent to `apply_set_list_append` as `rest = "#0"` (no closing `)`)
2. `:0)` — treated as a separate malformed assignment, silently ignored

In `apply_set_list_append`, `rest.strip_suffix(')')` found no `)` and returned early — no write, no error.

### Fix

Replace the naive `split(',')` with the existing `split_on_top_level_keyword(content, ",")` helper, which is already paren-depth-aware and is used by `split_on_and` / `split_on_or` for exactly the same reason. Commas inside balanced parentheses are now left intact.

## Test plan

Five new unit tests (all failing before the fix):

- [x] `test_parse_update_clauses_list_append_single_assignment` — parse level: `list_append(a, b)` stays as 1 assignment, not 2
- [x] `test_parse_update_clauses_list_append_mixed_with_plain_set` — parse level: outer comma still splits two SET assignments correctly
- [x] `test_list_append_into_empty_list` — exact repro from the bug report (empty existing list)
- [x] `test_list_append_into_nonempty_list` — append to a non-empty existing list
- [x] `test_list_append_combined_with_plain_set` — `list_append` and plain SET in the same expression both apply
- [x] `cargo test -p fakecloud-dynamodb` — 98 pass (was 93, +5 new)
- [x] `cargo clippy -p fakecloud-dynamodb -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Not run: real-AWS behavioral parity. I don't have credentials configured for this. The fix matches AWS's [documented UpdateExpression SET syntax](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.UpdatingListElements) for `list_append`, and the bug was purely in the comma tokeniser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parenthesis-aware splitting of SET clauses in `fakecloud-dynamodb` UpdateExpression parsing so `list_append(#a, :b)` applies correctly instead of no-oping.

- **Bug Fixes**
  - Replace naive comma split in `parse_update_clauses` with `split_on_top_level_keyword`; add tests for `list_append` parsing and execution, including mixed SETs and empty/non-empty list appends.

- **Refactors**
  - Run `cargo fmt` (style-only).

<sup>Written for commit 89f8716bb6897304f7eee0cedafc6d9732298871. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

