### PR TITLE
feat(iam): phase 3 batch 3 — session policies enforced

### DIFF
--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -112,6 +112,9 @@ pub struct ResolvedCredential {
     pub secret_access_key: String,
     pub session_token: Option<String>,
     pub principal: Principal,
+    /// Session policies passed to the STS call that minted this credential.
+    /// Empty for IAM user access keys.
+    pub session_policies: Vec<String>,
 }
 
 impl ResolvedCredential {
@@ -280,40 +283,27 @@ impl ConditionContext {
 pub trait IamPolicyEvaluator: Send + Sync {
     /// Evaluate `action` against the identity policies attached to
     /// `principal`, using `context` for `Condition` block resolution.
+    /// `session_policies` are the raw JSON session-policy documents
+    /// from the STS call that minted the caller's credential (empty
+    /// for IAM user access keys).
     fn evaluate(
         &self,
         principal: &Principal,
         action: &IamAction,
         context: &ConditionContext,
+        session_policies: &[String],
     ) -> IamDecision;
 
-    /// Evaluate `action` against the identity policies attached to
-    /// `principal` **and** an optional resource-based policy attached
-    /// to the target resource. Implements AWS's cross-account
-    /// evaluation semantics:
-    ///
-    /// - Either side returning an explicit `Deny` wins.
-    /// - Same-account (`principal.account_id == resource_account_id`):
-    ///   the request is allowed if the identity policy **or** the
-    ///   resource policy grants it.
-    /// - Cross-account: the request is allowed only if the identity
-    ///   policy **and** the resource policy both grant it.
-    ///
-    /// The default implementation delegates to [`Self::evaluate`] and
-    /// ignores `resource_policy_json` so implementations that don't
-    /// yet understand resource policies keep behaving as they did in
-    /// Phase 1. The real implementation in `fakecloud-iam` overrides
-    /// this.
+    /// Evaluate with resource-policy + session-policy intersection.
     fn evaluate_with_resource_policy(
         &self,
         principal: &Principal,
         action: &IamAction,
         context: &ConditionContext,
-        _resource_policy_json: Option<&str>,
-        _resource_account_id: &str,
-    ) -> IamDecision {
-        self.evaluate(principal, action, context)
-    }
+        resource_policy_json: Option<&str>,
+        resource_account_id: &str,
+        session_policies: &[String],
+    ) -> IamDecision;
 }
 
 /// Abstraction over "given a service + a fully-qualified resource ARN,
@@ -642,6 +632,7 @@ mod tests {
                 principal_type: PrincipalType::User,
                 source_identity: None,
             },
+            session_policies: Vec::new(),
         };
         assert_eq!(rc.principal_arn(), "arn:aws:iam::123456789012:user/alice");
         assert_eq!(rc.user_id(), "AIDAALICE");

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -131,6 +131,10 @@ pub async fn dispatch(
         None
     };
     let caller_principal = resolved.as_ref().map(|r| r.principal.clone());
+    let caller_session_policies = resolved
+        .as_ref()
+        .map(|r| r.session_policies.clone())
+        .unwrap_or_default();
 
     // Opt-in SigV4 cryptographic verification. Runs before the service
     // handler so a failing signature never reaches business logic. The
