### PR TITLE
feat(iam,sts): wire Phase 1 enforcement for IAM + STS services

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -1,0 +1,231 @@
+//! End-to-end tests for opt-in IAM identity-policy enforcement on IAM + STS.
+//!
+//! Each test spawns fakecloud with `FAKECLOUD_IAM=strict`, bootstraps a
+//! user via the reserved `test*` root-bypass credentials, attaches an
+//! inline policy, then signs a follow-up request with the user's own
+//! access key to observe Allow / Deny. Batch 7 wires IAM + STS first;
+//! batches 7b/8 roll out the rest.
+
+mod helpers;
+
+use aws_credential_types::Credentials;
+use aws_sdk_iam::Client as IamClient;
+use aws_sdk_sts::Client as StsClient;
+use helpers::TestServer;
+
+async fn start_strict() -> TestServer {
+    TestServer::start_with_env(&[
+        ("FAKECLOUD_IAM", "strict"),
+        ("FAKECLOUD_VERIFY_SIGV4", "true"),
+    ])
+    .await
+}
+
+async fn start_soft() -> TestServer {
+    TestServer::start_with_env(&[("FAKECLOUD_IAM", "soft")]).await
+}
+
+async fn sdk_config_with(server: &TestServer, akid: &str, secret: &str) -> aws_config::SdkConfig {
+    aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(
+            akid,
+            secret,
+            None,
+            None,
+            "fakecloud-iam-enf",
+        ))
+        .load()
+        .await
+}
+
+/// Bootstrap a user via root-bypass credentials and return their
+/// freshly-created (access_key_id, secret_access_key) plus an
+/// `aws-sdk-iam` client signed with those credentials.
+async fn bootstrap_user(server: &TestServer, name: &str) -> (String, String) {
+    let boot = sdk_config_with(server, "test", "test").await;
+    let iam_boot = IamClient::new(&boot);
+    iam_boot.create_user().user_name(name).send().await.unwrap();
+    let ak = iam_boot
+        .create_access_key()
+        .user_name(name)
+        .send()
+        .await
+        .unwrap();
+    let key = ak.access_key().unwrap();
+    (
+        key.access_key_id().to_string(),
+        key.secret_access_key().to_string(),
+    )
+}
+
+async fn attach_inline_policy(server: &TestServer, user: &str, name: &str, document: &str) {
+    let boot = sdk_config_with(server, "test", "test").await;
+    IamClient::new(&boot)
+        .put_user_policy()
+        .user_name(user)
+        .policy_name(name)
+        .policy_document(document)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ======================================================================
+// STS tests
+// ======================================================================
+
+#[tokio::test]
+async fn sts_get_caller_identity_denied_without_policy() {
+    // A user with no attached policies has implicit-deny on STS actions
+    // in strict mode. GetCallerIdentity with their credentials must fail.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "alice").await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sts = StsClient::new(&cfg);
+    let err = sts.get_caller_identity().send().await.unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn sts_get_caller_identity_allowed_with_explicit_policy() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "bob").await;
+    attach_inline_policy(
+        &server,
+        "bob",
+        "AllowGetCallerIdentity",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sts:GetCallerIdentity","Resource":"*"}]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sts = StsClient::new(&cfg);
+    let identity = sts.get_caller_identity().send().await.unwrap();
+    assert!(identity.arn().unwrap().contains("user/bob"));
+}
+
+#[tokio::test]
+async fn sts_explicit_deny_beats_allow_all() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "carol").await;
+    attach_inline_policy(
+        &server,
+        "carol",
+        "AllowAll",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+    )
+    .await;
+    attach_inline_policy(
+        &server,
+        "carol",
+        "DenySts",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"sts:GetCallerIdentity","Resource":"*"}]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sts = StsClient::new(&cfg);
+    let err = sts.get_caller_identity().send().await.unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(msg.contains("AccessDeniedException"), "got {msg}");
+}
+
+#[tokio::test]
+async fn root_bypass_skips_enforcement() {
+    // The reserved `test`/`test` root bypass should succeed even under
+    // strict enforcement with no explicit policy.
+    let server = start_strict().await;
+    let cfg = sdk_config_with(&server, "test", "test").await;
+    let sts = StsClient::new(&cfg);
+    let identity = sts.get_caller_identity().send().await.unwrap();
+    assert!(identity.arn().unwrap().contains(":root"));
+}
+
+// ======================================================================
+// IAM tests
+// ======================================================================
+
+#[tokio::test]
+async fn iam_get_user_resource_scoped_policy() {
+    // Bob can read his own user record but not alice's.
+    let server = start_strict().await;
+    // Create both users via root bypass.
+    {
+        let boot = sdk_config_with(&server, "test", "test").await;
+        let boot_iam = IamClient::new(&boot);
+        boot_iam
+            .create_user()
+            .user_name("alice")
+            .send()
+            .await
+            .unwrap();
+    }
+    let (akid, secret) = bootstrap_user(&server, "bob").await;
+    attach_inline_policy(
+        &server,
+        "bob",
+        "ReadSelf",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"iam:GetUser","Resource":"arn:aws:iam::123456789012:user/bob"}]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let iam = IamClient::new(&cfg);
+
+    // Bob -> self: allowed.
+    let self_resp = iam.get_user().user_name("bob").send().await.unwrap();
+    assert_eq!(self_resp.user().unwrap().user_name(), "bob");
+
+    // Bob -> alice: denied because resource doesn't match.
+    let err = iam.get_user().user_name("alice").send().await.unwrap_err();
+    assert!(format!("{err:?}").contains("AccessDeniedException"));
+}
+
+#[tokio::test]
+async fn iam_wildcard_action_allows_everything() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "dave").await;
+    attach_inline_policy(
+        &server,
+        "dave",
+        "AllowAllIam",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"iam:*","Resource":"*"}]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let iam = IamClient::new(&cfg);
+    iam.list_users().send().await.unwrap();
+    iam.get_user().user_name("dave").send().await.unwrap();
+}
+
+#[tokio::test]
+async fn iam_soft_mode_does_not_fail_denied_requests() {
+    // Soft mode should log the deny but let the request through.
+    let server = start_soft().await;
+    let (akid, secret) = bootstrap_user(&server, "erin").await;
+    // No policies attached -> implicit deny in the evaluator, but soft
+    // mode lets it through.
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let iam = IamClient::new(&cfg);
+    // This would AccessDeny under strict mode; in soft mode it succeeds.
+    iam.list_users().send().await.unwrap();
+}
+
+#[tokio::test]
+async fn off_mode_does_not_enforce() {
+    // Regression guard for off-by-default: no FAKECLOUD_IAM env set.
+    let server = TestServer::start().await;
+    let (akid, secret) = bootstrap_user(&server, "frank").await;
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let iam = IamClient::new(&cfg);
+    // Frank has no policies, but enforcement is off -> succeeds.
+    iam.list_users().send().await.unwrap();
+}

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -256,6 +256,284 @@ impl AwsService for IamService {
     fn supported_actions(&self) -> &[&str] {
         SUPPORTED_ACTIONS
     }
+
+    /// IAM opts into Phase 1 enforcement. Every action in
+    /// [`SUPPORTED_ACTIONS`] maps to a concrete `IamAction` — see
+    /// [`iam_action_resource`] for the resource-ARN extraction logic.
+    fn iam_enforceable(&self) -> bool {
+        true
+    }
+
+    fn iam_action_for(&self, request: &AwsRequest) -> Option<fakecloud_core::auth::IamAction> {
+        // The action list is small enough to reuse SUPPORTED_ACTIONS as
+        // the whitelist: anything we didn't declare support for isn't
+        // enforced (and would be handled as action_not_implemented by
+        // the match in `handle()`).
+        let static_action = SUPPORTED_ACTIONS
+            .iter()
+            .copied()
+            .find(|a| *a == request.action)?;
+        let account = request
+            .principal
+            .as_ref()
+            .map(|p| p.account_id.as_str())
+            .unwrap_or(request.account_id.as_str());
+        let partition = partition_for_region(&request.region);
+        Some(fakecloud_core::auth::IamAction {
+            service: "iam",
+            action: static_action,
+            resource: iam_action_resource(static_action, partition, account, request),
+        })
+    }
+}
+
+/// Derive the fully-qualified IAM resource ARN for a given action +
+/// request. Reads the relevant parameter (UserName, RoleName, PolicyArn,
+/// etc.) from the request's query params or body. Falls back to `*` when
+/// the action targets no specific resource (e.g. `ListUsers`,
+/// `GetAccountSummary`) or the parameter is missing.
+///
+/// IAM resources follow a small set of shapes
+/// (`user/`, `role/`, `group/`, `policy/`, `instance-profile/`,
+/// `mfa/`, `server-certificate/`, `saml-provider/`, `oidc-provider/`).
+/// Each action is classified by which shape it targets.
+fn iam_action_resource(
+    action: &str,
+    partition: &str,
+    account: &str,
+    request: &AwsRequest,
+) -> String {
+    let params = &request.query_params;
+    let wildcard = || "*".to_string();
+    let user_arn = |name: &str| format!("arn:{}:iam::{}:user/{}", partition, account, name);
+    let role_arn = |name: &str| format!("arn:{}:iam::{}:role/{}", partition, account, name);
+    let group_arn = |name: &str| format!("arn:{}:iam::{}:group/{}", partition, account, name);
+    let policy_arn = |name: &str| format!("arn:{}:iam::{}:policy/{}", partition, account, name);
+    let profile_arn = |name: &str| {
+        format!(
+            "arn:{}:iam::{}:instance-profile/{}",
+            partition, account, name
+        )
+    };
+    let mfa_arn = |name: &str| format!("arn:{}:iam::{}:mfa/{}", partition, account, name);
+    let server_cert_arn = |name: &str| {
+        format!(
+            "arn:{}:iam::{}:server-certificate/{}",
+            partition, account, name
+        )
+    };
+
+    // User-scoped actions: read `UserName` from params. Missing -> wildcard.
+    let user_scoped: &[&str] = &[
+        "CreateUser",
+        "GetUser",
+        "DeleteUser",
+        "UpdateUser",
+        "TagUser",
+        "UntagUser",
+        "ListUserTags",
+        "CreateAccessKey",
+        "DeleteAccessKey",
+        "ListAccessKeys",
+        "UpdateAccessKey",
+        "GetAccessKeyLastUsed",
+        "CreateLoginProfile",
+        "GetLoginProfile",
+        "DeleteLoginProfile",
+        "UpdateLoginProfile",
+        "AttachUserPolicy",
+        "DetachUserPolicy",
+        "ListAttachedUserPolicies",
+        "PutUserPolicy",
+        "GetUserPolicy",
+        "DeleteUserPolicy",
+        "ListUserPolicies",
+        "AddUserToGroup",
+        "RemoveUserFromGroup",
+        "ListGroupsForUser",
+        "EnableMFADevice",
+        "DeactivateMFADevice",
+        "ListMFADevices",
+        "UploadSSHPublicKey",
+        "GetSSHPublicKey",
+        "UpdateSSHPublicKey",
+        "DeleteSSHPublicKey",
+        "ListSSHPublicKeys",
+        "UploadSigningCertificate",
+        "UpdateSigningCertificate",
+        "DeleteSigningCertificate",
+        "ListSigningCertificates",
+    ];
+
+    // Role-scoped actions: read `RoleName` from params.
+    let role_scoped: &[&str] = &[
+        "CreateRole",
+        "GetRole",
+        "DeleteRole",
+        "UpdateRole",
+        "UpdateRoleDescription",
+        "UpdateAssumeRolePolicy",
+        "TagRole",
+        "UntagRole",
+        "ListRoleTags",
+        "PutRolePermissionsBoundary",
+        "DeleteRolePermissionsBoundary",
+        "AttachRolePolicy",
+        "DetachRolePolicy",
+        "ListAttachedRolePolicies",
+        "PutRolePolicy",
+        "GetRolePolicy",
+        "DeleteRolePolicy",
+        "ListRolePolicies",
+        "CreateServiceLinkedRole",
+        "DeleteServiceLinkedRole",
+        "GetServiceLinkedRoleDeletionStatus",
+        "ListInstanceProfilesForRole",
+    ];
+
+    // Group-scoped actions: read `GroupName` from params.
+    let group_scoped: &[&str] = &[
+        "CreateGroup",
+        "GetGroup",
+        "DeleteGroup",
+        "UpdateGroup",
+        "PutGroupPolicy",
+        "GetGroupPolicy",
+        "DeleteGroupPolicy",
+        "ListGroupPolicies",
+        "AttachGroupPolicy",
+        "DetachGroupPolicy",
+        "ListAttachedGroupPolicies",
+    ];
+
+    // Policy-scoped actions: read `PolicyArn` from params (ARN in place).
+    let policy_scoped_arn: &[&str] = &[
+        "GetPolicy",
+        "DeletePolicy",
+        "TagPolicy",
+        "UntagPolicy",
+        "ListPolicyTags",
+        "CreatePolicyVersion",
+        "GetPolicyVersion",
+        "ListPolicyVersions",
+        "DeletePolicyVersion",
+        "SetDefaultPolicyVersion",
+        "ListEntitiesForPolicy",
+    ];
+
+    // Instance-profile-scoped actions: read `InstanceProfileName`.
+    let profile_scoped: &[&str] = &[
+        "CreateInstanceProfile",
+        "GetInstanceProfile",
+        "DeleteInstanceProfile",
+        "TagInstanceProfile",
+        "UntagInstanceProfile",
+        "ListInstanceProfileTags",
+        "AddRoleToInstanceProfile",
+        "RemoveRoleFromInstanceProfile",
+    ];
+
+    if user_scoped.contains(&action) {
+        return params
+            .get("UserName")
+            .map(|n| user_arn(n))
+            .unwrap_or_else(wildcard);
+    }
+    if role_scoped.contains(&action) {
+        return params
+            .get("RoleName")
+            .map(|n| role_arn(n))
+            .unwrap_or_else(wildcard);
+    }
+    if group_scoped.contains(&action) {
+        return params
+            .get("GroupName")
+            .map(|n| group_arn(n))
+            .unwrap_or_else(wildcard);
+    }
+    if policy_scoped_arn.contains(&action) {
+        return params.get("PolicyArn").cloned().unwrap_or_else(wildcard);
+    }
+    if profile_scoped.contains(&action) {
+        return params
+            .get("InstanceProfileName")
+            .map(|n| profile_arn(n))
+            .unwrap_or_else(wildcard);
+    }
+
+    match action {
+        // CreatePolicy: target ARN is the to-be-created policy.
+        "CreatePolicy" => params
+            .get("PolicyName")
+            .map(|n| policy_arn(n))
+            .unwrap_or_else(wildcard),
+        // MFA actions keyed by SerialNumber (which is the mfa ARN itself
+        // for virtual devices, a plain string for hardware devices).
+        "CreateVirtualMFADevice" => params
+            .get("VirtualMFADeviceName")
+            .map(|n| mfa_arn(n))
+            .unwrap_or_else(wildcard),
+        "DeleteVirtualMFADevice" => params.get("SerialNumber").cloned().unwrap_or_else(wildcard),
+        "ResyncMFADevice" => params.get("SerialNumber").cloned().unwrap_or_else(wildcard),
+        // Server certificates keyed by ServerCertificateName.
+        "UploadServerCertificate" | "GetServerCertificate" | "DeleteServerCertificate" => params
+            .get("ServerCertificateName")
+            .map(|n| server_cert_arn(n))
+            .unwrap_or_else(wildcard),
+        // SAML / OIDC providers reference their ARN directly.
+        "CreateSAMLProvider" => params
+            .get("Name")
+            .map(|n| format!("arn:{}:iam::{}:saml-provider/{}", partition, account, n))
+            .unwrap_or_else(wildcard),
+        "UpdateSAMLProvider" | "DeleteSAMLProvider" | "GetSAMLProvider" => params
+            .get("SAMLProviderArn")
+            .cloned()
+            .unwrap_or_else(wildcard),
+        "CreateOpenIDConnectProvider" => params
+            .get("Url")
+            .map(|u| {
+                format!(
+                    "arn:{}:iam::{}:oidc-provider/{}",
+                    partition,
+                    account,
+                    u.trim_start_matches("https://")
+                )
+            })
+            .unwrap_or_else(wildcard),
+        "GetOpenIDConnectProvider"
+        | "DeleteOpenIDConnectProvider"
+        | "AddClientIDToOpenIDConnectProvider"
+        | "RemoveClientIDFromOpenIDConnectProvider"
+        | "UpdateOpenIDConnectProviderThumbprint"
+        | "TagOpenIDConnectProvider"
+        | "UntagOpenIDConnectProvider"
+        | "ListOpenIDConnectProviderTags" => params
+            .get("OpenIDConnectProviderArn")
+            .cloned()
+            .unwrap_or_else(wildcard),
+        // Account-scoped / listing actions have no per-resource target.
+        "ListUsers"
+        | "ListRoles"
+        | "ListGroups"
+        | "ListPolicies"
+        | "ListInstanceProfiles"
+        | "ListVirtualMFADevices"
+        | "ListServerCertificates"
+        | "ListSAMLProviders"
+        | "ListOpenIDConnectProviders"
+        | "ListAccountAliases"
+        | "CreateAccountAlias"
+        | "DeleteAccountAlias"
+        | "GetAccountSummary"
+        | "GetAccountAuthorizationDetails"
+        | "GenerateCredentialReport"
+        | "GetCredentialReport"
+        | "GetAccountPasswordPolicy"
+        | "UpdateAccountPasswordPolicy"
+        | "DeleteAccountPasswordPolicy" => wildcard(),
+        // Anything we didn't classify above — be conservative.
+        _ => wildcard(),
+    }
 }
 
 /// All IAM actions fakecloud handles. Promoted to a file-level const so

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -385,9 +385,13 @@ fn iam_action_resource(
         "GetRolePolicy",
         "DeleteRolePolicy",
         "ListRolePolicies",
-        "CreateServiceLinkedRole",
+        // NOTE: CreateServiceLinkedRole excluded — its target resource is
+        // built from `AWSServiceName`, not `RoleName`, and is handled in
+        // the match block below (identified by cubic on PR #395).
+        // GetServiceLinkedRoleDeletionStatus is also excluded — it
+        // operates on a deletion-task id rather than a role name; it
+        // falls through to the wildcard branch below.
         "DeleteServiceLinkedRole",
-        "GetServiceLinkedRoleDeletionStatus",
         "ListInstanceProfilesForRole",
     ];
 
