### PR TITLE
feat(kinesis): opt-in disk persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,11 +2283,13 @@ dependencies = [
  "bytes",
  "chrono",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "md-5 0.10.6",
  "parking_lot",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/fakecloud-e2e/tests/kinesis_persistence.rs
+++ b/crates/fakecloud-e2e/tests/kinesis_persistence.rs
@@ -1,0 +1,168 @@
+mod helpers;
+
+use aws_sdk_kinesis::primitives::Blob;
+use aws_sdk_kinesis::types::ShardIteratorType;
+use helpers::TestServer;
+
+/// Stream, tags, shards, and previously-put records all survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_stream_and_records() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let k = server.kinesis_client().await;
+
+    k.create_stream()
+        .stream_name("events")
+        .shard_count(2)
+        .send()
+        .await
+        .unwrap();
+
+    k.add_tags_to_stream()
+        .stream_name("events")
+        .tags("env", "prod")
+        .send()
+        .await
+        .unwrap();
+
+    for i in 0..3u32 {
+        k.put_record()
+            .stream_name("events")
+            .partition_key(format!("pk-{i}"))
+            .data(Blob::new(format!("record-{i}").into_bytes()))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    server.restart().await;
+    let k = server.kinesis_client().await;
+
+    // Stream survives.
+    let desc = k
+        .describe_stream()
+        .stream_name("events")
+        .send()
+        .await
+        .unwrap();
+    let sd = desc.stream_description().unwrap();
+    assert_eq!(sd.stream_name(), "events");
+    assert_eq!(sd.shards().len(), 2);
+
+    // Tags survive.
+    let tags = k
+        .list_tags_for_stream()
+        .stream_name("events")
+        .send()
+        .await
+        .unwrap();
+    assert!(tags
+        .tags()
+        .iter()
+        .any(|t| t.key() == "env" && t.value() == Some("prod")));
+
+    // Fetch records from both shards and make sure all three pre-restart
+    // payloads come back.
+    let mut seen: Vec<String> = Vec::new();
+    for shard in sd.shards() {
+        let it = k
+            .get_shard_iterator()
+            .stream_name("events")
+            .shard_id(shard.shard_id())
+            .shard_iterator_type(ShardIteratorType::TrimHorizon)
+            .send()
+            .await
+            .unwrap()
+            .shard_iterator
+            .unwrap();
+        let recs = k.get_records().shard_iterator(it).send().await.unwrap();
+        for r in recs.records() {
+            seen.push(String::from_utf8(r.data().as_ref().to_vec()).unwrap());
+        }
+    }
+    seen.sort();
+    assert_eq!(seen, vec!["record-0", "record-1", "record-2"]);
+}
+
+/// DeleteStream durability.
+#[tokio::test]
+async fn persistence_delete_stream_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let k = server.kinesis_client().await;
+
+    k.create_stream()
+        .stream_name("ephemeral")
+        .shard_count(1)
+        .send()
+        .await
+        .unwrap();
+    k.delete_stream()
+        .stream_name("ephemeral")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let k = server.kinesis_client().await;
+
+    let streams = k.list_streams().send().await.unwrap();
+    assert!(!streams.stream_names().iter().any(|s| s == "ephemeral"));
+}
+
+/// Retention period + encryption state survive restart.
+#[tokio::test]
+async fn persistence_retention_and_encryption_survive_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let k = server.kinesis_client().await;
+
+    k.create_stream()
+        .stream_name("secure")
+        .shard_count(1)
+        .send()
+        .await
+        .unwrap();
+    k.increase_stream_retention_period()
+        .stream_name("secure")
+        .retention_period_hours(48)
+        .send()
+        .await
+        .unwrap();
+    k.start_stream_encryption()
+        .stream_name("secure")
+        .encryption_type(aws_sdk_kinesis::types::EncryptionType::Kms)
+        .key_id("alias/aws/kinesis")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let k = server.kinesis_client().await;
+
+    let sd = k
+        .describe_stream()
+        .stream_name("secure")
+        .send()
+        .await
+        .unwrap()
+        .stream_description
+        .unwrap();
+    assert_eq!(sd.retention_period_hours(), 48);
+    assert_eq!(
+        sd.encryption_type(),
+        Some(&aws_sdk_kinesis::types::EncryptionType::Kms)
+    );
+
+    // describe_stream doesn't surface KeyId, but describe_stream_summary
+    // does -- verify through it.
+    let summary = k
+        .describe_stream_summary()
+        .stream_name("secure")
+        .send()
+        .await
+        .unwrap()
+        .stream_description_summary
+        .unwrap();
+    assert_eq!(summary.key_id(), Some("alias/aws/kinesis"));
+}

--- a/crates/fakecloud-kinesis/Cargo.toml
+++ b/crates/fakecloud-kinesis/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
@@ -17,6 +18,7 @@ md-5 = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -1,17 +1,22 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use base64::Engine;
 use chrono::Utc;
 use http::StatusCode;
 use md5::{Digest, Md5};
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::{
     validate_optional_json_range, validate_optional_string_length, validate_string_length,
 };
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    KinesisConsumer, KinesisRecord, KinesisShard, KinesisStream, SharedKinesisState,
+    KinesisConsumer, KinesisRecord, KinesisShard, KinesisSnapshot, KinesisStream,
+    SharedKinesisState, KINESIS_SNAPSHOT_SCHEMA_VERSION,
 };
 
 /// Locate the index of an open shard by id, returning the caller-friendly
@@ -83,13 +88,85 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "UpdateStreamWarmThroughput",
 ];
 
