### PR TITLE
feat(eventbridge): opt-in disk persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,6 +2242,7 @@ dependencies = [
  "fakecloud-core",
  "fakecloud-lambda",
  "fakecloud-logs",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "reqwest",

--- a/crates/fakecloud-e2e/tests/eventbridge_persistence.rs
+++ b/crates/fakecloud-e2e/tests/eventbridge_persistence.rs
@@ -1,0 +1,172 @@
+mod helpers;
+
+use aws_sdk_eventbridge::types::{RuleState, Target};
+use helpers::TestServer;
+
+/// Custom bus + rule + targets + tags survive restart.
+#[tokio::test]
+async fn persistence_round_trip_bus_rule_and_targets() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let eb = server.eventbridge_client().await;
+    let sqs = server.sqs_client().await;
+
+    eb.create_event_bus()
+        .name("orders-bus")
+        .send()
+        .await
+        .unwrap();
+
+    eb.put_rule()
+        .name("order-created")
+        .event_bus_name("orders-bus")
+        .event_pattern(r#"{"source":["shop.orders"]}"#)
+        .state(RuleState::Enabled)
+        .description("route order.created events")
+        .send()
+        .await
+        .unwrap();
+
+    let q_url = sqs
+        .create_queue()
+        .queue_name("orders-target")
+        .send()
+        .await
+        .unwrap()
+        .queue_url
+        .unwrap();
+    let q_arn = sqs
+        .get_queue_attributes()
+        .queue_url(&q_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .clone();
+
+    eb.put_targets()
+        .rule("order-created")
+        .event_bus_name("orders-bus")
+        .targets(Target::builder().id("sqs-1").arn(&q_arn).build().unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    eb.tag_resource()
+        .resource_arn(
+            eb.describe_rule()
+                .name("order-created")
+                .event_bus_name("orders-bus")
+                .send()
+                .await
+                .unwrap()
+                .arn
+                .unwrap(),
+        )
+        .tags(
+            aws_sdk_eventbridge::types::Tag::builder()
+                .key("env")
+                .value("prod")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let eb = server.eventbridge_client().await;
+
+    // Bus survives.
+    let buses = eb.list_event_buses().send().await.unwrap();
+    assert!(buses
+        .event_buses()
+        .iter()
+        .any(|b| b.name() == Some("orders-bus")));
+
+    // Rule survives on the custom bus.
+    let rules = eb
+        .list_rules()
+        .event_bus_name("orders-bus")
+        .send()
+        .await
+        .unwrap();
+    let rule = rules
+        .rules()
+        .iter()
+        .find(|r| r.name() == Some("order-created"))
+        .unwrap();
+    assert_eq!(rule.state(), Some(&RuleState::Enabled));
+    assert_eq!(rule.description(), Some("route order.created events"));
+
+    // Target survives.
+    let targets = eb
+        .list_targets_by_rule()
+        .rule("order-created")
+        .event_bus_name("orders-bus")
+        .send()
+        .await
+        .unwrap();
+    assert!(targets
+        .targets()
+        .iter()
+        .any(|t| t.id() == "sqs-1" && t.arn() == q_arn));
+
+    // Describe rule returns description still.
+    let desc = eb
+        .describe_rule()
+        .name("order-created")
+        .event_bus_name("orders-bus")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desc.description(), Some("route order.created events"));
+}
+
+/// Disabled rule stays disabled after restart.
+#[tokio::test]
+async fn persistence_disabled_rule_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let eb = server.eventbridge_client().await;
+
+    eb.put_rule()
+        .name("off-rule")
+        .schedule_expression("rate(5 minutes)")
+        .state(RuleState::Disabled)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let eb = server.eventbridge_client().await;
+
+    let desc = eb.describe_rule().name("off-rule").send().await.unwrap();
+    assert_eq!(desc.state(), Some(&RuleState::Disabled));
+    assert_eq!(desc.schedule_expression(), Some("rate(5 minutes)"));
+}
+
+/// DeleteRule is durable.
+#[tokio::test]
+async fn persistence_delete_rule_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let eb = server.eventbridge_client().await;
+
+    eb.put_rule()
+        .name("ephemeral")
+        .event_pattern(r#"{"source":["x"]}"#)
+        .send()
+        .await
+        .unwrap();
+    eb.delete_rule().name("ephemeral").send().await.unwrap();
+
+    server.restart().await;
+    let eb = server.eventbridge_client().await;
+    let rules = eb.list_rules().send().await.unwrap();
+    assert!(!rules.rules().iter().any(|r| r.name() == Some("ephemeral")));
+}

--- a/crates/fakecloud-eventbridge/Cargo.toml
+++ b/crates/fakecloud-eventbridge/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 fakecloud-lambda = { workspace = true }
 fakecloud-logs = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -6,19 +6,23 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use tokio::sync::Mutex as AsyncMutex;
+
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
+use fakecloud_persistence::SnapshotStore;
 
 use fakecloud_lambda::runtime::ContainerRuntime;
 use fakecloud_lambda::state::{LambdaInvocation, SharedLambdaState};
 use fakecloud_logs::state::SharedLogsState;
 
 use crate::state::{
-    ApiDestination, Archive, Connection, Endpoint, EventBus, EventRule, EventTarget,
-    PartnerEventSource, PutEvent, Replay, SharedEventBridgeState,
+    ApiDestination, Archive, Connection, Endpoint, EventBridgeSnapshot, EventBus, EventRule,
+    EventTarget, PartnerEventSource, PutEvent, Replay, SharedEventBridgeState,
+    EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
 };
 
 /// Validate a single `PutEvents` entry's required fields (`Source`,
@@ -73,12 +77,55 @@ fn parse_put_events_time(raw: &Value) -> DateTime<Utc> {
     Utc::now()
 }
 
+/// Actions that mutate EventBridge state.
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "CreateEventBus"
+            | "DeleteEventBus"
+            | "UpdateEventBus"
+            | "PutRule"
+            | "DeleteRule"
+            | "EnableRule"
+            | "DisableRule"
+            | "PutTargets"
+            | "RemoveTargets"
+            | "PutEvents"
+            | "PutPermission"
+            | "RemovePermission"
+            | "TagResource"
+            | "UntagResource"
+            | "CreateArchive"
+            | "UpdateArchive"
+            | "DeleteArchive"
+            | "CreateConnection"
+            | "UpdateConnection"
+            | "DeleteConnection"
+            | "DeauthorizeConnection"
+            | "CreateApiDestination"
+            | "UpdateApiDestination"
+            | "DeleteApiDestination"
+            | "StartReplay"
+            | "CancelReplay"
+            | "CreatePartnerEventSource"
+            | "DeletePartnerEventSource"
+            | "ActivateEventSource"
+            | "DeactivateEventSource"
+            | "PutPartnerEvents"
+            | "CreateEndpoint"
+            | "DeleteEndpoint"
+            | "UpdateEndpoint"
+    )
+}
+
 pub struct EventBridgeService {
     state: SharedEventBridgeState,
     delivery: Arc<DeliveryBus>,
     lambda_state: Option<SharedLambdaState>,
     logs_state: Option<SharedLogsState>,
     container_runtime: Option<Arc<ContainerRuntime>>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl EventBridgeService {
@@ -89,6 +136,8 @@ impl EventBridgeService {
             lambda_state: None,
             logs_state: None,
             container_runtime: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -106,6 +155,36 @@ impl EventBridgeService {
         self.container_runtime = Some(runtime);
         self
     }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes,
+    /// with serde + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = EventBridgeSnapshot {
+            schema_version: EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write eventbridge snapshot"),
+            Err(err) => tracing::error!(%err, "eventbridge snapshot task panicked"),
+        }
+    }
 }
 
 #[async_trait]