@@ -467,6 +471,18 @@ fn iam_action_resource(
             .get("PolicyName")
             .map(|n| policy_arn(n))
             .unwrap_or_else(wildcard),
+        // Service-linked roles are created by AWS service name, not
+        // role name. Their ARNs follow the `role/aws-service-role/<svc>`
+        // convention (identified by cubic on PR #395).
+        "CreateServiceLinkedRole" => params
+            .get("AWSServiceName")
+            .map(|svc| {
+                format!(
+                    "arn:{}:iam::{}:role/aws-service-role/{}",
+                    partition, account, svc
+                )
+            })
+            .unwrap_or_else(wildcard),
         // MFA actions keyed by SerialNumber (which is the mfa ARN itself
         // for virtual devices, a plain string for hardware devices).
         "CreateVirtualMFADevice" => params
@@ -474,7 +490,9 @@ fn iam_action_resource(
             .map(|n| mfa_arn(n))
             .unwrap_or_else(wildcard),
         "DeleteVirtualMFADevice" => params.get("SerialNumber").cloned().unwrap_or_else(wildcard),
-        "ResyncMFADevice" => params.get("SerialNumber").cloned().unwrap_or_else(wildcard),
+        // Note: ResyncMFADevice is not in SUPPORTED_ACTIONS and so
+        // never reaches this match — if it's added later, handle
+        // `SerialNumber` here.
         // Server certificates keyed by ServerCertificateName.
         "UploadServerCertificate" | "GetServerCertificate" | "DeleteServerCertificate" => params
             .get("ServerCertificateName")

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -97,6 +97,45 @@ impl AwsService for StsService {
             "DecodeAuthorizationMessage",
         ]
     }
+
+    /// STS opts into Phase 1 IAM enforcement.
+    fn iam_enforceable(&self) -> bool {
+        true
+    }
+
+    /// STS actions operate on `*` per AWS — see
+    /// <https://docs.aws.amazon.com/service-authorization/latest/reference/list_awssecuritytokenservice.html>.
+    /// `AssumeRole*` variants additionally carry a role ARN as the
+    /// target resource so policies can scope by role name.
+    fn iam_action_for(
+        &self,
+        request: &fakecloud_core::service::AwsRequest,
+    ) -> Option<fakecloud_core::auth::IamAction> {
+        let action: &'static str = match request.action.as_str() {
+            "GetCallerIdentity" => "GetCallerIdentity",
+            "AssumeRole" => "AssumeRole",
+            "AssumeRoleWithWebIdentity" => "AssumeRoleWithWebIdentity",
+            "AssumeRoleWithSAML" => "AssumeRoleWithSAML",
+            "GetSessionToken" => "GetSessionToken",
+            "GetFederationToken" => "GetFederationToken",
+            "GetAccessKeyInfo" => "GetAccessKeyInfo",
+            "DecodeAuthorizationMessage" => "DecodeAuthorizationMessage",
+            _ => return None,
+        };
+        let resource = match action {
+            "AssumeRole" | "AssumeRoleWithWebIdentity" | "AssumeRoleWithSAML" => request
+                .query_params
+                .get("RoleArn")
+                .cloned()
+                .unwrap_or_else(|| "*".to_string()),
+            _ => "*".to_string(),
+        };
+        Some(fakecloud_core::auth::IamAction {
+            service: "sts",
+            action,
+            resource,
+        })
+    }
 }
 
 /// Get the AWS partition from a region string.


