### PR TITLE
feat(dynamodb): process GlobalSecondaryIndexUpdates in UpdateTable

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -457,7 +457,7 @@ fn parse_lsi(val: &Value) -> Vec<LocalSecondaryIndex> {
         .collect()
 }
 
-fn parse_projection(val: &Value) -> Projection {
+pub(super) fn parse_projection(val: &Value) -> Projection {
     Projection {
         projection_type: val["ProjectionType"].as_str().unwrap_or("ALL").to_string(),
         non_key_attributes: val["NonKeyAttributes"]

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -10,8 +10,11 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
 use crate::state::{
-    BackupDescription, DynamoTable, ExportDescription, ImportDescription, ProvisionedThroughput,
+    BackupDescription, DynamoTable, ExportDescription, GlobalSecondaryIndex, ImportDescription,
+    ProvisionedThroughput,
 };
+
+use super::parse_projection;
 
 use super::{
     build_table_description, build_table_description_json, find_table_by_arn,
@@ -344,6 +347,52 @@ impl DynamoDbService {
 
         if let Some(bm) = body["BillingMode"].as_str() {
             table.billing_mode = bm.to_string();
+        }
+
+        // Handle GlobalSecondaryIndexUpdates: a list of {Create, Update, Delete}
+        // operations. Real AWS supports all three; fakecloud now mirrors the
+        // semantics so Terraform's `aws_dynamodb_table` GSI lifecycle works.
+        if let Some(updates) = body
+            .get("GlobalSecondaryIndexUpdates")
+            .and_then(|v| v.as_array())
+        {
+            for op in updates {
+                if let Some(create) = op.get("Create") {
+                    let name = match create.get("IndexName").and_then(|v| v.as_str()) {
+                        Some(n) => n.to_string(),
+                        None => continue,
+                    };
+                    let key_schema = parse_key_schema(&create["KeySchema"]).unwrap_or_default();
+                    let projection = parse_projection(&create["Projection"]);
+                    let provisioned_throughput =
+                        parse_provisioned_throughput(&create["ProvisionedThroughput"]).ok();
+                    table.gsi.retain(|g| g.index_name != name);
+                    table.gsi.push(GlobalSecondaryIndex {
+                        index_name: name,
+                        key_schema,
+                        projection,
+                        provisioned_throughput,
+                    });
+                }
+                if let Some(update) = op.get("Update") {
+                    let name = match update.get("IndexName").and_then(|v| v.as_str()) {
+                        Some(n) => n,
+                        None => continue,
+                    };
+                    if let Some(gsi) = table.gsi.iter_mut().find(|g| g.index_name == name) {
+                        if let Ok(throughput) =
+                            parse_provisioned_throughput(&update["ProvisionedThroughput"])
+                        {
+                            gsi.provisioned_throughput = Some(throughput);
+                        }
+                    }
+                }
+                if let Some(delete) = op.get("Delete") {
+                    if let Some(name) = delete.get("IndexName").and_then(|v| v.as_str()) {
+                        table.gsi.retain(|g| g.index_name != name);
+                    }
+                }
+            }
         }
 
         if let Some(dpe) = body

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -2660,3 +2660,110 @@ async fn dynamodb_deletion_protection_blocks_delete_table() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn dynamodb_update_table_processes_global_secondary_index_updates() {
+    // Regression guard for `TestAccDynamoDBTable_gsiUpdateCapacity`:
+    // UpdateTable must process `GlobalSecondaryIndexUpdates` to add new
+    // GSIs (Create), change capacity (Update), and drop GSIs (Delete).
+    // Real AWS supports all three op types; previously fakecloud silently
+    // ignored every entry in the list.
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("GsiUpdates")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("att1")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::Provisioned)
+        .provisioned_throughput(
+            ProvisionedThroughput::builder()
+                .read_capacity_units(1)
+                .write_capacity_units(1)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_indexes(
+            GlobalSecondaryIndex::builder()
+                .index_name("att1-index")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("att1")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::All)
+                        .build(),
+                )
+                .provisioned_throughput(
+                    ProvisionedThroughput::builder()
+                        .read_capacity_units(1)
+                        .write_capacity_units(1)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_table()
+        .table_name("GsiUpdates")
+        .global_secondary_index_updates(
+            aws_sdk_dynamodb::types::GlobalSecondaryIndexUpdate::builder()
+                .update(
+                    aws_sdk_dynamodb::types::UpdateGlobalSecondaryIndexAction::builder()
+                        .index_name("att1-index")
+                        .provisioned_throughput(
+                            ProvisionedThroughput::builder()
+                                .read_capacity_units(5)
+                                .write_capacity_units(7)
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_table()
+        .table_name("GsiUpdates")
+        .send()
+        .await
+        .unwrap();
+    let gsi = &desc.table().unwrap().global_secondary_indexes()[0];
+    let pt = gsi.provisioned_throughput().unwrap();
+    assert_eq!(pt.read_capacity_units(), Some(5));
+    assert_eq!(pt.write_capacity_units(), Some(7));
+}

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -203,8 +203,6 @@ pub const SERVICES: &[Service] = &[
             "TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned",
             "TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest",
             "TestAccDynamoDBTable_Disappears_payPerRequestWithGSI",
-            // --- gap: GSI capacity update ---
-            "TestAccDynamoDBTable_gsiUpdateCapacity",
             // --- gap: encryption attribute round-trip ---
             "TestAccDynamoDBTable_encryption",
             // --- hung: did not complete in triage run; revisit in a later batch ---


### PR DESCRIPTION
## Summary

Batch 12 — second batch driving the DynamoDB tfacc deny-list down. Implements GSI lifecycle ops on \`UpdateTable\`.

Real AWS DynamoDB \`UpdateTable\` accepts a \`GlobalSecondaryIndexUpdates\` list with three op types — \`Create\`, \`Update\`, \`Delete\` — to manage GSIs across the table's lifetime. fakecloud was silently ignoring the entire list, which broke any Terraform \`aws_dynamodb_table\` workflow that mutated GSI capacity, projection, or membership after create.

- **Create**: add a new GSI from the supplied \`KeySchema\`, \`Projection\`, and \`ProvisionedThroughput\`. Replaces any existing GSI with the same name (idempotent re-create).
- **Update**: change \`ProvisionedThroughput\` on an existing GSI by name.
- **Delete**: drop a GSI by name.

Closes the \`TestAccDynamoDBTable_gsiUpdateCapacity\` gap; removes it from the tfacc deny-list. The other GSI gap entries (BillingMode transitions, on-demand throughput) need separate fakecloud work and stay denied.

## Test plan

- [x] New e2e test \`dynamodb_update_table_processes_global_secondary_index_updates\` covers Update path — passes
- [x] \`cargo test -p fakecloud-dynamodb\` clean (98 unit tests)
- [x] \`cargo clippy -p fakecloud-dynamodb -p fakecloud-tfacc -p fakecloud-e2e --all-targets -- -D warnings\` clean
- [x] Conformance suite locally clean
- [x] Upstream locally: \`TestAccDynamoDBTable_gsiUpdateCapacity\` passes (~14s)
- [ ] CI \`tfacc dynamodb\` green
- [ ] All other tfacc jobs still green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full `GlobalSecondaryIndexUpdates` support to DynamoDB `UpdateTable`, matching AWS behavior for GSI create, update, and delete. This unblocks Terraform `aws_dynamodb_table` GSI lifecycle updates and removes `TestAccDynamoDBTable_gsiUpdateCapacity` from the `fakecloud-tfacc` deny-list.

- **New Features**
  - Implemented GSI Create (idempotent by name), Update (provisioned throughput), and Delete in `UpdateTable` (`fakecloud-dynamodb`).
  - Exposed `parse_projection` for GSI Create logic.
  - Added e2e test `dynamodb_update_table_processes_global_secondary_index_updates` (`fakecloud-e2e`) and updated `fakecloud-tfacc/allowlist.rs`.

<sup>Written for commit d4b1d7e7ace9c3e7ffe0836b1c4964eeef0bbe61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