@@ -321,6 +325,7 @@ pub async fn dispatch(
                             &condition_context,
                             resource_policy_json.as_deref(),
                             &resource_account_id,
+                            &caller_session_policies,
                         );
                         if !decision.is_allow() {
                             tracing::warn!(

--- a/crates/fakecloud-e2e/tests/iam_enforcement_session_policy.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement_session_policy.rs
@@ -199,8 +199,8 @@ async fn no_session_policy_unchanged_behavior() {
     )
     .await;
     let iam = IamClient::new(&cfg);
-    let users = iam.list_users().send().await.unwrap();
-    assert!(users.users().is_empty() || true);
+    // Must succeed — the role has Allow-all and no session policy.
+    let _users = iam.list_users().send().await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/iam_enforcement_session_policy.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement_session_policy.rs
@@ -1,0 +1,270 @@
+//! E2E tests for Phase 3 session-policy enforcement.
+//!
+//! Each test spawns fakecloud with `FAKECLOUD_IAM=strict`, creates a
+//! role with an Allow-all trust + identity policy, then calls
+//! `AssumeRole` with a restrictive `Policy` parameter and verifies that
+//! the returned temporary credentials are gated by the session policy.
+
+mod helpers;
+
+use aws_credential_types::Credentials;
+use aws_sdk_iam::Client as IamClient;
+use aws_sdk_sts::Client as StsClient;
+use helpers::TestServer;
+
+async fn start_strict() -> TestServer {
+    TestServer::start_with_env(&[
+        ("FAKECLOUD_IAM", "strict"),
+        ("FAKECLOUD_VERIFY_SIGV4", "true"),
+    ])
+    .await
+}
+
+async fn sdk_config_with(server: &TestServer, akid: &str, secret: &str) -> aws_config::SdkConfig {
+    aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(
+            akid,
+            secret,
+            None,
+            None,
+            "fakecloud-iam-session",
+        ))
+        .load()
+        .await
+}
+
+async fn sdk_config_with_session(
+    server: &TestServer,
+    akid: &str,
+    secret: &str,
+    token: &str,
+) -> aws_config::SdkConfig {
+    aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(
+            akid,
+            secret,
+            Some(token.to_string()),
+            None,
+            "fakecloud-iam-session",
+        ))
+        .load()
+        .await
+}
+
+async fn root_client(server: &TestServer) -> IamClient {
+    let boot = sdk_config_with(server, "test", "test").await;
+    IamClient::new(&boot)
+}
+
+const TRUST_POLICY: &str = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"sts:AssumeRole"}]}"#;
+
+async fn setup_role(server: &TestServer, name: &str) {
+    let iam = root_client(server).await;
+    iam.create_role()
+        .role_name(name)
+        .assume_role_policy_document(TRUST_POLICY)
+        .send()
+        .await
+        .unwrap();
+    iam.put_role_policy()
+        .role_name(name)
+        .policy_name("AllowAll")
+        .policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+async fn assume_role_with_policy(
+    server: &TestServer,
+    role_name: &str,
+    session_name: &str,
+    policy: &str,
+) -> (String, String, String) {
+    let boot = sdk_config_with(server, "test", "test").await;
+    let sts = StsClient::new(&boot);
+    let resp = sts
+        .assume_role()
+        .role_arn(format!("arn:aws:iam::123456789012:role/{role_name}"))
+        .role_session_name(session_name)
+        .policy(policy)
+        .send()
+        .await
+        .unwrap();
+    let creds = resp.credentials().unwrap();
+    (
+        creds.access_key_id().to_string(),
+        creds.secret_access_key().to_string(),
+        creds.session_token().to_string(),
+    )
+}
+
+// ======================================================================
+
+#[tokio::test]
+async fn session_policy_caps_assumed_role_permissions() {
+    // Role has Allow-all identity policy. AssumeRole with a session
+    // policy that only allows sts:GetCallerIdentity. The returned
+    // credentials should be denied on iam:ListUsers but allowed on
+    // sts:GetCallerIdentity.
+    let server = start_strict().await;
+    setup_role(&server, "wide-role").await;
+
+    let (akid, secret, token) = assume_role_with_policy(
+        &server,
+        "wide-role",
+        "narrow-session",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sts:GetCallerIdentity","Resource":"*"}]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with_session(&server, &akid, &secret, &token).await;
+
+    // Allowed by both role policy and session policy.
+    let sts = StsClient::new(&cfg);
+    let identity = sts.get_caller_identity().send().await.unwrap();
+    assert!(identity
+        .arn()
+        .unwrap()
+        .contains("assumed-role/wide-role/narrow-session"));
+
+    // Denied by session policy (even though role has Allow-all).
+    let iam = IamClient::new(&cfg);
+    let err = iam.list_users().send().await.unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn session_policy_explicit_deny_wins() {
+    let server = start_strict().await;
+    setup_role(&server, "deny-role").await;
+
+    let (akid, secret, token) = assume_role_with_policy(
+        &server,
+        "deny-role",
+        "deny-session",
+        r#"{
+            "Version":"2012-10-17",
+            "Statement":[
+                {"Effect":"Allow","Action":"*","Resource":"*"},
+                {"Effect":"Deny","Action":"sts:GetCallerIdentity","Resource":"*"}
+            ]
+        }"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with_session(&server, &akid, &secret, &token).await;
+    let sts = StsClient::new(&cfg);
+    let err = sts.get_caller_identity().send().await.unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn no_session_policy_unchanged_behavior() {
+    // Regression: AssumeRole without a Policy parameter still works
+    // exactly as before — role's identity policy is the sole gate.
+    let server = start_strict().await;
+    setup_role(&server, "plain-role").await;
+
+    let boot = sdk_config_with(&server, "test", "test").await;
+    let sts = StsClient::new(&boot);
+    let resp = sts
+        .assume_role()
+        .role_arn("arn:aws:iam::123456789012:role/plain-role")
+        .role_session_name("plain-session")
+        .send()
+        .await
+        .unwrap();
+    let creds = resp.credentials().unwrap();
+
+    let cfg = sdk_config_with_session(
+        &server,
+        creds.access_key_id(),
+        creds.secret_access_key(),
+        creds.session_token(),
+    )
+    .await;
+    let iam = IamClient::new(&cfg);
+    let users = iam.list_users().send().await.unwrap();
+    assert!(users.users().is_empty() || true);
+}
+
+#[tokio::test]
+async fn get_federation_token_session_policy_restricts() {
+    // GetFederationToken also takes a Policy parameter. The explicit
+    // Deny in the session policy must block the federated credential
+    // even if the calling user had Allow-all.
+    let server = start_strict().await;
+
+    let iam = root_client(&server).await;
+    iam.create_user().user_name("feduser").send().await.unwrap();
+    let ak = iam
+        .create_access_key()
+        .user_name("feduser")
+        .send()
+        .await
+        .unwrap();
+    let key = ak.access_key().unwrap();
+    iam.put_user_policy()
+        .user_name("feduser")
+        .policy_name("AllowAll")
+        .policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let user_cfg = sdk_config_with(&server, key.access_key_id(), key.secret_access_key()).await;
+    let sts = StsClient::new(&user_cfg);
+    let resp = sts
+        .get_federation_token()
+        .name("fed-session")
+        .policy(
+            r#"{
+                "Version":"2012-10-17",
+                "Statement":[
+                    {"Effect":"Allow","Action":"*","Resource":"*"},
+                    {"Effect":"Deny","Action":"iam:ListUsers","Resource":"*"}
+                ]
+            }"#,
+        )
+        .send()
+        .await
+        .unwrap();
+    let creds = resp.credentials().unwrap();
+
+    let fed_cfg = sdk_config_with_session(
+        &server,
+        creds.access_key_id(),
+        creds.secret_access_key(),
+        creds.session_token(),
+    )
+    .await;
+
+    // Session policy explicit Deny must block even though the calling
+    // user had Allow-all. (The federated-user identity-policy path
+    // is a known gap — FederatedUser principals don't inherit the
+    // calling user's policies yet.)
+    let iam_fed = IamClient::new(&fed_cfg);
+    let err = iam_fed.list_users().send().await.unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDeniedException"),
+        "expected AccessDeniedException, got {msg}"
+    );
+}

--- a/crates/fakecloud-iam/src/credential_resolver.rs
+++ b/crates/fakecloud-iam/src/credential_resolver.rs
@@ -49,6 +49,7 @@ impl CredentialResolver for IamCredentialResolver {
                 principal_type,
                 source_identity: None,
             },
+            session_policies: lookup.session_policies,
         })
     }
 }