### PR DESCRIPTION
## Summary

First real services to opt into the ``FAKECLOUD_IAM=soft|strict`` enforcement path from PR #394. Adds ``iam_enforceable()`` + ``iam_action_for()`` implementations for both **STS** and **IAM**, covering every action they advertise. **Off by default** — zero behavior change for existing workflows.

### STS

All 8 STS actions map to ``sts:<Action>`` with resource ``*``, except the ``AssumeRole*`` variants, which use the request's ``RoleArn`` as the target resource so policies can scope by role.

### IAM

- All 128 ``SUPPORTED_ACTIONS`` map to ``iam:<Action>``.
- New ``iam_action_resource()`` helper classifies every action by its target shape: ``user/`` / ``role/`` / ``group/`` / ``policy/`` / ``instance-profile/`` / ``mfa/`` / ``server-certificate/`` / ``saml-provider/`` / ``oidc-provider/``, builds the fully-qualified ARN from the request's named parameter (``UserName``, ``RoleName``, ``PolicyArn``, etc.), and sources the account id from ``principal.account_id`` (not global config) so multi-account isolation (#381) becomes a drop-in.
- Account-scoped and listing actions (``ListUsers``, ``ListRoles``, ``GetAccountSummary``, ``CreateAccountAlias``, ...) resolve to ``*``, matching the AWS documentation.

