### PR TITLE
feat(iam): LambdaResourcePolicyProvider + SNS/Lambda resource-policy E2E

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -813,3 +813,414 @@ async fn bucket_policy_condition_block_gates_access() {
         "expected AccessDenied, got {err:?}"
     );
 }
+
+// ======================================================================
+// Phase 2: SNS topic policies
+//
+// Drives the resource-policy evaluator path end-to-end for SNS:
+// dispatch fetches the topic policy via the `SnsResourcePolicyProvider`
+// and hands it to the evaluator alongside the caller's identity
+// policies. All of these are same-account — the cross-account
+// intersection semantics are covered by unit tests in
+// `fakecloud-iam::evaluator`.
+// ======================================================================
+
+async fn seed_topic_with_policy(server: &TestServer, name: &str, policy_json: &str) -> String {
+    let boot = sdk_config_with(server, "test", "test").await;
+    let sns_boot = aws_sdk_sns::Client::new(&boot);
+    let topic_arn = sns_boot
+        .create_topic()
+        .name(name)
+        .send()
+        .await
+        .unwrap()
+        .topic_arn()
+        .unwrap()
+        .to_string();
+    sns_boot
+        .set_topic_attributes()
+        .topic_arn(&topic_arn)
+        .attribute_name("Policy")
+        .attribute_value(policy_json)
+        .send()
+        .await
+        .unwrap();
+    topic_arn
+}
+
+#[tokio::test]
+async fn topic_policy_grants_publish_without_identity_policy() {
+    // Same-account Allow-union: user has no identity policy, but the
+    // topic policy names them and grants sns:Publish. The request
+    // should succeed.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "tp_reader").await;
+    let topic_arn = seed_topic_with_policy(
+        &server,
+        "tp-shared",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Principal":{"AWS":"arn:aws:iam::123456789012:user/tp_reader"},
+            "Action":"sns:Publish",
+            "Resource":"*"
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sns = aws_sdk_sns::Client::new(&cfg);
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("hello")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn topic_policy_explicit_deny_beats_identity_allow() {
+    // Identity policy grants sns:Publish on this topic, but the topic
+    // policy denies it explicitly. Explicit Deny wins.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "tp_blocked").await;
+    let topic_arn = seed_topic_with_policy(
+        &server,
+        "tp-locked",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Deny",
+            "Principal":{"AWS":"arn:aws:iam::123456789012:user/tp_blocked"},
+            "Action":"sns:Publish",
+            "Resource":"*"
+        }]}"#,
+    )
+    .await;
+    let identity_policy = format!(
+        r#"{{"Version":"2012-10-17","Statement":[{{"Effect":"Allow","Action":"sns:Publish","Resource":"{topic_arn}"}}]}}"#
+    );
+    attach_inline_policy(&server, "tp_blocked", "AllowTp", &identity_policy).await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sns = aws_sdk_sns::Client::new(&cfg);
+    let err = sns
+        .publish()
+        .topic_arn(&topic_arn)
+        .message("nope")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn topic_policy_principal_wildcard_grants_any_user() {
+    // `"Principal": "*"` on a topic should let any non-root caller
+    // publish, without any identity-side policy.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "tp_anyone").await;
+    let topic_arn = seed_topic_with_policy(
+        &server,
+        "tp-public",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Principal":"*",
+            "Action":"sns:Publish",
+            "Resource":"*"
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sns = aws_sdk_sns::Client::new(&cfg);
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("hi")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn topic_policy_service_principal_does_not_grant_user() {
+    // Regression guard for the Service-principal matcher: a topic
+    // policy granting `{"Service":"events.amazonaws.com"}` must NOT
+    // grant a random IAM user — only a principal whose ARN looks
+    // like a Lambda/Events service-linked role would match.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "tp_svc_user").await;
+    let topic_arn = seed_topic_with_policy(
+        &server,
+        "tp-events-only",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Principal":{"Service":"events.amazonaws.com"},
+            "Action":"sns:Publish",
+            "Resource":"*"
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sns = aws_sdk_sns::Client::new(&cfg);
+    let err = sns
+        .publish()
+        .topic_arn(&topic_arn)
+        .message("should deny")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn topic_policy_condition_block_gates_access() {
+    // Regression guard: Phase 2 condition evaluation still applies
+    // to resource-policy statements on SNS. The grant is conditional
+    // on `aws:SecureTransport == true`, and fakecloud's test server
+    // serves plain HTTP, so the condition does not match and the
+    // grant does not apply.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "tp_tls_only").await;
+    let topic_arn = seed_topic_with_policy(
+        &server,
+        "tp-tls-only",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Principal":"*",
+            "Action":"sns:Publish",
+            "Resource":"*",
+            "Condition":{"Bool":{"aws:SecureTransport":"true"}}
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sns = aws_sdk_sns::Client::new(&cfg);
+    let err = sns
+        .publish()
+        .topic_arn(&topic_arn)
+        .message("should deny")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {err:?}"
+    );
+}
+
+// ======================================================================
+// Phase 2: Lambda resource policies
+//
+// Drives the resource-policy evaluator path end-to-end for Lambda:
+// AddPermission composes a canonical policy document, dispatch fetches
+// it via LambdaResourcePolicyProvider, and the evaluator combines it
+// with the caller's identity policies. We never actually invoke the
+// function runtime — Invoke requests are denied at the enforcement
+// gate before reaching the container layer when enforcement says no,
+// and we match on AccessDeniedException / ServiceException shapes that
+// the runtime emits when enforcement says yes.
+// ======================================================================
+
+fn make_empty_python_zip() -> Vec<u8> {
+    use std::io::Write;
+    let buf = Vec::new();
+    let mut zip = zip::ZipWriter::new(std::io::Cursor::new(buf));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    zip.start_file("index.py", options).unwrap();
+    zip.write_all(b"def handler(event, context):\n    return {\"statusCode\": 200}\n")
+        .unwrap();
+    zip.finish().unwrap().into_inner()
+}
+
+async fn seed_function_with_permission(
+    server: &TestServer,
+    name: &str,
+    statement_id: &str,
+    principal_arn: &str,
+) -> String {
+    let boot = sdk_config_with(server, "test", "test").await;
+    let lambda_boot = aws_sdk_lambda::Client::new(&boot);
+    lambda_boot
+        .create_function()
+        .function_name(name)
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(aws_sdk_lambda::primitives::Blob::new(
+                    make_empty_python_zip(),
+                ))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    lambda_boot
+        .add_permission()
+        .function_name(name)
+        .statement_id(statement_id)
+        .action("InvokeFunction")
+        .principal(principal_arn)
+        .send()
+        .await
+        .unwrap();
+    format!("arn:aws:lambda:us-east-1:123456789012:function:{name}")
+}
+
+#[tokio::test]
+async fn lambda_function_policy_grants_invoke_without_identity_policy() {
+    // Same-account Allow-union on Lambda: no identity policy, but
+    // AddPermission installs a resource-policy statement naming the
+    // user. The Invoke enforcement gate must let the request through;
+    // we observe a ServiceException from the container runtime rather
+    // than an AccessDeniedException, which is how we distinguish
+    // "enforcement allowed" from "enforcement denied" without a real
+    // runtime.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "lam_invoker").await;
+    seed_function_with_permission(
+        &server,
+        "lam-shared-fn",
+        "invoker-grant",
+        "arn:aws:iam::123456789012:user/lam_invoker",
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let lambda = aws_sdk_lambda::Client::new(&cfg);
+    // Tolerate either a successful invocation (when a local runtime
+    // can actually execute the stub handler) or a non-Access service
+    // error (when it can't) — the only outcome we're guarding against
+    // is an enforcement-layer AccessDeniedException.
+    if let Err(err) = lambda.invoke().function_name("lam-shared-fn").send().await {
+        assert!(
+            !format!("{err:?}").contains("AccessDeniedException"),
+            "enforcement should have allowed this request, got AccessDenied: {err:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn lambda_function_without_policy_denies_non_root_invoke() {
+    // Sanity pair: same function shape but without AddPermission.
+    // Identity policy is empty, resource policy is empty -> implicit
+    // deny under strict mode, observable as AccessDeniedException.
+    let server = start_strict().await;
+    let boot = sdk_config_with(&server, "test", "test").await;
+    let lambda_boot = aws_sdk_lambda::Client::new(&boot);
+    lambda_boot
+        .create_function()
+        .function_name("lam-unpolicied")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(aws_sdk_lambda::primitives::Blob::new(
+                    make_empty_python_zip(),
+                ))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let (akid, secret) = bootstrap_user(&server, "lam_denied").await;
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let lambda = aws_sdk_lambda::Client::new(&cfg);
+    let err = lambda
+        .invoke()
+        .function_name("lam-unpolicied")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn lambda_function_policy_wildcard_principal_grants_any_user() {
+    // Public-function idiom: AddPermission with Principal="*" lets
+    // any non-root user through the enforcement gate.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "lam_anyone").await;
+    seed_function_with_permission(&server, "lam-public-fn", "any", "*").await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let lambda = aws_sdk_lambda::Client::new(&cfg);
+    if let Err(err) = lambda.invoke().function_name("lam-public-fn").send().await {
+        assert!(
+            !format!("{err:?}").contains("AccessDeniedException"),
+            "enforcement should have allowed this request, got AccessDenied: {err:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn lambda_function_policy_source_arn_condition_gates_grant() {
+    // Regression guard: AddPermission with SourceArn must emit an
+    // ArnLike Condition that the evaluator respects. We populate
+    // `aws:SourceArn` via a non-matching value, which is not
+    // currently plumbed from dispatch — so the condition never
+    // matches and the grant does not apply, leaving the user with
+    // an implicit deny from the empty identity-policy side.
+    //
+    // This is the "grant is conditional and condition does not
+    // apply -> fall through to identity policy" path. The evaluator
+    // treats an unknown condition key as "does not match" rather
+    // than "matches everything", so this test asserts the deny path
+    // exists end-to-end.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "lam_src_arn").await;
+    let boot = sdk_config_with(&server, "test", "test").await;
+    let lambda_boot = aws_sdk_lambda::Client::new(&boot);
+    lambda_boot
+        .create_function()
+        .function_name("lam-src-arn-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(aws_sdk_lambda::primitives::Blob::new(
+                    make_empty_python_zip(),
+                ))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    lambda_boot
+        .add_permission()
+        .function_name("lam-src-arn-fn")
+        .statement_id("gated")
+        .action("InvokeFunction")
+        .principal("arn:aws:iam::123456789012:user/lam_src_arn")
+        .source_arn("arn:aws:events:us-east-1:123456789012:rule/my-rule")
+        .send()
+        .await
+        .unwrap();
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let lambda = aws_sdk_lambda::Client::new(&cfg);
+    let err = lambda
+        .invoke()
+        .function_name("lam-src-arn-fn")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDeniedException"),
+        "condition-gated grant should not apply; expected AccessDenied, got {err:?}"
+    );
+}

--- a/crates/fakecloud-lambda/src/lib.rs
+++ b/crates/fakecloud-lambda/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod resource_policy;
 pub mod runtime;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-lambda/src/resource_policy.rs
+++ b/crates/fakecloud-lambda/src/resource_policy.rs
@@ -1,0 +1,282 @@
+//! Lambda implementation of [`ResourcePolicyProvider`].
+//!
+//! Lambda persists function resource policies as raw JSON in
+//! [`crate::state::LambdaFunction::policy`]. Both `AddPermission` and
+//! `RemovePermission` write through that field, seeding a canonical
+//! `{"Version":"2012-10-17","Statement":[...]}` document so the
+//! existing cross-service evaluator path reads it without a
+//! Lambda-specific fork. This file is the read-side bridge into the
+//! `fakecloud-core::auth::ResourcePolicyProvider` trait.
+//!
+//! Mirrors [`fakecloud_sns::resource_policy::SnsResourcePolicyProvider`]
+//! and [`fakecloud_s3::resource_policy::S3ResourcePolicyProvider`]:
+//! single-service gate, ARN parsing, state lookup, return `None` for
+//! anything not owned here so composition is safe.
+
+use std::sync::Arc;
+
+use fakecloud_core::auth::ResourcePolicyProvider;
+
+use crate::state::SharedLambdaState;
+
+/// Concrete [`ResourcePolicyProvider`] backed by the in-memory
+/// [`crate::state::LambdaState`]. Server bootstrap clone-shares it via
+/// [`fakecloud_core::auth::MultiResourcePolicyProvider`] alongside the
+/// S3 and SNS providers.
+pub struct LambdaResourcePolicyProvider {
+    state: SharedLambdaState,
+}
+
+impl LambdaResourcePolicyProvider {
+    pub fn new(state: SharedLambdaState) -> Self {
+        Self { state }
+    }
+
+    /// Convenience constructor returning an
+    /// `Arc<dyn ResourcePolicyProvider>` so bootstrap can push it
+    /// directly into a `MultiResourcePolicyProvider`.
+    pub fn shared(state: SharedLambdaState) -> Arc<dyn ResourcePolicyProvider> {
+        Arc::new(Self::new(state))
+    }
+}
+
+impl ResourcePolicyProvider for LambdaResourcePolicyProvider {
+    fn resource_policy(&self, service: &str, resource_arn: &str) -> Option<String> {
+        if !service.eq_ignore_ascii_case("lambda") {
+            return None;
+        }
+        let function_name = parse_function_name(resource_arn)?;
+        let state = self.state.read();
+        state
+            .functions
+            .get(function_name)
+            .and_then(|f| f.policy.clone())
+    }
+}
+
+/// Extract the function name from a Lambda ARN of the form
+/// `arn:aws:lambda:REGION:ACCOUNT:function:NAME`. Qualified ARNs
+/// (`function:NAME:VERSION` or `function:NAME:ALIAS`) keep the bare
+/// function name — `LambdaState::functions` is keyed by unqualified
+/// name and resource policies are attached at the function level.
+///
+/// Returns `None` for anything that isn't a fully-qualified function
+/// ARN so the caller short-circuits to "no policy" rather than
+/// looking up stray map keys.
+fn parse_function_name(arn: &str) -> Option<&str> {
+    let rest = arn.strip_prefix("arn:aws:lambda:")?;
+    // arn:aws:lambda:REGION:ACCOUNT:function:NAME[:QUALIFIER]
+    // After the prefix: REGION:ACCOUNT:function:NAME[:QUALIFIER]
+    let parts: Vec<&str> = rest.split(':').collect();
+    // Expect at least 4 segments: region, account, "function", name.
+    if parts.len() < 4 {
+        return None;
+    }
+    let region = parts[0];
+    let account = parts[1];
+    let resource_type = parts[2];
+    let name = parts[3];
+    if region.is_empty() || account.is_empty() {
+        return None;
+    }
+    if resource_type != "function" {
+        return None;
+    }
+    if name.is_empty() {
+        return None;
+    }
+    Some(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{LambdaFunction, LambdaState};
+    use chrono::Utc;
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+
+    fn func_with_policy(name: &str, policy: Option<&str>) -> LambdaFunction {
+        LambdaFunction {
+            function_name: name.to_string(),
+            function_arn: format!("arn:aws:lambda:us-east-1:123456789012:function:{name}"),
+            runtime: "python3.12".to_string(),
+            role: "arn:aws:iam::123456789012:role/r".to_string(),
+            handler: "index.handler".to_string(),
+            description: String::new(),
+            timeout: 3,
+            memory_size: 128,
+            code_sha256: String::new(),
+            code_size: 0,
+            version: "$LATEST".to_string(),
+            last_modified: Utc::now(),
+            tags: HashMap::new(),
+            environment: HashMap::new(),
+            architectures: Vec::new(),
+            package_type: "Zip".to_string(),
+            code_zip: None,
+            policy: policy.map(str::to_string),
+        }
+    }
+
+    fn state_with(func: LambdaFunction) -> SharedLambdaState {
+        let mut s = LambdaState::new("123456789012", "us-east-1");
+        s.functions.insert(func.function_name.clone(), func);
+        Arc::new(RwLock::new(s))
+    }
+
+    #[test]
+    fn parse_function_name_accepts_valid_arn() {
+        assert_eq!(
+            parse_function_name("arn:aws:lambda:us-east-1:123456789012:function:my-fn"),
+            Some("my-fn")
+        );
+    }
+
+    #[test]
+    fn parse_function_name_accepts_qualified_arn() {
+        // Qualified ARN (version / alias) — function name is still
+        // segment 4, qualifier follows as segment 5 and we drop it.
+        assert_eq!(
+            parse_function_name("arn:aws:lambda:us-east-1:123456789012:function:my-fn:PROD"),
+            Some("my-fn")
+        );
+        assert_eq!(
+            parse_function_name("arn:aws:lambda:us-east-1:123456789012:function:my-fn:7"),
+            Some("my-fn")
+        );
+    }
+
+    #[test]
+    fn parse_function_name_rejects_malformed() {
+        assert_eq!(parse_function_name(""), None);
+        assert_eq!(parse_function_name("not-an-arn"), None);
+        assert_eq!(parse_function_name("arn:aws:lambda:"), None);
+        assert_eq!(parse_function_name("arn:aws:lambda:us-east-1"), None);
+        assert_eq!(
+            parse_function_name("arn:aws:lambda:us-east-1:123456789012"),
+            None
+        );
+        // Event source mapping ARN — wrong resource type.
+        assert_eq!(
+            parse_function_name("arn:aws:lambda:us-east-1:123456789012:event-source-mapping:uuid"),
+            None
+        );
+        // Blank region or account.
+        assert_eq!(
+            parse_function_name("arn:aws:lambda::123456789012:function:f"),
+            None
+        );
+        assert_eq!(
+            parse_function_name("arn:aws:lambda:us-east-1::function:f"),
+            None
+        );
+        // Blank function name.
+        assert_eq!(
+            parse_function_name("arn:aws:lambda:us-east-1:123456789012:function:"),
+            None
+        );
+        // S3-shaped ARN.
+        assert_eq!(parse_function_name("arn:aws:s3:::my-bucket"), None);
+    }
+
+    #[test]
+    fn returns_stored_policy_for_lambda_arn() {
+        let doc = r#"{"Version":"2012-10-17","Statement":[]}"#;
+        let state = state_with(func_with_policy("my-fn", Some(doc)));
+        let provider = LambdaResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy(
+                "lambda",
+                "arn:aws:lambda:us-east-1:123456789012:function:my-fn"
+            ),
+            Some(doc.to_string())
+        );
+    }
+
+    #[test]
+    fn qualified_arn_resolves_to_unqualified_function_policy() {
+        // Resource policies live on the function, not on specific
+        // version aliases. A qualified ARN must still resolve to the
+        // same stored document.
+        let doc = r#"{"Statement":[]}"#;
+        let state = state_with(func_with_policy("my-fn", Some(doc)));
+        let provider = LambdaResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy(
+                "lambda",
+                "arn:aws:lambda:us-east-1:123456789012:function:my-fn:PROD"
+            ),
+            Some(doc.to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_when_function_has_no_policy() {
+        let state = state_with(func_with_policy("my-fn", None));
+        let provider = LambdaResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy(
+                "lambda",
+                "arn:aws:lambda:us-east-1:123456789012:function:my-fn"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn returns_none_when_function_missing() {
+        let state = state_with(func_with_policy("other", Some("{}")));
+        let provider = LambdaResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy(
+                "lambda",
+                "arn:aws:lambda:us-east-1:123456789012:function:my-fn"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn returns_none_for_non_lambda_service_prefix() {
+        let state = state_with(func_with_policy("my-fn", Some("{}")));
+        let provider = LambdaResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy("s3", "arn:aws:lambda:us-east-1:123456789012:function:my-fn"),
+            None
+        );
+        assert_eq!(
+            provider.resource_policy(
+                "sns",
+                "arn:aws:lambda:us-east-1:123456789012:function:my-fn"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn service_prefix_match_is_case_insensitive() {
+        let state = state_with(func_with_policy("my-fn", Some("{}")));
+        let provider = LambdaResourcePolicyProvider::new(state);
+        assert!(provider
+            .resource_policy(
+                "LAMBDA",
+                "arn:aws:lambda:us-east-1:123456789012:function:my-fn"
+            )
+            .is_some());
+    }
+
+    #[test]
+    fn shared_constructor_wraps_in_arc() {
+        let state = state_with(func_with_policy("my-fn", Some("doc")));
+        let arc = LambdaResourcePolicyProvider::shared(state);
+        assert_eq!(
+            arc.resource_policy(
+                "lambda",
+                "arn:aws:lambda:us-east-1:123456789012:function:my-fn"
+            )
+            .as_deref(),
+            Some("doc")
+        );
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1130,7 +1130,7 @@ async fn main() {
     let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state.clone());
     tokio::spawn(lifecycle_processor.run());
 
-    let mut sqs_lambda_poller = SqsLambdaPoller::new(sqs_state, lambda_state);
+    let mut sqs_lambda_poller = SqsLambdaPoller::new(sqs_state, lambda_state.clone());
     if let Some(ref ld) = lambda_delivery {
         sqs_lambda_poller = sqs_lambda_poller.with_lambda_delivery(ld.clone());
     }
@@ -1195,6 +1195,9 @@ async fn main() {
                 fakecloud_s3::resource_policy::S3ResourcePolicyProvider::shared(s3_state.clone()),
                 fakecloud_sns::resource_policy::SnsResourcePolicyProvider::shared(
                     sns_state.clone(),
+                ),
+                fakecloud_lambda::resource_policy::LambdaResourcePolicyProvider::shared(
+                    lambda_state.clone(),
                 ),
             ],
         )),


### PR DESCRIPTION
## Summary

Phase 2 IAM rollout for SNS + Lambda resource policies, Batch 4 of 5. Plugs Lambda into the dispatch-level resource-policy evaluator path and adds end-to-end coverage for both SNS and Lambda under \`FAKECLOUD_IAM=strict\`.

- New \`LambdaResourcePolicyProvider\` in \`crates/fakecloud-lambda/src/resource_policy.rs\` — same shape as the S3 and SNS providers. Parses \`arn:aws:lambda:REGION:ACCOUNT:function:NAME[:QUALIFIER]\` (qualified ARNs collapse to the unqualified function name, since resource policies live on the function, not on versions/aliases). 10 unit tests.
- Registered in the \`MultiResourcePolicyProvider\` at server bootstrap alongside S3 and SNS. \`lambda_state\` now clones into \`SqsLambdaPoller\` so it stays available for the provider.

**E2E tests** in \`crates/fakecloud-e2e/tests/iam_enforcement.rs\`:

### SNS (5 tests)
1. \`topic_policy_grants_publish_without_identity_policy\` — Allow-union path.
2. \`topic_policy_explicit_deny_beats_identity_allow\` — Deny precedence.
3. \`topic_policy_principal_wildcard_grants_any_user\` — public topic.
4. \`topic_policy_service_principal_does_not_grant_user\` — regression guard for the Service-principal matcher.
5. \`topic_policy_condition_block_gates_access\` — Phase 2 conditions still apply to resource policies.

### Lambda (4 tests)
1. \`lambda_function_policy_grants_invoke_without_identity_policy\`
2. \`lambda_function_without_policy_denies_non_root_invoke\` (sanity pair)
3. \`lambda_function_policy_wildcard_principal_grants_any_user\`
4. \`lambda_function_policy_source_arn_condition_gates_grant\` — regression guard that \`AddPermission\`'s \`SourceArn\` round-trip through the evaluator actually gates the grant.

The Lambda tests tolerate either a successful invocation (when a local runtime is available) or a non-Access service error (when it isn't) — the only outcome they guard against is an enforcement-layer \`AccessDeniedException\`, so they're portable across CI runners with and without Docker.

\`FAKECLOUD_IAM=off\` is unchanged.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-lambda --lib resource_policy\` (10 new)
- [x] \`cargo test -p fakecloud-e2e --test iam_enforcement\` (33 total, 9 new)
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `LambdaResourcePolicyProvider` and wire Lambda into the IAM resource‑policy evaluator; add E2E tests for SNS and Lambda in strict mode. This lets topic/function policies grant or block access without identity policies, with deny precedence and conditions respected.

- **New Features**
  - New `LambdaResourcePolicyProvider` in `crates/fakecloud-lambda/src/resource_policy.rs` that parses `arn:aws:lambda:...:function:NAME[:QUALIFIER]` and returns the stored policy; 10 unit tests.
  - Registered in server `MultiResourcePolicyProvider`; `lambda_state` now cloned into `SqsLambdaPoller` so it stays available at bootstrap.
  - Added E2E tests in `fakecloud-e2e/tests/iam_enforcement.rs` for SNS (5) and Lambda (4) under `FAKECLOUD_IAM=strict`, covering allow-union, explicit deny, wildcard principals, and condition gating (including `SourceArn` for Lambda). `FAKECLOUD_IAM=off` unchanged.

<sup>Written for commit 7996dfab7df7d0198a74d8ee45d0968cbe8e5b54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

