### PR TITLE
feat(parity): run same tests against fakecloud and real AWS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# CODEOWNERS for fakecloud.
+#
+# This file pins ownership on every path that can cause the parity workflow
+# to execute against real AWS credentials. Combined with branch protection
+# ("Require review from Code Owners" on `main`), a contributor physically
+# cannot merge a PR that modifies these paths without an explicit review
+# from the repo owner.
+#
+# The CODEOWNERS file itself is owned so a malicious PR can't remove the
+# other rules in the same commit.
+
+.github/CODEOWNERS                        @vieiralucas
+.github/workflows/parity-aws.yml          @vieiralucas
+.github/workflows/parity-fakecloud.yml    @vieiralucas
+crates/fakecloud-parity/**                @vieiralucas
+crates/fakecloud-testkit/**               @vieiralucas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance --exclude fakecloud-tfacc
+      - run: cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance --exclude fakecloud-tfacc --exclude fakecloud-parity
       - run: cargo test -p fakecloud-conformance --lib

--- a/.github/workflows/parity-aws.yml
+++ b/.github/workflows/parity-aws.yml
@@ -1,0 +1,72 @@
+name: Parity (real AWS)
+
+# Runs the fakecloud-parity test suite against a real AWS account, so we
+# can compare pass/fail against the Parity (fakecloud) workflow on main.
+#
+# SECURITY NOTES — READ BEFORE EDITING:
+#
+#  1. There is intentionally NO `pull_request` trigger on this workflow.
+#     Do not add one. Credentials must never be exposed to contributor PRs.
+#     PRs that modify files in `crates/fakecloud-parity/`, this file, or
+#     any other file referenced by this workflow are gated through
+#     CODEOWNERS in `.github/CODEOWNERS` — they cannot merge without an
+#     explicit review from the owner.
+#
+#  2. The `real-aws` job targets a protected GitHub Environment
+#     (`aws-parity`) with a required reviewer. Even on a scheduled run,
+#     GitHub pauses the job and waits for a human click before any step
+#     runs against AWS. This is the second line of defense after
+#     CODEOWNERS.
+#
+#  3. The job is additionally gated on `vars.AWS_PARITY_ROLE_ARN` being
+#     set. Until the sandbox AWS account exists and the repo variable is
+#     populated, the job is a no-op — nothing reaches AWS.
+#
+#  4. OIDC is used instead of long-lived access keys: `role-to-assume`
+#     is read from a repo variable (not a secret — role ARNs are not
+#     sensitive). The assumed role's IAM policy is the ground-truth
+#     blast radius limit — keep it scoped to `fcparity-*` resource
+#     prefixes.
+
+on:
+  schedule:
+    # 07:00 UTC daily. Low-traffic hour, lets us notice drift within 24h.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+  # Deliberately no `pull_request` trigger. See SECURITY NOTES above.
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  # Serialize real-AWS runs so two ticks can't race and leak resources
+  # past each other's cleanup.
+  group: parity-aws
+  cancel-in-progress: false
+
+jobs:
+  real-aws:
+    # Skip cleanly until the sandbox account exists and the repo variable
+    # is set. Nothing else below this line runs without that gate.
+    if: ${{ vars.AWS_PARITY_ROLE_ARN != '' }}
+    runs-on: ubuntu-latest
+    environment: aws-parity
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_PARITY_ROLE_ARN }}
+          aws-region: us-east-1
+          role-session-name: fakecloud-parity-${{ github.run_id }}
+
+      - name: Run parity tests against real AWS
+        env:
+          FAKECLOUD_PARITY_BACKEND: aws
+          AWS_REGION: us-east-1
+        run: cargo test -p fakecloud-parity -- --test-threads=1

--- a/.github/workflows/parity-fakecloud.yml
+++ b/.github/workflows/parity-fakecloud.yml
@@ -1,0 +1,41 @@
+name: Parity (fakecloud)
+
+# Runs the fakecloud-parity test suite against a local fakecloud process.
+# No AWS credentials are used here; this job is safe to run on every PR.
+# The companion workflow `parity-aws.yml` runs the same crate against real
+# AWS on a schedule.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/fakecloud-parity/**'
+      - 'crates/fakecloud-testkit/**'
+      - '.github/workflows/parity-fakecloud.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/fakecloud-parity/**'
+      - 'crates/fakecloud-testkit/**'
+      - '.github/workflows/parity-fakecloud.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fakecloud:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build fakecloud binary
+        run: cargo build --bin fakecloud
+
+      - name: Run parity tests against local fakecloud
+        env:
+          FAKECLOUD_PARITY_BACKEND: fakecloud
+        run: cargo test -p fakecloud-parity

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,6 +2195,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "fakecloud-sdk",
+ "fakecloud-testkit",
  "flate2",
  "reqwest",
  "serde_json",
@@ -2339,6 +2340,25 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "fakecloud-parity"
+version = "0.9.1"
+dependencies = [
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-dynamodb",
+ "aws-sdk-kms",
+ "aws-sdk-s3",
+ "aws-sdk-secretsmanager",
+ "aws-sdk-sns",
+ "aws-sdk-sqs",
+ "aws-sdk-sts",
+ "aws-types",
+ "fakecloud-testkit",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -2531,6 +2551,19 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "fakecloud-testkit"
+version = "0.9.1"
+dependencies = [
+ "aws-config",
+ "aws-credential-types",
+ "aws-types",
+ "reqwest",
+ "serde_json",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ members = [
     "crates/fakecloud-conformance",
     "crates/fakecloud-conformance-macros",
     "crates/fakecloud-tfacc",
+    "crates/fakecloud-testkit",
+    "crates/fakecloud-parity",
 ]
 resolver = "2"
 

--- a/crates/fakecloud-e2e/Cargo.toml
+++ b/crates/fakecloud-e2e/Cargo.toml
@@ -45,5 +45,6 @@ base64 = { workspace = true }
 flate2 = { workspace = true }
 zip = { workspace = true }
 fakecloud-sdk = { path = "../fakecloud-sdk" }
+fakecloud-testkit = { path = "../fakecloud-testkit" }
 tempfile = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -1,276 +1,99 @@
-use std::net::TcpListener;
+//! Thin newtype wrapper over `fakecloud_testkit::TestServer` that adds the
+//! per-service SDK client factories e2e tests rely on. Keeps testkit itself
+//! free of the `aws-sdk-*` dependency sprawl while preserving the
+//! `helpers::TestServer` API existing e2e tests already use.
+
+#![allow(dead_code, unused_imports)]
+
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Output, Stdio};
-use std::time::Duration;
+use std::process::Command;
 
-use aws_config::BehaviorVersion;
-use aws_credential_types::Credentials;
-use aws_types::region::Region;
+pub use fakecloud_testkit::{data_path_for, run_until_exit, CliOutput};
 
-/// A test server that spawns fakecloud on a random port.
-#[allow(dead_code)]
-pub struct TestServer {
-    child: Option<Child>,
-    port: u16,
-    endpoint: String,
-    container_cli: String,
-    extra_args: Vec<String>,
-    env_vars: Vec<(String, String)>,
-    log_level: String,
-}
+/// Newtype wrapper around `fakecloud_testkit::TestServer`. Delegates all
+/// lifecycle methods and layers on per-service AWS SDK client factories.
+pub struct TestServer(fakecloud_testkit::TestServer);
 
-#[allow(dead_code)]
 impl TestServer {
-    /// Start a new FakeCloud server on a random available port.
     pub async fn start() -> Self {
-        Self::start_with_env(&[]).await
+        Self(fakecloud_testkit::TestServer::start().await)
     }
 
-    /// Start with extra environment variables passed to the server process.
     pub async fn start_with_env(env: &[(&str, &str)]) -> Self {
-        Self::start_full(env, &[]).await
+        Self(fakecloud_testkit::TestServer::start_with_env(env).await)
     }
 
-    /// Start fakecloud in persistent mode with the given data directory.
+    pub async fn start_full(env: &[(&str, &str)], extra_args: &[&str]) -> Self {
+        Self(fakecloud_testkit::TestServer::start_full(env, extra_args).await)
+    }
+
     pub async fn start_persistent(data_path: &Path) -> Self {
-        Self::start_persistent_with_cache(data_path, None).await
+        Self(fakecloud_testkit::TestServer::start_persistent(data_path).await)
     }
 
     pub async fn start_persistent_with_cache(data_path: &Path, s3_cache_size: Option<u64>) -> Self {
-        let data_path_str = data_path.display().to_string();
-        let mut args: Vec<String> = vec![
-            "--storage-mode".to_string(),
-            "persistent".to_string(),
-            "--data-path".to_string(),
-            data_path_str,
-        ];
-        if let Some(size) = s3_cache_size {
-            args.push("--s3-cache-size".to_string());
-            args.push(size.to_string());
-        }
-        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-        Self::start_full(&[("FAKECLOUD_CONTAINER_CLI", "false")], &arg_refs).await
+        Self(
+            fakecloud_testkit::TestServer::start_persistent_with_cache(data_path, s3_cache_size)
+                .await,
+        )
     }
 
-    /// Full form — extra env vars + extra CLI args. Used internally by
-    /// the specialised `start_*` helpers.
-    pub async fn start_full(env: &[(&str, &str)], extra_args: &[&str]) -> Self {
-        let bin = find_binary();
-
-        let container_cli = env
-            .iter()
-            .find(|(k, _)| *k == "FAKECLOUD_CONTAINER_CLI")
-            .map(|(_, v)| v.to_string())
-            .unwrap_or_else(detect_container_cli);
-
-        let log_level = env
-            .iter()
-            .find(|(k, _)| *k == "FAKECLOUD_TEST_LOG_LEVEL")
-            .map(|(_, v)| v.to_string())
-            .or_else(|| std::env::var("FAKECLOUD_TEST_LOG_LEVEL").ok())
-            .unwrap_or_else(|| "warn".to_string());
-
-        let env_vars: Vec<(String, String)> = env
-            .iter()
-            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-            .collect();
-        let extra_args_owned: Vec<String> = extra_args.iter().map(|s| (*s).to_string()).collect();
-
-        for _ in 0..3 {
-            let port = find_available_port();
-            let endpoint = format!("http://127.0.0.1:{port}");
-
-            let mut cmd = Command::new(&bin);
-            cmd.arg("--addr")
-                .arg(format!("0.0.0.0:{port}"))
-                .arg("--log-level")
-                .arg(&log_level)
-                .args(&extra_args_owned)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
-
-            for (key, value) in &env_vars {
-                cmd.env(key, value);
-            }
-
-            let mut child = cmd.spawn().expect("failed to start fakecloud");
-
-            if wait_for_port(&mut child, port).await {
-                return Self {
-                    child: Some(child),
-                    port,
-                    endpoint,
-                    container_cli,
-                    extra_args: extra_args_owned,
-                    env_vars,
-                    log_level,
-                };
-            }
-
-            let _ = child.kill();
-            let _ = child.wait();
-        }
-
-        panic!("fakecloud failed to start after 3 attempts");
-    }
-
-    /// Kill the current child and respawn with the same extra args/env.
-    /// Allocates a new port because the previous one may still be in TIME_WAIT.
     pub async fn restart(&mut self) {
-        if let Some(mut child) = self.child.take() {
-            let _ = child.kill();
-            let _ = child.wait();
-        }
-        let bin = find_binary();
-        for _ in 0..5 {
-            let port = find_available_port();
-            let endpoint = format!("http://127.0.0.1:{port}");
-            let mut cmd = Command::new(&bin);
-            cmd.arg("--addr")
-                .arg(format!("0.0.0.0:{port}"))
-                .arg("--log-level")
-                .arg(&self.log_level)
-                .args(&self.extra_args)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
-            for (key, value) in &self.env_vars {
-                cmd.env(key, value);
-            }
-            let mut child = cmd.spawn().expect("failed to respawn fakecloud");
-            if wait_for_port(&mut child, port).await {
-                self.child = Some(child);
-                self.port = port;
-                self.endpoint = endpoint;
-                return;
-            }
-            let _ = child.kill();
-            let _ = child.wait();
-        }
-        panic!("fakecloud failed to restart");
+        self.0.restart().await
     }
-}
 
-/// Run fakecloud once and collect its exit status + stderr output.
-/// For tests that deliberately cause the server to fail at boot.
-#[allow(dead_code)]
-pub fn run_until_exit(
-    extra_args: &[&str],
-    env: &[(&str, &str)],
-    timeout: Duration,
-) -> (std::process::ExitStatus, String) {
-    let bin = find_binary();
-    let port = find_available_port();
-    let mut cmd = Command::new(&bin);
-    cmd.arg("--addr")
-        .arg(format!("127.0.0.1:{port}"))
-        .arg("--log-level")
-        .arg("warn")
-        .args(extra_args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    for (k, v) in env {
-        cmd.env(k, v);
-    }
-    let mut child = cmd.spawn().expect("failed to spawn fakecloud");
-    let deadline = std::time::Instant::now() + timeout;
-    loop {
-        if let Some(status) = child.try_wait().expect("try_wait") {
-            let output = child.wait_with_output().expect("wait_with_output");
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            return (status, stderr);
-        }
-        if std::time::Instant::now() >= deadline {
-            let _ = child.kill();
-            let output = child.wait_with_output().expect("wait_with_output");
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            return (output.status, stderr);
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-}
-
-#[allow(dead_code)]
-pub fn data_path_for(dir: &tempfile::TempDir) -> PathBuf {
-    dir.path().to_path_buf()
-}
-
-#[allow(dead_code)]
-impl TestServer {
     pub fn endpoint(&self) -> &str {
-        &self.endpoint
+        self.0.endpoint()
     }
 
     pub fn port(&self) -> u16 {
-        self.port
+        self.0.port()
     }
 
-    /// Create a shared AWS SDK config pointing at this test server.
     pub async fn aws_config(&self) -> aws_config::SdkConfig {
-        aws_config::defaults(BehaviorVersion::latest())
-            .endpoint_url(self.endpoint())
-            .region(Region::new("us-east-1"))
-            .credentials_provider(Credentials::new(
-                "AKIAIOSFODNN7EXAMPLE",
-                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                None,
-                None,
-                "test",
-            ))
-            .load()
-            .await
+        self.0.aws_config().await
     }
 
-    /// Create an SQS client.
     pub async fn sqs_client(&self) -> aws_sdk_sqs::Client {
         aws_sdk_sqs::Client::new(&self.aws_config().await)
     }
 
-    /// Create an SNS client.
     pub async fn sns_client(&self) -> aws_sdk_sns::Client {
         aws_sdk_sns::Client::new(&self.aws_config().await)
     }
 
-    /// Create an EventBridge client.
     pub async fn eventbridge_client(&self) -> aws_sdk_eventbridge::Client {
         aws_sdk_eventbridge::Client::new(&self.aws_config().await)
     }
 
-    /// Create an IAM client.
     pub async fn iam_client(&self) -> aws_sdk_iam::Client {
         aws_sdk_iam::Client::new(&self.aws_config().await)
     }
 
-    /// Create an STS client.
     pub async fn sts_client(&self) -> aws_sdk_sts::Client {
         aws_sdk_sts::Client::new(&self.aws_config().await)
     }
 
-    /// Create an SSM client.
     pub async fn ssm_client(&self) -> aws_sdk_ssm::Client {
         aws_sdk_ssm::Client::new(&self.aws_config().await)
     }
 
-    /// Create a DynamoDB client.
     pub async fn dynamodb_client(&self) -> aws_sdk_dynamodb::Client {
         aws_sdk_dynamodb::Client::new(&self.aws_config().await)
     }
 
-    /// Create a Lambda client.
     pub async fn lambda_client(&self) -> aws_sdk_lambda::Client {
         aws_sdk_lambda::Client::new(&self.aws_config().await)
     }
 
-    /// Create a Secrets Manager client.
     pub async fn secretsmanager_client(&self) -> aws_sdk_secretsmanager::Client {
         aws_sdk_secretsmanager::Client::new(&self.aws_config().await)
     }
 
-    /// Create a CloudWatch Logs client.
     pub async fn logs_client(&self) -> aws_sdk_cloudwatchlogs::Client {
         aws_sdk_cloudwatchlogs::Client::new(&self.aws_config().await)
     }
 
-    /// Create a KMS client.
     pub async fn kms_client(&self) -> aws_sdk_kms::Client {
         aws_sdk_kms::Client::new(&self.aws_config().await)
     }
@@ -287,47 +110,38 @@ impl TestServer {
         aws_sdk_elasticache::Client::new(&self.aws_config().await)
     }
 
-    /// Create a CloudFormation client.
     pub async fn cloudformation_client(&self) -> aws_sdk_cloudformation::Client {
         aws_sdk_cloudformation::Client::new(&self.aws_config().await)
     }
 
-    /// Create an SES v1 client.
     pub async fn ses_client(&self) -> aws_sdk_ses::Client {
         aws_sdk_ses::Client::new(&self.aws_config().await)
     }
 
-    /// Create an SES v2 client.
     pub async fn sesv2_client(&self) -> aws_sdk_sesv2::Client {
         aws_sdk_sesv2::Client::new(&self.aws_config().await)
     }
 
-    /// Create a Cognito Identity Provider client.
     pub async fn cognito_client(&self) -> aws_sdk_cognitoidentityprovider::Client {
         aws_sdk_cognitoidentityprovider::Client::new(&self.aws_config().await)
     }
 
-    /// Create a Step Functions client.
     pub async fn sfn_client(&self) -> aws_sdk_sfn::Client {
         aws_sdk_sfn::Client::new(&self.aws_config().await)
     }
 
-    /// Create an API Gateway v2 client.
     pub async fn apigatewayv2_client(&self) -> aws_sdk_apigatewayv2::Client {
         aws_sdk_apigatewayv2::Client::new(&self.aws_config().await)
     }
 
-    /// Create a Bedrock client.
     pub async fn bedrock_client(&self) -> aws_sdk_bedrock::Client {
         aws_sdk_bedrock::Client::new(&self.aws_config().await)
     }
 
-    /// Create a Bedrock Runtime client.
     pub async fn bedrock_runtime_client(&self) -> aws_sdk_bedrockruntime::Client {
         aws_sdk_bedrockruntime::Client::new(&self.aws_config().await)
     }
 
-    /// Create an S3 client (path-style addressing for single-endpoint emulator).
     pub async fn s3_client(&self) -> aws_sdk_s3::Client {
         let config = self.aws_config().await;
         let s3_config = aws_sdk_s3::config::Builder::from(&config)
@@ -336,7 +150,6 @@ impl TestServer {
         aws_sdk_s3::Client::from_conf(s3_config)
     }
 
-    /// Run an AWS CLI command against this test server.
     pub async fn aws_cli(&self, args: &[&str]) -> CliOutput {
         let output = Command::new("aws")
             .args(args)
@@ -349,140 +162,22 @@ impl TestServer {
             .env("AWS_DEFAULT_REGION", "us-east-1")
             .output()
             .expect("failed to run aws cli");
-
         CliOutput(output)
     }
 }
 
-impl Drop for TestServer {
-    fn drop(&mut self) {
-        if let Some(mut child) = self.child.take() {
-            let pid = child.id();
-            let _ = child.kill();
-            let _ = child.wait();
-
-            // Clean up any Lambda containers spawned by this server instance
-            let label = format!("fakecloud-instance=fakecloud-{}", pid);
-            let cli = &self.container_cli;
-            let output = Command::new(cli)
-                .args(["ps", "-aq", "--filter", &format!("label={}", label)])
-                .output();
-            if let Ok(output) = output {
-                let ids = String::from_utf8_lossy(&output.stdout);
-                for id in ids.split_whitespace() {
-                    let _ = Command::new(cli)
-                        .args(["rm", "-f", id])
-                        .stdout(Stdio::null())
-                        .stderr(Stdio::null())
-                        .status();
-                }
-            }
-        }
-    }
-}
-
-/// Output from an AWS CLI invocation.
-pub struct CliOutput(Output);
-
-#[allow(dead_code)]
-impl CliOutput {
-    pub fn success(&self) -> bool {
-        self.0.status.success()
-    }
-
-    pub fn stdout_text(&self) -> String {
-        String::from_utf8_lossy(&self.0.stdout).to_string()
-    }
-
-    pub fn stderr_text(&self) -> String {
-        String::from_utf8_lossy(&self.0.stderr).to_string()
-    }
-
-    pub fn stdout_json(&self) -> serde_json::Value {
-        serde_json::from_slice(&self.0.stdout).unwrap_or(serde_json::Value::Null)
-    }
-}
-
-fn find_available_port() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind to random port");
-    listener.local_addr().unwrap().port()
-}
-
-fn find_binary() -> String {
-    let debug_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/debug/fakecloud");
-    let release_path = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../../target/release/fakecloud"
-    );
-
-    if std::path::Path::new(debug_path).exists() {
-        return debug_path.to_string();
-    }
-    if std::path::Path::new(release_path).exists() {
-        return release_path.to_string();
-    }
-
-    panic!(
-        "fakecloud binary not found. Run `cargo build` first.\n\
-         Looked in:\n  {debug_path}\n  {release_path}"
-    );
-}
-
-fn detect_container_cli() -> String {
-    if cli_available("docker") {
-        "docker".to_string()
-    } else if cli_available("podman") {
-        "podman".to_string()
-    } else {
-        "docker".to_string()
-    }
-}
-
-fn cli_available(cli: &str) -> bool {
-    Command::new(cli)
-        .arg("info")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
-}
-
-async fn wait_for_port(child: &mut Child, port: u16) -> bool {
-    // Two-stage readiness: (1) TCP connect succeeds, (2) an HTTP request
-    // actually reaches an axum handler. A bare TCP connect only proves
-    // the kernel accepted SYNs into fakecloud's listen queue — it does
-    // not prove axum has reached `serve().await` and installed request
-    // handlers. Tests that hit the server immediately after a bare TCP
-    // connect occasionally saw ConnectionRefused / EOF mid-flight.
-    let loopback = format!("127.0.0.1:{port}");
-    let wildcard = format!("0.0.0.0:{port}");
-    let health_url = format!("http://127.0.0.1:{port}/");
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_millis(500))
-        .build()
-        .expect("build reqwest client");
-
-    for _ in 0..300 {
-        if child.try_wait().ok().flatten().is_some() {
-            return false;
-        }
-        let tcp_ok = std::net::TcpStream::connect(&loopback).is_ok()
-            || std::net::TcpStream::connect(&wildcard).is_ok();
-        if tcp_ok && client.get(&health_url).send().await.is_ok() {
-            return true;
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    false
-}
-
-/// Decompress gzipped data
-#[allow(dead_code)]
+/// Decompress gzipped data.
 pub fn gunzip(data: &[u8]) -> Vec<u8> {
     use std::io::Read;
     let mut decoder = flate2::read::GzDecoder::new(data);
     let mut result = Vec::new();
     decoder.read_to_end(&mut result).unwrap();
     result
+}
+
+/// Re-exported for historical reasons. Some test helpers construct a
+/// `PathBuf` from a `tempfile::TempDir` through this shim.
+#[allow(dead_code)]
+pub fn _path_buf_shim(p: PathBuf) -> PathBuf {
+    p
 }

--- a/crates/fakecloud-parity/Cargo.toml
+++ b/crates/fakecloud-parity/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fakecloud-parity"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+
+[dev-dependencies]
+fakecloud-testkit = { path = "../fakecloud-testkit" }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+aws-config = "1"
+aws-credential-types = "1"
+aws-types = "1"
+aws-sdk-sqs = "1"
+aws-sdk-sns = "1"
+aws-sdk-s3 = "1"
+aws-sdk-dynamodb = "1"
+aws-sdk-kms = "1"
+aws-sdk-secretsmanager = "1"
+aws-sdk-sts = "1"

--- a/crates/fakecloud-parity/src/lib.rs
+++ b/crates/fakecloud-parity/src/lib.rs
@@ -1,0 +1,2 @@
+// Placeholder so cargo recognises fakecloud-parity as a crate. All logic
+// lives in tests/ (common.rs + per-service files).

--- a/crates/fakecloud-parity/tests/common/mod.rs
+++ b/crates/fakecloud-parity/tests/common/mod.rs
@@ -1,0 +1,156 @@
+//! Shared parity harness.
+//!
+//! Each test in this crate reads `FAKECLOUD_PARITY_BACKEND` at runtime and
+//! runs the same body against either a local fakecloud process or a real
+//! AWS account. The parity signal comes from comparing the pass/fail status
+//! of the two CI jobs that run this crate, NOT from diffing responses
+//! inside the tests.
+//!
+//! Rule of thumb for writing tests:
+//!   - fakecloud passes, AWS passes -> good.
+//!   - AWS passes, fakecloud fails -> fakecloud bug.
+//!   - AWS fails, fakecloud passes -> test bug (assumed something wrong
+//!     about AWS).
+//!   - both fail -> test bug.
+//!
+//! A test must therefore never assert something that can't be true on real
+//! AWS (exact ARNs, exact error messages, account IDs).
+
+#![allow(dead_code, unused_imports)]
+
+use aws_config::BehaviorVersion;
+use aws_types::region::Region;
+use fakecloud_testkit::TestServer;
+
+pub use fakecloud_testkit::unique_name;
+
+/// Which backend the current test run is targeting.
+pub enum Backend {
+    /// Spawns a local fakecloud process for the duration of the test.
+    Fakecloud(TestServer),
+    /// Uses the ambient AWS credentials from the environment.
+    /// `region` is honoured explicitly so tests are reproducible.
+    RealAws { region: String },
+}
+
+impl Backend {
+    /// Pick a backend based on `FAKECLOUD_PARITY_BACKEND`. Defaults to
+    /// `fakecloud` so a bare `cargo test -p fakecloud-parity` Just Works
+    /// offline. Setting the env var to `aws` runs against real AWS and
+    /// hard-panics if credentials are missing (tests never silently skip).
+    pub async fn from_env() -> Self {
+        let raw = std::env::var("FAKECLOUD_PARITY_BACKEND").unwrap_or_else(|_| "fakecloud".into());
+        match raw.as_str() {
+            "fakecloud" => Self::Fakecloud(TestServer::start().await),
+            "aws" => {
+                Self::require_aws_creds();
+                let region =
+                    std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".to_string());
+                Self::RealAws { region }
+            }
+            other => panic!(
+                "unknown FAKECLOUD_PARITY_BACKEND={other:?} \
+                 (expected `fakecloud` or `aws`)"
+            ),
+        }
+    }
+
+    fn require_aws_creds() {
+        let have_keys = std::env::var("AWS_ACCESS_KEY_ID").is_ok()
+            && std::env::var("AWS_SECRET_ACCESS_KEY").is_ok();
+        let have_profile = std::env::var("AWS_PROFILE").is_ok();
+        let have_web_identity = std::env::var("AWS_WEB_IDENTITY_TOKEN_FILE").is_ok()
+            && std::env::var("AWS_ROLE_ARN").is_ok();
+        if !(have_keys || have_profile || have_web_identity) {
+            panic!(
+                "FAKECLOUD_PARITY_BACKEND=aws but no AWS credentials found. \
+                 Set AWS_ACCESS_KEY_ID+AWS_SECRET_ACCESS_KEY, AWS_PROFILE, or \
+                 AWS_WEB_IDENTITY_TOKEN_FILE+AWS_ROLE_ARN before running."
+            );
+        }
+    }
+
+    /// Short label used in panic messages / logs to tell the two runs apart.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Fakecloud(_) => "fakecloud",
+            Self::RealAws { .. } => "real-aws",
+        }
+    }
+
+    /// Is this run against real AWS? Some cleanup paths need to know
+    /// (e.g. schedule-key-deletion has a 7-day minimum on real AWS).
+    pub fn is_real_aws(&self) -> bool {
+        matches!(self, Self::RealAws { .. })
+    }
+
+    /// Build an `SdkConfig` targeted at the current backend.
+    pub async fn sdk_config(&self) -> aws_config::SdkConfig {
+        match self {
+            Self::Fakecloud(server) => server.aws_config().await,
+            Self::RealAws { region } => {
+                aws_config::defaults(BehaviorVersion::latest())
+                    .region(Region::new(region.clone()))
+                    .load()
+                    .await
+            }
+        }
+    }
+
+    pub async fn sqs(&self) -> aws_sdk_sqs::Client {
+        aws_sdk_sqs::Client::new(&self.sdk_config().await)
+    }
+
+    pub async fn sns(&self) -> aws_sdk_sns::Client {
+        aws_sdk_sns::Client::new(&self.sdk_config().await)
+    }
+
+    pub async fn s3(&self) -> aws_sdk_s3::Client {
+        let cfg = self.sdk_config().await;
+        // Path-style keeps fakecloud happy (single endpoint) and also works
+        // on real AWS. No downside.
+        let s3_cfg = aws_sdk_s3::config::Builder::from(&cfg)
+            .force_path_style(true)
+            .build();
+        aws_sdk_s3::Client::from_conf(s3_cfg)
+    }
+
+    pub async fn dynamodb(&self) -> aws_sdk_dynamodb::Client {
+        aws_sdk_dynamodb::Client::new(&self.sdk_config().await)
+    }
+
+    pub async fn kms(&self) -> aws_sdk_kms::Client {
+        aws_sdk_kms::Client::new(&self.sdk_config().await)
+    }
+
+    pub async fn secretsmanager(&self) -> aws_sdk_secretsmanager::Client {
+        aws_sdk_secretsmanager::Client::new(&self.sdk_config().await)
+    }
+
+    pub async fn sts(&self) -> aws_sdk_sts::Client {
+        aws_sdk_sts::Client::new(&self.sdk_config().await)
+    }
+}
+
+/// Retry a fallible async fn up to `attempts` times with a fixed delay
+/// between tries. Needed because real AWS is eventually consistent for
+/// some list-after-create flows (S3 list after bucket create, DynamoDB
+/// describe during table transition, etc.). Fakecloud is immediately
+/// consistent so retries never fire against it.
+pub async fn retry<F, Fut, T, E>(attempts: usize, delay_ms: u64, mut f: F) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    let mut last: Option<E> = None;
+    for _ in 0..attempts {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                last = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+        }
+    }
+    Err(last.expect("retry called with attempts=0"))
+}

--- a/crates/fakecloud-parity/tests/dynamodb.rs
+++ b/crates/fakecloud-parity/tests/dynamodb.rs
@@ -1,0 +1,89 @@
+mod common;
+
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
+    ScalarAttributeType, TableStatus,
+};
+use common::{retry, unique_name, Backend};
+
+#[tokio::test]
+async fn dynamodb_create_put_get_delete() {
+    let backend = Backend::from_env().await;
+    let ddb = backend.dynamodb().await;
+    let table = unique_name("ddb");
+
+    ddb.create_table()
+        .table_name(&table)
+        .billing_mode(BillingMode::PayPerRequest)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create_table");
+
+    // Wait until the table is ACTIVE. Real AWS takes several seconds.
+    retry(60, 1000, || async {
+        let desc = ddb
+            .describe_table()
+            .table_name(&table)
+            .send()
+            .await
+            .map_err(|e| format!("describe_table: {e}"))?;
+        let status = desc
+            .table()
+            .and_then(|t| t.table_status())
+            .cloned()
+            .ok_or_else(|| "no table_status".to_string())?;
+        if status == TableStatus::Active {
+            Ok(())
+        } else {
+            Err(format!("table status = {status:?}"))
+        }
+    })
+    .await
+    .expect("table did not become ACTIVE");
+
+    // Put -> Get.
+    ddb.put_item()
+        .table_name(&table)
+        .item("pk", AttributeValue::S("alpha".into()))
+        .item("value", AttributeValue::N("42".into()))
+        .send()
+        .await
+        .expect("put_item");
+
+    let got = ddb
+        .get_item()
+        .table_name(&table)
+        .key("pk", AttributeValue::S("alpha".into()))
+        .consistent_read(true)
+        .send()
+        .await
+        .expect("get_item");
+    let item = got.item().expect("item returned");
+    assert_eq!(
+        item.get("value")
+            .and_then(|v| v.as_n().ok())
+            .map(String::as_str),
+        Some("42")
+    );
+
+    // Delete table.
+    ddb.delete_table()
+        .table_name(&table)
+        .send()
+        .await
+        .expect("delete_table");
+}

--- a/crates/fakecloud-parity/tests/kms.rs
+++ b/crates/fakecloud-parity/tests/kms.rs
@@ -1,0 +1,60 @@
+mod common;
+
+use aws_sdk_kms::primitives::Blob;
+use common::Backend;
+
+#[tokio::test]
+async fn kms_encrypt_decrypt_roundtrip() {
+    let backend = Backend::from_env().await;
+    let kms = backend.kms().await;
+
+    // Create a symmetric CMK. On real AWS this costs $1/month if not
+    // cleaned up, so we schedule deletion in tearDown with the minimum
+    // pending window (7 days).
+    let key = kms
+        .create_key()
+        .description("fcparity test key")
+        .send()
+        .await
+        .expect("create_key");
+    let metadata = key.key_metadata().expect("key_metadata");
+    let key_id = metadata.key_id().to_string();
+    let arn = metadata.arn().expect("arn").to_string();
+    assert!(
+        arn.starts_with("arn:aws:kms:"),
+        "kms key arn should start with arn:aws:kms: ; got {arn}"
+    );
+
+    let plaintext = b"hello kms parity".to_vec();
+    let enc = kms
+        .encrypt()
+        .key_id(&key_id)
+        .plaintext(Blob::new(plaintext.clone()))
+        .send()
+        .await
+        .expect("encrypt");
+    let ciphertext = enc.ciphertext_blob().expect("ciphertext_blob").clone();
+    assert!(
+        ciphertext.as_ref() != plaintext,
+        "ciphertext should differ from plaintext"
+    );
+
+    let dec = kms
+        .decrypt()
+        .ciphertext_blob(ciphertext)
+        .key_id(&key_id)
+        .send()
+        .await
+        .expect("decrypt");
+    let decrypted = dec.plaintext().expect("plaintext").clone();
+    assert_eq!(decrypted.as_ref(), plaintext.as_slice());
+
+    // Teardown: 7 days is the minimum pending window on real AWS.
+    // Fakecloud accepts the same call; it's idempotent in both.
+    let _ = kms
+        .schedule_key_deletion()
+        .key_id(key_id)
+        .pending_window_in_days(7)
+        .send()
+        .await;
+}

--- a/crates/fakecloud-parity/tests/s3.rs
+++ b/crates/fakecloud-parity/tests/s3.rs
@@ -1,0 +1,83 @@
+mod common;
+
+use aws_sdk_s3::primitives::ByteStream;
+use common::{retry, unique_name, Backend};
+
+#[tokio::test]
+async fn s3_put_get_head_list_delete() {
+    let backend = Backend::from_env().await;
+    let s3 = backend.s3().await;
+    // S3 bucket names have stricter rules than other resource names:
+    // lowercase only, no underscores, 3-63 chars, globally unique.
+    let bucket = unique_name("s3").to_lowercase().replace('_', "-");
+    assert!(bucket.len() <= 63, "s3 bucket name too long: {bucket}");
+
+    // Create. In us-east-1, CreateBucket must NOT set a LocationConstraint.
+    // fakecloud accepts either, but real us-east-1 rejects a LocationConstraint.
+    s3.create_bucket()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("create_bucket");
+
+    let key = "parity/object.txt";
+    let body = b"hello s3 parity".to_vec();
+
+    s3.put_object()
+        .bucket(&bucket)
+        .key(key)
+        .body(ByteStream::from(body.clone()))
+        .send()
+        .await
+        .expect("put_object");
+
+    // HeadObject -> content length matches.
+    let head = retry(10, 200, || async {
+        s3.head_object().bucket(&bucket).key(key).send().await
+    })
+    .await
+    .expect("head_object");
+    assert_eq!(head.content_length().unwrap_or(0), body.len() as i64);
+
+    // GetObject -> byte-for-byte round-trip.
+    let get = s3
+        .get_object()
+        .bucket(&bucket)
+        .key(key)
+        .send()
+        .await
+        .expect("get_object");
+    let got = get
+        .body
+        .collect()
+        .await
+        .expect("collect get_object body")
+        .into_bytes();
+    assert_eq!(got.as_ref(), body.as_slice());
+
+    // List -> contains the key we wrote.
+    let list = s3
+        .list_objects_v2()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("list_objects_v2");
+    let keys: Vec<&str> = list.contents().iter().filter_map(|o| o.key()).collect();
+    assert!(
+        keys.contains(&key),
+        "expected {key} in listing, got {keys:?}"
+    );
+
+    // Teardown.
+    s3.delete_object()
+        .bucket(&bucket)
+        .key(key)
+        .send()
+        .await
+        .expect("delete_object");
+    s3.delete_bucket()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("delete_bucket");
+}

--- a/crates/fakecloud-parity/tests/secretsmanager.rs
+++ b/crates/fakecloud-parity/tests/secretsmanager.rs
@@ -1,0 +1,56 @@
+mod common;
+
+use common::{unique_name, Backend};
+
+#[tokio::test]
+async fn secretsmanager_create_get_put_delete() {
+    let backend = Backend::from_env().await;
+    let sm = backend.secretsmanager().await;
+    let name = unique_name("sec");
+
+    let create = sm
+        .create_secret()
+        .name(&name)
+        .secret_string("v1")
+        .send()
+        .await
+        .expect("create_secret");
+    let arn = create.arn().expect("arn").to_string();
+    assert!(
+        arn.starts_with("arn:aws:secretsmanager:"),
+        "secret arn should start with arn:aws:secretsmanager: ; got {arn}"
+    );
+
+    let got = sm
+        .get_secret_value()
+        .secret_id(&name)
+        .send()
+        .await
+        .expect("get_secret_value");
+    assert_eq!(got.secret_string(), Some("v1"));
+
+    // Put a new version.
+    sm.put_secret_value()
+        .secret_id(&name)
+        .secret_string("v2")
+        .send()
+        .await
+        .expect("put_secret_value");
+
+    let got2 = sm
+        .get_secret_value()
+        .secret_id(&name)
+        .send()
+        .await
+        .expect("get_secret_value v2");
+    assert_eq!(got2.secret_string(), Some("v2"));
+
+    // Force delete so real AWS cleans up immediately instead of the
+    // default 7-day recovery window.
+    sm.delete_secret()
+        .secret_id(&name)
+        .force_delete_without_recovery(true)
+        .send()
+        .await
+        .expect("delete_secret");
+}

--- a/crates/fakecloud-parity/tests/sns.rs
+++ b/crates/fakecloud-parity/tests/sns.rs
@@ -1,0 +1,131 @@
+mod common;
+
+use common::{unique_name, Backend};
+
+#[tokio::test]
+async fn sns_create_topic_publish_to_sqs() {
+    let backend = Backend::from_env().await;
+    let sns = backend.sns().await;
+    let sqs = backend.sqs().await;
+
+    let topic_name = unique_name("sns");
+    let queue_name = unique_name("sns-queue");
+
+    // Create a queue to receive the SNS message.
+    let queue = sqs
+        .create_queue()
+        .queue_name(&queue_name)
+        .send()
+        .await
+        .expect("create_queue");
+    let queue_url = queue.queue_url().expect("queue_url").to_string();
+
+    let attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .expect("get_queue_attributes");
+    let queue_arn = attrs
+        .attributes()
+        .and_then(|m| m.get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn))
+        .expect("queue arn")
+        .clone();
+
+    // Create a topic.
+    let topic = sns
+        .create_topic()
+        .name(&topic_name)
+        .send()
+        .await
+        .expect("create_topic");
+    let topic_arn = topic.topic_arn().expect("topic_arn").to_string();
+    assert!(
+        topic_arn.starts_with("arn:aws:sns:"),
+        "topic arn should start with arn:aws:sns: ; got {topic_arn}"
+    );
+    assert!(
+        topic_arn.ends_with(&topic_name),
+        "topic arn should end with topic name; got {topic_arn}"
+    );
+
+    // Subscribe the SQS queue to the topic. Real AWS delivery requires an
+    // SQS queue policy allowing sns.amazonaws.com to send; set one.
+    // Wildcarding the Principal is fine because the queue name itself is
+    // unique-per-run.
+    let policy = format!(
+        r#"{{"Version":"2012-10-17","Statement":[{{"Effect":"Allow","Principal":{{"AWS":"*"}},"Action":"sqs:SendMessage","Resource":"{queue_arn}","Condition":{{"ArnEquals":{{"aws:SourceArn":"{topic_arn}"}}}}}}]}}"#
+    );
+    sqs.set_queue_attributes()
+        .queue_url(&queue_url)
+        .attributes(aws_sdk_sqs::types::QueueAttributeName::Policy, policy)
+        .send()
+        .await
+        .expect("set_queue_attributes policy");
+
+    let sub = sns
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&queue_arn)
+        .send()
+        .await
+        .expect("subscribe");
+    let subscription_arn = sub
+        .subscription_arn()
+        .expect("subscription_arn")
+        .to_string();
+    assert!(
+        subscription_arn.starts_with("arn:aws:sns:"),
+        "subscription arn should start with arn:aws:sns: ; got {subscription_arn}"
+    );
+
+    // Publish.
+    let message = "hello sns parity";
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message(message)
+        .send()
+        .await
+        .expect("publish");
+
+    // Poll the queue for the SNS delivery envelope.
+    let recv = sqs
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(1)
+        .wait_time_seconds(20)
+        .send()
+        .await
+        .expect("receive_message");
+    let messages = recv.messages();
+    assert_eq!(messages.len(), 1, "expected SNS-delivered message");
+    let body = messages[0].body().unwrap_or_default();
+    // SNS delivers a JSON envelope containing a "Message" field.
+    let envelope: serde_json::Value =
+        serde_json::from_str(body).expect("sns envelope should be JSON");
+    assert_eq!(
+        envelope
+            .get("Message")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default(),
+        message
+    );
+    assert_eq!(
+        envelope
+            .get("TopicArn")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default(),
+        topic_arn
+    );
+
+    // Teardown.
+    let _ = sns
+        .unsubscribe()
+        .subscription_arn(subscription_arn)
+        .send()
+        .await;
+    let _ = sns.delete_topic().topic_arn(topic_arn).send().await;
+    let _ = sqs.delete_queue().queue_url(queue_url).send().await;
+}

--- a/crates/fakecloud-parity/tests/sqs.rs
+++ b/crates/fakecloud-parity/tests/sqs.rs
@@ -1,0 +1,88 @@
+mod common;
+
+use common::{unique_name, Backend};
+
+#[tokio::test]
+async fn sqs_create_send_receive_delete() {
+    let backend = Backend::from_env().await;
+    let sqs = backend.sqs().await;
+    let queue_name = unique_name("sqs");
+
+    // Create.
+    let create = sqs
+        .create_queue()
+        .queue_name(&queue_name)
+        .send()
+        .await
+        .expect("create_queue");
+    let queue_url = create.queue_url().expect("queue_url returned").to_string();
+    assert!(
+        queue_url.ends_with(&queue_name),
+        "queue url should end with queue name; got {queue_url}"
+    );
+
+    // GetQueueAttributes sanity: ARN is present and starts with arn:aws:sqs:.
+    let attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .expect("get_queue_attributes");
+    let arn = attrs
+        .attributes()
+        .and_then(|m| m.get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn))
+        .expect("queue arn attribute");
+    assert!(
+        arn.starts_with("arn:aws:sqs:"),
+        "queue arn should start with arn:aws:sqs: ; got {arn}"
+    );
+    assert!(
+        arn.ends_with(&queue_name),
+        "queue arn should end with queue name; got {arn}"
+    );
+
+    // Send -> Receive -> Delete a message.
+    let body = "hello from parity";
+    sqs.send_message()
+        .queue_url(&queue_url)
+        .message_body(body)
+        .send()
+        .await
+        .expect("send_message");
+
+    // Real SQS takes a short moment for the message to become visible.
+    // 20-second long poll is the right primitive for this.
+    let recv = sqs
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(1)
+        .wait_time_seconds(20)
+        .send()
+        .await
+        .expect("receive_message");
+    let messages = recv.messages();
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected 1 message, got {}",
+        messages.len()
+    );
+    let msg = &messages[0];
+    assert_eq!(msg.body().unwrap_or_default(), body);
+
+    let receipt = msg.receipt_handle().expect("receipt_handle").to_string();
+    sqs.delete_message()
+        .queue_url(&queue_url)
+        .receipt_handle(receipt)
+        .send()
+        .await
+        .expect("delete_message");
+
+    // Teardown.
+    sqs.delete_queue()
+        .queue_url(&queue_url)
+        .send()
+        .await
+        .expect("delete_queue");
+}

--- a/crates/fakecloud-parity/tests/sts.rs
+++ b/crates/fakecloud-parity/tests/sts.rs
@@ -1,0 +1,29 @@
+mod common;
+
+use common::Backend;
+
+#[tokio::test]
+async fn sts_get_caller_identity_shape() {
+    let backend = Backend::from_env().await;
+    let sts = backend.sts().await;
+    let id = sts
+        .get_caller_identity()
+        .send()
+        .await
+        .expect("get_caller_identity");
+
+    let account = id.account().expect("account");
+    assert!(
+        account.len() == 12 && account.chars().all(|c| c.is_ascii_digit()),
+        "account should be 12 digits; got {account:?}"
+    );
+
+    let arn = id.arn().expect("arn");
+    assert!(
+        arn.starts_with("arn:aws:"),
+        "arn should start with arn:aws: ; got {arn}"
+    );
+
+    let user_id = id.user_id().expect("user_id");
+    assert!(!user_id.is_empty(), "user_id should not be empty");
+}

--- a/crates/fakecloud-testkit/Cargo.toml
+++ b/crates/fakecloud-testkit/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fakecloud-testkit"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+tokio = { workspace = true }
+reqwest = { workspace = true }
+tempfile = { workspace = true }
+serde_json = { workspace = true }
+aws-config = "1"
+aws-credential-types = "1"
+aws-types = "1"

--- a/crates/fakecloud-testkit/src/lib.rs
+++ b/crates/fakecloud-testkit/src/lib.rs
@@ -1,0 +1,364 @@
+//! Shared harness for spawning a local fakecloud process under test.
+//!
+//! Consumed by `fakecloud-e2e`, `fakecloud-parity`, and any other test crate
+//! that wants a real fakecloud binary on a random port without each crate
+//! rolling its own process-lifecycle code.
+//!
+//! Scope is intentionally narrow: spawn / endpoint / `SdkConfig` / cleanup.
+//! Per-service SDK client factories live in each consumer so this crate
+//! doesn't drag in every `aws-sdk-*` dependency.
+
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::Duration;
+
+use aws_config::BehaviorVersion;
+use aws_credential_types::Credentials;
+use aws_types::region::Region;
+
+/// A test server that spawns fakecloud on a random port.
+pub struct TestServer {
+    child: Option<Child>,
+    port: u16,
+    endpoint: String,
+    container_cli: String,
+    extra_args: Vec<String>,
+    env_vars: Vec<(String, String)>,
+    log_level: String,
+}
+
+impl TestServer {
+    /// Start a new fakecloud server on a random available port.
+    pub async fn start() -> Self {
+        Self::start_with_env(&[]).await
+    }
+
+    /// Start with extra environment variables passed to the server process.
+    pub async fn start_with_env(env: &[(&str, &str)]) -> Self {
+        Self::start_full(env, &[]).await
+    }
+
+    /// Start fakecloud in persistent mode with the given data directory.
+    pub async fn start_persistent(data_path: &Path) -> Self {
+        Self::start_persistent_with_cache(data_path, None).await
+    }
+
+    pub async fn start_persistent_with_cache(data_path: &Path, s3_cache_size: Option<u64>) -> Self {
+        let data_path_str = data_path.display().to_string();
+        let mut args: Vec<String> = vec![
+            "--storage-mode".to_string(),
+            "persistent".to_string(),
+            "--data-path".to_string(),
+            data_path_str,
+        ];
+        if let Some(size) = s3_cache_size {
+            args.push("--s3-cache-size".to_string());
+            args.push(size.to_string());
+        }
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        Self::start_full(&[("FAKECLOUD_CONTAINER_CLI", "false")], &arg_refs).await
+    }
+
+    /// Full form: extra env vars + extra CLI args.
+    pub async fn start_full(env: &[(&str, &str)], extra_args: &[&str]) -> Self {
+        let bin = find_binary();
+
+        let container_cli = env
+            .iter()
+            .find(|(k, _)| *k == "FAKECLOUD_CONTAINER_CLI")
+            .map(|(_, v)| v.to_string())
+            .unwrap_or_else(detect_container_cli);
+
+        let log_level = env
+            .iter()
+            .find(|(k, _)| *k == "FAKECLOUD_TEST_LOG_LEVEL")
+            .map(|(_, v)| v.to_string())
+            .or_else(|| std::env::var("FAKECLOUD_TEST_LOG_LEVEL").ok())
+            .unwrap_or_else(|| "warn".to_string());
+
+        let env_vars: Vec<(String, String)> = env
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        let extra_args_owned: Vec<String> = extra_args.iter().map(|s| (*s).to_string()).collect();
+
+        for _ in 0..3 {
+            let port = find_available_port();
+            let endpoint = format!("http://127.0.0.1:{port}");
+
+            let mut cmd = Command::new(&bin);
+            cmd.arg("--addr")
+                .arg(format!("0.0.0.0:{port}"))
+                .arg("--log-level")
+                .arg(&log_level)
+                .args(&extra_args_owned)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+
+            for (key, value) in &env_vars {
+                cmd.env(key, value);
+            }
+
+            let mut child = cmd.spawn().expect("failed to start fakecloud");
+
+            if wait_for_port(&mut child, port).await {
+                return Self {
+                    child: Some(child),
+                    port,
+                    endpoint,
+                    container_cli,
+                    extra_args: extra_args_owned,
+                    env_vars,
+                    log_level,
+                };
+            }
+
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+
+        panic!("fakecloud failed to start after 3 attempts");
+    }
+
+    /// Kill the current child and respawn with the same extra args/env.
+    /// Allocates a new port because the previous one may still be in TIME_WAIT.
+    pub async fn restart(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        let bin = find_binary();
+        for _ in 0..5 {
+            let port = find_available_port();
+            let endpoint = format!("http://127.0.0.1:{port}");
+            let mut cmd = Command::new(&bin);
+            cmd.arg("--addr")
+                .arg(format!("0.0.0.0:{port}"))
+                .arg("--log-level")
+                .arg(&self.log_level)
+                .args(&self.extra_args)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            for (key, value) in &self.env_vars {
+                cmd.env(key, value);
+            }
+            let mut child = cmd.spawn().expect("failed to respawn fakecloud");
+            if wait_for_port(&mut child, port).await {
+                self.child = Some(child);
+                self.port = port;
+                self.endpoint = endpoint;
+                return;
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        panic!("fakecloud failed to restart");
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Create a shared AWS SDK config pointing at this test server.
+    pub async fn aws_config(&self) -> aws_config::SdkConfig {
+        aws_config::defaults(BehaviorVersion::latest())
+            .endpoint_url(self.endpoint())
+            .region(Region::new("us-east-1"))
+            .credentials_provider(Credentials::new(
+                "AKIAIOSFODNN7EXAMPLE",
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                None,
+                None,
+                "test",
+            ))
+            .load()
+            .await
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let pid = child.id();
+            let _ = child.kill();
+            let _ = child.wait();
+
+            // Clean up any Lambda containers spawned by this server instance.
+            let label = format!("fakecloud-instance=fakecloud-{}", pid);
+            let cli = &self.container_cli;
+            let output = Command::new(cli)
+                .args(["ps", "-aq", "--filter", &format!("label={}", label)])
+                .output();
+            if let Ok(output) = output {
+                let ids = String::from_utf8_lossy(&output.stdout);
+                for id in ids.split_whitespace() {
+                    let _ = Command::new(cli)
+                        .args(["rm", "-f", id])
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .status();
+                }
+            }
+        }
+    }
+}
+
+/// Run fakecloud once and collect its exit status + stderr output.
+/// For tests that deliberately cause the server to fail at boot.
+pub fn run_until_exit(
+    extra_args: &[&str],
+    env: &[(&str, &str)],
+    timeout: Duration,
+) -> (std::process::ExitStatus, String) {
+    let bin = find_binary();
+    let port = find_available_port();
+    let mut cmd = Command::new(&bin);
+    cmd.arg("--addr")
+        .arg(format!("127.0.0.1:{port}"))
+        .arg("--log-level")
+        .arg("warn")
+        .args(extra_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("failed to spawn fakecloud");
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("try_wait") {
+            let output = child.wait_with_output().expect("wait_with_output");
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return (status, stderr);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let output = child.wait_with_output().expect("wait_with_output");
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return (output.status, stderr);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+pub fn data_path_for(dir: &tempfile::TempDir) -> PathBuf {
+    dir.path().to_path_buf()
+}
+
+/// Generate a unique, prefixed resource name for parity-style tests.
+///
+/// Every name starts with `fcparity-` so a sweep tool can safely reap
+/// leftovers by prefix if a test crashes before cleanup runs.
+pub fn unique_name(prefix: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("fcparity-{prefix}-{ts}-{seq:06}")
+}
+
+/// Output from an `aws` CLI invocation. Kept here so consumers that want to
+/// run `aws ...` against the test server don't have to reimplement it.
+pub struct CliOutput(pub Output);
+
+impl CliOutput {
+    pub fn success(&self) -> bool {
+        self.0.status.success()
+    }
+
+    pub fn stdout_text(&self) -> String {
+        String::from_utf8_lossy(&self.0.stdout).to_string()
+    }
+
+    pub fn stderr_text(&self) -> String {
+        String::from_utf8_lossy(&self.0.stderr).to_string()
+    }
+
+    pub fn stdout_json(&self) -> serde_json::Value {
+        serde_json::from_slice(&self.0.stdout).unwrap_or(serde_json::Value::Null)
+    }
+}
+
+fn find_available_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind to random port");
+    listener.local_addr().unwrap().port()
+}
+
+fn find_binary() -> String {
+    // testkit lives at crates/fakecloud-testkit, and every consumer crate
+    // also lives at crates/<name>, so ../../target is the workspace target.
+    let debug_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/debug/fakecloud");
+    let release_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../target/release/fakecloud"
+    );
+
+    if std::path::Path::new(debug_path).exists() {
+        return debug_path.to_string();
+    }
+    if std::path::Path::new(release_path).exists() {
+        return release_path.to_string();
+    }
+
+    panic!(
+        "fakecloud binary not found. Run `cargo build --bin fakecloud` first.\n\
+         Looked in:\n  {debug_path}\n  {release_path}"
+    );
+}
+
+fn detect_container_cli() -> String {
+    if cli_available("docker") {
+        "docker".to_string()
+    } else if cli_available("podman") {
+        "podman".to_string()
+    } else {
+        "docker".to_string()
+    }
+}
+
+fn cli_available(cli: &str) -> bool {
+    Command::new(cli)
+        .arg("info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+async fn wait_for_port(child: &mut Child, port: u16) -> bool {
+    // Two-stage readiness: (1) TCP connect succeeds, (2) an HTTP request
+    // actually reaches an axum handler. A bare TCP connect only proves
+    // the kernel accepted SYNs into fakecloud's listen queue -- it does
+    // not prove axum has reached `serve().await` and installed request
+    // handlers. Tests that hit the server immediately after a bare TCP
+    // connect occasionally saw ConnectionRefused / EOF mid-flight.
+    let loopback = format!("127.0.0.1:{port}");
+    let wildcard = format!("0.0.0.0:{port}");
+    let health_url = format!("http://127.0.0.1:{port}/");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(500))
+        .build()
+        .expect("build reqwest client");
+
+    for _ in 0..300 {
+        if child.try_wait().ok().flatten().is_some() {
+            return false;
+        }
+        let tcp_ok = std::net::TcpStream::connect(&loopback).is_ok()
+            || std::net::TcpStream::connect(&wildcard).is_ok();
+        if tcp_ok && client.get(&health_url).send().await.is_ok() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}


### PR DESCRIPTION
## Summary

Adds `fakecloud-parity`, a new opt-in test crate that runs the same SDK-level tests against either a local fakecloud process or a real AWS account, selected at runtime via `FAKECLOUD_PARITY_BACKEND`. The parity signal comes from comparing pass/fail status across two CI jobs — not from diffing responses inside the tests.

- ✅ fakecloud passes, ✅ AWS passes -> good.
- ❌ fakecloud fails, ✅ AWS passes -> fakecloud bug. Fix fakecloud.
- ✅ fakecloud passes, ❌ AWS fails -> test bug (assumed something wrong about AWS).
- ❌ both fail -> test bug.

## What's in this PR

- **New `fakecloud-testkit` crate** — extracts the `TestServer` harness previously duplicated in `fakecloud-e2e/tests/helpers/` so fakecloud-e2e and fakecloud-parity share a single process-lifecycle implementation. `fakecloud-e2e`'s helpers become a thin newtype wrapper adding per-service SDK client factories; existing e2e tests are unchanged.
- **New `fakecloud-parity` crate** — Batch 1 coverage: SQS, SNS→SQS, S3, DynamoDB, KMS, Secrets Manager, STS. All resources are prefixed `fcparity-` and tests tear themselves down.
- **`.github/workflows/parity-fakecloud.yml`** — runs the suite against local fakecloud on every PR touching the parity/testkit crates. No credentials, safe to run on PRs.
- **`.github/workflows/parity-aws.yml`** — runs the same suite against real AWS on a nightly schedule. See SECURITY NOTES below.
- **`.github/CODEOWNERS`** — pins ownership on both workflow files, the parity/testkit crates, and CODEOWNERS itself.

## Security model for the real-AWS job

Four layers, all of which must hold:

1. **No `pull_request` trigger on `parity-aws.yml`.** Contributors physically cannot cause the real-AWS job to execute by opening a PR. Only `schedule` and `workflow_dispatch`.
2. **CODEOWNERS.** The workflow files, `fakecloud-parity/`, `fakecloud-testkit/`, and `.github/CODEOWNERS` itself are all owned by @vieiralucas. Combined with \"Require review from Code Owners\" on `main`, no contributor can modify these paths without an explicit owner review. The CODEOWNERS self-ownership line means a PR can't strip the other rules in the same commit.
3. **Protected GitHub Environment (`aws-parity`) with required reviewer.** Even on a scheduled run after a merge, GitHub pauses the job and waits for a human click before any step runs against AWS.
4. **Gated on `vars.AWS_PARITY_ROLE_ARN`.** Until the sandbox account exists and the repo variable is populated, the job is a no-op.

OIDC (not static keys) is used via `aws-actions/configure-aws-credentials@v4`. The assumed role's IAM policy is where blast-radius is actually controlled — keep it scoped to `fcparity-*` resource prefixes.

## Action items for @vieiralucas before the real-AWS job can run

None of these block merging this PR — the workflow is a no-op until all three are done.

1. **Create a dedicated AWS sandbox account.** Nothing here should ever touch a production account.
2. **Create an IAM role in that account with a GitHub OIDC trust policy** scoped to this repo + the `aws-parity` environment. Minimum-scope permissions for the Batch 1 services (SQS full, SNS full, S3 on `fcparity-*` buckets, DynamoDB on `fcparity-*` tables, KMS create/encrypt/decrypt/schedule-deletion, Secrets Manager on `fcparity-*`, STS GetCallerIdentity). Resource-name conditions on `fcparity-*` mean a compromised role still can't touch non-parity resources.
3. **Create the `aws-parity` GitHub Environment** in repo settings, add yourself as a required reviewer, then set repo variable `AWS_PARITY_ROLE_ARN` to the role ARN from step 2.
4. **Confirm branch protection on `main` has \"Require review from Code Owners\" enabled.** Without this, CODEOWNERS is advisory.

Once those are done, the next scheduled tick (07:00 UTC) will pause for your approval in the Environment UI, and — if you click approve — run all seven parity tests against the sandbox account.

## Test plan

- [x] `cargo build --bin fakecloud`
- [x] `cargo test -p fakecloud-parity` — all 7 tests pass against local fakecloud
- [x] `cargo test -p fakecloud-e2e --test smoke --test sqs --test sns --test s3` — existing e2e tests still pass after testkit migration
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [ ] CI `Parity (fakecloud)` job runs green
- [ ] CI `Parity (real AWS)` job correctly skips on PRs (should not appear in the check list at all)
- [ ] (Follow-up, after action items above) first real-AWS run completes green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the same SDK tests against local fakecloud or real AWS to spot behavior drift early. Adds a shared test harness and CI jobs to run both backends safely.

- **New Features**
  - `fakecloud-parity` runs tests against `fakecloud` or AWS via `FAKECLOUD_PARITY_BACKEND` (default `fakecloud`). Coverage: SQS, SNS->SQS, S3, DynamoDB, KMS, Secrets Manager, STS. Resources use `fcparity-*` and tests clean up.
  - `fakecloud-testkit` centralizes the `TestServer` harness; `fakecloud-e2e` wraps it with per-service clients. No changes to existing e2e tests.
  - CI: `.github/workflows/parity-fakecloud.yml` runs on PRs; `.github/workflows/parity-aws.yml` runs nightly with OIDC and `aws-parity` env approval, gated by `vars.AWS_PARITY_ROLE_ARN`. Workspace `ci.yml` excludes `fakecloud-parity` from the default test job to avoid requiring the built `fakecloud` binary.
  - Security: `.github/CODEOWNERS` protects both workflows, the new crates, and itself.

- **Migration**
  - Create a sandbox AWS account and an OIDC role scoped to `fcparity-*`; set repo var `AWS_PARITY_ROLE_ARN`.
  - Add the `aws-parity` GitHub Environment with a required reviewer.
  - Ensure `main` requires Code Owner review.

<sup>Written for commit c4f107613141c967c00cca4f1e146586bf9411fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

