### PR TITLE
feat(logs): opt-in disk persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,6 +2348,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "flate2",
  "http 1.4.0",
  "parking_lot",

--- a/crates/fakecloud-e2e/tests/logs_persistence.rs
+++ b/crates/fakecloud-e2e/tests/logs_persistence.rs
@@ -1,0 +1,158 @@
+mod helpers;
+
+use aws_sdk_cloudwatchlogs::types::InputLogEvent;
+use helpers::TestServer;
+
+/// Log group, retention, tags, and log streams + events survive restart.
+#[tokio::test]
+async fn persistence_round_trip_group_stream_and_events() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let logs = server.logs_client().await;
+
+    logs.create_log_group()
+        .log_group_name("/app/web")
+        .send()
+        .await
+        .unwrap();
+    logs.put_retention_policy()
+        .log_group_name("/app/web")
+        .retention_in_days(7)
+        .send()
+        .await
+        .unwrap();
+    logs.tag_resource()
+        .resource_arn("arn:aws:logs:us-east-1:123456789012:log-group:/app/web")
+        .tags("env", "prod")
+        .send()
+        .await
+        .unwrap();
+
+    logs.create_log_stream()
+        .log_group_name("/app/web")
+        .log_stream_name("instance-1")
+        .send()
+        .await
+        .unwrap();
+
+    let now = chrono::Utc::now().timestamp_millis();
+    logs.put_log_events()
+        .log_group_name("/app/web")
+        .log_stream_name("instance-1")
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now)
+                .message("hello persistence")
+                .build()
+                .unwrap(),
+        )
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now + 1)
+                .message("second line")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let logs = server.logs_client().await;
+
+    // Log group survives with retention.
+    let groups = logs
+        .describe_log_groups()
+        .log_group_name_prefix("/app/web")
+        .send()
+        .await
+        .unwrap();
+    let g = groups
+        .log_groups()
+        .iter()
+        .find(|g| g.log_group_name() == Some("/app/web"))
+        .unwrap();
+    assert_eq!(g.retention_in_days(), Some(7));
+
+    // Stream survives.
+    let streams = logs
+        .describe_log_streams()
+        .log_group_name("/app/web")
+        .send()
+        .await
+        .unwrap();
+    assert!(streams
+        .log_streams()
+        .iter()
+        .any(|s| s.log_stream_name() == Some("instance-1")));
+
+    // Events survive in order.
+    let events = logs
+        .get_log_events()
+        .log_group_name("/app/web")
+        .log_stream_name("instance-1")
+        .start_from_head(true)
+        .send()
+        .await
+        .unwrap();
+    let msgs: Vec<&str> = events.events().iter().filter_map(|e| e.message()).collect();
+    assert_eq!(msgs, vec!["hello persistence", "second line"]);
+}
+
+/// Subscription filters and delete-group durability.
+#[tokio::test]
+async fn persistence_subscription_filter_and_delete_survive_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let logs = server.logs_client().await;
+
+    logs.create_log_group()
+        .log_group_name("/app/keeper")
+        .send()
+        .await
+        .unwrap();
+    logs.create_log_group()
+        .log_group_name("/app/goner")
+        .send()
+        .await
+        .unwrap();
+
+    logs.put_subscription_filter()
+        .log_group_name("/app/keeper")
+        .filter_name("errs")
+        .filter_pattern("ERROR")
+        .destination_arn("arn:aws:lambda:us-east-1:123456789012:function:notify")
+        .send()
+        .await
+        .unwrap();
+
+    logs.delete_log_group()
+        .log_group_name("/app/goner")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let logs = server.logs_client().await;
+
+    // Keeper and its filter survive.
+    let filters = logs
+        .describe_subscription_filters()
+        .log_group_name("/app/keeper")
+        .send()
+        .await
+        .unwrap();
+    assert!(filters
+        .subscription_filters()
+        .iter()
+        .any(|f| f.filter_name() == Some("errs") && f.filter_pattern() == Some("ERROR")));
+
+    // Goner is gone.
+    let groups = logs
+        .describe_log_groups()
+        .log_group_name_prefix("/app/goner")
+        .send()
+        .await
+        .unwrap();
+    assert!(groups.log_groups().is_empty());
+}

--- a/crates/fakecloud-logs/Cargo.toml
+++ b/crates/fakecloud-logs/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -4,10 +4,13 @@ use serde_json::{json, Value};
 
 use std::sync::Arc;
 