@@ -125,6 +126,7 @@ mod tests {
                 user_id: "AROA:session".into(),
                 account_id: "123456789012".into(),
                 expiration: Utc::now() + chrono::Duration::minutes(30),
+                session_policies: Vec::new(),
             },
         );
         let resolver = IamCredentialResolver::new(Arc::new(RwLock::new(state)));

--- a/crates/fakecloud-iam/src/policy_evaluator.rs
+++ b/crates/fakecloud-iam/src/policy_evaluator.rs
@@ -36,10 +36,12 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
         principal: &Principal,
         action: &IamAction,
         context: &ConditionContext,
+        session_policies: &[String],
     ) -> IamDecision {
         let state = self.state.read();
         let identity_policies = evaluator::collect_identity_policies(&state, principal);
         let boundary = evaluator::collect_boundary_policies(&state, principal);
+        let session = parse_session_policies(session_policies);
         let request = EvalRequest {
             principal,
             action: action.action_string(),
@@ -49,7 +51,7 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
         decision_to_core(evaluator::evaluate_with_gates(
             &identity_policies,
             boundary.as_deref(),
-            None,
+            session.as_deref(),
             &request,
         ))
     }
@@ -61,10 +63,12 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
         context: &ConditionContext,
         resource_policy_json: Option<&str>,
         resource_account_id: &str,
+        session_policies: &[String],
     ) -> IamDecision {
         let state = self.state.read();
         let identity_policies = evaluator::collect_identity_policies(&state, principal);
         let boundary = evaluator::collect_boundary_policies(&state, principal);
+        let session = parse_session_policies(session_policies);
         let request = EvalRequest {
             principal,
             action: action.action_string(),
@@ -75,12 +79,23 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
         decision_to_core(evaluator::evaluate_with_resource_policy_and_gates(
             &identity_policies,
             boundary.as_deref(),
-            None,
+            session.as_deref(),
             resource_policy.as_ref(),
             &request,
             resource_account_id,
         ))
     }
+}
+
+fn parse_session_policies(raw: &[String]) -> Option<Vec<evaluator::PolicyDocument>> {
+    if raw.is_empty() {
+        return None;
+    }
+    Some(
+        raw.iter()
+            .map(|doc| evaluator::PolicyDocument::parse(doc))
+            .collect(),
+    )
 }
 
 fn decision_to_core(decision: Decision) -> IamDecision {
@@ -154,7 +169,7 @@ mod tests {
             resource: "arn:aws:s3:::bucket/key".into(),
         };
         assert_eq!(
-            eval.evaluate(&principal(), &action, &ConditionContext::default()),
+            eval.evaluate(&principal(), &action, &ConditionContext::default(), &[]),
             IamDecision::Allow
         );
     }
