### PR TITLE
chore: release 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "reqwest",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.9.1"
+version = "0.9.2"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
@@ -78,27 +78,27 @@ regex = "1"
 tokio-postgres = "0.7"
 
 # Internal crates
-fakecloud-core = { path = "crates/fakecloud-core", version = "0.9.1" }
-fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.9.1" }
-fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.9.1" }
-fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.9.1" }
-fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.9.1" }
-fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.9.1" }
-fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.9.1" }
-fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.9.1" }
-fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.9.1" }
-fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.9.1" }
-fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.9.1" }
-fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.9.1" }
-fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.9.1" }
-fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.9.1" }
-fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.9.1" }
-fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.9.1" }
-fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.9.1" }
-fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.9.1" }
-fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.9.1" }
-fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.9.1" }
-fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.9.1" }
-fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.9.1" }
-fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.9.1" }
-fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.9.1" }
+fakecloud-core = { path = "crates/fakecloud-core", version = "0.9.2" }
+fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.9.2" }
+fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.9.2" }
+fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.9.2" }
+fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.9.2" }
+fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.9.2" }
+fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.9.2" }
+fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.9.2" }
+fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.9.2" }
+fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.9.2" }
+fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.9.2" }
+fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.9.2" }
+fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.9.2" }
+fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.9.2" }
+fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.9.2" }
+fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.9.2" }
+fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.9.2" }
+fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.9.2" }
+fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.9.2" }
+fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.9.2" }
+fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.9.2" }
+fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.9.2" }
+fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.9.2" }
+fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.9.2" }

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.9.1"
+version = "0.9.2"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.9.1"
+version = "0.9.2"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakecloud",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump to `0.9.2` across the workspace + all SDKs. Primary purpose: cut a release that publishes the new Java SDK to Maven Central for the first time, alongside the usual npm / PyPI / crates.io / Go tag publish.

- `Cargo.toml` + `Cargo.lock` — all 22 crates bumped
- `sdks/python/pyproject.toml`
- `sdks/typescript/package.json` + `package-lock.json`
- `sdks/java/build.gradle.kts`

After merge, push tag `v0.9.2` and the release workflow will:
1. Publish all crates to crates.io
2. Publish `fakecloud` to npm
3. Publish `fakecloud` to PyPI
4. **Publish `dev.fakecloud:fakecloud:0.9.2` to Maven Central** (new)
5. Create the `sdks/go/v0.9.2` tag for the Go module

## Test plan

- [x] `cargo check --workspace` passes
- [ ] CI green
- [ ] Cubic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps all workspace crates and SDKs to version 0.9.2 and prepares the release. This release introduces first-time Maven Central publishing for the Java SDK.

- **New Features**
  - Java SDK is now published to Maven Central as `dev.fakecloud:fakecloud:0.9.2`.

- **Migration**
  - After merge, push tag `v0.9.2` to trigger publishing to crates.io, npm `fakecloud`, PyPI `fakecloud`, Maven Central `dev.fakecloud:fakecloud:0.9.2`, and the Go module tag `sdks/go/v0.9.2`.

<sup>Written for commit 7b5a8c9664fa5c7cc1dd6e5c75510239b0ad3a94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

