### PR TITLE
feat(iam): SnsResourcePolicyProvider

### DIFF
--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -507,7 +507,7 @@ async fn main() {
         } else {
             None
         };
-    let mut sns_service = SnsService::new(sns_state, delivery_for_sns);
+    let mut sns_service = SnsService::new(sns_state.clone(), delivery_for_sns);
     if let Some(store) = sns_snapshot_store {
         sns_service = sns_service.with_snapshot_store(store);
     }
@@ -1191,7 +1191,12 @@ async fn main() {
         // it doesn't own, so additional services can be added by
         // appending to this list without touching the core crate.
         resource_policy_provider: Some(fakecloud_core::auth::MultiResourcePolicyProvider::shared(
-            vec![fakecloud_s3::resource_policy::S3ResourcePolicyProvider::shared(s3_state.clone())],
+            vec![
+                fakecloud_s3::resource_policy::S3ResourcePolicyProvider::shared(s3_state.clone()),
+                fakecloud_sns::resource_policy::SnsResourcePolicyProvider::shared(
+                    sns_state.clone(),
+                ),
+            ],
         )),
     };
 

--- a/crates/fakecloud-sns/src/lib.rs
+++ b/crates/fakecloud-sns/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod delivery;
+pub mod resource_policy;
 pub mod service;
 pub mod simulation;
 pub mod state;

