### PR TITLE
feat(sns): opt-in disk persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,6 +2495,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "reqwest",

--- a/crates/fakecloud-e2e/tests/sns_persistence.rs
+++ b/crates/fakecloud-e2e/tests/sns_persistence.rs
@@ -1,0 +1,204 @@
+mod helpers;
+
+use std::collections::HashMap;
+
+use helpers::TestServer;
+
+/// Standard topic round-trip: attributes, tags, subscriptions (standard +
+/// SQS target), and subscription attributes survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_topic_and_subscriptions() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let sns = server.sns_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create a standard topic.
+    let topic = sns.create_topic().name("orders").send().await.unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    // Set topic attributes.
+    sns.set_topic_attributes()
+        .topic_arn(&topic_arn)
+        .attribute_name("DisplayName")
+        .attribute_value("Orders Topic")
+        .send()
+        .await
+        .unwrap();
+
+    // Tags.
+    sns.tag_resource()
+        .resource_arn(&topic_arn)
+        .tags(
+            aws_sdk_sns::types::Tag::builder()
+                .key("env")
+                .value("prod")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Subscribe an SQS queue to the topic.
+    let q = sqs
+        .create_queue()
+        .queue_name("orders-downstream")
+        .send()
+        .await
+        .unwrap()
+        .queue_url
+        .unwrap();
+    let q_arn = sqs
+        .get_queue_attributes()
+        .queue_url(&q)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .clone();
+
+    let sub_arn = sns
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&q_arn)
+        .attributes("RawMessageDelivery", "true")
+        .return_subscription_arn(true)
+        .send()
+        .await
+        .unwrap()
+        .subscription_arn
+        .unwrap();
+
+    server.restart().await;
+    let sns = server.sns_client().await;
+
+    // Topic survives.
+    let topics = sns.list_topics().send().await.unwrap();
+    assert!(topics
+        .topics()
+        .iter()
+        .any(|t| t.topic_arn() == Some(topic_arn.as_str())));
+
+    // Topic attributes survive.
+    let attrs = sns
+        .get_topic_attributes()
+        .topic_arn(&topic_arn)
+        .send()
+        .await
+        .unwrap();
+    let am: HashMap<String, String> = attrs.attributes().unwrap_or(&HashMap::new()).clone();
+    assert_eq!(
+        am.get("DisplayName").map(String::as_str),
+        Some("Orders Topic")
+    );
+
+    // Tags survive.
+    let tags = sns
+        .list_tags_for_resource()
+        .resource_arn(&topic_arn)
+        .send()
+        .await
+        .unwrap();
+    let tag_map: HashMap<String, String> = tags
+        .tags()
+        .iter()
+        .map(|t| (t.key().to_string(), t.value().to_string()))
+        .collect();
+    assert_eq!(tag_map.get("env").map(String::as_str), Some("prod"));
+
+    // Subscription survives, with RawMessageDelivery=true still set.
+    let subs = sns
+        .list_subscriptions_by_topic()
+        .topic_arn(&topic_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(subs
+        .subscriptions()
+        .iter()
+        .any(|s| s.subscription_arn() == Some(sub_arn.as_str())));
+    let sub_attrs = sns
+        .get_subscription_attributes()
+        .subscription_arn(&sub_arn)
+        .send()
+        .await
+        .unwrap()
+        .attributes
+        .unwrap_or_default();
+    assert_eq!(
+        sub_attrs.get("RawMessageDelivery").map(String::as_str),
+        Some("true"),
+    );
+}
+
+/// FIFO topic persists and is still recognized as FIFO after restart.
+#[tokio::test]
+async fn persistence_round_trip_fifo_topic() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let sns = server.sns_client().await;
+
+    let topic_arn = sns
+        .create_topic()
+        .name("events.fifo")
+        .attributes("FifoTopic", "true")
+        .attributes("ContentBasedDeduplication", "true")
+        .send()
+        .await
+        .unwrap()
+        .topic_arn
+        .unwrap();
+
+    server.restart().await;
+    let sns = server.sns_client().await;
+
+    let attrs = sns
+        .get_topic_attributes()
+        .topic_arn(&topic_arn)
+        .send()
+        .await
+        .unwrap()
+        .attributes
+        .unwrap_or_default();
+    assert_eq!(attrs.get("FifoTopic").map(String::as_str), Some("true"));
+    assert_eq!(
+        attrs.get("ContentBasedDeduplication").map(String::as_str),
+        Some("true"),
+    );
+}
+
+/// Unsubscribe + delete-topic durability.
+#[tokio::test]
+async fn persistence_delete_topic_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let sns = server.sns_client().await;
+
+    let topic_arn = sns
+        .create_topic()
+        .name("ephemeral")
+        .send()
+        .await
+        .unwrap()
+        .topic_arn
+        .unwrap();
+    sns.delete_topic()
+        .topic_arn(&topic_arn)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let sns = server.sns_client().await;
+    let topics = sns.list_topics().send().await.unwrap();
+    assert!(!topics
+        .topics()
+        .iter()
+        .any(|t| t.topic_arn() == Some(topic_arn.as_str())));
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -384,7 +384,6 @@ async fn main() {
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
         for service in [
             "cloudformation",
-            "sns",
             "events",
             "ssm",
             "lambda",
@@ -467,7 +466,58 @@ async fn main() {
     registry.register(Arc::new(sqs_service));
     let sns_state_for_sfn = sns_state.clone();
     let delivery_for_sns_sfn = delivery_for_sns.clone();
-    registry.register(Arc::new(SnsService::new(sns_state, delivery_for_sns)));
+    let sns_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("sns").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_sns::state::SnsSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_sns::state::SNS_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "sns persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_sns::state::SNS_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let topic_count = snapshot.state.topics.len();
+                            let sub_count = snapshot.state.subscriptions.len();
+                            *sns_state.write() = snapshot.state;
+                            tracing::info!(
+                                topics = topic_count,
+                                subscriptions = sub_count,
+                                "loaded sns persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse sns persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no sns persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read sns persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut sns_service = SnsService::new(sns_state, delivery_for_sns);
+    if let Some(store) = sns_snapshot_store {
+        sns_service = sns_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(sns_service));
     let mut eb_service = EventBridgeService::new(eb_state.clone(), delivery_for_eb.clone())
         .with_lambda(lambda_state.clone())
         .with_logs(logs_state.clone());

--- a/crates/fakecloud-sns/Cargo.toml
+++ b/crates/fakecloud-sns/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -4,28 +4,94 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
     MessageAttribute, PlatformApplication, PlatformEndpoint, PublishedMessage, SharedSnsState,
-    SnsSubscription, SnsTopic,
+    SnsSnapshot, SnsSubscription, SnsTopic, SNS_SNAPSHOT_SCHEMA_VERSION,
 };
 
 pub struct SnsService {
     state: SharedSnsState,
     delivery: Arc<DeliveryBus>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl SnsService {
     pub fn new(state: SharedSnsState, delivery: Arc<DeliveryBus>) -> Self {
-        Self { state, delivery }
+        Self {
+            state,
+            delivery,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes,
+    /// with serde + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = SnsSnapshot {
+            schema_version: SNS_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write sns snapshot"),
+            Err(err) => tracing::error!(%err, "sns snapshot task panicked"),
+        }
     }
 }
 
-use std::sync::Arc;
+/// Actions that mutate SNS state.
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "CreateTopic"
+            | "DeleteTopic"
+            | "SetTopicAttributes"
+            | "Subscribe"
+            | "ConfirmSubscription"
+            | "Unsubscribe"
+            | "Publish"
+            | "PublishBatch"
+            | "SetSubscriptionAttributes"
+            | "TagResource"
+            | "UntagResource"
+            | "AddPermission"
+            | "RemovePermission"
+            | "CreatePlatformApplication"
+            | "DeletePlatformApplication"
+            | "SetPlatformApplicationAttributes"
+            | "CreatePlatformEndpoint"
+            | "DeleteEndpoint"
+            | "SetEndpointAttributes"
+            | "SetSMSAttributes"
+            | "OptInPhoneNumber"
+    )
+}
 
 const DEFAULT_PAGE_SIZE: usize = 100;
 
@@ -84,7 +150,8 @@ impl AwsService for SnsService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateTopic" => self.create_topic(&req),
             "DeleteTopic" => self.delete_topic(&req),
             "ListTopics" => self.list_topics(&req),
@@ -124,7 +191,11 @@ impl AwsService for SnsService {
             "ListPhoneNumbersOptedOut" => self.list_phone_numbers_opted_out(&req),
             "OptInPhoneNumber" => self.opt_in_phone_number(&req),
             _ => Err(AwsServiceError::action_not_implemented("sns", &req.action)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-sns/src/state.rs
+++ b/crates/fakecloud-sns/src/state.rs
@@ -3,7 +3,7 @@ use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SnsTopic {
     pub topic_arn: String,
     pub name: String,
@@ -13,7 +13,7 @@ pub struct SnsTopic {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SnsSubscription {
     pub subscription_arn: String,
     pub topic_arn: String,
@@ -27,14 +27,14 @@ pub struct SnsSubscription {
 }
 
 /// An SNS message attribute (key-value with a data type).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MessageAttribute {
     pub data_type: String,
     pub string_value: Option<String>,
     pub binary_value: Option<Vec<u8>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PublishedMessage {
     pub message_id: String,
     pub topic_arn: String,
@@ -46,7 +46,7 @@ pub struct PublishedMessage {
     pub timestamp: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PlatformApplication {
     pub arn: String,
     pub name: String,
@@ -55,7 +55,7 @@ pub struct PlatformApplication {
     pub endpoints: HashMap<String, PlatformEndpoint>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PlatformEndpoint {
     pub arn: String,
     pub token: String,
@@ -65,7 +65,7 @@ pub struct PlatformEndpoint {
 }
 
 /// A recorded Lambda invocation from SNS delivery.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LambdaInvocation {
     pub function_arn: String,
     pub message: String,
@@ -74,7 +74,7 @@ pub struct LambdaInvocation {
 }
 
 /// A recorded email delivery from SNS (stub).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SentEmail {
     pub email_address: String,
     pub message: String,
@@ -83,6 +83,7 @@ pub struct SentEmail {
     pub timestamp: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SnsState {
     pub account_id: String,
     pub region: String,
@@ -140,3 +141,13 @@ impl SnsState {
 }
 
 pub type SharedSnsState = Arc<RwLock<SnsState>>;
+
+/// On-disk snapshot envelope for SNS state. Versioned so format
+/// changes fail loudly on upgrade.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SnsSnapshot {
+    pub schema_version: u32,
+    pub state: SnsState,
+}
+
+pub const SNS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;


### PR DESCRIPTION
## Summary

Fourth and final batch of the persistence push (after DynamoDB #404/#411, SQS #409, IAM+STS #412). SNS topics, subscriptions + attributes, tags, platform applications, endpoints, SMS attributes, and opt-out lists now survive restarts.

Same pattern as prior batches: serde + versioned envelope + central mutation gate + async Mutex + spawn_blocking.

## Test plan

- [x] \`cargo test -p fakecloud-e2e --test sns_persistence\` — 3 tests (standard topic + tags + subscription, FIFO, delete durability) pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\`
- [ ] CI green
- [ ] Cubic satisfied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in disk persistence for SNS so topics, subscriptions, attributes, tags, platform apps/endpoints, SMS attributes, and opt-out lists survive restarts when using persistent storage mode.

- **New Features**
  - Persist SNS snapshots to `<data-path>/sns/snapshot.json` via versioned `SnsSnapshot` (guarded by `SNS_SNAPSHOT_SCHEMA_VERSION`).
  - Load snapshot on boot; fail fast on schema mismatch; start empty if none.
  - Save after each successful mutating action; I/O runs in `spawn_blocking` and is serialized with an async mutex; memory mode has no overhead.

- **Migration**
  - To enable, run the server with `--storage-mode=persistent` and set `--data-path`.
  - No changes needed for memory mode; existing snapshots are auto-loaded.

<sup>Written for commit 8c68d4a187980326e688def362d3eb82cb3a732a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

