### PR TITLE
feat(dynamodb): opt-in disk persistence

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -267,7 +267,7 @@ impl AwsService for DynamoDbService {
                 &req.action,
             )),
         };
-        if mutates && result.is_ok() {
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
             self.save_snapshot();
         }
         result

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -16,13 +16,13 @@ use serde_json::{json, Value};
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
-use fakecloud_persistence::S3Store;
+use fakecloud_persistence::{S3Store, SnapshotStore};
 use fakecloud_s3::state::SharedS3State;
 
 use crate::state::{
-    attribute_type_and_value, AttributeDefinition, AttributeValue, DynamoTable,
+    attribute_type_and_value, AttributeDefinition, AttributeValue, DynamoDbSnapshot, DynamoTable,
     GlobalSecondaryIndex, KeySchemaElement, KinesisDestination, LocalSecondaryIndex, Projection,
-    ProvisionedThroughput, SharedDynamoDbState,
+    ProvisionedThroughput, SharedDynamoDbState, DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
 };
 
 /// Minimal subset of a ``DynamoTable`` that Kinesis streaming delivery needs.
@@ -42,6 +42,7 @@ pub struct DynamoDbService {
     pub(crate) s3_state: Option<SharedS3State>,
     pub(crate) s3_store: Option<Arc<dyn S3Store>>,
     delivery: Option<Arc<DeliveryBus>>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
 }
 
 impl DynamoDbService {
@@ -51,6 +52,7 @@ impl DynamoDbService {
             s3_state: None,
             s3_store: None,
             delivery: None,
+            snapshot_store: None,
         }
     }
 
@@ -67,6 +69,34 @@ impl DynamoDbService {
     pub fn with_delivery(mut self, delivery: Arc<DeliveryBus>) -> Self {
         self.delivery = Some(delivery);
         self
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist the current in-memory state as a snapshot. Called after
+    /// every state-mutating action. A noop when no snapshot store is
+    /// configured (i.e. `StorageMode::Memory`).
+    fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.as_ref() else {
+            return;
+        };
+        let snapshot = DynamoDbSnapshot {
+            schema_version: DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let bytes = match serde_json::to_vec(&snapshot) {
+            Ok(b) => b,
+            Err(err) => {
+                tracing::error!(%err, "failed to serialize dynamodb snapshot");
+                return;
+            }
+        };
+        if let Err(err) = store.save(&bytes) {
+            tracing::error!(%err, "failed to write dynamodb snapshot");
+        }
     }
 
     fn kinesis_target(table: &DynamoTable) -> Option<KinesisDeliveryTarget> {
@@ -163,7 +193,8 @@ impl AwsService for DynamoDbService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateTable" => self.create_table(&req),
             "DeleteTable" => self.delete_table(&req),
             "DescribeTable" => self.describe_table(&req),
@@ -235,7 +266,11 @@ impl AwsService for DynamoDbService {
                 "dynamodb",
                 &req.action,
             )),
+        };
+        if mutates && result.is_ok() {
+            self.save_snapshot();
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {
@@ -300,6 +335,45 @@ impl AwsService for DynamoDbService {
         ]
     }
 }
+/// Actions that mutate DynamoDB state and therefore require a snapshot
+/// write after success. Kept in sync with the dispatch table above.
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "CreateTable"
+            | "DeleteTable"
+            | "UpdateTable"
+            | "PutItem"
+            | "DeleteItem"
+            | "UpdateItem"
+            | "BatchWriteItem"
+            | "TagResource"
+            | "UntagResource"
+            | "TransactWriteItems"
+            | "ExecuteStatement"
+            | "BatchExecuteStatement"
+            | "ExecuteTransaction"
+            | "UpdateTimeToLive"
+            | "PutResourcePolicy"
+            | "DeleteResourcePolicy"
+            | "CreateBackup"
+            | "DeleteBackup"
+            | "RestoreTableFromBackup"
+            | "RestoreTableToPointInTime"
+            | "UpdateContinuousBackups"
+            | "CreateGlobalTable"
+            | "UpdateGlobalTable"
+            | "UpdateGlobalTableSettings"
+            | "UpdateTableReplicaAutoScaling"
+            | "EnableKinesisStreamingDestination"
+            | "DisableKinesisStreamingDestination"
+            | "UpdateKinesisStreamingDestination"
+            | "UpdateContributorInsights"
+            | "ExportTableToPointInTime"
+            | "ImportTable"
+    )
+}
+
 // ── Helper functions ────────────────────────────────────────────────────
 
 fn require_str<'a>(body: &'a Value, field: &str) -> Result<&'a str, AwsServiceError> {

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -1,8 +1,13 @@
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
+
+fn empty_stream_records() -> Arc<RwLock<Vec<StreamRecord>>> {
+    Arc::new(RwLock::new(Vec::new()))
+}
 
 /// A single DynamoDB attribute value (tagged union matching the AWS wire format).
 /// AWS sends attribute values as `{"S": "hello"}`, `{"N": "42"}`, etc.
