### PR TITLE
feat(kms): opt-in disk persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,12 +2300,15 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/fakecloud-e2e/tests/kms_persistence.rs
+++ b/crates/fakecloud-e2e/tests/kms_persistence.rs
@@ -1,0 +1,171 @@
+mod helpers;
+
+use aws_sdk_kms::primitives::Blob;
+use helpers::TestServer;
+
+/// Key metadata, alias, tags, enabled state, and a round-trippable
+/// ciphertext all survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_key_alias_and_ciphertext() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let kms = server.kms_client().await;
+
+    let created = kms
+        .create_key()
+        .description("app signing key")
+        .send()
+        .await
+        .unwrap();
+    let key_id = created.key_metadata().unwrap().key_id().to_string();
+    let key_arn = created.key_metadata().unwrap().arn().unwrap().to_string();
+
+    kms.create_alias()
+        .alias_name("alias/app-signing")
+        .target_key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+
+    kms.tag_resource()
+        .key_id(&key_id)
+        .tags(
+            aws_sdk_kms::types::Tag::builder()
+                .tag_key("env")
+                .tag_value("prod")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Encrypt something while server is up; we'll try to decrypt after restart.
+    let plaintext = b"top-secret-payload".to_vec();
+    let enc = kms
+        .encrypt()
+        .key_id(&key_id)
+        .plaintext(Blob::new(plaintext.clone()))
+        .send()
+        .await
+        .unwrap();
+    let ciphertext = enc.ciphertext_blob().unwrap().as_ref().to_vec();
+
+    server.restart().await;
+    let kms = server.kms_client().await;
+
+    // Key survives with its ARN.
+    let desc = kms.describe_key().key_id(&key_id).send().await.unwrap();
+    let meta = desc.key_metadata().unwrap();
+    assert_eq!(meta.arn(), Some(key_arn.as_str()));
+    assert_eq!(meta.description(), Some("app signing key"));
+    assert!(meta.enabled());
+
+    // Alias survives and still resolves to the same key.
+    let aliases = kms.list_aliases().send().await.unwrap();
+    let found = aliases
+        .aliases()
+        .iter()
+        .find(|a| a.alias_name() == Some("alias/app-signing"));
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().target_key_id(), Some(key_id.as_str()));
+
+    // Tag survives.
+    let tags = kms
+        .list_resource_tags()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags
+        .tags()
+        .iter()
+        .any(|t| t.tag_key() == "env" && t.tag_value() == "prod"));
+
+    // Ciphertext from before restart still decrypts.
+    let dec = kms
+        .decrypt()
+        .ciphertext_blob(Blob::new(ciphertext))
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dec.plaintext().unwrap().as_ref(), plaintext.as_slice());
+}
+
+/// DisableKey / ScheduleKeyDeletion state is durable across a restart.
+#[tokio::test]
+async fn persistence_disabled_and_scheduled_deletion_survive_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let kms = server.kms_client().await;
+
+    let key_id = kms
+        .create_key()
+        .send()
+        .await
+        .unwrap()
+        .key_metadata()
+        .unwrap()
+        .key_id()
+        .to_string();
+    kms.disable_key().key_id(&key_id).send().await.unwrap();
+    kms.schedule_key_deletion()
+        .key_id(&key_id)
+        .pending_window_in_days(7)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let kms = server.kms_client().await;
+
+    let meta = kms
+        .describe_key()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap()
+        .key_metadata
+        .unwrap();
+    assert!(!meta.enabled());
+    assert!(meta.deletion_date().is_some());
+    assert_eq!(
+        meta.key_state(),
+        Some(&aws_sdk_kms::types::KeyState::PendingDeletion)
+    );
+}
+
+/// Key rotation toggled on persists after restart.
+#[tokio::test]
+async fn persistence_key_rotation_enabled_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let kms = server.kms_client().await;
+
+    let key_id = kms
+        .create_key()
+        .send()
+        .await
+        .unwrap()
+        .key_metadata()
+        .unwrap()
+        .key_id()
+        .to_string();
+    kms.enable_key_rotation()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let kms = server.kms_client().await;
+
+    let status = kms
+        .get_key_rotation_status()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(status.key_rotation_enabled());
+}

--- a/crates/fakecloud-kms/Cargo.toml
+++ b/crates/fakecloud-kms/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
@@ -19,4 +20,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -1,18 +1,22 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use base64::Engine;
 use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    CustomKeyStore, KeyRotation, KmsAlias, KmsGrant, KmsKey, KmsState, SharedKmsState,
+    CustomKeyStore, KeyRotation, KmsAlias, KmsGrant, KmsKey, KmsSnapshot, KmsState, SharedKmsState,
+    KMS_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const FAKE_ENVELOPE_PREFIX: &str = "fakecloud-kms:";
@@ -136,13 +140,83 @@ const VALID_SIGNING_ALGORITHMS: &[&str] = &[
     "ECDSA_SHA_512",
 ];
 
+/// Actions that mutate KMS state.
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "CreateKey"
+            | "EnableKey"
+            | "DisableKey"
+            | "ScheduleKeyDeletion"
+            | "CancelKeyDeletion"
+            | "CreateAlias"
+            | "DeleteAlias"
+            | "UpdateAlias"
+            | "TagResource"
+            | "UntagResource"
+            | "UpdateKeyDescription"
+            | "PutKeyPolicy"
+            | "EnableKeyRotation"
+            | "DisableKeyRotation"
+            | "RotateKeyOnDemand"
+            | "CreateGrant"
+            | "RevokeGrant"
+            | "RetireGrant"
+            | "ReplicateKey"
+            | "ImportKeyMaterial"
+            | "DeleteImportedKeyMaterial"
+            | "UpdatePrimaryRegion"
+            | "CreateCustomKeyStore"
+            | "DeleteCustomKeyStore"
+            | "ConnectCustomKeyStore"
+            | "DisconnectCustomKeyStore"
+            | "UpdateCustomKeyStore"
+    )
+}
+
 pub struct KmsService {
     state: SharedKmsState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl KmsService {
     pub fn new(state: SharedKmsState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes,
+    /// with serde + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = KmsSnapshot {
+            schema_version: KMS_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write kms snapshot"),
+            Err(err) => tracing::error!(%err, "kms snapshot task panicked"),
+        }
     }
 }
 
