### PR TITLE
feat(tfacc): run upstream terraform-provider-aws acc tests against fakecloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance
+      - run: cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance --exclude fakecloud-tfacc
       - run: cargo test -p fakecloud-conformance --lib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check
       - run: cargo clippy --workspace -- -D warnings
-      - run: cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance
+      - run: cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance --exclude fakecloud-tfacc
 
   build:
     name: Build ${{ matrix.name }}

--- a/.github/workflows/tfacc.yml
+++ b/.github/workflows/tfacc.yml
@@ -1,0 +1,66 @@
+name: Terraform Acceptance
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  tfacc-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.m.outputs.services }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Emit service matrix
+        run: cargo run -q -p fakecloud-tfacc --bin tfacc_services > services.json
+
+      - id: m
+        run: echo "services=$(cat services.json)" >> "$GITHUB_OUTPUT"
+
+  tfacc:
+    name: tfacc ${{ matrix.service }}
+    needs: tfacc-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.tfacc-matrix.outputs.services) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.x"
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.14.5"
+          terraform_wrapper: false
+
+      # Cache the upstream provider source and Go caches together — the
+      # checkout dominates first-run time (~300MB shallow clone) and the Go
+      # module + build caches dominate go-test compile time.
+      - name: Cache Go + provider source
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            target/tfacc
+          key: tfacc-${{ runner.os }}-${{ hashFiles('crates/fakecloud-tfacc/src/lib.rs') }}
+          restore-keys: |
+            tfacc-${{ runner.os }}-
+
+      - name: Build fakecloud
+        run: cargo build --bin fakecloud
+
+      - name: Run ${{ matrix.service }} acceptance tests
+        run: cargo test -p fakecloud-tfacc --test acc ${{ matrix.service }}_acceptance -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,6 +2534,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fakecloud-tfacc"
+version = "0.9.0"
+dependencies = [
+ "reqwest",
+ "tokio",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/fakecloud-e2e",
     "crates/fakecloud-conformance",
     "crates/fakecloud-conformance-macros",
+    "crates/fakecloud-tfacc",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 - **Free, forever.** AGPL-3.0, no paid tier, no account, no token.
 - **100% conformance** per implemented service. Every operation validated against AWS's own Smithy models — 54,000+ generated test variants on every commit.
+- **Tested against upstream Terraform acceptance tests.** CI runs `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud. Catches waiter/field-presence/drift bugs that pure SDK tests miss.
 - **Real cross-service wiring.** EventBridge → Step Functions, S3 → Lambda, SES inbound → S3/SNS/Lambda, and 15+ more integrations actually execute end-to-end.
 - **Real infrastructure for stateful services.** Lambda runs in Docker containers (13 runtimes). RDS runs real Postgres/MySQL/MariaDB. ElastiCache runs real Redis/Valkey.
 - **Single binary.** ~19 MB, ~10 MiB idle memory, ~500ms startup. No Docker required to run fakecloud itself (only to exercise the services that need real containers).

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -2136,7 +2136,10 @@ fn build_table_description(table: &DynamoTable) -> Value {
         }
     }
 
-    // Add SSE description
+    // SSEDescription is only returned when the customer explicitly enabled
+    // a KMS-backed SSE. Real AWS tables using the default AWS-owned key omit
+    // this field entirely, and the Terraform provider's Read asserts
+    // `server_side_encryption.#` == 0 in that case.
     if let Some(ref sse_type) = table.sse_type {
         let mut sse_desc = json!({
             "Status": "ENABLED",
@@ -2146,12 +2149,6 @@ fn build_table_description(table: &DynamoTable) -> Value {
             sse_desc["KMSMasterKeyArn"] = json!(key_arn);
         }
         desc["SSEDescription"] = sse_desc;
-    } else {
-        // Default: AWS owned key encryption (always enabled in real AWS)
-        desc["SSEDescription"] = json!({
-            "Status": "ENABLED",
-            "SSEType": "AES256",
-        });
     }
 
     desc

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -2442,11 +2442,13 @@ async fn dynamodb_sse_specification_kms() {
 }
 
 #[tokio::test]
-async fn dynamodb_sse_default_aes256() {
+async fn dynamodb_sse_default_omitted() {
     let server = TestServer::start().await;
     let client = server.dynamodb_client().await;
 
-    // Create table without SSE spec — should default to AES256
+    // A table without an explicit SSE spec uses the default AWS-owned key.
+    // Real AWS DescribeTable omits SSEDescription entirely in that case, and
+    // the Terraform provider enforces this (server_side_encryption.# == 0).
     client
         .create_table()
         .table_name("DefaultSseTable")
@@ -2476,9 +2478,7 @@ async fn dynamodb_sse_default_aes256() {
         .await
         .unwrap();
     let table = desc.table().unwrap();
-    let sse = table.sse_description().unwrap();
-    assert_eq!(sse.status().unwrap().as_str(), "ENABLED");
-    assert_eq!(sse.sse_type().unwrap().as_str(), "AES256");
+    assert!(table.sse_description().is_none());
 }
 
 #[tokio::test]

--- a/crates/fakecloud-tfacc/Cargo.toml
+++ b/crates/fakecloud-tfacc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fakecloud-tfacc"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+tokio = { workspace = true }
+reqwest = { workspace = true }
+
+[[bin]]
+name = "tfacc_services"
+path = "src/bin/tfacc_services.rs"

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -1,0 +1,96 @@
+//! Two-layer opt-in for upstream `terraform-provider-aws` acceptance tests.
+//!
+//! Layer 1: `SERVICES` is an allow-list. A service is only exercised at all
+//! if it appears here. This matches fakecloud's parity-per-implemented-service
+//! invariant — we don't want CI noise from services we don't claim to
+//! support.
+//!
+//! Layer 2: each `Service` carries a `deny` array of specific upstream test
+//! names to skip, with reasons grouped in inline comments. These are passed
+//! to `go test -skip '^(name1|name2|...)$'` (Go ≥ 1.20).
+//!
+//! Deny-list semantics:
+//!
+//! * **unsupportable**: the test needs a fakecloud feature that we don't
+//!   plan to implement (cross-region replicas, real backup encryption,
+//!   import from S3). Stays denied permanently.
+//! * **gap**: the test fails because of a real fakecloud bug. Denied
+//!   temporarily — driving these to zero is the point of later batches.
+//! * **hung**: the test never completed in our initial triage run. Denied
+//!   until we can characterise it; may move to gap or unsupportable later.
+//!
+//! Every entry must have a reason comment. Adding an entry without one is
+//! a review-blocking mistake.
+
+pub struct Service {
+    /// Directory name under `internal/service/` — e.g. `sqs`, `dynamodb`.
+    pub name: &'static str,
+    /// Go `-run` regex. Narrow this to carve out a subset of a service's
+    /// upstream tests while the rest of that service's deny-list is being
+    /// populated. Widening (or removing the override) is the mechanism for
+    /// growing coverage in later batches.
+    pub run_regex: &'static str,
+    /// Upstream test function names to skip, one per line, grouped by
+    /// reason in inline comments.
+    pub deny: &'static [&'static str],
+}
+
+pub const SERVICES: &[Service] = &[Service {
+    name: "dynamodb",
+    // Batch 1: only the `aws_dynamodb_table` resource tests. The
+    // upstream dynamodb service directory also has ~90 tests covering
+    // table_item, replica, export, kinesis_streaming_destination, and
+    // global_table which surface deeper fakecloud gaps and will be
+    // added in follow-up batches.
+    run_regex: "^TestAccDynamoDBTable_",
+    deny: &[
+        // --- unsupportable: DynamoDB Global Tables / cross-region replicas ---
+        "TestAccDynamoDBTable_Replica_single",
+        "TestAccDynamoDBTable_Replica_singleCMK",
+        "TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted",
+        "TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned",
+        "TestAccDynamoDBTable_Replica_singleStreamSpecification",
+        "TestAccDynamoDBTable_Replica_multiple",
+        "TestAccDynamoDBTable_Replica_doubleAddCMK",
+        "TestAccDynamoDBTable_Replica_pitr",
+        "TestAccDynamoDBTable_Replica_pitrKMS",
+        "TestAccDynamoDBTable_Replica_tagsUpdate",
+        "TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica",
+        "TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica",
+        "TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged",
+        "TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo",
+        "TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo",
+        "TestAccDynamoDBTable_restoreCrossRegion",
+        // --- unsupportable: INFREQUENT_ACCESS table class ---
+        "TestAccDynamoDBTable_tableClassInfrequentAccess",
+        "TestAccDynamoDBTable_tableClass_migrate",
+        "TestAccDynamoDBTable_tableClass_ConcurrentModification",
+        // --- unsupportable: backup encryption (S3 import/export path) ---
+        "TestAccDynamoDBTable_backupEncryption",
+        "TestAccDynamoDBTable_backup_overrideEncryption",
+        "TestAccDynamoDBTable_importTable",
+        // --- gap: DynamoDB Streams shape parity not yet complete ---
+        "TestAccDynamoDBTable_streamSpecification",
+        "TestAccDynamoDBTable_streamSpecificationDiffs",
+        // --- gap: on-demand throughput attribute ---
+        "TestAccDynamoDBTable_onDemandThroughput",
+        "TestAccDynamoDBTable_gsiOnDemandThroughput",
+        // --- gap: billing-mode transitions with GSI ---
+        "TestAccDynamoDBTable_BillingMode_payPerRequestBasic",
+        "TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned",
+        "TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest",
+        "TestAccDynamoDBTable_Disappears_payPerRequestWithGSI",
+        // --- gap: GSI capacity update ---
+        "TestAccDynamoDBTable_gsiUpdateCapacity",
+        // --- gap: deletion_protection attribute not yet implemented ---
+        "TestAccDynamoDBTable_deletion_protection",
+        // --- gap: encryption attribute round-trip ---
+        "TestAccDynamoDBTable_encryption",
+        // --- hung: did not complete in triage run; revisit in a later batch ---
+        "TestAccDynamoDBTable_attributeUpdate",
+        "TestAccDynamoDBTable_extended",
+        "TestAccDynamoDBTable_gsiUpdateNonKeyAttributes",
+        "TestAccDynamoDBTable_gsiUpdateOtherAttributes",
+        "TestAccDynamoDBTable_TTL_updateDisable",
+    ],
+}];

--- a/crates/fakecloud-tfacc/src/bin/tfacc_services.rs
+++ b/crates/fakecloud-tfacc/src/bin/tfacc_services.rs
@@ -1,0 +1,30 @@
+//! Emits the `SERVICES` allow-list as a JSON array of strings for CI matrix
+//! fan-out. Matches the shape consumed by the `tfacc` workflow — one
+//! GitHub Actions runner per service.
+//!
+//! Kept as a tiny binary (not a cargo feature) so CI can invoke it without
+//! building the rest of the workspace first.
+
+use fakecloud_tfacc::SERVICES;
+
+fn main() {
+    let names: Vec<&str> = SERVICES.iter().map(|s| s.name).collect();
+    let json = serde_json_mini(&names);
+    println!("{json}");
+}
+
+/// Tiny hand-rolled JSON encoder — avoids pulling serde_json into this
+/// binary's dep graph just to emit `["a","b"]`.
+fn serde_json_mini(items: &[&str]) -> String {
+    let mut out = String::from("[");
+    for (i, name) in items.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('"');
+        out.push_str(name);
+        out.push('"');
+    }
+    out.push(']');
+    out
+}

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -1,0 +1,315 @@
+//! Upstream Terraform Provider acceptance-test harness.
+//!
+//! Each `#[tokio::test]` in `tests/acc.rs` spawns a fakecloud process, sets
+//! `TF_ACC=1` plus `AWS_ENDPOINT_URL_<SERVICE>=…` env vars, and invokes a
+//! single `TestAcc*` function from `hashicorp/terraform-provider-aws` via
+//! `go test`. The upstream test does its own Terraform apply/plan/destroy
+//! cycle and asserts on the returned resource state — giving us semantic
+//! coverage (waiters, field presence, drift) that SDK-based tests miss.
+//!
+//! Prior art: `bblommers/localstack-terraform-test`. We invert the model to
+//! an *allow*-list rather than a deny-list to match fakecloud's
+//! parity-per-implemented-service invariant.
+
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::Duration;
+
+pub mod allowlist;
+
+pub use allowlist::{Service, SERVICES};
+
+/// Pinned upstream provider tag. Bumping is a deliberate edit; newer tags
+/// may add acc tests that assume fields fakecloud does not yet return.
+pub const PROVIDER_TAG: &str = "v5.97.0";
+pub const PROVIDER_REPO: &str = "https://github.com/hashicorp/terraform-provider-aws.git";
+
+/// Returns true if both `go` and `terraform` are on PATH. If either is
+/// missing, acc tests skip (they don't fail) — matching the
+/// `FAKECLOUD_CONTAINER_CLI=false` skip pattern in fakecloud-e2e.
+pub fn toolchain_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+        && Command::new("terraform")
+            .arg("version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+}
+
+/// Idempotently clone + patch the upstream provider into `target/tfacc/`.
+///
+/// Returns the absolute path to the provider source tree, ready for
+/// `go test ./internal/service/<svc>/`.
+///
+/// On Go ≥ 1.24 the upstream `go.mod` needs its `godebug tlskyber=0`
+/// directive stripped (the pragma was removed in 1.24). We apply the strip
+/// unconditionally — it's harmless on 1.23.
+pub fn setup_provider_source() -> std::io::Result<PathBuf> {
+    let target = provider_dir();
+    if !target.exists() {
+        std::fs::create_dir_all(target.parent().unwrap())?;
+        let status = Command::new("git")
+            .args([
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                PROVIDER_TAG,
+                PROVIDER_REPO,
+                &target.display().to_string(),
+            ])
+            .status()?;
+        if !status.success() {
+            return Err(std::io::Error::other(format!(
+                "failed to clone {PROVIDER_REPO}@{PROVIDER_TAG}"
+            )));
+        }
+    }
+    strip_godebug(&target.join("go.mod"))?;
+    Ok(target)
+}
+
+fn provider_dir() -> PathBuf {
+    // target/tfacc/terraform-provider-aws — sibling to target/debug
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .join("..")
+        .join("..")
+        .join("target")
+        .join("tfacc")
+        .join(format!("terraform-provider-aws-{PROVIDER_TAG}"))
+}
+
+fn strip_godebug(go_mod: &Path) -> std::io::Result<()> {
+    let contents = std::fs::read_to_string(go_mod)?;
+    let stripped: String = contents
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("godebug tlskyber"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if stripped != contents {
+        std::fs::write(go_mod, format!("{stripped}\n"))?;
+    }
+    Ok(())
+}
+
+/// Minimal fakecloud test server — lifecycle only, no SDK clients.
+pub struct TestServer {
+    child: Option<Child>,
+    port: u16,
+}
+
+impl TestServer {
+    pub async fn start() -> Self {
+        let bin = find_binary();
+        for _ in 0..3 {
+            let port = find_available_port();
+            let mut child = Command::new(&bin)
+                .arg("--addr")
+                .arg(format!("0.0.0.0:{port}"))
+                .arg("--log-level")
+                .arg("warn")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("failed to start fakecloud");
+            if wait_for_ready(&mut child, port).await {
+                return Self {
+                    child: Some(child),
+                    port,
+                };
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        panic!("fakecloud failed to start after 3 attempts");
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn endpoint(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Runs every `TestAcc*` test for a service — minus deny-listed names —
+/// against a running fakecloud instance.
+///
+/// We intentionally run the whole service at once rather than one Go test
+/// per Rust test: provider process startup dominates per-test time, and
+/// `go test -skip` lets us exclude unsupportable tests cheaply.
+pub struct GoTestRunner<'a> {
+    pub provider_root: &'a Path,
+    pub endpoint: String,
+}
+
+impl<'a> GoTestRunner<'a> {
+    pub fn run_service(&self, service: &Service) -> GoTestResult {
+        let service_path = format!("./internal/service/{}/", service.name);
+        let run_re = service.run_regex;
+        let skip_re = if service.deny.is_empty() {
+            String::new()
+        } else {
+            format!("^({})$", service.deny.join("|"))
+        };
+
+        // `-parallel 8` lets Go's test runner execute up to 8 `t.Parallel()`
+        // subtests concurrently within a single `go test` invocation. Most
+        // upstream TestAcc* functions opt into parallelism, so this is the
+        // main lever for wall-time inside a single service. CI fan-out
+        // across services is handled by the GitHub Actions matrix.
+        let mut cmd = Command::new("go");
+        let mut args: Vec<String> = vec![
+            "test".into(),
+            service_path,
+            "-run".into(),
+            run_re.into(),
+            "-v".into(),
+            "-timeout".into(),
+            "60m".into(),
+            "-count=1".into(),
+            "-parallel".into(),
+            "8".into(),
+        ];
+        if !skip_re.is_empty() {
+            args.push("-skip".into());
+            args.push(skip_re);
+        }
+        cmd.args(&args)
+            .current_dir(self.provider_root)
+            .env("TF_ACC", "1")
+            .env("AWS_ACCESS_KEY_ID", "test")
+            .env("AWS_SECRET_ACCESS_KEY", "test")
+            .env("AWS_DEFAULT_REGION", "us-east-1")
+            .env("AWS_REGION", "us-east-1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        // Route every service we care about to the single fakecloud endpoint.
+        // AWS SDK Go v2 honours AWS_ENDPOINT_URL_<SERVICE>; these override any
+        // default endpoint lookup.
+        for (key, _service_id) in ENDPOINT_ENV_VARS {
+            cmd.env(key, &self.endpoint);
+        }
+
+        let output = cmd.output().expect("run go test");
+        GoTestResult {
+            success: output.status.success(),
+            output,
+        }
+    }
+}
+
+pub struct GoTestResult {
+    pub success: bool,
+    pub output: Output,
+}
+
+impl GoTestResult {
+    /// Panics with the last few lines of `go test` output when the service
+    /// run had any failing upstream test. Keeps passing runs silent.
+    pub fn assert_pass(self, service: &str) {
+        if self.success {
+            return;
+        }
+        let stdout = String::from_utf8_lossy(&self.output.stdout);
+        let stderr = String::from_utf8_lossy(&self.output.stderr);
+        let fails: Vec<&str> = stdout.lines().filter(|l| l.contains("--- FAIL:")).collect();
+        let combined = format!("--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}");
+        let lines: Vec<&str> = combined.lines().collect();
+        let start = lines.len().saturating_sub(200);
+        let tail = lines[start..].join("\n");
+        panic!(
+            "upstream TestAcc failures in service `{service}` ({} failed):\n{}\n\n{tail}",
+            fails.len(),
+            fails.join("\n")
+        );
+    }
+}
+
+/// `(env_var, provider_service_id)` — set every entry to the fakecloud
+/// endpoint so a single acc test can touch multiple services.
+pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
+    ("AWS_ENDPOINT_URL", "default"),
+    ("AWS_ENDPOINT_URL_SQS", "sqs"),
+    ("AWS_ENDPOINT_URL_SNS", "sns"),
+    ("AWS_ENDPOINT_URL_S3", "s3"),
+    ("AWS_ENDPOINT_URL_IAM", "iam"),
+    ("AWS_ENDPOINT_URL_STS", "sts"),
+    ("AWS_ENDPOINT_URL_SSM", "ssm"),
+    ("AWS_ENDPOINT_URL_DYNAMODB", "dynamodb"),
+    ("AWS_ENDPOINT_URL_LAMBDA", "lambda"),
+    ("AWS_ENDPOINT_URL_SECRETSMANAGER", "secretsmanager"),
+    ("AWS_ENDPOINT_URL_EVENTBRIDGE", "eventbridge"),
+    ("AWS_ENDPOINT_URL_KMS", "kms"),
+    ("AWS_ENDPOINT_URL_LOGS", "logs"),
+    ("AWS_ENDPOINT_URL_KINESIS", "kinesis"),
+    ("AWS_ENDPOINT_URL_RDS", "rds"),
+    ("AWS_ENDPOINT_URL_ELASTICACHE", "elasticache"),
+    ("AWS_ENDPOINT_URL_CLOUDFORMATION", "cloudformation"),
+    ("AWS_ENDPOINT_URL_SESV2", "sesv2"),
+    ("AWS_ENDPOINT_URL_SES", "ses"),
+    ("AWS_ENDPOINT_URL_COGNITO_IDP", "cognitoidp"),
+    ("AWS_ENDPOINT_URL_SFN", "sfn"),
+    ("AWS_ENDPOINT_URL_APIGATEWAYV2", "apigatewayv2"),
+    ("AWS_ENDPOINT_URL_BEDROCK", "bedrock"),
+];
+
+fn find_available_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind to random port");
+    listener.local_addr().unwrap().port()
+}
+
+fn find_binary() -> PathBuf {
+    let candidates = [
+        concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/debug/fakecloud"),
+        concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../target/release/fakecloud"
+        ),
+    ];
+    for path in candidates {
+        if Path::new(path).exists() {
+            return PathBuf::from(path);
+        }
+    }
+    panic!("fakecloud binary not found. Run `cargo build --bin fakecloud` first.");
+}
+
+async fn wait_for_ready(child: &mut Child, port: u16) -> bool {
+    let health = format!("http://127.0.0.1:{port}/");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(500))
+        .build()
+        .expect("build reqwest client");
+    for _ in 0..300 {
+        if child.try_wait().ok().flatten().is_some() {
+            return false;
+        }
+        if client.get(&health).send().await.is_ok() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -91,15 +91,17 @@ fn provider_dir() -> PathBuf {
 
 fn strip_godebug(go_mod: &Path) -> std::io::Result<()> {
     let contents = std::fs::read_to_string(go_mod)?;
-    let stripped: String = contents
-        .lines()
-        .filter(|line| !line.trim_start().starts_with("godebug tlskyber"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    if stripped != contents {
-        std::fs::write(go_mod, format!("{stripped}\n"))?;
+    if !contents.contains("godebug tlskyber") {
+        return Ok(());
     }
-    Ok(())
+    // Preserve the original line endings (including whether the file has a
+    // trailing newline) by splitting on `\n` rather than `lines()`, which
+    // silently swallows the final empty element.
+    let stripped: String = contents
+        .split_inclusive('\n')
+        .filter(|line| !line.trim_start().starts_with("godebug tlskyber"))
+        .collect();
+    std::fs::write(go_mod, stripped)
 }
 
 /// Minimal fakecloud test server — lifecycle only, no SDK clients.

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -25,24 +25,33 @@ pub use allowlist::{Service, SERVICES};
 pub const PROVIDER_TAG: &str = "v5.97.0";
 pub const PROVIDER_REPO: &str = "https://github.com/hashicorp/terraform-provider-aws.git";
 
-/// Returns true if both `go` and `terraform` are on PATH. If either is
-/// missing, acc tests skip (they don't fail) — matching the
-/// `FAKECLOUD_CONTAINER_CLI=false` skip pattern in fakecloud-e2e.
-pub fn toolchain_available() -> bool {
-    Command::new("go")
-        .arg("version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-        && Command::new("terraform")
-            .arg("version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+/// Panics with an actionable message if `go` or `terraform` are missing.
+/// Called at the top of every tfacc test so the failure mode is loud:
+/// running this crate is an opt-in signal that the caller wants the
+/// upstream Terraform suite exercised, and silently skipping would just
+/// hide regressions.
+pub fn require_toolchain() {
+    let missing: Vec<&str> = [("go", "go"), ("terraform", "terraform")]
+        .into_iter()
+        .filter(|(_, bin)| {
+            Command::new(bin)
+                .arg("version")
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .map(|s| !s.success())
+                .unwrap_or(true)
+        })
+        .map(|(name, _)| name)
+        .collect();
+    if !missing.is_empty() {
+        panic!(
+            "fakecloud-tfacc requires {} on PATH. Install them (or run a \
+             different test crate) before exercising the upstream Terraform \
+             acceptance suite.",
+            missing.join(" and "),
+        );
+    }
 }
 
 /// Idempotently clone + patch the upstream provider into `target/tfacc/`.

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -1,0 +1,34 @@
+//! One `#[tokio::test]` per allow-listed service. Each runs every
+//! `TestAcc*` test matching the service's `run_regex` minus its deny-list.
+//!
+//! Skips cleanly (doesn't fail) if the `go` or `terraform` binaries are
+//! missing.
+
+use fakecloud_tfacc::{
+    allowlist::{Service, SERVICES},
+    setup_provider_source, toolchain_available, GoTestRunner, TestServer,
+};
+
+async fn run_service(name: &str) {
+    if !toolchain_available() {
+        eprintln!("[tfacc] go or terraform not installed, skipping service `{name}`");
+        return;
+    }
+    let service: &Service = SERVICES
+        .iter()
+        .find(|s| s.name == name)
+        .unwrap_or_else(|| panic!("service `{name}` not in SERVICES allow-list"));
+
+    let provider_root = setup_provider_source().expect("setup terraform-provider-aws");
+    let server = TestServer::start().await;
+    let runner = GoTestRunner {
+        provider_root: &provider_root,
+        endpoint: server.endpoint(),
+    };
+    runner.run_service(service).assert_pass(name);
+}
+
+#[tokio::test]
+async fn dynamodb_acceptance() {
+    run_service("dynamodb").await;
+}

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -1,19 +1,18 @@
 //! One `#[tokio::test]` per allow-listed service. Each runs every
 //! `TestAcc*` test matching the service's `run_regex` minus its deny-list.
 //!
-//! Skips cleanly (doesn't fail) if the `go` or `terraform` binaries are
-//! missing.
+//! Hard-fails if the `go` or `terraform` binaries are missing. Running
+//! this crate is an opt-in signal that the caller wants the upstream
+//! Terraform suite exercised — silently passing on a machine that can't
+//! run it would just hide regressions.
 
 use fakecloud_tfacc::{
     allowlist::{Service, SERVICES},
-    setup_provider_source, toolchain_available, GoTestRunner, TestServer,
+    require_toolchain, setup_provider_source, GoTestRunner, TestServer,
 };
 
 async fn run_service(name: &str) {
-    if !toolchain_available() {
-        eprintln!("[tfacc] go or terraform not installed, skipping service `{name}`");
-        return;
-    }
+    require_toolchain();
     let service: &Service = SERVICES
         .iter()
         .find(|s| s.name == name)


### PR DESCRIPTION
## Summary

- New `fakecloud-tfacc` crate runs `hashicorp/terraform-provider-aws` `TestAcc*` against a live fakecloud. This is the semantic test layer PR #362 highlighted as a gap: pure SDK round-trip tests tolerate missing optional fields, but the Terraform provider enforces waiters, field presence, and drift. Now we catch that class of bug in CI.
- Two-layer opt-in: a service allow-list (only services we claim to support get run) plus a per-service deny-list for upstream tests that are structurally unsupportable or track a known fakecloud gap. Each deny entry has a reason comment grouped by category (\`unsupportable\`, \`gap\`, \`hung\`).
- Batch 1 ships DynamoDB coverage: **38 `TestAccDynamoDBTable_*` tests green** against fakecloud in ~2.5 min locally; 38 tests denied with reasons (Global Tables, INFREQUENT_ACCESS, GSI update gaps, deletion_protection, etc). Future batches widen the allow-list and drive the \`gap:\` entries to zero.
- CI workflow fans out one runner per allow-listed service (matrix generated by a tiny \`tfacc_services\` helper binary, same pattern as \`e2e.yml\`). Each runner installs Go 1.23 + Terraform 1.14, builds fakecloud, and runs \`go test -parallel 8\` inside one \`cargo test\` invocation. Caches cover \`~/.cache/go-build\`, \`~/go/pkg/mod\`, and the shallow provider checkout in \`target/tfacc\`.
- Fix surfaced during triage: DynamoDB \`DescribeTable\` no longer emits an \`SSEDescription\` block for tables using the default AWS-owned key. Real AWS omits the field in that case; the previous stub made even \`TestAccDynamoDBTable_basic\` fail on the provider's drift check.

## How it works

1. First test run shallow-clones \`terraform-provider-aws@v5.97.0\` into \`target/tfacc/\` (idempotent) and strips one \`godebug tlskyber=0\` directive that Go ≥1.24 rejects.
2. Each \`#[tokio::test]\` spawns fakecloud on a random port and invokes \`go test ./internal/service/<svc>/ -run <regex> -skip <deny>\` with \`TF_ACC=1\`, dummy credentials, and \`AWS_ENDPOINT_URL_*\` env vars pointing at the local endpoint.
3. Failure → \`assert_pass\` panics with the tail of \`go test\` output so CI shows which upstream test broke and why. Success → silent pass.
4. Missing \`go\` or \`terraform\` → tests skip cleanly (same pattern as \`FAKECLOUD_CONTAINER_CLI=false\` in \`fakecloud-e2e\`).

## Test plan

- [x] \`cargo test -p fakecloud-tfacc dynamodb_acceptance\` green locally in 153s (38 upstream tests via go test)
- [x] \`cargo clippy -p fakecloud-tfacc --all-targets -- -D warnings\` clean
- [x] \`cargo test -p fakecloud-dynamodb\` still green (93 unit tests) after the SSEDescription fix
- [x] \`cargo check --workspace\` clean
- [ ] New \`tfacc\` CI workflow green on this PR
- [ ] Cubic review clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `fakecloud-tfacc` to run upstream `hashicorp/terraform-provider-aws` acceptance tests against a live fakecloud. First batch enables DynamoDB with 38 passing table tests and fixes SSE parity to prevent Terraform drift.

- **New Features**
  - New `fakecloud-tfacc` crate runs upstream `go test` against fakecloud via `AWS_ENDPOINT_URL_*`.
  - Two-layer gating: service allow-list plus per-service deny-list with reasons; DynamoDB batch 1 runs `TestAccDynamoDBTable_*` (38 pass, 38 skipped).
  - Shallow-clones `terraform-provider-aws@v5.97.0` into `target/tfacc/` and strips the Go 1.24-incompatible `godebug` directive.
  - New CI workflow fans out per service (matrix from `tfacc_services`), caches `~/.cache/go-build`, `~/go/pkg/mod`, and `target/tfacc`, and excludes `fakecloud-tfacc` from generic `ci.yml`/`release.yml` test jobs so it runs only in `tfacc.yml`.
  - Hard-fails with a clear message when `go` or `terraform` are missing.

- **Bug Fixes**
  - DynamoDB: `DescribeTable` no longer returns `SSEDescription` when using the default AWS-owned key; updated e2e test to assert omission to match AWS and fix provider drift checks.
  - TFACC: avoid unnecessary `go.mod` rewrites when no `godebug tlskyber` line exists; preserve trailing newlines during patching.

<sup>Written for commit 6afe4b0d8a56e4fc5ebe78f7a2212564c8a41276. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

