### PR TITLE
feat(iam): persist STS temp credential secrets for later lookup

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -217,15 +217,66 @@ async fn sts_assume_role_unique_credentials() {
 }
 
 #[tokio::test]
+async fn sts_assume_role_temp_credentials_resolve_via_get_caller_identity() {
+    // End-to-end regression guard for STS temp credential persistence:
+    // AssumeRole -> take the returned creds -> call GetCallerIdentity
+    // signed with the temporary access key -> expect the assumed-role ARN.
+    use aws_credential_types::Credentials;
+
+    let server = TestServer::start().await;
+    let sts = server.sts_client().await;
+
+    let resp = sts
+        .assume_role()
+        .role_arn("arn:aws:iam::123456789012:role/ops")
+        .role_session_name("ci-e2e")
+        .send()
+        .await
+        .unwrap();
+    let creds = resp.credentials().unwrap();
+
+    let temp_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(
+            creds.access_key_id(),
+            creds.secret_access_key(),
+            Some(creds.session_token().to_string()),
+            None,
+            "fakecloud-temp",
+        ))
+        .load()
+        .await;
+    let temp_sts = aws_sdk_sts::Client::new(&temp_config);
+
+    let identity = temp_sts.get_caller_identity().send().await.unwrap();
+    assert!(
+        identity.arn().unwrap().contains("assumed-role/ops/ci-e2e"),
+        "expected assumed-role ARN, got {:?}",
+        identity.arn()
+    );
+    assert_eq!(identity.account().unwrap(), "123456789012");
+}
+
+#[tokio::test]
 async fn sts_get_session_token() {
     let server = TestServer::start().await;
     let client = server.sts_client().await;
 
-    let resp = client.get_session_token().send().await.unwrap();
-    let creds = resp.credentials().unwrap();
-    assert!(creds.access_key_id().starts_with("FSIA"));
-    assert!(!creds.secret_access_key().is_empty());
-    assert!(creds.session_token().starts_with("AQoEXAMPLEH4"));
+    let resp1 = client.get_session_token().send().await.unwrap();
+    let creds1 = resp1.credentials().unwrap();
+    assert!(creds1.access_key_id().starts_with("FSIA"));
+    assert_eq!(creds1.secret_access_key().len(), 40);
+    assert!(creds1.session_token().starts_with("FQoGZXIvYXdzE"));
+
+    // Two successive calls must return distinct credentials so later
+    // batches can match signatures against per-request state rather than
+    // a shared constant.
+    let resp2 = client.get_session_token().send().await.unwrap();
+    let creds2 = resp2.credentials().unwrap();
+    assert_ne!(creds1.access_key_id(), creds2.access_key_id());
+    assert_ne!(creds1.secret_access_key(), creds2.secret_access_key());
+    assert_ne!(creds1.session_token(), creds2.session_token());
 }
 
 #[tokio::test]
@@ -241,9 +292,21 @@ async fn sts_get_federation_token() {
         .unwrap();
     let creds = resp.credentials().unwrap();
     assert!(creds.access_key_id().starts_with("FSIA"));
+    assert_eq!(creds.secret_access_key().len(), 40);
+    assert!(creds.session_token().starts_with("FQoGZXIvYXdzE"));
     let fed_user = resp.federated_user().unwrap();
     assert!(fed_user.arn().contains("federated-user/Bob"));
     assert!(fed_user.federated_user_id().contains("Bob"));
+
+    // Per-request generation: a second call must return different creds.
+    let resp2 = client
+        .get_federation_token()
+        .name("Bob")
+        .send()
+        .await
+        .unwrap();
+    let creds2 = resp2.credentials().unwrap();
+    assert_ne!(creds.access_key_id(), creds2.access_key_id());
 }
 
 #[tokio::test]

--- a/crates/fakecloud-iam/src/state.rs
+++ b/crates/fakecloud-iam/src/state.rs
@@ -190,6 +190,41 @@ pub struct CredentialIdentity {
     pub account_id: String,
 }
 