@@ -183,7 +198,7 @@ mod tests {
             resource: "arn:aws:s3:::bucket/key".into(),
         };
         assert_eq!(
-            eval.evaluate(&principal(), &action, &ConditionContext::default()),
+            eval.evaluate(&principal(), &action, &ConditionContext::default(), &[]),
             IamDecision::ExplicitDeny
         );
     }
@@ -255,7 +270,8 @@ mod tests {
             eval.evaluate(
                 &principal(),
                 &s3_get_object_action(),
-                &ConditionContext::default()
+                &ConditionContext::default(),
+                &[]
             ),
             IamDecision::Allow
         );
@@ -263,7 +279,8 @@ mod tests {
             eval.evaluate(
                 &principal(),
                 &s3_put_object_action(),
-                &ConditionContext::default()
+                &ConditionContext::default(),
+                &[]
             ),
             IamDecision::ImplicitDeny
         );
@@ -294,7 +311,8 @@ mod tests {
             eval.evaluate(
                 &principal(),
                 &s3_put_object_action(),
-                &ConditionContext::default()
+                &ConditionContext::default(),
+                &[]
             ),
             IamDecision::ExplicitDeny
         );
@@ -322,7 +340,8 @@ mod tests {
             eval.evaluate(
                 &principal(),
                 &s3_get_object_action(),
-                &ConditionContext::default()
+                &ConditionContext::default(),
+                &[]
             ),
             IamDecision::ImplicitDeny
         );
