### PR TITLE
feat(auth): plumb --verify-sigv4 and --iam flags through DispatchConfig

### DIFF
--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -99,11 +99,10 @@ impl FromStr for IamMode {
 /// enforcement is turned on so users understand that unsigned `test` clients
 /// will silently receive positive results.
 pub fn is_root_bypass(access_key_id: &str) -> bool {
-    let trimmed = access_key_id.trim();
-    if trimmed.is_empty() {
-        return false;
-    }
-    trimmed.len() >= 4 && trimmed[..4].eq_ignore_ascii_case("test")
+    access_key_id
+        .trim()
+        .get(..4)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("test"))
 }
 
 #[cfg(test)]
@@ -168,6 +167,14 @@ mod tests {
         assert!(is_root_bypass("Test"));
         assert!(is_root_bypass("testAccessKey"));
         assert!(is_root_bypass("TESTAKIAIOSFODNN7EXAMPLE"));
+    }
+
+    #[test]
+    fn root_bypass_does_not_panic_on_multibyte_input() {
+        // Byte index 4 falls inside a multi-byte UTF-8 character; must not panic.
+        assert!(!is_root_bypass("té"));
+        assert!(!is_root_bypass("日本語キー"));
+        assert!(!is_root_bypass("🔑🔑"));
     }
 
     #[test]

--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -1,0 +1,182 @@
+//! Authentication and authorization primitives shared across services.
+//!
+//! This module defines the opt-in modes for SigV4 signature verification and
+//! IAM policy enforcement, plus the reserved "root bypass" identity that
+//! short-circuits both checks when enabled.
+//!
+//! Neither feature is enforced at this layer — the types are plumbed through
+//! [`crate::dispatch::DispatchConfig`] and consulted later by dispatch and
+//! service handlers once the corresponding batches land. See
+//! `/docs/reference/security` (added in a later batch) for the user-facing
+//! contract.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// How IAM identity policies are evaluated for incoming requests.
+///
+/// Default is [`IamMode::Off`] — existing behavior, policies are stored but
+/// never consulted. [`IamMode::Soft`] evaluates and logs denied decisions via
+/// the `fakecloud::iam::audit` tracing target without failing the request, and
+/// [`IamMode::Strict`] returns an `AccessDeniedException` in the protocol-
+/// correct shape.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum IamMode {
+    /// Do not evaluate IAM policies.
+    #[default]
+    Off,
+    /// Evaluate policies and log audit events for denied requests, but allow
+    /// the request to proceed.
+    Soft,
+    /// Evaluate policies and reject denied requests with `AccessDeniedException`.
+    Strict,
+}
+
+impl IamMode {
+    /// Returns true when policy evaluation should occur at all.
+    pub fn is_enabled(self) -> bool {
+        !matches!(self, IamMode::Off)
+    }
+
+    /// Returns true when denied decisions should fail the request.
+    pub fn is_strict(self) -> bool {
+        matches!(self, IamMode::Strict)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IamMode::Off => "off",
+            IamMode::Soft => "soft",
+            IamMode::Strict => "strict",
+        }
+    }
+}
+
+impl fmt::Display for IamMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Parse error for [`IamMode`] from string.
+#[derive(Debug)]
+pub struct ParseIamModeError(String);
+
+impl fmt::Display for ParseIamModeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid IAM mode `{}`; expected one of: off, soft, strict",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for ParseIamModeError {}
+
+impl FromStr for IamMode {
+    type Err = ParseIamModeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "off" | "none" | "disabled" => Ok(IamMode::Off),
+            "soft" | "audit" | "warn" => Ok(IamMode::Soft),
+            "strict" | "enforce" | "deny" => Ok(IamMode::Strict),
+            other => Err(ParseIamModeError(other.to_string())),
+        }
+    }
+}
+
+/// Reserved root-identity convention.
+///
+/// Any access key whose ID begins with `test` (case-insensitive) is treated as
+/// the de-facto root bypass. This matches the long-standing community
+/// convention used by LocalStack and Floci: `test`/`test` credentials should
+/// always "just work" for local development.
+///
+/// When SigV4 verification or IAM enforcement is enabled, callers using a
+/// bypass AKID skip both checks. We emit a one-time startup WARN whenever
+/// enforcement is turned on so users understand that unsigned `test` clients
+/// will silently receive positive results.
+pub fn is_root_bypass(access_key_id: &str) -> bool {
+    let trimmed = access_key_id.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    trimmed.len() >= 4 && trimmed[..4].eq_ignore_ascii_case("test")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iam_mode_default_is_off() {
+        assert_eq!(IamMode::default(), IamMode::Off);
+        assert!(!IamMode::default().is_enabled());
+    }
+
+    #[test]
+    fn iam_mode_from_str_accepts_primary_values() {
+        assert_eq!(IamMode::from_str("off").unwrap(), IamMode::Off);
+        assert_eq!(IamMode::from_str("soft").unwrap(), IamMode::Soft);
+        assert_eq!(IamMode::from_str("strict").unwrap(), IamMode::Strict);
+    }
+
+    #[test]
+    fn iam_mode_from_str_is_case_insensitive_and_trimmed() {
+        assert_eq!(IamMode::from_str(" OFF ").unwrap(), IamMode::Off);
+        assert_eq!(IamMode::from_str("Soft").unwrap(), IamMode::Soft);
+        assert_eq!(IamMode::from_str("STRICT").unwrap(), IamMode::Strict);
+    }
+
+    #[test]
+    fn iam_mode_from_str_accepts_aliases() {
+        assert_eq!(IamMode::from_str("disabled").unwrap(), IamMode::Off);
+        assert_eq!(IamMode::from_str("audit").unwrap(), IamMode::Soft);
+        assert_eq!(IamMode::from_str("enforce").unwrap(), IamMode::Strict);
+    }
+
+    #[test]
+    fn iam_mode_from_str_rejects_garbage() {
+        assert!(IamMode::from_str("").is_err());
+        assert!(IamMode::from_str("allow").is_err());
+        assert!(IamMode::from_str("yes").is_err());
+    }
+
+    #[test]
+    fn iam_mode_display_roundtrips() {
+        for mode in [IamMode::Off, IamMode::Soft, IamMode::Strict] {
+            assert_eq!(IamMode::from_str(&mode.to_string()).unwrap(), mode);
+        }
+    }
+
+    #[test]
+    fn iam_mode_flags() {
+        assert!(!IamMode::Off.is_enabled());
+        assert!(!IamMode::Off.is_strict());
+        assert!(IamMode::Soft.is_enabled());
+        assert!(!IamMode::Soft.is_strict());
+        assert!(IamMode::Strict.is_enabled());
+        assert!(IamMode::Strict.is_strict());
+    }
+
+    #[test]
+    fn root_bypass_matches_test_prefix() {
+        assert!(is_root_bypass("test"));
+        assert!(is_root_bypass("TEST"));
+        assert!(is_root_bypass("Test"));
+        assert!(is_root_bypass("testAccessKey"));
+        assert!(is_root_bypass("TESTAKIAIOSFODNN7EXAMPLE"));
+    }
+
+    #[test]
+    fn root_bypass_rejects_non_test_keys() {
+        assert!(!is_root_bypass(""));
+        assert!(!is_root_bypass("   "));
+        assert!(!is_root_bypass("AKIAIOSFODNN7EXAMPLE"));
+        assert!(!is_root_bypass("FKIA123456"));
+        assert!(!is_root_bypass("tes"));
+        assert!(!is_root_bypass("tst"));
+    }
+}

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -5,6 +5,7 @@ use axum::response::Response;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::auth::IamMode;
 use crate::protocol::{self, AwsProtocol};
 use crate::registry::ServiceRegistry;
 use crate::service::{AwsRequest, ResponseBody};
