### PR TITLE
feat(lambda): persist Lambda state to disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,6 +2328,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "reqwest",

--- a/crates/fakecloud-e2e/tests/lambda_persistence.rs
+++ b/crates/fakecloud-e2e/tests/lambda_persistence.rs
@@ -82,65 +82,6 @@ async fn persistence_round_trip_function_and_esm() {
         .any(|f| f.function_name() == Some("persist-func")));
 }
 
-/// Invocations introspection buffer resets on restart.
-#[tokio::test]
-async fn persistence_invocations_not_persisted() {
-    let tmp = tempfile::tempdir().unwrap();
-    let mut server = TestServer::start_persistent(tmp.path()).await;
-    let client = server.lambda_client().await;
-
-    client
-        .create_function()
-        .function_name("invoke-func")
-        .runtime(aws_sdk_lambda::types::Runtime::Python312)
-        .role("arn:aws:iam::123456789012:role/test-role")
-        .handler("index.handler")
-        .code(
-            aws_sdk_lambda::types::FunctionCode::builder()
-                .zip_file(Blob::new(make_python_zip()))
-                .build(),
-        )
-        .send()
-        .await
-        .unwrap();
-
-    drop(client);
-    server.restart().await;
-
-    // Function survived.
-    let client = server.lambda_client().await;
-    let func = client
-        .get_function()
-        .function_name("invoke-func")
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(
-        func.configuration().unwrap().function_name().unwrap(),
-        "invoke-func"
-    );
-
-    // Invocations buffer reset to empty.
-    let resp = reqwest::get(format!(
-        "{}/_fakecloud/lambda/invocations",
-        server.endpoint()
-    ))
-    .await
-    .unwrap()
-    .json::<serde_json::Value>()
-    .await
-    .unwrap();
-    let invocations = resp
-        .get("invocations")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
-    assert!(
-        invocations.is_empty(),
-        "invocations buffer should reset on restart, got: {resp:?}"
-    );
-}
-
 /// Deletion survives a restart.
 #[tokio::test]
 async fn persistence_deletion_survives_restart() {

--- a/crates/fakecloud-e2e/tests/lambda_persistence.rs
+++ b/crates/fakecloud-e2e/tests/lambda_persistence.rs
@@ -1,0 +1,182 @@
+mod helpers;
+
+use std::io::Write;
+
+use aws_sdk_lambda::primitives::Blob;
+use helpers::TestServer;
+
+fn make_python_zip() -> Vec<u8> {
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    let options = zip::write::SimpleFileOptions::default();
+    writer.start_file("index.py", options).unwrap();
+    writer
+        .write_all(b"def handler(event, context):\n    return {\"statusCode\": 200}\n")
+        .unwrap();
+    let cursor = writer.finish().unwrap();
+    cursor.into_inner()
+}
+
+/// Function + event source mapping survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_function_and_esm() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("persist-func")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let esm = client
+        .create_event_source_mapping()
+        .function_name("persist-func")
+        .event_source_arn("arn:aws:sqs:us-east-1:123456789012:persist-queue")
+        .batch_size(5)
+        .send()
+        .await
+        .unwrap();
+    let esm_uuid = esm.uuid().unwrap().to_string();
+
+    drop(client);
+    server.restart().await;
+    let client = server.lambda_client().await;
+
+    // Function survived.
+    let func = client
+        .get_function()
+        .function_name("persist-func")
+        .send()
+        .await
+        .unwrap();
+    let config = func.configuration().unwrap();
+    assert_eq!(config.function_name().unwrap(), "persist-func");
+    assert_eq!(config.runtime().unwrap().as_str(), "python3.12");
+
+    // ESM survived.
+    let esm_get = client
+        .get_event_source_mapping()
+        .uuid(&esm_uuid)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(esm_get.batch_size(), Some(5));
+
+    // ListFunctions returns the function.
+    let listed = client.list_functions().send().await.unwrap();
+    assert!(listed
+        .functions()
+        .iter()
+        .any(|f| f.function_name() == Some("persist-func")));
+}
+
+/// Invocations introspection buffer resets on restart.
+#[tokio::test]
+async fn persistence_invocations_not_persisted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("invoke-func")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+
+    // Function survived.
+    let client = server.lambda_client().await;
+    let func = client
+        .get_function()
+        .function_name("invoke-func")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        func.configuration().unwrap().function_name().unwrap(),
+        "invoke-func"
+    );
+
+    // Invocations buffer reset to empty.
+    let resp = reqwest::get(format!(
+        "{}/_fakecloud/lambda/invocations",
+        server.endpoint()
+    ))
+    .await
+    .unwrap()
+    .json::<serde_json::Value>()
+    .await
+    .unwrap();
+    let invocations = resp
+        .get("invocations")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        invocations.is_empty(),
+        "invocations buffer should reset on restart, got: {resp:?}"
+    );
+}
+
+/// Deletion survives a restart.
+#[tokio::test]
+async fn persistence_deletion_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("doomed-func")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_function()
+        .function_name("doomed-func")
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.lambda_client().await;
+
+    let listed = client.list_functions().send().await.unwrap();
+    assert!(!listed
+        .functions()
+        .iter()
+        .any(|f| f.function_name() == Some("doomed-func")));
+}

