### PR TITLE
feat(dynamodb): implement deletion_protection_enabled

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -692,6 +692,8 @@ impl ResourceProvisioner {
             stream_records: Arc::new(RwLock::new(Vec::new())),
             sse_type: None,
             sse_kms_key_arn: None,
+
+            deletion_protection_enabled: false,
         };
 
         state.tables.insert(table_name.to_string(), table);

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -647,6 +647,11 @@ impl ResourceProvisioner {
                 (false, None)
             };
 
+        let deletion_protection_enabled = props
+            .get("DeletionProtectionEnabled")
+            .and_then(|v| v.as_bool().or_else(|| v.as_str().map(|s| s == "true")))
+            .unwrap_or(false);
+
         let mut state = self.dynamodb_state.write();
         let arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}",
@@ -692,8 +697,7 @@ impl ResourceProvisioner {
             stream_records: Arc::new(RwLock::new(Vec::new())),
             sse_type: None,
             sse_kms_key_arn: None,
-
-            deletion_protection_enabled: false,
+            deletion_protection_enabled,
         };
 
         state.tables.insert(table_name.to_string(), table);

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -1979,6 +1979,7 @@ pub(super) struct TableDescriptionInput<'a> {
     pub item_count: i64,
     pub size_bytes: i64,
     pub status: &'a str,
+    pub deletion_protection_enabled: bool,
 }
 
 fn build_table_description_json(input: &TableDescriptionInput<'_>) -> Value {
@@ -1995,6 +1996,7 @@ fn build_table_description_json(input: &TableDescriptionInput<'_>) -> Value {
         item_count,
         size_bytes,
         status,
+        deletion_protection_enabled,
     } = *input;
     let table_name = arn.rsplit('/').next().unwrap_or("");
     let creation_timestamp =
@@ -2021,6 +2023,7 @@ fn build_table_description_json(input: &TableDescriptionInput<'_>) -> Value {
         "ItemCount": item_count,
         "TableSizeBytes": size_bytes,
         "BillingModeSummary": { "BillingMode": billing_mode },
+        "DeletionProtectionEnabled": deletion_protection_enabled,
     });
 
     if billing_mode != "PAY_PER_REQUEST" {
@@ -2126,6 +2129,7 @@ fn build_table_description(table: &DynamoTable) -> Value {
         item_count: table.item_count,
         size_bytes: table.size_bytes,
         status: &table.status,
+        deletion_protection_enabled: table.deletion_protection_enabled,
     });
 
     // Add stream specification if streams are enabled

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -38,6 +38,14 @@ impl DynamoDbService {
         let key_schema = parse_key_schema(&body["KeySchema"])?;
         let attribute_definitions = parse_attribute_definitions(&body["AttributeDefinitions"])?;
 
+        if key_schema.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "KeySchema must contain at least one element",
+            ));
+        }
+
         // Validate that key schema attributes are defined
         for ks in &key_schema {
             if !attribute_definitions
@@ -99,6 +107,11 @@ impl DynamoDbService {
             } else {
                 (false, None)
             };
+
+        let deletion_protection_enabled = body
+            .get("DeletionProtectionEnabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         // Parse SSESpecification
         let (sse_type, sse_kms_key_arn) = if let Some(sse_spec) = body.get("SSESpecification") {
@@ -180,6 +193,7 @@ impl DynamoDbService {
             stream_records: Arc::new(RwLock::new(Vec::new())),
             sse_type,
             sse_kms_key_arn,
+            deletion_protection_enabled,
         };
 
         let table_id = table.table_id.clone();
@@ -198,6 +212,7 @@ impl DynamoDbService {
             item_count: 0,
             size_bytes: 0,
             status: "ACTIVE",
+            deletion_protection_enabled,
         });
 
         Self::ok_json(json!({ "TableDescription": table_desc }))
@@ -208,6 +223,21 @@ impl DynamoDbService {
         let table_name = require_str(&body, "TableName")?;
 
         let mut state = self.state.write();
+        // Refuse if deletion protection is enabled (real AWS returns
+        // ResourceInUseException with this message).
+        if state
+            .tables
+            .get(table_name)
+            .is_some_and(|t| t.deletion_protection_enabled)
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceInUseException",
+                format!(
+                    "Table '{table_name}' can't be deleted while DeletionProtection is enabled"
+                ),
+            ));
+        }
         let table = state.tables.remove(table_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -229,6 +259,7 @@ impl DynamoDbService {
             item_count: table.item_count,
             size_bytes: table.size_bytes,
             status: "DELETING",
+            deletion_protection_enabled: table.deletion_protection_enabled,
         });
 
         Self::ok_json(json!({ "TableDescription": table_desc }))
