### PR TITLE
feat(auth): wire IAM enforcement through dispatch

### DIFF
--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -140,6 +140,59 @@ pub trait CredentialResolver: Send + Sync {
     fn resolve(&self, access_key_id: &str) -> Option<ResolvedCredential>;
 }
 
+/// One IAM action that the dispatch layer should evaluate against the
+/// caller's effective policy set.
+///
+/// Produced by [`crate::service::AwsService::iam_action_for`] on services
+/// that opt into enforcement. The `resource` is a fully-qualified AWS ARN
+/// built from `request.principal.account_id` so multi-account isolation
+/// (#381) becomes a state-partitioning change rather than a cross-cutting
+/// rewrite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IamAction {
+    /// IAM service prefix, e.g. `"s3"`, `"sqs"`, `"iam"`.
+    pub service: &'static str,
+    /// AWS action name, e.g. `"GetObject"`, `"SendMessage"`.
+    pub action: &'static str,
+    /// Fully-qualified ARN of the target resource.
+    pub resource: String,
+}
+
+impl IamAction {
+    /// Compose the canonical `service:Action` string the evaluator
+    /// matches against.
+    pub fn action_string(&self) -> String {
+        format!("{}:{}", self.service, self.action)
+    }
+}
+
+/// Result of evaluating a request against an identity's effective policy
+/// set. Abstract over the concrete evaluator [`Decision`] in
+/// `fakecloud-iam::evaluator` so `fakecloud-core` can consume it without
+/// depending on `fakecloud-iam`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IamDecision {
+    Allow,
+    ImplicitDeny,
+    ExplicitDeny,
+}
+
+impl IamDecision {
+    pub fn is_allow(self) -> bool {
+        matches!(self, IamDecision::Allow)
+    }
+}
+
+/// Abstraction over "given a principal and an action, say Allow / Deny".
+/// Implemented by `fakecloud-iam` against `IamState` + the Phase 1
+/// evaluator. Dispatch calls this for every request when
+/// `FAKECLOUD_IAM != off` and the target service opts into enforcement.
+pub trait IamPolicyEvaluator: Send + Sync {
+    /// Evaluate `action` against the identity policies attached to
+    /// `principal`.
+    fn evaluate(&self, principal: &Principal, action: &IamAction) -> IamDecision;
+}
+
 /// How IAM identity policies are evaluated for incoming requests.
 ///
 /// Default is [`IamMode::Off`] — existing behavior, policies are stored but

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -5,7 +5,7 @@ use axum::response::Response;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::auth::{is_root_bypass, CredentialResolver, IamMode};
+use crate::auth::{is_root_bypass, CredentialResolver, IamMode, IamPolicyEvaluator};
 use crate::protocol::{self, AwsProtocol};
 use crate::registry::ServiceRegistry;
 use crate::service::{AwsRequest, ResponseBody};
@@ -273,6 +273,67 @@ pub async fn dispatch(
         "handling request"
     );
 