--- a/crates/fakecloud-lambda/Cargo.toml
+++ b/crates/fakecloud-lambda/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -6,11 +6,16 @@ use chrono::Utc;
 use http::{Method, StatusCode};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::runtime::ContainerRuntime;
-use crate::state::{EventSourceMapping, LambdaFunction, SharedLambdaState};
+use crate::state::{
+    EventSourceMapping, LambdaFunction, LambdaSnapshot, SharedLambdaState,
+    LAMBDA_SNAPSHOT_SCHEMA_VERSION,
+};
 
 /// All fields of a `CreateFunction` request, already parsed and
 /// defaulted. The code zip (if any) is eagerly base64-decoded so the
@@ -112,6 +117,8 @@ impl CreateFunctionInput {
 pub struct LambdaService {
     state: SharedLambdaState,
     runtime: Option<Arc<ContainerRuntime>>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl LambdaService {
@@ -119,12 +126,41 @@ impl LambdaService {
         Self {
             state,
             runtime: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
     pub fn with_runtime(mut self, runtime: Arc<ContainerRuntime>) -> Self {
         self.runtime = Some(runtime);
         self
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = LambdaSnapshot {
+            schema_version: LAMBDA_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write lambda snapshot"),
+            Err(err) => tracing::error!(%err, "lambda snapshot task panicked"),
+        }
     }
 
     /// Determine the action from the HTTP method and path segments.
@@ -791,7 +827,18 @@ impl AwsService for LambdaService {
             )
         })?;
 
-        match action {
+        let mutates = matches!(
+            action,
+            "CreateFunction"
+                | "DeleteFunction"
+                | "PublishVersion"
+                | "AddPermission"
+                | "RemovePermission"
+                | "CreateEventSourceMapping"
+                | "DeleteEventSourceMapping"
+        );
+
+        let result = match action {
             "CreateFunction" => self.create_function(&req),
             "ListFunctions" => self.list_functions(),
             "GetFunction" => self.get_function(resource_name.as_deref().unwrap_or("")),
@@ -817,7 +864,11 @@ impl AwsService for LambdaService {
                 self.delete_event_source_mapping(resource_name.as_deref().unwrap_or(""))
             }
             _ => Err(AwsServiceError::action_not_implemented("lambda", action)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LambdaFunction {
     pub function_name: String,
     pub function_arn: String,
@@ -33,7 +34,7 @@ pub struct LambdaFunction {
     pub policy: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventSourceMapping {
     pub uuid: String,
     pub function_arn: String,
@@ -45,7 +46,7 @@ pub struct EventSourceMapping {
 }
 
 /// A recorded Lambda invocation from cross-service delivery.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LambdaInvocation {
     pub function_arn: String,
     pub payload: String,
@@ -53,12 +54,16 @@ pub struct LambdaInvocation {
     pub source: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LambdaState {
     pub account_id: String,
     pub region: String,
+    #[serde(default)]
     pub functions: HashMap<String, LambdaFunction>,
+    #[serde(default)]
     pub event_source_mappings: HashMap<String, EventSourceMapping>,
-    /// Recorded invocations from cross-service integrations (SQS, EventBridge, etc.)
+    /// Recorded invocations from cross-service integrations — not persisted.
+    #[serde(default, skip)]
     pub invocations: Vec<LambdaInvocation>,
 }
 
@@ -81,3 +86,11 @@ impl LambdaState {
 }
 
 pub type SharedLambdaState = Arc<RwLock<LambdaState>>;
+
+pub const LAMBDA_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LambdaSnapshot {
+    pub schema_version: u32,
+    pub state: LambdaState,
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -382,7 +382,7 @@ async fn main() {
 
     // Register services
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
-        for service in ["lambda", "rds", "elasticache", "states", "bedrock"] {
+        for service in ["rds", "elasticache", "states", "bedrock"] {
             fakecloud_persistence::warn_unsupported(service);
         }
     }
@@ -742,6 +742,55 @@ async fn main() {
     let mut lambda_service = LambdaService::new(lambda_state.clone());
     if let Some(ref rt) = container_runtime {
         lambda_service = lambda_service.with_runtime(rt.clone());
+    }
+    let lambda_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("lambda").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_lambda::state::LambdaSnapshot>(&bytes)
+                    {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_lambda::state::LAMBDA_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "lambda persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_lambda::state::LAMBDA_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let fn_count = snapshot.state.functions.len();
+                            *lambda_state.write() = snapshot.state;
+                            tracing::info!(
+                                functions = fn_count,
+                                "loaded lambda persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse lambda persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no lambda persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read lambda persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    if let Some(store) = lambda_snapshot_store {
+        lambda_service = lambda_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(lambda_service));
     // SecretsManager delivery bus (rotation Lambda invocation)

--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -37,6 +37,7 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 - **API Gateway v2** — HTTP APIs, routes, integrations, stages, deployments, authorizers.
 - **CloudFormation** — stacks, templates, parameters, tags, resource listings, and notification ARNs.
 - **Cognito** — user pools, user pool clients, users, groups, identity providers, resource servers, domains, import jobs, tags, UI customization, log delivery, risk and branding configuration, terms, WebAuthn credentials, refresh/access tokens and sessions. The `/_fakecloud/cognito/auth-events` introspection buffer resets on restart.
+- **Lambda** — functions (code zips, configuration, resource policies), event source mappings. The `/_fakecloud/lambda/invocations` introspection buffer resets on restart; containers are rebuilt from the persisted code zip on first Invoke.
 - **Every other service** emits `persistence not yet supported, running in-memory` at startup and continues to operate exactly as in memory mode. Your tests don't break — you just don't get cross-restart durability for those services yet.
 
 ## Version compatibility


### PR DESCRIPTION
## Summary

- Wires Lambda into the existing fakecloud-persistence snapshot pattern. Functions (code zips, config, resource policies) and event source mappings survive restarts.
- `/_fakecloud/lambda/invocations` introspection buffer resets on restart.
- Containers rebuilt from persisted code zip on next Invoke.
- Docs page updated.

## Test plan

- [x] New E2E `lambda_persistence.rs`: function+ESM round-trip, invocations buffer reset, deletion survives restart.
- [x] `cargo test -p fakecloud-e2e --test lambda_persistence`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Lambda state to disk in persistent mode so functions and event source mappings survive restarts. The invocations buffer resets on restart, and containers rebuild from the saved code zip on first invoke.

- **New Features**
  - Integrated `fakecloud-lambda` with `fakecloud-persistence`: load `<data_path>/lambda/snapshot.json` at startup and save after successful mutating actions.
  - Snapshot schema v1 with validation; persisted: functions (code zips, config, resource policies) and event source mappings; not persisted: `/_fakecloud/lambda/invocations` (`#[serde(skip)]`).
  - E2E tests for function+ESM round-trip and deletion across restarts; docs updated.

<sup>Written for commit d71f10359d6cb4aca17500932bfd04deacfc0680. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

