### PR TITLE
feat(ses): persist SES state to disk via snapshot store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,6 +2483,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "form_urlencoded",
  "http 1.4.0",
  "parking_lot",

--- a/crates/fakecloud-e2e/tests/ses_persistence.rs
+++ b/crates/fakecloud-e2e/tests/ses_persistence.rs
@@ -1,0 +1,188 @@
+mod helpers;
+
+use helpers::TestServer;
+
+/// Identity + configuration set + email template round-trip across a restart.
+#[tokio::test]
+async fn persistence_round_trip_identity_config_set_and_template() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let ses = server.sesv2_client().await;
+
+    ses.create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    ses.create_configuration_set()
+        .configuration_set_name("primary")
+        .send()
+        .await
+        .unwrap();
+
+    ses.create_email_template()
+        .template_name("welcome")
+        .template_content(
+            aws_sdk_sesv2::types::EmailTemplateContent::builder()
+                .subject("Hi {{name}}")
+                .text("Hello {{name}}, welcome aboard.")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let ses = server.sesv2_client().await;
+
+    let identities = ses.list_email_identities().send().await.unwrap();
+    assert!(identities
+        .email_identities()
+        .iter()
+        .any(|i| i.identity_name() == Some("sender@example.com")));
+
+    let config_sets = ses.list_configuration_sets().send().await.unwrap();
+    assert!(config_sets
+        .configuration_sets()
+        .iter()
+        .any(|n| n == "primary"));
+
+    let template = ses
+        .get_email_template()
+        .template_name("welcome")
+        .send()
+        .await
+        .unwrap();
+    let content = template.template_content().unwrap();
+    assert_eq!(content.subject(), Some("Hi {{name}}"));
+}
+
+/// Tags on a configuration set survive a restart.
+#[tokio::test]
+async fn persistence_configuration_set_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let ses = server.sesv2_client().await;
+
+    ses.create_configuration_set()
+        .configuration_set_name("tagged")
+        .send()
+        .await
+        .unwrap();
+    let arn_for_tag = "arn:aws:ses:us-east-1:123456789012:configuration-set/tagged";
+    ses.tag_resource()
+        .resource_arn(arn_for_tag)
+        .tags(
+            aws_sdk_sesv2::types::Tag::builder()
+                .key("env")
+                .value("prod")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let ses = server.sesv2_client().await;
+
+    let tags = ses
+        .list_tags_for_resource()
+        .resource_arn(arn_for_tag)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags
+        .tags()
+        .iter()
+        .any(|t| t.key() == "env" && t.value() == "prod"));
+}
+
+/// Suppression list entries persist, but the `/_fakecloud/ses/emails`
+/// introspection buffer does not.
+#[tokio::test]
+async fn persistence_suppression_persists_introspection_does_not() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let ses = server.sesv2_client().await;
+
+    ses.create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    ses.put_suppressed_destination()
+        .email_address("blocked@example.com")
+        .reason(aws_sdk_sesv2::types::SuppressionListReason::Bounce)
+        .send()
+        .await
+        .unwrap();
+
+    ses.send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            aws_sdk_sesv2::types::Destination::builder()
+                .to_addresses("to@example.com")
+                .build(),
+        )
+        .content(
+            aws_sdk_sesv2::types::EmailContent::builder()
+                .simple(
+                    aws_sdk_sesv2::types::Message::builder()
+                        .subject(
+                            aws_sdk_sesv2::types::Content::builder()
+                                .data("hi")
+                                .build()
+                                .unwrap(),
+                        )
+                        .body(
+                            aws_sdk_sesv2::types::Body::builder()
+                                .text(
+                                    aws_sdk_sesv2::types::Content::builder()
+                                        .data("hello")
+                                        .build()
+                                        .unwrap(),
+                                )
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let ses = server.sesv2_client().await;
+
+    let suppressed = ses
+        .get_suppressed_destination()
+        .email_address("blocked@example.com")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        suppressed
+            .suppressed_destination()
+            .map(|d| d.email_address()),
+        Some("blocked@example.com"),
+    );
+
+    // Introspection buffer must NOT be restored.
+    let resp = reqwest::get(format!("{}/_fakecloud/ses/emails", server.endpoint()))
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let emails = body
+        .get("emails")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        emails.is_empty(),
+        "introspection sent_emails should not persist across restarts, got: {body:?}"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -385,7 +385,6 @@ async fn main() {
         for service in [
             "cloudformation",
             "lambda",
-            "ses",
             "cognito-idp",
             "rds",
             "elasticache",
@@ -1000,9 +999,58 @@ async fn main() {
         ses_state: ses_state.clone(),
         delivery_bus: delivery_for_ses,
     };
-    registry.register(Arc::new(
-        SesV2Service::new(ses_state).with_delivery(ses_delivery_ctx),
-    ));
+    let ses_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("ses").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_ses::state::SesSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_ses::state::SES_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "ses persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_ses::state::SES_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let identity_count = snapshot.state.identities.len();
+                            let template_count = snapshot.state.templates.len();
+                            *ses_state.write() = snapshot.state;
+                            tracing::info!(
+                                identities = identity_count,
+                                templates = template_count,
+                                "loaded ses persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse ses persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no ses persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read ses persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut ses_service = SesV2Service::new(ses_state).with_delivery(ses_delivery_ctx);
+    if let Some(store) = ses_snapshot_store {
+        ses_service = ses_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(ses_service));
     let delivery_for_cognito = {
         let mut bus = DeliveryBus::new();
         if let Some(ref ld) = lambda_delivery {

--- a/crates/fakecloud-ses/Cargo.toml
+++ b/crates/fakecloud-ses/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-core = { workspace = true }
 fakecloud-aws = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 form_urlencoded = "1"
 chrono = { workspace = true }
@@ -18,6 +19,7 @@ parking_lot = { workspace = true }
 percent-encoding = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/fakecloud-ses/src/service/mod.rs
+++ b/crates/fakecloud-ses/src/service/mod.rs
@@ -10,15 +10,23 @@ mod templates;
 use async_trait::async_trait;
 use http::{Method, StatusCode};
 use serde_json::{json, Value};
+use std::sync::Arc;
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::fanout::SesDeliveryContext;
-use crate::state::{EventDestination, SharedSesState, Topic, TopicPreference};
+use crate::state::{
+    EventDestination, SesSnapshot, SharedSesState, Topic, TopicPreference,
+    SES_SNAPSHOT_SCHEMA_VERSION,
+};
 
 pub struct SesV2Service {
     state: SharedSesState,
     delivery_ctx: Option<SesDeliveryContext>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl SesV2Service {
@@ -26,6 +34,8 @@ impl SesV2Service {
         Self {
             state,
             delivery_ctx: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -33,6 +43,36 @@ impl SesV2Service {
     pub fn with_delivery(mut self, ctx: SesDeliveryContext) -> Self {
         self.delivery_ctx = Some(ctx);
         self
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes,
+    /// with serde + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = SesSnapshot {
+            schema_version: SES_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write ses snapshot"),
+            Err(err) => tracing::error!(%err, "ses snapshot task panicked"),
+        }
     }
 
     /// Determine the action from the HTTP method and path segments.
@@ -640,6 +680,25 @@ fn event_destination_to_json(dest: &EventDestination) -> Value {
     obj
 }
 
+fn is_mutating_action(action: &str) -> bool {
+    const MUTATING_PREFIXES: &[&str] = &[
+        "Create",
+        "Update",
+        "Delete",
+        "Put",
+        "Tag",
+        "Untag",
+        "Send",
+        "Cancel",
+        "Verify",
+        "Set",
+        "Clone",
+        "Reorder",
+        "BatchUpdate",
+    ];
+    MUTATING_PREFIXES.iter().any(|p| action.starts_with(p))
+}
+
 #[async_trait]
 impl fakecloud_core::service::AwsService for SesV2Service {
     fn service_name(&self) -> &str {
@@ -649,7 +708,12 @@ impl fakecloud_core::service::AwsService for SesV2Service {
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         // Route v1 Query protocol requests to the v1 module.
         if req.is_query_protocol {
-            return crate::v1::handle_v1_action(&self.state, &req);
+            let mutates = is_mutating_action(req.action.as_str());
+            let result = crate::v1::handle_v1_action(&self.state, &req);
+            if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+                self.save_snapshot().await;
+            }
+            return result;
         }
 
         let (action, resource_name, sub_resource) =
@@ -663,8 +727,9 @@ impl fakecloud_core::service::AwsService for SesV2Service {
 
         let res = resource_name.as_deref().unwrap_or("");
         let sub = sub_resource.as_deref().unwrap_or("");
+        let mutates = is_mutating_action(action);
 
-        match action {
+        let result = match action {
             "GetAccount" => self.get_account(),
             "CreateEmailIdentity" => self.create_email_identity(&req),
             "ListEmailIdentities" => self.list_email_identities(),
@@ -807,7 +872,11 @@ impl fakecloud_core::service::AwsService for SesV2Service {
             "UpdateReputationEntityPolicy" => self.update_reputation_entity_policy(res, sub, &req),
             "BatchGetMetricData" => self.batch_get_metric_data(&req),
             _ => Err(AwsServiceError::action_not_implemented("ses", action)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmailIdentity {
     pub identity_name: String,
     pub identity_type: String,
@@ -25,7 +25,7 @@ pub struct EmailIdentity {
     pub configuration_set_name: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmailTemplate {
     pub template_name: String,
     pub subject: Option<String>,
@@ -34,7 +34,7 @@ pub struct EmailTemplate {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigurationSet {
     pub name: String,
     // Sending options
@@ -55,7 +55,7 @@ pub struct ConfigurationSet {
     pub archive_arn: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CustomVerificationEmailTemplate {
     pub template_name: String,
     pub from_email_address: String,
@@ -66,7 +66,7 @@ pub struct CustomVerificationEmailTemplate {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SentEmail {
     pub message_id: String,
     pub from: String,
@@ -82,7 +82,7 @@ pub struct SentEmail {
     pub timestamp: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContactList {
     pub contact_list_name: String,
     pub description: Option<String>,
@@ -99,7 +99,7 @@ pub struct Topic {
     pub default_subscription_status: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Contact {
     pub email_address: String,
     pub topic_preferences: Vec<TopicPreference>,
@@ -115,7 +115,7 @@ pub struct TopicPreference {
     pub subscription_status: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SuppressedDestination {
     pub email_address: String,
     pub reason: String,
@@ -139,13 +139,13 @@ pub struct EventDestination {
     pub pinpoint_destination: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DedicatedIpPool {
     pub pool_name: String,
     pub scaling_mode: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DedicatedIp {
     pub ip: String,
     pub warmup_status: String,
@@ -153,7 +153,7 @@ pub struct DedicatedIp {
     pub pool_name: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MultiRegionEndpoint {
     pub endpoint_name: String,
     pub endpoint_id: String,
@@ -163,7 +163,7 @@ pub struct MultiRegionEndpoint {
     pub last_updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AccountDetails {
     pub mail_type: Option<String>,
     pub website_url: Option<String>,
@@ -173,7 +173,7 @@ pub struct AccountDetails {
     pub production_access_enabled: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AccountSettings {
     pub sending_enabled: bool,
     pub dedicated_ip_auto_warmup_enabled: bool,
@@ -182,7 +182,7 @@ pub struct AccountSettings {
     pub details: Option<AccountDetails>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImportJob {
     pub job_id: String,
     pub import_destination: serde_json::Value,
@@ -194,7 +194,7 @@ pub struct ImportJob {
     pub failed_records_count: i32,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExportJob {
     pub job_id: String,
     pub export_source_type: String,
@@ -205,7 +205,7 @@ pub struct ExportJob {
     pub completed_timestamp: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tenant {
     pub tenant_name: String,
     pub tenant_id: String,
@@ -215,13 +215,13 @@ pub struct Tenant {
     pub tags: Vec<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TenantResourceAssociation {
     pub resource_arn: String,
     pub associated_timestamp: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReputationEntityState {
     pub reputation_entity_reference: String,
     pub reputation_entity_type: String,
@@ -307,12 +307,17 @@ pub struct InboundEmail {
     pub timestamp: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SesState {
     pub account_id: String,
     pub region: String,
+    #[serde(default)]
     pub identities: HashMap<String, EmailIdentity>,
+    #[serde(default)]
     pub configuration_sets: HashMap<String, ConfigurationSet>,
+    #[serde(default)]
     pub templates: HashMap<String, EmailTemplate>,
+    #[serde(default, skip_serializing)]
     pub sent_emails: Vec<SentEmail>,
     pub contact_lists: HashMap<String, ContactList>,
     pub contacts: HashMap<String, HashMap<String, Contact>>,
@@ -352,7 +357,16 @@ pub struct SesState {
     /// Receipt filters: name → filter.
     pub receipt_filters: HashMap<String, ReceiptFilter>,
     /// Inbound emails processed by the introspection endpoint.
+    #[serde(default, skip_serializing)]
     pub inbound_emails: Vec<InboundEmail>,
+}
+
+pub const SES_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SesSnapshot {
+    pub schema_version: u32,
+    pub state: SesState,
 }
 
 impl SesState {

--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -23,6 +23,17 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 ## What's persisted
 
 - **S3** — buckets, objects, versions, delete markers, multipart uploads (resumable across restarts), and every bucket subresource: tags, lifecycle, CORS, policy, notification, logging, website, public access block, object lock, replication, ownership, inventory, encryption, ACL, accelerate. Written to disk on every mutation and reloaded on startup.
+- **SQS** — queues, attributes, tags, in-flight and delayed messages.
+- **SNS** — topics, subscriptions, attributes, tags, platform applications and endpoints, SMS settings.
+- **EventBridge** — event buses, rules, targets, archives, replays, connections.
+- **IAM / STS** — users, groups, roles, policies, instance profiles, access keys.
+- **SSM Parameter Store** — parameters (String/SecureString/StringList), history.
+- **Secrets Manager** — secrets, versions, rotation settings.
+- **CloudWatch Logs** — log groups, streams, and log events.
+- **KMS** — keys, aliases, key policies, grants.
+- **DynamoDB** — tables, items, indexes, streams metadata.
+- **Kinesis** — streams, shards, records.
+- **SES** — identities, configuration sets, templates, contact lists and contacts, tags, suppression list, event destinations, identity policies, dedicated IP pools, tenants, receipt rule sets / rules / filters, account settings.
 - **Every other service** emits `persistence not yet supported, running in-memory` at startup and continues to operate exactly as in memory mode. Your tests don't break — you just don't get cross-restart durability for those services yet.
 
 ## Version compatibility
@@ -37,4 +48,4 @@ Object bodies are streamed straight to disk in persistent mode, not held in RAM.
 
 ## Introspection buffers are not persisted
 
-The `/_fakecloud/s3/notifications` buffer — and every other `/_fakecloud/*` introspection endpoint — is intentionally not persisted. These exist so tests can assert which events fired during the current run, not as a long-term audit log.
+The `/_fakecloud/s3/notifications` buffer — and every other `/_fakecloud/*` introspection endpoint, including `/_fakecloud/ses/emails` and `/_fakecloud/ses/inbound-emails` — is intentionally not persisted. These exist so tests can assert which events fired during the current run, not as a long-term audit log.


### PR DESCRIPTION
## Summary

- Wires SES into the existing `fakecloud-persistence` snapshot pattern (same as SNS/SQS/DynamoDB/Kinesis/etc.), so identities, configuration sets, templates, contact lists, suppression list, event destinations, receipt rule sets/rules/filters, tags, and account settings survive restarts in `--storage-mode persistent`.
- `/_fakecloud/ses/emails` and `/_fakecloud/ses/inbound-emails` introspection buffers are intentionally `skip_serializing` — they reset on every restart, matching every other `/_fakecloud/*` endpoint.
- Refreshes the persistence docs page, which was still claiming only S3 was persisted when in fact 11 services already were.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p fakecloud-ses` (139 tests pass)
- [x] `cargo test -p fakecloud-e2e --test ses --test ses_v1 --test ses_receipt_rules --test ses_persistence` (all pass, including 3 new persistence tests covering identity/template/config-set round-trip, tag round-trip, and suppression-vs-introspection)
- [x] Non-persistent mode still works unchanged (SES is no longer on the "unsupported persistence" warning list)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds on-disk persistence for SES using the `fakecloud-persistence` snapshot store so SES state survives restarts in persistent mode. Introspection buffers stay ephemeral. Docs updated and new e2e tests cover round-trips.

- New Features
  - Wired SES to `fakecloud-persistence`: load snapshot on startup, save after successful mutating actions (v1 and v2), with schema versioning.
  - Persisted SES state: identities, configuration sets, templates, contact lists/contacts, suppression list, event destinations, receipt rule sets/rules/filters, tags, account settings.
  - Do not persist `/_fakecloud/ses/emails` and `/_fakecloud/ses/inbound-emails`.
  - Added e2e tests for identity/config-set/template round-trip, config-set tags, and suppression vs introspection behavior.
  - Updated persistence docs to include SES and clarify that `/_fakecloud/*` introspection endpoints are not persisted.

<sup>Written for commit 5f851eb19b94fc74c4e39d834a6ea4413ae1c8f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