### Why this batch ships IAM + STS together

They live in the same crate, naturally share the ``partition_for_region`` helper, and together form the minimum surface that demonstrates end-to-end enforcement against real signed requests. Batches 7b/8 roll out S3, SQS, SNS, and the rest.

## Test plan

8 new end-to-end tests in ``crates/fakecloud-e2e/tests/iam_enforcement.rs`` that spawn a real fakecloud process with ``FAKECLOUD_IAM=strict`` and drive real signed ``aws-sdk-rust`` requests:

- [x] STS ``GetCallerIdentity`` implicit-denied for a user with no policy
- [x] STS ``GetCallerIdentity`` allowed with an explicit ``Allow`` statement
- [x] STS explicit ``Deny`` beats ``Allow`` ``*:*`` on the same action
- [x] STS root bypass (``test``/``test``) skips enforcement in strict mode
- [x] IAM ``GetUser`` scoped to the caller's own ARN (bob can read himself but not alice, both verified via resource-pattern matching)
- [x] IAM wildcard ``iam:*`` grants access to ``ListUsers`` + ``GetUser``
- [x] IAM soft mode logs denials but still returns success
- [x] IAM off mode (regression guard) accepts everything

This is the **first end-to-end validation** that the full enforcement pipeline works: dispatch resolves the principal via the credential resolver, the evaluator picks up the inline/group policies, and dispatch returns a protocol-correct ``AccessDeniedException`` in strict mode.

