### PR TITLE
feat(apigatewayv2): persist API Gateway v2 state via snapshot store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,6 +1981,7 @@ dependencies = [
  "bytes",
  "chrono",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "reqwest",

--- a/crates/fakecloud-apigatewayv2/Cargo.toml
+++ b/crates/fakecloud-apigatewayv2/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -2,13 +2,16 @@ use async_trait::async_trait;
 use http::{Method, StatusCode};
 use serde_json::json;
 use std::sync::Arc;
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    ApiRequest, Authorizer, Deployment, HttpApi, Integration, Route, SharedApiGatewayV2State, Stage,
+    ApiGatewayV2Snapshot, ApiRequest, Authorizer, Deployment, HttpApi, Integration, Route,
+    SharedApiGatewayV2State, Stage, APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
 };
 use crate::{cors, http_proxy, lambda_proxy, mock, router::Router};
 
@@ -46,6 +49,8 @@ const SUPPORTED: &[&str] = &[
 pub struct ApiGatewayV2Service {
     state: SharedApiGatewayV2State,
     delivery: Option<Arc<DeliveryBus>>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl ApiGatewayV2Service {
@@ -53,12 +58,41 @@ impl ApiGatewayV2Service {
         Self {
             state,
             delivery: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
     pub fn with_delivery(mut self, delivery: Arc<DeliveryBus>) -> Self {
         self.delivery = Some(delivery);
         self
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = ApiGatewayV2Snapshot {
+            schema_version: APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write apigatewayv2 snapshot"),
+            Err(err) => tracing::error!(%err, "apigatewayv2 snapshot task panicked"),
+        }
     }
 
     /// Determine the action from the HTTP method and path segments.
@@ -203,8 +237,11 @@ impl ApiGatewayV2Service {
                 format!("Unknown path: {}", req.raw_path),
             )
         })?;
+        let mutates = action.starts_with("Create")
+            || action.starts_with("Update")
+            || action.starts_with("Delete");
 
-        match action {
+        let result = match action {
             "CreateApi" => self.create_api(&req),
             "GetApi" => self.get_api(&req, api_id.as_deref()),
             "GetApis" => self.get_apis(&req),
@@ -247,7 +284,11 @@ impl ApiGatewayV2Service {
                 "apigateway",
                 action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     // ─── API CRUD ───────────────────────────────────────────────────────

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -5,17 +5,34 @@ use std::sync::Arc;
 
 pub type SharedApiGatewayV2State = Arc<parking_lot::RwLock<ApiGatewayV2State>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiGatewayV2State {
     pub account_id: String,
     pub region: String,
+    #[serde(default)]
     pub apis: HashMap<String, HttpApi>,
-    pub routes: HashMap<String, HashMap<String, Route>>, // api-id -> (route-id -> Route)
-    pub integrations: HashMap<String, HashMap<String, Integration>>, // api-id -> (integration-id -> Integration)
-    pub stages: HashMap<String, HashMap<String, Stage>>, // api-id -> (stage-name -> Stage)
-    pub deployments: HashMap<String, HashMap<String, Deployment>>, // api-id -> (deployment-id -> Deployment)
-    pub authorizers: HashMap<String, HashMap<String, Authorizer>>, // api-id -> (authorizer-id -> Authorizer)
-    pub request_history: Vec<ApiRequest>, // For /_fakecloud/apigatewayv2/requests
+    #[serde(default)]
+    pub routes: HashMap<String, HashMap<String, Route>>,
+    #[serde(default)]
+    pub integrations: HashMap<String, HashMap<String, Integration>>,
+    #[serde(default)]
+    pub stages: HashMap<String, HashMap<String, Stage>>,
+    #[serde(default)]
+    pub deployments: HashMap<String, HashMap<String, Deployment>>,
+    #[serde(default)]
+    pub authorizers: HashMap<String, HashMap<String, Authorizer>>,
+    /// Introspection-only buffer backing `/_fakecloud/apigatewayv2/requests`.
+    /// Intentionally not persisted across restarts.
+    #[serde(default, skip_serializing)]
+    pub request_history: Vec<ApiRequest>,
+}
+
+pub const APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiGatewayV2Snapshot {
+    pub schema_version: u32,
+    pub state: ApiGatewayV2State,
 }
 
 impl ApiGatewayV2State {

--- a/crates/fakecloud-e2e/tests/apigatewayv2_persistence.rs
+++ b/crates/fakecloud-e2e/tests/apigatewayv2_persistence.rs
@@ -1,0 +1,115 @@
+mod helpers;
+
+use aws_sdk_apigatewayv2::types::{IntegrationType, ProtocolType};
+use helpers::TestServer;
+
+/// API + route + integration + stage survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_api_route_integration_stage() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let apigw = server.apigatewayv2_client().await;
+
+    let api = apigw
+        .create_api()
+        .name("orders-api")
+        .protocol_type(ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+    let api_id = api.api_id().unwrap().to_string();
+
+    let integration = apigw
+        .create_integration()
+        .api_id(&api_id)
+        .integration_type(IntegrationType::HttpProxy)
+        .integration_uri("https://example.com/orders")
+        .payload_format_version("2.0")
+        .send()
+        .await
+        .unwrap();
+    let integration_id = integration.integration_id().unwrap().to_string();
+
+    apigw
+        .create_route()
+        .api_id(&api_id)
+        .route_key("GET /orders")
+        .target(format!("integrations/{integration_id}"))
+        .send()
+        .await
+        .unwrap();
+
+    apigw
+        .create_stage()
+        .api_id(&api_id)
+        .stage_name("prod")
+        .auto_deploy(true)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let apigw = server.apigatewayv2_client().await;
+
+    let apis = apigw.get_apis().send().await.unwrap();
+    assert!(apis
+        .items()
+        .iter()
+        .any(|a| a.api_id() == Some(api_id.as_str()) && a.name() == Some("orders-api")));
+
+    let routes = apigw.get_routes().api_id(&api_id).send().await.unwrap();
+    assert!(routes
+        .items()
+        .iter()
+        .any(|r| r.route_key() == Some("GET /orders")));
+
+    let integrations = apigw
+        .get_integrations()
+        .api_id(&api_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(integrations
+        .items()
+        .iter()
+        .any(|i| i.integration_id() == Some(integration_id.as_str())));
+
+    let stage = apigw
+        .get_stage()
+        .api_id(&api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(stage.stage_name(), Some("prod"));
+    assert_eq!(stage.auto_deploy(), Some(true));
+}
+
+/// Deleting an API removes it (and its children) from disk too.
+#[tokio::test]
+async fn persistence_delete_api_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let apigw = server.apigatewayv2_client().await;
+
+    let api_id = apigw
+        .create_api()
+        .name("ephemeral")
+        .protocol_type(ProtocolType::Http)
+        .send()
+        .await
+        .unwrap()
+        .api_id()
+        .unwrap()
+        .to_string();
+    apigw.delete_api().api_id(&api_id).send().await.unwrap();
+
+    server.restart().await;
+    let apigw = server.apigatewayv2_client().await;
+
+    let apis = apigw.get_apis().send().await.unwrap();
+    assert!(!apis
+        .items()
+        .iter()
+        .any(|a| a.api_id() == Some(api_id.as_str())));
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -390,7 +390,6 @@ async fn main() {
             "rds",
             "elasticache",
             "states",
-            "apigatewayv2",
             "bedrock",
         ] {
             fakecloud_persistence::warn_unsupported(service);
@@ -1118,10 +1117,61 @@ async fn main() {
         .with_dynamodb(dynamodb_state.clone());
     registry.register(Arc::new(sfn_service));
 
+    let apigw_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("apigatewayv2").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<
+                        fakecloud_apigatewayv2::state::ApiGatewayV2Snapshot,
+                    >(&bytes)
+                    {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_apigatewayv2::state::APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "apigatewayv2 persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_apigatewayv2::state::APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let api_count = snapshot.state.apis.len();
+                            *apigatewayv2_state.write() = snapshot.state;
+                            tracing::info!(
+                                apis = api_count,
+                                "loaded apigatewayv2 persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse apigatewayv2 persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no apigatewayv2 persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read apigatewayv2 persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
     let mut apigw_service = ApiGatewayV2Service::new(apigatewayv2_state.clone());
     if let Some(ref ld) = lambda_delivery {
         let delivery_for_apigw = Arc::new(DeliveryBus::new().with_lambda(ld.clone()));
         apigw_service = apigw_service.with_delivery(delivery_for_apigw);
+    }
+    if let Some(store) = apigw_snapshot_store {
+        apigw_service = apigw_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(apigw_service));
     registry.register(Arc::new(BedrockService::new(bedrock_state.clone())));

--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -23,6 +23,7 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 ## What's persisted
 
 - **S3** — buckets, objects, versions, delete markers, multipart uploads (resumable across restarts), and every bucket subresource: tags, lifecycle, CORS, policy, notification, logging, website, public access block, object lock, replication, ownership, inventory, encryption, ACL, accelerate. Written to disk on every mutation and reloaded on startup.
+- **API Gateway v2** — HTTP APIs, routes, integrations, stages, deployments, authorizers.
 - **Every other service** emits `persistence not yet supported, running in-memory` at startup and continues to operate exactly as in memory mode. Your tests don't break — you just don't get cross-restart durability for those services yet.
 
 ## Version compatibility


### PR DESCRIPTION
## Summary

- Wires API Gateway v2 into the existing `fakecloud-persistence` snapshot pattern. HTTP APIs, routes, integrations, stages, deployments, and authorizers now survive restarts in \`--storage-mode persistent\`.
- \`request_history\` (the \`/_fakecloud/apigatewayv2/requests\` introspection buffer) is \`skip_serializing\`, matching every other \`/_fakecloud/*\` endpoint — assertions are per-run only, not cross-restart.
- Mutating-action detection is prefix-based (\`Create*\`/\`Update*\`/\`Delete*\`) from the resolved REST action name.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-apigatewayv2\` (17 tests pass)
- [x] \`cargo test -p fakecloud-e2e --test apigatewayv2 --test apigatewayv2_persistence\` (32 + 2 pass, including new round-trip + delete-persistence tests)
- [x] Persistent mode startup logs show apigatewayv2 snapshot load/save path instead of the \"unsupported\" warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist API Gateway v2 state to disk so HTTP APIs, routes, integrations, stages, deployments, and authorizers survive restarts in persistent mode. Adds schema‑versioned snapshot load/save and keeps the request introspection buffer in-memory only.

- **New Features**
  - Wired APIGWv2 into `fakecloud-persistence`: load snapshot on startup; save after successful Create/Update/Delete (guarded by an async lock).
  - Versioned snapshots via `APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION`; mismatches exit with a clear error; logs show loaded/empty status.
  - Do not persist `request_history` for `/_fakecloud/apigatewayv2/requests`.
  - Added e2e tests for round‑trip persistence and delete‑then‑restart behavior.
  - Docs updated to list API Gateway v2 as persisted.

- **Dependencies**
  - Added `fakecloud-persistence` to `fakecloud-apigatewayv2`.

<sup>Written for commit b1b6ea4b247123570375b02170ec30135ddeea33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

