### PR TITLE
feat(iam): dispatch wires resource policies into evaluation

### DIFF
--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -299,8 +299,27 @@ pub async fn dispatch(
                             &aws_request.region,
                             is_secure_transport(&aws_request.headers),
                         );
-                        let decision =
-                            evaluator.evaluate(principal, &iam_action, &condition_context);
+                        // Phase 2: fetch the resource-based policy (if
+                        // any) attached to the target resource and
+                        // pass it to the evaluator alongside the
+                        // principal's identity policies. The resource's
+                        // owning account is parsed from the ARN (#381
+                        // multi-account alignment); S3 ARNs have an
+                        // empty account field, so we fall back to the
+                        // server's configured account ID in that case.
+                        let resource_policy_json =
+                            config.resource_policy_provider.as_ref().and_then(|p| {
+                                p.resource_policy(&detected.service, &iam_action.resource)
+                            });
+                        let resource_account_id = parse_account_from_arn(&iam_action.resource)
+                            .unwrap_or_else(|| config.account_id.clone());
+                        let decision = evaluator.evaluate_with_resource_policy(
+                            principal,
+                            &iam_action,
+                            &condition_context,
+                            resource_policy_json.as_deref(),
+                            &resource_account_id,
+                        );
                         if !decision.is_allow() {
                             tracing::warn!(
                                 target: "fakecloud::iam::audit",
@@ -308,6 +327,7 @@ pub async fn dispatch(
                                 action = %iam_action.action_string(),
                                 resource = %iam_action.resource,
                                 principal = %principal.arn,
+                                resource_policy_present = resource_policy_json.is_some(),
                                 decision = ?decision,
                                 mode = %config.iam_mode,
                                 request_id = %request_id,
@@ -484,6 +504,33 @@ impl DispatchConfig {
             policy_evaluator: None,
             resource_policy_provider: None,
         }
+    }
+}
+
+/// Extract the 12-digit account ID segment from an AWS ARN.
+///
+/// ARNs follow `arn:<partition>:<service>:<region>:<account>:<resource>`.
+/// For the cross-account decision in IAM enforcement, the "resource
+/// account" is the ARN's account segment. Some services (notably S3)
+/// produce ARNs with an empty account field — for those we return
+/// `None` and let the caller fall back to the server's configured
+/// account ID. Malformed or non-ARN strings also return `None`.
+fn parse_account_from_arn(arn: &str) -> Option<String> {
+    let mut parts = arn.splitn(6, ':');
+    if parts.next()? != "arn" {
+        return None;
+    }
+    let _partition = parts.next()?;
+    let _service = parts.next()?;
+    let _region = parts.next()?;
+    let account = parts.next()?;
+    // Resource segment must exist (parts.next().is_some()) for the ARN
+    // to be well-formed, but we don't consume its value here.
+    parts.next()?;
+    if account.is_empty() {
+        None
+    } else {
+        Some(account.to_string())
     }
 }
 
@@ -701,6 +748,36 @@ mod tests {
         assert!(!is_secure_transport(&headers));
         let empty = http::HeaderMap::new();
         assert!(!is_secure_transport(&empty));
+    }
+
+    #[test]
+    fn parse_account_from_arn_extracts_standard_shapes() {
+        assert_eq!(
+            parse_account_from_arn("arn:aws:sqs:us-east-1:123456789012:queue"),
+            Some("123456789012".to_string())
+        );
+        assert_eq!(
+            parse_account_from_arn("arn:aws:iam::123456789012:user/alice"),
+            Some("123456789012".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_account_from_arn_returns_none_for_s3_empty_account() {
+        // S3 ARNs have both region and account empty.
+        assert_eq!(parse_account_from_arn("arn:aws:s3:::my-bucket"), None);
+        assert_eq!(
+            parse_account_from_arn("arn:aws:s3:::my-bucket/path/to/key"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_account_from_arn_returns_none_for_malformed() {
+        assert_eq!(parse_account_from_arn(""), None);
+        assert_eq!(parse_account_from_arn("not-an-arn"), None);
+        assert_eq!(parse_account_from_arn("arn:aws:sqs:us-east-1"), None);
+        assert_eq!(parse_account_from_arn("arn:aws:sqs"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 2 IAM rollout, Batch 3 of 5. Connects the plumbing from Batches 1 and 2: when enforcement is on, dispatch now fetches the target resource's resource-based policy via the \`ResourcePolicyProvider\` and hands it to the evaluator alongside the principal's identity policies.

- Dispatch looks up the resource policy via \`DispatchConfig::resource_policy_provider\` (S3 only in the initial rollout).
- New \`parse_account_from_arn\` helper extracts the resource's owning account from the ARN; falls back to the server's configured account ID when the ARN has an empty account segment (S3 ARNs always do). Per #381 the cross-account decision is per-ARN, not a global config knob.
- Calls \`IamPolicyEvaluator::evaluate_with_resource_policy\` instead of \`evaluate\`, reusing the AWS-shaped cross-account semantics from Batch 2.
- Audit log gains \`resource_policy_present\` so operators can see whether a resource policy was consulted on a deny.
- Unit tests on \`parse_account_from_arn\` cover standard ARNs (sqs, iam), S3 empty-account shapes, and malformed input.

Soft/strict branching, root-bypass, and test-AKID short-circuit are unchanged. \`FAKECLOUD_IAM=off\` is unchanged — the provider is only consulted when enforcement is enabled. Existing Phase 1 identity-only tests stay green because same-account without a resource policy preserves the Phase 1 path exactly.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-core --lib\` (55 tests, 3 new)
- [x] \`cargo test --workspace --lib\` green
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires resource-based policies into IAM evaluation in dispatch. Dispatch now fetches the target resource’s policy and evaluates it with identity policies; adds per-ARN account parsing and an audit flag. Initial rollout supports S3.

- **New Features**
  - Fetch resource policy via `DispatchConfig::resource_policy_provider` (S3 only).
  - Call `IamPolicyEvaluator::evaluate_with_resource_policy`, passing policy JSON and the resource account.
  - Add `parse_account_from_arn` to extract the account; fall back to the configured account for empty-account ARNs.
  - Log `resource_policy_present` in the audit trail for denies.
  - Only consults the provider when IAM enforcement is enabled; Phase 1 same-account path remains unchanged without a resource policy.

<sup>Written for commit 0043a0475cdd38ea309dd457096f8c15d6034f64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

