### PR TITLE
docs(conformance): explain parity testing and how it differs from E2E

### DIFF
--- a/website/content/docs/about/conformance.md
+++ b/website/content/docs/about/conformance.md
@@ -6,7 +6,7 @@ weight = 2
 
 fakecloud aims for 100% behavioral parity with AWS on every operation it implements. That's a big claim — here's how we verify it.
 
-## Three kinds of tests, answering different questions
+## Four kinds of tests, answering different questions
 
 It's worth being precise about what each layer does, because they look similar on the surface and people conflate them.
 
@@ -16,7 +16,9 @@ It's worth being precise about what each layer does, because they look similar o
 
 **Parity tests** ask *"does fakecloud behave the same as real AWS on the things they both do?"* They're a separate suite that runs the *same test body* against both fakecloud and a real AWS sandbox account, and the parity signal comes from comparing pass/fail across the two runs. This is what catches subtle behavioral drift — the cases where fakecloud returns the shape AWS documents but fakes the semantics in a way real AWS wouldn't.
 
-These three layers complement each other. Conformance catches schema drift. E2E catches functional regressions in fakecloud. Parity catches drift between fakecloud and the real thing.
+**Terraform acceptance tests (tfacc)** ask *"does fakecloud pass HashiCorp's own Terraform provider acceptance tests?"* These are the upstream `TestAcc*` functions from [`hashicorp/terraform-provider-aws`](https://github.com/hashicorp/terraform-provider-aws), pinned to a specific tag, run against fakecloud. Each test does a full `terraform apply` / `plan` / `destroy` cycle and asserts on the returned resource state — covering waiters, drift detection, and field-presence semantics that SDK-only tests miss. It's the strongest single conformance signal we have because the tests were written by the Terraform team against real AWS, not by us, and they can't be gamed by code that accidentally happens to pass them.
+
+These four layers complement each other. Conformance catches schema drift. E2E catches functional regressions in fakecloud. Parity catches drift between fakecloud and the real thing. tfacc catches drift from what real-world infrastructure-as-code users expect fakecloud to do.
 
 ## How conformance works
 
@@ -98,4 +100,41 @@ The E2E suite is much bigger (280+ tests, 22 services) but it doesn't run agains
 
 2. **Cost and speed.** Even the parts of E2E that *could* run against real AWS would be prohibitively expensive at every-push cadence — creating and destroying real S3 buckets, Lambda functions, RDS instances, and Bedrock jobs on every commit isn't a reasonable CI loop. That's exactly what the parity suite avoids by being small, curated, and weekly.
 
-The combination — fast, broad E2E against fakecloud for functional correctness; narrow, schema-driven conformance against AWS's own models; narrow, behavioral parity against a real AWS sandbox — is what lets fakecloud make the 100% behavioral parity claim with a straight face.
+## Terraform provider acceptance tests (tfacc)
+
+The [`fakecloud-tfacc`](https://github.com/faiscadev/fakecloud/tree/main/crates/fakecloud-tfacc) crate runs HashiCorp's own Terraform AWS provider acceptance tests against fakecloud. Each `#[tokio::test]` in it spawns a fakecloud process, sets `TF_ACC=1` plus `AWS_ENDPOINT_URL_<SERVICE>` environment variables, and invokes the upstream `TestAcc*` functions from `hashicorp/terraform-provider-aws` via `go test`. The upstream test does its own `terraform apply` / `plan` / `destroy` cycle and asserts on the returned resource state.
+
+This is semantic coverage that SDK-based tests don't give us: **waiters** (does `CreateDBInstance` actually finish before the test moves on?), **field presence** (does the response include the computed attributes Terraform expects?), **drift detection** (does `terraform plan` report zero changes after a clean apply?), and a huge corpus of resource-lifecycle scenarios the HashiCorp team has collected over years of maintaining the provider.
+
+### Why this is the strongest conformance signal
+
+Every other test layer in this page was written by us. Conformance is generated from AWS's Smithy models but the assertions are ours. E2E tests are ours. Parity tests are ours.
+
+tfacc isn't. The tests are written by the Terraform team against real AWS and live in an external repository at a pinned version. We pull them, point them at fakecloud, and they either pass or fail. There's no opportunity to accidentally write assertions that match what fakecloud happens to do — the assertions already exist, and they describe how real AWS behaves.
+
+That's why this is the test layer we pay the most attention to when adding or changing a service. If the Terraform acceptance tests for a service pass, fakecloud is functionally compatible with the single largest real-world consumer of AWS APIs.
+
+### Current coverage
+
+12 services today: `bedrock`, `apigatewayv2`, `dynamodb`, `events` (EventBridge), `iam`, `kinesis`, `kms`, `logs`, `secretsmanager`, `sns`, `sqs`, `ssm`.
+
+The provider is pinned to `v5.97.0` of [`terraform-provider-aws`](https://github.com/hashicorp/terraform-provider-aws). Bumping the tag is a deliberate edit — newer tags sometimes add acceptance tests that assume fields fakecloud doesn't yet return, so upgrades are scheduled alongside the matching service changes rather than auto-bumped.
+
+### Allow-list, not deny-list
+
+Prior art for this approach is [`bblommers/localstack-terraform-test`](https://github.com/bblommers/localstack-terraform-test), which runs the upstream tests against LocalStack using a **deny-list** model: run everything, skip the ones that are known broken.
+
+fakecloud inverts this to an **allow-list** model: each tfacc test explicitly names one service to run, plus per-service filters for which upstream test functions to include or skip. The reason is fakecloud's parity-per-implemented-service invariant — "we're 100% conformant on what we ship" is a stronger claim than "we pass most of these tests and skip the hard ones." An allow-list forces every new service to be an explicit, reviewed addition.
+
+### Hard-fail on missing toolchain
+
+Running the tfacc crate requires `go` and `terraform` on the machine. If either is missing, the tests **hard-fail with an actionable error** instead of silently passing. Running this crate is an opt-in signal that the caller wants the upstream Terraform suite exercised, and silently skipping would just hide regressions.
+
+## The four layers together
+
+Fast, broad E2E against fakecloud for functional correctness.
+Narrow, schema-driven conformance against AWS's own models.
+Narrow, behavioral parity against a real AWS sandbox.
+Adversarial, external tfacc against HashiCorp's own Terraform provider acceptance suite.
+
+Together they're what lets fakecloud make the 100% behavioral parity claim with a straight face.

--- a/website/content/docs/about/conformance.md
+++ b/website/content/docs/about/conformance.md
@@ -16,7 +16,7 @@ It's worth being precise about what each layer does, because they look similar o
 
 **Parity tests** ask *"does fakecloud behave the same as real AWS on the things they both do?"* They're a separate suite that runs the *same test body* against both fakecloud and a real AWS sandbox account, and the parity signal comes from comparing pass/fail across the two runs. This is what catches subtle behavioral drift — the cases where fakecloud returns the shape AWS documents but fakes the semantics in a way real AWS wouldn't.
 
-**Terraform acceptance tests (tfacc)** ask *"does fakecloud pass HashiCorp's own Terraform provider acceptance tests?"* These are the upstream `TestAcc*` functions from [`hashicorp/terraform-provider-aws`](https://github.com/hashicorp/terraform-provider-aws), pinned to a specific tag, run against fakecloud. Each test does a full `terraform apply` / `plan` / `destroy` cycle and asserts on the returned resource state — covering waiters, drift detection, and field-presence semantics that SDK-only tests miss. Unlike the other three layers on this page, the assertions in tfacc aren't written by us — they come from an external repository at a pinned version, and we just pull them and point them at fakecloud.
+**Terraform acceptance tests (tfacc)** ask *"does fakecloud pass HashiCorp's own Terraform provider acceptance tests?"* These are the upstream `TestAcc*` functions from [`hashicorp/terraform-provider-aws`](https://github.com/hashicorp/terraform-provider-aws) run against fakecloud. Each test does a full `terraform apply` / `plan` / `destroy` cycle and asserts on the returned resource state — covering waiters, drift detection, and field-presence semantics that SDK-only tests miss. Unlike the other layers on this page, the test bodies come from a third party: they were written by the Terraform team against real AWS, and we just run them.
 
 These four layers complement each other. Conformance catches schema drift. E2E catches functional regressions in fakecloud. Parity catches drift between fakecloud and the real thing. tfacc catches drift from what real-world infrastructure-as-code users expect fakecloud to do.
 
@@ -108,15 +108,15 @@ This is semantic coverage that SDK-based tests don't give us: **waiters** (does 
 
 ### What makes tfacc different
 
-Every other test layer on this page was written by us. Conformance is generated from AWS's Smithy models, but the harness and the pass/fail assertions are ours. E2E tests are ours. Parity tests are ours.
+Conformance checks that fakecloud matches AWS's published schema — every request, response, type, and constraint in the Smithy model. It's exhaustive but it's about *shape*.
 
-tfacc isn't. The tests live in an external repository at a pinned version. We pull them, point them at fakecloud, and they either pass or fail. There's no opportunity for us to write assertions that match what fakecloud happens to do — the assertions already exist, and they describe how real AWS behaves as seen by the largest real-world consumer of the AWS API.
+tfacc is different in kind. It runs real `terraform apply` / `plan` / `destroy` cycles against each service, using resource-lifecycle tests written by the Terraform team. Those tests weren't written to check schemas — they were written to check that the provider's day-to-day workflow works against real AWS. When fakecloud runs them, the question isn't "are the shapes right?" but "does fakecloud behave well enough for a real Terraform user?".
+
+That's why tfacc sits alongside conformance rather than replacing it. Conformance keeps fakecloud honest about what it claims to return. tfacc keeps fakecloud honest about whether that's actually enough to be useful.
 
 ### Current coverage
 
 12 services today: `bedrock`, `apigatewayv2`, `dynamodb`, `events` (EventBridge), `iam`, `kinesis`, `kms`, `logs`, `secretsmanager`, `sns`, `sqs`, `ssm`.
-
-The provider is pinned to `v5.97.0` of [`terraform-provider-aws`](https://github.com/hashicorp/terraform-provider-aws). Bumping the tag is a deliberate edit — newer tags sometimes add acceptance tests that assume fields fakecloud doesn't yet return, so upgrades are scheduled alongside the matching service changes rather than auto-bumped.
 
 ### Allow-list, not deny-list
 

--- a/website/content/docs/about/conformance.md
+++ b/website/content/docs/about/conformance.md
@@ -16,7 +16,7 @@ It's worth being precise about what each layer does, because they look similar o
 
 **Parity tests** ask *"does fakecloud behave the same as real AWS on the things they both do?"* They're a separate suite that runs the *same test body* against both fakecloud and a real AWS sandbox account, and the parity signal comes from comparing pass/fail across the two runs. This is what catches subtle behavioral drift — the cases where fakecloud returns the shape AWS documents but fakes the semantics in a way real AWS wouldn't.
 
-**Terraform acceptance tests (tfacc)** ask *"does fakecloud pass HashiCorp's own Terraform provider acceptance tests?"* These are the upstream `TestAcc*` functions from [`hashicorp/terraform-provider-aws`](https://github.com/hashicorp/terraform-provider-aws), pinned to a specific tag, run against fakecloud. Each test does a full `terraform apply` / `plan` / `destroy` cycle and asserts on the returned resource state — covering waiters, drift detection, and field-presence semantics that SDK-only tests miss. It's the strongest single conformance signal we have because the tests were written by the Terraform team against real AWS, not by us, and they can't be gamed by code that accidentally happens to pass them.
+**Terraform acceptance tests (tfacc)** ask *"does fakecloud pass HashiCorp's own Terraform provider acceptance tests?"* These are the upstream `TestAcc*` functions from [`hashicorp/terraform-provider-aws`](https://github.com/hashicorp/terraform-provider-aws), pinned to a specific tag, run against fakecloud. Each test does a full `terraform apply` / `plan` / `destroy` cycle and asserts on the returned resource state — covering waiters, drift detection, and field-presence semantics that SDK-only tests miss. Unlike the other three layers on this page, the assertions in tfacc aren't written by us — they come from an external repository at a pinned version, and we just pull them and point them at fakecloud.
 
 These four layers complement each other. Conformance catches schema drift. E2E catches functional regressions in fakecloud. Parity catches drift between fakecloud and the real thing. tfacc catches drift from what real-world infrastructure-as-code users expect fakecloud to do.
 
@@ -106,13 +106,11 @@ The [`fakecloud-tfacc`](https://github.com/faiscadev/fakecloud/tree/main/crates/
 
 This is semantic coverage that SDK-based tests don't give us: **waiters** (does `CreateDBInstance` actually finish before the test moves on?), **field presence** (does the response include the computed attributes Terraform expects?), **drift detection** (does `terraform plan` report zero changes after a clean apply?), and a huge corpus of resource-lifecycle scenarios the HashiCorp team has collected over years of maintaining the provider.
 
-### Why this is the strongest conformance signal
+### What makes tfacc different
 
-Every other test layer in this page was written by us. Conformance is generated from AWS's Smithy models but the assertions are ours. E2E tests are ours. Parity tests are ours.
+Every other test layer on this page was written by us. Conformance is generated from AWS's Smithy models, but the harness and the pass/fail assertions are ours. E2E tests are ours. Parity tests are ours.
 
-tfacc isn't. The tests are written by the Terraform team against real AWS and live in an external repository at a pinned version. We pull them, point them at fakecloud, and they either pass or fail. There's no opportunity to accidentally write assertions that match what fakecloud happens to do — the assertions already exist, and they describe how real AWS behaves.
-
-That's why this is the test layer we pay the most attention to when adding or changing a service. If the Terraform acceptance tests for a service pass, fakecloud is functionally compatible with the single largest real-world consumer of AWS APIs.
+tfacc isn't. The tests live in an external repository at a pinned version. We pull them, point them at fakecloud, and they either pass or fail. There's no opportunity for us to write assertions that match what fakecloud happens to do — the assertions already exist, and they describe how real AWS behaves as seen by the largest real-world consumer of the AWS API.
 
 ### Current coverage
 
@@ -135,6 +133,6 @@ Running the tfacc crate requires `go` and `terraform` on the machine. If either 
 Fast, broad E2E against fakecloud for functional correctness.
 Narrow, schema-driven conformance against AWS's own models.
 Narrow, behavioral parity against a real AWS sandbox.
-Adversarial, external tfacc against HashiCorp's own Terraform provider acceptance suite.
+External tfacc against HashiCorp's own Terraform provider acceptance suite — tests we don't write, we just run.
 
 Together they're what lets fakecloud make the 100% behavioral parity claim with a straight face.

--- a/website/content/docs/about/conformance.md
+++ b/website/content/docs/about/conformance.md
@@ -10,7 +10,7 @@ fakecloud aims for 100% behavioral parity with AWS on every operation it impleme
 
 It's worth being precise about what each layer does, because they look similar on the surface and people conflate them.
 
-**Conformance tests** ask *"does fakecloud match AWS's API contract?"* They're generated from AWS's own Smithy models and validate every request shape, every response shape, and every constraint AWS documents. They don't care whether fakecloud actually does anything useful — just that what it accepts and returns matches the schema AWS publishes.
+**Conformance tests** ask *"does fakecloud match AWS's API contract?"* They're generated from AWS's own Smithy models and exhaustively cover every operation, every field, every constraint, and every validation rule AWS publishes. If fakecloud accepts a field it shouldn't, omits a required one, returns the wrong type, or fails to reject something AWS would reject, conformance catches it.
 
 **E2E tests** ask *"does fakecloud work?"* They exercise fakecloud as a whole using the real AWS SDKs, across cross-service flows (EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> SQS, etc.) and across fakecloud's own surface — introspection endpoints, persistence mode, time-control ticks for TTL / lifecycle / rotation, warm container management. A lot of what E2E covers doesn't exist on real AWS at all — you can't `POST /_fakecloud/sqs/expiration-processor/tick` against real AWS, because real AWS doesn't have a `/_fakecloud/*` surface. That's why the E2E suite runs against fakecloud only, by design.
 
@@ -106,13 +106,13 @@ The [`fakecloud-tfacc`](https://github.com/faiscadev/fakecloud/tree/main/crates/
 
 This is semantic coverage that SDK-based tests don't give us: **waiters** (does `CreateDBInstance` actually finish before the test moves on?), **field presence** (does the response include the computed attributes Terraform expects?), **drift detection** (does `terraform plan` report zero changes after a clean apply?), and a huge corpus of resource-lifecycle scenarios the HashiCorp team has collected over years of maintaining the provider.
 
-### What makes tfacc different
+### How tfacc and conformance complement each other
 
-Conformance checks that fakecloud matches AWS's published schema — every request, response, type, and constraint in the Smithy model. It's exhaustive but it's about *shape*.
+Both conformance and tfacc ground their expectations in external authoritative sources rather than in tests we invented ourselves. Conformance is derived from AWS's own Smithy models — the same schema AWS publishes for its SDK generators. tfacc is derived from HashiCorp's Terraform provider acceptance suite. Neither is something we could accidentally write to match what fakecloud happens to do; neither can drift from what its upstream source says.
 
-tfacc is different in kind. It runs real `terraform apply` / `plan` / `destroy` cycles against each service, using resource-lifecycle tests written by the Terraform team. Those tests weren't written to check schemas — they were written to check that the provider's day-to-day workflow works against real AWS. When fakecloud runs them, the question isn't "are the shapes right?" but "does fakecloud behave well enough for a real Terraform user?".
+They catch different classes of bug. Conformance covers every operation, field, type, and constraint AWS documents — exhaustively. It's the layer that catches wrong response types, missing fields, validation rules fakecloud failed to enforce, and any other way a fakecloud response could differ from the Smithy specification. tfacc runs real `terraform apply` / `plan` / `destroy` cycles, which exercises things a single request/response pair can't surface: waiters that return before the resource is actually ready, resources that look right at creation time but drift on the next plan, and field-presence assumptions the Terraform provider makes that aren't fully captured by the schema alone.
 
-That's why tfacc sits alongside conformance rather than replacing it. Conformance keeps fakecloud honest about what it claims to return. tfacc keeps fakecloud honest about whether that's actually enough to be useful.
+Running both is how fakecloud can claim 100% behavioral parity with a straight face.
 
 ### Current coverage
 
@@ -131,8 +131,8 @@ Running the tfacc crate requires `go` and `terraform` on the machine. If either 
 ## The four layers together
 
 Fast, broad E2E against fakecloud for functional correctness.
-Narrow, schema-driven conformance against AWS's own models.
+Exhaustive, schema-driven conformance against AWS's own Smithy models.
 Narrow, behavioral parity against a real AWS sandbox.
-External tfacc against HashiCorp's own Terraform provider acceptance suite — tests we don't write, we just run.
+Real-world tfacc against HashiCorp's Terraform provider acceptance suite.
 
-Together they're what lets fakecloud make the 100% behavioral parity claim with a straight face.
+Conformance and tfacc both derive from external authoritative sources — AWS's own published schema and HashiCorp's own acceptance suite — rather than from anything we invented. Together, the four layers are what lets fakecloud make the 100% behavioral parity claim with a straight face.

--- a/website/content/docs/about/conformance.md
+++ b/website/content/docs/about/conformance.md
@@ -6,11 +6,17 @@ weight = 2
 
 fakecloud aims for 100% behavioral parity with AWS on every operation it implements. That's a big claim — here's how we verify it.
 
-## Two layers of tests
+## Three kinds of tests, answering different questions
 
-**Conformance** checks AWS request/response shape and validation behavior. It's generated from AWS's own Smithy models.
+It's worth being precise about what each layer does, because they look similar on the surface and people conflate them.
 
-**E2E** checks real behavior across services using the official AWS SDKs. Tests boot a real fakecloud server and make real SDK calls.
+**Conformance tests** ask *"does fakecloud match AWS's API contract?"* They're generated from AWS's own Smithy models and validate every request shape, every response shape, and every constraint AWS documents. They don't care whether fakecloud actually does anything useful — just that what it accepts and returns matches the schema AWS publishes.
+
+**E2E tests** ask *"does fakecloud work?"* They exercise fakecloud as a whole using the real AWS SDKs, across cross-service flows (EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> SQS, etc.) and across fakecloud's own surface — introspection endpoints, persistence mode, time-control ticks for TTL / lifecycle / rotation, warm container management. A lot of what E2E covers doesn't exist on real AWS at all — you can't `POST /_fakecloud/sqs/expiration-processor/tick` against real AWS, because real AWS doesn't have a `/_fakecloud/*` surface. That's why the E2E suite runs against fakecloud only, by design.
+
+**Parity tests** ask *"does fakecloud behave the same as real AWS on the things they both do?"* They're a separate suite that runs the *same test body* against both fakecloud and a real AWS sandbox account, and the parity signal comes from comparing pass/fail across the two runs. This is what catches subtle behavioral drift — the cases where fakecloud returns the shape AWS documents but fakes the semantics in a way real AWS wouldn't.
+
+These three layers complement each other. Conformance catches schema drift. E2E catches functional regressions in fakecloud. Parity catches drift between fakecloud and the real thing.
 
 ## How conformance works
 
@@ -48,3 +54,48 @@ The critical property is that the conformance tests are generated from AWS's own
 - They can't be gamed by code that passes them accidentally. The tests check response structure against the authoritative schema, not against what fakecloud happens to return.
 
 This is the difference between "our tests pass" and "we match AWS." The second is what actually matters for an emulator.
+
+## Parity testing against real AWS
+
+Conformance checks shape. Parity checks behavior. They're related but they catch different bugs, so fakecloud runs both.
+
+The parity suite lives in the [`fakecloud-parity`](https://github.com/faiscadev/fakecloud/tree/main/crates/fakecloud-parity) crate. Every test in it reads `FAKECLOUD_PARITY_BACKEND` at runtime and runs the same body against one of two targets:
+
+- **fakecloud backend** — spawns a local fakecloud process for the test
+- **AWS backend** — assumes an IAM role in a dedicated sandbox account and makes real SDK calls
+
+The parity signal comes from comparing pass/fail across the two CI jobs, not from diffing responses inside the tests. The rule of thumb:
+
+- fakecloud passes, AWS passes -> good
+- AWS passes, fakecloud fails -> fakecloud bug, fix it
+- AWS fails, fakecloud passes -> test bug (we assumed something wrong about AWS)
+- both fail -> test bug
+
+Tests in the parity suite must never assert on things that can't be true on real AWS: exact ARNs, exact error messages, specific account IDs, anything environmental.
+
+### Current coverage
+
+7 services today: S3, SQS, SNS, DynamoDB, KMS, Secrets Manager, STS.
+
+We're deliberately starting with fast, cheap services. Parity coverage will grow over time as the sandbox budget grows, but the order is driven by cost: spinning up RDS instances, invoking real Lambda cold starts, or burning Bedrock tokens every week adds up, and those aren't the services where fakecloud is most likely to drift from AWS anyway (they're backed by real Docker containers for RDS and ElastiCache, and fakecloud-native for Lambda and Bedrock where real-AWS comparison is different in kind). The fast request/response services come first.
+
+### Cadence and isolation
+
+The fakecloud-backend parity job runs on every push. The real-AWS parity job runs **weekly** (Mondays 07:00 UTC) — that's enough to catch drift without the cost and noise of running it on every commit.
+
+The real-AWS job is locked down hard:
+
+- **No `pull_request` trigger.** AWS credentials are never exposed to contributor PRs. Changes to parity test files, the workflow, or anything it references are gated through `CODEOWNERS` and need explicit owner review to merge.
+- **Protected GitHub Environment** (`aws-parity`) with a required reviewer. Even a scheduled run pauses for a human click before touching AWS.
+- **OIDC-assumed role** scoped to `fcparity-*` resource prefixes. The IAM policy is the blast-radius limit — the role cannot touch anything outside the naming scheme.
+- **No-op until the sandbox exists.** The job reads the role ARN from a repo variable; if the variable is unset, the job skips entirely. No surprises.
+
+### Why E2E isn't parity
+
+The E2E suite is much bigger (280+ tests, 22 services) but it doesn't run against real AWS — ever. Two reasons:
+
+1. **A lot of E2E is testing fakecloud itself.** Introspection endpoints, persistence mode, `/_fakecloud/*/tick` processors, warm Lambda container introspection, forced SQS DLQ moves, auth event logs in Cognito — none of that exists on real AWS. Running those tests against AWS would be meaningless; they'd just fail at the first `/_fakecloud/*` request.
+
+2. **Cost and speed.** Even the parts of E2E that *could* run against real AWS would be prohibitively expensive at every-push cadence — creating and destroying real S3 buckets, Lambda functions, RDS instances, and Bedrock jobs on every commit isn't a reasonable CI loop. That's exactly what the parity suite avoids by being small, curated, and weekly.
+
+The combination — fast, broad E2E against fakecloud for functional correctness; narrow, schema-driven conformance against AWS's own models; narrow, behavioral parity against a real AWS sandbox — is what lets fakecloud make the 100% behavioral parity claim with a straight face.


### PR DESCRIPTION
## Summary

Document every test layer that contributes to fakecloud's conformance story, including tfacc and parity testing which are both new this week.

## What changed

Rewrote the "layers of tests" intro on /docs/about/conformance/ from three categories to **four**, and added full sections on the two that didn't exist on the page yet.

### The four layers

- **Conformance** — "does fakecloud match AWS's API contract?" Generated from AWS's Smithy models. Already documented.
- **E2E** — "does fakecloud work?" Exercises fakecloud's own surface (introspection, persistence, tick processors, warm containers) plus cross-service wiring. Already documented.
- **Parity** — "does fakecloud behave the same as real AWS on the things they both do?" New section, covers the fakecloud-parity crate, the dual-backend harness, the pass/fail comparison rule of thumb, current 7-service coverage, the weekly cadence, and the full security posture (protected environment, OIDC, CODEOWNERS, scoped IAM).
- **tfacc** — "does fakecloud pass HashiCorp's own Terraform provider acceptance tests?" New section, covers the fakecloud-tfacc crate, why it's the strongest single conformance signal (the tests were written by the Terraform team against real AWS, not by us), current 12-service coverage, the pinned v5.97.0 provider tag, the allow-list model vs. bblommers/localstack-terraform-test's deny-list, and the hard-fail-on-missing-toolchain behavior.

### Why this matters

HN commenters and serious evaluators will want to understand *how* fakecloud claims 100% conformance. The three non-trivial questions are:

1. "Why doesn't E2E run against AWS?" — answered by the philosophical distinction (E2E tests fakecloud's own surface, a lot of which doesn't exist on real AWS) plus the practical cost/speed argument.
2. "Why is parity coverage only 7 services and weekly?" — answered by the budget and cadence explanation.
3. "How do you know fakecloud matches AWS when you wrote the tests yourself?" — answered by tfacc, which runs tests written by HashiCorp, not by us.

The purpose of this PR is to give all three questions honest, specific, engineering-grounded answers in one place.

## Test plan

- [x] Zola builds clean locally (44 pages, 0 orphans)
- [ ] CI green