### PR TITLE
fix(dynamodb): serialize snapshot writes + offload to blocking pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/crates/fakecloud-dynamodb/Cargo.toml
+++ b/crates/fakecloud-dynamodb/Cargo.toml
@@ -21,5 +21,6 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -43,6 +43,11 @@ pub struct DynamoDbService {
     pub(crate) s3_store: Option<Arc<dyn S3Store>>,
     delivery: Option<Arc<DeliveryBus>>,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    /// Serializes concurrent snapshot writes so the newest observed
+    /// state always wins on disk. Without it, two tasks could race
+    /// between state.read().clone() and store.save() and leave older
+    /// bytes as the final on-disk state.
+    snapshot_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl DynamoDbService {
@@ -53,6 +58,7 @@ impl DynamoDbService {
             s3_store: None,
             delivery: None,
             snapshot_store: None,
+            snapshot_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -79,23 +85,30 @@ impl DynamoDbService {
     /// Persist the current in-memory state as a snapshot. Called after
     /// every state-mutating action. A noop when no snapshot store is
     /// configured (i.e. `StorageMode::Memory`).
-    fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.as_ref() else {
+    ///
+    /// The snapshot lock serializes the full clone + serialize + write
+    /// so concurrent mutators cannot leave older bytes on disk, and
+    /// serialization + the blocking file write are offloaded to the
+    /// blocking pool to keep Tokio workers responsive.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
             return;
         };
+        let _guard = self.snapshot_lock.lock().await;
         let snapshot = DynamoDbSnapshot {
             schema_version: DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
             state: self.state.read().clone(),
         };
-        let bytes = match serde_json::to_vec(&snapshot) {
-            Ok(b) => b,
-            Err(err) => {
-                tracing::error!(%err, "failed to serialize dynamodb snapshot");
-                return;
-            }
-        };
-        if let Err(err) = store.save(&bytes) {
-            tracing::error!(%err, "failed to write dynamodb snapshot");
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write dynamodb snapshot"),
+            Err(err) => tracing::error!(%err, "dynamodb snapshot task panicked"),
         }
     }
 
@@ -268,7 +281,7 @@ impl AwsService for DynamoDbService {
             )),
         };
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
-            self.save_snapshot();
+            self.save_snapshot().await;
         }
         result
     }


### PR DESCRIPTION
## Summary

Applies the same two fixes #409 applies to SQS, to the DynamoDB snapshot pipeline introduced in #404. Cubic didn't flag these on #404 but raised them when reviewing the SQS copy of the same code:

- **P1, concurrency race**: two mutating requests could each clone state, serialize independently, and race on save(). Last writer could persist older bytes than in-memory state.
- **P2, blocking I/O in async handler**: serialization + atomic file write ran inline on the Tokio worker thread.

Fix: dedicated \`tokio::sync::Mutex\` held across the full clone + serialize + write, with the CPU + I/O offloaded via \`spawn_blocking\`. \`save_snapshot\` is now \`async\`.

## Test plan

- [x] \`cargo test -p fakecloud-e2e --test dynamodb_persistence\` passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\`
- [ ] CI green
- [ ] Cubic satisfied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes DynamoDB snapshot writes and offloads serialization + file I/O to the blocking pool to prevent races and keep Tokio workers responsive. `save_snapshot` is now async and awaited after successful mutations.

- **Bug Fixes**
  - Add `tokio::sync::Mutex` to serialize clone → serialize → write so the newest state always wins on disk.
  - Use `tokio::task::spawn_blocking` for snapshot serialization and file write to avoid blocking async workers.

- **Dependencies**
  - Add direct `tokio` dependency to `fakecloud-dynamodb`.

<sup>Written for commit f03ced051a2fb72f7501cbe8afe142a317aa9df1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