+/// Actions that mutate Kinesis state. Note: GetShardIterator also
+/// writes (it records a lease in `iterators`), and GetRecords advances
+/// that lease, so both are treated as mutating.
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "CreateStream"
+            | "DeleteStream"
+            | "PutRecord"
+            | "PutRecords"
+            | "AddTagsToStream"
+            | "RemoveTagsFromStream"
+            | "IncreaseStreamRetentionPeriod"
+            | "DecreaseStreamRetentionPeriod"
+            | "TagResource"
+            | "UntagResource"
+            | "PutResourcePolicy"
+            | "DeleteResourcePolicy"
+            | "StartStreamEncryption"
+            | "StopStreamEncryption"
+            | "EnableEnhancedMonitoring"
+            | "DisableEnhancedMonitoring"
+            | "UpdateAccountSettings"
+            | "UpdateStreamMode"
+            | "UpdateStreamWarmThroughput"
+            | "UpdateMaxRecordSize"
+            | "RegisterStreamConsumer"
+            | "DeregisterStreamConsumer"
+            | "MergeShards"
+            | "SplitShard"
+            | "UpdateShardCount"
+            | "GetShardIterator"
+            | "GetRecords"
+    )
+}
+
 pub struct KinesisService {
     state: SharedKinesisState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl KinesisService {
     pub fn new(state: SharedKinesisState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes,
+    /// with serde + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = KinesisSnapshot {
+            schema_version: KINESIS_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write kinesis snapshot"),
+            Err(err) => tracing::error!(%err, "kinesis snapshot task panicked"),
+        }
     }
 }
 
@@ -100,7 +177,8 @@ impl AwsService for KinesisService {
     }
 
     async fn handle(&self, request: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match request.action.as_str() {
+        let mutates = is_mutating_action(request.action.as_str());
+        let result = match request.action.as_str() {
             "CreateStream" => self.create_stream(&request),
             "DescribeStream" => self.describe_stream(&request),
             "DescribeStreamSummary" => self.describe_stream_summary(&request),
@@ -144,7 +222,11 @@ impl AwsService for KinesisService {
                 self.service_name(),
                 &request.action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-kinesis/src/state.rs
+++ b/crates/fakecloud-kinesis/src/state.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 pub type SharedKinesisState = Arc<RwLock<KinesisState>>;
 
+#[derive(Clone, Serialize, Deserialize)]
 pub struct KinesisState {
     pub account_id: String,
     pub region: String,
@@ -158,3 +159,13 @@ impl KinesisState {
             .insert(format!("{mapping_uuid}:{shard_id}"), offset);
     }
 }
+
+/// On-disk snapshot envelope for Kinesis state. Versioned so format
+/// changes fail loudly on upgrade.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct KinesisSnapshot {
+    pub schema_version: u32,
+    pub state: KinesisState,
+}
+
+pub const KINESIS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -392,7 +392,6 @@ async fn main() {
             "kms",
             "ses",
             "cognito-idp",
-            "kinesis",
             "rds",
             "elasticache",
             "states",
@@ -776,7 +775,58 @@ async fn main() {
     registry.register(Arc::new(
         CognitoService::new(cognito_state.clone()).with_delivery(cognito_delivery_ctx),
     ));
-    registry.register(Arc::new(KinesisService::new(kinesis_state.clone())));
+    let kinesis_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("kinesis").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_kinesis::state::KinesisSnapshot>(
+                        &bytes,
+                    ) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_kinesis::state::KINESIS_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "kinesis persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_kinesis::state::KINESIS_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let stream_count = snapshot.state.streams.len();
+                            *kinesis_state.write() = snapshot.state;
+                            tracing::info!(
+                                streams = stream_count,
+                                "loaded kinesis persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse kinesis persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no kinesis persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read kinesis persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut kinesis_service = KinesisService::new(kinesis_state.clone());
+    if let Some(store) = kinesis_snapshot_store {
+        kinesis_service = kinesis_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(kinesis_service));
     let mut rds_service = RdsService::new(rds_state);
     if let Some(ref rt) = rds_runtime {
         rds_service = rds_service.with_runtime(rt.clone());


### PR DESCRIPTION
## Summary
- Apply the SnapshotStore pattern to Kinesis: versioned envelope, async Mutex-serialized clone+serialize+write, spawn_blocking offload, store wired only in persistent mode, save gated on HTTP 2xx.
- Streams, shards, records, tags, retention, encryption, consumers, and resource policies all survive restart.
- GetShardIterator / GetRecords are treated as mutating because they persist / advance the shard iterator lease.
- Removes \`kinesis\` from the warn_unsupported list.

## Test plan
- [x] cargo build -p fakecloud-kinesis -p fakecloud
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test -p fakecloud-e2e --test kinesis_persistence (3/3 green)
- [ ] CI green
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opt‑in disk persistence for Kinesis. When persistent mode is enabled, `fakecloud-kinesis` saves and loads a versioned snapshot so streams, records, and settings survive restarts.

- **New Features**
  - Opt‑in persistence using a versioned `KinesisSnapshot` via `SnapshotStore`; loads at startup and exits on schema mismatch.
  - State saved after 2xx mutating actions (including `GetShardIterator` and `GetRecords`).
  - Survives restart: streams, shards, records, tags, retention, encryption, consumers, and resource policies.
  - Removed Kinesis from unsupported warnings and added restart e2e tests.

- **Migration**
  - Enable persistent mode to turn on Kinesis snapshots.
  - Snapshot path: `<data_path>/kinesis/snapshot.json`.
  - Startup exits on schema mismatch; delete the snapshot to reset.

<sup>Written for commit 02667ec362fec9632f52329c96231a5c5fd43528. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