+    // Opt-in IAM identity-policy enforcement. Runs before the service
+    // handler so a deny never reaches business logic. Root principals
+    // (both `test*` bypass AKIDs and the account's IAM root) are exempt,
+    // matching AWS behavior. Services that haven't opted in via
+    // `iam_enforceable()` are transparently skipped — the startup log
+    // lists which services are under enforcement so users always know.
+    if config.iam_mode.is_enabled()
+        && service.iam_enforceable()
+        && !is_root_bypass(aws_request.access_key_id.as_deref().unwrap_or(""))
+    {
+        if let Some(evaluator) = config.policy_evaluator.as_ref() {
+            if let Some(principal) = aws_request.principal.as_ref() {
+                if !principal.is_root() {
+                    if let Some(iam_action) = service.iam_action_for(&aws_request) {
+                        let decision = evaluator.evaluate(principal, &iam_action);
+                        if !decision.is_allow() {
+                            tracing::warn!(
+                                target: "fakecloud::iam::audit",
+                                service = %detected.service,
+                                action = %iam_action.action_string(),
+                                resource = %iam_action.resource,
+                                principal = %principal.arn,
+                                decision = ?decision,
+                                mode = %config.iam_mode,
+                                request_id = %request_id,
+                                "IAM policy evaluation denied request"
+                            );
+                            if config.iam_mode.is_strict() {
+                                return build_error_response(
+                                    StatusCode::FORBIDDEN,
+                                    "AccessDeniedException",
+                                    &format!(
+                                        "User: {} is not authorized to perform: {} on resource: {}",
+                                        principal.arn,
+                                        iam_action.action_string(),
+                                        iam_action.resource
+                                    ),
+                                    &request_id,
+                                    detected.protocol,
+                                );
+                            }
+                            // Soft mode: audit log already emitted; fall
+                            // through to the handler.
+                        }
+                    } else {
+                        // Service opted in but didn't return an IamAction
+                        // for this specific operation — programming bug,
+                        // surface it loudly in soft/strict mode so it's
+                        // visible during rollout.
+                        tracing::warn!(
+                            target: "fakecloud::iam::audit",
+                            service = %detected.service,
+                            action = %aws_request.action,
+                            "service is iam_enforceable but has no IamAction mapping for this action; skipping evaluation"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     match service.handle(aws_request).await {
         Ok(resp) => {
             let mut builder = Response::builder()
@@ -352,6 +413,10 @@ pub struct DispatchConfig {
     /// Required when `verify_sigv4` or `iam_mode != Off`. When `None`, both
     /// features gracefully degrade to off-by-default behavior.
     pub credential_resolver: Option<Arc<dyn CredentialResolver>>,
+    /// Evaluates IAM identity policies for a resolved principal + action.
+    /// Required when `iam_mode != Off`. When `None`, enforcement silently
+    /// degrades to off even if `iam_mode` is set.
+    pub policy_evaluator: Option<Arc<dyn IamPolicyEvaluator>>,
 }
 
 impl std::fmt::Debug for DispatchConfig {
@@ -368,6 +433,13 @@ impl std::fmt::Debug for DispatchConfig {
                     .as_ref()
                     .map(|_| "<CredentialResolver>"),
             )
+            .field(
+                "policy_evaluator",
+                &self
+                    .policy_evaluator
+                    .as_ref()
+                    .map(|_| "<IamPolicyEvaluator>"),
+            )
             .finish()
     }
 }
@@ -382,6 +454,7 @@ impl DispatchConfig {
             verify_sigv4: false,
             iam_mode: IamMode::Off,
             credential_resolver: None,
+            policy_evaluator: None,
         }
     }
 }
@@ -473,6 +546,7 @@ mod tests {
             verify_sigv4: true,
             iam_mode: IamMode::Strict,
             credential_resolver: None,
+            policy_evaluator: None,
         };
         assert!(cfg.verify_sigv4);
         assert!(cfg.iam_mode.is_strict());

--- a/crates/fakecloud-core/src/registry.rs
+++ b/crates/fakecloud-core/src/registry.rs
@@ -25,4 +25,22 @@ impl ServiceRegistry {
     pub fn service_names(&self) -> Vec<&str> {
         self.services.keys().map(|s| s.as_str()).collect()
     }
+
+    /// Partition registered services into `(iam_enforceable, not
+    /// enforceable)` lists, sorted alphabetically within each group. Used
+    /// by main.rs to emit the startup log when IAM enforcement is on.
+    pub fn iam_enforcement_split(&self) -> (Vec<&str>, Vec<&str>) {
+        let mut enforced: Vec<&str> = Vec::new();
+        let mut skipped: Vec<&str> = Vec::new();
+        for (name, service) in &self.services {
+            if service.iam_enforceable() {
+                enforced.push(name.as_str());
+            } else {
+                skipped.push(name.as_str());
+            }
+        }
+        enforced.sort();
+        skipped.sort();
+        (enforced, skipped)
+    }
 }

--- a/crates/fakecloud-core/src/service.rs
+++ b/crates/fakecloud-core/src/service.rs
@@ -284,4 +284,38 @@ pub trait AwsService: Send + Sync {
 
     /// List of actions this service supports (for introspection).
     fn supported_actions(&self) -> &[&str];
+
+    /// Whether this service participates in opt-in IAM enforcement
+    /// (`FAKECLOUD_IAM=soft|strict`).
+    ///
+    /// Defaults to `false`: unless a service has a full
+    /// `iam_action_for` implementation covering every operation it
+    /// supports plus resource-ARN extractors, it's silently skipped when
+    /// IAM enforcement is on. The startup log enumerates which services
+    /// are enforced and which are not so users always know the current
+    /// enforcement surface.
+    ///
+    /// Phase 1 contract: a service that returns `true` here MUST also
+    /// provide a fully populated [`AwsService::iam_action_for`]
+    /// implementation covering every action it advertises. Returning
+    /// `true` without the action mapping is a programming bug.
+    fn iam_enforceable(&self) -> bool {
+        false
+    }
+
+    /// Derive the IAM action + resource ARN for an incoming request.
+    ///
+    /// Only called when [`AwsService::iam_enforceable`] returns `true`
+    /// and IAM enforcement is enabled. Services must map every action
+    /// they implement; returning `None` for a covered action causes the
+    /// evaluator to skip the request and flag it via the
+    /// `fakecloud::iam::audit` tracing target so gaps are visible in
+    /// soft mode.
+    ///
+    /// The `IamAction.resource` is built from `request.principal`'s
+    /// account id (not global config) so multi-account isolation
+    /// (#381) works once per-account state partitioning lands.
+    fn iam_action_for(&self, _request: &AwsRequest) -> Option<crate::auth::IamAction> {
+        None
+    }
 }

--- a/crates/fakecloud-iam/src/lib.rs
+++ b/crates/fakecloud-iam/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod credential_resolver;
 pub mod evaluator;
 pub mod iam_service;
+pub mod policy_evaluator;
 pub mod policy_validation;
 pub mod state;
 pub mod sts_service;

--- a/crates/fakecloud-iam/src/policy_evaluator.rs
+++ b/crates/fakecloud-iam/src/policy_evaluator.rs
@@ -1,0 +1,157 @@
+//! Adapter that implements [`fakecloud_core::auth::IamPolicyEvaluator`]
+//! over the shared IAM state + Phase 1 evaluator.
+//!
+//! Mirrors the shape of [`crate::credential_resolver`]: the trait lives in
+//! `fakecloud-core`, the concrete implementation lives here, and dispatch
+//! calls through the trait so the dependency edge points core -> iam only.
+
+use std::sync::Arc;
+
+use fakecloud_core::auth::{IamAction, IamDecision, IamPolicyEvaluator, Principal};
+
+use crate::evaluator::{self, Decision, EvalRequest, RequestContext};
+use crate::state::SharedIamState;
+
+/// [`IamPolicyEvaluator`] backed by shared [`crate::state::IamState`].
+#[derive(Clone)]
+pub struct IamPolicyEvaluatorImpl {
+    state: SharedIamState,
+}
+
+impl IamPolicyEvaluatorImpl {
+    pub fn new(state: SharedIamState) -> Self {
+        Self { state }
+    }
+
+    pub fn shared(state: SharedIamState) -> Arc<dyn IamPolicyEvaluator> {
+        Arc::new(Self::new(state))
+    }
+}
+
+impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
+    fn evaluate(&self, principal: &Principal, action: &IamAction) -> IamDecision {
+        let state = self.state.read();
+        let policies = evaluator::collect_identity_policies(&state, principal);
+        let request = EvalRequest {
+            principal,
+            action: action.action_string(),
+            resource: action.resource.clone(),
+            context: RequestContext::default(),
+        };
+        match evaluator::evaluate(&policies, &request) {
+            Decision::Allow => IamDecision::Allow,
+            Decision::ImplicitDeny => IamDecision::ImplicitDeny,
+            Decision::ExplicitDeny => IamDecision::ExplicitDeny,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{IamAccessKey, IamState, IamUser};
+    use chrono::Utc;
+    use fakecloud_core::auth::PrincipalType;
+    use parking_lot::RwLock;
+
+    fn principal() -> Principal {
+        Principal {
+            arn: "arn:aws:iam::123456789012:user/alice".to_string(),
+            user_id: "AIDAALICE".to_string(),
+            account_id: "123456789012".to_string(),
+            principal_type: PrincipalType::User,
+            source_identity: None,
+        }
+    }
+
+    fn setup() -> Arc<RwLock<IamState>> {
+        let mut state = IamState::new("123456789012");
+        state.users.insert(
+            "alice".into(),
+            IamUser {
+                user_name: "alice".into(),
+                user_id: "AIDAALICE".into(),
+                arn: "arn:aws:iam::123456789012:user/alice".into(),
+                path: "/".into(),
+                created_at: Utc::now(),
+                tags: Vec::new(),
+                permissions_boundary: None,
+            },
+        );
+        state.access_keys.insert(
+            "alice".into(),
+            vec![IamAccessKey {
+                access_key_id: "FKIAALICE".into(),
+                secret_access_key: "s".into(),
+                user_name: "alice".into(),
+                status: "Active".into(),
+                created_at: Utc::now(),
+            }],
+        );
+        Arc::new(RwLock::new(state))
+    }
+
+    #[test]
+    fn allow_policy_produces_allow_decision() {
+        let state = setup();
+        state.write().user_inline_policies.insert(
+            "alice".into(),
+            std::collections::HashMap::from([(
+                "AllowGet".into(),
+                r#"{"Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#
+                    .into(),
+            )]),
+        );
+        let eval = IamPolicyEvaluatorImpl::new(state);
+        let action = IamAction {
+            service: "s3",
+            action: "GetObject",
+            resource: "arn:aws:s3:::bucket/key".into(),
+        };
+        assert_eq!(eval.evaluate(&principal(), &action), IamDecision::Allow);
+    }
+
+    #[test]
+    fn explicit_deny_takes_precedence() {
+        let state = setup();
+        state.write().user_inline_policies.insert(
+            "alice".into(),
+            std::collections::HashMap::from([
+                (
+                    "AllowAll".into(),
+                    r#"{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.into(),
+                ),
+                (
+                    "DenyGet".into(),
+                    r#"{"Statement":[{"Effect":"Deny","Action":"s3:GetObject","Resource":"*"}]}"#
+                        .into(),
+                ),
+            ]),
+        );
+        let eval = IamPolicyEvaluatorImpl::new(state);
+        let action = IamAction {
+            service: "s3",
+            action: "GetObject",
+            resource: "arn:aws:s3:::bucket/key".into(),
+        };
+        assert_eq!(
+            eval.evaluate(&principal(), &action),
+            IamDecision::ExplicitDeny
+        );
+    }
+
+    #[test]
+    fn empty_policy_set_is_implicit_deny() {
+        let state = setup();
+        let eval = IamPolicyEvaluatorImpl::new(state);
+        let action = IamAction {
+            service: "s3",
+            action: "GetObject",
+            resource: "arn:aws:s3:::bucket/key".into(),
+        };
+        assert_eq!(
+            eval.evaluate(&principal(), &action),
+            IamDecision::ImplicitDeny
+        );
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -668,6 +668,14 @@ async fn main() {
             "opt-in security features enabled: access keys with the `test` prefix bypass SigV4 verification and IAM enforcement — see /docs/reference/security"
         );
     }
+    if iam_mode.is_enabled() {
+        let (enforced, skipped) = registry.iam_enforcement_split();
+        tracing::info!(
+            enforced = ?enforced,
+            skipped = ?skipped,
+            "IAM enforcement surface: listed `enforced` services evaluate policies; `skipped` services are not yet wired for enforcement"
+        );
+    }
 
     let config = DispatchConfig {
         region: cli.region,
@@ -676,6 +684,9 @@ async fn main() {
         iam_mode,
         credential_resolver: Some(
             fakecloud_iam::credential_resolver::IamCredentialResolver::shared(iam_state.clone()),
+        ),
+        policy_evaluator: Some(
+            fakecloud_iam::policy_evaluator::IamPolicyEvaluatorImpl::shared(iam_state.clone()),
         ),
     };
 


### PR DESCRIPTION
## Summary

Batch 6 of 9. Introduces the ``ServiceMetadata`` hooks on ``AwsService`` and plumbs the Phase 1 evaluator (PR #392) into dispatch so ``FAKECLOUD_IAM=soft|strict`` actually enforces identity policies. **No service opts in yet** — that's batch 7. Existing behavior is unchanged for every currently-registered service.

### Service metadata hooks

- ``AwsService::iam_enforceable()`` → default ``false``
- ``AwsService::iam_action_for(&AwsRequest)`` → default ``None``

Both have default implementations, so the 22 existing services compile without any changes. Batch 7 + 8 override these on the services that ship resource-ARN extractors.

### Architecture

- New ``IamAction``, ``IamDecision``, ``IamPolicyEvaluator`` in ``fakecloud-core::auth``. Dependency edge stays ``core → iam``: the trait lives in core, the concrete ``IamPolicyEvaluatorImpl`` lives in ``fakecloud-iam`` and bridges to the Phase 1 evaluator module.
- ``DispatchConfig`` gains ``policy_evaluator: Option<Arc<dyn IamPolicyEvaluator>>``, wired in ``main.rs`` alongside the existing ``credential_resolver``.
- ``ServiceRegistry::iam_enforcement_split()`` partitions services into enforced / skipped lists, used by ``main.rs`` to emit a startup info log when ``FAKECLOUD_IAM`` is enabled so users always know the current enforcement surface.

### Dispatch integration

Runs between SigV4 verification and ``service.handle()``:

1. Short-circuits for the ``test*`` root-bypass AKID and for IAM root principals (``Principal::is_root``) — matches AWS behavior that root bypasses IAM evaluation.
2. Services that haven't opted in via ``iam_enforceable()`` are transparently skipped.
3. Services that opt in but don't map a specific action emit a warn on ``fakecloud::iam::audit`` so rollout gaps stay visible.
4. On ``Allow``: flows through to the handler.
5. On ``ImplicitDeny`` / ``ExplicitDeny`` in **soft** mode: emits a structured warn on ``fakecloud::iam::audit`` and flows through.
6. On ``ImplicitDeny`` / ``ExplicitDeny`` in **strict** mode: returns protocol-correct ``AccessDeniedException`` before the handler runs.

### Decisions

- Audit logs all go through the ``fakecloud::iam::audit`` tracing target so users can filter just the enforcement events with ``RUST_LOG=fakecloud::iam::audit=warn``.
- The denied-request error message matches AWS shape: ``User: <arn> is not authorized to perform: <service:Action> on resource: <arn>``.
- No dispatch integration test in this PR. The evaluator adapter (``policy_evaluator.rs``) has 3 unit tests covering allow / explicit-deny / implicit-deny through the trait boundary. End-to-end validation of the dispatch wiring lands in batch 7 when the first real service (IAM/STS) opts into enforcement — creating a test-only service just to validate the mechanism would duplicate batch 7 work.

## Test plan

- [x] ``cargo test -p fakecloud-core`` — 47 tests, no regressions
- [x] ``cargo test -p fakecloud-iam`` — 113 tests, including 3 new ``policy_evaluator`` tests covering allow / explicit deny / implicit deny through the ``IamPolicyEvaluator`` trait boundary
- [x] ``cargo test -p fakecloud-e2e --test iam --test sigv4_verification`` — 63 tests, no regressions
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo fmt --check`` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires opt-in IAM identity-policy enforcement into request dispatch so `FAKECLOUD_IAM=soft|strict` evaluates policies before handlers run. No service opts in yet, so current behavior is unchanged.

- **New Features**
  - Added service hooks: `AwsService::iam_enforceable()` and `iam_action_for(&AwsRequest)`.
  - Introduced `IamAction`, `IamDecision`, and `IamPolicyEvaluator` in `fakecloud-core::auth`; concrete `IamPolicyEvaluatorImpl` lives in `fakecloud-iam`.
  - `DispatchConfig` now includes `policy_evaluator`; wired in `fakecloud-server` using shared IAM state.
  - Enforcement runs after SigV4 verification and before `service.handle()`: bypasses root/test keys, skips non-opt-in services, warns on missing action mappings, soft mode warns and continues, strict mode returns `AccessDeniedException`.
  - Startup logs list enforced vs skipped services via `ServiceRegistry::iam_enforcement_split()` when `FAKECLOUD_IAM` is enabled.

- **Migration**
  - To opt in, implement `iam_action_for()` for all actions and return `true` from `iam_enforceable()`.
  - Use `FAKECLOUD_IAM=soft` to audit and `strict` to block; filter events with `RUST_LOG=fakecloud::iam::audit=warn`.

<sup>Written for commit aa654931480d4a8b22796cf8ec2d30d960609dbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