@@ -374,7 +393,8 @@ mod tests {
             eval.evaluate(
                 &principal,
                 &s3_get_object_action(),
-                &ConditionContext::default()
+                &ConditionContext::default(),
+                &[]
             ),
             IamDecision::Allow
         );
@@ -390,7 +410,7 @@ mod tests {
             resource: "arn:aws:s3:::bucket/key".into(),
         };
         assert_eq!(
-            eval.evaluate(&principal(), &action, &ConditionContext::default()),
+            eval.evaluate(&principal(), &action, &ConditionContext::default(), &[]),
             IamDecision::ImplicitDeny
         );
     }

--- a/crates/fakecloud-iam/src/state.rs
+++ b/crates/fakecloud-iam/src/state.rs
@@ -209,6 +209,13 @@ pub struct StsTempCredential {
     pub user_id: String,
     pub account_id: String,
     pub expiration: DateTime<Utc>,
+    /// Session policies passed to the STS call that minted this credential.
+    /// Raw JSON policy documents. The `Policy` parameter contributes one
+    /// entry; `PolicyArns` contribute additional entries (resolved to
+    /// documents at mint time). Empty when the STS call carried no
+    /// session policies.
+    #[serde(default)]
+    pub session_policies: Vec<String>,
 }
 
 /// Result of looking up a set of credentials by access key ID.
@@ -224,6 +231,9 @@ pub struct SecretLookup {
     pub principal_arn: String,
     pub user_id: String,
     pub account_id: String,
+    /// Session policies from the STS call that minted this credential.
+    /// Empty for IAM user access keys.
+    pub session_policies: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -340,6 +350,7 @@ impl IamState {
                             principal_arn: user.arn.clone(),
                             user_id: user.user_id.clone(),
                             account_id: self.account_id.clone(),
+                            session_policies: Vec::new(),
                         });
                     }
                 }
@@ -357,6 +368,7 @@ impl IamState {
                     principal_arn: temp.principal_arn.clone(),
                     user_id: temp.user_id.clone(),
                     account_id: temp.account_id.clone(),
+                    session_policies: temp.session_policies.clone(),
                 });
             }
             self.sts_temp_credentials.remove(access_key_id);
@@ -378,6 +390,7 @@ impl IamState {
                             principal_arn: user.arn.clone(),
                             user_id: user.user_id.clone(),
                             account_id: self.account_id.clone(),
+                            session_policies: Vec::new(),
                         });
                     }
                 }
@@ -395,6 +408,7 @@ impl IamState {
             principal_arn: temp.principal_arn.clone(),
             user_id: temp.user_id.clone(),
             account_id: temp.account_id.clone(),
+            session_policies: temp.session_policies.clone(),
         })
     }
 }
@@ -467,6 +481,7 @@ mod tests {
                 user_id: "AROA:session".to_string(),
                 account_id: "123456789012".to_string(),
                 expiration: Utc::now() + chrono::Duration::minutes(30),
+                session_policies: Vec::new(),
             },
         );
         let lookup = state.credential_secret("FSIATEMPKEY").unwrap();
@@ -491,6 +506,7 @@ mod tests {
                 user_id: "id".to_string(),
                 account_id: "123456789012".to_string(),
                 expiration: Utc::now() - chrono::Duration::seconds(1),
+                session_policies: Vec::new(),
             },
         );
         assert!(state.credential_secret("FSIAOLD").is_none());
@@ -510,6 +526,7 @@ mod tests {
                 user_id: "id".to_string(),
                 account_id: "123456789012".to_string(),
                 expiration: Utc::now() - chrono::Duration::seconds(1),
+                session_policies: Vec::new(),
             },
         );
         assert!(state.credential_secret_readonly("FSIAOLD").is_none());

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -9,7 +9,7 @@ use fakecloud_core::validation::*;
 use fakecloud_persistence::SnapshotStore;
 
 use crate::persistence::{save_iam_snapshot, IamSnapshotLock};
-use crate::state::{CredentialIdentity, SharedIamState, StsTempCredential};
+use crate::state::{CredentialIdentity, IamState, SharedIamState, StsTempCredential};
 use crate::xml_responses::{self, StsCredentials};
 
 /// Default duration for AssumeRole and similar operations (1 hour).