+use tokio::sync::Mutex as AsyncMutex;
+
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
-use crate::state::SharedLogsState;
+use crate::state::{LogsSnapshot, SharedLogsState, LOGS_SNAPSHOT_SCHEMA_VERSION};
 
 mod anomaly;
 mod deliveries;
@@ -21,9 +24,70 @@ mod queries;
 mod streams;
 mod tags;
 
+/// CloudWatch Logs actions that do NOT mutate state. Everything else
+/// triggers a snapshot save on HTTP 2xx.
+fn is_read_only_action(action: &str) -> bool {
+    matches!(
+        action,
+        "DescribeLogGroups"
+            | "DescribeLogStreams"
+            | "GetLogEvents"
+            | "FilterLogEvents"
+            | "ListTagsLogGroup"
+            | "ListTagsForResource"
+            | "DescribeSubscriptionFilters"
+            | "DescribeMetricFilters"
+            | "DescribeResourcePolicies"
+            | "DescribeDestinations"
+            | "GetQueryResults"
+            | "DescribeQueries"
+            | "DescribeExportTasks"
+            | "GetDeliveryDestination"
+            | "DescribeDeliveryDestinations"
+            | "GetDeliveryDestinationPolicy"
+            | "GetDeliverySource"
+            | "DescribeDeliverySources"
+            | "GetDelivery"
+            | "DescribeDeliveries"
+            | "DescribeQueryDefinitions"
+            | "DescribeAccountPolicies"
+            | "GetDataProtectionPolicy"
+            | "DescribeIndexPolicies"
+            | "DescribeFieldIndexes"
+            | "GetTransformer"
+            | "TestTransformer"
+            | "GetLogAnomalyDetector"
+            | "ListLogAnomalyDetectors"
+            | "GetLogGroupFields"
+            | "TestMetricFilter"
+            | "GetLogRecord"
+            | "ListAnomalies"
+            | "DescribeImportTasks"
+            | "DescribeImportTaskBatches"
+            | "GetIntegration"
+            | "ListIntegrations"
+            | "GetLookupTable"
+            | "DescribeLookupTables"
+            | "GetScheduledQuery"
+            | "GetScheduledQueryHistory"
+            | "ListScheduledQueries"
+            | "StartLiveTail"
+            | "ListLogGroups"
+            | "ListLogGroupsForQuery"
+            | "ListAggregateLogGroupSummaries"
+            | "GetLogObject"
+            | "GetLogFields"
+            | "ListSourcesForS3TableIntegration"
+            | "DescribeConfigurationTemplates"
+            | "GetExportedData"
+    )
+}
+
 pub struct LogsService {
     state: SharedLogsState,
     delivery_bus: Arc<DeliveryBus>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl LogsService {
@@ -31,6 +95,38 @@ impl LogsService {
         Self {
             state,
             delivery_bus,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes,
+    /// with serde + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = LogsSnapshot {
+            schema_version: LOGS_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write logs snapshot"),
+            Err(err) => tracing::error!(%err, "logs snapshot task panicked"),
         }
     }
 }
@@ -42,7 +138,8 @@ impl AwsService for LogsService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = !is_read_only_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateLogGroup" => self.create_log_group(&req),
             "DeleteLogGroup" => self.delete_log_group(&req),
             "DescribeLogGroups" => self.describe_log_groups(&req),
@@ -163,7 +260,11 @@ impl AwsService for LogsService {
             // Internal action for testing export storage
             "GetExportedData" => self.get_exported_data(&req),
             _ => Err(AwsServiceError::action_not_implemented("logs", &req.action)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -5,6 +5,37 @@ use parking_lot::RwLock;
 
 pub type SharedLogsState = Arc<RwLock<LogsState>>;
 
+/// JSON object keys must be strings, so serialize
+/// `HashMap<(String,String), AccountPolicy>` as a list of
+/// `[policy_name, policy_type, policy]` tuples.
+mod account_policy_map_serde {
+    use super::AccountPolicy;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::collections::HashMap;
+
+    pub fn serialize<S: Serializer>(
+        map: &HashMap<(String, String), AccountPolicy>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        let entries: Vec<(&String, &String, &AccountPolicy)> = map
+            .iter()
+            .map(|((name, kind), p)| (name, kind, p))
+            .collect();
+        entries.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<HashMap<(String, String), AccountPolicy>, D::Error> {
+        let entries: Vec<(String, String, AccountPolicy)> = Vec::deserialize(d)?;
+        Ok(entries
+            .into_iter()
+            .map(|(name, kind, p)| ((name, kind), p))
+            .collect())
+    }
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct LogsState {
     pub account_id: String,
     pub region: String,
@@ -19,6 +50,7 @@ pub struct LogsState {
     pub deliveries: HashMap<String, Delivery>,
     pub query_definitions: HashMap<String, QueryDefinition>,
     /// Account policies keyed by (policy_name, policy_type)
+    #[serde(with = "account_policy_map_serde")]
     pub account_policies: HashMap<(String, String), AccountPolicy>,
     /// Anomaly detectors keyed by detector ARN
     pub anomaly_detectors: HashMap<String, AnomalyDetector>,
@@ -89,6 +121,7 @@ impl LogsState {
     }
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct LogGroup {
     pub name: String,
     pub arn: String,
@@ -109,6 +142,7 @@ pub struct LogGroup {
     pub log_group_class: Option<String>,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct LogStream {
     pub name: String,
     pub arn: String,
@@ -120,13 +154,14 @@ pub struct LogStream {
     pub events: Vec<LogEvent>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct LogEvent {
     pub timestamp: i64,
     pub message: String,
     pub ingestion_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct SubscriptionFilter {
     pub filter_name: String,
     pub log_group_name: String,
@@ -137,6 +172,7 @@ pub struct SubscriptionFilter {
     pub creation_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct MetricFilter {
     pub filter_name: String,
     pub filter_pattern: String,
@@ -145,6 +181,7 @@ pub struct MetricFilter {
     pub creation_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct MetricTransformation {
     pub metric_name: String,
     pub metric_namespace: String,
@@ -152,12 +189,14 @@ pub struct MetricTransformation {
     pub default_value: Option<f64>,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ResourcePolicy {
     pub policy_name: String,
     pub policy_document: String,
     pub last_updated_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct Destination {
     pub destination_name: String,
     pub target_arn: String,
@@ -168,6 +207,7 @@ pub struct Destination {
     pub tags: HashMap<String, String>,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct QueryInfo {
     pub query_id: String,
     pub log_group_name: String,
@@ -178,6 +218,7 @@ pub struct QueryInfo {
     pub create_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExportTask {
     pub task_id: String,
     pub task_name: Option<String>,
@@ -191,6 +232,7 @@ pub struct ExportTask {
     pub status_message: String,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct DeliveryDestination {
     pub name: String,
     pub arn: String,
@@ -200,6 +242,7 @@ pub struct DeliveryDestination {
     pub delivery_destination_policy: Option<String>,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct DeliverySource {
     pub name: String,
     pub arn: String,
@@ -209,6 +252,7 @@ pub struct DeliverySource {
     pub tags: HashMap<String, String>,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct Delivery {
     pub id: String,
     pub delivery_source_name: String,
@@ -218,6 +262,7 @@ pub struct Delivery {
     pub tags: HashMap<String, String>,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct QueryDefinition {
     pub query_definition_id: String,
     pub name: String,
@@ -226,6 +271,7 @@ pub struct QueryDefinition {
     pub last_modified: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct AccountPolicy {
     pub policy_name: String,
     pub policy_type: String,
@@ -236,23 +282,27 @@ pub struct AccountPolicy {
     pub last_updated_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct DataProtectionPolicy {
     pub policy_document: String,
     pub last_updated_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct IndexPolicy {
     pub policy_name: String,
     pub policy_document: String,
     pub last_updated_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct Transformer {
     pub transformer_config: serde_json::Value,
     pub creation_time: i64,
     pub last_modified_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct AnomalyDetector {
     pub detector_name: String,
     pub arn: String,
@@ -265,6 +315,7 @@ pub struct AnomalyDetector {
     pub enabled: bool,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ImportTask {
     pub import_id: String,
     pub import_source_arn: String,
@@ -274,6 +325,7 @@ pub struct ImportTask {
     pub creation_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct Integration {
     pub integration_name: String,
     pub integration_type: String,
@@ -282,6 +334,7 @@ pub struct Integration {
     pub creation_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct LookupTable {
     pub lookup_table_name: String,
     pub arn: String,
@@ -290,6 +343,7 @@ pub struct LookupTable {
     pub last_modified_time: i64,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ScheduledQuery {
     pub name: String,
     pub arn: String,
@@ -301,3 +355,13 @@ pub struct ScheduledQuery {
     pub creation_time: i64,
     pub last_modified_time: i64,
 }
+
+/// On-disk snapshot envelope for CloudWatch Logs state. Versioned so
+/// format changes fail loudly on upgrade.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct LogsSnapshot {
+    pub schema_version: u32,
+    pub state: LogsState,
+}
+
+pub const LOGS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -386,7 +386,6 @@ async fn main() {
             "cloudformation",
             "events",
             "lambda",
-            "logs",
             "ses",
             "cognito-idp",
             "rds",
@@ -699,7 +698,9 @@ async fn main() {
                     }
                 }
                 Ok(None) => {
-                    tracing::info!("no secretsmanager persistence snapshot found; starting empty");
+                    tracing::info!(
+                        "no secretsmanager persistence snapshot found; starting empty"
+                    );
                 }
                 Err(err) => fatal_exit(format_args!(
                     "failed to read secretsmanager persistence snapshot: {err}"
@@ -709,13 +710,62 @@ async fn main() {
         } else {
             None
         };
-    let mut secretsmanager_service =
-        SecretsManagerService::new(secretsmanager_state).with_delivery(delivery_for_secretsmanager);
+    let mut secretsmanager_service = SecretsManagerService::new(secretsmanager_state)
+        .with_delivery(delivery_for_secretsmanager);
     if let Some(store) = secretsmanager_snapshot_store {
         secretsmanager_service = secretsmanager_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(secretsmanager_service));
-    registry.register(Arc::new(LogsService::new(logs_state, delivery_for_logs)));
+    let logs_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("logs").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_logs::state::LogsSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_logs::state::LOGS_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "logs persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_logs::state::LOGS_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let group_count = snapshot.state.log_groups.len();
+                            *logs_state.write() = snapshot.state;
+                            tracing::info!(
+                                log_groups = group_count,
+                                "loaded logs persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse logs persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no logs persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read logs persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut logs_service = LogsService::new(logs_state, delivery_for_logs);
+    if let Some(store) = logs_snapshot_store {
+        logs_service = logs_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(logs_service));
     let kms_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
             let data_path = persistence_config

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -698,9 +698,7 @@ async fn main() {
                     }
                 }
                 Ok(None) => {
-                    tracing::info!(
-                        "no secretsmanager persistence snapshot found; starting empty"
-                    );
+                    tracing::info!("no secretsmanager persistence snapshot found; starting empty");
                 }
                 Err(err) => fatal_exit(format_args!(
                     "failed to read secretsmanager persistence snapshot: {err}"
@@ -710,8 +708,8 @@ async fn main() {
         } else {
             None
         };
-    let mut secretsmanager_service = SecretsManagerService::new(secretsmanager_state)
-        .with_delivery(delivery_for_secretsmanager);
+    let mut secretsmanager_service =
+        SecretsManagerService::new(secretsmanager_state).with_delivery(delivery_for_secretsmanager);
     if let Some(store) = secretsmanager_snapshot_store {
         secretsmanager_service = secretsmanager_service.with_snapshot_store(store);
     }


### PR DESCRIPTION
## Summary
- Apply the SnapshotStore pattern to CloudWatch Logs: versioned envelope, async Mutex-serialized clone+serialize+write, spawn_blocking offload, store wired only in persistent mode, save gated on HTTP 2xx.
- Log groups, streams, events, retention, tags, subscription filters, destinations, and delete state all survive restart.
- AccountPolicy is tuple-keyed; JSON object keys must be strings, so a local serde helper round-trips it as a list of triples.
- Read-only allowlist approach (same as SSM) since Logs has ~100 actions.
- Bumps rustls-webpki to 0.103.12 for RUSTSEC-2026-0099.

## Test plan
- [x] cargo build -p fakecloud-logs -p fakecloud
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test -p fakecloud-e2e --test logs_persistence (2/2 green)
- [ ] CI green
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt‑in disk persistence for CloudWatch Logs so groups, streams, events, and settings survive restarts in persistent mode. Snapshots load on boot (fatal on schema mismatch) and start empty if none exists.

- **New Features**
  - Versioned `LogsSnapshot` (schema_version=1); save after successful 2xx on non‑read actions; serialization guarded by an async mutex and offloaded via `spawn_blocking`; wired only in persistent mode; drops the unsupported‑logs warning.
  - Serde derives across all Logs structs with custom serde for tuple‑keyed AccountPolicy; e2e restart tests for groups/streams/events/retention/tags, subscription filters, and delete durability.

- **Dependencies**
  - Added `fakecloud-persistence` to `fakecloud-logs`.
  - Bumped `rustls-webpki` to `0.103.12` for RUSTSEC-2026-0099.

<sup>Written for commit 2f5540b9443329ae83f2fe06fcefffe80768250b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