--- a/crates/fakecloud-sns/src/resource_policy.rs
+++ b/crates/fakecloud-sns/src/resource_policy.rs
@@ -1,0 +1,209 @@
+//! SNS implementation of [`ResourcePolicyProvider`].
+//!
+//! SNS persists topic policies as raw JSON in
+//! [`crate::state::SnsTopic::attributes`] under the `Policy` key; both
+//! `SetTopicAttributes` and `AddPermission` / `RemovePermission` write
+//! through that same slot. This file is the read-side bridge into the
+//! `fakecloud-core::auth::ResourcePolicyProvider` trait — dispatch
+//! fetches the stored document and hands it to the evaluator alongside
+//! the caller's identity policies.
+//!
+//! Mirrors the shape of `fakecloud_s3::resource_policy` intentionally:
+//! single-service gate, ARN parsing, state lookup, return `None` for
+//! anything not owned here so composition is safe.
+
+use std::sync::Arc;
+
+use fakecloud_core::auth::ResourcePolicyProvider;
+
+use crate::state::SharedSnsState;
+
+/// Concrete [`ResourcePolicyProvider`] backed by the in-memory
+/// [`crate::state::SnsState`]. Server bootstrap clone-shares it via
+/// [`fakecloud_core::auth::MultiResourcePolicyProvider`].
+pub struct SnsResourcePolicyProvider {
+    state: SharedSnsState,
+}
+
+impl SnsResourcePolicyProvider {
+    pub fn new(state: SharedSnsState) -> Self {
+        Self { state }
+    }
+
+    /// Convenience constructor returning an
+    /// `Arc<dyn ResourcePolicyProvider>` so bootstrap can push it
+    /// directly into a `MultiResourcePolicyProvider`.
+    pub fn shared(state: SharedSnsState) -> Arc<dyn ResourcePolicyProvider> {
+        Arc::new(Self::new(state))
+    }
+}
+
+impl ResourcePolicyProvider for SnsResourcePolicyProvider {
+    fn resource_policy(&self, service: &str, resource_arn: &str) -> Option<String> {
+        if !service.eq_ignore_ascii_case("sns") {
+            return None;
+        }
+        if !is_sns_topic_arn(resource_arn) {
+            return None;
+        }
+        let state = self.state.read();
+        state
+            .topics
+            .get(resource_arn)
+            .and_then(|t| t.attributes.get("Policy"))
+            .cloned()
+    }
+}
+
+/// A very light validity check on an SNS topic ARN. Accepts the
+/// `arn:aws:sns:REGION:ACCOUNT:NAME` shape and nothing else — anything
+/// that doesn't look like an SNS ARN short-circuits to `None` before
+/// we reach the state map so we never accidentally hand out a policy
+/// belonging to some unrelated ARN that happens to be a map key.
+fn is_sns_topic_arn(arn: &str) -> bool {
+    let Some(rest) = arn.strip_prefix("arn:aws:sns:") else {
+        return false;
+    };
+    // Expect exactly 3 colon-separated segments after the prefix:
+    // REGION, ACCOUNT, NAME. Anything else is malformed for SNS.
+    let parts: Vec<&str> = rest.splitn(3, ':').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    // All three segments must be non-empty — AWS doesn't allow blank
+    // region, account, or name on a real SNS ARN, and our state map is
+    // keyed by the fully-qualified ARN so blanks would never match
+    // anyway.
+    parts.iter().all(|p| !p.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{SnsState, SnsTopic};
+    use chrono::Utc;
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+
+    fn state_with_topic(arn: &str, policy: Option<&str>) -> SharedSnsState {
+        let mut s = SnsState::new("123456789012", "us-east-1", "http://localhost:4566");
+        let mut attrs = HashMap::new();
+        if let Some(p) = policy {
+            attrs.insert("Policy".to_string(), p.to_string());
+        }
+        s.topics.insert(
+            arn.to_string(),
+            SnsTopic {
+                topic_arn: arn.to_string(),
+                name: arn.rsplit(':').next().unwrap_or("t").to_string(),
+                attributes: attrs,
+                tags: Vec::new(),
+                is_fifo: false,
+                created_at: Utc::now(),
+            },
+        );
+        Arc::new(RwLock::new(s))
+    }
+
+    #[test]
+    fn returns_stored_policy_for_sns_arn() {
+        let policy_json = r#"{"Version":"2012-10-17","Statement":[]}"#;
+        let state = state_with_topic(
+            "arn:aws:sns:us-east-1:123456789012:my-topic",
+            Some(policy_json),
+        );
+        let provider = SnsResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy("sns", "arn:aws:sns:us-east-1:123456789012:my-topic"),
+            Some(policy_json.to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_when_topic_has_no_policy_attribute() {
+        let state = state_with_topic("arn:aws:sns:us-east-1:123456789012:my-topic", None);
+        let provider = SnsResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy("sns", "arn:aws:sns:us-east-1:123456789012:my-topic"),
+            None
+        );
+    }
+
+    #[test]
+    fn returns_none_when_topic_missing() {
+        let state = state_with_topic("arn:aws:sns:us-east-1:123456789012:other", Some("{}"));
+        let provider = SnsResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy("sns", "arn:aws:sns:us-east-1:123456789012:my-topic"),
+            None
+        );
+    }
+
+    #[test]
+    fn returns_none_for_non_sns_service_prefix() {
+        let state = state_with_topic("arn:aws:sns:us-east-1:123456789012:t", Some("{}"));
+        let provider = SnsResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy("s3", "arn:aws:sns:us-east-1:123456789012:t"),
+            None
+        );
+        assert_eq!(
+            provider.resource_policy("lambda", "arn:aws:sns:us-east-1:123456789012:t"),
+            None
+        );
+    }
+
+    #[test]
+    fn service_prefix_match_is_case_insensitive() {
+        let state = state_with_topic("arn:aws:sns:us-east-1:123456789012:t", Some("{}"));
+        let provider = SnsResourcePolicyProvider::new(state);
+        assert!(provider
+            .resource_policy("SNS", "arn:aws:sns:us-east-1:123456789012:t")
+            .is_some());
+    }
+
+    #[test]
+    fn returns_none_for_malformed_arn() {
+        let state = state_with_topic("arn:aws:sns:us-east-1:123456789012:t", Some("{}"));
+        let provider = SnsResourcePolicyProvider::new(state);
+        assert_eq!(provider.resource_policy("sns", ""), None);
+        assert_eq!(provider.resource_policy("sns", "not-an-arn"), None);
+        assert_eq!(provider.resource_policy("sns", "arn:aws:sns:"), None);
+        assert_eq!(
+            provider.resource_policy("sns", "arn:aws:sns:us-east-1:"),
+            None
+        );
+        // S3-shaped ARN must not match even if service prefix is sns
+        assert_eq!(
+            provider.resource_policy("sns", "arn:aws:s3:::my-bucket"),
+            None
+        );
+    }
+
+    #[test]
+    fn is_sns_topic_arn_rejects_empty_segments() {
+        assert!(!is_sns_topic_arn("arn:aws:sns:::t"));
+        assert!(!is_sns_topic_arn("arn:aws:sns:us-east-1::t"));
+        assert!(!is_sns_topic_arn("arn:aws:sns:us-east-1:123456789012:"));
+    }
+
+    #[test]
+    fn is_sns_topic_arn_accepts_fifo_suffix() {
+        // FIFO topic ARNs end with .fifo; the prefix parser shouldn't
+        // care about the suffix.
+        assert!(is_sns_topic_arn(
+            "arn:aws:sns:us-east-1:123456789012:my-topic.fifo"
+        ));
+    }
+
+    #[test]
+    fn shared_constructor_wraps_in_arc() {
+        let state = state_with_topic("arn:aws:sns:us-east-1:123456789012:t", Some("doc"));
+        let arc = SnsResourcePolicyProvider::shared(state);
+        assert_eq!(
+            arc.resource_policy("sns", "arn:aws:sns:us-east-1:123456789012:t")
+                .as_deref(),
+            Some("doc")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 IAM rollout for SNS + Lambda resource policies, Batch 2 of 5. Exposes the already-stored SNS topic policy to the resource-policy evaluator path shipped in Batch 1.

- SNS already persists the topic policy as raw JSON in \`SnsTopic.attributes["Policy"]\` — both \`SetTopicAttributes\` and \`AddPermission\`/\`RemovePermission\` write through the same slot. \`iam_enforceable()\` has been \`true\` since the identity-policy rollout. This batch only adds the read-side bridge.
- New \`SnsResourcePolicyProvider\` wraps \`SharedSnsState\`, gates on the \`sns\` service prefix (case-insensitive), validates the ARN shape (\`arn:aws:sns:REGION:ACCOUNT:NAME\`, all segments non-empty), returns \`state.topics[arn].attributes["Policy"]\`.
- Registered in the \`MultiResourcePolicyProvider\` at server bootstrap alongside the existing S3 provider. \`sns_state\` now clones into the \`SnsService\` constructor so it stays available for the provider.
- 9 unit tests: stored policy hit, missing \`Policy\` attribute, missing topic, wrong service prefix (s3/lambda), case-insensitive match, malformed ARN (empty / non-ARN / too-short / S3-shaped), FIFO suffix, shared \`Arc\` constructor.

No evaluator changes. \`PrincipalPattern::Service\` matching already handles \`{"Service":"events.amazonaws.com"}\` grants (EventBridge → SNS), which is the common shape in the wild.

**Off-by-default:** \`FAKECLOUD_IAM=off\` skips the whole fetch path, no behavior change.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-sns --lib resource_policy\` (9 new)
- [x] \`cargo test --workspace --lib\` green
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `SnsResourcePolicyProvider` to expose stored SNS topic policies to the IAM resource-policy evaluator, so SNS topic policies are enforced like S3 bucket policies. Behavior is unchanged when `FAKECLOUD_IAM=off`.

- **New Features**
  - New `fakecloud_sns::resource_policy::SnsResourcePolicyProvider` that reads JSON from `SnsTopic.attributes["Policy"]`.
  - Handles only `sns` (case-insensitive) and validates ARNs as `arn:aws:sns:REGION:ACCOUNT:NAME`.
  - Registered in `fakecloud_core::auth::MultiResourcePolicyProvider`; `sns_state` is cloned at bootstrap and in `SnsService::new`.
  - No evaluator changes; existing service principal matching covers EventBridge → SNS.
  - 9 unit tests cover stored policy, missing policy/topic, service/ARN validation, FIFO suffix, and `Arc` constructor.

<sup>Written for commit 36e40651dcfc49aca145d0bd2485a4f98011efbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

