### PR TITLE
ci(coverage): add scripts/coverage.sh reproduction helper

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Reproduce the CI `test` job's coverage run locally.
+# Requires: cargo-llvm-cov (install with `cargo install cargo-llvm-cov`).
+#
+# Scope mirrors .github/workflows/ci.yml exactly: workspace minus the
+# end-to-end / acceptance / parity crates, plus the conformance crate's
+# library tests. Extra args are forwarded to `cargo llvm-cov report`
+# (e.g. `scripts/coverage.sh --lcov --output-path lcov.info`).
+set -euo pipefail
+
+cargo llvm-cov clean --workspace
+cargo llvm-cov --no-report --workspace \
+  --exclude fakecloud-e2e \
+  --exclude fakecloud-conformance \
+  --exclude fakecloud-tfacc \
+  --exclude fakecloud-parity
+cargo llvm-cov --no-report -p fakecloud-conformance --lib
+cargo llvm-cov report "$@"


### PR DESCRIPTION
## Summary

- Adds \`scripts/coverage.sh\`, a one-command wrapper around the CI \`test\` job's coverage invocation so contributors can reproduce the same numbers locally.
- Scope mirrors \`.github/workflows/ci.yml\` exactly: workspace minus e2e / conformance integration / tfacc / parity, plus \`fakecloud-conformance --lib\`.
- Extra args are forwarded to \`cargo llvm-cov report\`, e.g. \`scripts/coverage.sh --lcov --output-path lcov.info\`.
- **No changes to \`codecov.yml\` or CI.** This is purely the reproduction helper; the upcoming series of PRs will raise line coverage from 54.21% to >=80% by adding real unit tests, with no additions to the ignore list.

## Test plan

- [x] \`scripts/coverage.sh\` runs end-to-end and prints the per-file + TOTAL coverage table.
- [x] The TOTAL it prints matches the \`cargo llvm-cov\` invocations in ci.yml (54.21% lines / 46.60% functions / 58.49% regions on today's main).
- [ ] CI green.