### PR TITLE
feat(iam): populate condition context at dispatch (Phase 2 batch 3)

### DIFF
--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -10,8 +10,12 @@
 //! `/docs/reference/security` (added in a later batch) for the user-facing
 //! contract.
 
+use std::collections::BTreeMap;
 use std::fmt;
+use std::net::IpAddr;
 use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
 
 /// Kind of principal a set of credentials resolves to.
 ///
@@ -183,14 +187,104 @@ impl IamDecision {
     }
 }
 
-/// Abstraction over "given a principal and an action, say Allow / Deny".
-/// Implemented by `fakecloud-iam` against `IamState` + the Phase 1
-/// evaluator. Dispatch calls this for every request when
-/// `FAKECLOUD_IAM != off` and the target service opts into enforcement.
+/// Request-time values consulted when a policy statement carries a
+/// `Condition` block. Populated at dispatch time from the resolved
+/// [`Principal`] and the incoming HTTP request, then handed to
+/// [`IamPolicyEvaluator::evaluate`].
+///
+/// Lives in `fakecloud-core` (not `fakecloud-iam`) so the trait can
+/// reference it without creating a circular crate dependency. All
+/// fields are optional — a missing field means the key wasn't knowable
+/// at dispatch time, and any operator that references it safe-fails to
+/// `false` (unless the operator carries the `IfExists` suffix, in which
+/// case it evaluates to `true`, matching AWS).
+///
+/// The `service_keys` map is reserved for service-specific condition
+/// keys (`s3:prefix`, `sqs:MessageAttribute`, …) which Phase 2 ships
+/// empty; service-specific support lands in a follow-up batch without
+/// a signature change.
+#[derive(Debug, Clone, Default)]
+pub struct ConditionContext {
+    /// `aws:username` — username segment of an IAM user ARN, or `None`
+    /// for assumed roles / federated users where AWS does not set the key.
+    pub aws_username: Option<String>,
+    /// `aws:userid` — the unique `AIDA...`/`AROA...` identifier.
+    pub aws_userid: Option<String>,
+    /// `aws:PrincipalArn` — full principal ARN.
+    pub aws_principal_arn: Option<String>,
+    /// `aws:PrincipalAccount` — 12-digit account ID sourced from the
+    /// credential, not global config (#381 multi-account alignment).
+    pub aws_principal_account: Option<String>,
+    /// `aws:PrincipalType` — `"User"`, `"AssumedRole"`, etc.
+    pub aws_principal_type: Option<String>,
+    /// `aws:SourceIp` — remote address of the HTTP connection.
+    pub aws_source_ip: Option<IpAddr>,
+    /// `aws:CurrentTime` — evaluation timestamp (UTC).
+    pub aws_current_time: Option<DateTime<Utc>>,
+    /// `aws:EpochTime` — same moment as `aws_current_time` in seconds
+    /// since the Unix epoch.
+    pub aws_epoch_time: Option<i64>,
+    /// `aws:SecureTransport` — `true` iff the request came in over TLS.
+    pub aws_secure_transport: Option<bool>,
+    /// `aws:RequestedRegion` — region extracted from SigV4 / config.
+    pub aws_requested_region: Option<String>,
+    /// Service-specific keys (`s3:prefix`, `sqs:MessageAttribute`, …).
+    /// Reserved; empty in the initial Phase 2 rollout.
+    pub service_keys: BTreeMap<String, Vec<String>>,
+}
+
+impl ConditionContext {
+    /// Resolve a condition key (e.g. `"aws:username"`) to the list of
+    /// context values. Returns `None` if the key is not populated.
+    /// Key names are matched case-insensitively — AWS treats
+    /// `aws:username` and `AWS:UserName` as the same key.
+    pub fn lookup(&self, key: &str) -> Option<Vec<String>> {
+        let lower = key.to_ascii_lowercase();
+        let one = |s: &str| Some(vec![s.to_string()]);
+        match lower.as_str() {
+            "aws:username" => self.aws_username.as_deref().and_then(one),
+            "aws:userid" => self.aws_userid.as_deref().and_then(one),
+            "aws:principalarn" => self.aws_principal_arn.as_deref().and_then(one),
+            "aws:principalaccount" => self.aws_principal_account.as_deref().and_then(one),
+            "aws:principaltype" => self.aws_principal_type.as_deref().and_then(one),
+            "aws:sourceip" => self.aws_source_ip.map(|ip| vec![ip.to_string()]),
+            "aws:currenttime" => self
+                .aws_current_time
+                .map(|t| vec![t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)]),
+            "aws:epochtime" => self.aws_epoch_time.map(|e| vec![e.to_string()]),
+            "aws:securetransport" => self.aws_secure_transport.map(|b| vec![b.to_string()]),
+            "aws:requestedregion" => self.aws_requested_region.as_deref().and_then(one),
+            _ => {
+                if let Some(vs) = self.service_keys.get(&lower) {
+                    if vs.is_empty() {
+                        None
+                    } else {
+                        Some(vs.clone())
+                    }
+                } else {
+                    self.service_keys
+                        .iter()
+                        .find(|(k, _)| k.eq_ignore_ascii_case(key))
+                        .map(|(_, vs)| vs.clone())
+                }
+            }
+        }
+    }
+}
+
+/// Abstraction over "given a principal, an action, and request-time
+/// condition keys, say Allow / Deny". Implemented by `fakecloud-iam`
+/// against `IamState` + the evaluator. Dispatch calls this for every
+/// request when `FAKECLOUD_IAM != off` and the target service opts in.
 pub trait IamPolicyEvaluator: Send + Sync {
     /// Evaluate `action` against the identity policies attached to
-    /// `principal`.
-    fn evaluate(&self, principal: &Principal, action: &IamAction) -> IamDecision;
+    /// `principal`, using `context` for `Condition` block resolution.
+    fn evaluate(
+        &self,
+        principal: &Principal,
+        action: &IamAction,
+        context: &ConditionContext,
+    ) -> IamDecision;
 }
 
 /// How IAM identity policies are evaluated for incoming requests.

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -1,22 +1,28 @@
 use axum::body::Body;
