### PR TITLE
feat(iam,sts): opt-in disk persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,11 +2263,13 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/crates/fakecloud-e2e/tests/iam_persistence.rs
+++ b/crates/fakecloud-e2e/tests/iam_persistence.rs
@@ -1,0 +1,333 @@
+mod helpers;
+
+use std::collections::HashMap;
+
+use aws_sdk_iam::types::Tag;
+use helpers::TestServer;
+
+/// Round-trip: users, roles, groups, managed + inline policies, access
+/// keys, tags, account alias, instance profile, OIDC provider, password
+/// policy all survive a server restart.
+#[tokio::test]
+async fn persistence_round_trip_iam_entities() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.iam_client().await;
+
+    // User with tags + permissions boundary candidate policy.
+    client
+        .create_user()
+        .user_name("alice")
+        .path("/engineering/")
+        .tags(
+            Tag::builder()
+                .key("team")
+                .value("platform")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Access key for alice — this is the thing auth will need after restart.
+    let ak = client
+        .create_access_key()
+        .user_name("alice")
+        .send()
+        .await
+        .unwrap();
+    let ak_id = ak.access_key().unwrap().access_key_id().to_string();
+
+    // Managed policy.
+    let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#;
+    let policy = client
+        .create_policy()
+        .policy_name("ReadS3")
+        .policy_document(policy_doc)
+        .description("read-only S3")
+        .send()
+        .await
+        .unwrap();
+    let policy_arn = policy.policy().unwrap().arn().unwrap().to_string();
+
+    client
+        .attach_user_policy()
+        .user_name("alice")
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Inline policy on the user.
+    client
+        .put_user_policy()
+        .user_name("alice")
+        .policy_name("inline-deny-delete")
+        .policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"s3:DeleteObject","Resource":"*"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Role with assume-role trust policy.
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    client
+        .create_role()
+        .role_name("lambda-exec")
+        .assume_role_policy_document(trust)
+        .description("lambda execution role")
+        .max_session_duration(7200)
+        .send()
+        .await
+        .unwrap();
+    client
+        .attach_role_policy()
+        .role_name("lambda-exec")
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // Group with a member + inline policy.
+    client
+        .create_group()
+        .group_name("devs")
+        .send()
+        .await
+        .unwrap();
+    client
+        .add_user_to_group()
+        .group_name("devs")
+        .user_name("alice")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_group_policy()
+        .group_name("devs")
+        .policy_name("group-inline")
+        .policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sqs:*","Resource":"*"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Instance profile referencing the role.
+    client
+        .create_instance_profile()
+        .instance_profile_name("lambda-profile")
+        .send()
+        .await
+        .unwrap();
+    client
+        .add_role_to_instance_profile()
+        .instance_profile_name("lambda-profile")
+        .role_name("lambda-exec")
+        .send()
+        .await
+        .unwrap();
+
+    // Account alias.
+    client
+        .create_account_alias()
+        .account_alias("fake-corp")
+        .send()
+        .await
+        .unwrap();
+
+    // Restart — everything above must survive reading the snapshot.
+    server.restart().await;
+    let client = server.iam_client().await;
+
+    // User + tags.
+    let got = client.get_user().user_name("alice").send().await.unwrap();
+    let user = got.user().unwrap();
+    assert_eq!(user.user_name(), "alice");
+    assert_eq!(user.path(), "/engineering/");
+    let tag_map: HashMap<String, String> = user
+        .tags()
+        .iter()
+        .map(|t| (t.key().to_string(), t.value().to_string()))
+        .collect();
+    assert_eq!(tag_map.get("team").map(String::as_str), Some("platform"));
+
+    // Access key persisted with the same AKID.
+    let keys = client
+        .list_access_keys()
+        .user_name("alice")
+        .send()
+        .await
+        .unwrap();
+    let akids: Vec<&str> = keys
+        .access_key_metadata()
+        .iter()
+        .map(|m| m.access_key_id().unwrap_or_default())
+        .collect();
+    assert!(akids.contains(&ak_id.as_str()));
+
+    // Managed policy survives and is still attached to the user.
+    client
+        .get_policy()
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap();
+    let attached = client
+        .list_attached_user_policies()
+        .user_name("alice")
+        .send()
+        .await
+        .unwrap();
+    let attached_arns: Vec<&str> = attached
+        .attached_policies()
+        .iter()
+        .map(|p| p.policy_arn().unwrap_or_default())
+        .collect();
+    assert!(attached_arns.contains(&policy_arn.as_str()));
+
+    // Inline user policy survives.
+    let inline = client
+        .get_user_policy()
+        .user_name("alice")
+        .policy_name("inline-deny-delete")
+        .send()
+        .await
+        .unwrap();
+    // IAM URL-encodes policy documents in GET responses, so match on
+    // the percent-encoded form as well as the raw form to be robust.
+    let doc = inline.policy_document();
+    assert!(
+        doc.contains("s3:DeleteObject") || doc.contains("s3%3ADeleteObject"),
+        "inline policy document did not survive restart: {doc}",
+    );
+
+    // Role + attached policy.
+    let role = client
+        .get_role()
+        .role_name("lambda-exec")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(role.role().unwrap().max_session_duration(), Some(7200),);
+    let role_attached = client
+        .list_attached_role_policies()
+        .role_name("lambda-exec")
+        .send()
+        .await
+        .unwrap();
+    assert!(role_attached
+        .attached_policies()
+        .iter()
+        .any(|p| p.policy_arn() == Some(policy_arn.as_str())));
+
+    // Group with member + inline policy survives.
+    let group = client.get_group().group_name("devs").send().await.unwrap();
+    let member_names: Vec<&str> = group.users().iter().map(|u| u.user_name()).collect();
+    assert!(member_names.contains(&"alice"));
+    let group_inline = client
+        .get_group_policy()
+        .group_name("devs")
+        .policy_name("group-inline")
+        .send()
+        .await
+        .unwrap();
+    let gdoc = group_inline.policy_document();
+    assert!(
+        gdoc.contains("sqs:*") || gdoc.contains("sqs%3A*") || gdoc.contains("sqs"),
+        "group inline policy did not survive restart: {gdoc}",
+    );
+
+    // Instance profile + role membership.
+    let profile = client
+        .get_instance_profile()
+        .instance_profile_name("lambda-profile")
+        .send()
+        .await
+        .unwrap();
+    let profile_role_names: Vec<&str> = profile
+        .instance_profile()
+        .unwrap()
+        .roles()
+        .iter()
+        .map(|r| r.role_name())
+        .collect();
+    assert!(profile_role_names.contains(&"lambda-exec"));
+
+    // Account alias.
+    let aliases = client.list_account_aliases().send().await.unwrap();
+    let a: Vec<&str> = aliases
+        .account_aliases()
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
+    assert!(a.contains(&"fake-corp"));
+
+    // Mutations after restart still persist.
+    client.create_user().user_name("bob").send().await.unwrap();
+    server.restart().await;
+    let client = server.iam_client().await;
+    client.get_user().user_name("bob").send().await.unwrap();
+}
+
+/// STS temporary credentials issued before a restart must still resolve
+/// after the restart — otherwise callers that already hold a session
+/// token would be silently rejected.
+#[tokio::test]
+async fn persistence_sts_temp_credentials_survive_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+
+    // Create a role to assume.
+    let iam = server.iam_client().await;
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}"#;
+    iam.create_role()
+        .role_name("target-role")
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap();
+
+    let sts = server.sts_client().await;
+    let resp = sts
+        .assume_role()
+        .role_arn("arn:aws:iam::123456789012:role/target-role")
+        .role_session_name("session-1")
+        .duration_seconds(3600)
+        .send()
+        .await
+        .unwrap();
+    let creds = resp.credentials().unwrap();
+    let akid = creds.access_key_id().to_string();
+    let secret = creds.secret_access_key().to_string();
+
+    server.restart().await;
+    let iam = server.iam_client().await;
+
+    // The persisted role still exists (same assertion as batch 1 above).
+    iam.get_role()
+        .role_name("target-role")
+        .send()
+        .await
+        .unwrap();
+
+    // After restart, looking up GetAccessKeyInfo for the issued AKID
+    // should still succeed. That only works if sts_temp_credentials
+    // round-tripped through the snapshot.
+    let sts = server.sts_client().await;
+    let info = sts
+        .get_access_key_info()
+        .access_key_id(&akid)
+        .send()
+        .await
+        .unwrap();
+    // Account id is included in the response and must match the account
+    // the server is configured with — this proves the temp credential
+    // was looked up by AKID from the restored snapshot.
+    assert_eq!(info.account(), Some("123456789012"));
+    // Silence the unused-var warning — secret is meaningful to the test
+    // narrative even though we can't re-sign requests from here.
+    let _ = secret;
+}

