### PR TITLE
feat(tfacc): enable bedrock with foundation models data source

### DIFF
--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -37,6 +37,17 @@ pub struct Service {
 
 pub const SERVICES: &[Service] = &[
     Service {
+        name: "bedrock",
+        // Batch 10: `data.aws_bedrock_foundation_models` data source
+        // smoke. fakecloud's Bedrock implementation already returns the
+        // expected ListFoundationModels shape, so this passes out of
+        // the box. Resource tests (model invocation, guardrails) need
+        // the Bedrock runtime container path to be plumbed through TF
+        // and are deferred to a later batch.
+        run_regex: "^TestAccBedrockFoundationModelsDataSource_basic$",
+        deny: &[],
+    },
+    Service {
         name: "apigatewayv2",
         // Batch 9: core `aws_apigatewayv2_api` (HTTP) smoke. The fix
         // here is making CreateApi return four metadata fields that

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -28,6 +28,11 @@ async fn run_service(name: &str) {
 }
 
 #[tokio::test]
+async fn bedrock_acceptance() {
+    run_service("bedrock").await;
+}
+
+#[tokio::test]
 async fn apigatewayv2_acceptance() {
     run_service("apigatewayv2").await;
 }


### PR DESCRIPTION
## Summary

Batch 10 — adds Bedrock to the upstream Terraform acceptance harness.

\`TestAccBedrockFoundationModelsDataSource_basic\` passes against fakecloud out of the box. fakecloud's Bedrock implementation already returns the expected \`ListFoundationModels\` shape.

### Triaged but deferred

Several other services were triaged in this batch but each needs substantive fakecloud-side work bigger than a single-batch budget:

- **SES v2** — \`TestAccSESV2EmailIdentity_basic_emailAddress\` needs the verification flow rewired so new identities default to unverified (real AWS doesn't auto-verify email addresses), plus \`current_signing_key_length\` empty by default and \`tokens\` empty for email-address identities. Existing fakecloud e2e tests assume auto-verify, so fixing this needs both the impl change and updates to the e2e suite.
- **CloudFormation** — needs \`AWS::EC2::VPC\` resource type in the CFN provisioner.
- **Cognito** — needs ~5 schema blocks populated on \`DescribeUserPool\`.
- **RDS** — needs \`DescribeOrderableDBInstanceOptions\`.
- **Lambda** — needs EC2 \`DescribeAvailabilityZones\`.
- **Step Functions** — depends on Lambda; \`SFNActivity\` needs \`CreateActivity\`.
- **S3** — needs many fields populated (\`bucket_regional_domain_name\`, \`hosted_zone_id\`, \`region\`, etc).

Each gets its own batch as the underlying gaps close.

## Test plan

- [x] Upstream locally: \`TestAccBedrockFoundationModelsDataSource_basic\` passes (~6s)
- [x] \`cargo clippy -p fakecloud-tfacc --all-targets -- -D warnings\` clean
- [ ] CI \`tfacc bedrock\` green
- [ ] All other tfacc jobs still green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Bedrock acceptance in `fakecloud-tfacc` by running the `data.aws_bedrock_foundation_models` data source test against fakecloud. This adds the `bedrock` service to the allowlist and a test; `ListFoundationModels` is already supported, so the smoke test passes.

- New Features
  - Allowlist `bedrock` with regex `^TestAccBedrockFoundationModelsDataSource_basic$`.
  - Add `bedrock_acceptance` test to run the service in the tfacc harness.

<sup>Written for commit ece004e16d9922f6ac819b68c98d9c9d13142a13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