@@ -153,7 +227,8 @@ impl AwsService for KmsService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateKey" => self.create_key(&req),
             "DescribeKey" => self.describe_key(&req),
             "ListKeys" => self.list_keys(&req),
@@ -210,7 +285,11 @@ impl AwsService for KmsService {
             "DisconnectCustomKeyStore" => self.disconnect_custom_key_store(&req),
             "UpdateCustomKeyStore" => self.update_custom_key_store(&req),
             _ => Err(AwsServiceError::action_not_implemented("kms", &req.action)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-kms/src/state.rs
+++ b/crates/fakecloud-kms/src/state.rs
@@ -5,6 +5,7 @@ use parking_lot::RwLock;
 
 pub type SharedKmsState = Arc<RwLock<KmsState>>;
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct KmsState {
     pub account_id: String,
     pub region: String,
@@ -34,7 +35,7 @@ impl KmsState {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct KmsKey {
     pub key_id: String,
     pub arn: String,
@@ -64,6 +65,7 @@ pub struct KmsKey {
     pub primary_region: Option<String>,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct KmsAlias {
     pub alias_name: String,
     pub alias_arn: String,
@@ -71,6 +73,7 @@ pub struct KmsAlias {
     pub creation_date: f64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct KmsGrant {
     pub grant_id: String,
     pub grant_token: String,
@@ -83,13 +86,14 @@ pub struct KmsGrant {
     pub creation_date: f64,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct KeyRotation {
     pub key_id: String,
     pub rotation_date: f64,
     pub rotation_type: String,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct CustomKeyStore {
     pub custom_key_store_id: String,
     pub custom_key_store_name: String,
@@ -103,3 +107,13 @@ pub struct CustomKeyStore {
     pub xks_proxy_vpc_endpoint_service_name: Option<String>,
     pub xks_proxy_connectivity: Option<String>,
 }
+
+/// On-disk snapshot envelope for KMS state. Versioned so format
+/// changes fail loudly on upgrade.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct KmsSnapshot {
+    pub schema_version: u32,
+    pub state: KmsState,
+}
+
+pub const KMS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -389,7 +389,6 @@ async fn main() {
             "lambda",
             "secretsmanager",
             "logs",
-            "kms",
             "ses",
             "cognito-idp",
             "kinesis",
@@ -621,7 +620,53 @@ async fn main() {
         SecretsManagerService::new(secretsmanager_state).with_delivery(delivery_for_secretsmanager),
     ));
     registry.register(Arc::new(LogsService::new(logs_state, delivery_for_logs)));
-    registry.register(Arc::new(KmsService::new(kms_state.clone())));
+    let kms_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("kms").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_kms::state::KmsSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_kms::state::KMS_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "kms persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_kms::state::KMS_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let key_count = snapshot.state.keys.len();
+                            *kms_state.write() = snapshot.state;
+                            tracing::info!(keys = key_count, "loaded kms persistence snapshot",);
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse kms persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no kms persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read kms persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut kms_service = KmsService::new(kms_state.clone());
+    if let Some(store) = kms_snapshot_store {
+        kms_service = kms_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(kms_service));
     let mut shared_body_cache: Option<Arc<fakecloud_persistence::cache::BodyCache>> = None;
     let s3_store: Arc<dyn fakecloud_persistence::S3Store> = match persistence_config.mode {
         fakecloud_persistence::StorageMode::Persistent => {


### PR DESCRIPTION
## Summary
- Apply the SnapshotStore pattern (SNS/SQS/IAM/DynamoDB) to KMS: versioned envelope, async Mutex-serialized clone+serialize+write, spawn_blocking offload, store wired only in persistent mode, save gated on HTTP 2xx.
- Keys (including imported key material, rotation state, grants, aliases, tags, policy, custom key stores) and pre-restart ciphertext round-trip all survive restart.
- Removes \`kms\` from the warn_unsupported list.

## Test plan
- [x] cargo build -p fakecloud-kms -p fakecloud
- [x] cargo clippy --all-targets -- -D warnings (touched crates)
- [x] cargo test -p fakecloud-e2e --test kms_persistence (3/3 green)
- [ ] CI green
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in disk persistence for `fakecloud-kms` so keys, aliases, tags, policies, grants, rotation state, custom key stores, and pre-restart ciphertext survive restarts; also removes `kms` from the warn_unsupported list. Persistence is opt-in; in persistent mode the server loads a snapshot at startup and fails on schema mismatch.

- **New Features**
  - Versioned `KmsSnapshot` saved to `data_path/kms/snapshot.json` via `fakecloud-persistence`.
  - Saves only after successful mutating actions (HTTP 2xx); writes are serialized with an async mutex and offloaded via `spawn_blocking`.
  - E2E restart tests for key/alias/tag + ciphertext, disabled/scheduled-deletion, and rotation-enabled durability.

<sup>Written for commit a58091c34547063a8bc2abbc5b80a5cbf89bc7d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

