### PR TITLE
docs(iam): resync phase labels with shipped evaluator scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 - **Real infrastructure for stateful services.** Lambda runs in Docker containers (13 runtimes). RDS runs real Postgres/MySQL/MariaDB. ElastiCache runs real Redis/Valkey.
 - **Single binary.** ~19 MB, ~10 MiB idle memory, ~500ms startup. No Docker required to run fakecloud itself (only to exercise the services that need real containers).
 - **First-party test SDKs** for TypeScript, Python, Go, Java, and Rust. Assert on what your code called without writing raw HTTP.
-- **Opt-in SigV4 verification and IAM enforcement.** Off by default so tests just work; turn on `--verify-sigv4` for real cryptographic signature checking and `--iam soft|strict` for identity-policy evaluation (Allow/Deny with Deny precedence, Action/Resource wildcards, user/group/role policies, `Condition` blocks with all 28 AWS operators against global keys like `aws:username` / `aws:SourceIp` / `aws:CurrentTime`) across IAM, STS, SQS, SNS, and S3. See [the security docs](https://fakecloud.dev/docs/reference/security/).
+- **Opt-in SigV4 verification and IAM enforcement.** Off by default so tests just work; turn on `--verify-sigv4` for real cryptographic signature checking and `--iam soft|strict` for identity-policy evaluation (Allow/Deny with Deny precedence, Action/Resource wildcards, user/group/role policies, `Condition` blocks with all 28 AWS operators against global keys like `aws:username` / `aws:SourceIp` / `aws:CurrentTime`, plus resource-based policies for S3 bucket, SNS topic, and Lambda function policies with AWS's cross-account combining semantics) across IAM, STS, SQS, SNS, and S3. See [the security docs](https://fakecloud.dev/docs/reference/security/).
 
 ## Supported services
 

--- a/website/content/docs/reference/limitations.md
+++ b/website/content/docs/reference/limitations.md
@@ -30,10 +30,10 @@ fakecloud parses SigV4 headers for routing and stores IAM policies without evalu
 
 ```bash
 FAKECLOUD_VERIFY_SIGV4=true    # real cryptographic signature verification
-FAKECLOUD_IAM=soft|strict      # Phase 1 identity-policy evaluation
+FAKECLOUD_IAM=soft|strict      # identity + condition + resource-policy evaluation
 ```
 
-Phase 1 evaluation covers `Allow` / `Deny` with Deny precedence, `Action` / `NotAction` / `Resource` / `NotResource` with wildcards, and identity policies attached via user/group/role. It does **not** cover `Condition` blocks, resource-based policies (bucket policies, topic policies, etc.), permission boundaries, SCPs, session policies, or ABAC tag conditions — those are Phase 2 and explicitly skipped during evaluation. See [SigV4 verification and IAM enforcement](@/docs/reference/security.md) for the full scope, enforced-service list, and the reserved `test`/`test` root-bypass convention.
+Evaluation covers `Allow` / `Deny` with Deny precedence, `Action` / `NotAction` / `Resource` / `NotResource` with wildcards, identity policies attached via user/group/role, `Condition` blocks with all 28 AWS operators against global keys plus service-specific keys for S3/SNS/Lambda/SQS, and resource-based policies for S3 bucket policies, SNS topic policies, and Lambda function policies (with AWS's cross-account combining semantics). It does **not** yet cover permission boundaries, session policies passed to `AssumeRole`, ABAC tag conditions (`aws:ResourceTag` / `aws:RequestTag` / `aws:TagKeys`), KMS key policies, or `NotPrincipal` on resource policies — statements carrying `NotPrincipal` are skipped and never silently grant. SCPs are out of scope for fakecloud's single-account model. See [SigV4 verification and IAM enforcement](@/docs/reference/security.md) for the full scope, enforced-service list, and the reserved `test`/`test` root-bypass convention.
 
 ## Everything else is in scope
 

--- a/website/content/docs/reference/security.md
+++ b/website/content/docs/reference/security.md
@@ -149,7 +149,7 @@ The resource's owning account is parsed from the ARN; S3 ARNs have an empty acco
 
 - **S3 bucket policies** are stored by `PutBucketPolicy` and updated by `DeleteBucketPolicy`. `GetBucketPolicy` returns the raw JSON.
 - **SNS topic policies** are stored in the topic's `Policy` attribute by `SetTopicAttributes` (full document) or by `AddPermission` / `RemovePermission` (incremental statements). `GetTopicAttributes` returns them.
-- **Lambda function policies** are built incrementally by `AddPermission`: fakecloud composes a canonical `{"Version":"2012-10-17","Statement":[...]}` document from `(StatementId, Action, Principal, SourceArn?, SourceAccount?)` so the existing evaluator reads it without a Lambda-specific fork. `SourceArn` becomes an `ArnLike` `Condition` on `aws:SourceArn`, and `SourceAccount` becomes a `StringEquals` `Condition` on `aws:SourceAccount` — both are already in the Phase 2 operator set. `GetPolicy` returns the composed document; `RemovePermission` strips the matching `Sid` and leaves an empty `Statement` array behind, matching AWS.
+- **Lambda function policies** are built incrementally by `AddPermission`: fakecloud composes a canonical `{"Version":"2012-10-17","Statement":[...]}` document from `(StatementId, Action, Principal, SourceArn?, SourceAccount?)` so the existing evaluator reads it without a Lambda-specific fork. `SourceArn` becomes an `ArnLike` `Condition` on `aws:SourceArn`, and `SourceAccount` becomes a `StringEquals` `Condition` on `aws:SourceAccount` — both are already in the operator set. `GetPolicy` returns the composed document; `RemovePermission` strips the matching `Sid` and leaves an empty `Statement` array behind, matching AWS.
 
 **Principal matching.** Resource policies use `Principal` / `NotPrincipal` keys that identity policies don't. The evaluator supports the shapes resource policies actually use in practice:
 
@@ -169,13 +169,25 @@ The resource's owning account is parsed from the ARN; S3 ARNs have an empty acco
 
 ### Not implemented
 
+Ongoing coverage work:
+
 - Service-specific condition keys for services / operations beyond the ones listed in the table above. The hook is `AwsService::iam_condition_keys_for`; extending coverage is additive and requires no signature changes.
-- **KMS key policies.** KMS has a deny-by-default semantic (no policy means nothing is allowed, including the account root) that is materially different from S3 / SNS / Lambda's allow-on-match-or-fall-through and deserves its own migration story.
-- Permission boundaries.
-- Service control policies (SCPs).
-- Session policies passed to `AssumeRole`.
-- ABAC / tag conditions (`aws:ResourceTag`, `aws:RequestTag`, `aws:TagKeys`).
-- `NotPrincipal` (carrying it on a statement causes the statement to be skipped, never silently granted).
+
+**Phase 3 — policy gates (planned).** These sit alongside the main evaluation path and constrain what an otherwise-valid Allow can grant.
+
+- **Permission boundaries.** A managed policy attached to a user or role that caps the maximum permissions that identity can ever be granted — even by an explicit Allow. Not yet evaluated.
+- **Session policies passed to `AssumeRole`.** Inline policies handed to the STS call that further restrict the resulting temporary credentials below the role's own policies. Stored but not yet evaluated.
+
+**Phase 4 — ABAC (planned).** Tag-based access control: condition keys like `aws:ResourceTag/<k>`, `aws:RequestTag/<k>`, and `aws:TagKeys` that let statements key off resource and request tags. Requires propagating resource tags into the request context before the evaluator runs. Not yet implemented.
+
+**Phase 5 — niche cleanup (planned).**
+
+- **KMS key policies.** KMS has a deny-by-default semantic (no policy means nothing is allowed, including the account root) that is materially different from S3 / SNS / Lambda's allow-on-match-or-fall-through, and lands behind its own migration decision before wiring it into the evaluator.
+- **`NotPrincipal`.** The inverse-principal matcher on resource-policy statements. Statements carrying it are currently skipped with a `fakecloud::iam::audit` debug log and never silently grant — the safe-fail semantics are deliberate and part of the no-gaming invariant.
+
+**Will not ship.**
+
+- **Service control policies (SCPs).** An AWS Organizations construct that gates permissions across accounts in an org. fakecloud is a single-account model, so there is no org boundary for an SCP to attach to.
 
 If you need any of these for your test scenarios, **use real AWS**. fakecloud is a test tool, not a full IAM simulator.
 

--- a/website/content/docs/services/iam.md
+++ b/website/content/docs/services/iam.md
@@ -25,7 +25,7 @@ Query protocol. Form-encoded body, `Action` parameter, XML responses.
 
 ## Gotchas
 
-- **Policies are stored and optionally evaluated.** By default fakecloud records IAM policies without evaluating them. Set `FAKECLOUD_IAM=strict` (or `soft` for log-only) to turn on Phase 1 identity-policy evaluation — Allow/Deny with Deny precedence, Action/Resource wildcards, user/group/role inline and managed policies. `Condition` blocks, resource-based policies, permission boundaries, SCPs, and ABAC are explicitly not evaluated yet. See [SigV4 verification and IAM enforcement](@/docs/reference/security.md) for the full scope.
+- **Policies are stored and optionally evaluated.** By default fakecloud records IAM policies without evaluating them. Set `FAKECLOUD_IAM=strict` (or `soft` for log-only) to turn on policy evaluation — Allow/Deny with Deny precedence, Action/Resource wildcards, user/group/role inline and managed policies, `Condition` blocks with all 28 AWS operators and global + service-specific keys, and resource-based policies for S3 bucket, SNS topic, and Lambda function policies with AWS's cross-account combining semantics. Permission boundaries, session policies, ABAC tag conditions, KMS key policies, and `NotPrincipal` are not yet evaluated. See [SigV4 verification and IAM enforcement](@/docs/reference/security.md) for the full scope.
 - **SigV4 verification is opt-in.** By default fakecloud parses signatures for routing but doesn't verify them. Set `FAKECLOUD_VERIFY_SIGV4=true` to turn on cryptographic verification with the standard ±15-minute clock skew window. The reserved `test`/`test` root-bypass convention always passes, matching LocalStack.
 
 ## Source


### PR DESCRIPTION
## Summary

The IAM enforcement docs had drifted: `limitations.md`, `services/iam.md`, and the README IAM bullet still described policy evaluation as "Phase 1" with `Condition` blocks and resource-based policies "explicitly not evaluated yet". But conditions (all 28 operators, IfExists, ForAllValues/ForAnyValue, global + service-specific keys), S3 bucket policies, SNS topic policies, Lambda function policies, and cross-account combining semantics have all shipped across #403-445. A fresh reader of the docs today would think the evaluator is far less capable than it actually is.

This PR resyncs the labels with reality. Docs-only, zero code changes.

- **`website/content/docs/reference/security.md`**: reorganize the "Not implemented" list into forward-looking buckets — **Phase 3** (permission boundaries, session policies), **Phase 4** (ABAC tag conditions), **Phase 5** (KMS key policies, `NotPrincipal`), plus an explicit **Will not ship** entry for SCPs (single-account model). Each bullet gets a one-sentence definition so readers can tell "coming" from "never". Also drops the stale "Phase 2 operator set" aside in the Lambda bullet. The `Implemented` list, condition-operator table, global/service-specific key tables, resource-based policies section, enforced-services table, reserved root identity section, and practical example are all unchanged — they were already accurate.
- **`website/content/docs/reference/limitations.md`**: rewrite the IAM paragraph to describe actual scope (identity + conditions + resource policies for S3/SNS/Lambda). Drops the stale "Phase 2 and explicitly skipped during evaluation" sentence.
- **`website/content/docs/services/iam.md`**: same treatment on the "Policies are stored and optionally evaluated" gotcha.
- **`README.md`**: extend the opt-in enforcement bullet to mention resource-based policies alongside identity policies and Condition blocks.

Past work stays labeled under whatever phase it shipped under — no PR history is being rewritten. The reframe is forward-looking only: future work uses Phase 3/4/5 labels, and the docs accurately describe current state.

## Test plan

- [x] `rg -n "Phase 1 identity|explicitly skipped|not evaluated yet|Phase 2 operator" website/ README.md` returns no hits
- [x] `zola check` — no new broken links introduced (two pre-existing broken external links in `blog/localstack-alternative.md` are unrelated)
- [x] Manual read-through of security.md, limitations.md, iam.md, and README IAM bullet — story is now internally consistent

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resynced IAM enforcement docs to reflect the current evaluator: identity policies, full `Condition` operator set, and S3/SNS/Lambda resource policies are now documented, with future items grouped into Phase 3–5. Docs-only change.

- **Docs**
  - `security.md`: reorganized “Not implemented” into Phase 3 (permission boundaries, session policies), Phase 4 (ABAC), Phase 5 (KMS, `NotPrincipal`), and “Will not ship” (SCPs); removed stale operator note in the Lambda section.
  - `limitations.md`: updated IAM scope to include identity + conditions + resource policies; removed outdated skip text.
  - `services/iam.md`: updated “Policies are stored and optionally evaluated” to include conditions and resource policies; clarified what’s not yet evaluated.
  - `README.md`: expanded opt-in enforcement bullet to include resource-based policies and cross-account combining semantics.

<sup>Written for commit 33a1917766e2144952e48303583e6bdfb6d5256b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

