### PR TITLE
feat(cognito): persist Cognito state to disk via snapshot store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,6 +2069,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "serde",

--- a/crates/fakecloud-cognito/Cargo.toml
+++ b/crates/fakecloud-cognito/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -11,6 +11,7 @@ mod user_pools;
 mod users;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use base64::Engine;
@@ -18,22 +19,26 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    AccountRecoverySetting, AdminCreateUserConfig, Device, EmailConfiguration, Group,
-    IdentityProvider, InviteMessageTemplate, PasswordPolicy, RecoveryOption, ResourceServer,
+    AccountRecoverySetting, AdminCreateUserConfig, CognitoSnapshot, Device, EmailConfiguration,
+    Group, IdentityProvider, InviteMessageTemplate, PasswordPolicy, RecoveryOption, ResourceServer,
     ResourceServerScope, SchemaAttribute, SharedCognitoState, SignInPolicy, SmsConfiguration,
     StringAttributeConstraints, TokenValidityUnits, User, UserAttribute, UserImportJob, UserPool,
-    UserPoolClient, UserPoolDomain, VerificationMessageTemplate,
+    UserPoolClient, UserPoolDomain, VerificationMessageTemplate, COGNITO_SNAPSHOT_SCHEMA_VERSION,
 };
 use crate::triggers::CognitoDeliveryContext;
 
 pub struct CognitoService {
     state: SharedCognitoState,
     delivery_ctx: Option<CognitoDeliveryContext>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl CognitoService {
@@ -41,6 +46,8 @@ impl CognitoService {
         Self {
             state,
             delivery_ctx: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -49,6 +56,83 @@ impl CognitoService {
         self.delivery_ctx = Some(ctx);
         self
     }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes,
+    /// with serde + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = CognitoSnapshot {
+            schema_version: COGNITO_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write cognito snapshot"),
+            Err(err) => tracing::error!(%err, "cognito snapshot task panicked"),
+        }
+    }
+}
+
+/// Actions that mutate persistent state. List excludes pure reads
+/// (`Describe*`, `List*`, `Get*`, `AdminGet*`, `AdminList*`) and any
+/// other action that doesn't change state stored in `CognitoState`.
+fn is_mutating_action(action: &str) -> bool {
+    !matches!(
+        action,
+        "DescribeUserPool"
+            | "DescribeUserPoolClient"
+            | "DescribeUserPoolDomain"
+            | "DescribeIdentityProvider"
+            | "DescribeResourceServer"
+            | "DescribeRiskConfiguration"
+            | "DescribeManagedLoginBranding"
+            | "DescribeManagedLoginBrandingByClient"
+            | "DescribeUserImportJob"
+            | "DescribeTerms"
+            | "ListUserPools"
+            | "ListUserPoolClients"
+            | "ListUserPoolClientSecrets"
+            | "ListUsers"
+            | "ListUsersInGroup"
+            | "ListGroups"
+            | "ListIdentityProviders"
+            | "ListResourceServers"
+            | "ListDevices"
+            | "ListTagsForResource"
+            | "ListUserImportJobs"
+            | "ListTerms"
+            | "ListWebAuthnCredentials"
+            | "AdminGetUser"
+            | "AdminGetDevice"
+            | "AdminListDevices"
+            | "AdminListGroupsForUser"
+            | "AdminListUserAuthEvents"
+            | "GetUser"
+            | "GetGroup"
+            | "GetDevice"
+            | "GetUserPoolMfaConfig"
+            | "GetUserAuthFactors"
+            | "GetUICustomization"
+            | "GetLogDeliveryConfiguration"
+            | "GetSigningCertificate"
+            | "GetCSVHeader"
+            | "GetIdentityProviderByIdentifier"
+    )
 }
 
 #[async_trait]
@@ -58,7 +142,8 @@ impl AwsService for CognitoService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateUserPool" => self.create_user_pool(&req),
             "DescribeUserPool" => self.describe_user_pool(&req),
             "UpdateUserPool" => self.update_user_pool(&req),
@@ -187,7 +272,11 @@ impl AwsService for CognitoService {
                 "cognito-idp",
                 &req.action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -7,46 +7,75 @@ use serde::{Deserialize, Serialize};
 
 pub type SharedCognitoState = Arc<RwLock<CognitoState>>;
 
+pub const COGNITO_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CognitoSnapshot {
+    pub schema_version: u32,
+    pub state: CognitoState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CognitoState {
     pub account_id: String,
     pub region: String,
+    #[serde(default)]
     pub user_pools: HashMap<String, UserPool>,
+    #[serde(default)]
     pub user_pool_clients: HashMap<String, UserPoolClient>,
     /// pool_id -> (username -> User)
+    #[serde(default)]
     pub users: HashMap<String, HashMap<String, User>>,
     /// refresh_token -> RefreshTokenData
+    #[serde(default)]
     pub refresh_tokens: HashMap<String, RefreshTokenData>,
     /// session_token -> SessionData
+    #[serde(default)]
     pub sessions: HashMap<String, SessionData>,
     /// access_token -> AccessTokenData
+    #[serde(default)]
     pub access_tokens: HashMap<String, AccessTokenData>,
     /// pool_id -> (group_name -> Group)
+    #[serde(default)]
     pub groups: HashMap<String, HashMap<String, Group>>,
     /// pool_id -> (username -> [group_names])
+    #[serde(default)]
     pub user_groups: HashMap<String, HashMap<String, Vec<String>>>,
     /// pool_id -> (provider_name -> IdentityProvider)
+    #[serde(default)]
     pub identity_providers: HashMap<String, HashMap<String, IdentityProvider>>,
     /// pool_id -> (identifier -> ResourceServer)
+    #[serde(default)]
     pub resource_servers: HashMap<String, HashMap<String, ResourceServer>>,
     /// domain -> UserPoolDomain
+    #[serde(default)]
     pub domains: HashMap<String, UserPoolDomain>,
     /// resource_arn -> tags
+    #[serde(default)]
     pub tags: HashMap<String, HashMap<String, String>>,
     /// pool_id -> (job_id -> UserImportJob)
+    #[serde(default)]
     pub import_jobs: HashMap<String, HashMap<String, UserImportJob>>,
-    /// Auth events for introspection
+    /// Auth events for introspection — not persisted across restarts.
+    #[serde(default, skip)]
     pub auth_events: Vec<AuthEvent>,
     /// (pool_id, client_id|"") -> UICustomization JSON
+    #[serde(default)]
     pub ui_customizations: HashMap<String, serde_json::Value>,
     /// pool_id -> LogDeliveryConfiguration JSON
+    #[serde(default)]
     pub log_delivery_configs: HashMap<String, serde_json::Value>,
     /// (pool_id, client_id|"") -> RiskConfiguration JSON
+    #[serde(default)]
     pub risk_configurations: HashMap<String, serde_json::Value>,
     /// branding_id -> ManagedLoginBranding JSON
+    #[serde(default)]
     pub managed_login_brandings: HashMap<String, serde_json::Value>,
     /// terms_id -> Terms JSON
+    #[serde(default)]
     pub terms: HashMap<String, serde_json::Value>,
     /// (pool_id:username) -> WebAuthn credentials
+    #[serde(default)]
     pub webauthn_credentials: HashMap<String, Vec<WebAuthnCredential>>,
 }
 
@@ -132,6 +161,7 @@ impl CognitoState {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RefreshTokenData {
     pub user_pool_id: String,
     pub username: String,
@@ -139,6 +169,7 @@ pub struct RefreshTokenData {
     pub issued_at: DateTime<Utc>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccessTokenData {
     pub user_pool_id: String,
     pub username: String,
@@ -146,6 +177,7 @@ pub struct AccessTokenData {
     pub issued_at: DateTime<Utc>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SessionData {
     pub user_pool_id: String,
     pub username: String,
@@ -158,7 +190,7 @@ pub struct SessionData {
 }
 
 /// Tracks the result of a single challenge round in a CUSTOM_AUTH flow.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ChallengeResult {
     pub challenge_name: String,
     pub challenge_result: bool,

--- a/crates/fakecloud-e2e/tests/cognito_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cognito_persistence.rs
@@ -1,0 +1,216 @@
+mod helpers;
+
+use aws_sdk_cognitoidentityprovider::types::AttributeType;
+use helpers::TestServer;
+
+/// User pool + user pool client + admin-created user survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_pool_client_user() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("persist-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app_client = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("persist-client")
+        .send()
+        .await
+        .unwrap();
+    let client_id = app_client
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("alice")
+        .user_attributes(
+            AttributeType::builder()
+                .name("email")
+                .value("alice@example.com")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Drop pre-restart client before restart.
+    drop(client);
+    server.restart().await;
+    let client = server.cognito_client().await;
+
+    let described = client
+        .describe_user_pool()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(described.user_pool().unwrap().name(), Some("persist-pool"));
+
+    let described_client = client
+        .describe_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described_client.user_pool_client().unwrap().client_name(),
+        Some("persist-client")
+    );
+
+    let user = client
+        .admin_get_user()
+        .user_pool_id(&pool_id)
+        .username("alice")
+        .send()
+        .await
+        .unwrap();
+    let email = user
+        .user_attributes()
+        .iter()
+        .find(|a| a.name() == "email")
+        .and_then(|a| a.value());
+    assert_eq!(email, Some("alice@example.com"));
+}
+
+/// Groups and tag resources round-trip across a restart.
+#[tokio::test]
+async fn persistence_groups_and_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("tag-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let pool_arn = pool.user_pool().unwrap().arn().unwrap().to_string();
+
+    client
+        .create_group()
+        .user_pool_id(&pool_id)
+        .group_name("admins")
+        .description("Admin group")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .tag_resource()
+        .resource_arn(&pool_arn)
+        .tags("env", "prod")
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.cognito_client().await;
+
+    let group = client
+        .get_group()
+        .user_pool_id(&pool_id)
+        .group_name("admins")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(group.group().unwrap().description(), Some("Admin group"));
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(&pool_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        tags.tags().and_then(|t| t.get("env")).map(String::as_str),
+        Some("prod")
+    );
+}
+
+/// Auth events introspection buffer does NOT persist across restarts.
+#[tokio::test]
+async fn persistence_auth_events_not_persisted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("events-pool")
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("bob")
+        .send()
+        .await
+        .unwrap();
+
+    // Hit the introspection endpoint pre-restart to confirm it's non-empty.
+    let pre = reqwest::get(format!(
+        "{}/_fakecloud/cognito/auth-events",
+        server.endpoint()
+    ))
+    .await
+    .unwrap()
+    .json::<serde_json::Value>()
+    .await
+    .unwrap();
+    let _ = pre; // some flows may not push events; we only care about post-restart emptiness
+
+    drop(client);
+    server.restart().await;
+
+    // Pool survived.
+    let client = server.cognito_client().await;
+    let described = client
+        .describe_user_pool()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(described.user_pool().unwrap().name(), Some("events-pool"));
+
+    // Auth events buffer reset to empty.
+    let post = reqwest::get(format!(
+        "{}/_fakecloud/cognito/auth-events",
+        server.endpoint()
+    ))
+    .await
+    .unwrap()
+    .json::<serde_json::Value>()
+    .await
+    .unwrap();
+    let events = post
+        .get("events")
+        .or_else(|| post.get("auth_events"))
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        events.is_empty(),
+        "auth_events buffer should reset on restart, got: {post:?}"
+    );
+}

--- a/crates/fakecloud-e2e/tests/cognito_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cognito_persistence.rs
@@ -146,6 +146,9 @@ async fn persistence_groups_and_tags() {
 }
 
 /// Auth events introspection buffer does NOT persist across restarts.
+/// We deliberately trigger a failed AdminInitiateAuth so the pre-restart
+/// buffer is non-empty; if we skipped that step this test would pass
+/// trivially even if auth-events were persisted.
 #[tokio::test]
 async fn persistence_auth_events_not_persisted() {
     let tmp = tempfile::tempdir().unwrap();
@@ -160,6 +163,23 @@ async fn persistence_auth_events_not_persisted() {
         .unwrap();
     let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
 
+    let app_client = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("events-client")
+        .explicit_auth_flows(
+            aws_sdk_cognitoidentityprovider::types::ExplicitAuthFlowsType::AdminNoSrpAuth,
+        )
+        .send()
+        .await
+        .unwrap();
+    let client_id = app_client
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
     client
         .admin_create_user()
         .user_pool_id(&pool_id)
@@ -167,8 +187,29 @@ async fn persistence_auth_events_not_persisted() {
         .send()
         .await
         .unwrap();
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("bob")
+        .password("CorrectP@ssw0rd1")
+        .permanent(true)
+        .send()
+        .await
+        .unwrap();
 
-    // Hit the introspection endpoint pre-restart to confirm it's non-empty.
+    // Failed auth attempt — emits a SIGN_IN_FAILURE auth event.
+    let _ = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminNoSrpAuth)
+        .auth_parameters("USERNAME", "bob")
+        .auth_parameters("PASSWORD", "WrongPassword1!")
+        .send()
+        .await;
+
+    // Pre-restart buffer must be non-empty — otherwise the post-restart
+    // assertion is vacuous.
     let pre = reqwest::get(format!(
         "{}/_fakecloud/cognito/auth-events",
         server.endpoint()
@@ -178,7 +219,16 @@ async fn persistence_auth_events_not_persisted() {
     .json::<serde_json::Value>()
     .await
     .unwrap();
-    let _ = pre; // some flows may not push events; we only care about post-restart emptiness
+    let pre_events = pre
+        .get("events")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !pre_events.is_empty(),
+        "pre-restart auth_events buffer should be non-empty so the \
+         post-restart emptiness assertion is meaningful, got: {pre:?}"
+    );
 
     drop(client);
     server.restart().await;
@@ -205,7 +255,6 @@ async fn persistence_auth_events_not_persisted() {
     .unwrap();
     let events = post
         .get("events")
-        .or_else(|| post.get("auth_events"))
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -382,13 +382,7 @@ async fn main() {
 
     // Register services
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
-        for service in [
-            "lambda",
-            "rds",
-            "elasticache",
-            "states",
-            "bedrock",
-        ] {
+        for service in ["lambda", "rds", "elasticache", "states", "bedrock"] {
             fakecloud_persistence::warn_unsupported(service);
         }
     }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -384,7 +384,6 @@ async fn main() {
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
         for service in [
             "lambda",
-            "cognito-idp",
             "rds",
             "elasticache",
             "states",
@@ -1111,9 +1110,62 @@ async fn main() {
     let cognito_delivery_ctx = fakecloud_cognito::triggers::CognitoDeliveryContext {
         delivery_bus: delivery_for_cognito,
     };
-    registry.register(Arc::new(
-        CognitoService::new(cognito_state.clone()).with_delivery(cognito_delivery_ctx),
-    ));
+    let cognito_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("cognito-idp").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_cognito::state::CognitoSnapshot>(
+                        &bytes,
+                    ) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_cognito::state::COGNITO_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "cognito persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_cognito::state::COGNITO_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let pool_count = snapshot.state.user_pools.len();
+                            let user_count: usize =
+                                snapshot.state.users.values().map(|u| u.len()).sum();
+                            *cognito_state.write() = snapshot.state;
+                            tracing::info!(
+                                user_pools = pool_count,
+                                users = user_count,
+                                "loaded cognito persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse cognito persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no cognito persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read cognito persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut cognito_service =
+        CognitoService::new(cognito_state.clone()).with_delivery(cognito_delivery_ctx);
+    if let Some(store) = cognito_snapshot_store {
+        cognito_service = cognito_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(cognito_service));
     let kinesis_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
             let data_path = persistence_config

--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -36,6 +36,7 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 - **SES** — identities, configuration sets, templates, contact lists and contacts, tags, suppression list, event destinations, identity policies, dedicated IP pools, tenants, receipt rule sets / rules / filters, account settings.
 - **API Gateway v2** — HTTP APIs, routes, integrations, stages, deployments, authorizers.
 - **CloudFormation** — stacks, templates, parameters, tags, resource listings, and notification ARNs.
+- **Cognito** — user pools, user pool clients, users, groups, identity providers, resource servers, domains, import jobs, tags, UI customization, log delivery, risk and branding configuration, terms, WebAuthn credentials, refresh/access tokens and sessions. The `/_fakecloud/cognito/auth-events` introspection buffer resets on restart.
 - **Every other service** emits `persistence not yet supported, running in-memory` at startup and continues to operate exactly as in memory mode. Your tests don't break — you just don't get cross-restart durability for those services yet.
 
 ## Version compatibility


### PR DESCRIPTION
## Summary

- Wires Cognito into the existing fakecloud-persistence snapshot pattern (SES/API Gateway v2/SQS/…). User pools, clients, users, groups, identity providers, resource servers, domains, tags, UI/branding/risk/log configs, terms, and WebAuthn credentials now survive restarts.
- Refresh/access tokens and sessions are also persisted so in-flight auth flows survive a restart.
- `/_fakecloud/cognito/auth-events` introspection buffer is `#[serde(skip)]` and resets on every restart, matching every other `/_fakecloud/*` buffer.
- Docs page refreshed to list Cognito.

## Test plan

- [x] New E2E `cognito_persistence.rs`: pool+client+user round-trip, groups+tags round-trip, auth-events buffer reset.
- [x] `cargo test -p fakecloud-cognito`
- [x] `cargo test -p fakecloud-e2e --test cognito_persistence`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds disk persistence to Cognito via the `fakecloud-persistence` snapshot store so user pools, clients, users, and auth state survive restarts in persistent mode. Snapshots are written after successful mutating actions and loaded on boot from <DATA_PATH>/cognito-idp/snapshot.json with schema-version validation.

- **New Features**
  - Integrated `fakecloud-persistence` with Cognito; snapshots save on successful mutations and load on boot.
  - Persisted resources: user pools/clients, users, groups, identity providers, resource servers, domains, tags, UI/branding/risk/log configs, terms, WebAuthn credentials, and import jobs.
  - Persisted auth state: refresh/access tokens and sessions to keep in-flight auth flows after restart.
  - `/_fakecloud/cognito/auth-events` is not persisted and resets on restart; E2E test ensures the buffer is non-empty pre-restart (via a failed AdminInitiateAuth) and empty post-restart. Docs list Cognito under persisted services.

<sup>Written for commit 635d32d9dc4a1623b5cc6574072af0a80850fe1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