@@ -225,6 +226,29 @@ pub async fn dispatch(
 pub struct DispatchConfig {
     pub region: String,
     pub account_id: String,
+    /// Whether to cryptographically verify SigV4 signatures on incoming
+    /// requests. Wired through from `--verify-sigv4` /
+    /// `FAKECLOUD_VERIFY_SIGV4`. Off by default. Actual enforcement is added
+    /// in a later batch; today this field is plumbed but never consulted.
+    pub verify_sigv4: bool,
+    /// IAM policy evaluation mode. Wired through from `--iam` /
+    /// `FAKECLOUD_IAM`. Defaults to [`IamMode::Off`]. Actual evaluation is
+    /// added in a later batch; today this field is plumbed but never
+    /// consulted.
+    pub iam_mode: IamMode,
+}
+
+impl DispatchConfig {
+    /// Minimal constructor for tests and call sites that don't care about the
+    /// opt-in security features.
+    pub fn new(region: impl Into<String>, account_id: impl Into<String>) -> Self {
+        Self {
+            region: region.into(),
+            account_id: account_id.into(),
+            verify_sigv4: false,
+            iam_mode: IamMode::Off,
+        }
+    }
 }
 
 /// Extract region from User-Agent header suffix `region/<region>`.
@@ -290,5 +314,31 @@ trait ProtocolExt {
 impl ProtocolExt for AwsProtocol {
     fn error_status(&self) -> StatusCode {
         StatusCode::BAD_REQUEST
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatch_config_new_defaults_to_off() {
+        let cfg = DispatchConfig::new("us-east-1", "123456789012");
+        assert_eq!(cfg.region, "us-east-1");
+        assert_eq!(cfg.account_id, "123456789012");
+        assert!(!cfg.verify_sigv4);
+        assert_eq!(cfg.iam_mode, IamMode::Off);
+    }
+
+    #[test]
+    fn dispatch_config_carries_opt_in_flags() {
+        let cfg = DispatchConfig {
+            region: "eu-west-1".to_string(),
+            account_id: "000000000000".to_string(),
+            verify_sigv4: true,
+            iam_mode: IamMode::Strict,
+        };
+        assert!(cfg.verify_sigv4);
+        assert!(cfg.iam_mode.is_strict());
     }
 }

--- a/crates/fakecloud-core/src/lib.rs
+++ b/crates/fakecloud-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod delivery;
 pub mod dispatch;
 pub mod pagination;

--- a/crates/fakecloud-server/src/cli.rs
+++ b/crates/fakecloud-server/src/cli.rs
@@ -1,7 +1,26 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
+use fakecloud_core::auth::IamMode;
 use fakecloud_persistence::{PersistenceConfig, StorageMode};
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub(crate) enum IamModeArg {
+    Off,
+    Soft,
+    Strict,
+}
+
+impl From<IamModeArg> for IamMode {
+    fn from(value: IamModeArg) -> Self {
+        match value {
+            IamModeArg::Off => IamMode::Off,
+            IamModeArg::Soft => IamMode::Soft,
+            IamModeArg::Strict => IamMode::Strict,
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[clap(rename_all = "lowercase")]
@@ -60,6 +79,35 @@ pub(crate) struct Cli {
     /// no SI/IEC suffix parsing. Default 256 MiB.
     #[arg(long, default_value_t = DEFAULT_S3_CACHE_BYTES, env = "FAKECLOUD_S3_CACHE_SIZE")]
     pub s3_cache_size: u64,
+
+    /// Cryptographically verify SigV4 signatures on incoming requests.
+    /// Off by default — fakecloud parses SigV4 for routing regardless. When
+    /// enabled, requests with invalid signatures are rejected with
+    /// `SignatureDoesNotMatch`. The reserved `test`/`test` root identity
+    /// always bypasses verification. See `/docs/reference/security`.
+    #[arg(long, default_value_t = false, env = "FAKECLOUD_VERIFY_SIGV4")]
+    pub verify_sigv4: bool,
+
+    /// IAM identity-policy evaluation mode.
+    ///
+    /// - `off` (default): policies are stored but never consulted.
+    /// - `soft`: evaluate and audit-log denied decisions via the
+    ///   `fakecloud::iam::audit` tracing target, but allow the request.
+    /// - `strict`: evaluate and return `AccessDeniedException` on denied
+    ///   decisions.
+    ///
+    /// Phase 1 scope: identity policies, Allow/Deny with Deny precedence,
+    /// Action/Resource wildcards. Condition blocks, resource-based policies,
+    /// permission boundaries, SCPs, and ABAC are explicitly not evaluated
+    /// yet. The reserved `test`/`test` root identity always bypasses
+    /// enforcement. See `/docs/reference/security`.
+    #[arg(
+        long = "iam",
+        value_enum,
+        default_value_t = IamModeArg::Off,
+        env = "FAKECLOUD_IAM",
+    )]
+    pub iam_mode: IamModeArg,
 }
 
 impl Cli {
@@ -78,6 +126,11 @@ impl Cli {
         format!("http://{host}:{port}")
     }
 
+    /// Resolve the IAM mode as the cross-crate [`IamMode`] type.
+    pub fn iam_mode(&self) -> IamMode {
+        self.iam_mode.into()
+    }
+
     pub fn persistence_config(&self) -> Result<PersistenceConfig, String> {
         let mode: StorageMode = self.storage_mode.into();
         let config = PersistenceConfig {
@@ -87,5 +140,39 @@ impl Cli {
         };
         config.validate()?;
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn defaults_leave_security_features_off() {
+        let cli = Cli::try_parse_from(["fakecloud"]).unwrap();
+        assert!(!cli.verify_sigv4);
+        assert_eq!(cli.iam_mode(), IamMode::Off);
+    }
+
+    #[test]
+    fn verify_sigv4_flag_parses() {
+        let cli = Cli::try_parse_from(["fakecloud", "--verify-sigv4"]).unwrap();
+        assert!(cli.verify_sigv4);
+    }
+
+    #[test]
+    fn iam_flag_parses_all_variants() {
+        let cli = Cli::try_parse_from(["fakecloud", "--iam", "off"]).unwrap();
+        assert_eq!(cli.iam_mode(), IamMode::Off);
+        let cli = Cli::try_parse_from(["fakecloud", "--iam", "soft"]).unwrap();
+        assert_eq!(cli.iam_mode(), IamMode::Soft);
+        let cli = Cli::try_parse_from(["fakecloud", "--iam", "strict"]).unwrap();
+        assert_eq!(cli.iam_mode(), IamMode::Strict);
+    }
+
+    #[test]
+    fn iam_flag_rejects_garbage() {
+        assert!(Cli::try_parse_from(["fakecloud", "--iam", "allow"]).is_err());
     }
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -660,9 +660,20 @@ async fn main() {
     let services: Vec<&str> = registry.service_names();
     tracing::info!(services = ?services, "registered services");
 
+    let iam_mode = cli.iam_mode();
+    if iam_mode.is_enabled() || cli.verify_sigv4 {
+        tracing::warn!(
+            verify_sigv4 = cli.verify_sigv4,
+            iam_mode = %iam_mode,
+            "opt-in security features enabled: access keys with the `test` prefix bypass SigV4 verification and IAM enforcement — see /docs/reference/security"
+        );
+    }
+
     let config = DispatchConfig {
         region: cli.region,
         account_id: cli.account_id,
+        verify_sigv4: cli.verify_sigv4,
+        iam_mode,
     };
 
     let service_names: Vec<String> = registry


### PR DESCRIPTION
## Summary

First batch of the opt-in SigV4 verification + IAM policy enforcement work. This PR only plumbs the flags — **nothing is enforced yet**, existing behavior is unchanged.

- New ``fakecloud_core::auth`` module with ``IamMode`` (off/soft/strict) and ``is_root_bypass`` (matches ``test*`` AKIDs case-insensitively — the community-standard local-dev convention used by LocalStack and Floci).
- ``DispatchConfig`` gains ``verify_sigv4: bool`` and ``iam_mode: IamMode``.
- CLI exposes ``--verify-sigv4`` / ``FAKECLOUD_VERIFY_SIGV4`` and ``--iam off|soft|strict`` / ``FAKECLOUD_IAM``.
- Startup WARN when either feature is turned on, noting that ``test`` credentials bypass both checks — so users don't get false-positive "my policies work" results from unsigned test clients.

### Roadmap context

This is batch 1 of 9:

1. **This PR** — config flags + root-bypass predicate
2. STS temp credential secret persistence (prereq for verification)
3. SigV4 cryptographic verification via ``aws-sigv4``
4. Principal resolution + request-context enrichment
5. IAM policy evaluator (Phase 1: identity policies, Allow/Deny, wildcards)
6. Enforcement wiring + ``ServiceMetadata``
7-8. Per-service ``action_to_iam`` mappings + resource extractors
9. Docs + README

Also sets up the shape for #381 (multi-account isolation): the new types are designed so ``account_id`` will flow from the credential's owning account rather than from global config once later batches land.

## Test plan

- [x] ``cargo test -p fakecloud-core auth::`` — 9 tests
- [x] ``cargo test -p fakecloud-core dispatch::tests::`` — 2 tests
- [x] ``cargo test -p fakecloud cli::`` — 4 tests (CLI flag parsing)
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo fmt --check`` clean
- [x] Manual: ``fakecloud --iam strict --verify-sigv4`` prints the startup WARN and otherwise behaves identically to before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in SigV4 verification and IAM policy evaluation flags, wired from the CLI/env into `DispatchConfig`. Defaults are off; no request behavior changes. Also fixes a crash in `is_root_bypass` with non-ASCII AKIDs.

- **New Features**
  - New `fakecloud_core::auth` with `IamMode` (off/soft/strict) and `is_root_bypass` for `test*` AKIDs.
  - `DispatchConfig` adds `verify_sigv4: bool` and `iam_mode: IamMode`.
  - CLI: `--verify-sigv4` (`FAKECLOUD_VERIFY_SIGV4`) and `--iam off|soft|strict` (`FAKECLOUD_IAM`).
  - Startup WARN when enabled, noting `test` credentials bypass verification and IAM checks.

- **Bug Fixes**
  - Prevent UTF-8 boundary panic in `is_root_bypass` by using `str::get(..4)`; added regression tests.

<sup>Written for commit ba06607af3b33085a94add605b52a55b4982fb85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

