### PR TITLE
feat(iam): lambda:FunctionArn and lambda:Principal condition keys

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -1351,3 +1351,72 @@ async fn lambda_function_policy_source_arn_condition_gates_grant() {
         "condition-gated grant should not apply; expected AccessDenied, got {err:?}"
     );
 }
+
+#[tokio::test]
+async fn lambda_add_permission_principal_condition_key() {
+    // Policy allows lambda:AddPermission only when lambda:Principal
+    // == "s3.amazonaws.com". An s3 grant succeeds; an events grant
+    // is denied.
+    let server = start_strict().await;
+    let boot = sdk_config_with(&server, "test", "test").await;
+    let lambda_boot = aws_sdk_lambda::Client::new(&boot);
+    lambda_boot
+        .create_function()
+        .function_name("lam-cond-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(aws_sdk_lambda::primitives::Blob::new(
+                    make_empty_python_zip(),
+                ))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let (akid, secret) = bootstrap_user(&server, "lam_cond").await;
+    attach_inline_policy(
+        &server,
+        "lam_cond",
+        "AllowS3Principal",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Action":"lambda:AddPermission",
+            "Resource":"arn:aws:lambda:us-east-1:123456789012:function:lam-cond-fn",
+            "Condition":{"StringEquals":{"lambda:Principal":"s3.amazonaws.com"}}
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let lambda = aws_sdk_lambda::Client::new(&cfg);
+
+    // Allowed: Principal=s3.amazonaws.com matches the condition.
+    lambda
+        .add_permission()
+        .function_name("lam-cond-fn")
+        .statement_id("s3-ok")
+        .action("lambda:InvokeFunction")
+        .principal("s3.amazonaws.com")
+        .send()
+        .await
+        .unwrap();
+
+    // Denied: Principal=events.amazonaws.com fails the condition.
+    let err = lambda
+        .add_permission()
+        .function_name("lam-cond-fn")
+        .statement_id("events-no")
+        .action("lambda:InvokeFunction")
+        .principal("events.amazonaws.com")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDeniedException"),
+        "expected AccessDeniedException for non-s3 principal, got {err:?}"
+    );
+}

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -906,6 +906,28 @@ impl AwsService for LambdaService {
             resource,
         })
     }
+
+    fn iam_condition_keys_for(
+        &self,
+        request: &AwsRequest,
+        action: &fakecloud_core::auth::IamAction,
+    ) -> std::collections::BTreeMap<String, Vec<String>> {
+        let mut out = std::collections::BTreeMap::new();
+        if action.action == "AddPermission" {
+            if action.resource != "*" {
+                out.insert(
+                    "lambda:functionarn".to_string(),
+                    vec![action.resource.clone()],
+                );
+            }
+            if let Ok(body) = serde_json::from_slice::<Value>(&request.body) {
+                if let Some(principal) = body.get("Principal").and_then(|p| p.as_str()) {
+                    out.insert("lambda:principal".to_string(), vec![principal.to_string()]);
+                }
+            }
+        }
+        out
+    }
 }
 
 #[cfg(test)]
@@ -945,6 +967,61 @@ mod tests {
             access_key_id: None,
             principal: None,
         }
+    }
+
+    #[test]
+    fn iam_condition_keys_for_add_permission_populates_arn_and_principal() {
+        let svc = LambdaService::new(make_state());
+        let body = json!({
+            "StatementId": "stmt",
+            "Action": "lambda:InvokeFunction",
+            "Principal": "s3.amazonaws.com",
+        })
+        .to_string();
+        let req = make_request(Method::POST, "/2015-03-31/functions/my-func/policy", &body);
+        let action = fakecloud_core::auth::IamAction {
+            service: "lambda",
+            action: "AddPermission",
+            resource: "arn:aws:lambda:us-east-1:123456789012:function:my-func".to_string(),
+        };
+        let keys = svc.iam_condition_keys_for(&req, &action);
+        assert_eq!(
+            keys.get("lambda:functionarn"),
+            Some(&vec![
+                "arn:aws:lambda:us-east-1:123456789012:function:my-func".to_string()
+            ])
+        );
+        assert_eq!(
+            keys.get("lambda:principal"),
+            Some(&vec!["s3.amazonaws.com".to_string()])
+        );
+    }
+
+    #[test]
+    fn iam_condition_keys_for_add_permission_omits_missing_principal() {
+        let svc = LambdaService::new(make_state());
+        let body = json!({"StatementId": "stmt", "Action": "lambda:InvokeFunction"}).to_string();
+        let req = make_request(Method::POST, "/2015-03-31/functions/my-func/policy", &body);
+        let action = fakecloud_core::auth::IamAction {
+            service: "lambda",
+            action: "AddPermission",
+            resource: "arn:aws:lambda:us-east-1:123456789012:function:my-func".to_string(),
+        };
+        let keys = svc.iam_condition_keys_for(&req, &action);
+        assert!(!keys.contains_key("lambda:principal"));
+        assert!(keys.contains_key("lambda:functionarn"));
+    }
+
+    #[test]
+    fn iam_condition_keys_for_non_add_permission_is_empty() {
+        let svc = LambdaService::new(make_state());
+        let req = make_request(Method::GET, "/2015-03-31/functions/my-func", "");
+        let action = fakecloud_core::auth::IamAction {
+            service: "lambda",
+            action: "GetFunction",
+            resource: "arn:aws:lambda:us-east-1:123456789012:function:my-func".to_string(),
+        };
+        assert!(svc.iam_condition_keys_for(&req, &action).is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Lambda `AddPermission` now emits `lambda:FunctionArn` and `lambda:Principal` as service-specific IAM condition keys via `iam_condition_keys_for`.
- Policies like `"Condition":{"StringEquals":{"lambda:Principal":"s3.amazonaws.com"}}` now match the actual request value; absent fields safe-fail.

## Test plan
- [x] Unit tests for present / missing principal and non-AddPermission actions (`cargo test -p fakecloud-lambda`)
- [x] E2E drives `aws-sdk-lambda` AddPermission under `FAKECLOUD_IAM=strict`; verifies s3 allowed and events denied
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IAM condition keys for Lambda AddPermission: lambda:FunctionArn and lambda:Principal. Policies can now match the real function ARN and principal; missing values are omitted.

- New Features
  - Implemented `iam_condition_keys_for` in `LambdaService` to populate these keys for `AddPermission`; other actions return no keys.
  - `lambda:FunctionArn` comes from the resolved resource ARN; `lambda:Principal` comes from the request body’s Principal.
  - Added unit and E2E tests using `aws-sdk-lambda` under `FAKECLOUD_IAM=strict` (s3 allowed, events denied).

<sup>Written for commit 05da192d4a37d5d9528a8bc9f42f89b40cb3adb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