@@ -198,6 +198,51 @@ fn partition_for_region(region: &str) -> &str {
     }
 }
 
+/// Collect session policies from the STS request parameters.
+///
+/// Reads the `Policy` parameter (inline JSON) and `PolicyArns.member.N`
+/// (managed-policy ARNs, resolved against `state.policies` at mint time).
+/// Returns the raw JSON documents. Dangling `PolicyArns` entries are stored
+/// as empty strings so they produce `ImplicitDeny` at evaluate time,
+/// matching boundary dangling-ARN semantics.
+fn collect_session_policies(req: &AwsRequest, state: &IamState) -> Vec<String> {
+    let mut docs = Vec::new();
+    if let Some(inline) = req.query_params.get("Policy") {
+        docs.push(inline.clone());
+    }
+    // PolicyArns.member.1, PolicyArns.member.2, ...
+    for i in 1..=12 {
+        let key = format!("PolicyArns.member.{i}.arn");
+        let arn = match req.query_params.get(&key) {
+            Some(a) => a,
+            None => break,
+        };
+        match state
+            .policies
+            .get(arn.as_str())
+            .and_then(|p| {
+                p.versions
+                    .iter()
+                    .find(|v| v.is_default)
+                    .or_else(|| p.versions.first())
+            })
+            .map(|v| v.document.clone())
+        {
+            Some(doc) => docs.push(doc),
+            None => {
+                tracing::debug!(
+                    target: "fakecloud::iam::audit",
+                    arn = %arn,
+                    "PolicyArns entry does not resolve to a known managed policy; \
+                     session will deny all actions covered by this entry"
+                );
+                docs.push(String::new());
+            }
+        }
+    }
+    docs
+}
+
 /// Extract the caller's access key from the SigV4 Authorization header.
 fn extract_access_key(req: &AwsRequest) -> Option<String> {
     let auth = req.headers.get("authorization")?.to_str().ok()?;
@@ -325,6 +370,8 @@ impl StsService {
 
         let mut state = self.state.write();
 
+        let session_policies = collect_session_policies(req, &state);
+
         // Extract account ID from role ARN if present, otherwise use default
         let account_id =
             extract_account_from_arn(role_arn).unwrap_or_else(|| state.account_id.clone());
@@ -352,8 +399,6 @@ impl StsService {
                 account_id: account_id.clone(),
             },
         );
-        // Store full temp credential so SigV4 verification (batch 3) and IAM
-        // enforcement (batch 4+) can look up the secret by access key ID.
         state.sts_temp_credentials.insert(
             creds.access_key_id.clone(),
             StsTempCredential {
@@ -364,6 +409,7 @@ impl StsService {
                 user_id: assumed_role_id,
                 account_id: account_id.clone(),
                 expiration: expiration_at,
+                session_policies,
             },
         );
 
@@ -454,6 +500,7 @@ impl StsService {
         let role_id = xml_responses::generate_role_id();
 
         let mut state = self.state.write();
+        let session_policies = collect_session_policies(req, &state);
         let account_id =
             extract_account_from_arn(role_arn).unwrap_or_else(|| state.account_id.clone());
 
@@ -482,6 +529,7 @@ impl StsService {
                 user_id: assumed_role_id_str,
                 account_id: account_id.clone(),
                 expiration: expiration_at,
+                session_policies,
             },
         );
 
@@ -568,6 +616,7 @@ impl StsService {
         let role_id = xml_responses::generate_role_id();
 
         let mut state = self.state.write();
+        let session_policies = collect_session_policies(req, &state);
         let account_id =
             extract_account_from_arn(role_arn).unwrap_or_else(|| state.account_id.clone());
 
@@ -596,6 +645,7 @@ impl StsService {
                 user_id: assumed_role_id_str,
                 account_id: account_id.clone(),
                 expiration: expiration_at,
+                session_policies,
             },
         );
 
@@ -686,6 +736,8 @@ impl StsService {
                 account_id: account_id.clone(),
             },
         );
+        // GetSessionToken does not accept a Policy parameter per AWS
+        // docs, so session_policies is always empty for this operation.
         state.sts_temp_credentials.insert(
             creds.access_key_id.clone(),
             StsTempCredential {
@@ -696,6 +748,7 @@ impl StsService {
                 user_id,
                 account_id,
                 expiration: expiration_at,
+                session_policies: Vec::new(),
             },
         );
 
@@ -746,6 +799,7 @@ impl StsService {
         let creds = StsCredentials::generate();
 
         let mut state = self.state.write();
+        let session_policies = collect_session_policies(req, &state);
         let account_id = state.account_id.clone();
         let federated_user_arn = format!(
             "arn:{}:sts::{}:federated-user/{}",
@@ -771,6 +825,7 @@ impl StsService {
                 user_id: federated_user_id,
                 account_id: account_id.clone(),
                 expiration: expiration_at,
+                session_policies,
             },
         );
 


### PR DESCRIPTION
## Summary

Phase 3 step 3 of 4: plumb session policies from STS credential minting through to the evaluator so strict-mode callers can rely on \`AssumeRole\`/\`GetFederationToken\`'s \`Policy\` parameter actually restricting the returned temporary credentials.

Wire:
- \`StsTempCredential\` gains \`session_policies: Vec<String>\` (\`#[serde(default)]\` for backwards-compatible deserialization of persisted state).
- All five STS mint paths (\`AssumeRole\`, \`AssumeRoleWithWebIdentity\`, \`AssumeRoleWithSAML\`, \`GetSessionToken\`, \`GetFederationToken\`) capture \`Policy\` (inline JSON) and \`PolicyArns.member.N\` (resolved against \`IamState.policies\` at mint time) via new \`collect_session_policies\` helper.
- \`SecretLookup\` and \`ResolvedCredential\` carry session policies through the credential resolver to dispatch.
- \`IamPolicyEvaluator\` trait methods gain \`session_policies: &[String]\` parameter. The single concrete impl parses them to \`PolicyDocument\`s and feeds them to \`evaluate_with_gates\` / \`evaluate_with_resource_policy_and_gates\` as the session layer.
- \`dispatch.rs\` passes \`caller_session_policies\` from \`ResolvedCredential\` into both evaluator calls.

## Test plan

- [x] \`cargo test -p fakecloud-iam\` — 194 passed
- [x] \`cargo test -p fakecloud-e2e --test iam_enforcement_session_policy\` — 4/4 green
- [x] \`cargo test -p fakecloud-e2e --test iam_enforcement\` — 37/37 green (regression)
- [x] \`cargo test -p fakecloud-e2e --test iam_enforcement_boundary\` — 5/5 green (regression)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] CI green
- [ ] Cubic review addressed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces STS session policies for temporary credentials in strict mode by capturing `Policy`/`PolicyArns` at mint time and applying them during authorization. Session policies cap permissions and explicit Deny wins.

- **New Features**
  - Capture session policies on STS mints (`AssumeRole`, `AssumeRoleWithWebIdentity`, `AssumeRoleWithSAML`, `GetFederationToken`; `GetSessionToken` unchanged).
  - Store on `StsTempCredential.session_policies` (backwards-compatible via `#[serde(default)]`), propagate through `SecretLookup` and `ResolvedCredential` into `dispatch`.
  - `IamPolicyEvaluator::evaluate` and `::evaluate_with_resource_policy` now take `session_policies`; `fakecloud-iam` parses and feeds them to the session gate.
  - Resolve `PolicyArns` at mint time; unresolved entries are recorded as empty documents to yield deny semantics. Added strict-mode E2E tests covering cap behavior, explicit Deny, no-policy regression, and `GetFederationToken`.

- **Migration**
  - Update any custom `IamPolicyEvaluator` implementations to accept `session_policies`.
  - Persisted snapshots remain compatible; no client changes required.

<sup>Written for commit fe28af4bb31ecf64ad0bf2afb6d3c8cd5fa36460. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

