### PR TITLE
ci(coverage): pass CODECOV_TOKEN to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,4 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Authenticates the \`codecov/codecov-action@v4\` upload step with the repo-scoped upload token (stored in the \`CODECOV_TOKEN\` repository secret).

Without the token, the tokenless upload path that \`codecov-action\` attempts on public repos was failing silently — \`continue-on-error: true\` meant CI stayed green but no report ever landed on Codecov, which is why the README badge still reads \"coverage | unknown\". With this merged, the next \`main\` CI run will upload its \`lcov.info\` to Codecov and the badge will flip to the real number.

## Test plan

- [x] \`CODECOV_TOKEN\` repository secret is already in place
- [ ] CI green
- [ ] After merge, verify the \`Upload coverage to Codecov\` step on the main-branch run logs a successful upload (not a \`token required\` error)
- [ ] README badge shows a numeric coverage value

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass `CODECOV_TOKEN` to `codecov/codecov-action@v4` so coverage uploads authenticate and reach Codecov. Fixes silent tokenless uploads and updates the README badge from "unknown" to the real number.

<sup>Written for commit 3d227ad641570c41f58858d040c36025e2924896. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