-use axum::extract::{Extension, Query};
+use axum::extract::{ConnectInfo, Extension, Query};
 use axum::http::{Request, StatusCode};
 use axum::response::Response;
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
-use crate::auth::{is_root_bypass, CredentialResolver, IamMode, IamPolicyEvaluator};
+use crate::auth::{
+    is_root_bypass, ConditionContext, CredentialResolver, IamMode, IamPolicyEvaluator, Principal,
+    PrincipalType,
+};
 use crate::protocol::{self, AwsProtocol};
 use crate::registry::ServiceRegistry;
 use crate::service::{AwsRequest, ResponseBody};
 
 /// The main dispatch handler. All HTTP requests come through here.
 pub async fn dispatch(
+    ConnectInfo(remote_addr): ConnectInfo<SocketAddr>,
     Extension(registry): Extension<Arc<ServiceRegistry>>,
     Extension(config): Extension<Arc<DispatchConfig>>,
     Query(query_params): Query<HashMap<String, String>>,
     request: Request<Body>,
 ) -> Response<Body> {
+    let remote_addr = Some(remote_addr);
     let request_id = uuid::Uuid::new_v4().to_string();
 
     let (parts, body) = request.into_parts();
@@ -287,7 +293,14 @@ pub async fn dispatch(
             if let Some(principal) = aws_request.principal.as_ref() {
                 if !principal.is_root() {
                     if let Some(iam_action) = service.iam_action_for(&aws_request) {
-                        let decision = evaluator.evaluate(principal, &iam_action);
+                        let condition_context = build_condition_context(
+                            principal,
+                            remote_addr,
+                            &aws_request.region,
+                            is_secure_transport(&aws_request.headers),
+                        );
+                        let decision =
+                            evaluator.evaluate(principal, &iam_action, &condition_context);
                         if !decision.is_allow() {
                             tracing::warn!(
                                 target: "fakecloud::iam::audit",
@@ -515,6 +528,69 @@ fn build_error_response_with_fields(
         .unwrap()
 }
 
+/// Build the [`ConditionContext`] passed to the IAM evaluator for one
+/// request. Populates the 10 global condition keys from the resolved
+/// principal + the HTTP request. Service-specific keys are deferred to
+/// a follow-up batch and left empty.
+fn build_condition_context(
+    principal: &Principal,
+    remote_addr: Option<SocketAddr>,
+    region: &str,
+    secure_transport: bool,
+) -> ConditionContext {
+    let now = chrono::Utc::now();
+    ConditionContext {
+        aws_username: aws_username_from_principal(principal),
+        aws_userid: Some(principal.user_id.clone()),
+        aws_principal_arn: Some(principal.arn.clone()),
+        aws_principal_account: Some(principal.account_id.clone()),
+        aws_principal_type: Some(principal_type_label(principal.principal_type).to_string()),
+        aws_source_ip: remote_addr.map(|sa| sa.ip()),
+        aws_current_time: Some(now),
+        aws_epoch_time: Some(now.timestamp()),
+        aws_secure_transport: Some(secure_transport),
+        aws_requested_region: Some(region.to_string()),
+        service_keys: Default::default(),
+    }
+}
+
+/// `aws:username` is only set for IAM users, matching AWS. For assumed
+/// roles, federated users, root, and unknown principals the key is
+/// absent — operators that reference it without `IfExists` safe-fail.
+fn aws_username_from_principal(principal: &Principal) -> Option<String> {
+    if principal.principal_type != PrincipalType::User {
+        return None;
+    }
+    let after = principal.arn.rsplit_once(":user/").map(|(_, s)| s)?;
+    // Strip any IAM path prefix; bare username is the last segment.
+    Some(after.rsplit('/').next().unwrap_or(after).to_string())
+}
+
+/// AWS's `aws:PrincipalType` uses PascalCase identifiers, distinct from
+/// the lowercase ones [`PrincipalType::as_str`] returns for ARNs.
+fn principal_type_label(t: PrincipalType) -> &'static str {
+    match t {
+        PrincipalType::User => "User",
+        PrincipalType::AssumedRole => "AssumedRole",
+        PrincipalType::FederatedUser => "FederatedUser",
+        PrincipalType::Root => "Account",
+        PrincipalType::Unknown => "Unknown",
+    }
+}
+
+/// Best-effort detection of TLS-terminated requests. Direct HTTPS
+/// connections are not yet supported by the fakecloud server (it speaks
+/// plain HTTP), so the only signal is an `x-forwarded-proto: https`
+/// header set by an upstream proxy. Anything else evaluates to `false`,
+/// which matches the typical local-dev setup.
+fn is_secure_transport(headers: &http::HeaderMap) -> bool {
+    headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.eq_ignore_ascii_case("https"))
+        .unwrap_or(false)
+}
+
 trait ProtocolExt {
     fn error_status(&self) -> StatusCode;
 }
@@ -536,6 +612,80 @@ mod tests {
         assert_eq!(cfg.account_id, "123456789012");
         assert!(!cfg.verify_sigv4);
         assert_eq!(cfg.iam_mode, IamMode::Off);
+    }
+
+    #[test]
+    fn aws_username_strips_iam_path_for_users() {
+        let p = Principal {
+            arn: "arn:aws:iam::123456789012:user/engineering/alice".into(),
+            user_id: "AIDAALICE".into(),
+            account_id: "123456789012".into(),
+            principal_type: PrincipalType::User,
+            source_identity: None,
+        };
+        assert_eq!(aws_username_from_principal(&p), Some("alice".into()));
+    }
+
+    #[test]
+    fn aws_username_unset_for_assumed_role() {
+        let p = Principal {
+            arn: "arn:aws:sts::123456789012:assumed-role/ops/session".into(),
+            user_id: "AROAOPS:session".into(),
+            account_id: "123456789012".into(),
+            principal_type: PrincipalType::AssumedRole,
+            source_identity: None,
+        };
+        assert_eq!(aws_username_from_principal(&p), None);
+    }
+
+    #[test]
+    fn principal_type_label_matches_aws_casing() {
+        assert_eq!(principal_type_label(PrincipalType::User), "User");
+        assert_eq!(
+            principal_type_label(PrincipalType::AssumedRole),
+            "AssumedRole"
+        );
+        assert_eq!(principal_type_label(PrincipalType::Root), "Account");
+    }
+
+    #[test]
+    fn build_condition_context_populates_global_keys() {
+        let p = Principal {
+            arn: "arn:aws:iam::123456789012:user/alice".into(),
+            user_id: "AIDAALICE".into(),
+            account_id: "123456789012".into(),
+            principal_type: PrincipalType::User,
+            source_identity: None,
+        };
+        let addr: SocketAddr = "10.0.0.1:54321".parse().unwrap();
+        let ctx = build_condition_context(&p, Some(addr), "us-east-1", false);
+        assert_eq!(ctx.aws_username.as_deref(), Some("alice"));
+        assert_eq!(ctx.aws_userid.as_deref(), Some("AIDAALICE"));
+        assert_eq!(
+            ctx.aws_principal_arn.as_deref(),
+            Some("arn:aws:iam::123456789012:user/alice")
+        );
+        assert_eq!(ctx.aws_principal_account.as_deref(), Some("123456789012"));
+        assert_eq!(ctx.aws_principal_type.as_deref(), Some("User"));
+        assert_eq!(
+            ctx.aws_source_ip.map(|i| i.to_string()).as_deref(),
+            Some("10.0.0.1")
+        );
+        assert_eq!(ctx.aws_requested_region.as_deref(), Some("us-east-1"));
+        assert_eq!(ctx.aws_secure_transport, Some(false));
+        assert!(ctx.aws_current_time.is_some());
+        assert!(ctx.aws_epoch_time.is_some());
+    }
+
+    #[test]
+    fn is_secure_transport_reads_x_forwarded_proto() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-forwarded-proto", "https".parse().unwrap());
+        assert!(is_secure_transport(&headers));
+        headers.insert("x-forwarded-proto", "http".parse().unwrap());
+        assert!(!is_secure_transport(&headers));
+        let empty = http::HeaderMap::new();
+        assert!(!is_secure_transport(&empty));
     }
 
     #[test]

--- a/crates/fakecloud-iam/src/condition.rs
+++ b/crates/fakecloud-iam/src/condition.rs
@@ -53,95 +53,16 @@
 //! grant access we can't actually verify, which would defeat the whole
 //! opt-in enforcement story.
 
-use std::collections::BTreeMap;
 use std::net::IpAddr;
 
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 
-/// Request-time values that [`evaluate_condition_block`] compares against
-/// a statement's `Condition` block.
-///
-/// Fields are populated at dispatch time from the resolved [`Principal`]
-/// plus the incoming HTTP request. All fields are optional: a missing
-/// field means the key was not knowable at dispatch time, and any
-/// operator that references it will safe-fail to `false` (unless the
-/// operator carries the `IfExists` suffix, in which case a missing key
-/// evaluates to `true`, matching AWS).
-///
-/// [`Principal`]: fakecloud_core::auth::Principal
-#[derive(Debug, Clone, Default)]
-pub struct ConditionContext {
-    /// `aws:username` — username segment of an IAM user ARN, or `None`
-    /// for assumed roles / federated users where AWS does not set the key.
-    pub aws_username: Option<String>,
-    /// `aws:userid` — the unique `AIDA...`/`AROA...` identifier.
-    pub aws_userid: Option<String>,
-    /// `aws:PrincipalArn` — full principal ARN.
-    pub aws_principal_arn: Option<String>,
-    /// `aws:PrincipalAccount` — 12-digit account ID sourced from the
-    /// credential, not global config (keeps #381 multi-account alignment).
-    pub aws_principal_account: Option<String>,
-    /// `aws:PrincipalType` — `"User"`, `"AssumedRole"`, etc.
-    pub aws_principal_type: Option<String>,
-    /// `aws:SourceIp` — remote address of the HTTP connection.
-    pub aws_source_ip: Option<IpAddr>,
-    /// `aws:CurrentTime` — evaluation timestamp (UTC).
-    pub aws_current_time: Option<DateTime<Utc>>,
-    /// `aws:EpochTime` — same moment as `aws_current_time` in seconds
-    /// since the Unix epoch; populated alongside it for `Numeric*` ops.
-    pub aws_epoch_time: Option<i64>,
-    /// `aws:SecureTransport` — `true` iff the request came in over TLS.
-    pub aws_secure_transport: Option<bool>,
-    /// `aws:RequestedRegion` — region extracted from SigV4 / config.
-    pub aws_requested_region: Option<String>,
-    /// Service-specific keys (`s3:prefix`, `sqs:MessageAttribute`, …).
-    /// Empty in the initial Phase 2 rollout; reserved so service-specific
-    /// key support can land without a signature change.
-    pub service_keys: BTreeMap<String, Vec<String>>,
-}
-
-impl ConditionContext {
-    /// Resolve a condition key (e.g. `"aws:username"`) to the list of
-    /// context values. Returns `None` if the key is not populated.
-    ///
-    /// Key names are matched case-insensitively — AWS treats
-    /// `aws:username` and `AWS:UserName` as the same key.
-    pub fn lookup(&self, key: &str) -> Option<Vec<String>> {
-        let lower = key.to_ascii_lowercase();
-        let one = |s: &str| Some(vec![s.to_string()]);
-        match lower.as_str() {
-            "aws:username" => self.aws_username.as_deref().and_then(one),
-            "aws:userid" => self.aws_userid.as_deref().and_then(one),
-            "aws:principalarn" => self.aws_principal_arn.as_deref().and_then(one),
-            "aws:principalaccount" => self.aws_principal_account.as_deref().and_then(one),
-            "aws:principaltype" => self.aws_principal_type.as_deref().and_then(one),
-            "aws:sourceip" => self.aws_source_ip.map(|ip| vec![ip.to_string()]),
-            "aws:currenttime" => self
-                .aws_current_time
-                .map(|t| vec![t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)]),
-            "aws:epochtime" => self.aws_epoch_time.map(|e| vec![e.to_string()]),
-            "aws:securetransport" => self.aws_secure_transport.map(|b| vec![b.to_string()]),
-            "aws:requestedregion" => self.aws_requested_region.as_deref().and_then(one),
-            _ => {
-                if let Some(vs) = self.service_keys.get(&lower) {
-                    if vs.is_empty() {
-                        None
-                    } else {
-                        Some(vs.clone())
-                    }
-                } else {
-                    // Try case-insensitive scan of service_keys — policies
-                    // in the wild mix casing on service-specific keys too.
-                    self.service_keys
-                        .iter()
-                        .find(|(k, _)| k.eq_ignore_ascii_case(key))
-                        .map(|(_, vs)| vs.clone())
-                }
-            }
-        }
-    }
-}
+/// Re-export of the data type defined in `fakecloud-core::auth` — see
+/// [`fakecloud_core::auth::ConditionContext`] for field documentation.
+/// The condition operator framework in this module is implemented
+/// against this type.
+pub use fakecloud_core::auth::ConditionContext;
 
 /// Base condition operator name (without `IfExists` suffix or
 /// `ForAllValues:` / `ForAnyValue:` qualifier).

--- a/crates/fakecloud-iam/src/policy_evaluator.rs
+++ b/crates/fakecloud-iam/src/policy_evaluator.rs
@@ -7,9 +7,11 @@
 
 use std::sync::Arc;
 
-use fakecloud_core::auth::{IamAction, IamDecision, IamPolicyEvaluator, Principal};
+use fakecloud_core::auth::{
+    ConditionContext, IamAction, IamDecision, IamPolicyEvaluator, Principal,
+};
 
-use crate::evaluator::{self, Decision, EvalRequest, RequestContext};
+use crate::evaluator::{self, Decision, EvalRequest};
 use crate::state::SharedIamState;
 
 /// [`IamPolicyEvaluator`] backed by shared [`crate::state::IamState`].
@@ -29,14 +31,19 @@ impl IamPolicyEvaluatorImpl {
 }
 
 impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
-    fn evaluate(&self, principal: &Principal, action: &IamAction) -> IamDecision {
+    fn evaluate(
+        &self,
+        principal: &Principal,
+        action: &IamAction,
+        context: &ConditionContext,
+    ) -> IamDecision {
         let state = self.state.read();
         let policies = evaluator::collect_identity_policies(&state, principal);
         let request = EvalRequest {
             principal,
             action: action.action_string(),
             resource: action.resource.clone(),
-            context: RequestContext::default(),
+            context: context.clone(),
         };
         match evaluator::evaluate(&policies, &request) {
             Decision::Allow => IamDecision::Allow,
@@ -108,7 +115,10 @@ mod tests {
             action: "GetObject",
             resource: "arn:aws:s3:::bucket/key".into(),
         };
-        assert_eq!(eval.evaluate(&principal(), &action), IamDecision::Allow);
+        assert_eq!(
+            eval.evaluate(&principal(), &action, &ConditionContext::default()),
+            IamDecision::Allow
+        );
     }
 
     #[test]
@@ -135,7 +145,7 @@ mod tests {
             resource: "arn:aws:s3:::bucket/key".into(),
         };
         assert_eq!(
-            eval.evaluate(&principal(), &action),
+            eval.evaluate(&principal(), &action, &ConditionContext::default()),
             IamDecision::ExplicitDeny
         );
     }
@@ -150,7 +160,7 @@ mod tests {
             resource: "arn:aws:s3:::bucket/key".into(),
         };
         assert_eq!(
-            eval.evaluate(&principal(), &action),
+            eval.evaluate(&principal(), &action, &ConditionContext::default()),
             IamDecision::ImplicitDeny
         );
     }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1846,10 +1846,13 @@ async fn main() {
     let listener = TcpListener::bind(&cli.addr).await.unwrap();
     tracing::info!(addr = %cli.addr, "fakecloud is ready");
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await
-        .unwrap();
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await
+    .unwrap();
 
     // Clean up Lambda containers on shutdown
     if let Some(rt) = container_runtime {


### PR DESCRIPTION
## Summary

Batch 3 of Phase 2 IAM enforcement. Wires the per-request global condition keys through dispatch into the evaluator. With this batch, opt-in IAM enforcement (\`FAKECLOUD_IAM=soft|strict\`) finally evaluates \`Condition\` blocks against real request data instead of a default-empty context.

- Moves \`ConditionContext\` from \`fakecloud-iam::condition\` to \`fakecloud-core::auth\` so the \`IamPolicyEvaluator\` trait can reference it without a circular crate dep; the iam side re-exports it.
- \`IamPolicyEvaluator::evaluate\` gains a \`&ConditionContext\` parameter; the adapter forwards it into \`EvalRequest.context\`.
- \`dispatch.rs\` builds the context per request via a new \`build_condition_context\` helper populating all 10 global keys:
  - \`aws:username\` parsed from \`principal.arn\` (only for IAM users — assumed-roles intentionally have none, matching AWS)
  - \`aws:userid\`, \`aws:PrincipalArn\`, \`aws:PrincipalAccount\` from \`Principal\`
  - \`aws:PrincipalType\` in PascalCase (\`User\`/\`AssumedRole\`/...)
  - \`aws:SourceIp\` from a new \`ConnectInfo<SocketAddr>\` extractor
  - \`aws:CurrentTime\` + \`aws:EpochTime\` from \`chrono::Utc::now()\`
  - \`aws:SecureTransport\` from \`x-forwarded-proto: https\` (fakecloud is HTTP-only otherwise)
  - \`aws:RequestedRegion\` from the resolved request region
- Server bootstrap switches to \`axum::serve(..., into_make_service_with_connect_info::<SocketAddr>())\` so the dispatch handler's \`ConnectInfo\` extractor resolves.
- \`service_keys\` map left empty — service-specific keys land in a follow-up batch without a signature change.
- New unit tests in \`dispatch.rs\` cover username extraction (with IAM path), assumed-role missing username, PrincipalType label mapping, full ConditionContext population, and x-forwarded-proto parsing.

Zero behavior change when \`FAKECLOUD_IAM=off\`: the evaluator isn't called and the context isn't built.

Part of the Phase 2 rollout (batches 1-5):
1. #403 — framework (merged)
2. #406 — evaluator integration (merged)
3. **This PR** — dispatch plumbing
4. e2e tests against \`FAKECLOUD_IAM=strict\`
5. Docs

## Test plan

- [x] \`cargo test -p fakecloud-iam -p fakecloud-core\` — all green (existing + 5 new helper tests)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all\`
- [ ] CI green (full e2e suite verifies \`FAKECLOUD_IAM=off\` is unchanged)
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate per-request IAM condition context at dispatch so `Condition` blocks are evaluated against real request data when `FAKECLOUD_IAM=soft|strict`. No change when `FAKECLOUD_IAM=off`.

- **New Features**
  - Build a `ConditionContext` for each request in `fakecloud-core::auth`, populating global keys: `aws:username`, `aws:userid`, `aws:PrincipalArn`, `aws:PrincipalAccount`, `aws:PrincipalType`, `aws:SourceIp`, `aws:CurrentTime`, `aws:EpochTime`, `aws:SecureTransport`, `aws:RequestedRegion` (service-specific keys deferred).
  - `fakecloud-server` switches to `axum::Router::into_make_service_with_connect_info::<SocketAddr>()` so `aws:SourceIp` is available.

- **Refactors**
  - Move `ConditionContext` from `fakecloud-iam::condition` to `fakecloud-core::auth` (re-exported by `fakecloud-iam`).
  - Update `IamPolicyEvaluator::evaluate` to accept `&ConditionContext`; the IAM adapter forwards it into the evaluator.

<sup>Written for commit 82195d3d5f00f728abf94464ba74e33b66573bb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

