### PR TITLE
ci(coverage): measure unit+integration coverage with cargo llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,18 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance --exclude fakecloud-tfacc --exclude fakecloud-parity
-      - run: cargo test -p fakecloud-conformance --lib
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov clean --workspace
+      - run: cargo llvm-cov --no-report --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance --exclude fakecloud-tfacc --exclude fakecloud-parity
+      - run: cargo llvm-cov --no-report -p fakecloud-conformance --lib
+      - run: cargo llvm-cov report --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        if: always()
+        continue-on-error: true
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 <p align="center">
   <a href="https://github.com/faiscadev/fakecloud/actions"><img src="https://img.shields.io/github/actions/workflow/status/faiscadev/fakecloud/ci.yml?branch=main&label=CI" alt="CI"></a>
+  <a href="https://codecov.io/gh/faiscadev/fakecloud"><img src="https://img.shields.io/codecov/c/github/faiscadev/fakecloud?label=coverage" alt="Coverage"></a>
   <a href="https://github.com/faiscadev/fakecloud/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License"></a>
   <a href="https://github.com/faiscadev/fakecloud/pkgs/container/fakecloud"><img src="https://img.shields.io/badge/ghcr.io-fakecloud-blue?logo=docker" alt="GHCR"></a>
   <a href="https://crates.io/crates/fakecloud"><img src="https://img.shields.io/crates/v/fakecloud" alt="crates.io"></a>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "crates/fakecloud-e2e/**"
+  - "crates/fakecloud-conformance/tests/**"
+  - "crates/fakecloud-tfacc/**"
+  - "crates/fakecloud-parity/**"
+  - "crates/fakecloud-testkit/**"
+  - "crates/fakecloud-conformance-macros/**"
+  - "**/tests/**"
+  - "**/build.rs"


### PR DESCRIPTION
## Summary

- Swaps the `test` job's `cargo test` invocations for `cargo llvm-cov` equivalents — same tests, same compile, now also emits an LCOV report uploaded to Codecov.
- Adds `codecov.yml` with informational-only status, PR comment layout, and an ignore list covering e2e/tfacc/parity/testkit, the conformance integration tests, proc-macro crate, build scripts, and the `tests/` dirs themselves.
- Adds a Codecov badge to README.

## Why

fakecloud already has strong behavior coverage via e2e, conformance, tfacc, and parity — those prove the software works. What was missing was a signal on **unit + integration** test coverage, which acts as design pressure: testable code is maintainable code. Coverage here is a maintainability proxy, deliberately scoped to exclude behavior-level test crates.

Day-one informational only; no gate. Once we see the baseline we can decide whether/where to gate.

## Test plan

- [ ] CI `test` job goes green (runs llvm-cov in place of cargo test)
- [ ] Codecov upload step succeeds and a coverage report appears on the PR
- [ ] Per-crate numbers look sane (non-zero for crates we know have unit tests)
- [ ] Badge renders in README

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit and integration coverage to CI using `cargo llvm-cov`, with LCOV uploads to Codecov. Coverage is informational-only and adds a README badge; no gates.

- New Features
  - CI runs `cargo llvm-cov` instead of `cargo test`, generates `lcov.info`, and uploads via `codecov/codecov-action@v4`. Installs `llvm-tools-preview` and `taiki-e/install-action@cargo-llvm-cov`.
  - Scope excludes `fakecloud-e2e`, `fakecloud-conformance` tests, `fakecloud-tfacc`, `fakecloud-parity`, testkit, proc-macros, `**/tests/**`, and `build.rs`.
  - Adds `codecov.yml` with informational project/patch statuses and PR comments, plus a coverage badge in the README.

<sup>Written for commit 2d386d7a113c3aa0c5ca9dbe6e489d23d823020a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

