### PR TITLE
feat(logs,tfacc): return logGroupClass on DescribeLogGroups; enable kms + logs

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -746,6 +746,7 @@ impl ResourceProvisioner {
             index_policies: Vec::new(),
             transformer: None,
             deletion_protection: false,
+            log_group_class: Some("STANDARD".to_string()),
         };
 
         state

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -2463,3 +2463,33 @@ async fn logs_subscription_filter_streams_to_kinesis() {
     assert_eq!(log_events[0]["message"], "event one");
     assert_eq!(log_events[1]["message"], "event two");
 }
+
+#[tokio::test]
+async fn logs_describe_log_groups_returns_log_group_class() {
+    // Regression guard for `TestAccLogsGroup_basic`: real AWS
+    // DescribeLogGroups always returns `logGroupClass` (defaulting to
+    // STANDARD), and Terraform's `aws_cloudwatch_log_group` provider
+    // asserts on the value. Omitting it surfaces as `expected STANDARD
+    // got ""` drift on every refresh.
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("class-default")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .describe_log_groups()
+        .log_group_name_prefix("class-default")
+        .send()
+        .await
+        .unwrap();
+    let groups = resp.log_groups();
+    assert_eq!(groups.len(), 1);
+    assert_eq!(
+        groups[0].log_group_class(),
+        Some(&aws_sdk_cloudwatchlogs::types::LogGroupClass::Standard)
+    );
+}

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -3943,6 +3943,7 @@ pub fn deliver_to_logs(
             index_policies: Vec::new(),
             transformer: None,
             deletion_protection: false,
+            log_group_class: Some("STANDARD".to_string()),
         });
 
     let stream = group

--- a/crates/fakecloud-logs/src/service/groups.rs
+++ b/crates/fakecloud-logs/src/service/groups.rs
@@ -58,6 +58,10 @@ impl LogsService {
             .unwrap_or_default();
 
         let kms_key_id = body["kmsKeyId"].as_str().map(|s| s.to_string());
+        let log_group_class = body["logGroupClass"]
+            .as_str()
+            .map(|s| s.to_string())
+            .or_else(|| Some("STANDARD".to_string()));
 
         state.log_groups.insert(
             name.clone(),
@@ -75,6 +79,7 @@ impl LogsService {
                 index_policies: Vec::new(),
                 transformer: None,
                 deletion_protection: false,
+                log_group_class,
             },
         );
 
@@ -184,6 +189,15 @@ impl LogsService {
                     "creationTime": g.creation_time,
                     "storedBytes": g.stored_bytes,
                     "metricFilterCount": 0,
+                    // Real AWS DescribeLogGroups always returns logGroupClass.
+                    // Terraform's `aws_cloudwatch_log_group` provider asserts
+                    // `log_group_class == "STANDARD"` on every refresh, so
+                    // omitting the field surfaces as drift / `expected
+                    // STANDARD got ""` failures.
+                    "logGroupClass": g
+                        .log_group_class
+                        .as_deref()
+                        .unwrap_or("STANDARD"),
                 });
                 if let Some(days) = g.retention_in_days {
                     obj["retentionInDays"] = json!(days);

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -103,6 +103,10 @@ pub struct LogGroup {
     pub index_policies: Vec<IndexPolicy>,
     pub transformer: Option<Transformer>,
     pub deletion_protection: bool,
+    /// `STANDARD` (default), `INFREQUENT_ACCESS`, or `DELIVERY`. Set at
+    /// creation time via `CreateLogGroup`'s `logGroupClass` parameter.
+    /// Tracked here so `DescribeLogGroups` round-trips it correctly.
+    pub log_group_class: Option<String>,
 }
 
 pub struct LogStream {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -37,6 +37,22 @@ pub struct Service {
 
 pub const SERVICES: &[Service] = &[
     Service {
+        name: "kms",
+        // Batch 6: core `aws_kms_key` smoke. Passes against fakecloud
+        // out of the box.
+        run_regex: "^TestAccKMSKey_basic$",
+        deny: &[],
+    },
+    Service {
+        name: "logs",
+        // Batch 6: core `aws_cloudwatch_log_group` smoke. The fix here
+        // is making DescribeLogGroups always return `logGroupClass`
+        // (defaulting to STANDARD), which Terraform's provider asserts
+        // on every refresh.
+        run_regex: "^TestAccLogsGroup_basic$",
+        deny: &[],
+    },
+    Service {
         name: "iam",
         // Batch 5: core CRUD smoke for the four most-used IAM resource
         // types. Passes against fakecloud out of the box — no

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -28,6 +28,16 @@ async fn run_service(name: &str) {
 }
 
 #[tokio::test]
+async fn kms_acceptance() {
+    run_service("kms").await;
+}
+
+#[tokio::test]
+async fn logs_acceptance() {
+    run_service("logs").await;
+}
+
+#[tokio::test]
 async fn iam_acceptance() {
     run_service("iam").await;
 }


### PR DESCRIPTION
## Summary

Batch 6 — adds KMS and CloudWatch Logs to the upstream Terraform acceptance harness.

### CloudWatch Logs \`logGroupClass\` round-trip

Real AWS CloudWatch Logs \`DescribeLogGroups\` always returns \`logGroupClass\` (defaulting to \`STANDARD\`), and Terraform's \`aws_cloudwatch_log_group\` provider asserts on the value. Omitting it surfaced as \`expected STANDARD got \"\"\` drift on every refresh in \`TestAccLogsGroup_basic\`.

- \`LogGroup\` state struct now carries \`log_group_class\` (Option<String>).
- \`CreateLogGroup\` captures the parameter, defaulting to \`STANDARD\` when the caller doesn't specify.
- \`DescribeLogGroups\` always emits the field.
- Cross-crate constructor sites updated: \`fakecloud-eventbridge\` (auto-create log group on rule target delivery) and \`fakecloud-cloudformation\` (CFN resource provisioner).

### KMS

\`TestAccKMSKey_basic\` passes against fakecloud out of the box. No fakecloud-side changes needed.

## Test plan

- [x] New e2e test \`logs_describe_log_groups_returns_log_group_class\` — passes
- [x] \`cargo clippy -p fakecloud-logs -p fakecloud-tfacc -p fakecloud-e2e -p fakecloud-eventbridge -p fakecloud-cloudformation --all-targets -- -D warnings\` clean
- [x] Upstream locally: \`TestAccLogsGroup_basic\` and \`TestAccKMSKey_basic\` both pass
- [ ] CI \`tfacc kms\` green
- [ ] CI \`tfacc logs\` green
- [ ] Other tfacc jobs still green (regression check)
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return `logGroupClass` from CloudWatch Logs `DescribeLogGroups` (default `STANDARD`) to match AWS and stop Terraform drift; enable KMS and Logs in the `fakecloud-tfacc` harness.

- **Bug Fixes**
  - `fakecloud-logs`: `DescribeLogGroups` now always includes `logGroupClass` (default `STANDARD`); `CreateLogGroup` captures it; state tracks `log_group_class`.
  - Updated `fakecloud-eventbridge` and `fakecloud-cloudformation` to set `log_group_class: STANDARD` when auto-creating log groups.

- **New Features**
  - `fakecloud-tfacc`: allowlisted `kms` and `logs` suites to run (`TestAccKMSKey_basic`, `TestAccLogsGroup_basic`).

<sup>Written for commit d25e6a2d67e1f38934b7b88d53478d5713fd110a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