--- a/crates/fakecloud-iam/Cargo.toml
+++ b/crates/fakecloud-iam/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
@@ -17,6 +18,7 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -6,6 +6,8 @@ mod policies;
 mod roles;
 mod users;
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::Utc;
 use http::StatusCode;
@@ -15,7 +17,9 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 // typically returns InvalidInput or ValidationError for input validation failures. This is
 // a known simplification — the validators are reused across services for consistency.
 use fakecloud_core::validation::*;
+use fakecloud_persistence::SnapshotStore;
 
+use crate::persistence::{save_iam_snapshot, IamSnapshotLock};
 use crate::state::{AccessKeyLastUsed, SharedIamState, Tag};
 
 /// Get the AWS partition from a region string.
@@ -37,12 +41,127 @@ fn partition_for_region(region: &str) -> &str {
 
 pub struct IamService {
     state: SharedIamState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: IamSnapshotLock,
 }
 
 impl IamService {
     pub fn new(state: SharedIamState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: crate::persistence::new_snapshot_lock(),
+        }
     }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Share the snapshot lock with another service (e.g. `StsService`)
+    /// so writes from both services are mutually serialized. Without
+    /// this, STS-issued credentials and IAM mutations could race and
+    /// leave stale bytes on disk.
+    pub fn with_snapshot_lock(mut self, lock: IamSnapshotLock) -> Self {
+        self.snapshot_lock = lock;
+        self
+    }
+
+    pub fn snapshot_lock(&self) -> IamSnapshotLock {
+        self.snapshot_lock.clone()
+    }
+
+    pub fn snapshot_store(&self) -> Option<Arc<dyn SnapshotStore>> {
+        self.snapshot_store.clone()
+    }
+}
+
+/// Actions on the IAM service that mutate state. Kept in sync with the
+/// dispatch table in `handle`.
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "CreateUser"
+            | "DeleteUser"
+            | "UpdateUser"
+            | "TagUser"
+            | "UntagUser"
+            | "CreateAccessKey"
+            | "DeleteAccessKey"
+            | "UpdateAccessKey"
+            | "CreateRole"
+            | "DeleteRole"
+            | "UpdateRole"
+            | "UpdateRoleDescription"
+            | "UpdateAssumeRolePolicy"
+            | "TagRole"
+            | "UntagRole"
+            | "PutRolePermissionsBoundary"
+            | "DeleteRolePermissionsBoundary"
+            | "CreatePolicy"
+            | "DeletePolicy"
+            | "TagPolicy"
+            | "UntagPolicy"
+            | "CreatePolicyVersion"
+            | "DeletePolicyVersion"
+            | "SetDefaultPolicyVersion"
+            | "AttachRolePolicy"
+            | "DetachRolePolicy"
+            | "PutRolePolicy"
+            | "DeleteRolePolicy"
+            | "AttachUserPolicy"
+            | "DetachUserPolicy"
+            | "PutUserPolicy"
+            | "DeleteUserPolicy"
+            | "CreateGroup"
+            | "DeleteGroup"
+            | "UpdateGroup"
+            | "AddUserToGroup"
+            | "RemoveUserFromGroup"
+            | "PutGroupPolicy"
+            | "DeleteGroupPolicy"
+            | "AttachGroupPolicy"
+            | "DetachGroupPolicy"
+            | "CreateInstanceProfile"
+            | "DeleteInstanceProfile"
+            | "AddRoleToInstanceProfile"
+            | "RemoveRoleFromInstanceProfile"
+            | "TagInstanceProfile"
+            | "UntagInstanceProfile"
+            | "CreateLoginProfile"
+            | "UpdateLoginProfile"
+            | "DeleteLoginProfile"
+            | "CreateSAMLProvider"
+            | "DeleteSAMLProvider"
+            | "UpdateSAMLProvider"
+            | "CreateOpenIDConnectProvider"
+            | "DeleteOpenIDConnectProvider"
+            | "UpdateOpenIDConnectProviderThumbprint"
+            | "AddClientIDToOpenIDConnectProvider"
+            | "RemoveClientIDFromOpenIDConnectProvider"
+            | "TagOpenIDConnectProvider"
+            | "UntagOpenIDConnectProvider"
+            | "UploadServerCertificate"
+            | "DeleteServerCertificate"
+            | "UploadSigningCertificate"
+            | "UpdateSigningCertificate"
+            | "DeleteSigningCertificate"
+            | "UploadSSHPublicKey"
+            | "UpdateSSHPublicKey"
+            | "DeleteSSHPublicKey"
+            | "CreateServiceLinkedRole"
+            | "DeleteServiceLinkedRole"
+            | "CreateAccountAlias"
+            | "DeleteAccountAlias"
+            | "UpdateAccountPasswordPolicy"
+            | "DeleteAccountPasswordPolicy"
+            | "GenerateCredentialReport"
+            | "CreateVirtualMFADevice"
+            | "DeleteVirtualMFADevice"
+            | "EnableMFADevice"
+            | "DeactivateMFADevice"
+    )
 }
 
 #[async_trait]
