### PR TITLE
feat(auth): resolve principal up front and attach to AwsRequest

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/cors.rs
+++ b/crates/fakecloud-apigatewayv2/src/cors.rs
@@ -135,6 +135,7 @@ mod tests {
             request_id: "request-id".to_string(),
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-apigatewayv2/src/http_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/http_proxy.rs
@@ -113,6 +113,7 @@ mod tests {
             request_id: "request-id".to_string(),
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -242,6 +242,7 @@ mod tests {
             request_id: "request-id".to_string(),
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -841,6 +841,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: true,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1326,6 +1326,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         match svc.create_user_pool(&req) {
             Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
@@ -1389,6 +1390,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let pool_resp = svc.create_user_pool(&create_pool_req).unwrap();
         let pool_json: Value =
@@ -1418,6 +1420,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let resp = svc.create_user_pool_client(&req).unwrap();
         let resp_json: Value =
@@ -1449,6 +1452,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let pool_resp = svc.create_user_pool(&create_pool_req).unwrap();
         let pool_json: Value =
@@ -1479,6 +1483,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let resp = svc.create_user_pool_client(&req).unwrap();
         let resp_json: Value =
@@ -1516,6 +1521,7 @@ mod tests {
                 method: http::Method::POST,
                 is_query_protocol: false,
                 access_key_id: None,
+                principal: None,
             };
             svc.create_user_pool(&req).unwrap();
         }
@@ -1546,6 +1552,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let resp = svc.create_user_pool_client(&req).unwrap();
         let resp_json: Value =
@@ -1577,6 +1584,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         match svc.describe_user_pool_client(&req) {
             Err(e) => assert_eq!(e.code(), "ResourceNotFoundException"),
@@ -1739,6 +1747,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let pool_resp = svc.create_user_pool(&req).unwrap();
         let pool_json: Value =
@@ -1768,6 +1777,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let resp = block_on(svc.admin_create_user(&req)).unwrap();
         let resp_json: Value =
@@ -2036,6 +2046,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let resp = svc.create_user_pool(&create_pool_req).unwrap();
         let resp_json: Value =
@@ -2064,6 +2075,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let result = svc.create_group(&create_group_req);
         assert!(result.is_ok());
@@ -2108,6 +2120,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let resp = svc.create_user_pool(&create_pool_req).unwrap();
         let resp_json: Value =
@@ -2136,6 +2149,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         block_on(svc.admin_create_user(&create_user_req)).unwrap();
 
@@ -2161,6 +2175,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         svc.create_group(&create_group_req).unwrap();
 
@@ -2187,6 +2202,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         svc.admin_add_user_to_group(&add_req).unwrap();
 
@@ -2221,6 +2237,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         svc.admin_remove_user_from_group(&remove_req).unwrap();
 
@@ -2257,6 +2274,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let pool_resp = svc.create_user_pool(&req).unwrap();
         let pool_json: Value =
@@ -2289,6 +2307,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         block_on(svc.admin_create_user(&req)).unwrap();
 
@@ -2324,6 +2343,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let resp = svc.get_user(&req).unwrap();
         let resp_json: Value =
@@ -2348,6 +2368,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         match svc.get_user(&req) {
             Err(e) => assert_eq!(e.code(), "NotAuthorizedException"),
@@ -2379,6 +2400,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let pool_resp = svc.create_user_pool(&req).unwrap();
         let pool_json: Value =
@@ -2408,6 +2430,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         block_on(svc.admin_create_user(&req)).unwrap();
 
@@ -2452,6 +2475,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         svc.delete_user(&req).unwrap();
 
@@ -2490,6 +2514,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let pool_resp = svc.create_user_pool(&req).unwrap();
         let pool_json: Value =
@@ -2520,6 +2545,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         block_on(svc.admin_create_user(&req)).unwrap();
 
@@ -2559,6 +2585,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let resp = svc.get_user_attribute_verification_code(&req).unwrap();
         let resp_json: Value =
@@ -2599,6 +2626,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         svc.verify_user_attribute(&req).unwrap();
 
@@ -2636,6 +2664,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         svc.get_user_attribute_verification_code(&req).unwrap();
 
@@ -2661,6 +2690,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         match svc.verify_user_attribute(&req) {
             Err(e) => assert_eq!(e.code(), "CodeMismatchException"),
@@ -2716,6 +2746,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         let pool_resp = svc.create_user_pool(&create_pool_req).unwrap();
         let pool_body: Value = serde_json::from_slice(pool_resp.body.expect_bytes()).unwrap();
@@ -2742,6 +2773,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         block_on(svc.admin_create_user(&create_user_req)).unwrap();
 
@@ -2775,6 +2807,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         };
         svc.admin_set_user_mfa_preference(&set_pref_req).unwrap();
 
@@ -2804,6 +2837,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -13,19 +13,105 @@
 use std::fmt;
 use std::str::FromStr;
 
+/// Kind of principal a set of credentials resolves to.
+///
+/// Used to drive IAM policy evaluation (Phase 2) and the `GetCallerIdentity`
+/// response shape. Inferred from the credential's storage path in
+/// [`IamState`] and — for STS temporary credentials — from the ARN form
+/// `arn:aws:sts::<account>:assumed-role/...` or `federated-user/...`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PrincipalType {
+    /// An IAM user access key (AKID created via `CreateAccessKey`).
+    User,
+    /// An assumed role session issued by `AssumeRole` /
+    /// `AssumeRoleWithWebIdentity` / `AssumeRoleWithSAML`.
+    AssumedRole,
+    /// Credentials issued by `GetFederationToken` — i.e. a federated user.
+    FederatedUser,
+    /// `GetSessionToken` or the default account-root session.
+    Root,
+}
+
+impl PrincipalType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PrincipalType::User => "user",
+            PrincipalType::AssumedRole => "assumed-role",
+            PrincipalType::FederatedUser => "federated-user",
+            PrincipalType::Root => "root",
+        }
+    }
+
+    /// Best-effort classification from an ARN. Falls back to
+    /// [`PrincipalType::Root`] when the ARN can't be classified (e.g. the
+    /// caller didn't present credentials at all).
+    pub fn from_arn(arn: &str) -> Self {
+        if arn.contains(":user/") {
+            PrincipalType::User
+        } else if arn.contains(":assumed-role/") {
+            PrincipalType::AssumedRole
+        } else if arn.contains(":federated-user/") {
+            PrincipalType::FederatedUser
+        } else {
+            PrincipalType::Root
+        }
+    }
+}
+
+/// Identity of the caller making a request, once its credentials have been
+/// resolved. Attached to [`crate::service::AwsRequest::principal`] so
+/// handlers can make identity-based decisions without re-parsing the
+/// Authorization header.
+///
+/// `account_id` is always sourced from the credential itself (via
+/// [`CredentialResolver`]), never from global config — #381 note.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Principal {
+    pub arn: String,
+    pub user_id: String,
+    pub account_id: String,
+    pub principal_type: PrincipalType,
+    /// Optional source identity string, carried through from
+    /// `AssumeRole`'s `SourceIdentity` parameter. Reserved for later
+    /// batches that wire session policies and auditing.
+    pub source_identity: Option<String>,
+}
+
+impl Principal {
+    /// Is this caller the account's root identity? Root bypasses IAM
+    /// evaluation, matching AWS.
+    pub fn is_root(&self) -> bool {
+        matches!(self.principal_type, PrincipalType::Root) || self.arn.ends_with(":root")
+    }
+}
+
 /// Credentials resolved from an access key ID.
 ///
