### PR TITLE
feat(cognito): close DescribeUserPool shape gaps for tfacc

### DIFF
--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -25,9 +25,9 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 use crate::state::{
     AccountRecoverySetting, AdminCreateUserConfig, Device, EmailConfiguration, Group,
     IdentityProvider, InviteMessageTemplate, PasswordPolicy, RecoveryOption, ResourceServer,
-    ResourceServerScope, SchemaAttribute, SharedCognitoState, SmsConfiguration,
+    ResourceServerScope, SchemaAttribute, SharedCognitoState, SignInPolicy, SmsConfiguration,
     StringAttributeConstraints, TokenValidityUnits, User, UserAttribute, UserImportJob, UserPool,
-    UserPoolClient, UserPoolDomain,
+    UserPoolClient, UserPoolDomain, VerificationMessageTemplate,
 };
 use crate::triggers::CognitoDeliveryContext;
 
@@ -542,6 +542,52 @@ fn parse_password_policy(val: &Value) -> PasswordPolicy {
     }
 }
 
+fn default_sign_in_policy() -> SignInPolicy {
+    SignInPolicy {
+        allowed_first_auth_factors: vec!["PASSWORD".to_string()],
+    }
+}
+
+pub(super) fn parse_sign_in_policy(val: &Value) -> SignInPolicy {
+    if !val.is_object() {
+        return default_sign_in_policy();
+    }
+    let factors = val["AllowedFirstAuthFactors"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if factors.is_empty() {
+        default_sign_in_policy()
+    } else {
+        SignInPolicy {
+            allowed_first_auth_factors: factors,
+        }
+    }
+}
+
+pub(super) fn parse_verification_message_template(
+    val: &Value,
+) -> Option<VerificationMessageTemplate> {
+    if !val.is_object() {
+        return None;
+    }
+    Some(VerificationMessageTemplate {
+        default_email_option: val["DefaultEmailOption"]
+            .as_str()
+            .unwrap_or("CONFIRM_WITH_CODE")
+            .to_string(),
+        email_message: val["EmailMessage"].as_str().map(|s| s.to_string()),
+        email_subject: val["EmailSubject"].as_str().map(|s| s.to_string()),
+        email_message_by_link: val["EmailMessageByLink"].as_str().map(|s| s.to_string()),
+        email_subject_by_link: val["EmailSubjectByLink"].as_str().map(|s| s.to_string()),
+        sms_message: val["SmsMessage"].as_str().map(|s| s.to_string()),
+    })
+}
+
 fn parse_string_array(val: &Value) -> Vec<String> {
     val.as_array()
         .map(|arr| {
@@ -900,12 +946,16 @@ fn user_pool_to_json(pool: &UserPool) -> Value {
                 "RequireNumbers": pool.policies.password_policy.require_numbers,
                 "RequireSymbols": pool.policies.password_policy.require_symbols,
                 "TemporaryPasswordValidityDays": pool.policies.password_policy.temporary_password_validity_days,
-            }
+            },
+            "SignInPolicy": {
+                "AllowedFirstAuthFactors": pool.policies.sign_in_policy.allowed_first_auth_factors,
+            },
         },
         "AutoVerifiedAttributes": pool.auto_verified_attributes,
         "MfaConfiguration": pool.mfa_configuration,
         "EstimatedNumberOfUsers": pool.estimated_number_of_users,
         "UserPoolTags": pool.user_pool_tags,
+        "UserPoolTier": pool.user_pool_tier,
         "SchemaAttributes": pool.schema_attributes.iter().map(|a| {
             let mut attr = json!({
                 "Name": a.name,
@@ -945,22 +995,26 @@ fn user_pool_to_json(pool: &UserPool) -> Value {
     if let Some(ref lc) = pool.lambda_config {
         obj["LambdaConfig"] = lc.clone();
     }
-    if let Some(ref ec) = pool.email_configuration {
-        let mut email = json!({});
-        if let Some(ref v) = ec.source_arn {
-            email["SourceArn"] = json!(v);
-        }
-        if let Some(ref v) = ec.reply_to_email_address {
-            email["ReplyToEmailAddress"] = json!(v);
-        }
-        if let Some(ref v) = ec.email_sending_account {
-            email["EmailSendingAccount"] = json!(v);
-        }
-        if let Some(ref v) = ec.from_email_address {
-            email["From"] = json!(v);
-        }
-        if let Some(ref v) = ec.configuration_set {
-            email["ConfigurationSet"] = json!(v);
+    {
+        let mut email = json!({
+            "EmailSendingAccount": "COGNITO_DEFAULT",
+        });
+        if let Some(ref ec) = pool.email_configuration {
+            if let Some(ref v) = ec.source_arn {
+                email["SourceArn"] = json!(v);
+            }
+            if let Some(ref v) = ec.reply_to_email_address {
+                email["ReplyToEmailAddress"] = json!(v);
+            }
+            if let Some(ref v) = ec.email_sending_account {
+                email["EmailSendingAccount"] = json!(v);
+            }
+            if let Some(ref v) = ec.from_email_address {
+                email["From"] = json!(v);
+            }
+            if let Some(ref v) = ec.configuration_set {
+                email["ConfigurationSet"] = json!(v);
+            }
         }
         obj["EmailConfiguration"] = email;
     }
@@ -977,42 +1031,74 @@ fn user_pool_to_json(pool: &UserPool) -> Value {
         }
         obj["SmsConfiguration"] = sms;
     }
-    if let Some(ref ac) = pool.admin_create_user_config {
-        let mut admin = json!({});
-        if let Some(v) = ac.allow_admin_create_user_only {
-            admin["AllowAdminCreateUserOnly"] = json!(v);
-        }
-        if let Some(ref imt) = ac.invite_message_template {
-            let mut tmpl = json!({});
-            if let Some(ref v) = imt.email_message {
-                tmpl["EmailMessage"] = json!(v);
+    {
+        let mut admin = json!({
+            "AllowAdminCreateUserOnly": false,
+        });
+        if let Some(ref ac) = pool.admin_create_user_config {
+            if let Some(v) = ac.allow_admin_create_user_only {
+                admin["AllowAdminCreateUserOnly"] = json!(v);
             }
-            if let Some(ref v) = imt.email_subject {
-                tmpl["EmailSubject"] = json!(v);
+            if let Some(ref imt) = ac.invite_message_template {
+                let mut tmpl = json!({});
+                if let Some(ref v) = imt.email_message {
+                    tmpl["EmailMessage"] = json!(v);
+                }
+                if let Some(ref v) = imt.email_subject {
+                    tmpl["EmailSubject"] = json!(v);
+                }
+                if let Some(ref v) = imt.sms_message {
+                    tmpl["SMSMessage"] = json!(v);
+                }
+                admin["InviteMessageTemplate"] = tmpl;
             }
-            if let Some(ref v) = imt.sms_message {
-                tmpl["SMSMessage"] = json!(v);
+            if let Some(v) = ac.unused_account_validity_days {
+                admin["UnusedAccountValidityDays"] = json!(v);
             }
-            admin["InviteMessageTemplate"] = tmpl;
-        }
-        if let Some(v) = ac.unused_account_validity_days {
-            admin["UnusedAccountValidityDays"] = json!(v);
         }
         obj["AdminCreateUserConfig"] = admin;
     }
-    if let Some(ref ars) = pool.account_recovery_setting {
-        obj["AccountRecoverySetting"] = json!({
-            "RecoveryMechanisms": ars.recovery_mechanisms.iter().map(|r| {
-                json!({
-                    "Name": r.name,
-                    "Priority": r.priority,
+    {
+        let mechanisms: Vec<Value> = match pool.account_recovery_setting {
+            Some(ref ars) if !ars.recovery_mechanisms.is_empty() => ars
+                .recovery_mechanisms
+                .iter()
+                .map(|r| {
+                    json!({
+                        "Name": r.name,
+                        "Priority": r.priority,
+                    })
                 })
-            }).collect::<Vec<Value>>(),
+                .collect(),
+            _ => vec![json!({ "Name": "verified_email", "Priority": 1 })],
+        };
+        obj["AccountRecoverySetting"] = json!({ "RecoveryMechanisms": mechanisms });
+    }
+    {
+        let mut vmt = json!({
+            "DefaultEmailOption": "CONFIRM_WITH_CODE",
         });
+        if let Some(ref t) = pool.verification_message_template {
+            vmt["DefaultEmailOption"] = json!(t.default_email_option);
+            if let Some(ref v) = t.email_message {
+                vmt["EmailMessage"] = json!(v);
+            }
+            if let Some(ref v) = t.email_subject {
+                vmt["EmailSubject"] = json!(v);
+            }
+            if let Some(ref v) = t.email_message_by_link {
+                vmt["EmailMessageByLink"] = json!(v);
+            }
+            if let Some(ref v) = t.email_subject_by_link {
+                vmt["EmailSubjectByLink"] = json!(v);
+            }
+            if let Some(ref v) = t.sms_message {
+                vmt["SmsMessage"] = json!(v);
+            }
+        }
+        obj["VerificationMessageTemplate"] = vmt;
     }
-    if let Some(ref dp) = pool.deletion_protection {
-        obj["DeletionProtection"] = json!(dp);
-    }
+    obj["DeletionProtection"] = json!(pool.deletion_protection.as_deref().unwrap_or("INACTIVE"));
 
     obj
 }

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -11,9 +11,10 @@ use crate::state::{
 use super::{
     ensure_user_pool_exists, generate_client_id, generate_client_secret, generate_pool_id,
     parse_account_recovery_setting, parse_admin_create_user_config, parse_email_configuration,
-    parse_password_policy, parse_schema_attribute, parse_sms_configuration, parse_string_array,
-    parse_tags, parse_token_validity_units, require_str, user_pool_client_to_json,
-    user_pool_to_json, validate_enum, validate_range, validate_string_length, CognitoService,
+    parse_password_policy, parse_schema_attribute, parse_sign_in_policy, parse_sms_configuration,
+    parse_string_array, parse_tags, parse_token_validity_units,
+    parse_verification_message_template, require_str, user_pool_client_to_json, user_pool_to_json,
+    validate_enum, validate_range, validate_string_length, CognitoService,
 };
 
 impl CognitoService {
@@ -75,6 +76,7 @@ impl CognitoService {
 
         // Parse password policy or use defaults
         let password_policy = parse_password_policy(&body["Policies"]["PasswordPolicy"]);
+        let sign_in_policy = parse_sign_in_policy(&body["Policies"]["SignInPolicy"]);
 
         // Parse auto verified attributes
         let auto_verified_attributes = parse_string_array(&body["AutoVerifiedAttributes"]);
@@ -128,6 +130,14 @@ impl CognitoService {
 
         let deletion_protection = body["DeletionProtection"].as_str().map(|s| s.to_string());
 
+        let user_pool_tier = body["UserPoolTier"]
+            .as_str()
+            .unwrap_or("ESSENTIALS")
+            .to_string();
+
+        let verification_message_template =
+            parse_verification_message_template(&body["VerificationMessageTemplate"]);
+
         let pool = UserPool {
             id: pool_id.clone(),
             name: pool_name.to_string(),
@@ -135,7 +145,10 @@ impl CognitoService {
             status: "ACTIVE".to_string(),
             creation_date: now,
             last_modified_date: now,
-            policies: PoolPolicies { password_policy },
+            policies: PoolPolicies {
+                password_policy,
+                sign_in_policy,
+            },
             auto_verified_attributes,
             username_attributes,
             alias_attributes,
@@ -151,6 +164,8 @@ impl CognitoService {
             estimated_number_of_users: 0,
             software_token_mfa_configuration: None,
             sms_mfa_configuration: None,
+            user_pool_tier,
+            verification_message_template,
         };
 
         let response = user_pool_to_json(&pool);
@@ -220,6 +235,20 @@ impl CognitoService {
         if body["Policies"]["PasswordPolicy"].is_object() {
             pool.policies.password_policy =
                 parse_password_policy(&body["Policies"]["PasswordPolicy"]);
+        }
+
+        if body["Policies"]["SignInPolicy"].is_object() {
+            pool.policies.sign_in_policy = parse_sign_in_policy(&body["Policies"]["SignInPolicy"]);
+        }
+
+        if body["VerificationMessageTemplate"].is_object() {
+            pool.verification_message_template =
+                parse_verification_message_template(&body["VerificationMessageTemplate"]);
+        }
+
+        if let Some(tier) = body["UserPoolTier"].as_str() {
+            validate_enum(tier, "userPoolTier", &["LITE", "ESSENTIALS", "PLUS"])?;
+            pool.user_pool_tier = tier.to_string();
         }
 
         if body["AutoVerifiedAttributes"].is_array() {

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -190,6 +190,23 @@ pub struct UserPool {
     pub estimated_number_of_users: i64,
     pub software_token_mfa_configuration: Option<SoftwareTokenMfaConfiguration>,
     pub sms_mfa_configuration: Option<SmsMfaConfiguration>,
+    pub user_pool_tier: String,
+    pub verification_message_template: Option<VerificationMessageTemplate>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct VerificationMessageTemplate {
+    pub default_email_option: String,
+    pub email_message: Option<String>,
+    pub email_subject: Option<String>,
+    pub email_message_by_link: Option<String>,
+    pub email_subject_by_link: Option<String>,
+    pub sms_message: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SignInPolicy {
+    pub allowed_first_auth_factors: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -206,6 +223,7 @@ pub struct SmsMfaConfiguration {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PoolPolicies {
     pub password_policy: PasswordPolicy,
+    pub sign_in_policy: SignInPolicy,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/fakecloud-cognito/src/triggers.rs
+++ b/crates/fakecloud-cognito/src/triggers.rs
@@ -540,6 +540,9 @@ mod tests {
                     last_modified_date: chrono::Utc::now(),
                     policies: crate::state::PoolPolicies {
                         password_policy: crate::state::PasswordPolicy::default(),
+                        sign_in_policy: crate::state::SignInPolicy {
+                            allowed_first_auth_factors: vec!["PASSWORD".to_string()],
+                        },
                     },
                     auto_verified_attributes: vec![],
                     username_attributes: None,
@@ -559,6 +562,8 @@ mod tests {
                     estimated_number_of_users: 0,
                     software_token_mfa_configuration: None,
                     sms_mfa_configuration: None,
+                    user_pool_tier: "ESSENTIALS".to_string(),
+                    verification_message_template: None,
                 },
             );
         }

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -77,6 +77,85 @@ async fn cognito_create_describe_user_pool() {
 }
 
 #[tokio::test]
+async fn cognito_user_pool_default_shape() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let result = client
+        .create_user_pool()
+        .pool_name("default-shape")
+        .send()
+        .await
+        .expect("create user pool");
+    let id = result.user_pool().unwrap().id().unwrap().to_string();
+
+    let described = client
+        .describe_user_pool()
+        .user_pool_id(&id)
+        .send()
+        .await
+        .expect("describe user pool");
+    let pool = described.user_pool().unwrap();
+
+    // user_pool_tier defaults to ESSENTIALS
+    assert_eq!(
+        pool.user_pool_tier().map(|t| t.as_str()),
+        Some("ESSENTIALS"),
+    );
+
+    // email_configuration default: COGNITO_DEFAULT
+    let ec = pool
+        .email_configuration()
+        .expect("EmailConfiguration must be returned");
+    assert_eq!(
+        ec.email_sending_account().map(|a| a.as_str()),
+        Some("COGNITO_DEFAULT"),
+    );
+
+    // verification_message_template default: CONFIRM_WITH_CODE
+    let vmt = pool
+        .verification_message_template()
+        .expect("VerificationMessageTemplate must be returned");
+    assert_eq!(
+        vmt.default_email_option().map(|o| o.as_str()),
+        Some("CONFIRM_WITH_CODE"),
+    );
+
+    // sign_in_policy.allowed_first_auth_factors defaults to [PASSWORD]
+    let sip = pool
+        .policies()
+        .and_then(|p| p.sign_in_policy())
+        .expect("SignInPolicy must be returned");
+    let factors: Vec<&str> = sip
+        .allowed_first_auth_factors()
+        .iter()
+        .map(|f| f.as_str())
+        .collect();
+    assert_eq!(factors, vec!["PASSWORD"]);
+
+    // account_recovery_setting default: at least one mechanism
+    let ars = pool
+        .account_recovery_setting()
+        .expect("AccountRecoverySetting must be returned");
+    assert!(
+        !ars.recovery_mechanisms().is_empty(),
+        "default account recovery must have at least one mechanism"
+    );
+
+    // admin_create_user_config is always returned
+    let acuc = pool
+        .admin_create_user_config()
+        .expect("AdminCreateUserConfig must be returned");
+    assert!(!acuc.allow_admin_create_user_only());
+
+    // deletion_protection default: INACTIVE
+    assert_eq!(
+        pool.deletion_protection().map(|d| d.as_str()),
+        Some("INACTIVE"),
+    );
+}
+
+#[tokio::test]
 async fn cognito_list_user_pools() {
     let server = TestServer::start().await;
     let client = server.cognito_client().await;

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -37,6 +37,21 @@ pub struct Service {
 
 pub const SERVICES: &[Service] = &[
     Service {
+        name: "cognitoidp",
+        // Batch 11: core `aws_cognito_user_pool` smoke. The fix here is
+        // returning five shape blocks with AWS defaults on every
+        // DescribeUserPool, which Terraform's provider asserts after
+        // create: `email_configuration.email_sending_account =
+        // COGNITO_DEFAULT`, `verification_message_template.
+        // default_email_option = CONFIRM_WITH_CODE`,
+        // `sign_in_policy.allowed_first_auth_factors = ["PASSWORD"]`,
+        // `user_pool_tier = ESSENTIALS`, and a non-empty
+        // `account_recovery_setting`. None of these were emitted
+        // unless the caller set them at create time.
+        run_regex: "^TestAccCognitoIDPUserPool_basic$",
+        deny: &[],
+    },
+    Service {
         name: "bedrock",
         // Batch 10: `data.aws_bedrock_foundation_models` data source
         // smoke. fakecloud's Bedrock implementation already returns the

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -28,6 +28,11 @@ async fn run_service(name: &str) {
 }
 
 #[tokio::test]
+async fn cognitoidp_acceptance() {
+    run_service("cognitoidp").await;
+}
+
+#[tokio::test]
 async fn bedrock_acceptance() {
     run_service("bedrock").await;
 }


### PR DESCRIPTION
## Summary

Enables \`TestAccCognitoIDPUserPool_basic\` against fakecloud by returning the five default-shaped blocks that the upstream Terraform provider asserts on every refresh after a bare \`aws_cognito_user_pool\` create:

- \`EmailConfiguration.EmailSendingAccount\` defaults to \`COGNITO_DEFAULT\`
- \`VerificationMessageTemplate.DefaultEmailOption\` defaults to \`CONFIRM_WITH_CODE\`
- \`Policies.SignInPolicy.AllowedFirstAuthFactors\` defaults to \`["PASSWORD"]\`
- \`UserPoolTier\` is persisted (was validated-then-dropped) and defaults to \`ESSENTIALS\`
- \`AccountRecoverySetting\`, \`AdminCreateUserConfig\`, and \`DeletionProtection\` are always emitted with AWS defaults

This is shape parity — we don't implement passwordless auth, tier billing, or real email sending, we just return the blocks AWS would return.

Cognito joins the tfacc allow-list with a narrow \`^TestAccCognitoIDPUserPool_basic$\` regex, matching earlier batches' tight CI-time budget.

## Test plan

- [x] New \`cognito_user_pool_default_shape\` e2e regression asserting each default block
- [x] Full \`fakecloud-e2e --test cognito\` suite (61 tests) still green
- [x] \`cognitoidp_acceptance\` tfacc test passes locally (\`FAKECLOUD_TFACC_PARALLEL=2\`, ~130s)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] Conformance stays at 100% (56694/56694 variants)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns AWS default-shaped blocks in DescribeUserPool so `aws_cognito_user_pool` refreshes cleanly in tfacc, and persists `UserPoolTier`. Enables `TestAccCognitoIDPUserPool_basic` against fakecloud.

- **New Features**
  - DescribeUserPool now returns AWS defaults for EmailConfiguration.EmailSendingAccount, VerificationMessageTemplate.DefaultEmailOption, Policies.SignInPolicy.AllowedFirstAuthFactors, AccountRecoverySetting, AdminCreateUserConfig, and DeletionProtection.
  - Persist `UserPoolTier` (default `ESSENTIALS`).
  - Implement parsing/serialization for `SignInPolicy` and `VerificationMessageTemplate` in `fakecloud-cognito`.
  - Enable tfacc: allowlist `cognitoidp` in `fakecloud-tfacc` with `^TestAccCognitoIDPUserPool_basic$`; add `cognito_user_pool_default_shape` e2e and an acceptance test.

<sup>Written for commit 3596c1629c04152d1511b1caa828bafd80cbf55c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