@@ -315,6 +346,13 @@ impl DynamoDbService {
             table.billing_mode = bm.to_string();
         }
 
+        if let Some(dpe) = body
+            .get("DeletionProtectionEnabled")
+            .and_then(|v| v.as_bool())
+        {
+            table.deletion_protection_enabled = dpe;
+        }
+
         // Handle SSESpecification update
         if let Some(sse_spec) = body.get("SSESpecification") {
             let enabled = sse_spec
@@ -352,6 +390,7 @@ impl DynamoDbService {
             item_count: table.item_count,
             size_bytes: table.size_bytes,
             status: &table.status,
+            deletion_protection_enabled: table.deletion_protection_enabled,
         });
 
         Self::ok_json(json!({ "TableDescription": table_desc }))
@@ -780,6 +819,8 @@ impl DynamoDbService {
             stream_records: Arc::new(RwLock::new(Vec::new())),
             sse_type: None,
             sse_kms_key_arn: None,
+
+            deletion_protection_enabled: false,
         };
         table.recalculate_stats();
 
@@ -858,6 +899,8 @@ impl DynamoDbService {
             stream_records: Arc::new(RwLock::new(Vec::new())),
             sse_type: None,
             sse_kms_key_arn: None,
+
+            deletion_protection_enabled: false,
         };
         table.recalculate_stats();
 
@@ -1322,6 +1365,8 @@ impl DynamoDbService {
             stream_records: Arc::new(RwLock::new(Vec::new())),
             sse_type: None,
             sse_kms_key_arn: None,
+
+            deletion_protection_enabled: false,
         };
         table.recalculate_stats();
         state.tables.insert(table_name.to_string(), table);

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -96,6 +96,10 @@ pub struct DynamoTable {
     pub sse_type: Option<String>,
     /// KMS key ARN for SSE (only when sse_type is KMS)
     pub sse_kms_key_arn: Option<String>,
+    /// Deletion protection: when true, DeleteTable is rejected with
+    /// `ResourceInUseException`. Defaults to false. Returned on every
+    /// `DescribeTable` and toggleable via `UpdateTable`.
+    pub deletion_protection_enabled: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -120,6 +120,8 @@ mod tests {
             stream_records: Arc::new(RwLock::new(Vec::new())),
             sse_type: None,
             sse_kms_key_arn: None,
+
+            deletion_protection_enabled: false,
         }
     }
 

--- a/crates/fakecloud-dynamodb/src/ttl.rs
+++ b/crates/fakecloud-dynamodb/src/ttl.rs
@@ -109,6 +109,8 @@ mod tests {
             stream_records: Arc::new(RwLock::new(Vec::new())),
             sse_type: None,
             sse_kms_key_arn: None,
+
+            deletion_protection_enabled: false,
         }
     }
 

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -2598,3 +2598,65 @@ async fn dynamodb_kinesis_streaming_delivers_records() {
     assert_eq!(remove_event["eventName"], "REMOVE");
     assert!(remove_event["dynamodb"]["OldImage"].is_object());
 }