@@ -115,7 +194,8 @@ impl AwsService for EventBridgeService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateEventBus" => self.create_event_bus(&req),
             "DeleteEventBus" => self.delete_event_bus(&req),
             "ListEventBuses" => self.list_event_buses(&req),
@@ -177,7 +257,11 @@ impl AwsService for EventBridgeService {
                 "events",
                 &req.action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-eventbridge/src/state.rs
+++ b/crates/fakecloud-eventbridge/src/state.rs
@@ -1,11 +1,12 @@
 use chrono::{DateTime, Utc};
 use fakecloud_aws::arn::Arn;
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventBus {
     pub name: String,
     pub arn: String,
@@ -18,7 +19,7 @@ pub struct EventBus {
     pub last_modified_time: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventRule {
     pub name: String,
     pub arn: String,
@@ -38,7 +39,7 @@ pub struct EventRule {
 /// Composite key for rules: (event_bus_name, rule_name)
 pub type RuleKey = (String, String);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventTarget {
     pub id: String,
     pub arn: String,
@@ -48,7 +49,7 @@ pub struct EventTarget {
     pub sqs_parameters: Option<Value>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PutEvent {
     pub event_id: String,
     pub source: String,
@@ -59,7 +60,7 @@ pub struct PutEvent {
     pub resources: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Archive {
     pub name: String,
     pub arn: String,
@@ -74,7 +75,7 @@ pub struct Archive {
     pub events: Vec<PutEvent>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Connection {
     pub name: String,
     pub arn: String,
@@ -88,7 +89,7 @@ pub struct Connection {
     pub last_authorized_time: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiDestination {
     pub name: String,
     pub arn: String,
@@ -102,7 +103,7 @@ pub struct ApiDestination {
     pub last_modified_time: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Replay {
     pub name: String,
     pub arn: String,
@@ -116,7 +117,7 @@ pub struct Replay {
     pub replay_end_time: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Endpoint {
     pub name: String,
     pub arn: String,
@@ -132,7 +133,7 @@ pub struct Endpoint {
     pub last_modified_time: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PartnerEventSource {
     pub name: String,
     pub arn: String,
@@ -143,7 +144,7 @@ pub struct PartnerEventSource {
 }
 
 /// A recorded Lambda invocation from EventBridge delivery.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LambdaInvocation {
     pub function_arn: String,
     pub payload: String,
@@ -151,7 +152,7 @@ pub struct LambdaInvocation {
 }
 
 /// A recorded CloudWatch Logs delivery from EventBridge.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogDelivery {
     pub log_group_arn: String,
     pub payload: String,
@@ -159,17 +160,48 @@ pub struct LogDelivery {
 }
 
 /// A recorded Step Functions invocation from EventBridge delivery.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StepFunctionExecution {
     pub state_machine_arn: String,
     pub payload: String,
     pub timestamp: DateTime<Utc>,
 }
 
+/// JSON object keys must be strings, so serialize `HashMap<(String,String), V>`
+/// as a list of `[bus, rule, value]` tuples.
+mod rule_map_serde {
+    use super::{EventRule, RuleKey};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::collections::HashMap;
+
+    pub fn serialize<S: Serializer>(
+        map: &HashMap<RuleKey, EventRule>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        let entries: Vec<(&String, &String, &EventRule)> = map
+            .iter()
+            .map(|((bus, name), rule)| (bus, name, rule))
+            .collect();
+        entries.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<HashMap<RuleKey, EventRule>, D::Error> {
+        let entries: Vec<(String, String, EventRule)> = Vec::deserialize(d)?;
+        Ok(entries
+            .into_iter()
+            .map(|(bus, name, rule)| ((bus, name), rule))
+            .collect())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventBridgeState {
     pub account_id: String,
     pub region: String,
     pub buses: HashMap<String, EventBus>,
+    #[serde(with = "rule_map_serde")]
     pub rules: HashMap<RuleKey, EventRule>,
     pub events: Vec<PutEvent>,
     pub archives: HashMap<String, Archive>,
@@ -272,3 +304,13 @@ impl EventBridgeState {
 }
 
 pub type SharedEventBridgeState = Arc<RwLock<EventBridgeState>>;
+
+/// On-disk snapshot envelope for EventBridge state. Versioned so
+/// format changes fail loudly on upgrade.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventBridgeSnapshot {
+    pub schema_version: u32,
+    pub state: EventBridgeState,
+}
+
+pub const EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION: u32 = 1;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -384,7 +384,6 @@ async fn main() {
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
         for service in [
             "cloudformation",
-            "events",
             "lambda",
             "logs",
             "ses",
@@ -514,11 +513,63 @@ async fn main() {
         sns_service = sns_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(sns_service));
+    let eb_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("eventbridge").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_eventbridge::state::EventBridgeSnapshot>(
+                        &bytes,
+                    ) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_eventbridge::state::EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "eventbridge persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_eventbridge::state::EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let bus_count = snapshot.state.buses.len();
+                            let rule_count = snapshot.state.rules.len();
+                            *eb_state.write() = snapshot.state;
+                            tracing::info!(
+                                buses = bus_count,
+                                rules = rule_count,
+                                "loaded eventbridge persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse eventbridge persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no eventbridge persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read eventbridge persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
     let mut eb_service = EventBridgeService::new(eb_state.clone(), delivery_for_eb.clone())
         .with_lambda(lambda_state.clone())
         .with_logs(logs_state.clone());
     if let Some(ref rt) = container_runtime {
         eb_service = eb_service.with_runtime(rt.clone());
+    }
+    if let Some(store) = eb_snapshot_store {
+        eb_service = eb_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(eb_service));
 


### PR DESCRIPTION
## Summary
- Apply the SnapshotStore pattern to EventBridge: versioned envelope, async Mutex-serialized clone+serialize+write, spawn_blocking offload, store wired only in persistent mode, save gated on HTTP 2xx.
- Custom buses, rules (scoped by bus), targets, archives, connections, API destinations, replays, partner sources, and endpoints all survive restart.
- Rules are keyed by a (bus, name) tuple; JSON object keys must be strings, so a local serde helper round-trips the rule map as a list of triples.
- Also bumps rustls-webpki to 0.103.12 for RUSTSEC-2026-0099 (CI audit fix).
- Removes \`events\` from the warn_unsupported list.

## Test plan
- [x] cargo build -p fakecloud-eventbridge -p fakecloud
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test -p fakecloud-e2e --test eventbridge_persistence (3/3 green)
- [ ] CI green
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in disk persistence for EventBridge so buses, rules, targets, and other resources (archives, connections, API destinations, replays, partner sources, endpoints, permissions, tags) survive restarts in persistent mode. Snapshots save after successful mutating actions and load at startup with a versioned schema.

- **New Features**
  - EventBridge now uses a versioned `EventBridgeSnapshot` (v1) and an optional `SnapshotStore`, wired only in persistent mode.
  - Saves occur only on HTTP 2xx after mutating actions; writes are serialized with an async mutex and offloaded to a blocking thread.
  - Snapshots load on boot; a schema mismatch causes a fatal exit.
  - Rules are keyed by `(bus, name)` with a serde helper to round-trip the map.
  - Removed `events` from the persistent-mode warn_unsupported list.

- **Dependencies**
  - Added `fakecloud-persistence` to `fakecloud-eventbridge`.
  - Bumped `rustls-webpki` to `0.103.12` (addresses RUSTSEC-2026-0099).

<sup>Written for commit 00ea53504248131734c705cab357d6d742c146d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

