### PR TITLE
feat(secretsmanager): opt-in disk persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,6 +2456,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "serde",

--- a/crates/fakecloud-e2e/tests/secretsmanager_persistence.rs
+++ b/crates/fakecloud-e2e/tests/secretsmanager_persistence.rs
@@ -1,0 +1,155 @@
+mod helpers;
+
+use aws_sdk_secretsmanager::primitives::Blob;
+use helpers::TestServer;
+
+/// Secret metadata, tags, description, and current version payload
+/// survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_secret_with_versions_and_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let sm = server.secretsmanager_client().await;
+
+    sm.create_secret()
+        .name("db/prod")
+        .description("prod db credentials")
+        .secret_string("v1-secret")
+        .tags(
+            aws_sdk_secretsmanager::types::Tag::builder()
+                .key("env")
+                .value("prod")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Write a second version.
+    sm.put_secret_value()
+        .secret_id("db/prod")
+        .secret_string("v2-secret")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let sm = server.secretsmanager_client().await;
+
+    // Current version is v2-secret.
+    let got = sm
+        .get_secret_value()
+        .secret_id("db/prod")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.secret_string(), Some("v2-secret"));
+
+    // Description survives.
+    let desc = sm
+        .describe_secret()
+        .secret_id("db/prod")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desc.description(), Some("prod db credentials"));
+    let tags: Vec<(String, String)> = desc
+        .tags()
+        .iter()
+        .map(|t| {
+            (
+                t.key().unwrap_or_default().to_string(),
+                t.value().unwrap_or_default().to_string(),
+            )
+        })
+        .collect();
+    assert!(tags.iter().any(|(k, v)| k == "env" && v == "prod"));
+
+    // Both version ids are still listed.
+    let versions = sm
+        .list_secret_version_ids()
+        .secret_id("db/prod")
+        .include_deprecated(true)
+        .send()
+        .await
+        .unwrap();
+    assert!(versions.versions().len() >= 2);
+}
+
+/// Binary secret payload survives a restart.
+#[tokio::test]
+async fn persistence_round_trip_binary_secret() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let sm = server.secretsmanager_client().await;
+
+    let bytes = b"\x00\x01\x02hello-binary\xff".to_vec();
+    sm.create_secret()
+        .name("blob")
+        .secret_binary(Blob::new(bytes.clone()))
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let sm = server.secretsmanager_client().await;
+
+    let got = sm
+        .get_secret_value()
+        .secret_id("blob")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.secret_binary().unwrap().as_ref(), bytes.as_slice());
+}
+
+/// DeleteSecret + RestoreSecret durability.
+#[tokio::test]
+async fn persistence_delete_and_restore_survive_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let sm = server.secretsmanager_client().await;
+
+    sm.create_secret()
+        .name("soft-delete")
+        .secret_string("payload")
+        .send()
+        .await
+        .unwrap();
+    sm.delete_secret()
+        .secret_id("soft-delete")
+        .recovery_window_in_days(7)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let sm = server.secretsmanager_client().await;
+
+    // Described secret should still show as scheduled for deletion.
+    let desc = sm
+        .describe_secret()
+        .secret_id("soft-delete")
+        .send()
+        .await
+        .unwrap();
+    assert!(desc.deleted_date().is_some());
+
+    // Restore and then verify value still there.
+    sm.restore_secret()
+        .secret_id("soft-delete")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let sm = server.secretsmanager_client().await;
+
+    let got = sm
+        .get_secret_value()
+        .secret_id("soft-delete")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.secret_string(), Some("payload"));
+}

--- a/crates/fakecloud-secretsmanager/Cargo.toml
+++ b/crates/fakecloud-secretsmanager/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -6,11 +6,17 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use tokio::sync::Mutex as AsyncMutex;
+
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
+use fakecloud_persistence::SnapshotStore;
 
-use crate::state::{RotationRules, Secret, SecretVersion, SharedSecretsManagerState};
+use crate::state::{
+    RotationRules, Secret, SecretVersion, SecretsManagerSnapshot, SharedSecretsManagerState,
+    SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
+};
 
 /// Information needed to invoke the rotation Lambda after releasing state lock.
 struct RotationInvocation {
@@ -53,9 +59,33 @@ fn check_secret_version_idempotency(
     }
 }
 