+
+#[tokio::test]
+async fn dynamodb_deletion_protection_blocks_delete_table() {
+    // Regression guard for `TestAccDynamoDBTable_deletion_protection`:
+    // CreateTable accepts `DeletionProtectionEnabled`, DescribeTable
+    // returns it, UpdateTable can toggle it, and DeleteTable refuses
+    // with `ResourceInUseException` while it's enabled.
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("Protected")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .deletion_protection_enabled(true)
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_table()
+        .table_name("Protected")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        desc.table().unwrap().deletion_protection_enabled(),
+        Some(true)
+    );
+
+    let err = client.delete_table().table_name("Protected").send().await;
+    assert!(err.is_err(), "DeleteTable should refuse while protected");
+
+    // Disable protection via UpdateTable; delete now succeeds.
+    client
+        .update_table()
+        .table_name("Protected")
+        .deletion_protection_enabled(false)
+        .send()
+        .await
+        .unwrap();
+    client
+        .delete_table()
+        .table_name("Protected")
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -205,8 +205,6 @@ pub const SERVICES: &[Service] = &[
             "TestAccDynamoDBTable_Disappears_payPerRequestWithGSI",
             // --- gap: GSI capacity update ---
             "TestAccDynamoDBTable_gsiUpdateCapacity",
-            // --- gap: deletion_protection attribute not yet implemented ---
-            "TestAccDynamoDBTable_deletion_protection",
             // --- gap: encryption attribute round-trip ---
             "TestAccDynamoDBTable_encryption",
             // --- hung: did not complete in triage run; revisit in a later batch ---


### PR DESCRIPTION
## Summary

Batch 11 — first batch driving the DynamoDB tfacc deny-list down. Implements \`deletion_protection_enabled\`.

Real AWS DynamoDB lets you mark a table as deletion-protected via \`CreateTable\` and \`UpdateTable\`, and rejects \`DeleteTable\` while the flag is set with \`ResourceInUseException\`. fakecloud was ignoring the attribute entirely — DescribeTable returned nothing, so Terraform's \`aws_dynamodb_table\` provider saw drift on every refresh and the upstream \`TestAccDynamoDBTable_deletion_protection\` test failed.

- \`DynamoTable\` state struct gains \`deletion_protection_enabled\`
- \`CreateTable\` parses \`DeletionProtectionEnabled\` from the request
- \`UpdateTable\` can toggle it
- \`DescribeTable\` always returns it
- \`DeleteTable\` refuses with \`ResourceInUseException\` while it's enabled

Removes \`TestAccDynamoDBTable_deletion_protection\` from the tfacc deny-list. First entry to be driven from the deny-list to zero — the harness is now closing its own gaps.

## Test plan

- [x] New e2e test \`dynamodb_deletion_protection_blocks_delete_table\` covers the full lifecycle (create → describe → delete denied → update → delete allowed) — passes
- [x] \`cargo test -p fakecloud-dynamodb\` clean (93 unit tests)
- [x] \`cargo clippy -p fakecloud-dynamodb -p fakecloud-tfacc -p fakecloud-e2e -p fakecloud-cloudformation --all-targets -- -D warnings\` clean
- [x] Upstream locally: \`TestAccDynamoDBTable_deletion_protection\` passes (~14s)
- [ ] CI \`tfacc dynamodb\` green with the wider allow-list
- [ ] Other tfacc jobs still green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add DynamoDB table deletion protection and enforce it on delete to match AWS behavior. `DescribeTable` now returns the flag to prevent Terraform drift; CloudFormation now honors `DeletionProtectionEnabled`.

- **New Features**
  - Support `DeletionProtectionEnabled` on `CreateTable`, `UpdateTable`, and `DescribeTable`.
  - Reject `DeleteTable` with `ResourceInUseException` when protection is enabled.
  - Persist `deletion_protection_enabled` in `DynamoTable` (default false); add an e2e lifecycle test and enable `TestAccDynamoDBTable_deletion_protection` in `tfacc`.

- **Bug Fixes**
  - Validate non-empty `KeySchema` on `CreateTable` and return `ValidationException`.
  - CloudFormation: honor `DeletionProtectionEnabled` for `AWS::DynamoDB::Table` (accepts bool or string) instead of defaulting to false.

<sup>Written for commit 17e2e43eb60958404461de5c17356a44dbb87bf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

