### PR TITLE
feat(stepfunctions): persist Step Functions state to disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,7 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-dynamodb",
+ "fakecloud-persistence",
  "http 1.4.0",
  "md-5 0.10.6",
  "parking_lot",

--- a/crates/fakecloud-e2e/tests/stepfunctions_persistence.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions_persistence.rs
@@ -1,0 +1,122 @@
+mod helpers;
+
+use aws_sdk_sfn::types::Tag;
+use helpers::TestServer;
+
+fn simple_definition() -> String {
+    serde_json::json!({
+        "StartAt": "Hello",
+        "States": {
+            "Hello": { "Type": "Pass", "Result": "Hello!", "End": true }
+        }
+    })
+    .to_string()
+}
+
+/// State machine, tags and execution survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_state_machine_and_execution() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("persist-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .tags(Tag::builder().key("env").value("prod").build())
+        .send()
+        .await
+        .unwrap();
+    let sm_arn = create.state_machine_arn().to_string();
+
+    let exec = client
+        .start_execution()
+        .state_machine_arn(&sm_arn)
+        .name("persist-exec")
+        .input("{}")
+        .send()
+        .await
+        .unwrap();
+    let exec_arn = exec.execution_arn().to_string();
+
+    drop(client);
+    server.restart().await;
+    let client = server.sfn_client().await;
+
+    let described = client
+        .describe_state_machine()
+        .state_machine_arn(&sm_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(described.name(), "persist-sm");
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(&sm_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags
+        .tags()
+        .iter()
+        .any(|t| t.key() == Some("env") && t.value() == Some("prod")));
+
+    let exec_desc = client
+        .describe_execution()
+        .execution_arn(&exec_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(exec_desc.execution_arn(), exec_arn.as_str());
+    assert_eq!(exec_desc.state_machine_arn(), sm_arn.as_str());
+
+    // Execution shows up in ListExecutions after restart.
+    let listed = client
+        .list_executions()
+        .state_machine_arn(&sm_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(listed
+        .executions()
+        .iter()
+        .any(|e| e.execution_arn() == exec_arn.as_str()));
+}
+
+/// Deletion survives a restart.
+#[tokio::test]
+async fn persistence_delete_state_machine_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("doomed-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+    let sm_arn = create.state_machine_arn().to_string();
+
+    client
+        .delete_state_machine()
+        .state_machine_arn(&sm_arn)
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.sfn_client().await;
+
+    let listed = client.list_state_machines().send().await.unwrap();
+    assert!(!listed
+        .state_machines()
+        .iter()
+        .any(|s| s.name() == "doomed-sm"));
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -382,7 +382,7 @@ async fn main() {
 
     // Register services
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
-        for service in ["rds", "elasticache", "states", "bedrock"] {
+        for service in ["rds", "elasticache", "bedrock"] {
             fakecloud_persistence::warn_unsupported(service);
         }
     }
@@ -1309,6 +1309,59 @@ async fn main() {
     sfn_service = sfn_service
         .with_delivery(sfn_delivery_bus.clone())
         .with_dynamodb(dynamodb_state.clone());
+    let sfn_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("stepfunctions").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<
+                        fakecloud_stepfunctions::state::StepFunctionsSnapshot,
+                    >(&bytes)
+                    {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_stepfunctions::state::STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "stepfunctions persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_stepfunctions::state::STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let sm_count = snapshot.state.state_machines.len();
+                            let exec_count = snapshot.state.executions.len();
+                            *stepfunctions_state.write() = snapshot.state;
+                            tracing::info!(
+                                state_machines = sm_count,
+                                executions = exec_count,
+                                "loaded stepfunctions persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse stepfunctions persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no stepfunctions persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read stepfunctions persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    if let Some(store) = sfn_snapshot_store {
+        sfn_service = sfn_service.with_snapshot_store(store);
+    }
     registry.register(Arc::new(sfn_service));
 
     let apigw_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =

--- a/crates/fakecloud-stepfunctions/Cargo.toml
+++ b/crates/fakecloud-stepfunctions/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-dynamodb = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -5,17 +5,19 @@ use async_trait::async_trait;
 use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 use fakecloud_dynamodb::state::SharedDynamoDbState;
+use fakecloud_persistence::SnapshotStore;
 
 use crate::interpreter;
 use crate::state::{
     Execution, ExecutionStatus, SharedStepFunctionsState, StateMachine, StateMachineStatus,
-    StateMachineType,
+    StateMachineType, StepFunctionsSnapshot, STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const SUPPORTED: &[&str] = &[
@@ -39,6 +41,8 @@ pub struct StepFunctionsService {
     state: SharedStepFunctionsState,
     delivery: Option<Arc<DeliveryBus>>,
     dynamodb_state: Option<SharedDynamoDbState>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl StepFunctionsService {
@@ -47,6 +51,8 @@ impl StepFunctionsService {
             state,
             delivery: None,
             dynamodb_state: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -59,6 +65,46 @@ impl StepFunctionsService {
         self.dynamodb_state = Some(dynamodb_state);
         self
     }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = StepFunctionsSnapshot {
+            schema_version: STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write stepfunctions snapshot"),
+            Err(err) => tracing::error!(%err, "stepfunctions snapshot task panicked"),
+        }
+    }
+}
+
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "CreateStateMachine"
+            | "DeleteStateMachine"
+            | "UpdateStateMachine"
+            | "TagResource"
+            | "UntagResource"
+            | "StartExecution"
+            | "StopExecution"
+    )
 }
 
 #[async_trait]
@@ -68,7 +114,8 @@ impl AwsService for StepFunctionsService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateStateMachine" => self.create_state_machine(&req),
             "DescribeStateMachine" => self.describe_state_machine(&req),
             "ListStateMachines" => self.list_state_machines(&req),
@@ -87,7 +134,11 @@ impl AwsService for StepFunctionsService {
                 "states",
                 &req.action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-stepfunctions/src/state.rs
+++ b/crates/fakecloud-stepfunctions/src/state.rs
@@ -3,20 +3,32 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 pub type SharedStepFunctionsState = Arc<RwLock<StepFunctionsState>>;
 
+pub const STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StepFunctionsSnapshot {
+    pub schema_version: u32,
+    pub state: StepFunctionsState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StepFunctionsState {
     pub account_id: String,
     pub region: String,
     /// State machines keyed by ARN.
+    #[serde(default)]
     pub state_machines: HashMap<String, StateMachine>,
     /// Executions keyed by execution ARN.
+    #[serde(default)]
     pub executions: HashMap<String, Execution>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StateMachine {
     pub name: String,
     pub arn: String,
@@ -33,7 +45,7 @@ pub struct StateMachine {
     pub description: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StateMachineType {
     Standard,
     Express,
@@ -56,7 +68,7 @@ impl StateMachineType {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StateMachineStatus {
     Active,
     Deleting,
@@ -71,7 +83,7 @@ impl StateMachineStatus {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Execution {
     pub execution_arn: String,
     pub state_machine_arn: String,
@@ -87,7 +99,7 @@ pub struct Execution {
     pub history_events: Vec<HistoryEvent>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ExecutionStatus {
     Running,
     Succeeded,
@@ -110,7 +122,7 @@ impl ExecutionStatus {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryEvent {
     pub id: i64,
     pub event_type: String,

--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -38,6 +38,7 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 - **CloudFormation** — stacks, templates, parameters, tags, resource listings, and notification ARNs.
 - **Cognito** — user pools, user pool clients, users, groups, identity providers, resource servers, domains, import jobs, tags, UI customization, log delivery, risk and branding configuration, terms, WebAuthn credentials, refresh/access tokens and sessions. The `/_fakecloud/cognito/auth-events` introspection buffer resets on restart.
 - **Lambda** — functions (code zips, configuration, resource policies), event source mappings. The `/_fakecloud/lambda/invocations` introspection buffer resets on restart; containers are rebuilt from the persisted code zip on first Invoke.
+- **Step Functions** — state machines, definitions, executions, execution history events, tags.
 - **Every other service** emits `persistence not yet supported, running in-memory` at startup and continues to operate exactly as in memory mode. Your tests don't break — you just don't get cross-restart durability for those services yet.
 
 ## Version compatibility


### PR DESCRIPTION
## Summary

- Wires Step Functions into the existing fakecloud-persistence snapshot pattern. State machines (definitions, tags) and executions (status, history events) survive restarts.
- Deletions persisted immediately.
- Docs page updated.

## Test plan

- [x] New E2E `stepfunctions_persistence.rs`: SM+exec round-trip, deletion survives restart.
- [x] `cargo test -p fakecloud-e2e --test stepfunctions_persistence`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds on-disk persistence for Step Functions so state machines, definitions, executions (including history), and tags survive restarts in persistent mode. Snapshots load at boot and save after each successful mutating API call; deletions persist immediately.

- **New Features**
  - Persists to `stepfunctions/snapshot.json` via `fakecloud-persistence` with schema versioning and boot-time validation; logs state machine and execution counts on load.
  - Wires the snapshot store into the server’s Step Functions service and removes the unsupported persistence warning for this service.
  - Adds E2E `stepfunctions_persistence.rs` for round-trip and deletion across restarts; docs now list Step Functions under supported persistence.

<sup>Written for commit d03242602aecf2a09cc615c2bb05d1282825b65e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

