### PR TITLE
docs(security): add SigV4 verification + IAM enforcement reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 - **Real infrastructure for stateful services.** Lambda runs in Docker containers (13 runtimes). RDS runs real Postgres/MySQL/MariaDB. ElastiCache runs real Redis/Valkey.
 - **Single binary.** ~19 MB, ~10 MiB idle memory, ~500ms startup. No Docker required to run fakecloud itself (only to exercise the services that need real containers).
 - **First-party test SDKs** for TypeScript, Python, Go, Java, and Rust. Assert on what your code called without writing raw HTTP.
+- **Opt-in SigV4 verification and IAM enforcement.** Off by default so tests just work; turn on `--verify-sigv4` for real cryptographic signature checking and `--iam soft|strict` for Phase 1 identity-policy evaluation (Allow/Deny with Deny precedence, Action/Resource wildcards, user/group/role policies) across IAM, STS, SQS, SNS, and S3. See [the security docs](https://fakecloud.dev/docs/reference/security/).
 
 ## Supported services
 

--- a/website/content/docs/reference/limitations.md
+++ b/website/content/docs/reference/limitations.md
@@ -24,9 +24,16 @@ Lambda function execution, RDS DB instances, and ElastiCache clusters all use re
 
 If you don't need Lambda/RDS/ElastiCache, fakecloud runs fine without Docker at all — just don't mount the socket and those services will return errors only when you try to use them.
 
-## SigV4 signatures are not validated
+## SigV4 signatures and IAM policies are off by default
 
-fakecloud parses SigV4 headers to route requests to the right service but does not validate the signature itself. This is intentional — fakecloud uses dummy credentials and there's nothing to validate against. If your test depends on signature rejection, you'll need to test that against real AWS.
+fakecloud parses SigV4 headers for routing and stores IAM policies without evaluating them. Both can be turned on explicitly:
+
+```bash
+FAKECLOUD_VERIFY_SIGV4=true    # real cryptographic signature verification
+FAKECLOUD_IAM=soft|strict      # Phase 1 identity-policy evaluation
+```
+
+Phase 1 evaluation covers `Allow` / `Deny` with Deny precedence, `Action` / `NotAction` / `Resource` / `NotResource` with wildcards, and identity policies attached via user/group/role. It does **not** cover `Condition` blocks, resource-based policies (bucket policies, topic policies, etc.), permission boundaries, SCPs, session policies, or ABAC tag conditions — those are Phase 2 and explicitly skipped during evaluation. See [SigV4 verification and IAM enforcement](@/docs/reference/security.md) for the full scope, enforced-service list, and the reserved `test`/`test` root-bypass convention.
 
 ## Everything else is in scope
 

--- a/website/content/docs/reference/security.md
+++ b/website/content/docs/reference/security.md
@@ -1,0 +1,136 @@
++++
+title = "SigV4 verification and IAM enforcement"
+description = "Opt-in security features: real SigV4 signature checking and Phase 1 IAM identity-policy evaluation."
+weight = 5
++++
+
+By default, fakecloud parses SigV4 headers for routing but doesn't verify signatures, and stores IAM policies without evaluating them. That's the right default for "tests just work" — real signature verification and policy enforcement get in the way of the happy path.
+
+When you explicitly need them, two orthogonal flags flip them on:
+
+```bash
+FAKECLOUD_VERIFY_SIGV4=true    # or --verify-sigv4
+FAKECLOUD_IAM=off|soft|strict  # or --iam off|soft|strict
+```
+
+They're independent: you can turn on SigV4 verification without touching IAM, or the other way around.
+
+## The reserved root identity
+
+The credential pair `test`/`test` (and any access key starting with `test`) is treated as the de-facto root bypass. It skips both SigV4 verification and IAM enforcement, matching the community convention that LocalStack and other emulators use for local development.
+
+When either opt-in feature is enabled, fakecloud emits a one-time WARN at startup noting this bypass so you don't silently get false-positive "my policies work" results from unsigned test clients.
+
+## `--verify-sigv4`
+
+When on, every incoming request is cryptographically verified:
+
+1. **Canonical request** rebuilt per the AWS SigV4 spec (double-encoded path for non-S3, single-encoded for S3; sorted, URL-encoded query string; lowercased + sorted headers; payload hash from `X-Amz-Content-Sha256` when present, otherwise `sha256(body)`).
+2. **Signing key** derived via the four-step HMAC chain `AWS4 -> date -> region -> service -> aws4_request`.
+3. **Constant-time comparison** against the signature the client sent.
+4. **Clock skew window** of ±15 minutes, matching AWS.
+
+Verification failures return protocol-correct AWS errors before business logic runs:
+
+| Failure | AWS error |
+| --- | --- |
+| Wrong signature | `SignatureDoesNotMatch` |
+| Unknown access key | `InvalidClientTokenId` |
+| Clock skew > 15 min | `RequestTimeTooSkewed` |
+| Malformed auth header | `IncompleteSignature` |
+
+Header-based `Authorization: AWS4-HMAC-SHA256 ...` and query-string (presigned URL) signatures are both supported. STS temporary credentials from `AssumeRole`, `GetSessionToken`, and `GetFederationToken` are persisted per-request and verified against the secret key the client received when it called STS.
+
+## `--iam off|soft|strict`
+
+Three modes, in order of aggressiveness:
+
+- **`off`** (default): policies are stored but never consulted. Zero behavior change from unconfigured fakecloud.
+- **`soft`**: policies are evaluated and each deny is logged on the `fakecloud::iam::audit` tracing target, but the request is allowed through. Useful for onboarding: you can see which statements would fire without breaking your test suite.
+- **`strict`**: policies are evaluated and denied requests fail with a protocol-correct `AccessDeniedException` before the service handler runs.
+
+Filter the audit events with `RUST_LOG=fakecloud::iam::audit=warn`.
+
+### Root is always allowed
+
+The account's IAM root identity (`arn:aws:iam::<account>:root`) and the reserved `test*` bypass AKIDs always pass enforcement, matching AWS's own behavior where root bypasses identity-based policies.
+
+### Enforced services
+
+Opt-in enforcement covers the services most commonly subject to real IAM policies:
+
+| Service | Covered actions | Resource ARN shape |
+| --- | --- | --- |
+| **IAM** | All 128 supported actions | `arn:aws:iam::<account>:{user,role,group,policy,instance-profile,mfa,server-certificate,saml-provider,oidc-provider}/<name>` |
+| **STS** | All 8 supported actions | `*` (or `RoleArn` for `AssumeRole*`) |
+| **SQS** | All 20 supported actions | `arn:aws:sqs:<region>:<account>:<queue-name>` |
+| **SNS** | All 34 supported actions | Topic / subscription / platform-app / endpoint ARNs |
+| **S3** | All 74 supported actions | `arn:aws:s3:::<bucket>[/<key>]` (object actions include the key; bucket actions don't) |
+
+Other services are not enforced even with `FAKECLOUD_IAM=strict`. The startup log enumerates which services are enforced vs. skipped so you always know the current surface. If a service you need is missing, [open an issue](https://github.com/faiscadev/fakecloud/issues) — the wiring is straightforward per-service.
+
+## Phase 1 evaluator scope
+
+The policy evaluator implements the essentials of AWS's identity-based policy evaluation. It deliberately stops short of Phase 2 features so you don't build false mental models from a half-evaluator.
+
+### Implemented
+
+- `Effect: "Allow"` / `Effect: "Deny"` with **Deny precedence** (any matching deny wins).
+- `Action` / `NotAction` with `*` and `?` wildcards. Service prefix match is case-insensitive; action names are case-sensitive (matches AWS).
+- `Resource` / `NotResource` with `*` and `?` wildcards.
+- Identity policies attached to:
+  - IAM users (inline + managed + via group membership, inline and managed)
+  - IAM roles (inline + managed, for assumed-role sessions)
+- Empty effective policy set -> implicit deny.
+
+### Not implemented (Phase 2)
+
+Statements that use any of these features are **skipped during evaluation** (with a `debug!` on the audit target). They're tracked for Phase 2 and will be announced when the evaluator can handle them:
+
+- `Condition` blocks (StringEquals, IpAddress, DateLessThan, etc.)
+- Resource-based policies (S3 bucket policies, SNS topic policies, KMS key policies, Lambda resource policies)
+- Permission boundaries
+- Service control policies (SCPs)
+- Session policies passed to `AssumeRole`
+- ABAC / tag conditions
+- `NotPrincipal`
+
+If you need any of these for your test scenarios, **use real AWS**. fakecloud is a test tool, not an IAM simulator.
+
+## Practical example
+
+Bootstrap a user with root credentials, attach a resource-scoped policy, then hit the service with their own access key:
+
+```bash
+# Start fakecloud with enforcement on.
+FAKECLOUD_VERIFY_SIGV4=true FAKECLOUD_IAM=strict ./fakecloud
+
+# Root-bypass bootstrap.
+AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+  aws --endpoint-url http://localhost:4566 iam create-user --user-name alice
+AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+  aws --endpoint-url http://localhost:4566 iam create-access-key --user-name alice
+# -> emits AKIA..., SECRET...
+
+AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+  aws --endpoint-url http://localhost:4566 iam put-user-policy \
+    --user-name alice \
+    --policy-name ReadSelf \
+    --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"iam:GetUser","Resource":"arn:aws:iam::123456789012:user/alice"}]}'
+
+# Alice can read herself...
+AWS_ACCESS_KEY_ID=<alice-akid> AWS_SECRET_ACCESS_KEY=<alice-secret> \
+  aws --endpoint-url http://localhost:4566 iam get-user --user-name alice
+# -> success
+
+# ...but not anyone else.
+AWS_ACCESS_KEY_ID=<alice-akid> AWS_SECRET_ACCESS_KEY=<alice-secret> \
+  aws --endpoint-url http://localhost:4566 iam get-user --user-name root
+# -> AccessDeniedException
+```
+
+## See also
+
+- [Limitations](@/docs/reference/limitations.md) — what fakecloud doesn't do at all
+- [Configuration](@/docs/reference/configuration.md) — full flag + env var reference
+- [IAM service docs](@/docs/services/iam.md) — per-action coverage

--- a/website/content/docs/services/iam.md
+++ b/website/content/docs/services/iam.md
@@ -25,8 +25,8 @@ Query protocol. Form-encoded body, `Action` parameter, XML responses.
 
 ## Gotchas
 
-- **Policies are stored, not evaluated.** fakecloud records IAM policies but does not enforce them at request time. Every request is treated as authorized. This is intentional — testing IAM policy evaluation belongs against real AWS (or dedicated policy simulators), and cross-cutting authz checks are out of scope for an emulator.
-- **Access keys are dummy.** fakecloud accepts any credentials for any request. Access keys created via IAM are recorded but never checked against SigV4 signatures.
+- **Policies are stored and optionally evaluated.** By default fakecloud records IAM policies without evaluating them. Set `FAKECLOUD_IAM=strict` (or `soft` for log-only) to turn on Phase 1 identity-policy evaluation — Allow/Deny with Deny precedence, Action/Resource wildcards, user/group/role inline and managed policies. `Condition` blocks, resource-based policies, permission boundaries, SCPs, and ABAC are explicitly not evaluated yet. See [SigV4 verification and IAM enforcement](@/docs/reference/security.md) for the full scope.
+- **SigV4 verification is opt-in.** By default fakecloud parses signatures for routing but doesn't verify them. Set `FAKECLOUD_VERIFY_SIGV4=true` to turn on cryptographic verification with the standard ±15-minute clock skew window. The reserved `test`/`test` root-bypass convention always passes, matching LocalStack.
 
 ## Source
 


### PR DESCRIPTION
## Summary

Final batch (9 of 9) for the opt-in SigV4 + IAM enforcement rollout — ships the user-facing documentation. No code changes.

- **New ``/docs/reference/security.md``**: full reference for the two opt-in flags, the reserved ``test``/``test`` root-bypass convention, the SigV4 verification flow, the three IAM modes (``off``/``soft``/``strict``), the Phase 1 evaluator scope (implemented vs explicitly not), the enforced-service list (IAM, STS, SQS, SNS, S3 with ARN shapes), and a practical bootstrap-alice-then-deny example.
- **``limitations.md``**: replaced the "SigV4 signatures are not validated" section with a pointer to the new security page, explicitly listing Phase 1 scope so users don't expect ``Condition`` blocks or resource-based policies.
- **``services/iam.md``**: updated the "Gotchas" section to describe the opt-in evaluation path instead of "policies are stored but not evaluated".
- **``README.md``**: added a "Why fakecloud" bullet calling out opt-in SigV4 verification + IAM enforcement as a differentiator.

## What shipped across the full rollout

| Batch | PR | Contents |
| --- | --- | --- |
| 1 | #388 | Config flags + ``IamMode`` + ``is_root_bypass`` + startup WARN |
| 2 | #389 | STS temp credential secret persistence + ``credential_secret`` lookup |
| 3 | #390 | SigV4 cryptographic verification (canonical request, signing key chain, constant-time compare, ±15min skew, 6 E2E tests) |
| 4 | #391 | Principal resolution + ``PrincipalType`` classifier + ``AwsRequest.principal`` plumbing |
| 5 | #392 | Phase 1 IAM policy evaluator (Allow/Deny precedence, Action/Resource wildcards, 29 unit tests) |
| 6 | #394 | ``ServiceMetadata`` hooks on ``AwsService`` + dispatch enforcement wiring + soft/strict audit logging |
| 7 | #395 | IAM + STS enforcement (128 + 8 actions) + 8 E2E tests proving the full pipeline end-to-end |
| 8 | #399 | SQS + SNS + S3 enforcement (20 + 34 + 74 actions) + 5 more E2E tests |
| **9** | **this PR** | Docs, README, website |

**Enforcement surface**: IAM, STS, SQS, SNS, S3 — matches the same services LocalStack Pro ships for its paid IAM feature.

**Cubic caught 5 real bugs** across the rollout (identified by cubic): multi-byte panic on root-bypass prefix check, ``PrincipalType::Root`` fallback silently bypassing enforcement, pathed IAM user names not resolving, ``CreateServiceLinkedRole`` wrong parameter, S3 ``?attributes``/``?restore`` missing method guards, SNS ``CreateTopic`` account id inconsistency, SNS ``ConfirmSubscription`` wrong ARN field. All fixed on the same PRs they were raised on.

## Test plan

- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean (docs-only PR, no new code)
- [x] Website builds (Zola) — no dead links to the new page
- [x] ``/docs/reference/security`` page renders with all internal links resolving

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new security reference page documenting opt-in SigV4 verification and Phase 1 IAM enforcement, and updates limitations, IAM docs, and README to point to it. No code changes.

- **New Features - New features added**
  - New `docs/reference/security.md` covering `--verify-sigv4`, `--iam off|soft|strict`, reserved `test`/`test` root-bypass, SigV4 verification flow, Phase 1 IAM scope, enforced services (IAM, STS, SQS, SNS, S3), and a quick-start example.
  - `docs/reference/limitations.md`: replaces the old SigV4 note with a link to the new page and the Phase 1 scope.
  - `docs/services/iam.md`: updates “Gotchas” to describe opt-in evaluation and what’s out of scope.
  - `README.md`: adds a “Why fakecloud” bullet highlighting opt-in SigV4 + IAM (`--verify-sigv4`, `--iam`) with a link to the security docs.

<sup>Written for commit 63002b1a353dd325e2fc667eec0a6dc24579ae5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

