### PR TITLE
ci(parity): run real-aws weekly instead of nightly

### DIFF
--- a/.github/workflows/parity-aws.yml
+++ b/.github/workflows/parity-aws.yml
@@ -30,8 +30,9 @@ name: Parity (real AWS)
 
 on:
   schedule:
-    # 07:00 UTC daily. Low-traffic hour, lets us notice drift within 24h.
-    - cron: '0 7 * * *'
+    # 07:00 UTC every Monday. Weekly is enough to catch drift between
+    # fakecloud and real AWS; daily would be noise for these services.
+    - cron: '0 7 * * 1'
   workflow_dispatch:
   # Deliberately no `pull_request` trigger. See SECURITY NOTES above.
 


### PR DESCRIPTION
## Summary

Changes the `parity-aws.yml` cron from `0 7 * * *` (daily) to `0 7 * * 1` (Mondays 07:00 UTC).

Once a week is enough to catch drift between fakecloud and real AWS for the Batch 1 services — daily was going to produce an approval-gate click every 24h without proportional signal.

## Test plan

- [x] Cron expression is valid (Monday = day-of-week 1)
- [ ] CI passes (nothing else in the workflow changed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the real AWS parity workflow weekly instead of daily to reduce approval noise while still catching drift between fakecloud and AWS for Batch 1 services. Schedule: Mondays at 07:00 UTC (`0 7 * * 1`).

<sup>Written for commit 062ae6fab13e6734ed133092fbb8c98f385691ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

