### PR TITLE
feat(iam): phase 3 batch 2 — permission boundaries enforced

### DIFF
--- a/crates/fakecloud-conformance/tests/iam.rs
+++ b/crates/fakecloud-conformance/tests/iam.rs
@@ -305,6 +305,36 @@ async fn iam_role_permissions_boundary() {
         .unwrap();
 }
 
+#[test_action("iam", "PutUserPermissionsBoundary", checksum = "af86aeea")]
+#[test_action("iam", "DeleteUserPermissionsBoundary", checksum = "91c97dd6")]
+#[tokio::test]
+async fn iam_user_permissions_boundary() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("conf-upb")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_user_permissions_boundary()
+        .user_name("conf-upb")
+        .permissions_boundary("arn:aws:iam::aws:policy/PowerUserAccess")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_user_permissions_boundary()
+        .user_name("conf-upb")
+        .send()
+        .await
+        .unwrap();
+}
+
 // ==========================================================================
 // Policies
 // ==========================================================================

--- a/crates/fakecloud-e2e/tests/iam_enforcement_boundary.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement_boundary.rs
@@ -1,0 +1,284 @@
+//! E2E tests for Phase 3 permission boundary enforcement.
+//!
+//! Each test spawns fakecloud with `FAKECLOUD_IAM=strict`, creates a
+//! user via the reserved root bypass, attaches an inline identity
+//! policy + a managed boundary, then signs a follow-up request with
+//! the user's own credentials and observes the gated decision.
+
+mod helpers;
+
+use aws_credential_types::Credentials;
+use aws_sdk_iam::Client as IamClient;
+use aws_sdk_sts::Client as StsClient;
+use helpers::TestServer;
+
+async fn start_strict() -> TestServer {
+    TestServer::start_with_env(&[
+        ("FAKECLOUD_IAM", "strict"),
+        ("FAKECLOUD_VERIFY_SIGV4", "true"),
+    ])
+    .await
+}
+
+async fn sdk_config_with(server: &TestServer, akid: &str, secret: &str) -> aws_config::SdkConfig {
+    aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(
+            akid,
+            secret,
+            None,
+            None,
+            "fakecloud-iam-boundary",
+        ))
+        .load()
+        .await
+}
+
+async fn root_client(server: &TestServer) -> IamClient {
+    let boot = sdk_config_with(server, "test", "test").await;
+    IamClient::new(&boot)
+}
+
+async fn bootstrap_user(server: &TestServer, name: &str) -> (String, String) {
+    let iam = root_client(server).await;
+    iam.create_user().user_name(name).send().await.unwrap();
+    let ak = iam
+        .create_access_key()
+        .user_name(name)
+        .send()
+        .await
+        .unwrap();
+    let key = ak.access_key().unwrap();
+    (
+        key.access_key_id().to_string(),
+        key.secret_access_key().to_string(),
+    )
+}
+
+async fn create_managed_policy(server: &TestServer, name: &str, document: &str) -> String {
+    let iam = root_client(server).await;
+    let resp = iam
+        .create_policy()
+        .policy_name(name)
+        .policy_document(document)
+        .send()
+        .await
+        .unwrap();
+    resp.policy().unwrap().arn().unwrap().to_string()
+}
+
+async fn attach_inline(server: &TestServer, user: &str, name: &str, document: &str) {
+    root_client(server)
+        .await
+        .put_user_policy()
+        .user_name(user)
+        .policy_name(name)
+        .policy_document(document)
+        .send()
+        .await
+        .unwrap();
+}
+
+async fn set_boundary(server: &TestServer, user: &str, boundary_arn: &str) {
+    root_client(server)
+        .await
+        .put_user_permissions_boundary()
+        .user_name(user)
+        .permissions_boundary(boundary_arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ======================================================================
+
+#[tokio::test]
+async fn boundary_caps_identity_allow_all() {
+    // alice has Allow-all on her identity side, but a boundary that
+    // only permits sts:GetCallerIdentity. GetCallerIdentity must
+    // succeed; everything else must be implicit-denied.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "alice").await;
+
+    attach_inline(
+        &server,
+        "alice",
+        "AllowAll",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+    )
+    .await;
+
+    let boundary_arn = create_managed_policy(
+        &server,
+        "BoundaryOnlyGetCallerIdentity",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sts:GetCallerIdentity","Resource":"*"}]}"#,
+    )
+    .await;
+    set_boundary(&server, "alice", &boundary_arn).await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+
+    // Allowed: action covered by both identity and boundary.
+    let sts = StsClient::new(&cfg);
+    let identity = sts.get_caller_identity().send().await.unwrap();
+    assert!(identity.arn().unwrap().contains("user/alice"));
+
+    // Denied: action allowed by identity but not by boundary.
+    let iam = IamClient::new(&cfg);
+    let err = iam.list_users().send().await.unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn boundary_cannot_escape_itself() {
+    // Canonical "can a user escape their boundary" test. bob's
+    // boundary forbids iam:DeleteUserPermissionsBoundary, so bob
+    // cannot remove his own boundary even though he has Allow-all
+    // on the identity side. After Phase 3 this is enforced.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "bob").await;
+
+    attach_inline(
+        &server,
+        "bob",
+        "AllowAll",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+    )
+    .await;
+
+    let boundary_arn = create_managed_policy(
+        &server,
+        "BoundaryNoBoundaryEscape",
+        r#"{
+            "Version":"2012-10-17",
+            "Statement":[
+                {"Effect":"Allow","Action":"*","Resource":"*"},
+                {"Effect":"Deny","Action":["iam:DeleteUserPermissionsBoundary","iam:PutUserPermissionsBoundary"],"Resource":"*"}
+            ]
+        }"#,
+    )
+    .await;
+    set_boundary(&server, "bob", &boundary_arn).await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let iam = IamClient::new(&cfg);
+
+    let err = iam
+        .delete_user_permissions_boundary()
+        .user_name("bob")
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn dangling_boundary_arn_denies_everything() {
+    // Attach a boundary that points at a managed policy ARN we then
+    // delete. Every action with the user's credentials must deny
+    // until the boundary is removed, matching AWS behavior.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "carol").await;
+
+    attach_inline(
+        &server,
+        "carol",
+        "AllowAll",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+    )
+    .await;
+
+    let boundary_arn = create_managed_policy(
+        &server,
+        "TransientBoundary",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+    )
+    .await;
+    set_boundary(&server, "carol", &boundary_arn).await;
+
+    // Delete the boundary managed policy out from under her.
+    root_client(&server)
+        .await
+        .delete_policy()
+        .policy_arn(&boundary_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sts = StsClient::new(&cfg);
+    let err = sts.get_caller_identity().send().await.unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn boundary_explicit_deny_wins() {
+    // boundary contains an explicit Deny — Deny precedence works
+    // across layers.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "dave").await;
+
+    attach_inline(
+        &server,
+        "dave",
+        "AllowAll",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+    )
+    .await;
+
+    let boundary_arn = create_managed_policy(
+        &server,
+        "BoundaryDenyCallerIdentity",
+        r#"{
+            "Version":"2012-10-17",
+            "Statement":[
+                {"Effect":"Allow","Action":"*","Resource":"*"},
+                {"Effect":"Deny","Action":"sts:GetCallerIdentity","Resource":"*"}
+            ]
+        }"#,
+    )
+    .await;
+    set_boundary(&server, "dave", &boundary_arn).await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sts = StsClient::new(&cfg);
+    let err = sts.get_caller_identity().send().await.unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn no_boundary_unchanged_behavior() {
+    // Regression guard: a user without any boundary behaves exactly
+    // as in Phase 1/2 — identity Allow is enough.
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "eve").await;
+    attach_inline(
+        &server,
+        "eve",
+        "AllowGetCallerIdentity",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sts:GetCallerIdentity","Resource":"*"}]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sts = StsClient::new(&cfg);
+    let identity = sts.get_caller_identity().send().await.unwrap();
+    assert!(identity.arn().unwrap().contains("user/eve"));
+}

--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -817,6 +817,69 @@ fn collect_role_policies(
     }
 }
 
+/// Look up the permission-boundary policy document attached to
+/// `principal`, if any.
+///
+/// Returns:
+/// - `None` — the principal has no boundary set, OR the principal is
+///   exempt from boundary evaluation (account root, service-linked
+///   role, or an unhandled principal type like a federated user). The
+///   caller should treat this as "boundary layer absent"
+///   (pass-through) when calling [`evaluate_with_gates`].
+/// - `Some(vec![])` — a boundary ARN is set but does not resolve to
+///   a known managed policy (dangling ARN, or the user/role was found
+///   but its boundary points at a deleted policy). The caller must
+///   treat this as **deny-all** — matching AWS's behavior when a
+///   permission boundary is deleted, the principal can no longer
+///   perform any action until the boundary is re-attached or removed.
+///   Emits a `fakecloud::iam::audit` debug log.
+/// - `Some(vec![doc])` — the boundary resolves to a policy document.
+///
+/// Service-linked roles are detected by the `AWSServiceRoleFor` name
+/// prefix (AWS rejects attaching boundaries to SLRs at the API layer
+/// anyway; this is defense-in-depth).
+pub fn collect_boundary_policies(
+    state: &IamState,
+    principal: &Principal,
+) -> Option<Vec<PolicyDocument>> {
+    if principal.is_root() {
+        return None;
+    }
+    let boundary_arn = match principal.principal_type {
+        PrincipalType::User => {
+            let user_name = user_name_from_arn(&principal.arn)?;
+            let user = state.users.get(user_name)?;
+            user.permissions_boundary.clone()?
+        }
+        PrincipalType::AssumedRole => {
+            let role_name = role_name_from_assumed_role_arn(&principal.arn)?;
+            if role_name.starts_with("AWSServiceRoleFor") {
+                // Service-linked roles are exempt from boundary
+                // evaluation — AWS rejects attaching one at the API
+                // layer, but if state has been force-injected we
+                // still bypass to match documented semantics.
+                return None;
+            }
+            let role = state.roles.get(role_name)?;
+            role.permissions_boundary.clone()?
+        }
+        // No boundary story for root / federated / unknown.
+        _ => return None,
+    };
+    match managed_policy_default_document(state, &boundary_arn) {
+        Some(doc) => Some(vec![PolicyDocument::parse(&doc)]),
+        None => {
+            tracing::debug!(
+                target: "fakecloud::iam::audit",
+                principal_arn = %principal.arn,
+                boundary_arn = %boundary_arn,
+                "permission boundary ARN does not resolve to a known managed policy; denying all actions"
+            );
+            Some(Vec::new())
+        }
+    }
+}
+
 fn managed_policy_default_document(state: &IamState, arn: &str) -> Option<String> {
     let policy = state.policies.get(arn)?;
     policy

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -114,6 +114,8 @@ fn is_mutating_action(action: &str) -> bool {
             | "DetachUserPolicy"
             | "PutUserPolicy"
             | "DeleteUserPolicy"
+            | "PutUserPermissionsBoundary"
+            | "DeleteUserPermissionsBoundary"
             | "CreateGroup"
             | "DeleteGroup"
             | "UpdateGroup"
@@ -267,6 +269,8 @@ impl AwsService for IamService {
             "GetUserPolicy" => self.get_user_policy(&req),
             "DeleteUserPolicy" => self.delete_user_policy(&req),
             "ListUserPolicies" => self.list_user_policies(&req),
+            "PutUserPermissionsBoundary" => self.put_user_permissions_boundary(&req),
+            "DeleteUserPermissionsBoundary" => self.delete_user_permissions_boundary(&req),
 
             // Groups
             "CreateGroup" => self.create_group(&req),
@@ -483,6 +487,8 @@ fn iam_action_resource(
         "GetUserPolicy",
         "DeleteUserPolicy",
         "ListUserPolicies",
+        "PutUserPermissionsBoundary",
+        "DeleteUserPermissionsBoundary",
         "AddUserToGroup",
         "RemoveUserFromGroup",
         "ListGroupsForUser",
@@ -745,6 +751,8 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "GetUserPolicy",
     "DeleteUserPolicy",
     "ListUserPolicies",
+    "PutUserPermissionsBoundary",
+    "DeleteUserPermissionsBoundary",
     "CreateGroup",
     "GetGroup",
     "DeleteGroup",

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use http::StatusCode;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -458,8 +459,12 @@ impl IamService {
         validate_string_length("roleName", &role_name, 1, 64)?;
         let boundary = required_param(&req.query_params, "PermissionsBoundary")?;
 
-        // Validate boundary ARN format
-        if !boundary.contains(":policy/") {
+        if boundary
+            .parse::<Arn>()
+            .ok()
+            .filter(|arn| arn.service == "iam" && arn.resource.starts_with("policy/"))
+            .is_none()
+        {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationError",

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -1583,7 +1583,12 @@ impl IamService {
         validate_string_length("userName", &user_name, 1, 64)?;
         let boundary = required_param(&req.query_params, "PermissionsBoundary")?;
 
-        if !boundary.contains(":policy/") {
+        if boundary
+            .parse::<Arn>()
+            .ok()
+            .filter(|arn| arn.service == "iam" && arn.resource.starts_with("policy/"))
+            .is_none()
+        {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationError",

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -1574,4 +1574,52 @@ impl IamService {
         );
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
+
+    pub(super) fn put_user_permissions_boundary(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let user_name = required_param(&req.query_params, "UserName")?;
+        validate_string_length("userName", &user_name, 1, 64)?;
+        let boundary = required_param(&req.query_params, "PermissionsBoundary")?;
+
+        if !boundary.contains(":policy/") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                format!("Value ({boundary}) for parameter PermissionsBoundary is invalid."),
+            ));
+        }
+
+        let mut state = self.state.write();
+        let user = state.users.get_mut(&user_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchEntity",
+                format!("User {user_name} not found"),
+            )
+        })?;
+        user.permissions_boundary = Some(boundary);
+        let xml = empty_response("PutUserPermissionsBoundary", &req.request_id);
+        Ok(AwsResponse::xml(StatusCode::OK, xml))
+    }
+
+    pub(super) fn delete_user_permissions_boundary(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let user_name = required_param(&req.query_params, "UserName")?;
+        validate_string_length("userName", &user_name, 1, 64)?;
+        let mut state = self.state.write();
+        let user = state.users.get_mut(&user_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchEntity",
+                format!("User {user_name} not found"),
+            )
+        })?;
+        user.permissions_boundary = None;
+        let xml = empty_response("DeleteUserPermissionsBoundary", &req.request_id);
+        Ok(AwsResponse::xml(StatusCode::OK, xml))
+    }
 }

--- a/crates/fakecloud-iam/src/policy_evaluator.rs
+++ b/crates/fakecloud-iam/src/policy_evaluator.rs
@@ -38,14 +38,20 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
         context: &ConditionContext,
     ) -> IamDecision {
         let state = self.state.read();
-        let policies = evaluator::collect_identity_policies(&state, principal);
+        let identity_policies = evaluator::collect_identity_policies(&state, principal);
+        let boundary = evaluator::collect_boundary_policies(&state, principal);
         let request = EvalRequest {
             principal,
             action: action.action_string(),
             resource: action.resource.clone(),
             context: context.clone(),
         };
-        decision_to_core(evaluator::evaluate(&policies, &request))
+        decision_to_core(evaluator::evaluate_with_gates(
+            &identity_policies,
+            boundary.as_deref(),
+            None,
+            &request,
+        ))
     }
 
     fn evaluate_with_resource_policy(
@@ -58,6 +64,7 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
     ) -> IamDecision {
         let state = self.state.read();
         let identity_policies = evaluator::collect_identity_policies(&state, principal);
+        let boundary = evaluator::collect_boundary_policies(&state, principal);
         let request = EvalRequest {
             principal,
             action: action.action_string(),
@@ -65,8 +72,10 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
             context: context.clone(),
         };
         let resource_policy = resource_policy_json.map(evaluator::PolicyDocument::parse);
-        decision_to_core(evaluator::evaluate_with_resource_policy(
+        decision_to_core(evaluator::evaluate_with_resource_policy_and_gates(
             &identity_policies,
+            boundary.as_deref(),
+            None,
             resource_policy.as_ref(),
             &request,
             resource_account_id,
@@ -85,7 +94,7 @@ fn decision_to_core(decision: Decision) -> IamDecision {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{IamAccessKey, IamState, IamUser};
+    use crate::state::{IamAccessKey, IamPolicy, IamState, IamUser, PolicyVersion};
     use chrono::Utc;
     use fakecloud_core::auth::PrincipalType;
     use parking_lot::RwLock;
@@ -176,6 +185,198 @@ mod tests {
         assert_eq!(
             eval.evaluate(&principal(), &action, &ConditionContext::default()),
             IamDecision::ExplicitDeny
+        );
+    }
+
+    fn insert_managed_policy(state: &mut IamState, arn: &str, document: &str) {
+        state.policies.insert(
+            arn.to_string(),
+            IamPolicy {
+                policy_name: arn.rsplit('/').next().unwrap_or("p").to_string(),
+                policy_id: "ANPATEST".into(),
+                arn: arn.to_string(),
+                path: "/".into(),
+                description: String::new(),
+                created_at: Utc::now(),
+                tags: Vec::new(),
+                default_version_id: "v1".into(),
+                versions: vec![PolicyVersion {
+                    version_id: "v1".into(),
+                    document: document.to_string(),
+                    is_default: true,
+                    created_at: Utc::now(),
+                }],
+                next_version_num: 2,
+                attachment_count: 1,
+            },
+        );
+    }
+
+    fn s3_get_object_action() -> IamAction {
+        IamAction {
+            service: "s3",
+            action: "GetObject",
+            resource: "arn:aws:s3:::bucket/key".into(),
+        }
+    }
+
+    fn s3_put_object_action() -> IamAction {
+        IamAction {
+            service: "s3",
+            action: "PutObject",
+            resource: "arn:aws:s3:::bucket/key".into(),
+        }
+    }
+
+    #[test]
+    fn boundary_caps_identity_allow_all() {
+        // alice has a catch-all Allow inline policy but her boundary
+        // only permits s3:GetObject → PutObject must be implicit-deny.
+        let state = setup();
+        {
+            let mut s = state.write();
+            s.user_inline_policies.insert(
+                "alice".into(),
+                std::collections::HashMap::from([(
+                    "AllowAll".into(),
+                    r#"{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.into(),
+                )]),
+            );
+            let boundary_arn = "arn:aws:iam::123456789012:policy/BoundaryReadOnly";
+            insert_managed_policy(
+                &mut s,
+                boundary_arn,
+                r#"{"Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#,
+            );
+            s.users.get_mut("alice").unwrap().permissions_boundary = Some(boundary_arn.to_string());
+        }
+        let eval = IamPolicyEvaluatorImpl::new(state);
+        assert_eq!(
+            eval.evaluate(
+                &principal(),
+                &s3_get_object_action(),
+                &ConditionContext::default()
+            ),
+            IamDecision::Allow
+        );
+        assert_eq!(
+            eval.evaluate(
+                &principal(),
+                &s3_put_object_action(),
+                &ConditionContext::default()
+            ),
+            IamDecision::ImplicitDeny
+        );
+    }
+
+    #[test]
+    fn boundary_explicit_deny_overrides_identity_allow() {
+        let state = setup();
+        {
+            let mut s = state.write();
+            s.user_inline_policies.insert(
+                "alice".into(),
+                std::collections::HashMap::from([(
+                    "AllowAll".into(),
+                    r#"{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.into(),
+                )]),
+            );
+            let boundary_arn = "arn:aws:iam::123456789012:policy/BoundaryDenyPut";
+            insert_managed_policy(
+                &mut s,
+                boundary_arn,
+                r#"{"Statement":[{"Effect":"Deny","Action":"s3:PutObject","Resource":"*"}]}"#,
+            );
+            s.users.get_mut("alice").unwrap().permissions_boundary = Some(boundary_arn.to_string());
+        }
+        let eval = IamPolicyEvaluatorImpl::new(state);
+        assert_eq!(
+            eval.evaluate(
+                &principal(),
+                &s3_put_object_action(),
+                &ConditionContext::default()
+            ),
+            IamDecision::ExplicitDeny
+        );
+    }
+
+    #[test]
+    fn dangling_boundary_arn_denies_all_actions() {
+        // Boundary ARN set but the managed policy was deleted (or
+        // never existed). Must deny every action, matching AWS.
+        let state = setup();
+        {
+            let mut s = state.write();
+            s.user_inline_policies.insert(
+                "alice".into(),
+                std::collections::HashMap::from([(
+                    "AllowAll".into(),
+                    r#"{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.into(),
+                )]),
+            );
+            s.users.get_mut("alice").unwrap().permissions_boundary =
+                Some("arn:aws:iam::123456789012:policy/DoesNotExist".into());
+        }
+        let eval = IamPolicyEvaluatorImpl::new(state);
+        assert_eq!(
+            eval.evaluate(
+                &principal(),
+                &s3_get_object_action(),
+                &ConditionContext::default()
+            ),
+            IamDecision::ImplicitDeny
+        );
+    }
+
+    #[test]
+    fn service_linked_role_bypasses_boundary() {
+        // Even if state is force-injected with a boundary on an SLR,
+        // the evaluator must not apply it — AWS exempts SLRs.
+        let state = setup();
+        {
+            use crate::state::IamRole;
+            let mut s = state.write();
+            s.roles.insert(
+                "AWSServiceRoleForLambda".into(),
+                IamRole {
+                    role_name: "AWSServiceRoleForLambda".into(),
+                    role_id: "AROASLR".into(),
+                    arn: "arn:aws:iam::123456789012:role/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda".into(),
+                    path: "/aws-service-role/lambda.amazonaws.com/".into(),
+                    assume_role_policy_document: "{}".into(),
+                    description: None,
+                    created_at: Utc::now(),
+                    max_session_duration: 3600,
+                    tags: Vec::new(),
+                    permissions_boundary: Some(
+                        "arn:aws:iam::123456789012:policy/ShouldBeIgnored".into(),
+                    ),
+                },
+            );
+            s.role_inline_policies.insert(
+                "AWSServiceRoleForLambda".into(),
+                std::collections::HashMap::from([(
+                    "AllowAll".into(),
+                    r#"{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.into(),
+                )]),
+            );
+        }
+        let principal = Principal {
+            arn: "arn:aws:sts::123456789012:assumed-role/AWSServiceRoleForLambda/session1"
+                .to_string(),
+            user_id: "AROASLR:session1".into(),
+            account_id: "123456789012".into(),
+            principal_type: PrincipalType::AssumedRole,
+            source_identity: None,
+        };
+        let eval = IamPolicyEvaluatorImpl::new(state);
+        assert_eq!(
+            eval.evaluate(
+                &principal,
+                &s3_get_object_action(),
+                &ConditionContext::default()
+            ),
+            IamDecision::Allow
         );
     }
 


### PR DESCRIPTION
## Summary

Phase 3 step 2 of 4: wire permission boundaries through the evaluator so strict-mode callers can rely on them. Builds on the \`evaluate_with_gates\` primitive from #453.

- \`collect_boundary_policies\` resolves a principal's boundary ARN and hands the document to the new gate slot. A dangling ARN becomes \`Some(vec![])\` (deny-all) to match AWS behavior when a boundary managed policy is deleted. Account root and service-linked roles (role name starts with \`AWSServiceRoleFor\`) are exempt from boundary evaluation.
- \`IamPolicyEvaluatorImpl::evaluate\` and \`evaluate_with_resource_policy\` both feed the boundary layer into \`evaluate_with_gates\` / \`evaluate_with_resource_policy_and_gates\`. Session-policy slot is still \`None\` — that lands in Batch 3.
- Adds the missing \`PutUserPermissionsBoundary\` / \`DeleteUserPermissionsBoundary\` handlers (the role variants already existed), registered in dispatch, action list, and mutation allowlist.

## Tests

4 new unit tests in \`policy_evaluator::tests\`:
- Boundary caps identity \`Allow: *\` → only boundary-allowed actions go through
- Explicit \`Deny\` in boundary overrides identity \`Allow\`
- Dangling boundary ARN denies everything
- Service-linked role with a boundary set in state is still allowed (exempt)

5 new E2E tests in \`iam_enforcement_boundary.rs\` driving \`aws-sdk-rust\` at \`FAKECLOUD_IAM=strict\`:
- \`boundary_caps_identity_allow_all\` — user with Allow-all inline + GetCallerIdentity-only boundary; GetCallerIdentity allowed, ListUsers denied
- \`boundary_cannot_escape_itself\` — canonical self-gating test: boundary forbids \`iam:DeleteUserPermissionsBoundary\`, so the user cannot remove their own boundary
- \`dangling_boundary_arn_denies_everything\` — delete the boundary managed policy out from under the user, every action denies
- \`boundary_explicit_deny_wins\` — Deny precedence across layers
- \`no_boundary_unchanged_behavior\` — regression guard for users with no boundary

## Test plan

- [x] \`cargo test -p fakecloud-iam\` — 194 passed
- [x] \`cargo test -p fakecloud-e2e --test iam_enforcement_boundary\` — 5/5 green
- [x] \`cargo test -p fakecloud-e2e --test iam_enforcement\` — 37/37 green (no regression)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] CI green
- [ ] Cubic review addressed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces IAM permission boundaries in strict mode, gating identity and resource decisions by the principal’s boundary. Adds user boundary APIs and stricter ARN validation.

- **New Features**
  - `collect_boundary_policies` resolves user/role boundaries; returns deny-all for dangling ARNs; exempts account root and service-linked roles (`AWSServiceRoleFor*`).
  - `IamPolicyEvaluatorImpl` passes the boundary into `evaluate_with_gates` and `evaluate_with_resource_policy_and_gates`; session-policy gate remains unset.
  - Added `PutUserPermissionsBoundary` and `DeleteUserPermissionsBoundary`; registered in dispatch, supported actions, and mutation allowlist.
  - New unit, E2E, and conformance tests for boundary capping, explicit deny precedence, dangling ARN deny-all, boundary self-escape prevention, SLR bypass, and no-boundary regression.

- **Bug Fixes**
  - Validate `PermissionsBoundary` as a proper ARN (`iam` service with `policy/*`) for both user and role APIs; rejects invalid values with `ValidationError`.

<sup>Written for commit bb6523c3b7023b842a2389e97053975d54cb766f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

