### PR TITLE
feat(tfacc): enable iam with 4 core CRUD tests

### DIFF
--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -37,6 +37,15 @@ pub struct Service {
 
 pub const SERVICES: &[Service] = &[
     Service {
+        name: "iam",
+        // Batch 5: core CRUD smoke for the four most-used IAM resource
+        // types. Passes against fakecloud out of the box — no
+        // fakecloud-side changes needed. Later batches widen to
+        // attached-policy, group-membership, and instance-profile tests.
+        run_regex: "^TestAccIAM(Role|User|Policy|Group)_basic$",
+        deny: &[],
+    },
+    Service {
         name: "ssm",
         // Batch 4: core `aws_ssm_parameter` smoke. The fix here is making
         // `lookup_param` tolerate the `name:version` selector that real

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -28,6 +28,11 @@ async fn run_service(name: &str) {
 }
 
 #[tokio::test]
+async fn iam_acceptance() {
+    run_service("iam").await;
+}
+
+#[tokio::test]
 async fn ssm_acceptance() {
     run_service("ssm").await;
 }


### PR DESCRIPTION
## Summary

Batch 5 — adds IAM to the upstream Terraform acceptance harness.

\`TestAccIAM{Role,User,Policy,Group}_basic\` all pass against fakecloud out of the box. No fakecloud-side changes needed — IAM has the most exhaustive existing implementation in the codebase, and the core CRUD smoke validates that. Later batches widen to attached-policy, group-membership, and instance-profile tests.

## Test plan

- [x] Upstream locally: 4/4 IAM core tests pass at -parallel 4 in ~16s
- [x] \`cargo clippy -p fakecloud-tfacc --all-targets -- -D warnings\` clean
- [ ] CI \`tfacc iam\` green
- [ ] Other tfacc jobs still green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable IAM in `fakecloud-tfacc` by running the four core CRUD acceptance tests for Role, User, Policy, and Group. All pass against fakecloud with no backend changes.

- **New Features**
  - Added `iam` service to the allowlist with run_regex "^TestAccIAM(Role|User|Policy|Group)_basic$".
  - Introduced `iam_acceptance` test to execute the IAM suite.

<sup>Written for commit d9fff3c1ba40d3b5f77c491cfe87f2357022ad41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

