### PR TITLE
feat(cloudformation): persist CloudFormation state to disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,6 +2043,7 @@ dependencies = [
  "fakecloud-eventbridge",
  "fakecloud-iam",
  "fakecloud-logs",
+ "fakecloud-persistence",
  "fakecloud-s3",
  "fakecloud-sns",
  "fakecloud-sqs",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 fakecloud-sqs = { workspace = true }
 fakecloud-sns = { workspace = true }
 fakecloud-ssm = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -10,13 +10,18 @@ use fakecloud_dynamodb::state::SharedDynamoDbState;
 use fakecloud_eventbridge::state::SharedEventBridgeState;
 use fakecloud_iam::state::SharedIamState;
 use fakecloud_logs::state::SharedLogsState;
+use fakecloud_persistence::SnapshotStore;
 use fakecloud_s3::state::SharedS3State;
 use fakecloud_sns::state::SharedSnsState;
 use fakecloud_sqs::state::SharedSqsState;
 use fakecloud_ssm::state::SharedSsmState;
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::resource_provisioner::ResourceProvisioner;
-use crate::state::{SharedCloudFormationState, Stack, StackResource};
+use crate::state::{
+    CloudFormationSnapshot, SharedCloudFormationState, Stack, StackResource,
+    CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION,
+};
 use crate::template;
 use crate::xml_responses;
 
@@ -116,11 +121,45 @@ pub struct CloudFormationDeps {
 pub struct CloudFormationService {
     state: SharedCloudFormationState,
     deps: CloudFormationDeps,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl CloudFormationService {
     pub fn new(state: SharedCloudFormationState, deps: CloudFormationDeps) -> Self {
-        Self { state, deps }
+        Self {
+            state,
+            deps,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = CloudFormationSnapshot {
+            schema_version: CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write cloudformation snapshot"),
+            Err(err) => tracing::error!(%err, "cloudformation snapshot task panicked"),
+        }
     }
 
     fn provisioner(&self, stack_id: &str) -> ResourceProvisioner {
@@ -618,7 +657,11 @@ impl AwsService for CloudFormationService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = matches!(
+            req.action.as_str(),
+            "CreateStack" | "DeleteStack" | "UpdateStack"
+        );
+        let result = match req.action.as_str() {
             "CreateStack" => self.create_stack(&req),
             "DeleteStack" => self.delete_stack(&req),
             "DescribeStacks" => self.describe_stacks(&req),
@@ -631,7 +674,11 @@ impl AwsService for CloudFormationService {
                 "cloudformation",
                 &req.action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-cloudformation/src/state.rs
+++ b/crates/fakecloud-cloudformation/src/state.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StackResource {
     pub logical_id: String,
     pub physical_id: String,
@@ -13,7 +14,7 @@ pub struct StackResource {
     pub service_token: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Stack {
     pub name: String,
     pub stack_id: String,
@@ -28,9 +29,11 @@ pub struct Stack {
     pub notification_arns: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloudFormationState {
     pub account_id: String,
     pub region: String,
+    #[serde(default)]
     pub stacks: HashMap<String, Stack>,
 }
 
@@ -49,3 +52,11 @@ impl CloudFormationState {
 }
 
 pub type SharedCloudFormationState = Arc<RwLock<CloudFormationState>>;
+
+pub const CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CloudFormationSnapshot {
+    pub schema_version: u32,
+    pub state: CloudFormationState,
+}

--- a/crates/fakecloud-e2e/tests/cloudformation_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_persistence.rs
@@ -1,0 +1,126 @@
+mod helpers;
+
+use helpers::TestServer;
+
+/// Stack, template, parameters and tags survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_stack() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let cf = server.cloudformation_client().await;
+
+    let template = r#"{
+        "Parameters": { "QueueName": { "Type": "String" } },
+        "Resources": {
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": { "Ref": "QueueName" } }
+            }
+        }
+    }"#;
+
+    cf.create_stack()
+        .stack_name("persist-stack")
+        .template_body(template)
+        .parameters(
+            aws_sdk_cloudformation::types::Parameter::builder()
+                .parameter_key("QueueName")
+                .parameter_value("persist-queue")
+                .build(),
+        )
+        .tags(
+            aws_sdk_cloudformation::types::Tag::builder()
+                .key("env")
+                .value("prod")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    drop(cf);
+    server.restart().await;
+    let cf = server.cloudformation_client().await;
+
+    let described = cf
+        .describe_stacks()
+        .stack_name("persist-stack")
+        .send()
+        .await
+        .unwrap();
+    let stacks = described.stacks();
+    assert_eq!(stacks.len(), 1);
+    let stack = &stacks[0];
+    assert_eq!(stack.stack_name(), Some("persist-stack"));
+    assert!(stack
+        .tags()
+        .iter()
+        .any(|t| t.key() == Some("env") && t.value() == Some("prod")));
+    assert!(stack
+        .parameters()
+        .iter()
+        .any(|p| p.parameter_key() == Some("QueueName")
+            && p.parameter_value() == Some("persist-queue")));
+
+    // Template body recoverable.
+    let got_template = cf
+        .get_template()
+        .stack_name("persist-stack")
+        .send()
+        .await
+        .unwrap();
+    assert!(got_template
+        .template_body()
+        .unwrap_or_default()
+        .contains("MyQueue"));
+
+    // Resources list still populated.
+    let resources = cf
+        .list_stack_resources()
+        .stack_name("persist-stack")
+        .send()
+        .await
+        .unwrap();
+    assert!(resources
+        .stack_resource_summaries()
+        .iter()
+        .any(|r| r.logical_resource_id() == Some("MyQueue")));
+}
+
+/// Deletion survives a restart: a deleted stack does not reappear.
+#[tokio::test]
+async fn persistence_deletion_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let cf = server.cloudformation_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": { "QueueName": "to-delete" }
+            }
+        }
+    }"#;
+
+    cf.create_stack()
+        .stack_name("doomed")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    cf.delete_stack().stack_name("doomed").send().await.unwrap();
+
+    drop(cf);
+    server.restart().await;
+    let cf = server.cloudformation_client().await;
+
+    let listed = cf.list_stacks().send().await.unwrap();
+    assert!(!listed
+        .stack_summaries()
+        .iter()
+        .any(|s| s.stack_name() == Some("doomed")
+            && s.stack_status()
+                != Some(&aws_sdk_cloudformation::types::StackStatus::DeleteComplete)));
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -383,7 +383,6 @@ async fn main() {
     // Register services
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
         for service in [
-            "cloudformation",
             "lambda",
             "cognito-idp",
             "rds",
@@ -395,8 +394,56 @@ async fn main() {
         }
     }
     let mut registry = ServiceRegistry::new();
-    registry.register(Arc::new(CloudFormationService::new(
-        cloudformation_state,
+    let cloudformation_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("cloudformation").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<
+                        fakecloud_cloudformation::state::CloudFormationSnapshot,
+                    >(&bytes)
+                    {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_cloudformation::state::CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "cloudformation persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_cloudformation::state::CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let stack_count = snapshot.state.stacks.len();
+                            *cloudformation_state.write() = snapshot.state;
+                            tracing::info!(
+                                stacks = stack_count,
+                                "loaded cloudformation persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse cloudformation persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no cloudformation persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read cloudformation persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut cloudformation_service = CloudFormationService::new(
+        cloudformation_state.clone(),
         fakecloud_cloudformation::service::CloudFormationDeps {
             sqs: sqs_state.clone(),
             sns: sns_state.clone(),
@@ -408,7 +455,11 @@ async fn main() {
             logs: logs_state.clone(),
             delivery: delivery_for_cf,
         },
-    )));
+    );
+    if let Some(store) = cloudformation_snapshot_store {
+        cloudformation_service = cloudformation_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(cloudformation_service));
     let sqs_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
             let data_path = persistence_config

--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -35,6 +35,7 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 - **Kinesis** — streams, shards, records.
 - **SES** — identities, configuration sets, templates, contact lists and contacts, tags, suppression list, event destinations, identity policies, dedicated IP pools, tenants, receipt rule sets / rules / filters, account settings.
 - **API Gateway v2** — HTTP APIs, routes, integrations, stages, deployments, authorizers.
+- **CloudFormation** — stacks, templates, parameters, tags, resource listings, and notification ARNs.
 - **Every other service** emits `persistence not yet supported, running in-memory` at startup and continues to operate exactly as in memory mode. Your tests don't break — you just don't get cross-restart durability for those services yet.
 
 ## Version compatibility


### PR DESCRIPTION
## Summary

- Wires CloudFormation into the existing fakecloud-persistence snapshot pattern (SES/API Gateway v2/Cognito/SQS/…). Stacks, templates, parameters, tags, resource listings, and notification ARNs now survive restarts.
- Stack deletions are persisted immediately so a deleted stack does not reappear on restart.
- Docs page refreshed to list CloudFormation.

## Test plan

- [x] New E2E \`cloudformation_persistence.rs\`: stack round-trip (template/params/tags/resources), deletion survives restart.
- [x] \`cargo test -p fakecloud-e2e --test cloudformation_persistence\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist CloudFormation state to disk using `fakecloud-persistence` so stacks survive restarts in persistent mode. Stack deletions are saved immediately to prevent reappearing after a restart.

- **New Features**
  - CloudFormation now saves and loads a snapshot with versioning; includes stacks, templates, parameters, tags, resource listings, and notification ARNs.
  - Snapshot is written after successful Create/Update/Delete actions; loaded at startup with schema validation.
  - Added E2E test `cloudformation_persistence.rs`; docs updated to list CloudFormation persistence.

<sup>Written for commit 441b03d0254b28be211ad1ee0116d3b4994eaddf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