Plus:

- [x] ``cargo test -p fakecloud-e2e --test iam --test sigv4_verification`` — 63 tests, no regressions
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo fmt --check`` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optional IAM policy enforcement is now available for `iam` and `sts` behind `FAKECLOUD_IAM=soft|strict`, with full action-to-resource mapping. Default behavior is unchanged when the env var is unset.

- **New Features**
  - `sts`: Adds `iam_enforceable()` and `iam_action_for()` for all 8 actions. `AssumeRole*` uses `RoleArn`; others use `*`.
  - `iam`: Enforcement for all 128 actions via `iam_action_resource()`. Builds ARNs for user/role/group/policy/instance-profile/mfa/server-certificate/saml-provider/oidc-provider. Uses `principal.account_id`; listing/account-scoped actions resolve to `*`.
  - E2E tests in `crates/fakecloud-e2e/tests/iam_enforcement.rs` cover strict/soft/off modes, explicit Deny precedence, root bypass, and resource-scoped `GetUser`.

- **Bug Fixes**
  - `iam`: Correct `CreateServiceLinkedRole` to build `role/aws-service-role/<svc>` from `AWSServiceName`; removed dead `ResyncMFADevice` match arm; noted `GetServiceLinkedRoleDeletionStatus` falls back to `*`.

<sup>Written for commit 1cff0c1e13959e5cf5f0961e02d6bf9df8b796f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

