### PR TITLE
feat(tfacc): enable sns + events services with core smoke tests

### DIFF
--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -37,6 +37,23 @@ pub struct Service {
 
 pub const SERVICES: &[Service] = &[
     Service {
+        name: "sns",
+        // Batch 7: core `aws_sns_topic` smoke. Passes against fakecloud
+        // out of the box.
+        run_regex: "^TestAccSNSTopic_basic$",
+        deny: &[],
+    },
+    Service {
+        name: "events",
+        // Batch 7: core EventBridge `aws_cloudwatch_event_bus` and
+        // `aws_cloudwatch_event_rule` smokes. Both pass out of the box.
+        // Note: the upstream service directory is `events`, not
+        // `eventbridge` — Terraform uses the legacy CloudWatch Events
+        // naming.
+        run_regex: "^TestAccEvents(Bus|Rule)_basic$",
+        deny: &[],
+    },
+    Service {
         name: "kms",
         // Batch 6: core `aws_kms_key` smoke. Passes against fakecloud
         // out of the box.

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -28,6 +28,16 @@ async fn run_service(name: &str) {
 }
 
 #[tokio::test]
+async fn sns_acceptance() {
+    run_service("sns").await;
+}
+
+#[tokio::test]
+async fn events_acceptance() {
+    run_service("events").await;
+}
+
+#[tokio::test]
 async fn kms_acceptance() {
     run_service("kms").await;
 }


### PR DESCRIPTION
## Summary

Batch 7 — adds SNS and EventBridge to the upstream Terraform acceptance harness.

\`TestAccSNSTopic_basic\`, \`TestAccEventsBus_basic\`, and \`TestAccEventsRule_basic\` all pass against fakecloud out of the box. No fakecloud-side changes needed.

Note: the upstream service directory for EventBridge is \`events\`, matching the legacy CloudWatch Events naming Terraform still uses internally.

## Test plan

- [x] Upstream locally: 3/3 pass (~50s wall at -parallel 4)
- [x] \`cargo clippy -p fakecloud-tfacc --all-targets -- -D warnings\` clean
- [ ] CI \`tfacc sns\` and \`tfacc events\` both green
- [ ] All other tfacc jobs still green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables SNS and EventBridge in the Terraform acceptance harness, adding core smoke tests that pass against `fakecloud` out of the box. Expands `fakecloud-tfacc` coverage with no backend changes.

- **New Features**
  - Allowlist `sns` and `events` in `allowlist.rs` with `^TestAccSNSTopic_basic$` and `^TestAccEvents(Bus|Rule)_basic$`.
  - Add `sns_acceptance` and `events_acceptance` tests in `tests/acc.rs`.
  - Note: EventBridge uses the upstream `events` service directory (legacy CloudWatch Events naming).

<sup>Written for commit 7c8442f2d2b475daaaecd4d0311f385eb68ac372. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

