### PR TITLE
feat(iam): sqs:MessageAttribute.<Name> condition keys on SendMessage

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -1420,3 +1420,90 @@ async fn lambda_add_permission_principal_condition_key() {
         "expected AccessDeniedException for non-s3 principal, got {err:?}"
     );
 }
+
+#[tokio::test]
+async fn sqs_send_message_attribute_condition_key() {
+    // Policy allows sqs:SendMessage only when
+    // `sqs:MessageAttribute.Color == "red"`. Verify a red message is
+    // accepted and a blue one is denied.
+    let server = start_strict().await;
+    let boot = sdk_config_with(&server, "test", "test").await;
+    let sqs_boot = aws_sdk_sqs::Client::new(&boot);
+    let queue_url = sqs_boot
+        .create_queue()
+        .queue_name("cond-attr")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+
+    let (akid, secret) = bootstrap_user(&server, "sqsattr").await;
+    attach_inline_policy(
+        &server,
+        "sqsattr",
+        "AllowRedOnly",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Action":"sqs:SendMessage",
+            "Resource":"arn:aws:sqs:us-east-1:123456789012:cond-attr",
+            "Condition":{"StringEquals":{"sqs:MessageAttribute.Color":"red"}}
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+
+    // Allowed: Color=red matches the condition.
+    sqs.send_message()
+        .queue_url(&queue_url)
+        .message_body("hi")
+        .message_attributes(
+            "Color",
+            aws_sdk_sqs::types::MessageAttributeValue::builder()
+                .data_type("String")
+                .string_value("red")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Denied: Color=blue fails the condition.
+    let err = sqs
+        .send_message()
+        .queue_url(&queue_url)
+        .message_body("hi")
+        .message_attributes(
+            "Color",
+            aws_sdk_sqs::types::MessageAttributeValue::builder()
+                .data_type("String")
+                .string_value("blue")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for blue color, got {err:?}"
+    );
+
+    // Denied: no attributes at all. The key is not populated so the
+    // condition evaluates to doesn't-apply.
+    let err = sqs
+        .send_message()
+        .queue_url(&queue_url)
+        .message_body("hi")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for no-attr send, got {err:?}"
+    );
+}

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -545,6 +545,32 @@ impl AwsService for SqsService {
             resource,
         })
     }
+
+    fn iam_condition_keys_for(
+        &self,
+        request: &AwsRequest,
+        action: &fakecloud_core::auth::IamAction,
+    ) -> std::collections::BTreeMap<String, Vec<String>> {
+        let mut out = std::collections::BTreeMap::new();
+        if action.action == "SendMessage" {
+            let body = parse_body(request);
+            let attrs = parse_message_attributes(&body);
+            for (name, attr) in &attrs {
+                let key = format!("sqs:messageattribute.{name}");
+                // String-typed attributes contribute their StringValue.
+                // Binary / Number attributes fall back to the data type
+                // so the key still shows up for existence-style
+                // conditions; evaluators that look for a concrete
+                // StringEquals value simply safe-fail on mismatch.
+                let value = attr
+                    .string_value
+                    .clone()
+                    .unwrap_or_else(|| attr.data_type.clone());
+                out.insert(key, vec![value]);
+            }
+        }
+        out
+    }
 }
 
 /// Build the SQS resource ARN for an incoming action. Returns `*` for
@@ -3188,6 +3214,60 @@ mod tests {
             access_key_id: None,
             principal: None,
         }
+    }
+
+    #[test]
+    fn iam_condition_keys_for_send_message_populates_attributes() {
+        let svc = make_service();
+        let req = make_request(
+            "SendMessage",
+            json!({
+                "QueueUrl": "http://localhost:4566/123456789012/q",
+                "MessageBody": "hi",
+                "MessageAttributes": {
+                    "Color": {"DataType": "String", "StringValue": "red"},
+                    "Priority": {"DataType": "Number", "StringValue": "1"}
+                }
+            }),
+        );
+        let action = fakecloud_core::auth::IamAction {
+            service: "sqs",
+            action: "SendMessage",
+            resource: "arn:aws:sqs:us-east-1:123456789012:q".to_string(),
+        };
+        let keys = svc.iam_condition_keys_for(&req, &action);
+        assert_eq!(
+            keys.get("sqs:messageattribute.Color"),
+            Some(&vec!["red".to_string()])
+        );
+        assert!(keys.contains_key("sqs:messageattribute.Priority"));
+    }
+
+    #[test]
+    fn iam_condition_keys_for_send_message_without_attrs_is_empty() {
+        let svc = make_service();
+        let req = make_request(
+            "SendMessage",
+            json!({"QueueUrl": "http://localhost:4566/123456789012/q", "MessageBody": "hi"}),
+        );
+        let action = fakecloud_core::auth::IamAction {
+            service: "sqs",
+            action: "SendMessage",
+            resource: "arn:aws:sqs:us-east-1:123456789012:q".to_string(),
+        };
+        assert!(svc.iam_condition_keys_for(&req, &action).is_empty());
+    }
+
+    #[test]
+    fn iam_condition_keys_for_non_send_message_is_empty() {
+        let svc = make_service();
+        let req = make_request("ReceiveMessage", json!({"QueueUrl": "http://x/q"}));
+        let action = fakecloud_core::auth::IamAction {
+            service: "sqs",
+            action: "ReceiveMessage",
+            resource: "arn:aws:sqs:us-east-1:123456789012:q".to_string(),
+        };
+        assert!(svc.iam_condition_keys_for(&req, &action).is_empty());
     }
 
     fn create_queue(svc: &SqsService, name: &str) -> String {


### PR DESCRIPTION
## Summary
- SQS `SendMessage` now emits `sqs:MessageAttribute.<Name>` condition keys populated from the request's parsed attribute map. Each named attribute becomes a concrete key — the "wildcard family" is the AWS terminology for any suffix, and the existing exact-match evaluator handles it natively.
- StringValue populates the context value; Binary / Number attributes fall back to the data type so existence-style conditions still see the key.

## Test plan
- [x] Unit tests for present / empty / non-SendMessage (`cargo test -p fakecloud-sqs`)
- [x] E2E drives `aws-sdk-sqs` SendMessage under `FAKECLOUD_IAM=strict` with a StringEquals sqs:MessageAttribute.Color policy; verifies allow (red) / deny (blue) / deny (missing)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IAM support for `sqs:MessageAttribute.<Name>` on SQS `SendMessage`, enabling policies to allow/deny sends based on message attributes (e.g., `StringEquals` on `Color`). String attributes use their `StringValue`; non-string attributes fall back to the data type so existence checks work.

- **New Features**
  - Implemented `iam_condition_keys_for` to emit `sqs:MessageAttribute.<Name>` keys from the request’s message attributes.
  - Covered with unit tests and an end-to-end scenario using `aws-sdk-sqs` verifying allow/deny and missing-attribute cases.

<sup>Written for commit 1892730fa38a02f9c477129adb132289ec8c01b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