+/// Actions that mutate Secrets Manager state.
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "CreateSecret"
+            | "PutSecretValue"
+            | "UpdateSecret"
+            | "DeleteSecret"
+            | "RestoreSecret"
+            | "TagResource"
+            | "UntagResource"
+            | "RotateSecret"
+            | "CancelRotateSecret"
+            | "UpdateSecretVersionStage"
+            | "PutResourcePolicy"
+            | "DeleteResourcePolicy"
+            | "ReplicateSecretToRegions"
+            | "RemoveRegionsFromReplication"
+            | "StopReplicationToReplica"
+    )
+}
+
 pub struct SecretsManagerService {
     state: SharedSecretsManagerState,
     delivery_bus: Option<Arc<DeliveryBus>>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl SecretsManagerService {
@@ -63,12 +93,44 @@ impl SecretsManagerService {
         Self {
             state,
             delivery_bus: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
     pub fn with_delivery(mut self, delivery_bus: Arc<DeliveryBus>) -> Self {
         self.delivery_bus = Some(delivery_bus);
         self
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes,
+    /// with serde + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = SecretsManagerSnapshot {
+            schema_version: SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write secretsmanager snapshot"),
+            Err(err) => tracing::error!(%err, "secretsmanager snapshot task panicked"),
+        }
     }
 
     fn create_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -2007,7 +2069,8 @@ impl AwsService for SecretsManagerService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateSecret" => self.create_secret(&req),
             "GetSecretValue" => self.get_secret_value(&req),
             "PutSecretValue" => self.put_secret_value(&req),
@@ -2074,7 +2137,11 @@ impl AwsService for SecretsManagerService {
                 "secretsmanager",
                 &req.action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-secretsmanager/src/state.rs
+++ b/crates/fakecloud-secretsmanager/src/state.rs
@@ -3,7 +3,7 @@ use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Secret {
     pub name: String,
     pub arn: String,
@@ -25,12 +25,12 @@ pub struct Secret {
     pub resource_policy: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RotationRules {
     pub automatically_after_days: Option<i64>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SecretVersion {
     pub version_id: String,
     pub secret_string: Option<String>,
@@ -39,6 +39,7 @@ pub struct SecretVersion {
     pub created_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SecretsManagerState {
     pub account_id: String,
     pub region: String,
@@ -60,3 +61,13 @@ impl SecretsManagerState {
 }
 
 pub type SharedSecretsManagerState = Arc<RwLock<SecretsManagerState>>;
+
+/// On-disk snapshot envelope for Secrets Manager state. Versioned so
+/// format changes fail loudly on upgrade.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SecretsManagerSnapshot {
+    pub schema_version: u32,
+    pub state: SecretsManagerState,
+}
+
+pub const SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION: u32 = 1;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -387,7 +387,6 @@ async fn main() {
             "events",
             "ssm",
             "lambda",
-            "secretsmanager",
             "logs",
             "kms",
             "ses",
@@ -617,9 +616,60 @@ async fn main() {
         Arc::new(bus)
     };
     let delivery_for_rotation_scheduler = delivery_for_secretsmanager.clone();
-    registry.register(Arc::new(
-        SecretsManagerService::new(secretsmanager_state).with_delivery(delivery_for_secretsmanager),
-    ));
+    let secretsmanager_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("secretsmanager").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<
+                        fakecloud_secretsmanager::state::SecretsManagerSnapshot,
+                    >(&bytes)
+                    {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_secretsmanager::state::SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "secretsmanager persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_secretsmanager::state::SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let secret_count = snapshot.state.secrets.len();
+                            *secretsmanager_state.write() = snapshot.state;
+                            tracing::info!(
+                                secrets = secret_count,
+                                "loaded secretsmanager persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse secretsmanager persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no secretsmanager persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read secretsmanager persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut secretsmanager_service =
+        SecretsManagerService::new(secretsmanager_state).with_delivery(delivery_for_secretsmanager);
+    if let Some(store) = secretsmanager_snapshot_store {
+        secretsmanager_service = secretsmanager_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(secretsmanager_service));
     registry.register(Arc::new(LogsService::new(logs_state, delivery_for_logs)));
     registry.register(Arc::new(KmsService::new(kms_state.clone())));
     let mut shared_body_cache: Option<Arc<fakecloud_persistence::cache::BodyCache>> = None;


### PR DESCRIPTION
## Summary
- Apply the SnapshotStore pattern (SNS/SQS/IAM/DynamoDB) to Secrets Manager: versioned envelope, async Mutex-serialized clone+serialize+write, spawn_blocking offload, store wired only in persistent mode, save gated on HTTP 2xx.
- Secrets (including multiple versions, stages, tags, description, rotation config, resource policies) and soft-delete state survive restart.
- Removes `secretsmanager` from the warn_unsupported list.

## Test plan
- [x] cargo build -p fakecloud-secretsmanager -p fakecloud
- [x] cargo clippy --all-targets -- -D warnings (touched crates + e2e)
- [x] cargo test -p fakecloud-e2e --test secretsmanager_persistence (3/3 green)
- [ ] CI green
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in disk persistence for Secrets Manager using a versioned snapshot. Secrets, versions, tags, policies, rotation settings, and soft-delete now survive restarts when persistent mode is enabled.

- **New Features**
  - Persist `fakecloud-secretsmanager` state to disk (schema_version=1) when persistent mode is enabled.
  - Save only after successful mutating actions; clone/serialize/write is serialized via async mutex and offloaded with spawn_blocking.
  - Load snapshot at `fakecloud-server` startup; schema mismatch exits with a clear error.
  - Removed `secretsmanager` from the warn_unsupported list.
  - E2E restart tests cover versions/tags/description, binary payloads, and delete/restore.
  - Dependencies: add `fakecloud-persistence`.

- **Migration**
  - Enable persistent mode and set data_path; snapshot at `<data_path>/secretsmanager/snapshot.json`.
  - Ephemeral mode is unchanged.
  - On schema mismatch, startup fails; delete the snapshot to reset.

<sup>Written for commit 1347de4492f35189d8400d14fd3092c42bd153f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

