### PR TITLE
fix(dynamodb): propagate billing-mode changes through GSIs

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -425,7 +425,7 @@ fn parse_provisioned_throughput(val: &Value) -> Result<ProvisionedThroughput, Aw
     })
 }
 
-fn parse_gsi(val: &Value) -> Vec<GlobalSecondaryIndex> {
+fn parse_gsi(val: &Value, billing_mode: &str) -> Vec<GlobalSecondaryIndex> {
     let Some(arr) = val.as_array() else {
         return Vec::new();
     };
@@ -435,11 +435,32 @@ fn parse_gsi(val: &Value) -> Vec<GlobalSecondaryIndex> {
                 index_name: g["IndexName"].as_str()?.to_string(),
                 key_schema: parse_key_schema(&g["KeySchema"]).ok()?,
                 projection: parse_projection(&g["Projection"]),
-                provisioned_throughput: parse_provisioned_throughput(&g["ProvisionedThroughput"])
-                    .ok(),
+                provisioned_throughput: Some(parse_gsi_throughput(
+                    &g["ProvisionedThroughput"],
+                    billing_mode,
+                )),
             })
         })
         .collect()
+}
+
+/// Resolve the provisioned-throughput slot for a GSI on a CreateTable or
+/// UpdateTable Create action. Real DynamoDB returns `{0, 0}` for GSIs on
+/// PAY_PER_REQUEST tables regardless of whether the caller sent a
+/// `ProvisionedThroughput` block, and the Terraform provider's `flatten`
+/// code keys `name`/`read_capacity`/`write_capacity` off the presence of
+/// that field — returning `None` would desynchronise state.
+fn parse_gsi_throughput(val: &Value, billing_mode: &str) -> ProvisionedThroughput {
+    if billing_mode == "PAY_PER_REQUEST" {
+        return ProvisionedThroughput {
+            read_capacity_units: 0,
+            write_capacity_units: 0,
+        };
+    }
+    ProvisionedThroughput {
+        read_capacity_units: val["ReadCapacityUnits"].as_i64().unwrap_or(5),
+        write_capacity_units: val["WriteCapacityUnits"].as_i64().unwrap_or(5),
+    }
 }
 
 fn parse_lsi(val: &Value) -> Vec<LocalSecondaryIndex> {

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -19,8 +19,8 @@ use super::parse_projection;
 use super::{
     build_table_description, build_table_description_json, find_table_by_arn,
     find_table_by_arn_mut, get_table, get_table_mut, parse_attribute_definitions, parse_gsi,
-    parse_key_schema, parse_lsi, parse_provisioned_throughput, parse_tags, require_str,
-    DynamoDbService,
+    parse_gsi_throughput, parse_key_schema, parse_lsi, parse_provisioned_throughput, parse_tags,
+    require_str, DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -87,7 +87,7 @@ impl DynamoDbService {
             parse_provisioned_throughput(&body["ProvisionedThroughput"])?
         };
 
-        let gsi = parse_gsi(&body["GlobalSecondaryIndexes"]);
+        let gsi = parse_gsi(&body["GlobalSecondaryIndexes"], &billing_mode);
         let lsi = parse_lsi(&body["LocalSecondaryIndexes"]);
         let tags = parse_tags(&body["Tags"]);
 
@@ -345,8 +345,49 @@ impl DynamoDbService {
             }
         }
 
+        // A billing-mode transition has ripple effects on provisioned
+        // capacity. Real AWS zeros out the table and every GSI's throughput
+        // when the table flips to PAY_PER_REQUEST, and expects the caller to
+        // provide new capacities (via ProvisionedThroughput and per-GSI
+        // Update actions) when flipping back to PROVISIONED — the Terraform
+        // provider's `updateDiffGSI` emits exactly that shape. fakecloud
+        // previously only flipped the scalar billing_mode field, leaving
+        // stale capacity numbers on the GSIs that then surfaced as drift in
+        // the provider's post-apply plan.
         if let Some(bm) = body["BillingMode"].as_str() {
-            table.billing_mode = bm.to_string();
+            let new_mode = bm.to_string();
+            if new_mode == "PAY_PER_REQUEST" && table.billing_mode != "PAY_PER_REQUEST" {
+                table.provisioned_throughput = crate::state::ProvisionedThroughput {
+                    read_capacity_units: 0,
+                    write_capacity_units: 0,
+                };
+                for gsi in table.gsi.iter_mut() {
+                    gsi.provisioned_throughput = Some(crate::state::ProvisionedThroughput {
+                        read_capacity_units: 0,
+                        write_capacity_units: 0,
+                    });
+                }
+            }
+            table.billing_mode = new_mode;
+        }
+
+        // AttributeDefinitions sent alongside a GSI Create must be merged
+        // into the table schema — real AWS accepts new scalar attributes on
+        // UpdateTable when they're referenced by a new index's KeySchema,
+        // and Terraform's `aws_dynamodb_table` relies on that to add a GSI
+        // whose hash/range key wasn't previously defined. Previously
+        // fakecloud dropped these, so a follow-up Read surfaced the old
+        // attribute list and Terraform planned a redundant update.
+        if let Ok(new_attrs) = parse_attribute_definitions(&body["AttributeDefinitions"]) {
+            for attr in new_attrs {
+                if !table
+                    .attribute_definitions
+                    .iter()
+                    .any(|a| a.attribute_name == attr.attribute_name)
+                {
+                    table.attribute_definitions.push(attr);
+                }
+            }
         }
 
         // Handle GlobalSecondaryIndexUpdates: a list of {Create, Update, Delete}
@@ -356,6 +397,7 @@ impl DynamoDbService {
             .get("GlobalSecondaryIndexUpdates")
             .and_then(|v| v.as_array())
         {
+            let current_billing = table.billing_mode.clone();
             for op in updates {
                 if let Some(create) = op.get("Create") {
                     let name = match create.get("IndexName").and_then(|v| v.as_str()) {
@@ -364,8 +406,10 @@ impl DynamoDbService {
                     };
                     let key_schema = parse_key_schema(&create["KeySchema"]).unwrap_or_default();
                     let projection = parse_projection(&create["Projection"]);
-                    let provisioned_throughput =
-                        parse_provisioned_throughput(&create["ProvisionedThroughput"]).ok();
+                    let provisioned_throughput = Some(parse_gsi_throughput(
+                        &create["ProvisionedThroughput"],
+                        &current_billing,
+                    ));
                     table.gsi.retain(|g| g.index_name != name);
                     table.gsi.push(GlobalSecondaryIndex {
                         index_name: name,

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -2767,3 +2767,257 @@ async fn dynamodb_update_table_processes_global_secondary_index_updates() {
     assert_eq!(pt.read_capacity_units(), Some(5));
     assert_eq!(pt.write_capacity_units(), Some(7));
 }
+
+// Regression guard for the "billing-mode transitions with GSI" gap that
+// used to deny four `TestAccDynamoDBTable_BillingMode*` upstream tests.
+// Real DynamoDB returns `{read: 0, write: 0}` for every GSI on a
+// PAY_PER_REQUEST table, and the Terraform provider's flatten code keys
+// `name`/`read_capacity`/`write_capacity` off the presence of that field.
+#[tokio::test]
+async fn dynamodb_create_pay_per_request_with_gsi_zeroes_throughput() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("PprGsi")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("gsipk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .global_secondary_indexes(
+            GlobalSecondaryIndex::builder()
+                .index_name("gsi1")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("gsipk")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::KeysOnly)
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_table()
+        .table_name("PprGsi")
+        .send()
+        .await
+        .unwrap();
+    let table = desc.table().unwrap();
+    let table_pt = table.provisioned_throughput().unwrap();
+    assert_eq!(table_pt.read_capacity_units(), Some(0));
+    assert_eq!(table_pt.write_capacity_units(), Some(0));
+    let gsi = &table.global_secondary_indexes()[0];
+    let pt = gsi.provisioned_throughput().unwrap();
+    assert_eq!(pt.read_capacity_units(), Some(0));
+    assert_eq!(pt.write_capacity_units(), Some(0));
+}
+
+#[tokio::test]
+async fn dynamodb_update_table_provisioned_to_pay_per_request_zeroes_gsi() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("ProvToPpr")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("gsipk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::Provisioned)
+        .provisioned_throughput(
+            ProvisionedThroughput::builder()
+                .read_capacity_units(3)
+                .write_capacity_units(4)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_indexes(
+            GlobalSecondaryIndex::builder()
+                .index_name("gsi1")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("gsipk")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::KeysOnly)
+                        .build(),
+                )
+                .provisioned_throughput(
+                    ProvisionedThroughput::builder()
+                        .read_capacity_units(2)
+                        .write_capacity_units(2)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_table()
+        .table_name("ProvToPpr")
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_table()
+        .table_name("ProvToPpr")
+        .send()
+        .await
+        .unwrap();
+    let table = desc.table().unwrap();
+    assert_eq!(
+        table
+            .billing_mode_summary()
+            .unwrap()
+            .billing_mode()
+            .unwrap(),
+        &BillingMode::PayPerRequest
+    );
+    let table_pt = table.provisioned_throughput().unwrap();
+    assert_eq!(table_pt.read_capacity_units(), Some(0));
+    assert_eq!(table_pt.write_capacity_units(), Some(0));
+    let gsi = &table.global_secondary_indexes()[0];
+    let pt = gsi.provisioned_throughput().unwrap();
+    assert_eq!(pt.read_capacity_units(), Some(0));
+    assert_eq!(pt.write_capacity_units(), Some(0));
+}
+
+#[tokio::test]
+async fn dynamodb_update_table_gsi_create_on_pay_per_request_zeroes_throughput() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("PprAddGsi")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_table()
+        .table_name("PprAddGsi")
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("gsipk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_index_updates(
+            aws_sdk_dynamodb::types::GlobalSecondaryIndexUpdate::builder()
+                .create(
+                    aws_sdk_dynamodb::types::CreateGlobalSecondaryIndexAction::builder()
+                        .index_name("gsi1")
+                        .key_schema(
+                            KeySchemaElement::builder()
+                                .attribute_name("gsipk")
+                                .key_type(KeyType::Hash)
+                                .build()
+                                .unwrap(),
+                        )
+                        .projection(
+                            Projection::builder()
+                                .projection_type(ProjectionType::KeysOnly)
+                                .build(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_table()
+        .table_name("PprAddGsi")
+        .send()
+        .await
+        .unwrap();
+    let table = desc.table().unwrap();
+    let gsi = &table.global_secondary_indexes()[0];
+    let pt = gsi.provisioned_throughput().unwrap();
+    assert_eq!(pt.read_capacity_units(), Some(0));
+    assert_eq!(pt.write_capacity_units(), Some(0));
+    // AttributeDefinitions provided on UpdateTable must be merged into the
+    // table schema, otherwise a follow-up DescribeTable would omit the new
+    // GSI hash key and Terraform would replan the same update.
+    assert!(table
+        .attribute_definitions()
+        .iter()
+        .any(|a| a.attribute_name() == "gsipk"));
+}

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -198,11 +198,6 @@ pub const SERVICES: &[Service] = &[
             // --- gap: on-demand throughput attribute ---
             "TestAccDynamoDBTable_onDemandThroughput",
             "TestAccDynamoDBTable_gsiOnDemandThroughput",
-            // --- gap: billing-mode transitions with GSI ---
-            "TestAccDynamoDBTable_BillingMode_payPerRequestBasic",
-            "TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned",
-            "TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest",
-            "TestAccDynamoDBTable_Disappears_payPerRequestWithGSI",
             // --- gap: encryption attribute round-trip ---
             "TestAccDynamoDBTable_encryption",
             // --- hung: did not complete in triage run; revisit in a later batch ---


### PR DESCRIPTION
## Summary

DynamoDB's UpdateTable zeroes every GSI's ProvisionedThroughput when a table flips to PAY_PER_REQUEST, and CreateTable returns `{0, 0}` for GSIs on PAY_PER_REQUEST tables regardless of whether the caller sent a ProvisionedThroughput block. fakecloud previously left stale capacity numbers on GSIs, defaulted missing throughput to `{5, 5}`, and dropped AttributeDefinitions sent alongside a GSI Create op. The Terraform provider's post-apply refresh plan then reported drift, which blocked four upstream TestAcc tests behind the "billing-mode transitions with GSI" gap.

Fix:
- `parse_gsi` / CreateTable: zero GSI ProvisionedThroughput when billing mode is PAY_PER_REQUEST; keep `{5, 5}` default only for PROVISIONED.
- UpdateTable: on PROVISIONED -> PAY_PER_REQUEST transition, zero the table and every GSI's throughput before applying index updates.
- UpdateTable GSI Create op: pick throughput based on the table's current billing mode, matching real AWS semantics.
- UpdateTable: merge new AttributeDefinitions into the table schema so a follow-up DescribeTable reflects GSI hash/range keys that were added alongside the Create op.

Removes these four entries from the DynamoDB tfacc deny list:
- TestAccDynamoDBTable_BillingMode_payPerRequestBasic
- TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
- TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
- TestAccDynamoDBTable_Disappears_payPerRequestWithGSI

## Test plan

- [x] Three new e2e regression tests in `crates/fakecloud-e2e/tests/dynamodb.rs` cover create + update paths (`dynamodb_create_pay_per_request_with_gsi_zeroes_throughput`, `dynamodb_update_table_provisioned_to_pay_per_request_zeroes_gsi`, `dynamodb_update_table_gsi_create_on_pay_per_request_zeroes_throughput`).
- [x] Full `cargo test -p fakecloud-e2e --test dynamodb` passes (41/41).
- [x] `cargo test -p fakecloud-conformance --test dynamodb` passes (30/30).
- [x] All four previously-denied upstream `TestAccDynamoDBTable_BillingMode*` tests pass locally against fakecloud via `go test ./internal/service/dynamodb/ -run ...`.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB billing-mode transitions so GSIs and table throughput follow AWS semantics, preventing Terraform drift. Unblocks four upstream `TestAccDynamoDBTable_BillingMode*` tests.

- **Bug Fixes**
  - CreateTable: zero GSI throughput on PAY_PER_REQUEST; keep {5,5} default only for PROVISIONED.
  - UpdateTable: on PROVISIONED → PAY_PER_REQUEST, zero table and all GSIs before index updates.
  - GSI Create (UpdateTable): set throughput based on current table billing mode; return {0,0} on PAY_PER_REQUEST.
  - Merge AttributeDefinitions provided with GSI Create into the table schema so DescribeTable shows new keys.
  - Added 3 e2e tests in `fakecloud-e2e` and removed 4 denylist entries in `fakecloud-tfacc`.

<sup>Written for commit 479ce5661538f97ab6bdcc032b0c8abc049793ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

