### PR TITLE
test(parity): add error-case and edge-semantics coverage

### DIFF
--- a/crates/fakecloud-parity/tests/dynamodb.rs
+++ b/crates/fakecloud-parity/tests/dynamodb.rs
@@ -87,3 +87,136 @@ async fn dynamodb_create_put_get_delete() {
         .await
         .expect("delete_table");
 }
+
+#[tokio::test]
+async fn dynamodb_query_and_conditional_put() {
+    let backend = Backend::from_env().await;
+    let ddb = backend.dynamodb().await;
+    let table = unique_name("ddb-query");
+
+    // Composite key: hash "pk", range "sk".
+    ddb.create_table()
+        .table_name(&table)
+        .billing_mode(BillingMode::PayPerRequest)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("sk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("sk")
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create_table");
+
+    retry(60, 1000, || async {
+        let desc = ddb
+            .describe_table()
+            .table_name(&table)
+            .send()
+            .await
+            .map_err(|e| format!("describe_table: {e}"))?;
+        let status = desc
+            .table()
+            .and_then(|t| t.table_status())
+            .cloned()
+            .ok_or_else(|| "no table_status".to_string())?;
+        if status == TableStatus::Active {
+            Ok(())
+        } else {
+            Err(format!("table status = {status:?}"))
+        }
+    })
+    .await
+    .expect("table did not become ACTIVE");
+
+    // Insert three rows in the same partition, different sort keys.
+    for sk in ["001", "002", "003"] {
+        ddb.put_item()
+            .table_name(&table)
+            .item("pk", AttributeValue::S("user-1".into()))
+            .item("sk", AttributeValue::S(sk.into()))
+            .send()
+            .await
+            .expect("put_item");
+    }
+
+    // Query the partition.
+    let query = ddb
+        .query()
+        .table_name(&table)
+        .key_condition_expression("pk = :pk")
+        .expression_attribute_values(":pk", AttributeValue::S("user-1".into()))
+        .send()
+        .await
+        .expect("query");
+    let items = query.items();
+    assert_eq!(items.len(), 3, "expected 3 rows, got {}", items.len());
+    // Default sort order is ascending on sk.
+    let sks: Vec<String> = items
+        .iter()
+        .filter_map(|i| i.get("sk").and_then(|v| v.as_s().ok()).cloned())
+        .collect();
+    assert_eq!(
+        sks,
+        vec!["001".to_string(), "002".to_string(), "003".to_string()]
+    );
+
+    // Conditional put: attribute_not_exists(pk) should succeed for a new
+    // row and fail with ConditionalCheckFailedException for an existing one.
+    ddb.put_item()
+        .table_name(&table)
+        .item("pk", AttributeValue::S("user-2".into()))
+        .item("sk", AttributeValue::S("001".into()))
+        .condition_expression("attribute_not_exists(pk)")
+        .send()
+        .await
+        .expect("conditional put first time");
+
+    let err = ddb
+        .put_item()
+        .table_name(&table)
+        .item("pk", AttributeValue::S("user-1".into()))
+        .item("sk", AttributeValue::S("001".into()))
+        .condition_expression("attribute_not_exists(pk)")
+        .send()
+        .await
+        .expect_err("conditional put should fail second time");
+    let code = err
+        .into_service_error()
+        .meta()
+        .code()
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(
+        code, "ConditionalCheckFailedException",
+        "expected ConditionalCheckFailedException, got {code:?}"
+    );
+
+    ddb.delete_table()
+        .table_name(&table)
+        .send()
+        .await
+        .expect("delete_table");
+}

--- a/crates/fakecloud-parity/tests/kms.rs
+++ b/crates/fakecloud-parity/tests/kms.rs
@@ -58,3 +58,64 @@ async fn kms_encrypt_decrypt_roundtrip() {
         .send()
         .await;
 }
+
+#[tokio::test]
+async fn kms_generate_data_key_roundtrip() {
+    let backend = Backend::from_env().await;
+    let kms = backend.kms().await;
+
+    let key = kms
+        .create_key()
+        .description("fcparity data-key test")
+        .send()
+        .await
+        .expect("create_key");
+    let key_id = key
+        .key_metadata()
+        .expect("key_metadata")
+        .key_id()
+        .to_string();
+
+    // Ask KMS for a 256-bit data key. We get back both the plaintext and
+    // an opaque ciphertext blob. Decrypting the blob should return the
+    // same plaintext bytes.
+    let dk = kms
+        .generate_data_key()
+        .key_id(&key_id)
+        .key_spec(aws_sdk_kms::types::DataKeySpec::Aes256)
+        .send()
+        .await
+        .expect("generate_data_key");
+    let plaintext = dk.plaintext().expect("plaintext").clone();
+    let ciphertext = dk.ciphertext_blob().expect("ciphertext_blob").clone();
+    assert_eq!(
+        plaintext.as_ref().len(),
+        32,
+        "AES-256 data key should be 32 bytes"
+    );
+    assert_ne!(
+        plaintext.as_ref(),
+        ciphertext.as_ref(),
+        "plaintext and ciphertext should differ"
+    );
+
+    let dec = kms
+        .decrypt()
+        .ciphertext_blob(ciphertext)
+        .key_id(&key_id)
+        .send()
+        .await
+        .expect("decrypt");
+    assert_eq!(
+        dec.plaintext().expect("decrypted plaintext").as_ref(),
+        plaintext.as_ref(),
+        "decrypted data key should match the original plaintext"
+    );
+
+    let _ = kms
+        .schedule_key_deletion()
+        .key_id(key_id)
+        .pending_window_in_days(7)
+        .send()
+        .await;
+}

--- a/crates/fakecloud-parity/tests/s3.rs
+++ b/crates/fakecloud-parity/tests/s3.rs
@@ -81,3 +81,137 @@ async fn s3_put_get_head_list_delete() {
         .await
         .expect("delete_bucket");
 }
+
+#[tokio::test]
+async fn s3_get_object_nonexistent_returns_expected_error() {
+    let backend = Backend::from_env().await;
+    let s3 = backend.s3().await;
+    let bucket = unique_name("s3-missing").to_lowercase().replace('_', "-");
+
+    s3.create_bucket()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("create_bucket");
+
+    let err = s3
+        .get_object()
+        .bucket(&bucket)
+        .key("does-not-exist")
+        .send()
+        .await
+        .expect_err("get_object on missing key should fail");
+    let code = err
+        .into_service_error()
+        .meta()
+        .code()
+        .unwrap_or_default()
+        .to_string();
+    assert!(code == "NoSuchKey", "expected NoSuchKey, got code={code:?}");
+
+    s3.delete_bucket()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("delete_bucket");
+}
+
+#[tokio::test]
+async fn s3_multipart_upload_roundtrip() {
+    let backend = Backend::from_env().await;
+    let s3 = backend.s3().await;
+    let bucket = unique_name("s3-mpu").to_lowercase().replace('_', "-");
+    let key = "multipart/object.bin";
+
+    s3.create_bucket()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("create_bucket");
+
+    // 5 MiB is the minimum non-final part size on real S3. Use two parts
+    // of 5 MiB + one 1 KiB tail, so we exercise the "last part can be
+    // smaller" semantics.
+    let part1: Vec<u8> = vec![0xAA; 5 * 1024 * 1024];
+    let part2: Vec<u8> = vec![0xBB; 5 * 1024 * 1024];
+    let tail: Vec<u8> = vec![0xCC; 1024];
+
+    let init = s3
+        .create_multipart_upload()
+        .bucket(&bucket)
+        .key(key)
+        .send()
+        .await
+        .expect("create_multipart_upload");
+    let upload_id = init.upload_id().expect("upload_id").to_string();
+
+    let mut completed_parts = Vec::new();
+    for (i, chunk) in [part1.clone(), part2.clone(), tail.clone()]
+        .iter()
+        .enumerate()
+    {
+        let part_number = (i as i32) + 1;
+        let resp = s3
+            .upload_part()
+            .bucket(&bucket)
+            .key(key)
+            .upload_id(&upload_id)
+            .part_number(part_number)
+            .body(ByteStream::from(chunk.clone()))
+            .send()
+            .await
+            .expect("upload_part");
+        completed_parts.push(
+            aws_sdk_s3::types::CompletedPart::builder()
+                .part_number(part_number)
+                .e_tag(resp.e_tag().unwrap_or_default())
+                .build(),
+        );
+    }
+
+    s3.complete_multipart_upload()
+        .bucket(&bucket)
+        .key(key)
+        .upload_id(&upload_id)
+        .multipart_upload(
+            aws_sdk_s3::types::CompletedMultipartUpload::builder()
+                .set_parts(Some(completed_parts))
+                .build(),
+        )
+        .send()
+        .await
+        .expect("complete_multipart_upload");
+
+    // Round-trip: read the object back and assert full byte equality.
+    let got = s3
+        .get_object()
+        .bucket(&bucket)
+        .key(key)
+        .send()
+        .await
+        .expect("get_object");
+    let body = got.body.collect().await.expect("collect body").into_bytes();
+
+    let mut expected = Vec::with_capacity(part1.len() + part2.len() + tail.len());
+    expected.extend_from_slice(&part1);
+    expected.extend_from_slice(&part2);
+    expected.extend_from_slice(&tail);
+    assert_eq!(
+        body.len(),
+        expected.len(),
+        "multipart object length mismatch"
+    );
+    assert_eq!(body.as_ref(), expected.as_slice());
+
+    s3.delete_object()
+        .bucket(&bucket)
+        .key(key)
+        .send()
+        .await
+        .expect("delete_object");
+    s3.delete_bucket()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("delete_bucket");
+}

--- a/crates/fakecloud-parity/tests/secretsmanager.rs
+++ b/crates/fakecloud-parity/tests/secretsmanager.rs
@@ -54,3 +54,27 @@ async fn secretsmanager_create_get_put_delete() {
         .await
         .expect("delete_secret");
 }
+
+#[tokio::test]
+async fn secretsmanager_get_nonexistent_returns_expected_error() {
+    let backend = Backend::from_env().await;
+    let sm = backend.secretsmanager().await;
+    let name = unique_name("sec-missing");
+
+    let err = sm
+        .get_secret_value()
+        .secret_id(&name)
+        .send()
+        .await
+        .expect_err("get on missing secret should fail");
+    let code = err
+        .into_service_error()
+        .meta()
+        .code()
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(
+        code, "ResourceNotFoundException",
+        "expected ResourceNotFoundException, got {code:?}"
+    );
+}

--- a/crates/fakecloud-parity/tests/sns.rs
+++ b/crates/fakecloud-parity/tests/sns.rs
@@ -129,3 +129,138 @@ async fn sns_create_topic_publish_to_sqs() {
     let _ = sns.delete_topic().topic_arn(topic_arn).send().await;
     let _ = sqs.delete_queue().queue_url(queue_url).send().await;
 }
+
+#[tokio::test]
+async fn sns_subscription_filter_policy() {
+    let backend = Backend::from_env().await;
+    let sns = backend.sns().await;
+    let sqs = backend.sqs().await;
+
+    let topic_name = unique_name("sns-filter");
+    let queue_name = unique_name("sns-filter-q");
+
+    let queue = sqs
+        .create_queue()
+        .queue_name(&queue_name)
+        .send()
+        .await
+        .expect("create_queue");
+    let queue_url = queue.queue_url().expect("queue_url").to_string();
+
+    let attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .expect("get_queue_attributes");
+    let queue_arn = attrs
+        .attributes()
+        .and_then(|m| m.get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn))
+        .expect("queue arn")
+        .clone();
+
+    let topic = sns
+        .create_topic()
+        .name(&topic_name)
+        .send()
+        .await
+        .expect("create_topic");
+    let topic_arn = topic.topic_arn().expect("topic_arn").to_string();
+
+    let policy = format!(
+        r#"{{"Version":"2012-10-17","Statement":[{{"Effect":"Allow","Principal":{{"AWS":"*"}},"Action":"sqs:SendMessage","Resource":"{queue_arn}","Condition":{{"ArnEquals":{{"aws:SourceArn":"{topic_arn}"}}}}}}]}}"#
+    );
+    sqs.set_queue_attributes()
+        .queue_url(&queue_url)
+        .attributes(aws_sdk_sqs::types::QueueAttributeName::Policy, policy)
+        .send()
+        .await
+        .expect("set_queue_attributes policy");
+
+    // Subscribe with a filter policy that only allows messages whose
+    // `event` attribute equals `wanted`.
+    let sub = sns
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&queue_arn)
+        .attributes("FilterPolicy", r#"{"event":["wanted"]}"#)
+        .send()
+        .await
+        .expect("subscribe");
+    let subscription_arn = sub
+        .subscription_arn()
+        .expect("subscription_arn")
+        .to_string();
+
+    let wanted_attr = aws_sdk_sns::types::MessageAttributeValue::builder()
+        .data_type("String")
+        .string_value("wanted")
+        .build()
+        .unwrap();
+    let other_attr = aws_sdk_sns::types::MessageAttributeValue::builder()
+        .data_type("String")
+        .string_value("other")
+        .build()
+        .unwrap();
+
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("should arrive")
+        .message_attributes("event", wanted_attr)
+        .send()
+        .await
+        .expect("publish matching");
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("should be filtered")
+        .message_attributes("event", other_attr)
+        .send()
+        .await
+        .expect("publish non-matching");
+
+    let mut bodies: Vec<String> = Vec::new();
+    for _ in 0..4 {
+        let recv = sqs
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(5)
+            .send()
+            .await
+            .expect("receive_message");
+        for msg in recv.messages() {
+            let body: serde_json::Value =
+                serde_json::from_str(msg.body().unwrap_or_default()).expect("sns envelope JSON");
+            bodies.push(
+                body.get("Message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+            );
+            if let Some(handle) = msg.receipt_handle() {
+                let _ = sqs
+                    .delete_message()
+                    .queue_url(&queue_url)
+                    .receipt_handle(handle)
+                    .send()
+                    .await;
+            }
+        }
+    }
+
+    assert_eq!(
+        bodies,
+        vec!["should arrive".to_string()],
+        "filter policy should have dropped the non-matching message; got {bodies:?}"
+    );
+
+    let _ = sns
+        .unsubscribe()
+        .subscription_arn(subscription_arn)
+        .send()
+        .await;
+    let _ = sns.delete_topic().topic_arn(topic_arn).send().await;
+    let _ = sqs.delete_queue().queue_url(queue_url).send().await;
+}

--- a/crates/fakecloud-parity/tests/sqs.rs
+++ b/crates/fakecloud-parity/tests/sqs.rs
@@ -86,3 +86,101 @@ async fn sqs_create_send_receive_delete() {
         .await
         .expect("delete_queue");
 }
+
+#[tokio::test]
+async fn sqs_get_queue_url_nonexistent_returns_expected_error() {
+    let backend = Backend::from_env().await;
+    let sqs = backend.sqs().await;
+    let name = unique_name("sqs-missing");
+
+    let err = sqs
+        .get_queue_url()
+        .queue_name(&name)
+        .send()
+        .await
+        .expect_err("get_queue_url on nonexistent queue should fail");
+
+    // Both fakecloud and real SQS should return
+    // AWS.SimpleQueueService.NonExistentQueue (error code). The SDK maps
+    // this to `QueueDoesNotExist` on the operation error. We assert the
+    // raw code string so shape changes in the SDK don't break us.
+    let service_err = err.into_service_error();
+    let code = service_err.meta().code().unwrap_or_default();
+    assert!(
+        code == "AWS.SimpleQueueService.NonExistentQueue" || code == "QueueDoesNotExist",
+        "expected NonExistentQueue / QueueDoesNotExist, got code={code:?}"
+    );
+}
+
+#[tokio::test]
+async fn sqs_fifo_dedup_and_ordering() {
+    let backend = Backend::from_env().await;
+    let sqs = backend.sqs().await;
+    // FIFO queue names must end with `.fifo`.
+    let queue_name = format!("{}.fifo", unique_name("sqs-fifo"));
+
+    let create = sqs
+        .create_queue()
+        .queue_name(&queue_name)
+        .attributes(aws_sdk_sqs::types::QueueAttributeName::FifoQueue, "true")
+        .attributes(
+            aws_sdk_sqs::types::QueueAttributeName::ContentBasedDeduplication,
+            "true",
+        )
+        .send()
+        .await
+        .expect("create_queue fifo");
+    let queue_url = create.queue_url().expect("queue_url").to_string();
+
+    // Send three messages to the same group. Send "alpha" twice with the
+    // same body -- content-based dedup should drop the second.
+    for body in ["alpha", "alpha", "beta"] {
+        sqs.send_message()
+            .queue_url(&queue_url)
+            .message_body(body)
+            .message_group_id("grp-1")
+            .send()
+            .await
+            .expect("send_message fifo");
+    }
+
+    // Receive both surviving messages. FIFO preserves send order within a
+    // group, so alpha should arrive before beta.
+    let mut received: Vec<String> = Vec::new();
+    for _ in 0..5 {
+        if received.len() >= 2 {
+            break;
+        }
+        let recv = sqs
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(5)
+            .send()
+            .await
+            .expect("receive_message fifo");
+        for msg in recv.messages() {
+            received.push(msg.body().unwrap_or_default().to_string());
+            if let Some(handle) = msg.receipt_handle() {
+                let _ = sqs
+                    .delete_message()
+                    .queue_url(&queue_url)
+                    .receipt_handle(handle)
+                    .send()
+                    .await;
+            }
+        }
+    }
+
+    assert_eq!(
+        received,
+        vec!["alpha".to_string(), "beta".to_string()],
+        "expected FIFO order alpha,beta after content-based dedup; got {received:?}"
+    );
+
+    sqs.delete_queue()
+        .queue_url(queue_url)
+        .send()
+        .await
+        .expect("delete_queue");
+}


### PR DESCRIPTION
## Summary

Expands parity from 7 happy-path tests to 15, focused on the drift-prone surfaces that real-AWS comparison actually catches: error codes, conditional writes, filter policies, FIFO ordering, multipart upload, data-key generation.

## New tests

| Service | Test | What it protects against |
|---|---|---|
| SQS | \`get_queue_url\` on missing queue | Error code drift (\`QueueDoesNotExist\`) |
| SQS | FIFO queue with content-based dedup | FIFO ordering + dedup semantics |
| SNS | Subscription filter policy | Attribute-based filtering actually filters |
| S3 | \`get_object\` on missing key | Error code drift (\`NoSuchKey\`) |
| S3 | 5 MiB multipart upload | Part-size handling, completion, byte-identical round-trip |
| DynamoDB | \`Query\` with \`KeyConditionExpression\` | Composite-key Query + sort order |
| DynamoDB | Conditional \`PutItem\` | \`ConditionalCheckFailedException\` code on attribute_not_exists |
| KMS | \`GenerateDataKey\` + decrypt | 32-byte AES key round-trip through Decrypt |
| SecretsManager | \`get_secret_value\` on missing secret | Error code drift (\`ResourceNotFoundException\`) |

Local run against fakecloud: 15/15 pass. Weekly real-AWS run will pick them up automatically on the next scheduled or dispatched tick.

## Test plan

- [x] \`cargo test -p fakecloud-parity\` — 15/15 pass against local fakecloud
- [x] \`cargo clippy -p fakecloud-parity --tests -- -D warnings\` — clean
- [x] \`cargo fmt\` — clean
- [ ] CI \`Parity (fakecloud)\` job runs green
- [ ] Next weekly real-AWS run confirms parity

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the parity test suite from 7 to 15 to lock in real-AWS error codes and edge-case semantics. Covers SQS, SNS, S3, DynamoDB, KMS, and Secrets Manager to reduce drift in high-risk paths.

- **New Features**
  - Error parity: SQS `get_queue_url` on missing queue, S3 `get_object` on missing key, Secrets Manager `get_secret_value` on missing secret, DynamoDB conditional `PutItem` failure code.
  - Edge semantics: SQS FIFO ordering with content-based dedup, SNS subscription filter policy, S3 5 MiB multipart upload round-trip, DynamoDB `Query` on composite key with sort order, KMS `GenerateDataKey` + `Decrypt` round-trip.

<sup>Written for commit 665370a30127df10b756350b0763185dcf53863d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

