### PR TITLE
feat(iam): sns:Protocol and sns:Endpoint condition keys on Subscribe

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -499,6 +499,66 @@ async fn s3_list_objects_v2_prefix_condition_key() {
     );
 }
 
+#[tokio::test]
+async fn sns_subscribe_protocol_condition_key() {
+    // Policy allows sns:Subscribe only when sns:Protocol == "https".
+    // HTTPS subscribe succeeds; email subscribe is denied.
+    let server = start_strict().await;
+    let boot = sdk_config_with(&server, "test", "test").await;
+    let sns_boot = aws_sdk_sns::Client::new(&boot);
+    let topic_arn = sns_boot
+        .create_topic()
+        .name("cond-topic")
+        .send()
+        .await
+        .unwrap()
+        .topic_arn()
+        .unwrap()
+        .to_string();
+
+    let (akid, secret) = bootstrap_user(&server, "snsproto").await;
+    attach_inline_policy(
+        &server,
+        "snsproto",
+        "AllowHttpsOnly",
+        &format!(
+            r#"{{"Version":"2012-10-17","Statement":[{{
+                "Effect":"Allow",
+                "Action":"sns:Subscribe",
+                "Resource":"{topic_arn}",
+                "Condition":{{"StringEquals":{{"sns:Protocol":"https"}}}}
+            }}]}}"#
+        ),
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sns = aws_sdk_sns::Client::new(&cfg);
+
+    // Allowed: Protocol=https.
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("https")
+        .endpoint("https://example.com/hook")
+        .send()
+        .await
+        .unwrap();
+
+    // Denied: Protocol=email fails the condition.
+    let err = sns
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("email")
+        .endpoint("user@example.com")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for email protocol, got {err:?}"
+    );
+}
+
 // ======================================================================
 // Phase 2: Condition block evaluation
 //

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -281,6 +281,23 @@ impl AwsService for SnsService {
             resource,
         })
     }
+
+    fn iam_condition_keys_for(
+        &self,
+        request: &AwsRequest,
+        action: &fakecloud_core::auth::IamAction,
+    ) -> std::collections::BTreeMap<String, Vec<String>> {
+        let mut out = std::collections::BTreeMap::new();
+        if action.action == "Subscribe" {
+            if let Some(protocol) = param(request, "Protocol") {
+                out.insert("sns:protocol".to_string(), vec![protocol]);
+            }
+            if let Some(endpoint) = param(request, "Endpoint") {
+                out.insert("sns:endpoint".to_string(), vec![endpoint]);
+            }
+        }
+        out
+    }
 }
 
 const SNS_SUPPORTED_ACTIONS: &[&str] = &[
@@ -4060,6 +4077,63 @@ mod tests {
     }
 
     // --- Subscribe / Unsubscribe / ListSubscriptions / ListSubscriptionsByTopic ---
+
+    #[test]
+    fn iam_condition_keys_for_subscribe_populates_protocol_and_endpoint() {
+        let (svc, _state) = make_sns();
+        let req = sns_request(
+            "Subscribe",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:t"),
+                ("Protocol", "https"),
+                ("Endpoint", "https://example.com/hook"),
+            ],
+        );
+        let action = fakecloud_core::auth::IamAction {
+            service: "sns",
+            action: "Subscribe",
+            resource: "arn:aws:sns:us-east-1:123456789012:t".to_string(),
+        };
+        let keys = svc.iam_condition_keys_for(&req, &action);
+        assert_eq!(keys.get("sns:protocol"), Some(&vec!["https".to_string()]));
+        assert_eq!(
+            keys.get("sns:endpoint"),
+            Some(&vec!["https://example.com/hook".to_string()])
+        );
+    }
+
+    #[test]
+    fn iam_condition_keys_for_subscribe_omits_missing_fields() {
+        let (svc, _state) = make_sns();
+        let req = sns_request(
+            "Subscribe",
+            vec![("TopicArn", "arn:aws:sns:us-east-1:123456789012:t")],
+        );
+        let action = fakecloud_core::auth::IamAction {
+            service: "sns",
+            action: "Subscribe",
+            resource: "arn:aws:sns:us-east-1:123456789012:t".to_string(),
+        };
+        assert!(svc.iam_condition_keys_for(&req, &action).is_empty());
+    }
+
+    #[test]
+    fn iam_condition_keys_for_non_subscribe_is_empty() {
+        let (svc, _state) = make_sns();
+        let req = sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:t"),
+                ("Protocol", "https"),
+            ],
+        );
+        let action = fakecloud_core::auth::IamAction {
+            service: "sns",
+            action: "Publish",
+            resource: "arn:aws:sns:us-east-1:123456789012:t".to_string(),
+        };
+        assert!(svc.iam_condition_keys_for(&req, &action).is_empty());
+    }
 
     #[test]
     fn subscribe_creates_subscription() {


### PR DESCRIPTION
## Summary
- SNS `Subscribe` now emits `sns:Protocol` and `sns:Endpoint` as service-specific IAM condition keys via the `iam_condition_keys_for` hook.
- Policies like `"Condition":{"StringEquals":{"sns:Protocol":"https"}}` now match the actual request value; absent fields safe-fail to "doesn't apply".

## Test plan
- [x] Unit tests for present / missing / non-Subscribe actions (`cargo test -p fakecloud-sns`)
- [x] E2E drives `aws-sdk-sns` Subscribe with a StringEquals sns:Protocol policy; verifies https allowed and email denied
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IAM condition keys for SNS Subscribe so policies can match on protocol and endpoint. Values are taken from the request; if missing, the keys are omitted and the statement doesn’t apply.

- **New Features**
  - Implemented `iam_condition_keys_for` in `fakecloud-sns` to emit sns:Protocol and sns:Endpoint for Subscribe.
  - Added unit and E2E tests in `fakecloud-sns` and `fakecloud-e2e` verifying StringEquals on sns:Protocol allows https and denies email.

<sup>Written for commit ec5dcbd2123d649a593f3c4ccb240e052059bdd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

