### PR TITLE
feat(sqs): opt-in disk persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,6 +2512,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "md-5 0.10.6",
  "parking_lot",

--- a/crates/fakecloud-e2e/tests/sqs_persistence.rs
+++ b/crates/fakecloud-e2e/tests/sqs_persistence.rs
@@ -1,0 +1,297 @@
+mod helpers;
+
+use std::collections::HashMap;
+
+use aws_sdk_sqs::types::{MessageAttributeValue, QueueAttributeName};
+use helpers::TestServer;
+
+/// Round-trip standard queue: messages + attributes + tags + redrive
+/// policy all survive a restart, and the queue keeps accepting writes
+/// afterwards.
+#[tokio::test]
+async fn persistence_round_trip_standard_queue() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.sqs_client().await;
+
+    // DLQ first so we can reference it from the primary queue redrive policy.
+    let dlq_url = client
+        .create_queue()
+        .queue_name("dead-letters")
+        .send()
+        .await
+        .unwrap()
+        .queue_url
+        .unwrap();
+    let dlq_arn = client
+        .get_queue_attributes()
+        .queue_url(&dlq_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .clone();
+
+    let redrive = format!(
+        "{{\"deadLetterTargetArn\":\"{}\",\"maxReceiveCount\":\"3\"}}",
+        dlq_arn
+    );
+
+    let q_url = client
+        .create_queue()
+        .queue_name("work-q")
+        .attributes(QueueAttributeName::VisibilityTimeout, "60")
+        .attributes(QueueAttributeName::MessageRetentionPeriod, "3600")
+        .attributes(QueueAttributeName::RedrivePolicy, redrive.clone())
+        .send()
+        .await
+        .unwrap()
+        .queue_url
+        .unwrap();
+
+    client
+        .tag_queue()
+        .queue_url(&q_url)
+        .tags("env", "prod")
+        .tags("team", "platform")
+        .send()
+        .await
+        .unwrap();
+
+    // Three messages with distinct bodies + one with message attributes.
+    client
+        .send_message()
+        .queue_url(&q_url)
+        .message_body("first")
+        .send()
+        .await
+        .unwrap();
+    client
+        .send_message()
+        .queue_url(&q_url)
+        .message_body("second")
+        .send()
+        .await
+        .unwrap();
+    client
+        .send_message()
+        .queue_url(&q_url)
+        .message_body("third-with-attrs")
+        .message_attributes(
+            "priority",
+            MessageAttributeValue::builder()
+                .data_type("String")
+                .string_value("high")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let client = server.sqs_client().await;
+
+    // Queue survives by name.
+    let list = client.list_queues().send().await.unwrap();
+    let urls: Vec<&str> = list.queue_urls().iter().map(|s| s.as_str()).collect();
+    assert!(urls.iter().any(|u| u.ends_with("/work-q")));
+    assert!(urls.iter().any(|u| u.ends_with("/dead-letters")));
+
+    // Attributes + redrive + tags survive.
+    let attrs = client
+        .get_queue_attributes()
+        .queue_url(&q_url)
+        .attribute_names(QueueAttributeName::All)
+        .send()
+        .await
+        .unwrap()
+        .attributes
+        .unwrap();
+    assert_eq!(
+        attrs
+            .get(&QueueAttributeName::VisibilityTimeout)
+            .map(String::as_str),
+        Some("60"),
+    );
+    assert_eq!(
+        attrs
+            .get(&QueueAttributeName::MessageRetentionPeriod)
+            .map(String::as_str),
+        Some("3600"),
+    );
+    let rp = attrs
+        .get(&QueueAttributeName::RedrivePolicy)
+        .expect("redrive policy should survive restart");
+    assert!(rp.contains("deadLetterTargetArn"));
+    assert!(rp.contains("dead-letters"));
+
+    let tags = client
+        .list_queue_tags()
+        .queue_url(&q_url)
+        .send()
+        .await
+        .unwrap()
+        .tags
+        .unwrap_or_default();
+    let tag_map: HashMap<String, String> = tags.into_iter().collect();
+    assert_eq!(tag_map.get("env").map(String::as_str), Some("prod"));
+    assert_eq!(tag_map.get("team").map(String::as_str), Some("platform"));
+
+    // All 3 messages are still in the queue and readable in FIFO-ish order.
+    // Drain with multi-receive so we're not sensitive to batch sizing.
+    let mut bodies = Vec::new();
+    let mut attrs_seen = Vec::new();
+    for _ in 0..5 {
+        let resp = client
+            .receive_message()
+            .queue_url(&q_url)
+            .max_number_of_messages(10)
+            .message_attribute_names("All")
+            .send()
+            .await
+            .unwrap();
+        if resp.messages().is_empty() {
+            break;
+        }
+        for m in resp.messages() {
+            bodies.push(m.body().unwrap_or_default().to_string());
+            if let Some(av) = m
+                .message_attributes()
+                .and_then(|m| m.get("priority"))
+                .and_then(|v| v.string_value())
+            {
+                attrs_seen.push(av.to_string());
+            }
+        }
+    }
+    bodies.sort();
+    assert_eq!(
+        bodies,
+        vec![
+            "first".to_string(),
+            "second".to_string(),
+            "third-with-attrs".to_string(),
+        ],
+    );
+    assert_eq!(attrs_seen, vec!["high".to_string()]);
+
+    // Mutations after restart still persist: send one more message,
+    // restart again, expect it to be there.
+    client
+        .send_message()
+        .queue_url(&q_url)
+        .message_body("post-restart")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let client = server.sqs_client().await;
+    let resp = client
+        .receive_message()
+        .queue_url(&q_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+    let bodies: Vec<&str> = resp
+        .messages()
+        .iter()
+        .map(|m| m.body().unwrap_or_default())
+        .collect();
+    assert!(bodies.contains(&"post-restart"));
+}
+
+/// FIFO queue round-trip: dedup/group IDs and sequence numbers are
+/// preserved, and the queue is still recognized as FIFO after restart.
+#[tokio::test]
+async fn persistence_round_trip_fifo_queue() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.sqs_client().await;
+
+    let q_url = client
+        .create_queue()
+        .queue_name("orders.fifo")
+        .attributes(QueueAttributeName::FifoQueue, "true")
+        .attributes(QueueAttributeName::ContentBasedDeduplication, "true")
+        .send()
+        .await
+        .unwrap()
+        .queue_url
+        .unwrap();
+
+    for body in ["a", "b", "c"] {
+        client
+            .send_message()
+            .queue_url(&q_url)
+            .message_body(body)
+            .message_group_id("group-1")
+            .send()
+            .await
+            .unwrap();
+    }
+
+    server.restart().await;
+    let client = server.sqs_client().await;
+
+    let attrs = client
+        .get_queue_attributes()
+        .queue_url(&q_url)
+        .attribute_names(QueueAttributeName::FifoQueue)
+        .send()
+        .await
+        .unwrap()
+        .attributes
+        .unwrap();
+    assert_eq!(
+        attrs
+            .get(&QueueAttributeName::FifoQueue)
+            .map(String::as_str),
+        Some("true"),
+    );
+
+    // FIFO order: within a single group, strict ordering.
+    let resp = client
+        .receive_message()
+        .queue_url(&q_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+    let bodies: Vec<&str> = resp
+        .messages()
+        .iter()
+        .map(|m| m.body().unwrap_or_default())
+        .collect();
+    assert_eq!(bodies, vec!["a", "b", "c"]);
+}
+
+/// DeleteQueue durability: removed queues don't resurrect after restart.
+#[tokio::test]
+async fn persistence_delete_queue_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.sqs_client().await;
+
+    let url = client
+        .create_queue()
+        .queue_name("ephemeral")
+        .send()
+        .await
+        .unwrap()
+        .queue_url
+        .unwrap();
+    client.delete_queue().queue_url(&url).send().await.unwrap();
+
+    server.restart().await;
+    let client = server.sqs_client().await;
+    let list = client.list_queues().send().await.unwrap();
+    let urls: Vec<&str> = list.queue_urls().iter().map(|s| s.as_str()).collect();
+    assert!(!urls.iter().any(|u| u.ends_with("/ephemeral")));
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -384,7 +384,6 @@ async fn main() {
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
         for service in [
             "cloudformation",
-            "sqs",
             "sns",
             "events",
             "iam",
@@ -421,7 +420,53 @@ async fn main() {
             delivery: delivery_for_cf,
         },
     )));
-    registry.register(Arc::new(SqsService::new(sqs_state.clone())));
+    let sqs_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("sqs").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_sqs::state::SqsSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_sqs::state::SQS_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "sqs persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_sqs::state::SQS_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let queue_count = snapshot.state.queues.len();
+                            *sqs_state.write() = snapshot.state;
+                            tracing::info!(queues = queue_count, "loaded sqs persistence snapshot",);
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse sqs persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no sqs persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read sqs persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut sqs_service = SqsService::new(sqs_state.clone());
+    if let Some(store) = sqs_snapshot_store {
+        sqs_service = sqs_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(sqs_service));
     let sns_state_for_sfn = sns_state.clone();
     let delivery_for_sns_sfn = delivery_for_sns.clone();
     registry.register(Arc::new(SnsService::new(sns_state, delivery_for_sns)));

--- a/crates/fakecloud-sqs/Cargo.toml
+++ b/crates/fakecloud-sqs/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 use sha2::Sha256;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
@@ -360,6 +361,11 @@ fn validate_redrive_policy_target(
 pub struct SqsService {
     state: SharedSqsState,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    /// Serializes concurrent snapshot writes so the newest observed
+    /// state always wins on disk. Without it, two tasks could race
+    /// between read-clone and save, leaving older bytes as the final
+    /// on-disk state (P1 in Cubic review).
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl SqsService {
@@ -367,6 +373,7 @@ impl SqsService {
         Self {
             state,
             snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -377,23 +384,31 @@ impl SqsService {
 
     /// Persist the current in-memory state as a snapshot. Called after
     /// every successful mutating action. Noop when no store is wired.
-    fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.as_ref() else {
+    ///
+    /// The snapshot lock is held across the clone + serialize + write
+    /// sequence so concurrent mutators cannot interleave and leave
+    /// stale bytes on disk. Serialization and the blocking write are
+    /// offloaded to the blocking pool to keep Tokio worker threads
+    /// responsive under write-heavy load.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
             return;
         };
+        let _guard = self.snapshot_lock.lock().await;
         let snapshot = SqsSnapshot {
             schema_version: SQS_SNAPSHOT_SCHEMA_VERSION,
             state: self.state.read().clone(),
         };
-        let bytes = match serde_json::to_vec(&snapshot) {
-            Ok(b) => b,
-            Err(err) => {
-                tracing::error!(%err, "failed to serialize sqs snapshot");
-                return;
-            }
-        };
-        if let Err(err) = store.save(&bytes) {
-            tracing::error!(%err, "failed to write sqs snapshot");
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write sqs snapshot"),
+            Err(err) => tracing::error!(%err, "sqs snapshot task panicked"),
         }
     }
 }
@@ -452,7 +467,7 @@ impl AwsService for SqsService {
             _ => Err(AwsServiceError::action_not_implemented("sqs", &req.action)),
         };
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
-            self.save_snapshot();
+            self.save_snapshot().await;
         }
         result
     }

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -5,12 +5,15 @@ use md5::Md5;
 use serde_json::{json, Value};
 use sha2::Sha256;
 use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    MessageAttribute, RedrivePolicy, SharedSqsState, SqsMessage, SqsQueue, SqsState,
+    MessageAttribute, RedrivePolicy, SharedSqsState, SqsMessage, SqsQueue, SqsSnapshot, SqsState,
+    SQS_SNAPSHOT_SCHEMA_VERSION,
 };
 
 /// Validate DelaySeconds (0–900) and MaximumMessageSize (1024–1 MiB) if
@@ -356,12 +359,65 @@ fn validate_redrive_policy_target(
 
 pub struct SqsService {
     state: SharedSqsState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
 }
 
 impl SqsService {
     pub fn new(state: SharedSqsState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+        }
     }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist the current in-memory state as a snapshot. Called after
+    /// every successful mutating action. Noop when no store is wired.
+    fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.as_ref() else {
+            return;
+        };
+        let snapshot = SqsSnapshot {
+            schema_version: SQS_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let bytes = match serde_json::to_vec(&snapshot) {
+            Ok(b) => b,
+            Err(err) => {
+                tracing::error!(%err, "failed to serialize sqs snapshot");
+                return;
+            }
+        };
+        if let Err(err) = store.save(&bytes) {
+            tracing::error!(%err, "failed to write sqs snapshot");
+        }
+    }
+}
+
+/// Actions that mutate SQS state. Kept in sync with the dispatch table.
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "CreateQueue"
+            | "DeleteQueue"
+            | "SetQueueAttributes"
+            | "SendMessage"
+            | "SendMessageBatch"
+            | "ReceiveMessage"
+            | "DeleteMessage"
+            | "DeleteMessageBatch"
+            | "PurgeQueue"
+            | "ChangeMessageVisibility"
+            | "ChangeMessageVisibilityBatch"
+            | "TagQueue"
+            | "UntagQueue"
+            | "AddPermission"
+            | "RemovePermission"
+    )
 }
 
 #[async_trait]