-/// Returned by [`CredentialResolver::resolve`]. `account_id` is always
-/// sourced from the credential's owning account, never from global config,
-/// so that once multi-account isolation (#381) lands the same lookup returns
-/// the correct account for the credential.
+/// Returned by [`CredentialResolver::resolve`]. Holds both the secret access
+/// key (needed for SigV4 verification) and the resolved [`Principal`]
+/// (needed for IAM enforcement and `GetCallerIdentity` consolidation).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedCredential {
     pub secret_access_key: String,
     pub session_token: Option<String>,
-    pub principal_arn: String,
-    pub user_id: String,
-    pub account_id: String,
+    pub principal: Principal,
+}
+
+impl ResolvedCredential {
+    /// Convenience accessors for the flat fields batch 3 callers use. Kept
+    /// as methods rather than re-adding the fields to avoid making the
+    /// shape inconsistent with [`Principal`] itself.
+    pub fn principal_arn(&self) -> &str {
+        &self.principal.arn
+    }
+
+    pub fn user_id(&self) -> &str {
+        &self.principal.user_id
+    }
+
+    pub fn account_id(&self) -> &str {
+        &self.principal.account_id
+    }
 }
 
 /// Abstraction over "given an access key ID, return the secret and resolved
@@ -204,6 +290,66 @@ mod tests {
         assert!(!is_root_bypass("té"));
         assert!(!is_root_bypass("日本語キー"));
         assert!(!is_root_bypass("🔑🔑"));
+    }
+
+    #[test]
+    fn principal_type_from_arn_classifies_known_shapes() {
+        assert_eq!(
+            PrincipalType::from_arn("arn:aws:iam::123456789012:user/alice"),
+            PrincipalType::User
+        );
+        assert_eq!(
+            PrincipalType::from_arn("arn:aws:sts::123456789012:assumed-role/R/s"),
+            PrincipalType::AssumedRole
+        );
+        assert_eq!(
+            PrincipalType::from_arn("arn:aws:sts::123456789012:federated-user/bob"),
+            PrincipalType::FederatedUser
+        );
+        assert_eq!(
+            PrincipalType::from_arn("arn:aws:iam::123456789012:root"),
+            PrincipalType::Root
+        );
+        assert_eq!(PrincipalType::from_arn("not-an-arn"), PrincipalType::Root);
+    }
+
+    #[test]
+    fn principal_is_root_covers_root_type_and_arn_suffix() {
+        let p = Principal {
+            arn: "arn:aws:iam::123456789012:root".to_string(),
+            user_id: "AIDAROOT".to_string(),
+            account_id: "123456789012".to_string(),
+            principal_type: PrincipalType::Root,
+            source_identity: None,
+        };
+        assert!(p.is_root());
+
+        let user = Principal {
+            arn: "arn:aws:iam::123456789012:user/alice".to_string(),
+            user_id: "AIDAALICE".to_string(),
+            account_id: "123456789012".to_string(),
+            principal_type: PrincipalType::User,
+            source_identity: None,
+        };
+        assert!(!user.is_root());
+    }
+
+    #[test]
+    fn resolved_credential_accessors_forward_to_principal() {
+        let rc = ResolvedCredential {
+            secret_access_key: "s".into(),
+            session_token: None,
+            principal: Principal {
+                arn: "arn:aws:iam::123456789012:user/alice".into(),
+                user_id: "AIDAALICE".into(),
+                account_id: "123456789012".into(),
+                principal_type: PrincipalType::User,
+                source_identity: None,
+            },
+        };
+        assert_eq!(rc.principal_arn(), "arn:aws:iam::123456789012:user/alice");
+        assert_eq!(rc.user_id(), "AIDAALICE");
+        assert_eq!(rc.account_id(), "123456789012");
     }
 
     #[test]

