### PR TITLE
feat(iam): s3:prefix / s3:delimiter / s3:max-keys condition keys

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -432,6 +432,73 @@ async fn s3_get_object_resource_scoped() {
     assert!(format!("{err:?}").contains("AccessDenied"));
 }
 
+#[tokio::test]
+async fn s3_list_objects_v2_prefix_condition_key() {
+    // A policy that only allows ListObjectsV2 when `s3:prefix` starts
+    // with "logs/" must let `prefix=logs/2026/` through and deny
+    // `prefix=secrets/`.
+    let server = start_strict().await;
+    let boot = sdk_config_with(&server, "test", "test").await;
+    let s3_boot = aws_sdk_s3::Client::new(&boot);
+    s3_boot
+        .create_bucket()
+        .bucket("prefixed")
+        .send()
+        .await
+        .unwrap();
+
+    let (akid, secret) = bootstrap_user(&server, "s3prefixuser").await;
+    attach_inline_policy(
+        &server,
+        "s3prefixuser",
+        "AllowListLogs",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Action":"s3:ListObjectsV2",
+            "Resource":"arn:aws:s3:::prefixed",
+            "Condition":{"StringLike":{"s3:prefix":"logs/*"}}
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let s3 = aws_sdk_s3::Client::new(&cfg);
+
+    // Allowed: prefix=logs/2026/ matches StringLike "logs/*".
+    s3.list_objects_v2()
+        .bucket("prefixed")
+        .prefix("logs/2026/")
+        .send()
+        .await
+        .unwrap();
+
+    // Denied: prefix=secrets/ fails the condition.
+    let err = s3
+        .list_objects_v2()
+        .bucket("prefixed")
+        .prefix("secrets/")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied, got {err:?}"
+    );
+
+    // Denied: no prefix at all. Without the key populated the
+    // condition is unmatched and the statement doesn't apply.
+    let err = s3
+        .list_objects_v2()
+        .bucket("prefixed")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied on missing prefix, got {err:?}"
+    );
+}
+
 // ======================================================================
 // Phase 2: Condition block evaluation
 //

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -709,6 +709,40 @@ impl AwsService for S3Service {
             resource,
         })
     }
+
+    fn iam_condition_keys_for(
+        &self,
+        request: &AwsRequest,
+        action: &fakecloud_core::auth::IamAction,
+    ) -> std::collections::BTreeMap<String, Vec<String>> {
+        s3_condition_keys(action.action, &request.query_params)
+    }
+}
+
+/// Extract service-specific IAM condition keys from an S3 request.
+///
+/// Today only `ListObjects` / `ListObjectsV2` expose keys (`s3:prefix`,
+/// `s3:delimiter`, `s3:max-keys`) via their query params. Other actions
+/// return an empty map so the evaluator's safe-fail semantics treat any
+/// policy condition referencing an unknown key as "doesn't apply".
+fn s3_condition_keys(
+    action: &str,
+    query: &std::collections::HashMap<String, String>,
+) -> std::collections::BTreeMap<String, Vec<String>> {
+    let mut out = std::collections::BTreeMap::new();
+    if matches!(action, "ListObjects" | "ListObjectsV2") {
+        // Both list variants share the same query param shape.
+        if let Some(prefix) = query.get("prefix") {
+            out.insert("s3:prefix".to_string(), vec![prefix.clone()]);
+        }
+        if let Some(delimiter) = query.get("delimiter") {
+            out.insert("s3:delimiter".to_string(), vec![delimiter.clone()]);
+        }
+        if let Some(max_keys) = query.get("max-keys") {
+            out.insert("s3:max-keys".to_string(), vec![max_keys.clone()]);
+        }
+    }
+    out
 }
 
 /// Derive the IAM action name from an S3 REST request. Handles the
@@ -2154,6 +2188,43 @@ pub(crate) fn check_object_lock_for_overwrite(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn s3_condition_keys_emits_list_params() {
+        let mut q = std::collections::HashMap::new();
+        q.insert("prefix".to_string(), "logs/".to_string());
+        q.insert("delimiter".to_string(), "/".to_string());
+        q.insert("max-keys".to_string(), "100".to_string());
+        let keys = s3_condition_keys("ListObjectsV2", &q);
+        assert_eq!(keys.get("s3:prefix"), Some(&vec!["logs/".to_string()]));
+        assert_eq!(keys.get("s3:delimiter"), Some(&vec!["/".to_string()]));
+        assert_eq!(keys.get("s3:max-keys"), Some(&vec!["100".to_string()]));
+    }
+
+    #[test]
+    fn s3_condition_keys_omits_absent_params() {
+        let q = std::collections::HashMap::new();
+        let keys = s3_condition_keys("ListObjectsV2", &q);
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn s3_condition_keys_partial_params() {
+        let mut q = std::collections::HashMap::new();
+        q.insert("prefix".to_string(), "archive/".to_string());
+        let keys = s3_condition_keys("ListObjects", &q);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys.get("s3:prefix"), Some(&vec!["archive/".to_string()]));
+    }
+
+    #[test]
+    fn s3_condition_keys_empty_for_non_list_actions() {
+        let mut q = std::collections::HashMap::new();
+        q.insert("prefix".to_string(), "logs/".to_string());
+        assert!(s3_condition_keys("GetObject", &q).is_empty());
+        assert!(s3_condition_keys("PutObject", &q).is_empty());
+        assert!(s3_condition_keys("ListBuckets", &q).is_empty());
+    }
 
     #[test]
     fn valid_bucket_names() {


### PR DESCRIPTION
## Summary
- First per-service use of the new `iam_condition_keys_for` hook (PR #436).
- S3 ListObjects / ListObjectsV2 now expose `s3:prefix`, `s3:delimiter`, `s3:max-keys` to the IAM evaluator from the request query params.
- Policies gated on these keys (StringLike / StringEquals / etc.) match the actual query value; missing-key requests safe-fail to "doesn't apply".

## Test plan
- [x] Unit tests for `s3_condition_keys` (`cargo test -p fakecloud-s3`)
- [x] E2E test drives `aws-sdk-s3` ListObjectsV2 against `FAKECLOUD_IAM=strict` with a `StringLike:{s3:prefix}` policy and verifies allow / deny / missing-prefix
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose S3 IAM condition keys `s3:prefix`, `s3:delimiter`, and `s3:max-keys` for `ListObjects` and `ListObjectsV2` so policies can match on query params. First per-service use of the new `iam_condition_keys_for` hook.

- **New Features**
  - Implemented `iam_condition_keys_for` in S3 to map query params to IAM keys for list operations.
  - Missing params are omitted, so related statements don’t apply (safe-fail).
  - Added unit tests for the extractor and an E2E test using `aws-sdk-s3` to verify allow/deny/missing-prefix behavior.

<sup>Written for commit 9164c7a20ee9b2148ebbd999986ee7f149563de6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