@@ -371,7 +427,8 @@ impl AwsService for SqsService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateQueue" => self.create_queue(&req),
             "DeleteQueue" => self.delete_queue(&req),
             "ListQueues" => self.list_queues(&req),
@@ -393,7 +450,11 @@ impl AwsService for SqsService {
             "RemovePermission" => self.remove_permission(&req),
             "ListDeadLetterSourceQueues" => self.list_dead_letter_source_queues(&req),
             _ => Err(AwsServiceError::action_not_implemented("sqs", &req.action)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot();
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-sqs/src/state.rs
+++ b/crates/fakecloud-sqs/src/state.rs
@@ -1,16 +1,17 @@
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageAttribute {
     pub data_type: String,
     pub string_value: Option<String>,
     pub binary_value: Option<Vec<u8>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SqsMessage {
     pub message_id: String,
     pub receipt_handle: Option<String>,
@@ -32,13 +33,13 @@ pub struct SqsMessage {
     pub sequence_number: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RedrivePolicy {
     pub dead_letter_target_arn: String,
     pub max_receive_count: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SqsQueue {
     pub queue_name: String,
     pub queue_url: String,
@@ -62,6 +63,7 @@ pub struct SqsQueue {
     pub receipt_handle_map: HashMap<String, Vec<String>>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SqsState {
     pub account_id: String,
     pub region: String,
@@ -90,3 +92,14 @@ impl SqsState {
 }
 
 pub type SharedSqsState = Arc<RwLock<SqsState>>;
+
+/// On-disk snapshot envelope for SQS. Mirrors the DynamoDB pattern: a
+/// versioned wrapper around the full [`SqsState`] so format changes fail
+/// loudly on upgrade instead of silently corrupting state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SqsSnapshot {
+    pub schema_version: u32,
+    pub state: SqsState,
+}
+
+pub const SQS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;


### PR DESCRIPTION
## Summary

Second batch of the persistence push (after DynamoDB in #404). SQS queue config and in-flight messages now survive restarts when the server is started with \`--storage-mode=persistent\`, for both standard and FIFO queues.

- Serde derives on all SQS state structs + a versioned \`SqsSnapshot\` envelope.
- \`SqsService::save_snapshot\` after every successful mutating action, gated on HTTP 2xx (not just Ok).
- Memory mode pays zero serialize-on-write cost — the store is only wired in persistent mode.
- Loads \`<data-path>/sqs/snapshot.json\` on boot; drops \`sqs\` from the warn-unsupported list.

## Test plan

- [x] \`cargo test -p fakecloud-e2e --test sqs_persistence\` — 3 tests (standard round-trip incl. DLQ/tags/msg attrs, FIFO ordering, DeleteQueue durability) all pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\`
- [ ] CI green
- [ ] Cubic satisfied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in disk persistence for SQS so queue config and in-flight messages survive restarts when running with `--storage-mode=persistent`. Works for standard and FIFO queues.

- **New Features**
  - Persist SQS via versioned `SqsSnapshot`; load from `<data-path>/sqs/snapshot.json` on boot.
  - Save a snapshot after each successful mutating action (HTTP 2xx). No serialize cost in memory mode.
  - Preserve attributes, tags, redrive policies, permissions, messages, and FIFO ordering/dedup IDs.
  - E2E tests cover standard queues, FIFO, and DeleteQueue durability.

- **Bug Fixes**
  - Serialize snapshot writes with an async mutex to prevent stale on-disk state under concurrent mutations.
  - Offload snapshot encode and disk write to a blocking pool to avoid stalling Tokio workers.

<sup>Written for commit bb492336da86d005d37fb37b043be104cf2464bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

