### PR TITLE
ci(e2e): free runner disk space for lambda runtime partitions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,6 +63,18 @@ jobs:
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      - name: Free disk space
+        if: startsWith(matrix.name, 'lambda-runtimes-') || matrix.name == 'lambda-container-clis'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - name: Install podman
         if: matrix.install_podman
         run: sudo apt-get update && sudo apt-get install -y podman

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,11 +58,6 @@ jobs:
       NEXTEST_PARTITION: ${{ matrix.partition }}
       INSTALL_PODMAN: ${{ matrix.install_podman }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
       - name: Free disk space
         if: startsWith(matrix.name, 'lambda-runtimes-') || matrix.name == 'lambda-container-clis'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -74,6 +69,11 @@ jobs:
           large-packages: false
           docker-images: false
           swap-storage: true
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install podman
         if: matrix.install_podman


### PR DESCRIPTION
## Summary
- Lambda runtime e2e partitions (e.g. `lambda-runtimes-python`) pull multiple multi-GB Lambda container images in one job and exhaust the ~14GB free on `ubuntu-latest`, failing mid-pull with `no space left on device`.
- Add `jlumbroso/free-disk-space` to the `e2e` job, gated to `lambda-runtimes-*` and `lambda-container-clis` matrix entries, reclaiming ~20GB by removing Android, .NET, Haskell SDKs and swap.
- Leaves `tool-cache` (Rust/Node) and Docker images untouched so the rest of the job is unaffected.

## Test plan
- [ ] CI: all e2e partitions green, especially `lambda-runtimes-python` / `-java` / `-dotnet`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent E2E failures in Lambda runtime partitions by freeing disk space before pulling large Lambda images on `ubuntu-latest`. The cleanup now runs first to avoid wasted cache restores.

- **Bug Fixes**
  - Run `jlumbroso/free-disk-space` at the start of the job, gated to `lambda-runtimes-*` and `lambda-container-clis`.
  - Reclaim ~20GB by removing Android, .NET, Haskell SDKs and swap; keep `tool-cache` and Docker images.

<sup>Written for commit ce8269a85fde99c5fc7ccc29c87b9f4e45a5f948. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

