### PR TITLE
feat(kinesis,tfacc): allow same-value IncreaseStreamRetentionPeriod; enable kinesis

### DIFF
--- a/crates/fakecloud-e2e/tests/kinesis.rs
+++ b/crates/fakecloud-e2e/tests/kinesis.rs
@@ -404,3 +404,41 @@ async fn kinesis_reports_millis_behind_latest_when_limit_truncates() {
     assert_eq!(records.records().len(), 1);
     assert!(records.millis_behind_latest().unwrap_or_default() > 0);
 }
+
+#[tokio::test]
+async fn kinesis_increase_retention_to_current_value_is_noop() {
+    // Regression guard for `TestAccKinesisStream_basic`: the upstream
+    // `aws_kinesis_stream` provider unconditionally calls
+    // `IncreaseStreamRetentionPeriod(24)` on every create — even when
+    // the configured value matches the default 24h. Real AWS treats
+    // same-value as a no-op despite the docs, and fakecloud must too,
+    // otherwise every basic apply fails with "must be greater".
+    let server = TestServer::start().await;
+    let client = server.kinesis_client().await;
+
+    client
+        .create_stream()
+        .stream_name("retention-noop")
+        .shard_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    // Same value as the default — must succeed.
+    client
+        .increase_stream_retention_period()
+        .stream_name("retention-noop")
+        .retention_period_hours(24)
+        .send()
+        .await
+        .unwrap();
+
+    // Strictly less is still a hard error.
+    let err = client
+        .increase_stream_retention_period()
+        .stream_name("retention-noop")
+        .retention_period_hours(23)
+        .send()
+        .await;
+    assert!(err.is_err());
+}

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -549,12 +549,20 @@ impl KinesisService {
             .get_mut(&stream_name)
             .ok_or_else(|| stream_not_found(&account_id, &stream_name))?;
 
-        if increasing && hours <= stream.retention_period_hours as i64 {
+        // Real AWS Kinesis treats `IncreaseStreamRetentionPeriod` with the
+        // current value as a no-op (despite what the API docs say) — the
+        // upstream `aws_kinesis_stream` provider unconditionally calls
+        // `IncreaseStreamRetentionPeriod(24)` on every create regardless
+        // of whether the user changed retention_period, and the test
+        // suite passes against real AWS. Strictly less-than is still an
+        // error for `IncreaseStreamRetentionPeriod`, and strictly
+        // greater-than is still an error for `DecreaseStreamRetentionPeriod`.
+        if increasing && hours < stream.retention_period_hours as i64 {
             return Err(invalid_argument(
                 "RetentionPeriodHours must be greater than the current retention period",
             ));
         }
-        if !increasing && hours >= stream.retention_period_hours as i64 {
+        if !increasing && hours > stream.retention_period_hours as i64 {
             return Err(invalid_argument(
                 "RetentionPeriodHours must be less than the current retention period",
             ));

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -37,6 +37,16 @@ pub struct Service {
 
 pub const SERVICES: &[Service] = &[
     Service {
+        name: "kinesis",
+        // Batch 8: core `aws_kinesis_stream` smoke. The fix here is
+        // making `IncreaseStreamRetentionPeriod` accept same-value as a
+        // no-op — real AWS does this despite what the API docs say,
+        // and the upstream provider unconditionally calls it with the
+        // default 24h on every create.
+        run_regex: "^TestAccKinesisStream_basic$",
+        deny: &[],
+    },
+    Service {
         name: "sns",
         // Batch 7: core `aws_sns_topic` smoke. Passes against fakecloud
         // out of the box.

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -28,6 +28,11 @@ async fn run_service(name: &str) {
 }
 
 #[tokio::test]
+async fn kinesis_acceptance() {
+    run_service("kinesis").await;
+}
+
+#[tokio::test]
 async fn sns_acceptance() {
     run_service("sns").await;
 }


### PR DESCRIPTION
## Summary

Batch 8 — adds Kinesis to the upstream Terraform acceptance harness with one fakecloud bug fix.

### Kinesis \`IncreaseStreamRetentionPeriod\` same-value no-op

Real AWS Kinesis treats \`IncreaseStreamRetentionPeriod\` with the current retention as a no-op (despite the API docs saying it must be greater). The upstream \`aws_kinesis_stream\` provider relies on this — it unconditionally calls \`IncreaseStreamRetentionPeriod(retention_period)\` on every create, even when the user didn't override the schema's default 24h. fakecloud was hard-rejecting same-value, breaking \`TestAccKinesisStream_basic\`.

Loosened both \`Increase\` and \`Decrease\` to use strict less-than / greater-than rather than less-than-or-equal / greater-than-or-equal.

### Deferred from this batch

- **Lambda**: \`TestAccLambdaFunction_basic\` needs EC2 \`DescribeAvailabilityZones\` (substantial fakecloud surface area not yet implemented).
- **Step Functions**: \`TestAccSFNStateMachine_createUpdate\` depends on Lambda. \`TestAccSFNActivity_basic\` skips because \`CreateActivity\` is not yet implemented in fakecloud-stepfunctions.

Both will get their own batches once the underlying surface gaps are closed.

## Test plan

- [x] New e2e test \`kinesis_increase_retention_to_current_value_is_noop\` — passes
- [x] \`cargo test -p fakecloud-kinesis\` clean
- [x] \`cargo clippy -p fakecloud-kinesis -p fakecloud-tfacc -p fakecloud-e2e --all-targets -- -D warnings\` clean
- [x] Upstream locally: \`TestAccKinesisStream_basic\` passes (~40s)
- [ ] CI \`tfacc kinesis\` green
- [ ] Other tfacc jobs still green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match AWS behavior by treating same-value `IncreaseStreamRetentionPeriod` as a no‑op in `fakecloud-kinesis`, and enable Kinesis in the `fakecloud-tfacc` acceptance harness. This unblocks the upstream `aws_kinesis_stream` `TestAccKinesisStream_basic` test.

- **Bug Fixes**
  - Use strict less-than for increase and strict greater-than for decrease when validating retention hours.
  - Prevent erroneous "must be greater/less than" errors when the requested value equals the current retention.

- **New Features**
  - Enable Kinesis in `fakecloud-tfacc` with run regex `^TestAccKinesisStream_basic$`.
  - Add e2e test `kinesis_increase_retention_to_current_value_is_noop`.
  - Add `kinesis_acceptance` test in `fakecloud-tfacc`.

<sup>Written for commit 9ec1a349a69474ac673e8df6bfc3409876c3c86a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

