### PR TITLE
ci(release): exclude fakecloud-parity from release check job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo fmt --check
       - run: cargo clippy --workspace -- -D warnings
-      - run: cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance --exclude fakecloud-tfacc
+      - run: cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance --exclude fakecloud-tfacc --exclude fakecloud-parity
 
   build:
     name: Build ${{ matrix.name }}


### PR DESCRIPTION
## Summary

Pre-existing bug that first bit us on the v0.9.2 release attempt (workflow run 24429422721). The release workflow's `check` job ran:

```
cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance --exclude fakecloud-tfacc
```

while `ci.yml` correctly excludes `fakecloud-parity` as well. `fakecloud-parity` tests added since v0.9.1 require the `fakecloud` binary to be pre-built, so they panic at runtime with `fakecloud binary not found`. Every publish job was skipped because `check` failed.

This is one extra `--exclude` flag to bring `release.yml` in line with `ci.yml`.

Once this merges, the `v0.9.2` tag will be deleted and re-pushed at the new main tip to retrigger the release workflow — no version bump needed.

## Test plan

- [x] Diff matches `ci.yml` line 48 exactly
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `fakecloud-parity` from the release workflow `check` job to match ci.yml and avoid "fakecloud binary not found" failures during cargo test. This keeps release checks green and unblocks publishing.

<sup>Written for commit 7f6b91572b2a7b86e655f6399024ace3ffc61c5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