+/// A temporary credential issued by STS (`AssumeRole`, `AssumeRoleWithWebIdentity`,
+/// `AssumeRoleWithSAML`, `GetSessionToken`, `GetFederationToken`).
+///
+/// Unlike [`CredentialIdentity`], which only remembers the principal ARN for
+/// `GetCallerIdentity`, this struct also retains the secret access key and
+/// session token so that SigV4 verification and IAM enforcement (added in
+/// later batches) can look them up when a client signs a request with
+/// temporary credentials. `expiration` is the absolute wall-clock time at
+/// which the credential becomes invalid.
+#[derive(Debug, Clone)]
+pub struct StsTempCredential {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub session_token: String,
+    pub principal_arn: String,
+    pub user_id: String,
+    pub account_id: String,
+    pub expiration: DateTime<Utc>,
+}
+
+/// Result of looking up a set of credentials by access key ID.
+///
+/// Carries the secret + resolved principal + owning account id. The account
+/// id is intentionally read from the credential itself rather than from
+/// global config, so that once #381 (multi-account isolation) lands, the same
+/// lookup already returns the correct account for the credential.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretLookup {
+    pub secret_access_key: String,
+    pub session_token: Option<String>,
+    pub principal_arn: String,
+    pub user_id: String,
+    pub account_id: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct SshPublicKey {
     pub ssh_public_key_id: String,
@@ -231,6 +266,11 @@ pub struct IamState {
     pub service_linked_role_deletions: HashMap<String, ServiceLinkedRoleDeletion>,
     /// Maps access key ID to the identity that should be returned by GetCallerIdentity.
     pub credential_identities: HashMap<String, CredentialIdentity>,
+    /// Temporary credentials issued by STS, keyed by access key ID. Includes
+    /// the secret access key and session token — required for SigV4
+    /// verification and IAM enforcement. Expired entries are purged lazily on
+    /// lookup.
+    pub sts_temp_credentials: HashMap<String, StsTempCredential>,
     pub credential_report_generated: bool,
     pub ssh_public_keys: HashMap<String, Vec<SshPublicKey>>, // user_name -> keys
     pub access_key_last_used: HashMap<String, AccessKeyLastUsed>,
@@ -260,6 +300,7 @@ impl IamState {
             virtual_mfa_devices: HashMap::new(),
             service_linked_role_deletions: HashMap::new(),
             credential_identities: HashMap::new(),
+            sts_temp_credentials: HashMap::new(),
             credential_report_generated: false,
             ssh_public_keys: HashMap::new(),
             access_key_last_used: HashMap::new(),
@@ -270,6 +311,202 @@ impl IamState {
         let account_id = self.account_id.clone();
         *self = Self::new(&account_id);
     }
+
+    /// Look up the secret access key, session token, and resolved principal
+    /// for a given access key ID.
+    ///
+    /// Searches IAM user access keys first, then STS temporary credentials.
+    /// Expired STS temporary credentials are purged in-place and skipped.
+    ///
+    /// Returns `None` if the AKID is unknown or its STS credential has
+    /// expired.
+    ///
+    /// Required for SigV4 signature verification (batch 3) and principal
+    /// resolution (batch 4). Callers must hold a write lock on
+    /// [`IamState`] to allow the lazy purge; read-only callers should use
+    /// [`IamState::credential_secret_readonly`].
+    pub fn credential_secret(&mut self, access_key_id: &str) -> Option<SecretLookup> {
+        // IAM user access keys: look up by scanning (same pattern the
+        // existing GetCallerIdentity path uses).
+        for keys in self.access_keys.values() {
+            for key in keys {
+                if key.access_key_id == access_key_id {
+                    if let Some(user) = self.users.get(&key.user_name) {
+                        return Some(SecretLookup {
+                            secret_access_key: key.secret_access_key.clone(),
+                            session_token: None,
+                            principal_arn: user.arn.clone(),
+                            user_id: user.user_id.clone(),
+                            account_id: self.account_id.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // STS temporary credentials: direct hash lookup, with lazy expiry
+        // purging so expired entries don't accumulate.
+        let now = Utc::now();
+        if let Some(temp) = self.sts_temp_credentials.get(access_key_id) {
+            if temp.expiration > now {
+                return Some(SecretLookup {
+                    secret_access_key: temp.secret_access_key.clone(),
+                    session_token: Some(temp.session_token.clone()),
+                    principal_arn: temp.principal_arn.clone(),
+                    user_id: temp.user_id.clone(),
+                    account_id: temp.account_id.clone(),
+                });
+            }
+            self.sts_temp_credentials.remove(access_key_id);
+        }
+        None
+    }
+
+    /// Read-only variant of [`IamState::credential_secret`] that does not
+    /// purge expired entries. Prefer the mutable variant wherever possible
+    /// to keep the temp-credential table small.
+    pub fn credential_secret_readonly(&self, access_key_id: &str) -> Option<SecretLookup> {
+        for keys in self.access_keys.values() {
+            for key in keys {
+                if key.access_key_id == access_key_id {
+                    if let Some(user) = self.users.get(&key.user_name) {
+                        return Some(SecretLookup {
+                            secret_access_key: key.secret_access_key.clone(),
+                            session_token: None,
+                            principal_arn: user.arn.clone(),
+                            user_id: user.user_id.clone(),
+                            account_id: self.account_id.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        let now = Utc::now();
+        let temp = self.sts_temp_credentials.get(access_key_id)?;
+        if temp.expiration <= now {
+            return None;
+        }
+        Some(SecretLookup {
+            secret_access_key: temp.secret_access_key.clone(),
+            session_token: Some(temp.session_token.clone()),
+            principal_arn: temp.principal_arn.clone(),
+            user_id: temp.user_id.clone(),
+            account_id: temp.account_id.clone(),
+        })
+    }
 }
 
 pub type SharedIamState = std::sync::Arc<RwLock<IamState>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn iam_user(name: &str, account_id: &str) -> IamUser {
+        IamUser {
+            user_name: name.to_string(),
+            user_id: format!("AIDA{}", name.to_uppercase()),
+            arn: format!("arn:aws:iam::{}:user/{}", account_id, name),
+            path: "/".to_string(),
+            created_at: Utc::now(),
+            tags: Vec::new(),
+            permissions_boundary: None,
+        }
+    }
+
+    fn iam_key(user: &str, akid: &str, secret: &str) -> IamAccessKey {
+        IamAccessKey {
+            access_key_id: akid.to_string(),
+            secret_access_key: secret.to_string(),
+            user_name: user.to_string(),
+            status: "Active".to_string(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn credential_secret_returns_iam_user_key() {
+        let mut state = IamState::new("123456789012");
+        state
+            .users
+            .insert("alice".to_string(), iam_user("alice", "123456789012"));
+        state.access_keys.insert(
+            "alice".to_string(),
+            vec![iam_key("alice", "FKIAALICE", "secret-alice")],
+        );
+        let lookup = state.credential_secret("FKIAALICE").unwrap();
+        assert_eq!(lookup.secret_access_key, "secret-alice");
+        assert_eq!(lookup.principal_arn, "arn:aws:iam::123456789012:user/alice");
+        assert_eq!(lookup.account_id, "123456789012");
+        assert_eq!(lookup.session_token, None);
+    }
+
+    #[test]
+    fn credential_secret_returns_sts_temp_credential_when_unexpired() {
+        let mut state = IamState::new("123456789012");
+        state.sts_temp_credentials.insert(
+            "FSIATEMPKEY".to_string(),
+            StsTempCredential {
+                access_key_id: "FSIATEMPKEY".to_string(),
+                secret_access_key: "temp-secret".to_string(),
+                session_token: "temp-token".to_string(),
+                principal_arn: "arn:aws:sts::123456789012:assumed-role/R/s".to_string(),
+                user_id: "AROA:session".to_string(),
+                account_id: "123456789012".to_string(),
+                expiration: Utc::now() + chrono::Duration::minutes(30),
+            },
+        );
+        let lookup = state.credential_secret("FSIATEMPKEY").unwrap();
+        assert_eq!(lookup.secret_access_key, "temp-secret");
+        assert_eq!(lookup.session_token.as_deref(), Some("temp-token"));
+        assert_eq!(
+            lookup.principal_arn,
+            "arn:aws:sts::123456789012:assumed-role/R/s"
+        );
+    }
+
+    #[test]
+    fn credential_secret_purges_expired_sts_credentials() {
+        let mut state = IamState::new("123456789012");
+        state.sts_temp_credentials.insert(
+            "FSIAOLD".to_string(),
+            StsTempCredential {
+                access_key_id: "FSIAOLD".to_string(),
+                secret_access_key: "s".to_string(),
+                session_token: "t".to_string(),
+                principal_arn: "arn".to_string(),
+                user_id: "id".to_string(),
+                account_id: "123456789012".to_string(),
+                expiration: Utc::now() - chrono::Duration::seconds(1),
+            },
+        );
+        assert!(state.credential_secret("FSIAOLD").is_none());
+        assert!(!state.sts_temp_credentials.contains_key("FSIAOLD"));
+    }
+
+    #[test]
+    fn credential_secret_readonly_does_not_purge() {
+        let mut state = IamState::new("123456789012");
+        state.sts_temp_credentials.insert(
+            "FSIAOLD".to_string(),
+            StsTempCredential {
+                access_key_id: "FSIAOLD".to_string(),
+                secret_access_key: "s".to_string(),
+                session_token: "t".to_string(),
+                principal_arn: "arn".to_string(),
+                user_id: "id".to_string(),
+                account_id: "123456789012".to_string(),
+                expiration: Utc::now() - chrono::Duration::seconds(1),
+            },
+        );
+        assert!(state.credential_secret_readonly("FSIAOLD").is_none());
+        assert!(state.sts_temp_credentials.contains_key("FSIAOLD"));
+    }
+
+    #[test]
+    fn credential_secret_returns_none_for_unknown_akid() {
+        let mut state = IamState::new("123456789012");
+        assert!(state.credential_secret("FKIAUNKNOWN").is_none());
+    }
+}

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use http::StatusCode;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{CredentialIdentity, SharedIamState};
+use crate::state::{CredentialIdentity, SharedIamState, StsTempCredential};
 use crate::xml_responses::{self, StsCredentials};
 
 /// Default duration for AssumeRole and similar operations (1 hour).
@@ -17,8 +17,11 @@ const DEFAULT_SESSION_TOKEN_DURATION: i64 = 43200;
 /// Default duration for GetFederationToken (12 hours).
 const DEFAULT_FEDERATION_TOKEN_DURATION: i64 = 43200;
 
-/// Compute an ISO 8601 expiration timestamp from an optional DurationSeconds parameter.
-fn compute_expiration(req: &AwsRequest, default_duration: i64) -> Result<String, AwsServiceError> {
+/// Compute an absolute expiration timestamp from an optional DurationSeconds parameter.
+fn compute_expiration_at(
+    req: &AwsRequest,
+    default_duration: i64,
+) -> Result<DateTime<Utc>, AwsServiceError> {
     let duration = if let Some(ds) = req.query_params.get("DurationSeconds") {
         ds.parse::<i64>().map_err(|_| {
             AwsServiceError::aws_error(
@@ -34,8 +37,22 @@ fn compute_expiration(req: &AwsRequest, default_duration: i64) -> Result<String,
     } else {
         default_duration
     };
-    let expiration = Utc::now() + chrono::Duration::seconds(duration);
-    Ok(expiration.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+    Ok(Utc::now() + chrono::Duration::seconds(duration))
+}
+
+/// Format an expiration timestamp as the ISO 8601 string AWS returns.
+fn format_expiration(ts: DateTime<Utc>) -> String {
+    ts.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+/// Test-only wrapper around [`compute_expiration_at`] used by the existing
+/// duration unit tests.
+#[cfg(test)]
+fn compute_expiration(req: &AwsRequest, default_duration: i64) -> Result<String, AwsServiceError> {
+    Ok(format_expiration(compute_expiration_at(
+        req,
+        default_duration,
+    )?))
 }
 
 pub struct StsService {
@@ -232,7 +249,8 @@ impl StsService {
         let token_code = req.query_params.get("TokenCode").cloned();
 
         // Compute expiration from DurationSeconds (default 3600s)
-        let expiration = compute_expiration(req, DEFAULT_ASSUME_ROLE_DURATION)?;
+        let expiration_at = compute_expiration_at(req, DEFAULT_ASSUME_ROLE_DURATION)?;
+        let expiration = format_expiration(expiration_at);
 
         // Accept MFA parameters without verification (emulator behavior)
         let _mfa_serial = serial_number;
@@ -265,9 +283,23 @@ impl StsService {
         state.credential_identities.insert(
             creds.access_key_id.clone(),
             CredentialIdentity {
-                arn: assumed_role_arn,
+                arn: assumed_role_arn.clone(),
+                user_id: assumed_role_id.clone(),
+                account_id: account_id.clone(),
+            },
+        );
+        // Store full temp credential so SigV4 verification (batch 3) and IAM
+        // enforcement (batch 4+) can look up the secret by access key ID.
+        state.sts_temp_credentials.insert(
+            creds.access_key_id.clone(),
+            StsTempCredential {
+                access_key_id: creds.access_key_id.clone(),
+                secret_access_key: creds.secret_access_key.clone(),
+                session_token: creds.session_token.clone(),
+                principal_arn: assumed_role_arn,
                 user_id: assumed_role_id,
                 account_id: account_id.clone(),
+                expiration: expiration_at,
             },
         );
 
@@ -350,7 +382,8 @@ impl StsService {
         }
 
         // Compute expiration from DurationSeconds (default 3600s)
-        let expiration = compute_expiration(req, DEFAULT_ASSUME_ROLE_DURATION)?;
+        let expiration_at = compute_expiration_at(req, DEFAULT_ASSUME_ROLE_DURATION)?;
+        let expiration = format_expiration(expiration_at);
 
         let partition = partition_for_region(&req.region);
         let creds = StsCredentials::generate();
@@ -370,9 +403,21 @@ impl StsService {
         state.credential_identities.insert(
             creds.access_key_id.clone(),
             CredentialIdentity {
-                arn: assumed_role_arn,
+                arn: assumed_role_arn.clone(),
+                user_id: assumed_role_id_str.clone(),
+                account_id: account_id.clone(),
+            },
+        );
+        state.sts_temp_credentials.insert(
+            creds.access_key_id.clone(),
+            StsTempCredential {
+                access_key_id: creds.access_key_id.clone(),
+                secret_access_key: creds.secret_access_key.clone(),
+                session_token: creds.session_token.clone(),
+                principal_arn: assumed_role_arn,
                 user_id: assumed_role_id_str,
                 account_id: account_id.clone(),
+                expiration: expiration_at,
             },
         );
 
@@ -447,7 +492,8 @@ impl StsService {
         }
 
         // Compute expiration from DurationSeconds (default 3600s)
-        let expiration = compute_expiration(req, DEFAULT_ASSUME_ROLE_DURATION)?;
+        let expiration_at = compute_expiration_at(req, DEFAULT_ASSUME_ROLE_DURATION)?;
+        let expiration = format_expiration(expiration_at);
 
         // Decode the SAML assertion to extract the RoleSessionName
         let role_session_name =
@@ -471,9 +517,21 @@ impl StsService {
         state.credential_identities.insert(
             creds.access_key_id.clone(),
             CredentialIdentity {
-                arn: assumed_role_arn,
+                arn: assumed_role_arn.clone(),
+                user_id: assumed_role_id_str.clone(),
+                account_id: account_id.clone(),
+            },
+        );
+        state.sts_temp_credentials.insert(
+            creds.access_key_id.clone(),
+            StsTempCredential {
+                access_key_id: creds.access_key_id.clone(),
+                secret_access_key: creds.secret_access_key.clone(),
+                session_token: creds.session_token.clone(),
+                principal_arn: assumed_role_arn,
                 user_id: assumed_role_id_str,
                 account_id: account_id.clone(),
+                expiration: expiration_at,
             },
         );
 
@@ -526,9 +584,58 @@ impl StsService {
         let _token_code = req.query_params.get("TokenCode").cloned();
 
         // Compute expiration from DurationSeconds (default 43200s / 12 hours)
-        let expiration = compute_expiration(req, DEFAULT_SESSION_TOKEN_DURATION)?;
+        let expiration_at = compute_expiration_at(req, DEFAULT_SESSION_TOKEN_DURATION)?;
+        let expiration = format_expiration(expiration_at);
 
-        let xml = xml_responses::get_session_token_response(&expiration, &req.request_id);
+        // Resolve the calling principal so the temporary credential is tied
+        // to a real identity that SigV4 verification and IAM enforcement can
+        // look up later. Falls back to the account root when the caller
+        // isn't a known IAM user — matches how `GetSessionToken` behaves
+        // against AWS with root credentials.
+        let partition = partition_for_region(&req.region);
+        let mut state = self.state.write();
+        let (principal_arn, user_id, account_id) =
+            if let Some(akid) = extract_access_key(req).as_deref() {
+                if let Some(lookup) = state.credential_secret(akid) {
+                    (lookup.principal_arn, lookup.user_id, lookup.account_id)
+                } else {
+                    (
+                        format!("arn:{}:iam::{}:root", partition, state.account_id),
+                        state.account_id.clone(),
+                        state.account_id.clone(),
+                    )
+                }
+            } else {
+                (
+                    format!("arn:{}:iam::{}:root", partition, state.account_id),
+                    state.account_id.clone(),
+                    state.account_id.clone(),
+                )
+            };
+
+        let creds = StsCredentials::generate();
+        state.credential_identities.insert(
+            creds.access_key_id.clone(),
+            CredentialIdentity {
+                arn: principal_arn.clone(),
+                user_id: user_id.clone(),
+                account_id: account_id.clone(),
+            },
+        );
+        state.sts_temp_credentials.insert(
+            creds.access_key_id.clone(),
+            StsTempCredential {
+                access_key_id: creds.access_key_id.clone(),
+                secret_access_key: creds.secret_access_key.clone(),
+                session_token: creds.session_token.clone(),
+                principal_arn,
+                user_id,
+                account_id,
+                expiration: expiration_at,
+            },
+        );
+
+        let xml = xml_responses::get_session_token_response(&creds, &expiration, &req.request_id);
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 
@@ -568,13 +675,45 @@ impl StsService {
         let policy = req.query_params.get("Policy").cloned();
 
         // Compute expiration from DurationSeconds (default 43200s / 12 hours)
-        let expiration = compute_expiration(req, DEFAULT_FEDERATION_TOKEN_DURATION)?;
+        let expiration_at = compute_expiration_at(req, DEFAULT_FEDERATION_TOKEN_DURATION)?;
+        let expiration = format_expiration(expiration_at);
 
         let partition = partition_for_region(&req.region);
-        let state = self.state.read();
+        let creds = StsCredentials::generate();
+
+        let mut state = self.state.write();
+        let account_id = state.account_id.clone();
+        let federated_user_arn = format!(
+            "arn:{}:sts::{}:federated-user/{}",
+            partition, account_id, name
+        );
+        let federated_user_id = format!("{}:{}", account_id, name);
+
+        state.credential_identities.insert(
+            creds.access_key_id.clone(),
+            CredentialIdentity {
+                arn: federated_user_arn.clone(),
+                user_id: federated_user_id.clone(),
+                account_id: account_id.clone(),
+            },
+        );
+        state.sts_temp_credentials.insert(
+            creds.access_key_id.clone(),
+            StsTempCredential {
+                access_key_id: creds.access_key_id.clone(),
+                secret_access_key: creds.secret_access_key.clone(),
+                session_token: creds.session_token.clone(),
+                principal_arn: federated_user_arn,
+                user_id: federated_user_id,
+                account_id: account_id.clone(),
+                expiration: expiration_at,
+            },
+        );
+
         let xml = xml_responses::get_federation_token_response(
+            &creds,
             name,
-            &state.account_id,
+            &account_id,
             partition,
             &expiration,
             policy.as_deref(),

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -700,11 +700,14 @@ pub fn assume_role_with_saml_response(info: &AssumedRoleInfo<'_>) -> String {
     )
 }
 
-pub fn get_session_token_response(expiration: &str, request_id: &str) -> String {
-    // AWS docs example credentials (deterministic for local testing)
-    let access_key_id = "FSIAIOSFODNN7EXAMPLE";
-    let secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY";
-    let session_token = "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE";
+pub fn get_session_token_response(
+    creds: &StsCredentials,
+    expiration: &str,
+    request_id: &str,
+) -> String {
+    let access_key_id = creds.access_key_id.as_str();
+    let secret_access_key = creds.secret_access_key.as_str();
+    let session_token = creds.session_token.as_str();
 
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -729,6 +732,7 @@ pub fn get_session_token_response(expiration: &str, request_id: &str) -> String 
 }
 
 pub fn get_federation_token_response(
+    creds: &StsCredentials,
     name: &str,
     account_id: &str,
     partition: &str,
@@ -736,10 +740,9 @@ pub fn get_federation_token_response(
     policy: Option<&str>,
     request_id: &str,
 ) -> String {
-    // AWS docs example credentials (deterministic for local testing)
-    let access_key_id = "FSIAIOSFODNN7EXAMPLE";
-    let secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY";
-    let session_token = "AQoDYXdzEPT//////////wEXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZTwdQWLWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI/qkPpKPi/kMcGdQrmGdeehM4IC1NtBmUpp2wUE8phUZampKsburEDy0KPkyQDYwT7WZ0wq5VSXDvp75YU9HFvlRd8Tx6q6fE8YQcHNVXAkiY9q6d+xo0rKwT38xVqr7ZD0u0iPPkUL64lIZbqBAz+scqKmlzm8FDrypNC9Yjc8fPOLn9FX9KSYvKTr4rvx3iSIlTJabIQwj2ICCR/oLxBA==";
+    let access_key_id = creds.access_key_id.as_str();
+    let secret_access_key = creds.secret_access_key.as_str();
+    let session_token = creds.session_token.as_str();
 
     let name = xml_escape(name);
     let federated_user_arn = format!(


### PR DESCRIPTION
## Summary

Batch 2 of 9 for the opt-in SigV4 verification + IAM enforcement work. Makes STS temporary credentials persistable and round-trippable so later batches can look them up by access key ID.

Previously:
- ``AssumeRole`` / ``AssumeRoleWithWebIdentity`` / ``AssumeRoleWithSAML`` stored only the access key ID in ``credential_identities``, discarding the secret and session token.
- ``GetSessionToken`` / ``GetFederationToken`` returned hardcoded ``AQoEXAMPLEH4`` / ``FSIAIOSFODNN7EXAMPLE`` constants that were not persisted.

Now:
- New ``StsTempCredential`` struct + ``sts_temp_credentials: HashMap<String, StsTempCredential>`` field on ``IamState``, carrying secret access key, session token, principal ARN, user id, account id, and absolute expiration.
- New ``IamState::credential_secret`` / ``credential_secret_readonly`` helpers that resolve AKID → ``SecretLookup {secret, session_token, principal_arn, user_id, account_id}``. Expired STS temp credentials are lazy-purged on the mutable variant.
- All five STS operations persist the full generated credential and return it in the XML response (the hardcoded ``xml_responses`` constants are gone).
- ``account_id`` is sourced from the credential itself (not from global config), so #381 (multi-account isolation) becomes a state-partitioning change rather than a cross-cutting rewrite.

### Why this batch comes before SigV4 verification

Batch 3 adds ``verify_sigv4``, which needs to look up the secret access key for any AKID in circulation — including STS temporary credentials. If the STS table doesn't store the secret, any SDK that calls ``AssumeRole`` and then uses the returned credentials would fail verification. This batch fixes that gap first.

### Decisions

- ``GetSessionToken`` now resolves the caller via ``credential_secret`` and scopes the new temporary credential to that principal (falling back to account root when the caller isn't a known IAM user — matches AWS behavior with root creds).
- ``GetFederationToken`` resolves the federated-user ARN from the ``Name`` parameter as before, but now persists a real per-request credential tied to that ARN.
- Hardcoded constants in ``xml_responses::{get_session_token_response, get_federation_token_response}`` are removed. They were compatible in isolation but are incompatible with per-request verification.
- Two existing E2E tests (``sts_get_session_token`` / ``sts_get_federation_token``) previously asserted on the hardcoded token prefix ``AQoEXAMPLEH4``; updated to the per-request ``FQoGZXIvYXdzE`` format and extended to assert two calls return distinct credentials.

## Test plan

- [x] ``cargo test -p fakecloud-iam`` — 78 tests including 5 new ``state::tests::credential_secret_*`` cases
- [x] ``cargo test -p fakecloud-e2e --test iam sts_`` — 11 STS e2e tests, including a new ``sts_assume_role_temp_credentials_resolve_via_get_caller_identity`` that round-trips AssumeRole → GetCallerIdentity with the temporary credentials and verifies the assumed-role ARN
- [x] ``cargo test -p fakecloud-conformance`` — 711+ tests, all green (zero regressions)
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo fmt --check`` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists STS temporary credential secrets and session tokens so we can look them up by access key ID for upcoming SigV4 verification and IAM enforcement. All STS APIs now return and persist per-request credentials instead of static examples.

- **New Features - New features added**
  - Added `StsTempCredential` and `sts_temp_credentials` on `IamState` with absolute expiration.
  - Added `IamState::credential_secret` and `credential_secret_readonly` to resolve AKID → {secret, session token, principal ARN, user id, account id}, with lazy purge of expired entries.
  - Updated `AssumeRole`, `AssumeRoleWithWebIdentity`, `AssumeRoleWithSAML`, `GetSessionToken`, and `GetFederationToken` to store full credentials and use them in XML responses.
  - `GetSessionToken` now scopes creds to the caller (falls back to account root); `GetFederationToken` ties creds to the federated-user ARN.
  - Account ID is sourced from the credential (prep for multi-account isolation, see #381).

<sup>Written for commit ec0efd15a11bd14898a8ed98a0301ab0d6f3c7d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

