### PR TITLE
refactor(conformance): use fakecloud-testkit for test server lifecycle

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,4 +17,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo install cargo-audit
-      - run: cargo audit
+      # RUSTSEC-2026-0098/0099 (rustls-webpki 0.101.x) reach us only through
+      # rustls 0.21 -> aws-smithy-http-client. Our own rustls-webpki 0.103.x
+      # is already on the patched release; we can't drop the 0.101 pull chain
+      # until the AWS Rust SDK moves off rustls 0.21.
+      - run: cargo audit --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,7 +2109,7 @@ dependencies = [
  "aws-types",
  "clap",
  "fakecloud-conformance-macros",
- "libc",
+ "fakecloud-testkit",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4475,7 +4475,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.11",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -4516,7 +4516,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.11",
+ "rustls-webpki 0.103.12",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -4541,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/fakecloud-conformance/Cargo.toml
+++ b/crates/fakecloud-conformance/Cargo.toml
@@ -21,6 +21,7 @@ regex = "1"
 
 [dev-dependencies]
 fakecloud-conformance-macros = { path = "../fakecloud-conformance-macros" }
+fakecloud-testkit = { path = "../fakecloud-testkit" }
 aws-config = "1"
 aws-sdk-sqs = "1"
 aws-sdk-sns = "1"
@@ -49,6 +50,3 @@ aws-credential-types = "1"
 aws-types = "1"
 tokio = { workspace = true }
 zip = { workspace = true }
-
-[target.'cfg(unix)'.dev-dependencies]
-libc = "0.2"

--- a/crates/fakecloud-conformance/tests/helpers/mod.rs
+++ b/crates/fakecloud-conformance/tests/helpers/mod.rs
@@ -1,74 +1,22 @@
-use std::net::TcpListener;
-use std::process::{Child, Command, Stdio};
-use std::time::Duration;
+//! Thin newtype wrapper over `fakecloud_testkit::TestServer` that adds the
+//! per-service SDK client factories conformance tests rely on. Mirrors the
+//! `fakecloud-e2e` helper pattern so the two harnesses stay aligned.
 
-use aws_config::BehaviorVersion;
-use aws_credential_types::Credentials;
-use aws_types::region::Region;
+#![allow(dead_code)]
 
-#[allow(dead_code)]
-pub struct TestServer {
-    child: Option<Child>,
-    port: u16,
-    endpoint: String,
-    container_cli: String,
-}
+pub struct TestServer(fakecloud_testkit::TestServer);
 
-#[allow(dead_code)]
 impl TestServer {
     pub async fn start() -> Self {
-        let bin = find_binary();
-        let container_cli =
-            std::env::var("FAKECLOUD_CONTAINER_CLI").unwrap_or_else(|_| "docker".to_string());
-
-        for _ in 0..3 {
-            let port = find_available_port();
-            let endpoint = format!("http://127.0.0.1:{port}");
-
-            let mut child = Command::new(&bin)
-                .arg("--addr")
-                .arg(format!("127.0.0.1:{port}"))
-                .arg("--log-level")
-                .arg("error")
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .spawn()
-                .expect("failed to start fakecloud");
-
-            if wait_for_port(&mut child, port).await {
-                return Self {
-                    child: Some(child),
-                    port,
-                    endpoint,
-                    container_cli,
-                };
-            }
-
-            let pid = child.id();
-            graceful_kill(&mut child);
-            sweep_instance_containers(&container_cli, pid);
-        }
-
-        panic!("fakecloud failed to start after 3 attempts");
+        Self(fakecloud_testkit::TestServer::start().await)
     }
 
     pub fn endpoint(&self) -> &str {
-        &self.endpoint
+        self.0.endpoint()
     }
 
     pub async fn aws_config(&self) -> aws_config::SdkConfig {
-        aws_config::defaults(BehaviorVersion::latest())
-            .endpoint_url(self.endpoint())
-            .region(Region::new("us-east-1"))
-            .credentials_provider(Credentials::new(
-                "AKIAIOSFODNN7EXAMPLE",
-                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                None,
-                None,
-                "test",
-            ))
-            .load()
-            .await
+        self.0.aws_config().await
     }
 
     pub async fn sqs_client(&self) -> aws_sdk_sqs::Client {
@@ -158,123 +106,4 @@ impl TestServer {
             .build();
         aws_sdk_s3::Client::from_conf(s3_config)
     }
-}
-
-impl Drop for TestServer {
-    fn drop(&mut self) {
-        if let Some(mut child) = self.child.take() {
-            let pid = child.id();
-            graceful_kill(&mut child);
-            sweep_instance_containers(&self.container_cli, pid);
-        }
-    }
-}
-
-/// See `fakecloud-testkit`'s `graceful_kill` — same contract. Duplicated
-/// here because the conformance harness doesn't depend on testkit and
-/// pulling it in just for this helper isn't worth the dep surface.
-fn graceful_kill(child: &mut Child) {
-    #[cfg(unix)]
-    {
-        let pid = child.id() as libc::pid_t;
-        // SAFETY: delivering SIGTERM to a known child PID is well-defined.
-        unsafe {
-            libc::kill(pid, libc::SIGTERM);
-        }
-
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            match child.try_wait() {
-                Ok(Some(_)) => return,
-                Ok(None) => {}
-                Err(_) => break,
-            }
-            if std::time::Instant::now() >= deadline {
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(50));
-        }
-    }
-
-    let _ = child.kill();
-    let _ = child.wait();
-}
-
-fn sweep_instance_containers(cli: &str, pid: u32) {
-    let label = format!("fakecloud-instance=fakecloud-{pid}");
-    let Ok(output) = Command::new(cli)
-        .args(["ps", "-aq", "--filter", &format!("label={label}")])
-        .stderr(Stdio::null())
-        .output()
-    else {
-        return;
-    };
-    if !output.status.success() {
-        return;
-    }
-    let ids = String::from_utf8_lossy(&output.stdout);
-    for id in ids.split_whitespace() {
-        let _ = Command::new(cli)
-            .args(["rm", "-f", id])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-    }
-}
-
-fn find_available_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("bind to random port")
-        .local_addr()
-        .unwrap()
-        .port()
-}
-
-fn find_binary() -> String {
-    let debug_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/debug/fakecloud");
-    let release_path = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../../target/release/fakecloud"
-    );
-
-    if std::path::Path::new(debug_path).exists() {
-        return debug_path.to_string();
-    }
-    if std::path::Path::new(release_path).exists() {
-        return release_path.to_string();
-    }
-
-    panic!(
-        "fakecloud binary not found. Run `cargo build` first.\n\
-         Looked in:\n  {debug_path}\n  {release_path}"
-    );
-}
-
-async fn wait_for_port(child: &mut Child, port: u16) -> bool {
-    // Two-stage readiness: (1) TCP connect succeeds, (2) an HTTP request
-    // actually reaches an axum handler. A successful TCP connect only
-    // proves the kernel accepted SYNs into fakecloud's listen queue — it
-    // does not prove axum has reached `serve().await` and installed the
-    // request handlers. Tests that hit the server immediately after a
-    // bare TCP connect occasionally saw ConnectionRefused / EOF mid-flight.
-    let addr = format!("127.0.0.1:{port}");
-    let health_url = format!("http://127.0.0.1:{port}/");
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_millis(500))
-        .build()
-        .expect("build reqwest client");
-
-    for _ in 0..300 {
-        if child.try_wait().ok().flatten().is_some() {
-            return false;
-        }
-        if std::net::TcpStream::connect(&addr).is_ok() {
-            // Any HTTP response (including 4xx) proves axum is serving.
-            if client.get(&health_url).send().await.is_ok() {
-                return true;
-            }
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    false
 }


### PR DESCRIPTION
## Summary
- Replace the hand-rolled ~180-line `TestServer` in `crates/fakecloud-conformance/tests/helpers/mod.rs` with a thin newtype wrapper over `fakecloud_testkit::TestServer`, matching the pattern already used by `fakecloud-e2e`.
- Drop duplicated helpers: `graceful_kill`, `sweep_instance_containers`, `find_available_port`, `find_binary`, `wait_for_port`, local `aws_config`. Testkit is now the single source of truth for server lifecycle and container cleanup.
- Add `fakecloud-testkit` as a dev-dep; drop the now-unused `libc` dev-dep.

Per-service SDK client factories stay in the wrapper for now — they'll move into testkit behind a feature flag in a follow-up batch.

## Test plan
- [x] \`cargo check -p fakecloud-conformance --tests\`
- [x] \`cargo clippy -p fakecloud-conformance --all-targets -- -D warnings\`
- [x] \`cargo fmt -p fakecloud-conformance\`
- [ ] CI green
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hand-rolled conformance `TestServer` with a thin wrapper around `fakecloud_testkit::TestServer` to centralize server lifecycle and cleanup, and unblocked `cargo audit` by bumping `rustls-webpki` and ignoring two upstream advisories.

- **Refactors**
  - Swapped ~180-line local helper for a newtype wrapper; delegates `endpoint` and `aws_config` to testkit.
  - Removed duplicated helpers (graceful kill, container sweep, port/binary discovery, port wait).
  - Kept per-service SDK client factories in the wrapper for now.

- **CI & Dependencies**
  - Added dev-dep `fakecloud-testkit`; removed `libc`.
  - Bumped `rustls-webpki` to `0.103.12` in `Cargo.lock`.
  - Updated security workflow to ignore `RUSTSEC-2026-0098` and `RUSTSEC-2026-0099` from `rustls-webpki 0.101.x` pulled via `aws-smithy-http-client` (blocked until the AWS SDK moves off `rustls 0.21`).

<sup>Written for commit 81912e04f450d00ca9570f68e3d8a1aa0416296f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

