### PR TITLE
blog: fix awkward em-dash in spicy post description

### DIFF
--- a/website/content/blog/people-not-reviewing-ai-code.md
+++ b/website/content/blog/people-not-reviewing-ai-code.md
@@ -1,7 +1,7 @@
 +++
 title = "People are not reviewing AI-generated code"
 date = 2026-04-15
-description = "I'd bet most developers are already shipping AI-generated code without properly reviewing it. Not because they have guardrails—because they're busy and the code looks fine. Here's what I think we should do about it."
+description = "I'd bet most developers are already shipping AI-generated code without properly reviewing it. Not because they have guardrails, but because they're busy and the code looks fine. Here's what I think we should do about it."
 
 [extra]
 author = "Lucas Vieira"


### PR DESCRIPTION
## Summary

Small typo / style fix in the scheduled "People are not reviewing AI-generated code" blog post (publishes tomorrow, 2026-04-15).

The description had `Not because they have guardrails—because they're busy and the code looks fine` — the em-dash is doing work that should belong to `but`. Switching to the conventional `Not because X, but because Y` form, which is unambiguous and reads naturally in a meta description.

## Test plan

- [x] Zola builds clean locally
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the em-dash in the "People are not reviewing AI-generated code" post description with "but" to use the clear "Not because X, but because Y" form. This improves clarity and reads naturally in meta descriptions and search previews.

<sup>Written for commit 7c2ef2f35495153d03a394027071252da92476c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