@@ -19,25 +24,25 @@ pub fn attribute_type_and_value(av: &Value) -> Option<(&str, &Value)> {
     Some((k.as_str(), v))
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeySchemaElement {
     pub attribute_name: String,
     pub key_type: String, // HASH or RANGE
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AttributeDefinition {
     pub attribute_name: String,
     pub attribute_type: String, // S, N, B
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProvisionedThroughput {
     pub read_capacity_units: i64,
     pub write_capacity_units: i64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GlobalSecondaryIndex {
     pub index_name: String,
     pub key_schema: Vec<KeySchemaElement>,
@@ -45,20 +50,20 @@ pub struct GlobalSecondaryIndex {
     pub provisioned_throughput: Option<ProvisionedThroughput>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalSecondaryIndex {
     pub index_name: String,
     pub key_schema: Vec<KeySchemaElement>,
     pub projection: Projection,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Projection {
     pub projection_type: String, // ALL, KEYS_ONLY, INCLUDE
     pub non_key_attributes: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DynamoTable {
     pub name: String,
     pub arn: String,
@@ -90,7 +95,9 @@ pub struct DynamoTable {
     pub stream_enabled: bool,
     pub stream_view_type: Option<String>, // KEYS_ONLY, NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES
     pub stream_arn: Option<String>,
-    /// Stream records (retained for 24 hours)
+    /// Stream records (retained for 24 hours). Not persisted: stream
+    /// records are ephemeral and would be garbage anyway across restarts.
+    #[serde(skip, default = "empty_stream_records")]
     pub stream_records: Arc<RwLock<Vec<StreamRecord>>>,
     /// Server-side encryption type: AES256 (owned) or KMS
     pub sse_type: Option<String>,
@@ -102,7 +109,7 @@ pub struct DynamoTable {
     pub deletion_protection_enabled: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamRecord {
     pub event_id: String,
     pub event_name: String, // INSERT, MODIFY, REMOVE
@@ -114,7 +121,7 @@ pub struct StreamRecord {
     pub timestamp: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DynamoDbStreamRecord {
     pub keys: HashMap<String, AttributeValue>,
     pub new_image: Option<HashMap<String, AttributeValue>>,
@@ -124,14 +131,14 @@ pub struct DynamoDbStreamRecord {
     pub stream_view_type: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KinesisDestination {
     pub stream_arn: String,
     pub destination_status: String,
     pub approximate_creation_date_time_precision: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BackupDescription {
     pub backup_arn: String,
     pub backup_name: String,
@@ -150,7 +157,7 @@ pub struct BackupDescription {
     pub items: Vec<HashMap<String, AttributeValue>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GlobalTableDescription {
     pub global_table_name: String,
     pub global_table_arn: String,
@@ -159,13 +166,13 @@ pub struct GlobalTableDescription {
     pub replication_group: Vec<ReplicaDescription>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReplicaDescription {
     pub region_name: String,
     pub replica_status: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExportDescription {
     pub export_arn: String,
     pub export_status: String,
@@ -180,7 +187,7 @@ pub struct ExportDescription {
     pub billed_size_bytes: i64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImportDescription {
     pub import_arn: String,
     pub import_status: String,
@@ -333,6 +340,7 @@ impl DynamoTable {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DynamoDbState {
     pub account_id: String,
     pub region: String,
@@ -342,6 +350,17 @@ pub struct DynamoDbState {
     pub exports: HashMap<String, ExportDescription>,
     pub imports: HashMap<String, ImportDescription>,
 }
+
+/// On-disk snapshot envelope. The payload is the full [`DynamoDbState`];
+/// `schema_version` lets us evolve the format without accidentally loading
+/// an incompatible dump on upgrade.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DynamoDbSnapshot {
+    pub schema_version: u32,
+    pub state: DynamoDbState,
+}
+
+pub const DYNAMODB_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
 
 impl DynamoDbState {
     pub fn new(account_id: &str, region: &str) -> Self {

--- a/crates/fakecloud-e2e/tests/dynamodb_persistence.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb_persistence.rs
@@ -1,0 +1,418 @@
+mod helpers;
+
+use std::collections::HashMap;
+
+use aws_sdk_dynamodb::primitives::Blob;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, AttributeValue, BillingMode, GlobalSecondaryIndex, KeySchemaElement,
+    KeyType, LocalSecondaryIndex, Projection, ProjectionType, ProvisionedThroughput,
+    ScalarAttributeType, TimeToLiveSpecification,
+};
+use helpers::TestServer;
+
+/// Full round-trip: create tables, populate items across every attribute
+/// type, configure TTL + tags + GSIs + LSIs, restart, and assert everything
+/// survives including item contents.
+#[tokio::test]
+async fn persistence_round_trip_tables_and_items() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.dynamodb_client().await;
+
+    // Table with composite key, LSI, GSI, PROVISIONED billing, TTL, tags.
+    client
+        .create_table()
+        .table_name("users")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("sk")
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("sk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("email")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("created_at")
+                .attribute_type(ScalarAttributeType::N)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_indexes(
+            GlobalSecondaryIndex::builder()
+                .index_name("by_email")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("email")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::All)
+                        .build(),
+                )
+                .provisioned_throughput(
+                    ProvisionedThroughput::builder()
+                        .read_capacity_units(5)
+                        .write_capacity_units(5)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .local_secondary_indexes(
+            LocalSecondaryIndex::builder()
+                .index_name("by_created_at")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("pk")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("created_at")
+                        .key_type(KeyType::Range)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::KeysOnly)
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .provisioned_throughput(
+            ProvisionedThroughput::builder()
+                .read_capacity_units(10)
+                .write_capacity_units(10)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // PAY_PER_REQUEST table, minimal schema, to exercise billing_mode persistence.
+    client
+        .create_table()
+        .table_name("events")
+        .billing_mode(BillingMode::PayPerRequest)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // TTL on users table.
+    client
+        .update_time_to_live()
+        .table_name("users")
+        .time_to_live_specification(
+            TimeToLiveSpecification::builder()
+                .attribute_name("expires_at")
+                .enabled(true)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Tags on users.
+    client
+        .tag_resource()
+        .resource_arn("arn:aws:dynamodb:us-east-1:123456789012:table/users")
+        .tags(
+            aws_sdk_dynamodb::types::Tag::builder()
+                .key("env")
+                .value("prod")
+                .build()
+                .unwrap(),
+        )
+        .tags(
+            aws_sdk_dynamodb::types::Tag::builder()
+                .key("team")
+                .value("platform")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Insert items exercising every AttributeValue variant.
+    let mut item1: HashMap<String, AttributeValue> = HashMap::new();
+    item1.insert("pk".into(), AttributeValue::S("user#1".into()));
+    item1.insert("sk".into(), AttributeValue::S("profile".into()));
+    item1.insert("email".into(), AttributeValue::S("a@example.com".into()));
+    item1.insert("created_at".into(), AttributeValue::N("1700000000".into()));
+    item1.insert("age".into(), AttributeValue::N("30".into()));
+    item1.insert("active".into(), AttributeValue::Bool(true));
+    item1.insert("middle_name".into(), AttributeValue::Null(true));
+    item1.insert(
+        "tags".into(),
+        AttributeValue::Ss(vec!["admin".into(), "beta".into()]),
+    );
+    item1.insert(
+        "scores".into(),
+        AttributeValue::Ns(vec!["1".into(), "2".into(), "3".into()]),
+    );
+    item1.insert(
+        "blobs".into(),
+        AttributeValue::Bs(vec![Blob::new(vec![1u8, 2, 3]), Blob::new(vec![4u8, 5, 6])]),
+    );
+    item1.insert("raw".into(), AttributeValue::B(Blob::new(vec![9u8; 16])));
+    item1.insert(
+        "history".into(),
+        AttributeValue::L(vec![
+            AttributeValue::S("created".into()),
+            AttributeValue::N("1".into()),
+        ]),
+    );
+    let mut nested: HashMap<String, AttributeValue> = HashMap::new();
+    nested.insert("city".into(), AttributeValue::S("SP".into()));
+    nested.insert("zip".into(), AttributeValue::S("01000".into()));
+    item1.insert("address".into(), AttributeValue::M(nested));
+
+    client
+        .put_item()
+        .table_name("users")
+        .set_item(Some(item1.clone()))
+        .send()
+        .await
+        .unwrap();
+
+    // Second simpler item.
+    let mut item2: HashMap<String, AttributeValue> = HashMap::new();
+    item2.insert("pk".into(), AttributeValue::S("user#2".into()));
+    item2.insert("sk".into(), AttributeValue::S("profile".into()));
+    item2.insert("email".into(), AttributeValue::S("b@example.com".into()));
+    item2.insert("created_at".into(), AttributeValue::N("1700000100".into()));
+    client
+        .put_item()
+        .table_name("users")
+        .set_item(Some(item2))
+        .send()
+        .await
+        .unwrap();
+
+    // Item in the PAY_PER_REQUEST table.
+    let mut ev: HashMap<String, AttributeValue> = HashMap::new();
+    ev.insert("id".into(), AttributeValue::S("evt-1".into()));
+    ev.insert("payload".into(), AttributeValue::S("hello".into()));
+    client
+        .put_item()
+        .table_name("events")
+        .set_item(Some(ev))
+        .send()
+        .await
+        .unwrap();
+
+    // Restart the server with the same data path — in-memory state is
+    // rebuilt exclusively from the persisted snapshot on disk.
+    server.restart().await;
+    let client = server.dynamodb_client().await;
+
+    // Tables still listed.
+    let list = client.list_tables().send().await.unwrap();
+    let mut table_names: Vec<String> = list.table_names().to_vec();
+    table_names.sort();
+    assert_eq!(table_names, vec!["events".to_string(), "users".to_string()]);
+
+    // Describe users: provisioned throughput, GSI, LSI, billing mode.
+    let desc = client
+        .describe_table()
+        .table_name("users")
+        .send()
+        .await
+        .unwrap();
+    let t = desc.table().unwrap();
+    assert_eq!(
+        t.provisioned_throughput().unwrap().read_capacity_units(),
+        Some(10)
+    );
+    assert_eq!(t.global_secondary_indexes().len(), 1);
+    assert_eq!(t.local_secondary_indexes().len(), 1);
+    assert_eq!(
+        t.global_secondary_indexes()
+            .first()
+            .unwrap()
+            .index_name()
+            .unwrap(),
+        "by_email"
+    );
+
+    let ev_desc = client
+        .describe_table()
+        .table_name("events")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        ev_desc
+            .table()
+            .unwrap()
+            .billing_mode_summary()
+            .and_then(|b| b.billing_mode()),
+        Some(&BillingMode::PayPerRequest),
+    );
+
+    // TTL config survives.
+    let ttl = client
+        .describe_time_to_live()
+        .table_name("users")
+        .send()
+        .await
+        .unwrap();
+    let ttl_spec = ttl.time_to_live_description().unwrap();
+    assert_eq!(ttl_spec.attribute_name(), Some("expires_at"));
+
+    // Tags survive.
+    let tags = client
+        .list_tags_of_resource()
+        .resource_arn("arn:aws:dynamodb:us-east-1:123456789012:table/users")
+        .send()
+        .await
+        .unwrap();
+    let tag_map: HashMap<String, String> = tags
+        .tags()
+        .iter()
+        .map(|t| (t.key().to_string(), t.value().to_string()))
+        .collect();
+    assert_eq!(tag_map.get("env").map(String::as_str), Some("prod"));
+    assert_eq!(tag_map.get("team").map(String::as_str), Some("platform"));
+
+    // Items survive with every attribute variant intact.
+    let got = client
+        .get_item()
+        .table_name("users")
+        .key("pk", AttributeValue::S("user#1".into()))
+        .key("sk", AttributeValue::S("profile".into()))
+        .send()
+        .await
+        .unwrap();
+    let got_item = got.item().unwrap();
+    assert_eq!(got_item, &item1);
+
+    // Scan returns both users.
+    let scan = client.scan().table_name("users").send().await.unwrap();
+    assert_eq!(scan.count(), 2);
+
+    // PAY_PER_REQUEST item survives.
+    let ev_got = client
+        .get_item()
+        .table_name("events")
+        .key("id", AttributeValue::S("evt-1".into()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        ev_got.item().unwrap().get("payload"),
+        Some(&AttributeValue::S("hello".into())),
+    );
+
+    // Mutations after restart still persist. Delete an item, restart again,
+    // and confirm it stays deleted.
+    client
+        .delete_item()
+        .table_name("users")
+        .key("pk", AttributeValue::S("user#2".into()))
+        .key("sk", AttributeValue::S("profile".into()))
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let client = server.dynamodb_client().await;
+    let scan = client.scan().table_name("users").send().await.unwrap();
+    assert_eq!(scan.count(), 1);
+}
+
+/// Dropping a table + restart: the table is gone, not resurrected by a
+/// stale snapshot.
+#[tokio::test]
+async fn persistence_delete_table_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("ephemeral")
+        .billing_mode(BillingMode::PayPerRequest)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_table()
+        .table_name("ephemeral")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let client = server.dynamodb_client().await;
+    let list = client.list_tables().send().await.unwrap();
+    assert!(list.table_names().is_empty(), "table should not resurrect");
+}

--- a/crates/fakecloud-e2e/tests/dynamodb_persistence.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb_persistence.rs
@@ -338,7 +338,40 @@ async fn persistence_round_trip_tables_and_items() {
         .await
         .unwrap();
     let got_item = got.item().unwrap();
-    assert_eq!(got_item, &item1);
+    // Set-valued attributes (SS/NS/BS) have no guaranteed element order
+    // across serialize/deserialize, so compare them as sorted vecs;
+    // everything else can use direct equality.
+    let sort_ss = |av: &AttributeValue| -> Vec<String> {
+        let mut v = av.as_ss().unwrap().clone();
+        v.sort();
+        v
+    };
+    let sort_ns = |av: &AttributeValue| -> Vec<String> {
+        let mut v = av.as_ns().unwrap().clone();
+        v.sort();
+        v
+    };
+    let sort_bs = |av: &AttributeValue| -> Vec<Vec<u8>> {
+        let mut v: Vec<Vec<u8>> = av
+            .as_bs()
+            .unwrap()
+            .iter()
+            .map(|b| b.as_ref().to_vec())
+            .collect();
+        v.sort();
+        v
+    };
+    assert_eq!(sort_ss(&got_item["tags"]), sort_ss(&item1["tags"]));
+    assert_eq!(sort_ns(&got_item["scores"]), sort_ns(&item1["scores"]));
+    assert_eq!(sort_bs(&got_item["blobs"]), sort_bs(&item1["blobs"]));
+    // Non-set attributes: compare the rest by removing sets from both sides.
+    let mut got_rest = got_item.clone();
+    let mut want_rest = item1.clone();
+    for key in ["tags", "scores", "blobs"] {
+        got_rest.remove(key);
+        want_rest.remove(key);
+    }
+    assert_eq!(got_rest, want_rest);
 
     // Scan returns both users.
     let scan = client.scan().table_name("users").send().await.unwrap();

--- a/crates/fakecloud-persistence/src/lib.rs
+++ b/crates/fakecloud-persistence/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cache;
 pub mod config;
 pub mod key_escape;
 pub mod s3;
+pub mod snapshot;
 pub mod version;
 pub mod warn;
 
@@ -13,4 +14,5 @@ pub use s3::{
     MpuInit, ObjectMeta, S3State as S3StateSnapshot, S3Store, StoreError, StoreResult,
     TagsSnapshot, UploadPartMeta,
 };
+pub use snapshot::{DiskSnapshotStore, MemorySnapshotStore, SnapshotStore};
 pub use warn::warn_unsupported;

--- a/crates/fakecloud-persistence/src/snapshot.rs
+++ b/crates/fakecloud-persistence/src/snapshot.rs
@@ -1,0 +1,102 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Generic opaque-blob snapshot store used by services that persist their
+/// whole state as a single serialized document (DynamoDB tables, SQS queues,
+/// etc.). Unlike the fine-grained [`crate::s3::S3Store`] which tracks
+/// individual objects and streams bodies to disk, this trait is designed for
+/// services whose state is small enough to fit in memory and can be written
+/// as one atomic file.
+pub trait SnapshotStore: Send + Sync {
+    /// Load the latest snapshot, if one exists. Returns `Ok(None)` when
+    /// there is nothing on disk yet (first boot).
+    fn load(&self) -> io::Result<Option<Vec<u8>>>;
+
+    /// Persist the given bytes as the new snapshot. Implementations must
+    /// ensure the write is atomic (crash-safe) and durable.
+    fn save(&self, bytes: &[u8]) -> io::Result<()>;
+}
+
+/// No-op store used in `StorageMode::Memory`. `load` always returns `None`
+/// and `save` is a noop.
+pub struct MemorySnapshotStore;
+
+impl MemorySnapshotStore {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for MemorySnapshotStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SnapshotStore for MemorySnapshotStore {
+    fn load(&self) -> io::Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    fn save(&self, _bytes: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Disk-backed snapshot store. Writes are atomic via the `.tmp` + rename
+/// dance in [`crate::atomic::write_atomic_bytes`], with the parent directory
+/// fsynced on success.
+pub struct DiskSnapshotStore {
+    path: PathBuf,
+}
+
+impl DiskSnapshotStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl SnapshotStore for DiskSnapshotStore {
+    fn load(&self) -> io::Result<Option<Vec<u8>>> {
+        match std::fs::read(&self.path) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn save(&self, bytes: &[u8]) -> io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        crate::atomic::write_atomic_bytes(&self.path, bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_store_is_noop() {
+        let store = MemorySnapshotStore::new();
+        assert!(store.load().unwrap().is_none());
+        store.save(b"anything").unwrap();
+        assert!(store.load().unwrap().is_none());
+    }
+
+    #[test]
+    fn disk_store_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = DiskSnapshotStore::new(tmp.path().join("sub/dir/snapshot.json"));
+        assert!(store.load().unwrap().is_none());
+        store.save(b"hello world").unwrap();
+        assert_eq!(store.load().unwrap().unwrap(), b"hello world");
+        store.save(b"second write").unwrap();
+        assert_eq!(store.load().unwrap().unwrap(), b"second write");
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -385,7 +385,6 @@ async fn main() {
             "iam",
             "sts",
             "ssm",
-            "dynamodb",
             "lambda",
             "secretsmanager",
             "logs",
@@ -531,11 +530,62 @@ async fn main() {
         S3Service::with_store(s3_state.clone(), delivery_for_s3, s3_store.clone())
             .with_kms(kms_state),
     ));
+    let dynamodb_snapshot_store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        match persistence_config.mode {
+            fakecloud_persistence::StorageMode::Persistent => {
+                let data_path = persistence_config
+                    .data_path
+                    .as_ref()
+                    .expect("validated above")
+                    .clone();
+                let path = data_path.join("dynamodb").join("snapshot.json");
+                let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+                match fakecloud_persistence::SnapshotStore::load(&store) {
+                    Ok(Some(bytes)) => {
+                        match serde_json::from_slice::<fakecloud_dynamodb::state::DynamoDbSnapshot>(
+                            &bytes,
+                        ) {
+                            Ok(snapshot) => {
+                                if snapshot.schema_version
+                                    != fakecloud_dynamodb::state::DYNAMODB_SNAPSHOT_SCHEMA_VERSION
+                                {
+                                    fatal_exit(format_args!(
+                                        "dynamodb persistence schema mismatch: on-disk={}, expected={}",
+                                        snapshot.schema_version,
+                                        fakecloud_dynamodb::state::DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
+                                    ));
+                                }
+                                let table_count = snapshot.state.tables.len();
+                                *dynamodb_state_for_register.write() = snapshot.state;
+                                tracing::info!(
+                                    tables = table_count,
+                                    "loaded dynamodb persistence snapshot",
+                                );
+                            }
+                            Err(err) => fatal_exit(format_args!(
+                                "failed to parse dynamodb persistence snapshot: {err}"
+                            )),
+                        }
+                    }
+                    Ok(None) => {
+                        tracing::info!("no dynamodb persistence snapshot found; starting empty");
+                    }
+                    Err(err) => fatal_exit(format_args!(
+                        "failed to read dynamodb persistence snapshot: {err}"
+                    )),
+                }
+                Arc::new(store)
+            }
+            fakecloud_persistence::StorageMode::Memory => {
+                Arc::new(fakecloud_persistence::MemorySnapshotStore::new())
+            }
+        };
     registry.register(Arc::new(
         DynamoDbService::new(dynamodb_state_for_register)
             .with_s3(s3_state.clone())
             .with_s3_store(s3_store.clone())
-            .with_delivery(delivery_for_dynamodb_register),
+            .with_delivery(delivery_for_dynamodb_register)
+            .with_snapshot_store(dynamodb_snapshot_store),
     ));
     // SES delivery bus (event fanout to SNS topics and EventBridge buses)
     let eb_delivery_for_ses = Arc::new(

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -530,63 +530,64 @@ async fn main() {
         S3Service::with_store(s3_state.clone(), delivery_for_s3, s3_store.clone())
             .with_kms(kms_state),
     ));
-    let dynamodb_snapshot_store: Arc<dyn fakecloud_persistence::SnapshotStore> =
-        match persistence_config.mode {
-            fakecloud_persistence::StorageMode::Persistent => {
-                let data_path = persistence_config
-                    .data_path
-                    .as_ref()
-                    .expect("validated above")
-                    .clone();
-                let path = data_path.join("dynamodb").join("snapshot.json");
-                let store = fakecloud_persistence::DiskSnapshotStore::new(path);
-                match fakecloud_persistence::SnapshotStore::load(&store) {
-                    Ok(Some(bytes)) => {
-                        match serde_json::from_slice::<fakecloud_dynamodb::state::DynamoDbSnapshot>(
-                            &bytes,
-                        ) {
-                            Ok(snapshot) => {
-                                if snapshot.schema_version
-                                    != fakecloud_dynamodb::state::DYNAMODB_SNAPSHOT_SCHEMA_VERSION
-                                {
-                                    fatal_exit(format_args!(
-                                        "dynamodb persistence schema mismatch: on-disk={}, expected={}",
-                                        snapshot.schema_version,
-                                        fakecloud_dynamodb::state::DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
-                                    ));
-                                }
-                                let table_count = snapshot.state.tables.len();
-                                *dynamodb_state_for_register.write() = snapshot.state;
-                                tracing::info!(
-                                    tables = table_count,
-                                    "loaded dynamodb persistence snapshot",
-                                );
+    // Snapshot store is only wired in persistent mode. In memory mode we
+    // leave it unset so the service doesn't pay the per-mutation
+    // serialization cost for a store that would just drop the bytes.
+    let dynamodb_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("dynamodb").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_dynamodb::state::DynamoDbSnapshot>(
+                        &bytes,
+                    ) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_dynamodb::state::DYNAMODB_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "dynamodb persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_dynamodb::state::DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
+                                ));
                             }
-                            Err(err) => fatal_exit(format_args!(
-                                "failed to parse dynamodb persistence snapshot: {err}"
-                            )),
+                            let table_count = snapshot.state.tables.len();
+                            *dynamodb_state_for_register.write() = snapshot.state;
+                            tracing::info!(
+                                tables = table_count,
+                                "loaded dynamodb persistence snapshot",
+                            );
                         }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse dynamodb persistence snapshot: {err}"
+                        )),
                     }
-                    Ok(None) => {
-                        tracing::info!("no dynamodb persistence snapshot found; starting empty");
-                    }
-                    Err(err) => fatal_exit(format_args!(
-                        "failed to read dynamodb persistence snapshot: {err}"
-                    )),
                 }
-                Arc::new(store)
+                Ok(None) => {
+                    tracing::info!("no dynamodb persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read dynamodb persistence snapshot: {err}"
+                )),
             }
-            fakecloud_persistence::StorageMode::Memory => {
-                Arc::new(fakecloud_persistence::MemorySnapshotStore::new())
-            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
         };
-    registry.register(Arc::new(
-        DynamoDbService::new(dynamodb_state_for_register)
-            .with_s3(s3_state.clone())
-            .with_s3_store(s3_store.clone())
-            .with_delivery(delivery_for_dynamodb_register)
-            .with_snapshot_store(dynamodb_snapshot_store),
-    ));
+    let mut dynamodb_service = DynamoDbService::new(dynamodb_state_for_register)
+        .with_s3(s3_state.clone())
+        .with_s3_store(s3_store.clone())
+        .with_delivery(delivery_for_dynamodb_register);
+    if let Some(store) = dynamodb_snapshot_store {
+        dynamodb_service = dynamodb_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(dynamodb_service));
     // SES delivery bus (event fanout to SNS topics and EventBridge buses)
     let eb_delivery_for_ses = Arc::new(
         fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(


### PR DESCRIPTION
## Summary

Advances the persistence front started with S3. DynamoDB state (tables, items across every attribute variant, GSI/LSI, TTL, tags, billing mode, backups, global tables, exports/imports) now survives restarts when the server is started with \`--storage-mode=persistent\`.

- New generic \`SnapshotStore\` primitive in \`fakecloud-persistence\` (Memory + Disk impls) for services that persist their whole state as a single atomic file. Builds on the existing \`write_atomic_bytes\` helper.
- Serde derives on every DynamoDB state struct. \`stream_records\` is skipped — ephemeral, 24h retention, would be garbage after restart anyway — and rehydrates empty.
- \`DynamoDbService::save_snapshot\` runs after every successful mutating action via a central \`is_mutating_action\` dispatch guard, so no per-handler plumbing.
- \`schema_version\` envelope so future format changes fail loudly instead of silently corrupting state.
- Wires \`DiskSnapshotStore\` at \`<data-path>/dynamodb/snapshot.json\` in \`main.rs\` and drops \`dynamodb\` from the unsupported-persistence warn list.

## Test plan

- [x] \`cargo test -p fakecloud-e2e --test dynamodb_persistence\` — round-trip + delete durability, both pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\`
- [ ] CI green
- [ ] Cubic satisfied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in disk persistence for DynamoDB. When run with `--storage-mode=persistent`, tables, items, indexes, TTL, tags, backups, global tables, and exports/imports survive restarts.

- **New Features**
  - Introduces `SnapshotStore` in `fakecloud-persistence` with `MemorySnapshotStore` (noop) and `DiskSnapshotStore` (atomic writes).
  - Adds `serde` to all `fakecloud-dynamodb` state structs; skips `stream_records` and rehydrates it empty.
  - `DynamoDbService` saves a full-state snapshot after successful mutating actions (2xx only).
  - Uses a snapshot envelope with `schema_version` to prevent incompatible loads.
  - `fakecloud-server` wires `DiskSnapshotStore` at `<data-path>/dynamodb/snapshot.json` only in persistent mode, loads a snapshot on boot, and removes the DynamoDB persistence warning.

- **Migration**
  - Start the server with `--storage-mode=persistent` and set a data path to enable DynamoDB persistence.
  - Existing snapshots auto-load; schema mismatches fail fast with a clear error.

<sup>Written for commit 0e953c16051d49249c285f8b027fa868924e920a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

