### PR TITLE
feat(ssm): opt-in disk persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,6 +2537,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "fakecloud-secretsmanager",
  "http 1.4.0",
  "md5",
@@ -2546,6 +2547,8 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.9",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/fakecloud-e2e/tests/ssm_persistence.rs
+++ b/crates/fakecloud-e2e/tests/ssm_persistence.rs
@@ -1,0 +1,154 @@
+mod helpers;
+
+use aws_sdk_ssm::types::{DocumentFormat, DocumentType, ParameterType};
+use helpers::TestServer;
+
+/// Parameter (with tags, description, version history) survives restart.
+#[tokio::test]
+async fn persistence_round_trip_parameter_with_history_and_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let ssm = server.ssm_client().await;
+
+    ssm.put_parameter()
+        .name("/app/db/url")
+        .value("postgres://v1")
+        .r#type(ParameterType::String)
+        .description("app db url")
+        .send()
+        .await
+        .unwrap();
+
+    ssm.add_tags_to_resource()
+        .resource_type("Parameter".into())
+        .resource_id("/app/db/url")
+        .tags(
+            aws_sdk_ssm::types::Tag::builder()
+                .key("env")
+                .value("prod")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // New version.
+    ssm.put_parameter()
+        .name("/app/db/url")
+        .value("postgres://v2")
+        .r#type(ParameterType::String)
+        .overwrite(true)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let ssm = server.ssm_client().await;
+
+    let got = ssm
+        .get_parameter()
+        .name("/app/db/url")
+        .send()
+        .await
+        .unwrap();
+    let p = got.parameter().unwrap();
+    assert_eq!(p.value(), Some("postgres://v2"));
+    assert_eq!(p.version(), 2);
+
+    let history = ssm
+        .get_parameter_history()
+        .name("/app/db/url")
+        .send()
+        .await
+        .unwrap();
+    assert!(history.parameters().len() >= 2);
+
+    let tags = ssm
+        .list_tags_for_resource()
+        .resource_type("Parameter".into())
+        .resource_id("/app/db/url")
+        .send()
+        .await
+        .unwrap();
+    assert!(tags
+        .tag_list()
+        .iter()
+        .any(|t| t.key() == "env" && t.value() == "prod"));
+}
+
+/// SecureString parameter and DeleteParameter survive restart.
+#[tokio::test]
+async fn persistence_secure_string_and_delete_survive_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let ssm = server.ssm_client().await;
+
+    ssm.put_parameter()
+        .name("/secret/token")
+        .value("s3cret")
+        .r#type(ParameterType::SecureString)
+        .send()
+        .await
+        .unwrap();
+    ssm.put_parameter()
+        .name("/will/be/deleted")
+        .value("ephemeral")
+        .r#type(ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+    ssm.delete_parameter()
+        .name("/will/be/deleted")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let ssm = server.ssm_client().await;
+
+    let got = ssm
+        .get_parameter()
+        .name("/secret/token")
+        .with_decryption(true)
+        .send()
+        .await
+        .unwrap();
+    let p = got.parameter().unwrap();
+    assert_eq!(p.value(), Some("s3cret"));
+    assert_eq!(p.r#type(), Some(&ParameterType::SecureString));
+
+    // Deleted parameter stays deleted.
+    let err = ssm
+        .get_parameter()
+        .name("/will/be/deleted")
+        .send()
+        .await
+        .err();
+    assert!(err.is_some());
+}
+
+/// Custom SSM document survives restart.
+#[tokio::test]
+async fn persistence_document_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let ssm = server.ssm_client().await;
+
+    let content = r#"{"schemaVersion":"2.2","description":"noop","mainSteps":[]}"#;
+    ssm.create_document()
+        .name("NoopDoc")
+        .content(content)
+        .document_type(DocumentType::Command)
+        .document_format(DocumentFormat::Json)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let ssm = server.ssm_client().await;
+
+    let got = ssm.get_document().name("NoopDoc").send().await.unwrap();
+    assert_eq!(got.name(), Some("NoopDoc"));
+    assert_eq!(got.content(), Some(content));
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -385,7 +385,6 @@ async fn main() {
         for service in [
             "cloudformation",
             "events",
-            "ssm",
             "lambda",
             "secretsmanager",
             "logs",
@@ -596,9 +595,57 @@ async fn main() {
     }
     registry.register(Arc::new(iam_service));
     registry.register(Arc::new(sts_service));
-    registry.register(Arc::new(
-        SsmService::new(ssm_state).with_secretsmanager(secretsmanager_state.clone()),
-    ));
+    let ssm_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("ssm").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_ssm::state::SsmSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_ssm::state::SSM_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "ssm persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_ssm::state::SSM_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let param_count = snapshot.state.parameters.len();
+                            *ssm_state.write() = snapshot.state;
+                            tracing::info!(
+                                parameters = param_count,
+                                "loaded ssm persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse ssm persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no ssm persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read ssm persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut ssm_service =
+        SsmService::new(ssm_state).with_secretsmanager(secretsmanager_state.clone());
+    if let Some(store) = ssm_snapshot_store {
+        ssm_service = ssm_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(ssm_service));
     // DynamoDB is registered later, after s3_store is constructed, so the
     // export path can persist result objects through the S3 store.
     let dynamodb_state_for_register = dynamodb_state.clone();

--- a/crates/fakecloud-ssm/Cargo.toml
+++ b/crates/fakecloud-ssm/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 fakecloud-secretsmanager = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
@@ -21,4 +22,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -14,20 +14,114 @@ mod resource_sync;
 mod sessions;
 mod tags;
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use http::StatusCode;
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
-use crate::state::SharedSsmState;
+use crate::state::{SharedSsmState, SsmSnapshot, SSM_SNAPSHOT_SCHEMA_VERSION};
 
 use fakecloud_secretsmanager::state::SharedSecretsManagerState;
 
 const PARAMETER_VERSION_LIMIT: i64 = 100;
 
+/// Actions that do NOT mutate SSM state. Everything else triggers a
+/// snapshot save on HTTP 2xx. Listing non-mutating actions (rather than
+/// mutating ones) is safer here because SSM has ~150 actions and the
+/// read-only set is small and stable.
+fn is_read_only_action(action: &str) -> bool {
+    matches!(
+        action,
+        "GetParameter"
+            | "GetParameters"
+            | "GetParametersByPath"
+            | "DescribeParameters"
+            | "GetParameterHistory"
+            | "ListTagsForResource"
+            | "GetDocument"
+            | "DescribeDocument"
+            | "ListDocuments"
+            | "DescribeDocumentPermission"
+            | "ListCommands"
+            | "GetCommandInvocation"
+            | "ListCommandInvocations"
+            | "DescribeMaintenanceWindows"
+            | "GetMaintenanceWindow"
+            | "DescribeMaintenanceWindowTargets"
+            | "DescribeMaintenanceWindowTasks"
+            | "DescribePatchBaselines"
+            | "GetPatchBaseline"
+            | "GetPatchBaselineForPatchGroup"
+            | "DescribePatchGroups"
+            | "DescribeAssociation"
+            | "ListAssociations"
+            | "ListAssociationVersions"
+            | "DescribeAssociationExecutions"
+            | "DescribeAssociationExecutionTargets"
+            | "GetOpsItem"
+            | "DescribeOpsItems"
+            | "ListDocumentVersions"
+            | "ListDocumentMetadataHistory"
+            | "GetResourcePolicies"
+            | "GetInventory"
+            | "GetInventorySchema"
+            | "ListInventoryEntries"
+            | "DescribeInventoryDeletions"
+            | "ListComplianceItems"
+            | "ListComplianceSummaries"
+            | "ListResourceComplianceSummaries"
+            | "GetMaintenanceWindowTask"
+            | "GetMaintenanceWindowExecution"
+            | "GetMaintenanceWindowExecutionTask"
+            | "GetMaintenanceWindowExecutionTaskInvocation"
+            | "DescribeMaintenanceWindowExecutions"
+            | "DescribeMaintenanceWindowExecutionTasks"
+            | "DescribeMaintenanceWindowExecutionTaskInvocations"
+            | "DescribeMaintenanceWindowSchedule"
+            | "DescribeMaintenanceWindowsForTarget"
+            | "DescribeInstancePatchStates"
+            | "DescribeInstancePatchStatesForPatchGroup"
+            | "DescribeInstancePatches"
+            | "DescribeEffectivePatchesForPatchBaseline"
+            | "GetDeployablePatchSnapshotForInstance"
+            | "ListResourceDataSync"
+            | "ListOpsItemRelatedItems"
+            | "ListOpsItemEvents"
+            | "GetOpsMetadata"
+            | "ListOpsMetadata"
+            | "GetOpsSummary"
+            | "GetAutomationExecution"
+            | "DescribeAutomationExecutions"
+            | "DescribeAutomationStepExecutions"
+            | "GetExecutionPreview"
+            | "DescribeSessions"
+            | "GetAccessToken"
+            | "DescribeActivations"
+            | "DescribeInstanceInformation"
+            | "DescribeInstanceProperties"
+            | "ListNodes"
+            | "ListNodesSummary"
+            | "DescribeEffectiveInstanceAssociations"
+            | "DescribeInstanceAssociationsStatus"
+            | "GetConnectionStatus"
+            | "GetCalendarState"
+            | "DescribePatchGroupState"
+            | "DescribePatchProperties"
+            | "DescribeAvailablePatches"
+            | "GetDefaultPatchBaseline"
+            | "GetServiceSetting"
+    )
+}
+
 pub struct SsmService {
     state: SharedSsmState,
     secretsmanager_state: Option<SharedSecretsManagerState>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl SsmService {
@@ -35,12 +129,44 @@ impl SsmService {
         Self {
             state,
             secretsmanager_state: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
     pub fn with_secretsmanager(mut self, sm_state: SharedSecretsManagerState) -> Self {
         self.secretsmanager_state = Some(sm_state);
         self
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes,
+    /// with serde + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = SsmSnapshot {
+            schema_version: SSM_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write ssm snapshot"),
+            Err(err) => tracing::error!(%err, "ssm snapshot task panicked"),
+        }
     }
 }
 
@@ -51,7 +177,8 @@ impl AwsService for SsmService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = !is_read_only_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "PutParameter" => self.put_parameter(&req),
             "GetParameter" => self.get_parameter(&req),
             "GetParameters" => self.get_parameters(&req),
@@ -248,7 +375,11 @@ impl AwsService for SsmService {
             "ResetServiceSetting" => self.reset_service_setting(&req),
             "UpdateServiceSetting" => self.update_service_setting(&req),
             _ => Err(AwsServiceError::action_not_implemented("ssm", &req.action)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -3,7 +3,7 @@ use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmParameter {
     pub name: String,
     pub value: String,
@@ -22,7 +22,7 @@ pub struct SsmParameter {
     pub policies: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmParameterVersion {
     pub value: String,
     pub version: i64,
@@ -33,7 +33,7 @@ pub struct SsmParameterVersion {
     pub labels: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmDocument {
     pub name: String,
     pub content: String,
@@ -51,7 +51,7 @@ pub struct SsmDocument {
     pub permissions: HashMap<String, Vec<String>>, // permission_type -> account_ids
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmDocumentVersion {
     pub content: String,
     pub document_version: String,
@@ -62,7 +62,7 @@ pub struct SsmDocumentVersion {
     pub is_default_version: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmCommand {
     pub command_id: String,
     pub document_name: String,
@@ -82,7 +82,7 @@ pub struct SsmCommand {
     pub document_hash_type: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MaintenanceWindowTarget {
     pub window_target_id: String,
     pub window_id: String,
@@ -93,7 +93,7 @@ pub struct MaintenanceWindowTarget {
     pub owner_information: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MaintenanceWindowTask {
     pub window_task_id: String,
     pub window_id: String,
@@ -108,7 +108,7 @@ pub struct MaintenanceWindowTask {
     pub description: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MaintenanceWindow {
     pub id: String,
     pub name: String,
@@ -128,7 +128,7 @@ pub struct MaintenanceWindow {
     pub client_token: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PatchBaseline {
     pub id: String,
     pub name: String,
@@ -147,13 +147,13 @@ pub struct PatchBaseline {
     pub client_token: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PatchGroup {
     pub baseline_id: String,
     pub patch_group: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmAssociation {
     pub association_id: String,
     pub name: String, // document name
@@ -184,7 +184,7 @@ pub struct SsmAssociation {
     pub versions: Vec<SsmAssociationVersion>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmAssociationVersion {
     pub version: i64,
     pub name: String,
@@ -199,7 +199,7 @@ pub struct SsmAssociationVersion {
     pub compliance_severity: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmOpsItem {
     pub ops_item_id: String,
     pub title: String,
@@ -224,7 +224,7 @@ pub struct SsmOpsItem {
     pub actual_end_time: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmResourcePolicy {
     pub policy_id: String,
     pub policy_hash: String,
@@ -232,7 +232,7 @@ pub struct SsmResourcePolicy {
     pub resource_arn: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmServiceSetting {
     pub setting_id: String,
     pub setting_value: String,
@@ -241,7 +241,7 @@ pub struct SsmServiceSetting {
     pub status: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OpsItemRelatedItem {
     pub association_id: String,
     pub ops_item_id: String,
@@ -254,7 +254,7 @@ pub struct OpsItemRelatedItem {
     pub last_modified_by: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OpsItemEvent {
     pub ops_item_id: String,
     pub event_id: String,
@@ -264,7 +264,7 @@ pub struct OpsItemEvent {
     pub created_by: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OpsMetadataEntry {
     pub ops_metadata_arn: String,
     pub resource_id: String,
@@ -272,7 +272,7 @@ pub struct OpsMetadataEntry {
     pub creation_date: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AutomationExecution {
     pub automation_execution_id: String,
     pub document_name: String,
@@ -295,7 +295,7 @@ pub struct AutomationExecution {
     pub scheduled_time: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AutomationStepExecution {
     pub step_name: String,
     pub action: String,
@@ -307,7 +307,7 @@ pub struct AutomationStepExecution {
     pub step_execution_id: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmSession {
     pub session_id: String,
     pub target: String,
@@ -318,7 +318,7 @@ pub struct SsmSession {
     pub reason: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmActivation {
     pub activation_id: String,
     pub iam_role: String,
@@ -332,7 +332,7 @@ pub struct SsmActivation {
     pub tags: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ManagedInstance {
     pub instance_id: String,
     pub activation_id: Option<String>,
@@ -353,7 +353,7 @@ pub struct ManagedInstance {
     pub source_type: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExecutionPreview {
     pub execution_preview_id: String,
     pub document_name: String,
@@ -361,6 +361,7 @@ pub struct ExecutionPreview {
     pub created_time: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmState {
     pub account_id: String,
     pub region: String,
@@ -644,7 +645,7 @@ impl SsmState {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MaintenanceWindowExecution {
     pub window_execution_id: String,
     pub window_id: String,
@@ -654,7 +655,7 @@ pub struct MaintenanceWindowExecution {
     pub tasks: Vec<MaintenanceWindowExecutionTask>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MaintenanceWindowExecutionTask {
     pub task_execution_id: String,
     pub window_execution_id: String,
@@ -666,7 +667,7 @@ pub struct MaintenanceWindowExecutionTask {
     pub invocations: Vec<MaintenanceWindowExecutionTaskInvocation>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MaintenanceWindowExecutionTaskInvocation {
     pub invocation_id: String,
     pub task_execution_id: String,
@@ -681,7 +682,7 @@ pub struct MaintenanceWindowExecutionTaskInvocation {
     pub status_details: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct InventoryItem {
     pub type_name: String,
     pub schema_version: String,
@@ -691,13 +692,13 @@ pub struct InventoryItem {
     pub context: Option<HashMap<String, String>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct InventoryEntry {
     pub instance_id: String,
     pub items: Vec<InventoryItem>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct InventoryDeletion {
     pub deletion_id: String,
     pub type_name: String,
@@ -708,7 +709,7 @@ pub struct InventoryDeletion {
     pub last_status_update_time: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ComplianceItem {
     pub resource_id: String,
     pub resource_type: String,
@@ -721,7 +722,7 @@ pub struct ComplianceItem {
     pub execution_summary: serde_json::Value,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ResourceDataSync {
     pub sync_name: String,
     pub sync_type: Option<String>,
@@ -735,3 +736,13 @@ pub struct ResourceDataSync {
 }
 
 pub type SharedSsmState = Arc<RwLock<SsmState>>;
+
+/// On-disk snapshot envelope for SSM state. Versioned so format
+/// changes fail loudly on upgrade.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SsmSnapshot {
+    pub schema_version: u32,
+    pub state: SsmState,
+}
+
+pub const SSM_SNAPSHOT_SCHEMA_VERSION: u32 = 1;


### PR DESCRIPTION
## Summary
- Apply the SnapshotStore pattern to SSM: versioned envelope, async Mutex-serialized clone+serialize+write, spawn_blocking offload, store wired only in persistent mode, save gated on HTTP 2xx.
- Parameters (with versions, tags, SecureString), documents, and delete state survive restart.
- SSM has ~150 actions, so the snapshot trigger is driven by a read-only allowlist (anything not read-only saves). Easier to maintain and safer against missing mutating ops.
- Removes \`ssm\` from the warn_unsupported list.

## Test plan
- [x] cargo build -p fakecloud-ssm -p fakecloud
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test -p fakecloud-e2e --test ssm_persistence (3/3 green)
- [ ] CI green
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in disk persistence for SSM via a versioned snapshot store. When enabled, parameters (versions, tags, SecureString), documents, and deletes survive restarts.

- **New Features**
  - `SsmService` in `fakecloud-ssm` persists state via an optional `SnapshotStore`, saving after any non-read-only action that returns HTTP 2xx.
  - Introduced `SsmSnapshot` (schema_version=1) and serde derives across SSM state; clone-serialize-write is guarded by an async mutex and offloaded with `tokio::spawn_blocking`.
  - `fakecloud-server` wires persistence: loads snapshot at startup from `<data_path>/ssm/snapshot.json`; schema mismatches fatal; logs when no snapshot is found; removed `ssm` from the warn_unsupported list.
  - Added e2e tests for parameter history+tags, SecureString + delete durability, and document persistence.

- **Dependencies**
  - Added `fakecloud-persistence`, `tokio`, and `tracing` to `fakecloud-ssm`; bumped `rustls-webpki` to `0.103.12` (addresses RUSTSEC-2026-0099).

<sup>Written for commit 4020fe3fd2e214ccad89dcec758af960c73f5365. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

