### PR TITLE
feat(sdk): publish Java SDK to Maven Central on release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,39 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
+  publish-maven:
+    name: Publish Maven Central
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Verify tag matches build.gradle.kts version
+        working-directory: sdks/java
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          VERSION=$(grep -E '^version = ' build.gradle.kts | head -1 | sed -E 's/.*"(.*)".*/\1/')
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "::error::Tag v${TAG} does not match build.gradle.kts version ${VERSION}"
+            exit 1
+          fi
+          echo "Tag v${TAG} matches build.gradle.kts version ${VERSION}"
+
+      - name: Publish to Maven Central
+        working-directory: sdks/java
+        run: ./gradlew publishToMavenCentral --no-daemon --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
+
   publish-go:
     name: Publish Go module
     needs: check

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -1,9 +1,14 @@
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     `java-library`
+    id("com.vanniktech.maven.publish") version "0.30.0"
 }
 
 group = "dev.fakecloud"
-version = "0.1.0"
+version = "0.9.1"
 
 repositories {
     mavenCentral()
@@ -13,8 +18,6 @@ java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))
     }
-    withSourcesJar()
-    withJavadocJar()
 }
 
 dependencies {
@@ -48,4 +51,51 @@ tasks.test {
 
 tasks.javadoc {
     (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
+}
+
+mavenPublishing {
+    configure(JavaLibrary(javadocJar = JavadocJar.Javadoc(), sourcesJar = true))
+
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+    signAllPublications()
+
+    coordinates(group.toString(), "fakecloud", version.toString())
+
+    pom {
+        name.set("fakecloud")
+        description.set(
+            "Java client SDK for fakecloud — a local AWS cloud emulator. Wraps the "
+                + "/_fakecloud/* introspection and simulation endpoints for JUnit, Spring Boot, "
+                + "Micronaut, and Quarkus tests."
+        )
+        url.set("https://github.com/faiscadev/fakecloud")
+        inceptionYear.set("2026")
+
+        licenses {
+            license {
+                name.set("GNU Affero General Public License v3.0")
+                url.set("https://www.gnu.org/licenses/agpl-3.0.txt")
+                distribution.set("repo")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("faiscadev")
+                name.set("Faisca Dev")
+                url.set("https://github.com/faiscadev")
+            }
+        }
+
+        scm {
+            url.set("https://github.com/faiscadev/fakecloud")
+            connection.set("scm:git:git://github.com/faiscadev/fakecloud.git")
+            developerConnection.set("scm:git:ssh://git@github.com/faiscadev/fakecloud.git")
+        }
+
+        issueManagement {
+            system.set("GitHub")
+            url.set("https://github.com/faiscadev/fakecloud/issues")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Wires the Java SDK into the existing release workflow alongside npm, PyPI, crates.io, and the Go module tag. After this PR merges, cutting the next `v*` tag will publish `dev.fakecloud:fakecloud:<version>` to Maven Central automatically.

- Adds the `com.vanniktech.maven.publish` Gradle plugin (0.30.0) — handles the new Sonatype Central Portal bundle-upload flow and in-memory GPG signing from env vars.
- Fills out the POM with every Central-required field (name, description, url, license, developer, scm, issueManagement) — validated locally via `./gradlew publishToMavenLocal` (POM inspected at `build/publications/maven/pom-default.xml`).
- Aligns `sdks/java` version with the other SDKs (`0.9.1`) so the next `v0.9.x` tag ships Java together with the rest.
- New `publish-maven` job in `.github/workflows/release.yml`: sets up JDK 17, verifies the tag matches `build.gradle.kts`, runs `./gradlew publishToMavenCentral`.
- `automaticRelease = true` — the publish task also promotes the staging bundle to live Central on success, no manual click.

## Secrets required (already set on this repo)

- `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` — Sonatype Central Portal user token
- `MAVEN_SIGNING_KEY` — ASCII-armored GPG private key (key id `476BD3C3C89A74A4`, published to `keys.openpgp.org` and `keyserver.ubuntu.com`)
- `MAVEN_SIGNING_PASSWORD` — passphrase for the signing key

The `dev.fakecloud` namespace is verified in Sonatype against a DNS TXT record on `fakecloud.dev`.

## Test plan

- [x] `./gradlew build` still green
- [x] `./gradlew publishToMavenLocal` generates a valid POM with all Central-required metadata (signing step fails locally by design — no credentials on disk)
- [x] CI SDK Java workflow green (unchanged build/test path)
- [ ] Cubic review
- [ ] Cut a tag after merge to validate end-to-end publication

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish the Java SDK to Maven Central on `v*` tags so it ships with the other SDKs. Produces `dev.fakecloud:fakecloud:<version>` and auto‑releases on success.

- **New Features**
  - Add `com.vanniktech.maven.publish` (0.30.0) with Central Portal upload, in‑memory GPG signing, and full POM metadata.
  - New `publish-maven` job in `.github/workflows/release.yml`: sets up JDK 17, verifies tag matches `build.gradle.kts`, runs `./gradlew publishToMavenCentral`, auto‑promotes on success.
  - Set Java SDK version to `0.9.1` to align with other SDKs.

<sup>Written for commit b1e1b9d2ef19fd48bca3370feb75517d5d249b41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

