### PR TITLE
feat(ssm,tfacc): tolerate name:version selector; enable ssm + secretsmanager

### DIFF
--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -2177,3 +2177,59 @@ async fn ssm_command_invocations() {
     assert_eq!(resp.command_invocations().len(), 1);
     assert_eq!(resp.command_invocations()[0].command_id().unwrap(), cmd_id);
 }
+
+#[tokio::test]
+async fn ssm_lookup_tolerates_version_suffix() {
+    // Regression guard for `TestAccSSMParameter_basic` step 3, which imports
+    // an SSM parameter using the `name:version` selector. Real AWS accepts
+    // `MyParam:1` as a parameter identifier on GetParameter and
+    // ListTagsForResource — fakecloud must too, otherwise import fails
+    // with InvalidResourceId.
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    client
+        .put_parameter()
+        .name("versioned")
+        .value("v1")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+    client
+        .add_tags_to_resource()
+        .resource_type(aws_sdk_ssm::types::ResourceTypeForTagging::Parameter)
+        .resource_id("versioned")
+        .tags(
+            aws_sdk_ssm::types::Tag::builder()
+                .key("env")
+                .value("test")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // GetParameter accepts the `name:version` selector.
+    let got = client
+        .get_parameter()
+        .name("versioned:1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.parameter().unwrap().name().unwrap(), "versioned");
+
+    // ListTagsForResource also accepts the `name:version` selector and
+    // returns the parameter-level tags (which are version-independent).
+    let tags = client
+        .list_tags_for_resource()
+        .resource_type(aws_sdk_ssm::types::ResourceTypeForTagging::Parameter)
+        .resource_id("versioned:1")
+        .send()
+        .await
+        .unwrap();
+    let tag_list = tags.tag_list().to_vec();
+    assert_eq!(tag_list.len(), 1);
+    assert_eq!(tag_list[0].key(), "env");
+}

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -1003,20 +1003,29 @@ impl SsmService {
     // ===== Document operations =====
 }
 
-/// Normalize a parameter name - try looking up with and without leading slash
+/// Strip an optional `:<version>` or `:<label>` suffix from a parameter
+/// name. Real AWS SSM lets callers reference a specific version via the
+/// `name:version` syntax, e.g. `MyParam:1`. The version selector is
+/// orthogonal to the parameter's identity — the parameter is stored
+/// once and the version selects which value/history entry to return.
+fn strip_version_suffix(name: &str) -> &str {
+    name.split_once(':').map(|(n, _)| n).unwrap_or(name)
+}
+
+/// Normalize a parameter name and resolve it. Tolerates leading slash
+/// variants and the `name:version` selector that real AWS accepts.
 pub(super) fn lookup_param<'a>(
     parameters: &'a std::collections::BTreeMap<String, SsmParameter>,
     name: &str,
 ) -> Option<&'a SsmParameter> {
-    // Direct lookup
-    if let Some(p) = parameters.get(name) {
+    let bare = strip_version_suffix(name);
+    if let Some(p) = parameters.get(bare) {
         return Some(p);
     }
-    // Try with leading slash added/removed
-    if let Some(stripped) = name.strip_prefix('/') {
+    if let Some(stripped) = bare.strip_prefix('/') {
         parameters.get(stripped)
     } else {
-        parameters.get(&format!("/{name}"))
+        parameters.get(&format!("/{bare}"))
     }
 }
 
@@ -1024,15 +1033,14 @@ pub(super) fn lookup_param_mut<'a>(
     parameters: &'a mut std::collections::BTreeMap<String, SsmParameter>,
     name: &str,
 ) -> Option<&'a mut SsmParameter> {
-    // Direct lookup first
-    if parameters.contains_key(name) {
-        return parameters.get_mut(name);
+    let bare = strip_version_suffix(name);
+    if parameters.contains_key(bare) {
+        return parameters.get_mut(bare);
     }
-    // Try alternate form
-    let alt = if let Some(stripped) = name.strip_prefix('/') {
+    let alt = if let Some(stripped) = bare.strip_prefix('/') {
         stripped.to_string()
     } else {
-        format!("/{name}")
+        format!("/{bare}")
     };
     parameters.get_mut(&alt)
 }

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -37,6 +37,23 @@ pub struct Service {
 
 pub const SERVICES: &[Service] = &[
     Service {
+        name: "ssm",
+        // Batch 4: core `aws_ssm_parameter` smoke. The fix here is making
+        // `lookup_param` tolerate the `name:version` selector that real
+        // AWS accepts on GetParameter / ListTagsForResource — without it
+        // the upstream import-with-version step fails with
+        // InvalidResourceId.
+        run_regex: "^TestAccSSMParameter_basic$",
+        deny: &[],
+    },
+    Service {
+        name: "secretsmanager",
+        // Batch 4: core `aws_secretsmanager_secret` smoke. Passes against
+        // fakecloud out of the box — no fakecloud-side changes needed.
+        run_regex: "^TestAccSecretsManagerSecret_basic$",
+        deny: &[],
+    },
+    Service {
         name: "sqs",
         // SQS tests are curated via a positive regex rather than
         // `^TestAcc` + deny-list because CI runners (2-core Linux) are

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -28,6 +28,16 @@ async fn run_service(name: &str) {
 }
 
 #[tokio::test]
+async fn ssm_acceptance() {
+    run_service("ssm").await;
+}
+
+#[tokio::test]
+async fn secretsmanager_acceptance() {
+    run_service("secretsmanager").await;
+}
+
+#[tokio::test]
 async fn sqs_acceptance() {
     run_service("sqs").await;
 }


### PR DESCRIPTION
## Summary

Batch 4 — adds two services to the upstream Terraform acceptance harness with one fakecloud bug fix.

### SSM \`name:version\` selector

Real AWS SSM accepts a \`name:version\` selector on every parameter API — e.g. \`MyParam:1\` resolves to version 1 of \`MyParam\`. fakecloud was rejecting the suffix with \`InvalidResourceId\`, which broke the upstream \`TestAccSSMParameter_basic\` step that imports a parameter via the \`name:version\` form (pinned in [terraform-provider-aws#37812](https://github.com/hashicorp/terraform-provider-aws/issues/37812)).

Fix: strip an optional \`:version\` (or \`:label\`) suffix in the shared \`lookup_param\` / \`lookup_param_mut\` helpers. The selector is orthogonal to the parameter's identity, so every read path benefits — \`ListTagsForResource\`, \`GetParameter\`, \`DescribeParameters\`, etc.

### Secrets Manager

Passes against fakecloud out of the box — no changes needed. Just adding the service to the allow-list.

### Allow-list pattern

Both services scoped to a single core test each (\`TestAccSSMParameter_basic\`, \`TestAccSecretsManagerSecret_basic\`) per the wall-time budget pattern established in earlier batches. Later batches widen each as parity grows.

## Test plan

- [x] New e2e test \`ssm_lookup_tolerates_version_suffix\` covers both GetParameter and ListTagsForResource — passes
- [x] \`cargo test -p fakecloud-ssm\` clean
- [x] \`cargo clippy -p fakecloud-ssm -p fakecloud-tfacc -p fakecloud-e2e --all-targets -- -D warnings\` clean
- [x] Upstream locally: \`TestAccSSMParameter_basic\` and \`TestAccSecretsManagerSecret_basic\` both pass
- [ ] CI \`tfacc ssm\` green
- [ ] CI \`tfacc secretsmanager\` green
- [ ] Other tfacc jobs still green (regression check)
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates SSM parameter selectors like name:version and enables `ssm` and `secretsmanager` in the Terraform acceptance harness. Fixes the SSM import failure and adds focused allow-list coverage.

- **Bug Fixes**
  - Strip optional `:version`/`:label` in `lookup_param` and `lookup_param_mut`, with leading-slash tolerance.
  - Applies to GetParameter, ListTagsForResource, DescribeParameters; resolves prior InvalidResourceId on `name:version`.

- **New Features**
  - Add `ssm` and `secretsmanager` to `fakecloud-tfacc` allow-list, scoped to `^TestAccSSMParameter_basic$` and `^TestAccSecretsManagerSecret_basic$`.
  - Add e2e `ssm_lookup_tolerates_version_suffix` and `tfacc` tests `ssm_acceptance` and `secretsmanager_acceptance`.

<sup>Written for commit 00ba4c17d8f087f72e3746e49dedb0f5f6e59543. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

