### PR TITLE
feat(auth): implement opt-in SigV4 cryptographic verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,10 +1996,16 @@ name = "fakecloud-aws"
 version = "0.9.1"
 dependencies = [
  "bytes",
+ "chrono",
+ "hex",
+ "hmac 0.12.1",
  "http 1.4.0",
+ "percent-encoding",
  "quick-xml",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "subtle",
  "thiserror 2.0.18",
 ]
 
@@ -2129,6 +2135,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bytes",
+ "chrono",
  "fakecloud-aws",
  "http 1.4.0",
  "serde",

--- a/crates/fakecloud-aws/Cargo.toml
+++ b/crates/fakecloud-aws/Cargo.toml
@@ -9,8 +9,14 @@ version.workspace = true
 
 [dependencies]
 bytes = { workspace = true }
+chrono = { workspace = true }
+hex = "0.4"
+hmac = "0.12"
 http = { workspace = true }
+percent-encoding = { workspace = true }
 quick-xml = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
+subtle = "2"
 thiserror = { workspace = true }

--- a/crates/fakecloud-aws/src/sigv4.rs
+++ b/crates/fakecloud-aws/src/sigv4.rs
@@ -1,7 +1,34 @@
-/// Information extracted from an AWS SigV4 Authorization header.
-///
-/// We parse this for routing (service name) and identity (access key),
-/// but never validate the actual signature.
+//! AWS Signature Version 4 parsing and verification.
+//!
+//! Used in two modes:
+//!
+//! 1. **Routing** — lightweight parse of the Authorization header or presigned
+//!    query string to extract the access key ID, region, and service. Always
+//!    on, used by dispatch to route requests regardless of whether signatures
+//!    are being verified.
+//!
+//! 2. **Verification** — reconstructs the canonical request, derives the
+//!    signing key from the access key's secret, and compares the computed
+//!    signature against the one the client sent. Opt-in via
+//!    `--verify-sigv4` / `FAKECLOUD_VERIFY_SIGV4`.
+//!
+//! The canonical request + string-to-sign + signing-key derivation follows
+//! the AWS SigV4 specification at
+//! <https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html>.
+//! S3 is the only service that single-encodes the path; all others
+//! double-encode.
+
+use chrono::{DateTime, TimeZone, Utc};
+use hmac::{Hmac, Mac};
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Lightweight view of a parsed SigV4 Authorization header or presigned URL.
+/// Used for request routing (access key → principal, region, service) without
+/// requiring cryptographic verification.
 #[derive(Debug, Clone)]
 pub struct SigV4Info {
     pub access_key: String,
@@ -9,22 +36,90 @@ pub struct SigV4Info {
     pub service: String,
 }
 
-/// Parse the SigV4 Authorization header.
-///
-/// Format: `AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/sqs/aws4_request, SignedHeaders=..., Signature=...`
-pub fn parse_sigv4(auth_header: &str) -> Option<SigV4Info> {
-    let auth = auth_header.strip_prefix("AWS4-HMAC-SHA256 ")?;
+/// Full parse of a SigV4-signed request. Carries everything needed to
+/// reconstruct the canonical request and re-derive the signature.
+#[derive(Debug, Clone)]
+pub struct ParsedSigV4 {
+    pub access_key: String,
+    /// 8-char `YYYYMMDD` date part of the credential scope.
+    pub date_stamp: String,
+    pub region: String,
+    pub service: String,
+    /// Lowercased, semicolon-separated list of signed headers
+    /// (e.g. `host;x-amz-content-sha256;x-amz-date`).
+    pub signed_headers: Vec<String>,
+    /// Hex-encoded signature the client sent.
+    pub signature: String,
+    /// `X-Amz-Date` / `x-amz-date` value in `YYYYMMDDTHHMMSSZ` form.
+    pub amz_date: String,
+    /// True if the request was signed via presigned URL query parameters
+    /// rather than the `Authorization` header.
+    pub is_presigned: bool,
+}
 
+impl ParsedSigV4 {
+    /// Borrow-view the routing subset of a full parse.
+    pub fn as_info(&self) -> SigV4Info {
+        SigV4Info {
+            access_key: self.access_key.clone(),
+            region: self.region.clone(),
+            service: self.service.clone(),
+        }
+    }
+}
+
+/// Reasons a SigV4 verification can fail. Each variant maps onto the
+/// AWS-shape error the caller should return.
+#[derive(Debug, thiserror::Error)]
+pub enum SigV4Error {
+    /// Request was signed more than 15 minutes from the server's clock.
+    /// Maps to AWS `RequestTimeTooSkewed`.
+    #[error("request time {signed} is outside the allowed 15-minute window from {server}")]
+    RequestTimeTooSkewed {
+        signed: DateTime<Utc>,
+        server: DateTime<Utc>,
+    },
+    /// `Authorization` header or presigned URL was not a well-formed
+    /// AWS4-HMAC-SHA256 signature. Maps to AWS `IncompleteSignature` or
+    /// `InvalidSignatureException`.
+    #[error("malformed SigV4 signature: {0}")]
+    Malformed(&'static str),
+    /// The computed signature did not match the signature the client sent.
+    /// Maps to AWS `SignatureDoesNotMatch`.
+    #[error("signature does not match")]
+    SignatureMismatch,
+    /// `X-Amz-Date` / credential-scope date could not be parsed.
+    #[error("invalid x-amz-date: {0}")]
+    InvalidDate(&'static str),
+}
+
+/// Maximum allowed drift between the request's `X-Amz-Date` and the server's
+/// wall clock. Matches the 15-minute window AWS uses.
+pub const CLOCK_SKEW_SECONDS: i64 = 15 * 60;
+
+/// Legacy routing-only parse. Extracts access key, region, and service from
+/// either an `Authorization: AWS4-HMAC-SHA256 …` header or a presigned URL's
+/// `X-Amz-Credential` component.
+///
+/// Returns `None` when the input isn't a recognizable SigV4 credential.
+pub fn parse_sigv4(auth_header: &str) -> Option<SigV4Info> {
+    parse_header_credential(auth_header)
+}
+
+fn parse_header_credential(auth_header: &str) -> Option<SigV4Info> {
+    let auth = auth_header.strip_prefix("AWS4-HMAC-SHA256 ")?;
     let credential_start = auth.find("Credential=")?;
-    let credential_value = &auth[credential_start + 11..];
+    let credential_value = &auth[credential_start + "Credential=".len()..];
     let credential_end = credential_value.find(',')?;
     let credential = &credential_value[..credential_end];
+    parse_credential_scope(credential)
+}
 
+fn parse_credential_scope(credential: &str) -> Option<SigV4Info> {
     let parts: Vec<&str> = credential.split('/').collect();
-    if parts.len() != 5 {
+    if parts.len() != 5 || parts[4] != "aws4_request" {
         return None;
     }
-
     Some(SigV4Info {
         access_key: parts[0].to_string(),
         region: parts[2].to_string(),
@@ -32,9 +127,388 @@ pub fn parse_sigv4(auth_header: &str) -> Option<SigV4Info> {
     })
 }
 
+/// Full parse of an `Authorization: AWS4-HMAC-SHA256 …` header.
+///
+/// Returns `None` if the header is missing required components. The returned
+/// value is suitable for both routing (`as_info`) and signature verification
+/// (`verify`). The caller must also supply the request's `X-Amz-Date` header
+/// because it isn't embedded in the credential — it's carried separately.
+pub fn parse_sigv4_header(auth_header: &str, amz_date: Option<&str>) -> Option<ParsedSigV4> {
+    let auth = auth_header.strip_prefix("AWS4-HMAC-SHA256 ")?;
+
+    // Each field is comma-separated and may or may not be preceded by a space.
+    let mut credential: Option<&str> = None;
+    let mut signed_headers: Option<&str> = None;
+    let mut signature: Option<&str> = None;
+    for part in auth.split(',') {
+        let part = part.trim();
+        if let Some(v) = part.strip_prefix("Credential=") {
+            credential = Some(v);
+        } else if let Some(v) = part.strip_prefix("SignedHeaders=") {
+            signed_headers = Some(v);
+        } else if let Some(v) = part.strip_prefix("Signature=") {
+            signature = Some(v);
+        }
+    }
+
+    let credential = credential?;
+    let signed_headers = signed_headers?;
+    let signature = signature?;
+    let scope = parse_credential_scope(credential)?;
+    let date_stamp = credential.split('/').nth(1)?.to_string();
+    let signed_headers: Vec<String> = signed_headers
+        .split(';')
+        .map(|s| s.to_ascii_lowercase())
+        .collect();
+    if signed_headers.is_empty() {
+        return None;
+    }
+
+    Some(ParsedSigV4 {
+        access_key: scope.access_key,
+        date_stamp,
+        region: scope.region,
+        service: scope.service,
+        signed_headers,
+        signature: signature.to_string(),
+        amz_date: amz_date?.to_string(),
+        is_presigned: false,
+    })
+}
+
+/// Full parse of a presigned URL's SigV4 query parameters.
+///
+/// Expects to be given the full query-parameter map. Returns `None` when the
+/// required `X-Amz-*` parameters are missing or malformed.
+pub fn parse_sigv4_presigned(
+    query: &std::collections::HashMap<String, String>,
+) -> Option<ParsedSigV4> {
+    if query.get("X-Amz-Algorithm").map(|s| s.as_str()) != Some("AWS4-HMAC-SHA256") {
+        return None;
+    }
+    let credential = query.get("X-Amz-Credential")?;
+    let scope = parse_credential_scope(credential)?;
+    let date_stamp = credential.split('/').nth(1)?.to_string();
+    let signed_headers = query.get("X-Amz-SignedHeaders")?;
+    let signed_headers: Vec<String> = signed_headers
+        .split(';')
+        .map(|s| s.to_ascii_lowercase())
+        .collect();
+    let signature = query.get("X-Amz-Signature")?.clone();
+    let amz_date = query.get("X-Amz-Date")?.clone();
+
+    Some(ParsedSigV4 {
+        access_key: scope.access_key,
+        date_stamp,
+        region: scope.region,
+        service: scope.service,
+        signed_headers,
+        signature,
+        amz_date,
+        is_presigned: true,
+    })
+}
+
+/// The fields of an incoming HTTP request relevant to SigV4 verification.
+///
+/// Held separately from the full HTTP request so tests can build synthetic
+/// requests without constructing an axum/hyper payload.
+#[derive(Debug, Clone)]
+pub struct VerifyRequest<'a> {
+    pub method: &'a str,
+    /// URI path as-received (already URL-decoded once by the HTTP framework).
+    pub path: &'a str,
+    /// Query string without the leading `?`. For presigned URLs the
+    /// `X-Amz-Signature` parameter is removed before signing.
+    pub query: &'a str,
+    /// Lowercased header name → header value. Multi-valued headers should be
+    /// joined by `", "`. Built by [`headers_from_http`] for real requests.
+    pub headers: &'a [(String, String)],
+    /// Full request body. Required unless `X-Amz-Content-Sha256` is set.
+    pub body: &'a [u8],
+}
+
+/// Flatten a [`http::HeaderMap`] into the lowercase key/value slice
+/// [`VerifyRequest`] expects. Multi-valued headers are joined with `", "`.
+pub fn headers_from_http(headers: &http::HeaderMap) -> Vec<(String, String)> {
+    let mut out: std::collections::BTreeMap<String, Vec<String>> = Default::default();
+    for (name, value) in headers.iter() {
+        let key = name.as_str().to_ascii_lowercase();
+        if let Ok(v) = value.to_str() {
+            out.entry(key).or_default().push(v.to_string());
+        }
+    }
+    out.into_iter().map(|(k, vs)| (k, vs.join(", "))).collect()
+}
+
+/// Cryptographically verify that the parsed SigV4 signature matches the
+/// incoming request under the given secret access key.
+///
+/// The verification procedure is the canonical AWS SigV4 flow:
+///
+/// 1. Parse the `X-Amz-Date` and check it's within `CLOCK_SKEW_SECONDS` of
+///    `now`.
+/// 2. Build the canonical request (method, canonical URI, canonical query
+///    string, canonical headers, signed headers, hashed payload).
+/// 3. Derive the string-to-sign.
+/// 4. Derive the signing key from the secret access key via the four-step
+///    HMAC chain (`date → region → service → aws4_request`).
+/// 5. Compute the expected HMAC-SHA256 signature and compare it against
+///    `parsed.signature` in constant time.
+pub fn verify(
+    parsed: &ParsedSigV4,
+    req: &VerifyRequest<'_>,
+    secret_access_key: &str,
+    now: DateTime<Utc>,
+) -> Result<(), SigV4Error> {
+    // 1. Clock-skew check.
+    let signed_at = parse_amz_date(&parsed.amz_date)?;
+    let drift = (now - signed_at).num_seconds().abs();
+    if drift > CLOCK_SKEW_SECONDS {
+        return Err(SigV4Error::RequestTimeTooSkewed {
+            signed: signed_at,
+            server: now,
+        });
+    }
+
+    // 2. Canonical request.
+    let canonical_request = build_canonical_request(parsed, req)?;
+    let hashed_canonical = hex::encode(Sha256::digest(canonical_request.as_bytes()));
+
+    // 3. String to sign.
+    let credential_scope = format!(
+        "{}/{}/{}/aws4_request",
+        parsed.date_stamp, parsed.region, parsed.service
+    );
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+        parsed.amz_date, credential_scope, hashed_canonical
+    );
+
+    // 4. Signing key.
+    let signing_key = derive_signing_key(
+        secret_access_key,
+        &parsed.date_stamp,
+        &parsed.region,
+        &parsed.service,
+    );
+
+    // 5. Expected signature.
+    let expected = hmac_sha256(&signing_key, string_to_sign.as_bytes());
+    let expected_hex = hex::encode(expected);
+
+    if constant_time_eq(expected_hex.as_bytes(), parsed.signature.as_bytes()) {
+        Ok(())
+    } else {
+        Err(SigV4Error::SignatureMismatch)
+    }
+}
+
+/// Parse the `YYYYMMDDTHHMMSSZ` basic-ISO-8601 form AWS uses.
+fn parse_amz_date(s: &str) -> Result<DateTime<Utc>, SigV4Error> {
+    let naive = chrono::NaiveDateTime::parse_from_str(s, "%Y%m%dT%H%M%SZ")
+        .map_err(|_| SigV4Error::InvalidDate("expected YYYYMMDDTHHMMSSZ"))?;
+    Utc.from_local_datetime(&naive)
+        .single()
+        .ok_or(SigV4Error::InvalidDate("ambiguous datetime"))
+}
+
+/// The SigV4 URI-encoding character set: everything except unreserved
+/// characters (`A-Za-z0-9-_.~`). Same set for all AWS services.
+const SIGV4_URI_ENCODE: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'!')
+    .add(b'"')
+    .add(b'#')
+    .add(b'$')
+    .add(b'%')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b',')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'<')
+    .add(b'=')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
+
+fn sigv4_encode(s: &str) -> String {
+    utf8_percent_encode(s, SIGV4_URI_ENCODE).to_string()
+}
+
+/// Canonicalize the URI path. S3 encodes each segment once; all other
+/// services encode twice.
+fn canonical_uri(path: &str, service: &str) -> String {
+    if path.is_empty() {
+        return "/".to_string();
+    }
+    // Split on '/' so the separators themselves aren't encoded.
+    let encoded: Vec<String> = path
+        .split('/')
+        .map(|seg| {
+            let once = sigv4_encode(seg);
+            if service == "s3" {
+                once
+            } else {
+                sigv4_encode(&once)
+            }
+        })
+        .collect();
+    encoded.join("/")
+}
+
+/// Canonicalize the query string per SigV4: URL-decode + re-encode each
+/// key/value, sort by key then value, exclude `X-Amz-Signature` for
+/// presigned URLs.
+fn canonical_query(query: &str, is_presigned: bool) -> String {
+    if query.is_empty() {
+        return String::new();
+    }
+    let mut pairs: Vec<(String, String)> = query
+        .split('&')
+        .filter_map(|kv| {
+            if kv.is_empty() {
+                return None;
+            }
+            let (k, v) = match kv.split_once('=') {
+                Some((k, v)) => (k, v),
+                None => (kv, ""),
+            };
+            // Decode then re-encode to normalize.
+            let k_dec = percent_decode(k);
+            let v_dec = percent_decode(v);
+            if is_presigned && k_dec == "X-Amz-Signature" {
+                return None;
+            }
+            Some((sigv4_encode(&k_dec), sigv4_encode(&v_dec)))
+        })
+        .collect();
+    pairs.sort();
+    pairs
+        .into_iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn percent_decode(s: &str) -> String {
+    percent_encoding::percent_decode_str(s)
+        .decode_utf8_lossy()
+        .into_owned()
+}
+
+fn build_canonical_request(
+    parsed: &ParsedSigV4,
+    req: &VerifyRequest<'_>,
+) -> Result<String, SigV4Error> {
+    let method = req.method.to_ascii_uppercase();
+    let canonical_path = canonical_uri(req.path, &parsed.service);
+    let canonical_qs = canonical_query(req.query, parsed.is_presigned);
+
+    // Canonical headers: lowercased name, trimmed ASCII-collapsed value,
+    // sorted by name, only those listed in `signed_headers`.
+    let header_map: BTreeMap<String, String> = req
+        .headers
+        .iter()
+        .map(|(k, v)| (k.to_ascii_lowercase(), collapse_ws(v)))
+        .collect();
+    let mut canonical_headers = String::new();
+    for name in &parsed.signed_headers {
+        let value = header_map.get(name).ok_or(SigV4Error::Malformed(
+            "signed header not present in request",
+        ))?;
+        canonical_headers.push_str(name);
+        canonical_headers.push(':');
+        canonical_headers.push_str(value);
+        canonical_headers.push('\n');
+    }
+    let signed_headers_list = parsed.signed_headers.join(";");
+
+    // Payload hash: prefer `x-amz-content-sha256` when present. S3's special
+    // values (`UNSIGNED-PAYLOAD`, `STREAMING-*`) flow through as-is and are
+    // matched against the client's signature without rehashing.
+    let payload_hash = if parsed.is_presigned {
+        // Presigned URLs always sign the empty payload hash marker on GET,
+        // or `UNSIGNED-PAYLOAD` on PUT. AWS sets `x-amz-content-sha256` to
+        // `UNSIGNED-PAYLOAD` for presigned PUT; match that.
+        header_map
+            .get("x-amz-content-sha256")
+            .cloned()
+            .unwrap_or_else(|| "UNSIGNED-PAYLOAD".to_string())
+    } else if let Some(h) = header_map.get("x-amz-content-sha256") {
+        h.clone()
+    } else {
+        hex::encode(Sha256::digest(req.body))
+    };
+
+    Ok(format!(
+        "{}\n{}\n{}\n{}\n{}\n{}",
+        method, canonical_path, canonical_qs, canonical_headers, signed_headers_list, payload_hash
+    ))
+}
+
+/// Trim and collapse internal runs of whitespace per the SigV4 spec.
+fn collapse_ws(v: &str) -> String {
+    let mut out = String::with_capacity(v.len());
+    let mut in_ws = false;
+    for ch in v.trim().chars() {
+        if ch == ' ' || ch == '\t' {
+            if !in_ws {
+                out.push(' ');
+                in_ws = true;
+            }
+        } else {
+            out.push(ch);
+            in_ws = false;
+        }
+    }
+    out
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn derive_signing_key(secret: &str, date: &str, region: &str, service: &str) -> Vec<u8> {
+    let k_secret = format!("AWS4{}", secret);
+    let k_date = hmac_sha256(k_secret.as_bytes(), date.as_bytes());
+    let k_region = hmac_sha256(&k_date, region.as_bytes());
+    let k_service = hmac_sha256(&k_region, service.as_bytes());
+    hmac_sha256(&k_service, b"aws4_request")
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    use subtle::ConstantTimeEq;
+    a.ct_eq(b).into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // AWS documentation's canonical example from
+    // https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+    // GetSessionToken request, us-east-1, iam service.
+    // Obviously-synthetic secret — real AWS example strings trip GitHub's
+    // secret-scanning push protection.
+    const AWS_EXAMPLE_SECRET: &str = "testtesttesttesttesttesttesttesttesttest";
+    const AWS_EXAMPLE_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
 
     #[test]
     fn parse_valid_header() {
@@ -46,8 +520,233 @@ mod tests {
     }
 
     #[test]
+    fn parse_full_header_extracts_all_fields() {
+        let header = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260101/us-east-1/sqs/aws4_request, SignedHeaders=host;x-amz-date, Signature=deadbeef";
+        let parsed = parse_sigv4_header(header, Some("20260101T000000Z")).unwrap();
+        assert_eq!(parsed.access_key, "AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(parsed.date_stamp, "20260101");
+        assert_eq!(parsed.signed_headers, vec!["host", "x-amz-date"]);
+        assert_eq!(parsed.signature, "deadbeef");
+        assert!(!parsed.is_presigned);
+    }
+
+    #[test]
+    fn parse_presigned_query_extracts_all_fields() {
+        let mut q = std::collections::HashMap::new();
+        q.insert(
+            "X-Amz-Algorithm".to_string(),
+            "AWS4-HMAC-SHA256".to_string(),
+        );
+        q.insert(
+            "X-Amz-Credential".to_string(),
+            "AKIAIOSFODNN7EXAMPLE/20260101/us-east-1/s3/aws4_request".to_string(),
+        );
+        q.insert("X-Amz-Date".to_string(), "20260101T000000Z".to_string());
+        q.insert("X-Amz-SignedHeaders".to_string(), "host".to_string());
+        q.insert("X-Amz-Signature".to_string(), "cafe".to_string());
+        let parsed = parse_sigv4_presigned(&q).unwrap();
+        assert_eq!(parsed.service, "s3");
+        assert!(parsed.is_presigned);
+        assert_eq!(parsed.signature, "cafe");
+    }
+
+    #[test]
     fn returns_none_for_invalid() {
         assert!(parse_sigv4("Bearer token123").is_none());
         assert!(parse_sigv4("").is_none());
+    }
+
+    #[test]
+    fn canonical_uri_non_s3_double_encodes() {
+        assert_eq!(canonical_uri("/foo bar", "iam"), "/foo%2520bar");
+        // path with slash stays as-is
+        assert_eq!(canonical_uri("/a/b", "iam"), "/a/b");
+    }
+
+    #[test]
+    fn canonical_uri_s3_single_encodes() {
+        assert_eq!(canonical_uri("/foo bar", "s3"), "/foo%20bar");
+    }
+
+    #[test]
+    fn canonical_query_sorts_and_drops_presigned_signature() {
+        let q = "X-Amz-Signature=ignored&B=2&A=1";
+        assert_eq!(canonical_query(q, true), "A=1&B=2");
+        assert_eq!(canonical_query(q, false), "A=1&B=2&X-Amz-Signature=ignored");
+    }
+
+    #[test]
+    fn derive_signing_key_is_deterministic_and_stable() {
+        // Regression guard: fix the derivation output for a known set of
+        // inputs so any future refactor that changes the HMAC chain is
+        // caught. The value is the hex HMAC-SHA256 of `aws4_request` under
+        // the four-step AWS4 → date → region → service → aws4_request chain,
+        // computed by this same function — the goal is stability over time,
+        // not agreement with an external reference.
+        let key = derive_signing_key(AWS_EXAMPLE_SECRET, "20150830", "us-east-1", "iam");
+        assert_eq!(
+            hex::encode(&key),
+            "0d041c02f01817181204845091e3445c37d6f6b200833f52d34d682b2005918a"
+        );
+        // Sanity: swapping any input changes the output.
+        let diff = derive_signing_key(AWS_EXAMPLE_SECRET, "20150831", "us-east-1", "iam");
+        assert_ne!(key, diff);
+    }
+
+    #[test]
+    fn verify_rejects_skewed_clock() {
+        // Signature content is irrelevant here; clock check runs first.
+        let parsed = ParsedSigV4 {
+            access_key: "X".into(),
+            date_stamp: "20260101".into(),
+            region: "us-east-1".into(),
+            service: "iam".into(),
+            signed_headers: vec!["host".into()],
+            signature: "00".into(),
+            amz_date: "20260101T000000Z".into(),
+            is_presigned: false,
+        };
+        let req = VerifyRequest {
+            method: "GET",
+            path: "/",
+            query: "",
+            headers: &[("host".into(), "iam.amazonaws.com".into())],
+            body: b"",
+        };
+        let server_now = Utc.with_ymd_and_hms(2026, 1, 1, 1, 0, 0).unwrap();
+        let result = verify(&parsed, &req, AWS_EXAMPLE_SECRET, server_now);
+        assert!(matches!(
+            result,
+            Err(SigV4Error::RequestTimeTooSkewed { .. })
+        ));
+    }
+
+    #[test]
+    fn verify_round_trip_matches_self_computed_signature() {
+        // Build a request, compute the signature using the same derivation
+        // `verify` uses, then assert `verify` accepts it.
+        let secret = AWS_EXAMPLE_SECRET;
+        let date_stamp = "20260101";
+        let amz_date = "20260101T120000Z";
+        let region = "us-east-1";
+        let service = "iam";
+        let method = "GET";
+        let path = "/";
+        let query = "Action=GetUser&Version=2010-05-08";
+        let headers = vec![
+            ("host".to_string(), "iam.amazonaws.com".to_string()),
+            ("x-amz-date".to_string(), amz_date.to_string()),
+        ];
+        let body: &[u8] = b"";
+
+        // Build canonical request manually, matching `build_canonical_request`.
+        let canonical_request = {
+            let mut parsed = ParsedSigV4 {
+                access_key: AWS_EXAMPLE_ACCESS_KEY.into(),
+                date_stamp: date_stamp.into(),
+                region: region.into(),
+                service: service.into(),
+                signed_headers: vec!["host".into(), "x-amz-date".into()],
+                signature: String::new(),
+                amz_date: amz_date.into(),
+                is_presigned: false,
+            };
+            let req = VerifyRequest {
+                method,
+                path,
+                query,
+                headers: &headers,
+                body,
+            };
+            let cr = build_canonical_request(&parsed, &req).unwrap();
+            parsed.signature = {
+                let scope = format!("{}/{}/{}/aws4_request", date_stamp, region, service);
+                let sts = format!(
+                    "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+                    amz_date,
+                    scope,
+                    hex::encode(Sha256::digest(cr.as_bytes()))
+                );
+                let sk = derive_signing_key(secret, date_stamp, region, service);
+                hex::encode(hmac_sha256(&sk, sts.as_bytes()))
+            };
+            parsed
+        };
+
+        let req = VerifyRequest {
+            method,
+            path,
+            query,
+            headers: &headers,
+            body,
+        };
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 30).unwrap();
+        verify(&canonical_request, &req, secret, now).unwrap();
+    }
+
+    #[test]
+    fn verify_rejects_tampered_body() {
+        let secret = AWS_EXAMPLE_SECRET;
+        let date_stamp = "20260101";
+        let amz_date = "20260101T120000Z";
+        let region = "us-east-1";
+        let service = "iam";
+        let method = "POST";
+        let path = "/";
+        let query = "";
+        let headers = vec![
+            ("host".to_string(), "iam.amazonaws.com".to_string()),
+            ("x-amz-date".to_string(), amz_date.to_string()),
+        ];
+        let original_body: &[u8] = b"Action=ListUsers&Version=2010-05-08";
+
+        // Sign the original body.
+        let mut parsed = ParsedSigV4 {
+            access_key: AWS_EXAMPLE_ACCESS_KEY.into(),
+            date_stamp: date_stamp.into(),
+            region: region.into(),
+            service: service.into(),
+            signed_headers: vec!["host".into(), "x-amz-date".into()],
+            signature: String::new(),
+            amz_date: amz_date.into(),
+            is_presigned: false,
+        };
+        let signing_req = VerifyRequest {
+            method,
+            path,
+            query,
+            headers: &headers,
+            body: original_body,
+        };
+        let cr = build_canonical_request(&parsed, &signing_req).unwrap();
+        let scope = format!("{}/{}/{}/aws4_request", date_stamp, region, service);
+        let sts = format!(
+            "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+            amz_date,
+            scope,
+            hex::encode(Sha256::digest(cr.as_bytes()))
+        );
+        let sk = derive_signing_key(secret, date_stamp, region, service);
+        parsed.signature = hex::encode(hmac_sha256(&sk, sts.as_bytes()));
+
+        // Verify against a tampered body.
+        let tampered = VerifyRequest {
+            method,
+            path,
+            query,
+            headers: &headers,
+            body: b"Action=DeleteUser&Version=2010-05-08",
+        };
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 30).unwrap();
+        assert!(matches!(
+            verify(&parsed, &tampered, secret, now),
+            Err(SigV4Error::SignatureMismatch)
+        ));
+    }
+
+    #[test]
+    fn collapse_ws_normalizes_runs() {
+        assert_eq!(collapse_ws("  foo   bar  "), "foo bar");
+        assert_eq!(collapse_ws("foo\tbar"), "foo bar");
     }
 }

--- a/crates/fakecloud-core/Cargo.toml
+++ b/crates/fakecloud-core/Cargo.toml
@@ -12,6 +12,7 @@ fakecloud-aws = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 bytes = { workspace = true }
+chrono = { workspace = true }
 http = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -13,6 +13,35 @@
 use std::fmt;
 use std::str::FromStr;
 
+/// Credentials resolved from an access key ID.
+///
+/// Returned by [`CredentialResolver::resolve`]. `account_id` is always
+/// sourced from the credential's owning account, never from global config,
+/// so that once multi-account isolation (#381) lands the same lookup returns
+/// the correct account for the credential.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedCredential {
+    pub secret_access_key: String,
+    pub session_token: Option<String>,
+    pub principal_arn: String,
+    pub user_id: String,
+    pub account_id: String,
+}
+
+/// Abstraction over "given an access key ID, return the secret and resolved
+/// principal." Implemented by the IAM crate against `IamState`; the core
+/// crate depends only on the trait so there's no circular dependency.
+///
+/// Implementations must be cheap to clone-share via `Arc` and must be
+/// thread-safe — dispatch calls them from an axum handler under a tokio
+/// worker.
+pub trait CredentialResolver: Send + Sync {
+    /// Resolve `access_key_id` to its secret access key and principal.
+    /// Returns `None` when the AKID is unknown or its underlying credential
+    /// has expired.
+    fn resolve(&self, access_key_id: &str) -> Option<ResolvedCredential>;
+}
+
 /// How IAM identity policies are evaluated for incoming requests.
 ///
 /// Default is [`IamMode::Off`] — existing behavior, policies are stored but

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -5,7 +5,7 @@ use axum::response::Response;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::auth::IamMode;
+use crate::auth::{is_root_bypass, CredentialResolver, IamMode};
 use crate::protocol::{self, AwsProtocol};
 use crate::registry::ServiceRegistry;
 use crate::service::{AwsRequest, ResponseBody};
@@ -90,19 +90,120 @@ pub async fn dispatch(
         }
     };
 
-    // Extract region and access key from auth header
-    let sigv4_info = fakecloud_aws::sigv4::parse_sigv4(
-        parts
-            .headers
-            .get("authorization")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or(""),
-    );
+    // Extract region and access key from auth header (or presigned query).
+    let auth_header = parts
+        .headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let header_info = fakecloud_aws::sigv4::parse_sigv4(auth_header);
+    let presigned_info = if header_info.is_none() {
+        // Presigned URL: credentials live in the query string.
+        fakecloud_aws::sigv4::parse_sigv4_presigned(&query_params).map(|p| p.as_info())
+    } else {
+        None
+    };
+    let sigv4_info = header_info.or(presigned_info);
     let access_key_id = sigv4_info.as_ref().map(|info| info.access_key.clone());
     let region = sigv4_info
         .map(|info| info.region)
         .or_else(|| extract_region_from_user_agent(&parts.headers))
         .unwrap_or_else(|| config.region.clone());
+
+    // Opt-in SigV4 cryptographic verification. Runs before the service
+    // handler so a failing signature never reaches business logic. The
+    // reserved `test*` root identity short-circuits verification to keep
+    // local-dev workflows frictionless.
+    if config.verify_sigv4 {
+        let caller_akid = access_key_id.as_deref().unwrap_or("");
+        if !is_root_bypass(caller_akid) {
+            if let Some(resolver) = config.credential_resolver.as_ref() {
+                let amz_date = parts
+                    .headers
+                    .get("x-amz-date")
+                    .and_then(|v| v.to_str().ok());
+                let parsed = fakecloud_aws::sigv4::parse_sigv4_header(auth_header, amz_date)
+                    .or_else(|| fakecloud_aws::sigv4::parse_sigv4_presigned(&query_params));
+                let parsed = match parsed {
+                    Some(p) => p,
+                    None => {
+                        return build_error_response(
+                            StatusCode::FORBIDDEN,
+                            "IncompleteSignature",
+                            "Request is missing or has a malformed AWS Signature",
+                            &request_id,
+                            detected.protocol,
+                        );
+                    }
+                };
+                let resolved = match resolver.resolve(&parsed.access_key) {
+                    Some(r) => r,
+                    None => {
+                        return build_error_response(
+                            StatusCode::FORBIDDEN,
+                            "InvalidClientTokenId",
+                            "The security token included in the request is invalid",
+                            &request_id,
+                            detected.protocol,
+                        );
+                    }
+                };
+                let headers_vec = fakecloud_aws::sigv4::headers_from_http(&parts.headers);
+                let raw_query_for_verify = parts.uri.query().unwrap_or("").to_string();
+                let verify_req = fakecloud_aws::sigv4::VerifyRequest {
+                    method: parts.method.as_str(),
+                    path: parts.uri.path(),
+                    query: &raw_query_for_verify,
+                    headers: &headers_vec,
+                    body: &body_bytes,
+                };
+                match fakecloud_aws::sigv4::verify(
+                    &parsed,
+                    &verify_req,
+                    &resolved.secret_access_key,
+                    chrono::Utc::now(),
+                ) {
+                    Ok(()) => {}
+                    Err(fakecloud_aws::sigv4::SigV4Error::RequestTimeTooSkewed { .. }) => {
+                        return build_error_response(
+                            StatusCode::FORBIDDEN,
+                            "RequestTimeTooSkewed",
+                            "The difference between the request time and the current time is too large",
+                            &request_id,
+                            detected.protocol,
+                        );
+                    }
+                    Err(fakecloud_aws::sigv4::SigV4Error::InvalidDate(msg)) => {
+                        return build_error_response(
+                            StatusCode::FORBIDDEN,
+                            "IncompleteSignature",
+                            &format!("Invalid x-amz-date: {msg}"),
+                            &request_id,
+                            detected.protocol,
+                        );
+                    }
+                    Err(fakecloud_aws::sigv4::SigV4Error::Malformed(msg)) => {
+                        return build_error_response(
+                            StatusCode::FORBIDDEN,
+                            "IncompleteSignature",
+                            &format!("Malformed SigV4 signature: {msg}"),
+                            &request_id,
+                            detected.protocol,
+                        );
+                    }
+                    Err(fakecloud_aws::sigv4::SigV4Error::SignatureMismatch) => {
+                        return build_error_response(
+                            StatusCode::FORBIDDEN,
+                            "SignatureDoesNotMatch",
+                            "The request signature we calculated does not match the signature you provided",
+                            &request_id,
+                            detected.protocol,
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     // Build path segments
     let path = parts.uri.path().to_string();
@@ -222,20 +323,41 @@ pub async fn dispatch(
 }
 
 /// Configuration passed to the dispatch handler.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DispatchConfig {
     pub region: String,
     pub account_id: String,
     /// Whether to cryptographically verify SigV4 signatures on incoming
     /// requests. Wired through from `--verify-sigv4` /
-    /// `FAKECLOUD_VERIFY_SIGV4`. Off by default. Actual enforcement is added
-    /// in a later batch; today this field is plumbed but never consulted.
+    /// `FAKECLOUD_VERIFY_SIGV4`. Off by default.
     pub verify_sigv4: bool,
     /// IAM policy evaluation mode. Wired through from `--iam` /
     /// `FAKECLOUD_IAM`. Defaults to [`IamMode::Off`]. Actual evaluation is
     /// added in a later batch; today this field is plumbed but never
     /// consulted.
     pub iam_mode: IamMode,
+    /// Resolves access key IDs to their secrets and owning principals.
+    /// Required when `verify_sigv4` or `iam_mode != Off`. When `None`, both
+    /// features gracefully degrade to off-by-default behavior.
+    pub credential_resolver: Option<Arc<dyn CredentialResolver>>,
+}
+
+impl std::fmt::Debug for DispatchConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DispatchConfig")
+            .field("region", &self.region)
+            .field("account_id", &self.account_id)
+            .field("verify_sigv4", &self.verify_sigv4)
+            .field("iam_mode", &self.iam_mode)
+            .field(
+                "credential_resolver",
+                &self
+                    .credential_resolver
+                    .as_ref()
+                    .map(|_| "<CredentialResolver>"),
+            )
+            .finish()
+    }
 }
 
 impl DispatchConfig {
@@ -247,6 +369,7 @@ impl DispatchConfig {
             account_id: account_id.into(),
             verify_sigv4: false,
             iam_mode: IamMode::Off,
+            credential_resolver: None,
         }
     }
 }
@@ -337,6 +460,7 @@ mod tests {
             account_id: "000000000000".to_string(),
             verify_sigv4: true,
             iam_mode: IamMode::Strict,
+            credential_resolver: None,
         };
         assert!(cfg.verify_sigv4);
         assert!(cfg.iam_mode.is_strict());

--- a/crates/fakecloud-e2e/tests/sigv4_verification.rs
+++ b/crates/fakecloud-e2e/tests/sigv4_verification.rs
@@ -1,0 +1,205 @@
+//! End-to-end tests for opt-in SigV4 cryptographic verification.
+//!
+//! Each test spawns a fakecloud process with `FAKECLOUD_VERIFY_SIGV4=true`,
+//! drives real signed requests through an `aws-sdk-*` client (or a hand-
+//! crafted `reqwest` request for tamper tests), and asserts that the
+//! verifier accepts or rejects as expected.
+
+mod helpers;
+
+use aws_credential_types::Credentials;
+use aws_sdk_sts::Client as StsClient;
+use helpers::TestServer;
+
+async fn start_verified() -> TestServer {
+    TestServer::start_with_env(&[("FAKECLOUD_VERIFY_SIGV4", "true")]).await
+}
+
+async fn sdk_config_with(
+    server: &TestServer,
+    akid: &str,
+    secret: &str,
+    token: Option<String>,
+) -> aws_config::SdkConfig {
+    aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(
+            akid,
+            secret,
+            token,
+            None,
+            "fakecloud-sigv4",
+        ))
+        .load()
+        .await
+}
+
+#[tokio::test]
+async fn verifies_valid_signed_request_from_iam_user() {
+    let server = start_verified().await;
+
+    // Bootstrap via root-bypass creds, which always pass verification.
+    let boot_config = sdk_config_with(&server, "test", "test", None).await;
+    let iam_boot = aws_sdk_iam::Client::new(&boot_config);
+    iam_boot
+        .create_user()
+        .user_name("alice")
+        .send()
+        .await
+        .unwrap();
+    let ak = iam_boot
+        .create_access_key()
+        .user_name("alice")
+        .send()
+        .await
+        .unwrap();
+    let key = ak.access_key().unwrap();
+    let akid = key.access_key_id();
+    let secret = key.secret_access_key();
+
+    // Sign a follow-up request with the real access key. Verification must
+    // succeed because the secret is looked up from IAM state.
+    let signed_config = sdk_config_with(&server, akid, secret, None).await;
+    let iam_signed = aws_sdk_iam::Client::new(&signed_config);
+    iam_signed
+        .get_user()
+        .user_name("alice")
+        .send()
+        .await
+        .expect("verifier should accept a correctly signed request");
+}
+
+#[tokio::test]
+async fn rejects_unknown_access_key_with_invalid_client_token_id() {
+    let server = start_verified().await;
+
+    // An AKID that was never created: verification must fail before the
+    // handler runs. Uses an `AKIA`-prefixed id to skip the root bypass.
+    let config = sdk_config_with(
+        &server,
+        "AKIANEVERCREATED1234",
+        "fakefakefakefakefakefakefakefakefake1234",
+        None,
+    )
+    .await;
+    let sts = StsClient::new(&config);
+    let err = sts.get_caller_identity().send().await.unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidClientTokenId"),
+        "expected InvalidClientTokenId, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn rejects_tampered_signature_with_signature_does_not_match() {
+    let server = start_verified().await;
+
+    // Bootstrap a user via root-bypass creds, then sign a request with
+    // the real access key ID but the wrong secret. The verifier must
+    // reject it.
+    let boot = sdk_config_with(&server, "test", "test", None).await;
+    let iam_boot = aws_sdk_iam::Client::new(&boot);
+    iam_boot
+        .create_user()
+        .user_name("bob")
+        .send()
+        .await
+        .unwrap();
+    let ak = iam_boot
+        .create_access_key()
+        .user_name("bob")
+        .send()
+        .await
+        .unwrap();
+    let akid = ak.access_key().unwrap().access_key_id().to_string();
+
+    let wrong = sdk_config_with(
+        &server,
+        &akid,
+        "wrongwrongwrongwrongwrongwrongwrongwrong",
+        None,
+    )
+    .await;
+    let iam_wrong = aws_sdk_iam::Client::new(&wrong);
+    let err = iam_wrong
+        .get_user()
+        .user_name("bob")
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("SignatureDoesNotMatch"),
+        "expected SignatureDoesNotMatch, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn root_bypass_accepts_unsigned_requests_when_verify_is_on() {
+    let server = start_verified().await;
+    // Default server creds start with `test` → root bypass → accepted even
+    // under verify_sigv4.
+    let config = sdk_config_with(&server, "test", "test", None).await;
+    let sts = StsClient::new(&config);
+    let identity = sts
+        .get_caller_identity()
+        .send()
+        .await
+        .expect("root-bypass identity should always succeed under verify_sigv4");
+    assert!(identity.arn().unwrap().contains(":root"));
+}
+
+#[tokio::test]
+async fn off_by_default_passes_any_signature() {
+    // No FAKECLOUD_VERIFY_SIGV4 env: the default behavior accepts garbage
+    // signatures. Regression guard for the off-by-default contract.
+    let server = TestServer::start().await;
+    let config = sdk_config_with(
+        &server,
+        "AKIAFAKEFAKEFAKEFAKE",
+        "garbagegarbagegarbagegarbagegarbage1234",
+        None,
+    )
+    .await;
+    let sts = StsClient::new(&config);
+    // Without verification, the request reaches the handler and the
+    // default identity is returned.
+    let identity = sts.get_caller_identity().send().await.unwrap();
+    assert_eq!(identity.account().unwrap(), "123456789012");
+}
+
+#[tokio::test]
+async fn sts_assume_role_temp_credentials_verify_successfully() {
+    // Regression guard for batch 2's STS temp credential persistence: when
+    // a client calls AssumeRole and then signs a follow-up request with
+    // the returned temporary creds, verification must succeed because the
+    // credential was persisted in sts_temp_credentials.
+    let server = start_verified().await;
+
+    let boot = sdk_config_with(&server, "test", "test", None).await;
+    let sts_boot = StsClient::new(&boot);
+    let resp = sts_boot
+        .assume_role()
+        .role_arn("arn:aws:iam::123456789012:role/temp-role")
+        .role_session_name("e2e-sigv4")
+        .send()
+        .await
+        .unwrap();
+    let creds = resp.credentials().unwrap();
+
+    let temp_cfg = sdk_config_with(
+        &server,
+        creds.access_key_id(),
+        creds.secret_access_key(),
+        Some(creds.session_token().to_string()),
+    )
+    .await;
+    let sts_temp = StsClient::new(&temp_cfg);
+    let identity = sts_temp.get_caller_identity().send().await.unwrap();
+    assert!(identity
+        .arn()
+        .unwrap()
+        .contains("assumed-role/temp-role/e2e-sigv4"));
+}

--- a/crates/fakecloud-iam/src/credential_resolver.rs
+++ b/crates/fakecloud-iam/src/credential_resolver.rs
@@ -1,0 +1,104 @@
+//! Adapter that implements [`fakecloud_core::auth::CredentialResolver`] over
+//! the shared IAM state.
+//!
+//! SigV4 verification (and later IAM enforcement) runs in `fakecloud-core`,
+//! which intentionally doesn't depend on `fakecloud-iam`. The trait lives in
+//! core and the concrete resolver lives here, keeping the dependency edge
+//! pointing the right way.
+
+use std::sync::Arc;
+
+use fakecloud_core::auth::{CredentialResolver, ResolvedCredential};
+
+use crate::state::SharedIamState;
+
+/// [`CredentialResolver`] backed by an [`IamState`] shared via
+/// [`SharedIamState`]. Acquires a write lock on lookup so expired STS
+/// temporary credentials are purged in place.
+#[derive(Clone)]
+pub struct IamCredentialResolver {
+    state: SharedIamState,
+}
+
+impl IamCredentialResolver {
+    pub fn new(state: SharedIamState) -> Self {
+        Self { state }
+    }
+
+    pub fn shared(state: SharedIamState) -> Arc<dyn CredentialResolver> {
+        Arc::new(Self::new(state))
+    }
+}
+
+impl CredentialResolver for IamCredentialResolver {
+    fn resolve(&self, access_key_id: &str) -> Option<ResolvedCredential> {
+        let mut state = self.state.write();
+        state
+            .credential_secret(access_key_id)
+            .map(|lookup| ResolvedCredential {
+                secret_access_key: lookup.secret_access_key,
+                session_token: lookup.session_token,
+                principal_arn: lookup.principal_arn,
+                user_id: lookup.user_id,
+                account_id: lookup.account_id,
+            })
+    }
+}
+
+// Prevent rustc from warning on the unused import when the module is
+// included via `lib.rs` without tests referencing it.
+#[allow(dead_code)]
+fn _assert_impl<T: CredentialResolver>() {}
+const _: fn() = || {
+    _assert_impl::<IamCredentialResolver>();
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{IamAccessKey, IamState, IamUser};
+    use chrono::Utc;
+    use parking_lot::RwLock;
+
+    #[test]
+    fn resolves_iam_user_secret_from_state() {
+        let mut state = IamState::new("123456789012");
+        state.users.insert(
+            "alice".to_string(),
+            IamUser {
+                user_name: "alice".into(),
+                user_id: "AIDAALICE".into(),
+                arn: "arn:aws:iam::123456789012:user/alice".into(),
+                path: "/".into(),
+                created_at: Utc::now(),
+                tags: Vec::new(),
+                permissions_boundary: None,
+            },
+        );
+        state.access_keys.insert(
+            "alice".to_string(),
+            vec![IamAccessKey {
+                access_key_id: "FKIAALICE".into(),
+                secret_access_key: "the-secret".into(),
+                user_name: "alice".into(),
+                status: "Active".into(),
+                created_at: Utc::now(),
+            }],
+        );
+        let resolver = IamCredentialResolver::new(Arc::new(RwLock::new(state)));
+        let resolved = resolver.resolve("FKIAALICE").unwrap();
+        assert_eq!(resolved.secret_access_key, "the-secret");
+        assert_eq!(
+            resolved.principal_arn,
+            "arn:aws:iam::123456789012:user/alice"
+        );
+        assert_eq!(resolved.session_token, None);
+    }
+
+    #[test]
+    fn returns_none_for_unknown_akid() {
+        let state = IamState::new("123456789012");
+        let resolver = IamCredentialResolver::new(Arc::new(RwLock::new(state)));
+        assert!(resolver.resolve("FKIANONE").is_none());
+    }
+}

--- a/crates/fakecloud-iam/src/lib.rs
+++ b/crates/fakecloud-iam/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod credential_resolver;
 pub mod iam_service;
 pub mod policy_validation;
 pub mod state;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -440,7 +440,7 @@ async fn main() {
     }
     tokio::spawn(scheduler.run());
     registry.register(Arc::new(IamService::new(iam_state.clone())));
-    registry.register(Arc::new(StsService::new(iam_state)));
+    registry.register(Arc::new(StsService::new(iam_state.clone())));
     registry.register(Arc::new(
         SsmService::new(ssm_state).with_secretsmanager(secretsmanager_state.clone()),
     ));
@@ -674,6 +674,9 @@ async fn main() {
         account_id: cli.account_id,
         verify_sigv4: cli.verify_sigv4,
         iam_mode,
+        credential_resolver: Some(
+            fakecloud_iam::credential_resolver::IamCredentialResolver::shared(iam_state.clone()),
+        ),
     };
 
     let service_names: Vec<String> = registry


### PR DESCRIPTION
## Summary

Batch 3 of 9 for the opt-in SigV4 + IAM enforcement work. Ships the real SigV4 verifier behind the ``--verify-sigv4`` / ``FAKECLOUD_VERIFY_SIGV4`` flag plumbed in batch 1. **Off by default** — existing workflows see zero behavior change.

### What's verified

When enabled, every incoming request is checked cryptographically before reaching the service handler:

- **Canonical request reconstruction** following the AWS SigV4 spec:
  - Double-encoded path for non-S3, single-encoded for S3
  - Sorted query string, dropping ``X-Amz-Signature`` for presigned URLs
  - Lowercased + sorted headers, whitespace-collapsed values
  - Payload hash from ``X-Amz-Content-Sha256`` when present (supports S3's ``UNSIGNED-PAYLOAD`` + ``STREAMING-*`` pass-through), otherwise ``sha256(body)``
- **Signing key derivation** via the four-step AWS4 -> date -> region -> service -> aws4_request HMAC chain
- **Constant-time comparison** via ``subtle::ConstantTimeEq``
- **±15-minute clock-skew window** matching AWS

### Error mapping

Verification failures are returned as protocol-correct AWS errors before business logic runs:

| Failure | AWS error |
| --- | --- |
| Wrong signature | ``SignatureDoesNotMatch`` |
| Unknown access key | ``InvalidClientTokenId`` |
| Clock skew > 15 min | ``RequestTimeTooSkewed`` |
| Malformed auth header / missing signed header | ``IncompleteSignature`` |

### Root bypass

The reserved ``test*`` AKID prefix (shipped in batch 1) short-circuits verification so ``test`` / ``test`` credentials always work — community convention matching LocalStack and Floci. A startup ``tracing::warn!`` already fires when the flag is on to prevent false-positive "my policies work" results from unsigned test clients.

### Architecture

- New ``CredentialResolver`` trait in ``fakecloud_core::auth`` and concrete ``IamCredentialResolver`` in ``fakecloud_iam`` — the dependency edge stays core → iam.
- ``DispatchConfig`` gains ``credential_resolver: Option<Arc<dyn CredentialResolver>>``.
- ``ResolvedCredential.account_id`` is sourced from the credential itself, not from global config, priming the shape #381 (multi-account isolation) will need.

### Decisions

- Hand-rolled SigV4 rather than using the ``aws-sigv4`` crate. The AWS crate pulls in ``aws-smithy-runtime-api`` + ``aws-credential-types`` transitively, which is a heavy dependency for a ~400-line well-specified algorithm. The round-trip E2E test below signs requests via the real aws-sdk-rust and verifies them through our implementation — that's the ground-truth correctness check.
- X-Amz-Content-Sha256 is trusted pass-through. S3's ``UNSIGNED-PAYLOAD`` / ``STREAMING-*`` markers are part of the signature, so echoing them into the canonical request matches what the client signed.
- Hardcoded secret constants in tests use obvious sentinels (``testtesttest...``, ``fakefakefake...``) to avoid GitHub's push-protection secret scanning.

## Test plan

- [x] ``cargo test -p fakecloud-aws sigv4::`` — 12 unit tests (parse header, parse presigned, canonical URI S3 vs non-S3, canonical query, signing key determinism, clock skew, round-trip verification, tampered body rejection)
- [x] ``cargo test -p fakecloud-iam credential_resolver`` — 2 unit tests for the IAM state adapter
- [x] ``cargo test -p fakecloud-core`` — 43 tests, no regressions
- [x] ``cargo test -p fakecloud-e2e --test sigv4_verification`` — **6 end-to-end tests** that spawn a real fakecloud with ``FAKECLOUD_VERIFY_SIGV4=true``, drive signed requests through ``aws-sdk-rust``, and cover:
  - valid signed request from a newly-created IAM user
  - unknown AKID → ``InvalidClientTokenId``
  - wrong secret → ``SignatureDoesNotMatch``
  - root bypass (``test``/``test``) always accepted
  - off-by-default regression guard
  - STS temp credentials from AssumeRole (batch 2) verify successfully
- [x] ``cargo test -p fakecloud-e2e --test iam`` — 57 tests, no regressions
- [x] ``cargo test -p fakecloud-conformance`` — no regressions
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo fmt --check`` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in SigV4 cryptographic verification behind `--verify-sigv4` / `FAKECLOUD_VERIFY_SIGV4`. Off by default; when enabled, bad signatures are rejected with AWS-accurate errors before any handler runs.

- **New Features**
  - Real SigV4 verifier in `fakecloud-aws` (`verify`, `parse_sigv4_header`, `parse_sigv4_presigned`).
  - Canonical request: double-encode path for non-S3, single for S3; sorted query (drops `X-Amz-Signature` for presigned); lowercased/sorted headers; payload hash trusts `X-Amz-Content-Sha256` (supports S3 `UNSIGNED-PAYLOAD`/`STREAMING-*`).
  - ±15-minute clock skew check and constant-time signature compare.
  - Error mapping: `SignatureDoesNotMatch`, `InvalidClientTokenId`, `RequestTimeTooSkewed`, `IncompleteSignature`.
  - `CredentialResolver` trait in `fakecloud-core`; `IamCredentialResolver` in `fakecloud-iam`. Dispatch resolves the secret and verifies per request. `test*` AKID root bypass remains.
  - E2E and unit tests cover header/presigned parsing, canonicalization, clock skew, round-trip, tampered body, IAM + STS flows.

- **Migration**
  - No changes needed unless you opt in.
  - To enable: run with `--verify-sigv4` or set `FAKECLOUD_VERIFY_SIGV4=true`.
  - Ensure callers use real IAM access keys; `test/test` still works via the bypass (for local bootstrapping).

<sup>Written for commit f4ff1d9860af23188a9dc8b71ee5c5db9dba1e30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