--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -330,7 +330,10 @@ mod tests {
         // malformed or unexpected ARNs bypass IAM enforcement, since
         // Principal::is_root short-circuits evaluation. The fallback must
         // be the non-bypassable Unknown variant.
-        assert_eq!(PrincipalType::from_arn("not-an-arn"), PrincipalType::Unknown);
+        assert_eq!(
+            PrincipalType::from_arn("not-an-arn"),
+            PrincipalType::Unknown
+        );
         assert_eq!(PrincipalType::from_arn(""), PrincipalType::Unknown);
         assert_eq!(
             PrincipalType::from_arn("arn:aws:iam::123456789012:something-weird"),

--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -28,8 +28,14 @@ pub enum PrincipalType {
     AssumedRole,
     /// Credentials issued by `GetFederationToken` — i.e. a federated user.
     FederatedUser,
-    /// `GetSessionToken` or the default account-root session.
+    /// The account root identity. Reserved for explicit `...:root` ARNs
+    /// only; do not return this from a generic fallback because root
+    /// principals bypass IAM enforcement (see `Principal::is_root`).
     Root,
+    /// The ARN didn't match any known shape. Treated as a non-root,
+    /// non-bypassable principal so a malformed or unexpected ARN can never
+    /// silently grant elevated permissions during IAM evaluation.
+    Unknown,
 }
 
 impl PrincipalType {
@@ -39,21 +45,27 @@ impl PrincipalType {
             PrincipalType::AssumedRole => "assumed-role",
             PrincipalType::FederatedUser => "federated-user",
             PrincipalType::Root => "root",
+            PrincipalType::Unknown => "unknown",
         }
     }
 
-    /// Best-effort classification from an ARN. Falls back to
-    /// [`PrincipalType::Root`] when the ARN can't be classified (e.g. the
-    /// caller didn't present credentials at all).
+    /// Classify a principal from its ARN. Returns [`PrincipalType::Unknown`]
+    /// for ARNs that don't match any of the well-known principal shapes —
+    /// **never** [`PrincipalType::Root`] as a fallback, because root
+    /// bypasses IAM enforcement and silently treating malformed ARNs as
+    /// root would let unexpected inputs grant elevated permissions
+    /// (identified by cubic in PR #391 review).
     pub fn from_arn(arn: &str) -> Self {
-        if arn.contains(":user/") {
+        if arn.ends_with(":root") {
+            PrincipalType::Root
+        } else if arn.contains(":user/") {
             PrincipalType::User
         } else if arn.contains(":assumed-role/") {
             PrincipalType::AssumedRole
         } else if arn.contains(":federated-user/") {
             PrincipalType::FederatedUser
         } else {
-            PrincipalType::Root
+            PrincipalType::Unknown
         }
     }
 }
@@ -310,7 +322,31 @@ mod tests {
             PrincipalType::from_arn("arn:aws:iam::123456789012:root"),
             PrincipalType::Root
         );
-        assert_eq!(PrincipalType::from_arn("not-an-arn"), PrincipalType::Root);
+    }
+
+    #[test]
+    fn principal_type_unparseable_is_unknown_not_root() {
+        // Identified by cubic on PR #391: falling back to Root would let
+        // malformed or unexpected ARNs bypass IAM enforcement, since
+        // Principal::is_root short-circuits evaluation. The fallback must
+        // be the non-bypassable Unknown variant.
+        assert_eq!(PrincipalType::from_arn("not-an-arn"), PrincipalType::Unknown);
+        assert_eq!(PrincipalType::from_arn(""), PrincipalType::Unknown);
+        assert_eq!(
+            PrincipalType::from_arn("arn:aws:iam::123456789012:something-weird"),
+            PrincipalType::Unknown
+        );
+
+        // And a Principal built from an Unknown ARN must not be treated
+        // as root for enforcement decisions.
+        let p = Principal {
+            arn: "garbage".to_string(),
+            user_id: "x".to_string(),
+            account_id: "123456789012".to_string(),
+            principal_type: PrincipalType::Unknown,
+            source_identity: None,
+        };
+        assert!(!p.is_root());
     }
 
     #[test]

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -110,97 +110,108 @@ pub async fn dispatch(
         .or_else(|| extract_region_from_user_agent(&parts.headers))
         .unwrap_or_else(|| config.region.clone());
 
+    // Resolve the caller's principal up front so both SigV4 verification
+    // (which needs the secret) and the service handler (which needs the
+    // identity for GetCallerIdentity and IAM enforcement) share a single
+    // lookup. The root-bypass AKID skips resolution entirely — `test`
+    // credentials have no backing identity and must always pass.
+    let caller_akid = access_key_id.as_deref().unwrap_or("");
+    let resolved = if !caller_akid.is_empty() && !is_root_bypass(caller_akid) {
+        config
+            .credential_resolver
+            .as_ref()
+            .and_then(|r| r.resolve(caller_akid))
+    } else {
+        None
+    };
+    let caller_principal = resolved.as_ref().map(|r| r.principal.clone());
+
     // Opt-in SigV4 cryptographic verification. Runs before the service
     // handler so a failing signature never reaches business logic. The
     // reserved `test*` root identity short-circuits verification to keep
     // local-dev workflows frictionless.
-    if config.verify_sigv4 {
-        let caller_akid = access_key_id.as_deref().unwrap_or("");
-        if !is_root_bypass(caller_akid) {
-            if let Some(resolver) = config.credential_resolver.as_ref() {
-                let amz_date = parts
-                    .headers
-                    .get("x-amz-date")
-                    .and_then(|v| v.to_str().ok());
-                let parsed = fakecloud_aws::sigv4::parse_sigv4_header(auth_header, amz_date)
-                    .or_else(|| fakecloud_aws::sigv4::parse_sigv4_presigned(&query_params));
-                let parsed = match parsed {
-                    Some(p) => p,
-                    None => {
-                        return build_error_response(
-                            StatusCode::FORBIDDEN,
-                            "IncompleteSignature",
-                            "Request is missing or has a malformed AWS Signature",
-                            &request_id,
-                            detected.protocol,
-                        );
-                    }
-                };
-                let resolved = match resolver.resolve(&parsed.access_key) {
-                    Some(r) => r,
-                    None => {
-                        return build_error_response(
-                            StatusCode::FORBIDDEN,
-                            "InvalidClientTokenId",
-                            "The security token included in the request is invalid",
-                            &request_id,
-                            detected.protocol,
-                        );
-                    }
-                };
-                let headers_vec = fakecloud_aws::sigv4::headers_from_http(&parts.headers);
-                let raw_query_for_verify = parts.uri.query().unwrap_or("").to_string();
-                let verify_req = fakecloud_aws::sigv4::VerifyRequest {
-                    method: parts.method.as_str(),
-                    path: parts.uri.path(),
-                    query: &raw_query_for_verify,
-                    headers: &headers_vec,
-                    body: &body_bytes,
-                };
-                match fakecloud_aws::sigv4::verify(
-                    &parsed,
-                    &verify_req,
-                    &resolved.secret_access_key,
-                    chrono::Utc::now(),
-                ) {
-                    Ok(()) => {}
-                    Err(fakecloud_aws::sigv4::SigV4Error::RequestTimeTooSkewed { .. }) => {
-                        return build_error_response(
-                            StatusCode::FORBIDDEN,
-                            "RequestTimeTooSkewed",
-                            "The difference between the request time and the current time is too large",
-                            &request_id,
-                            detected.protocol,
-                        );
-                    }
-                    Err(fakecloud_aws::sigv4::SigV4Error::InvalidDate(msg)) => {
-                        return build_error_response(
-                            StatusCode::FORBIDDEN,
-                            "IncompleteSignature",
-                            &format!("Invalid x-amz-date: {msg}"),
-                            &request_id,
-                            detected.protocol,
-                        );
-                    }
-                    Err(fakecloud_aws::sigv4::SigV4Error::Malformed(msg)) => {
-                        return build_error_response(
-                            StatusCode::FORBIDDEN,
-                            "IncompleteSignature",
-                            &format!("Malformed SigV4 signature: {msg}"),
-                            &request_id,
-                            detected.protocol,
-                        );
-                    }
-                    Err(fakecloud_aws::sigv4::SigV4Error::SignatureMismatch) => {
-                        return build_error_response(
-                            StatusCode::FORBIDDEN,
-                            "SignatureDoesNotMatch",
-                            "The request signature we calculated does not match the signature you provided",
-                            &request_id,
-                            detected.protocol,
-                        );
-                    }
-                }
+    if config.verify_sigv4 && !is_root_bypass(caller_akid) && config.credential_resolver.is_some() {
+        let amz_date = parts
+            .headers
+            .get("x-amz-date")
+            .and_then(|v| v.to_str().ok());
+        let parsed = fakecloud_aws::sigv4::parse_sigv4_header(auth_header, amz_date)
+            .or_else(|| fakecloud_aws::sigv4::parse_sigv4_presigned(&query_params));
+        let parsed = match parsed {
+            Some(p) => p,
+            None => {
+                return build_error_response(
+                    StatusCode::FORBIDDEN,
+                    "IncompleteSignature",
+                    "Request is missing or has a malformed AWS Signature",
+                    &request_id,
+                    detected.protocol,
+                );
+            }
+        };
+        let resolved_for_verify = match resolved.as_ref() {
+            Some(r) => r,
+            None => {
+                return build_error_response(
+                    StatusCode::FORBIDDEN,
+                    "InvalidClientTokenId",
+                    "The security token included in the request is invalid",
+                    &request_id,
+                    detected.protocol,
+                );
+            }
+        };
+        let headers_vec = fakecloud_aws::sigv4::headers_from_http(&parts.headers);
+        let raw_query_for_verify = parts.uri.query().unwrap_or("").to_string();
+        let verify_req = fakecloud_aws::sigv4::VerifyRequest {
+            method: parts.method.as_str(),
+            path: parts.uri.path(),
+            query: &raw_query_for_verify,
+            headers: &headers_vec,
+            body: &body_bytes,
+        };
+        match fakecloud_aws::sigv4::verify(
+            &parsed,
+            &verify_req,
+            &resolved_for_verify.secret_access_key,
+            chrono::Utc::now(),
+        ) {
+            Ok(()) => {}
+            Err(fakecloud_aws::sigv4::SigV4Error::RequestTimeTooSkewed { .. }) => {
+                return build_error_response(
+                    StatusCode::FORBIDDEN,
+                    "RequestTimeTooSkewed",
+                    "The difference between the request time and the current time is too large",
+                    &request_id,
+                    detected.protocol,
+                );
+            }
+            Err(fakecloud_aws::sigv4::SigV4Error::InvalidDate(msg)) => {
+                return build_error_response(
+                    StatusCode::FORBIDDEN,
+                    "IncompleteSignature",
+                    &format!("Invalid x-amz-date: {msg}"),
+                    &request_id,
+                    detected.protocol,
+                );
+            }
+            Err(fakecloud_aws::sigv4::SigV4Error::Malformed(msg)) => {
+                return build_error_response(
+                    StatusCode::FORBIDDEN,
+                    "IncompleteSignature",
+                    &format!("Malformed SigV4 signature: {msg}"),
+                    &request_id,
+                    detected.protocol,
+                );
+            }
+            Err(fakecloud_aws::sigv4::SigV4Error::SignatureMismatch) => {
+                return build_error_response(
+                    StatusCode::FORBIDDEN,
+                    "SignatureDoesNotMatch",
+                    "The request signature we calculated does not match the signature you provided",
+                    &request_id,
+                    detected.protocol,
+                );
             }
         }
     }
@@ -252,6 +263,7 @@ pub async fn dispatch(
         method: parts.method,
         is_query_protocol: detected.protocol == AwsProtocol::Query,
         access_key_id,
+        principal: caller_principal,
     };
 
     tracing::info!(

--- a/crates/fakecloud-core/src/service.rs
+++ b/crates/fakecloud-core/src/service.rs
@@ -3,6 +3,8 @@ use bytes::Bytes;
 use http::{HeaderMap, Method, StatusCode};
 use std::collections::HashMap;
 
+use crate::auth::Principal;
+
 /// A parsed AWS request.
 #[derive(Debug)]
 pub struct AwsRequest {
@@ -24,6 +26,13 @@ pub struct AwsRequest {
     pub is_query_protocol: bool,
     /// The access key ID from the SigV4 Authorization header, if present.
     pub access_key_id: Option<String>,
+    /// The resolved caller identity. `None` when the credential is unknown
+    /// or the caller used the reserved root-bypass credentials. Populated
+    /// by dispatch via the configured [`crate::auth::CredentialResolver`]
+    /// so service handlers can make identity-based decisions (e.g.
+    /// `GetCallerIdentity`, IAM enforcement) without re-parsing the
+    /// Authorization header.
+    pub principal: Option<Principal>,
 }
 
 impl AwsRequest {

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -2793,6 +2793,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -3969,6 +3969,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: true,
             access_key_id: None,
+            principal: None,
         }
     }
 
@@ -5331,6 +5332,7 @@ mod tests {
             method: Method::POST,
             is_query_protocol: true,
             access_key_id: None,
+            principal: None,
         };
         assert_eq!(
             parse_query_list_param(&req, "SecurityGroupIds", "SecurityGroupId"),

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -4356,6 +4356,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-iam/src/credential_resolver.rs
+++ b/crates/fakecloud-iam/src/credential_resolver.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use fakecloud_core::auth::{CredentialResolver, ResolvedCredential};
+use fakecloud_core::auth::{CredentialResolver, Principal, PrincipalType, ResolvedCredential};
 
 use crate::state::SharedIamState;
 
@@ -33,15 +33,23 @@ impl IamCredentialResolver {
 impl CredentialResolver for IamCredentialResolver {
     fn resolve(&self, access_key_id: &str) -> Option<ResolvedCredential> {
         let mut state = self.state.write();
-        state
-            .credential_secret(access_key_id)
-            .map(|lookup| ResolvedCredential {
-                secret_access_key: lookup.secret_access_key,
-                session_token: lookup.session_token,
-                principal_arn: lookup.principal_arn,
+        let lookup = state.credential_secret(access_key_id)?;
+        // Classify the principal by ARN shape. IAM user access keys carry
+        // a `:user/` ARN; STS temp credentials carry the assumed-role /
+        // federated-user / root ARN that was stashed when the credential
+        // was issued (batch 2).
+        let principal_type = PrincipalType::from_arn(&lookup.principal_arn);
+        Some(ResolvedCredential {
+            secret_access_key: lookup.secret_access_key,
+            session_token: lookup.session_token,
+            principal: Principal {
+                arn: lookup.principal_arn,
                 user_id: lookup.user_id,
                 account_id: lookup.account_id,
-            })
+                principal_type,
+                source_identity: None,
+            },
+        })
     }
 }
 
@@ -89,9 +97,10 @@ mod tests {
         let resolved = resolver.resolve("FKIAALICE").unwrap();
         assert_eq!(resolved.secret_access_key, "the-secret");
         assert_eq!(
-            resolved.principal_arn,
+            resolved.principal.arn,
             "arn:aws:iam::123456789012:user/alice"
         );
+        assert_eq!(resolved.principal.principal_type, PrincipalType::User);
         assert_eq!(resolved.session_token, None);
     }
 
@@ -100,5 +109,30 @@ mod tests {
         let state = IamState::new("123456789012");
         let resolver = IamCredentialResolver::new(Arc::new(RwLock::new(state)));
         assert!(resolver.resolve("FKIANONE").is_none());
+    }
+
+    #[test]
+    fn classifies_sts_assumed_role_principal() {
+        use crate::state::StsTempCredential;
+        let mut state = IamState::new("123456789012");
+        state.sts_temp_credentials.insert(
+            "FSIATEMP".to_string(),
+            StsTempCredential {
+                access_key_id: "FSIATEMP".into(),
+                secret_access_key: "temp-secret".into(),
+                session_token: "temp-token".into(),
+                principal_arn: "arn:aws:sts::123456789012:assumed-role/ops/session".into(),
+                user_id: "AROA:session".into(),
+                account_id: "123456789012".into(),
+                expiration: Utc::now() + chrono::Duration::minutes(30),
+            },
+        );
+        let resolver = IamCredentialResolver::new(Arc::new(RwLock::new(state)));
+        let resolved = resolver.resolve("FSIATEMP").unwrap();
+        assert_eq!(
+            resolved.principal.principal_type,
+            PrincipalType::AssumedRole
+        );
+        assert_eq!(resolved.session_token.as_deref(), Some("temp-token"));
     }
 }

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -740,6 +740,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: true,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -125,41 +125,23 @@ fn extract_access_key(req: &AwsRequest) -> Option<String> {
 
 impl StsService {
     fn get_caller_identity(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
-        let partition = partition_for_region(&req.region);
-
-        // Check if caller has credentials that map to a known identity
-        if let Some(access_key) = extract_access_key(req) {
-            // First check credential_identities (assumed roles, etc.)
-            if let Some(identity) = state.credential_identities.get(&access_key) {
-                let xml = xml_responses::get_caller_identity_response(
-                    &identity.account_id,
-                    &identity.arn,
-                    &identity.user_id,
-                    &req.request_id,
-                );
-                return Ok(AwsResponse::xml(StatusCode::OK, xml));
-            }
-
-            // Then check IAM user access keys
-            for keys in state.access_keys.values() {
-                for key in keys {
-                    if key.access_key_id == access_key {
-                        if let Some(user) = state.users.get(&key.user_name) {
-                            let xml = xml_responses::get_caller_identity_response(
-                                &state.account_id,
-                                &user.arn,
-                                &user.user_id,
-                                &req.request_id,
-                            );
-                            return Ok(AwsResponse::xml(StatusCode::OK, xml));
-                        }
-                    }
-                }
-            }
+        // Prefer the pre-resolved principal that dispatch attached via the
+        // credential resolver — avoids re-parsing the Authorization header
+        // and re-walking IamState. Falls back to the account-root identity
+        // when the caller didn't present resolvable credentials (e.g. the
+        // `test` root bypass, or no auth header at all).
+        if let Some(principal) = req.principal.as_ref() {
+            let xml = xml_responses::get_caller_identity_response(
+                &principal.account_id,
+                &principal.arn,
+                &principal.user_id,
+                &req.request_id,
+            );
+            return Ok(AwsResponse::xml(StatusCode::OK, xml));
         }
 
-        // Default identity — matches real AWS root credentials
+        let state = self.state.read();
+        let partition = partition_for_region(&req.region);
         let arn = format!("arn:{}:iam::{}:root", partition, state.account_id);
         let user_id = "FKIAIOSFODNN7EXAMPLE";
         let xml = xml_responses::get_caller_identity_response(
@@ -947,6 +929,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: true,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -1780,6 +1780,7 @@ mod tests {
             method: Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -3376,6 +3376,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -630,6 +630,7 @@ mod tests {
             method,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -627,6 +627,7 @@ pub(crate) mod test_helpers {
             method: Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -2843,6 +2843,7 @@ mod tests {
             method: Method::POST,
             is_query_protocol: true,
             access_key_id: None,
+            principal: None,
         }
     }
 }

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -2198,6 +2198,7 @@ mod tests {
             method: Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-ses/src/service/mod.rs
+++ b/crates/fakecloud-ses/src/service/mod.rs
@@ -962,6 +962,7 @@ mod tests {
             method,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-ses/src/v1.rs
+++ b/crates/fakecloud-ses/src/v1.rs
@@ -2105,6 +2105,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: true,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -3841,6 +3841,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: true,
             access_key_id: None,
+            principal: None,
         };
 
         // This should return an error, not panic
@@ -3889,6 +3890,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: true,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -3033,6 +3033,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -460,6 +460,7 @@ mod tests {
             method: http::Method::POST,
             is_query_protocol: false,
             access_key_id: None,
+            principal: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Batch 4 of 9. Introduces the ``Principal`` type and plumbs the resolved caller identity through ``AwsRequest`` so service handlers can make identity decisions without re-parsing the Authorization header. Prereq for batch 5/6 where the IAM evaluator needs to know the caller.

- New ``Principal`` struct + ``PrincipalType`` enum in ``fakecloud-core::auth`` (``User`` / ``AssumedRole`` / ``FederatedUser`` / ``Root``) with an ``is_root`` helper and an ARN classifier.
- ``ResolvedCredential`` now carries a ``Principal`` value instead of flat ``arn/user_id/account_id`` fields; accessor methods preserve batch 3's call sites.
- ``IamCredentialResolver`` classifies the principal type from the stored ARN shape so STS temporary credentials from ``AssumeRole``/``AssumeRoleWithSAML``/``AssumeRoleWithWebIdentity`` surface as ``AssumedRole``, and ``GetFederationToken`` credentials surface as ``FederatedUser``.
- ``AwsRequest.principal: Option<Principal>`` populated by dispatch via a single up-front resolver call. SigV4 verification reuses the same lookup instead of calling ``resolve()`` twice.
- ``StsService::get_caller_identity`` refactored to use ``req.principal`` first, removing ~30 lines of duplicated AKID-walking logic.
- ``account_id`` always sourced from the credential itself (#381 note) — multi-account isolation becomes a state-partitioning change rather than a cross-cutting rewrite.

### Decisions

- Added accessor methods (``principal_arn()`` / ``user_id()`` / ``account_id()``) on ``ResolvedCredential`` rather than duplicating the fields, keeping the struct honest and batch 3 call sites unchanged.
- ``PrincipalType::from_arn`` is best-effort and falls back to ``Root`` for unparseable ARNs. This matches how AWS treats unauthenticated callers — they resolve to the account root.
- The ~18 unchanged service crates had their test helpers and internal ``AwsRequest`` proxies bulk-updated to supply ``principal: None`` / ``req.principal.clone()``. No behavior change for those services.

## Test plan

- [x] ``cargo test -p fakecloud-core`` — 46 unit tests including 3 new ``auth::`` cases (``PrincipalType::from_arn``, ``Principal::is_root``, ``ResolvedCredential`` accessor forwarding)
- [x] ``cargo test -p fakecloud-iam credential_resolver`` — 3 tests including a new ``classifies_sts_assumed_role_principal``
- [x] ``cargo test -p fakecloud-e2e --test iam`` — 57 tests, ``GetCallerIdentity`` still round-trips IAM users and STS temp credentials via the new ``req.principal`` path
- [x] ``cargo test -p fakecloud-e2e --test sigv4_verification`` — 6 tests, SigV4 path uses the shared resolver lookup
- [x] ``cargo test -p fakecloud-conformance`` — no regressions
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo fmt --check`` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the caller’s identity once per request and attach a `Principal` to `AwsRequest`, so handlers can make identity-based decisions without re-parsing Authorization. Harden ARN classification so unknown shapes are never treated as root.

- **New Features**
  - Added `Principal` and `PrincipalType` to `fakecloud-core::auth` with `is_root` and an ARN classifier; introduced `Unknown` so unrecognized ARNs aren’t treated as root.
  - `ResolvedCredential` now carries a `Principal`; added `principal_arn()`, `user_id()`, and `account_id()` accessors.
  - `AwsRequest.principal: Option<Principal>` is set by dispatch; account ID is sourced from the credential.
  - `IamCredentialResolver` classifies principals (`User` / `AssumedRole` / `FederatedUser` / `Root`) and returns `Unknown` for unrecognized shapes; `Root` requires an explicit `:root` ARN.

- **Refactors**
  - SigV4 verification reuses the resolved credential instead of resolving twice.
  - `StsService::get_caller_identity` reads `req.principal` and falls back to account root only when needed.
  - Updated service test helpers to pass `principal: None`; no behavior changes.
  - Ran `rustfmt`; no behavior changes.

<sup>Written for commit 4e84e52c152e3ccfc95115e1b17b4f5113d84c08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