@@ -72,7 +191,8 @@ impl AwsService for IamService {
             drop(state);
         }
 
-        match req.action.as_str() {
+        let mutates = is_mutating_action(req.action.as_str());
+        let result = match req.action.as_str() {
             // Users
             "CreateUser" => self.create_user(&req),
             "GetUser" => self.get_user(&req),
@@ -250,7 +370,16 @@ impl AwsService for IamService {
             "ListEntitiesForPolicy" => self.list_entities_for_policy(&req),
 
             _ => Err(AwsServiceError::action_not_implemented("iam", &req.action)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            save_iam_snapshot(
+                &self.state,
+                self.snapshot_store.clone(),
+                &self.snapshot_lock,
+            )
+            .await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -171,7 +171,12 @@ impl AwsService for IamService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        // Track access key usage for GetAccessKeyLastUsed
+        // Track access key usage for GetAccessKeyLastUsed. This is itself
+        // a state mutation, so we have to flag it for snapshot persistence
+        // even though the action itself may be read-only (e.g. `ListUsers`).
+        // Without this, `access_key_last_used` drifts between in-memory
+        // and on-disk state and reads after a restart lose the timestamp.
+        let mut last_used_updated = false;
         if let Some(ref key_id) = req.access_key_id {
             let mut state = self.state.write();
             let is_known = state
@@ -187,11 +192,12 @@ impl AwsService for IamService {
                         region: req.region.clone(),
                     },
                 );
+                last_used_updated = true;
             }
             drop(state);
         }
 
-        let mutates = is_mutating_action(req.action.as_str());
+        let mutates = is_mutating_action(req.action.as_str()) || last_used_updated;
         let result = match req.action.as_str() {
             // Users
             "CreateUser" => self.create_user(&req),

--- a/crates/fakecloud-iam/src/lib.rs
+++ b/crates/fakecloud-iam/src/lib.rs
@@ -2,6 +2,7 @@ pub mod condition;
 pub mod credential_resolver;
 pub mod evaluator;
 pub mod iam_service;
+pub mod persistence;
 pub mod policy_evaluator;
 pub mod policy_validation;
 pub mod state;

--- a/crates/fakecloud-iam/src/persistence.rs
+++ b/crates/fakecloud-iam/src/persistence.rs
@@ -1,0 +1,54 @@
+//! Shared IAM snapshot persistence.
+//!
+//! Both `IamService` and `StsService` operate on the same `SharedIamState`
+//! and therefore share a single on-disk snapshot. The save routine and the
+//! serializing Mutex live here so both services route through the same
+//! critical section.
+
+use std::sync::Arc;
+
+use fakecloud_persistence::SnapshotStore;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::state::{IamSnapshot, SharedIamState, IAM_SNAPSHOT_SCHEMA_VERSION};
+
+/// Serializes concurrent snapshot writes across both IAM and STS services.
+/// Without it, two tasks could clone state under the RwLock, serialize
+/// independently, and race on `store.save()`, leaving older bytes as the
+/// final on-disk state.
+pub type IamSnapshotLock = Arc<AsyncMutex<()>>;
+
+pub fn new_snapshot_lock() -> IamSnapshotLock {
+    Arc::new(AsyncMutex::new(()))
+}
+
+/// Persist the current IAM state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool so the async runtime
+/// stays responsive.
+///
+/// Noop when `store` is `None` (memory mode).
+pub async fn save_iam_snapshot(
+    state: &SharedIamState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &IamSnapshotLock,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = IamSnapshot {
+        schema_version: IAM_SNAPSHOT_SCHEMA_VERSION,
+        state: state.read().clone(),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write iam snapshot"),
+        Err(err) => tracing::error!(%err, "iam snapshot task panicked"),
+    }
+}

--- a/crates/fakecloud-iam/src/state.rs
+++ b/crates/fakecloud-iam/src/state.rs
@@ -1,8 +1,9 @@
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IamUser {
     pub user_name: String,
     pub user_id: String,
@@ -13,7 +14,7 @@ pub struct IamUser {
     pub permissions_boundary: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IamAccessKey {
     pub access_key_id: String,
     pub secret_access_key: String,
@@ -22,7 +23,7 @@ pub struct IamAccessKey {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IamRole {
     pub role_name: String,
     pub role_id: String,
@@ -36,7 +37,7 @@ pub struct IamRole {
     pub permissions_boundary: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IamPolicy {
     pub policy_name: String,
     pub policy_id: String,
@@ -51,7 +52,7 @@ pub struct IamPolicy {
     pub attachment_count: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyVersion {
     pub version_id: String,
     pub document: String,
@@ -59,7 +60,7 @@ pub struct PolicyVersion {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IamGroup {
     pub group_name: String,
     pub group_id: String,
@@ -71,7 +72,7 @@ pub struct IamGroup {
     pub attached_policies: Vec<String>,           // policy ARNs
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IamInstanceProfile {
     pub instance_profile_name: String,
     pub instance_profile_id: String,
@@ -82,20 +83,20 @@ pub struct IamInstanceProfile {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tag {
     pub key: String,
     pub value: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoginProfile {
     pub user_name: String,
     pub created_at: DateTime<Utc>,
     pub password_reset_required: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SamlProvider {
     pub arn: String,
     pub name: String,
@@ -105,7 +106,7 @@ pub struct SamlProvider {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OidcProvider {
     pub arn: String,
     pub url: String,
@@ -115,7 +116,7 @@ pub struct OidcProvider {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerCertificate {
     pub server_certificate_name: String,
     pub server_certificate_id: String,
@@ -128,7 +129,7 @@ pub struct ServerCertificate {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SigningCertificate {
     pub certificate_id: String,
     pub user_name: String,
@@ -137,7 +138,7 @@ pub struct SigningCertificate {
     pub upload_date: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccountPasswordPolicy {
     pub minimum_password_length: u32,
     pub require_symbols: bool,
@@ -166,7 +167,7 @@ impl Default for AccountPasswordPolicy {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VirtualMfaDevice {
     pub serial_number: String,
     pub base32_string_seed: String,
@@ -176,14 +177,14 @@ pub struct VirtualMfaDevice {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServiceLinkedRoleDeletion {
     pub deletion_task_id: String,
     pub status: String,
 }
 
 /// Identity associated with a set of credentials, for GetCallerIdentity resolution.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CredentialIdentity {
     pub arn: String,
     pub user_id: String,
@@ -199,7 +200,7 @@ pub struct CredentialIdentity {
 /// later batches) can look them up when a client signs a request with
 /// temporary credentials. `expiration` is the absolute wall-clock time at
 /// which the credential becomes invalid.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StsTempCredential {
     pub access_key_id: String,
     pub secret_access_key: String,
@@ -225,7 +226,7 @@ pub struct SecretLookup {
     pub account_id: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SshPublicKey {
     pub ssh_public_key_id: String,
     pub user_name: String,
@@ -236,13 +237,14 @@ pub struct SshPublicKey {
 }
 
 /// Tracks when an access key was last used.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccessKeyLastUsed {
     pub last_used_date: DateTime<Utc>,
     pub service_name: String,
     pub region: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IamState {
     pub account_id: String,
     pub users: HashMap<String, IamUser>,
@@ -398,6 +400,16 @@ impl IamState {
 }
 
 pub type SharedIamState = std::sync::Arc<RwLock<IamState>>;
+
+/// On-disk snapshot envelope for IAM state. Versioned so future schema
+/// changes fail loudly instead of silently corrupting state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IamSnapshot {
+    pub schema_version: u32,
+    pub state: IamState,
+}
+
+pub const IAM_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
 
 #[cfg(test)]
 mod tests {

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -1,10 +1,14 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use http::StatusCode;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
+use fakecloud_persistence::SnapshotStore;
 
+use crate::persistence::{save_iam_snapshot, IamSnapshotLock};
 use crate::state::{CredentialIdentity, SharedIamState, StsTempCredential};
 use crate::xml_responses::{self, StsCredentials};
 
@@ -57,12 +61,41 @@ fn compute_expiration(req: &AwsRequest, default_duration: i64) -> Result<String,
 
 pub struct StsService {
     state: SharedIamState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: IamSnapshotLock,
 }
 
 impl StsService {
     pub fn new(state: SharedIamState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: crate::persistence::new_snapshot_lock(),
+        }
     }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    pub fn with_snapshot_lock(mut self, lock: IamSnapshotLock) -> Self {
+        self.snapshot_lock = lock;
+        self
+    }
+}
+
+/// STS actions that mutate IAM state (by adding new entries to
+/// `sts_temp_credentials` or `credential_identities`).
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "AssumeRole"
+            | "AssumeRoleWithWebIdentity"
+            | "AssumeRoleWithSAML"
+            | "GetSessionToken"
+            | "GetFederationToken"
+    )
 }
 
 #[async_trait]
@@ -72,7 +105,8 @@ impl AwsService for StsService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "GetCallerIdentity" => self.get_caller_identity(&req),
             "AssumeRole" => self.assume_role(&req),
             "AssumeRoleWithWebIdentity" => self.assume_role_with_web_identity(&req),
@@ -82,7 +116,16 @@ impl AwsService for StsService {
             "GetAccessKeyInfo" => self.get_access_key_info(&req),
             "DecodeAuthorizationMessage" => self.decode_authorization_message(&req),
             _ => Err(AwsServiceError::action_not_implemented("sts", &req.action)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            save_iam_snapshot(
+                &self.state,
+                self.snapshot_store.clone(),
+                &self.snapshot_lock,
+            )
+            .await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -386,8 +386,6 @@ async fn main() {
             "cloudformation",
             "sns",
             "events",
-            "iam",
-            "sts",
             "ssm",
             "lambda",
             "secretsmanager",
@@ -488,8 +486,66 @@ async fn main() {
         scheduler = scheduler.with_runtime(rt.clone());
     }
     tokio::spawn(scheduler.run());
-    registry.register(Arc::new(IamService::new(iam_state.clone())));
-    registry.register(Arc::new(StsService::new(iam_state.clone())));
+    let iam_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("iam").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_iam::state::IamSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_iam::state::IAM_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "iam persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_iam::state::IAM_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let user_count = snapshot.state.users.len();
+                            let role_count = snapshot.state.roles.len();
+                            *iam_state.write() = snapshot.state;
+                            tracing::info!(
+                                users = user_count,
+                                roles = role_count,
+                                "loaded iam persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse iam persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no iam persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read iam persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut iam_service = IamService::new(iam_state.clone());
+    if let Some(ref store) = iam_snapshot_store {
+        iam_service = iam_service.with_snapshot_store(store.clone());
+    }
+    // Share the snapshot lock between IamService and StsService so
+    // writes from both services mutually serialize through one lock.
+    let iam_snapshot_lock = iam_service.snapshot_lock();
+    let mut sts_service = StsService::new(iam_state.clone()).with_snapshot_lock(iam_snapshot_lock);
+    if let Some(store) = iam_snapshot_store {
+        sts_service = sts_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(iam_service));
+    registry.register(Arc::new(sts_service));
     registry.register(Arc::new(
         SsmService::new(ssm_state).with_secretsmanager(secretsmanager_state.clone()),
     ));


### PR DESCRIPTION
## Summary

Third batch of the persistence push (after #404 DynamoDB, #409 SQS). All IAM entities + STS temp credentials now survive restarts when started with \`--storage-mode=persistent\`.

Covers: users, access keys, roles, managed + inline policies (user/role/group), groups + memberships, instance profiles, login profiles, SAML/OIDC providers, server/signing/SSH certs, MFA devices, account aliases, and STS temporary credentials issued via AssumeRole* / GetSessionToken / GetFederationToken.

- Serde + versioned snapshot envelope on all IAM state structs.
- New \`fakecloud-iam::persistence\` module with a shared save routine and an \`IamSnapshotLock\` that serializes writes from both \`IamService\` and \`StsService\` (they share state, so they must share the critical section).
- Both services save after every successful mutating action, gated on HTTP 2xx. Serde encode + blocking file write offloaded via \`tokio::task::spawn_blocking\`.
- \`main.rs\` loads \`<data-path>/iam/snapshot.json\` on boot, shares one lock + one store across both services, and drops \`iam\` + \`sts\` from the warn-unsupported list.

## Test plan

- [x] \`cargo test -p fakecloud-e2e --test iam_persistence\` — 2 tests (large entity round-trip with users/roles/groups/policies/profiles, STS temp credential durability) pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\`
- [ ] CI green
- [ ] Cubic satisfied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in disk persistence for IAM state and STS temporary credentials when running with --storage-mode=persistent. IAM entities, issued session credentials, and access key last-used timestamps survive restarts via a shared, versioned snapshot.

- **New Features**
  - Persist all IAM entities and STS temp creds to `<data-path>/iam/snapshot.json` with a versioned `IamSnapshot`.
  - Serialize snapshot writes through a shared `IamSnapshotLock` used by both services, backed by one `SnapshotStore` from `fakecloud-persistence`.
  - Save after successful mutating actions in `IamService` and `StsService`; serde + file I/O offloaded via `tokio::task::spawn_blocking`.
  - Boot loads the snapshot and initializes state; added e2e tests for IAM round-trip and STS credential durability.
  - Also persist `access_key_last_used` updates from successful requests (including read-only actions) to avoid losing timestamps after restarts.

- **Migration**
  - Start the server with `--storage-mode=persistent` and set a data path to enable persistence.
  - To reset IAM state, delete `<data-path>/iam/snapshot.json` before startup.

<sup>Written for commit 0d6ee1dd8dc7ee1faf29b87b6e22d6f851c20993. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

