### PR TITLE
feat(rds): persist DB instances, snapshots, subnet groups, parameter groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,6 +2027,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tokio",
  "uuid",
 ]
 
@@ -2411,6 +2412,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "mysql_async",
  "parking_lot",
@@ -2419,6 +2421,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/fakecloud-e2e/tests/rds_persistence.rs
+++ b/crates/fakecloud-e2e/tests/rds_persistence.rs
@@ -1,0 +1,124 @@
+mod helpers;
+
+use helpers::TestServer;
+
+/// Parameter groups survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_parameter_group() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_parameter_group()
+        .db_parameter_group_name("persist-pg")
+        .db_parameter_group_family("postgres16")
+        .description("Persistence test parameter group")
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.rds_client().await;
+
+    let groups = client
+        .describe_db_parameter_groups()
+        .db_parameter_group_name("persist-pg")
+        .send()
+        .await
+        .unwrap();
+    let pgs = groups.db_parameter_groups();
+    assert!(
+        pgs.iter()
+            .any(|g| g.db_parameter_group_name() == Some("persist-pg")),
+        "parameter group should survive restart"
+    );
+    let pg = pgs
+        .iter()
+        .find(|g| g.db_parameter_group_name() == Some("persist-pg"))
+        .unwrap();
+    assert_eq!(pg.db_parameter_group_family(), Some("postgres16"));
+    assert_eq!(pg.description(), Some("Persistence test parameter group"));
+}
+
+/// Subnet groups survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_subnet_group() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_subnet_group()
+        .db_subnet_group_name("persist-subnet-grp")
+        .db_subnet_group_description("Persistence test subnet group")
+        .subnet_ids("subnet-aaa")
+        .subnet_ids("subnet-bbb")
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.rds_client().await;
+
+    let groups = client
+        .describe_db_subnet_groups()
+        .db_subnet_group_name("persist-subnet-grp")
+        .send()
+        .await
+        .unwrap();
+    let sgs = groups.db_subnet_groups();
+    assert_eq!(sgs.len(), 1);
+    let sg = &sgs[0];
+    assert_eq!(sg.db_subnet_group_name(), Some("persist-subnet-grp"));
+    assert_eq!(
+        sg.db_subnet_group_description(),
+        Some("Persistence test subnet group")
+    );
+    let subnet_ids: Vec<&str> = sg
+        .subnets()
+        .iter()
+        .filter_map(|s| s.subnet_identifier())
+        .collect();
+    assert!(subnet_ids.contains(&"subnet-aaa"));
+    assert!(subnet_ids.contains(&"subnet-bbb"));
+}
+
+/// Deletion survives a restart: a deleted parameter group does not reappear.
+#[tokio::test]
+async fn persistence_deletion_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_parameter_group()
+        .db_parameter_group_name("doomed-pg")
+        .db_parameter_group_family("postgres16")
+        .description("Will be deleted")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_db_parameter_group()
+        .db_parameter_group_name("doomed-pg")
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.rds_client().await;
+
+    let groups = client.describe_db_parameter_groups().send().await.unwrap();
+    assert!(
+        !groups
+            .db_parameter_groups()
+            .iter()
+            .any(|g| g.db_parameter_group_name() == Some("doomed-pg")),
+        "deleted parameter group should not reappear"
+    );
+}

--- a/crates/fakecloud-rds/Cargo.toml
+++ b/crates/fakecloud-rds/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
@@ -23,3 +24,4 @@ thiserror = { workspace = true }
 tokio-postgres = { workspace = true }
 mysql_async = "0.34"
 base64 = { workspace = true }
+tracing = { workspace = true }

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -5,17 +5,42 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use chrono::Utc;
 use http::StatusCode;
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_aws::xml::xml_escape;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::runtime::{RdsRuntime, RuntimeError};
 use crate::state::{
     default_engine_versions, default_orderable_options, DbInstance, DbParameterGroup, DbSnapshot,
-    DbSubnetGroup, EngineVersionInfo, OrderableDbInstanceOption, RdsTag, SharedRdsState,
+    DbSubnetGroup, EngineVersionInfo, OrderableDbInstanceOption, RdsSnapshot, RdsTag,
+    SharedRdsState, RDS_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const RDS_NS: &str = "http://rds.amazonaws.com/doc/2014-10-31/";
+
+fn is_mutating_action(action: &str) -> bool {
+    matches!(
+        action,
+        "AddTagsToResource"
+            | "CreateDBInstance"
+            | "CreateDBInstanceReadReplica"
+            | "CreateDBParameterGroup"
+            | "CreateDBSnapshot"
+            | "CreateDBSubnetGroup"
+            | "DeleteDBInstance"
+            | "DeleteDBParameterGroup"
+            | "DeleteDBSnapshot"
+            | "DeleteDBSubnetGroup"
+            | "ModifyDBInstance"
+            | "ModifyDBParameterGroup"
+            | "ModifyDBSubnetGroup"
+            | "RebootDBInstance"
+            | "RemoveTagsFromResource"
+            | "RestoreDBInstanceFromDBSnapshot"
+    )
+}
 const SUPPORTED_ACTIONS: &[&str] = &[
     "AddTagsToResource",
     "CreateDBInstance",
@@ -45,6 +70,8 @@ const SUPPORTED_ACTIONS: &[&str] = &[
 pub struct RdsService {
     state: SharedRdsState,
     runtime: Option<Arc<RdsRuntime>>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl RdsService {
@@ -52,12 +79,41 @@ impl RdsService {
         Self {
             state,
             runtime: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
     pub fn with_runtime(mut self, runtime: Arc<RdsRuntime>) -> Self {
         self.runtime = Some(runtime);
         self
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = RdsSnapshot {
+            schema_version: RDS_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write rds snapshot"),
+            Err(err) => tracing::error!(%err, "rds snapshot task panicked"),
+        }
     }
 
     /// Return the runtime or a ``ServiceUnavailable`` error if it was not configured.
@@ -83,7 +139,8 @@ impl AwsService for RdsService {
     }
 
     async fn handle(&self, request: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match request.action.as_str() {
+        let mutates = is_mutating_action(request.action.as_str());
+        let result = match request.action.as_str() {
             "AddTagsToResource" => self.add_tags_to_resource(&request),
             "CreateDBInstance" => self.create_db_instance(&request).await,
             "CreateDBInstanceReadReplica" => self.create_db_instance_read_replica(&request).await,
@@ -115,7 +172,11 @@ impl AwsService for RdsService {
                 self.service_name(),
                 &request.action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -20,7 +20,7 @@ pub const SUPPORTED_INSTANCE_CLASSES: &[&str] = &[
     "db.m5.large",
 ];
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct DbInstance {
     pub db_instance_identifier: String,
     pub db_instance_arn: String,
@@ -53,7 +53,7 @@ pub struct DbInstance {
     pub pending_modified_values: Option<PendingModifiedValues>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct PendingModifiedValues {
     pub db_instance_class: Option<String>,
     pub allocated_storage: Option<i32>,
@@ -121,13 +121,13 @@ impl fmt::Debug for DbInstance {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RdsTag {
     pub key: String,
     pub value: String,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct DbSnapshot {
     pub db_snapshot_identifier: String,
     pub db_snapshot_arn: String,
@@ -170,7 +170,7 @@ impl fmt::Debug for DbSnapshot {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RdsState {
     pub account_id: String,
     pub region: String,
@@ -202,7 +202,7 @@ pub struct OrderableDbInstanceOption {
     pub max_storage_size: i32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DbSubnetGroup {
     pub db_subnet_group_name: String,
     pub db_subnet_group_arn: String,
@@ -213,7 +213,7 @@ pub struct DbSubnetGroup {
     pub tags: Vec<RdsTag>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DbParameterGroup {
     pub db_parameter_group_name: String,
     pub db_parameter_group_arn: String,
@@ -462,6 +462,14 @@ pub fn default_parameter_groups(
     }
 
     groups
+}
+
+pub const RDS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RdsSnapshot {
+    pub schema_version: u32,
+    pub state: RdsState,
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -382,7 +382,7 @@ async fn main() {
 
     // Register services
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
-        for service in ["rds", "elasticache", "bedrock"] {
+        for service in ["elasticache", "bedrock"] {
             fakecloud_persistence::warn_unsupported(service);
         }
     }
@@ -1261,9 +1261,57 @@ async fn main() {
         kinesis_service = kinesis_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(kinesis_service));
+    let rds_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("rds").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_rds::state::RdsSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_rds::state::RDS_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "rds persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_rds::state::RDS_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let instance_count = snapshot.state.instances.len();
+                            *rds_state.write() = snapshot.state;
+                            tracing::info!(
+                                instances = instance_count,
+                                "loaded rds persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse rds persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no rds persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read rds persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
     let mut rds_service = RdsService::new(rds_state);
     if let Some(ref rt) = rds_runtime {
         rds_service = rds_service.with_runtime(rt.clone());
+    }
+    if let Some(store) = rds_snapshot_store {
+        rds_service = rds_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(rds_service));
     let mut elasticache_service = ElastiCacheService::new(elasticache_state);

--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -39,6 +39,7 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 - **Cognito** — user pools, user pool clients, users, groups, identity providers, resource servers, domains, import jobs, tags, UI customization, log delivery, risk and branding configuration, terms, WebAuthn credentials, refresh/access tokens and sessions. The `/_fakecloud/cognito/auth-events` introspection buffer resets on restart.
 - **Lambda** — functions (code zips, configuration, resource policies), event source mappings. The `/_fakecloud/lambda/invocations` introspection buffer resets on restart; containers are rebuilt from the persisted code zip on first Invoke.
 - **Step Functions** — state machines, definitions, executions, execution history events, tags.
+- **RDS** — DB instances (configuration, credentials, tags), DB snapshots (including dump data), subnet groups, parameter groups.
 - **Every other service** emits `persistence not yet supported, running in-memory` at startup and continues to operate exactly as in memory mode. Your tests don't break — you just don't get cross-restart durability for those services yet.
 
 ## Version compatibility


### PR DESCRIPTION
## Summary
- Add `Serialize`/`Deserialize` to `RdsState` and all nested types (`DbInstance`, `DbSnapshot`, `DbSubnetGroup`, `DbParameterGroup`, `PendingModifiedValues`, `RdsTag`)
- Add `RdsSnapshot` wrapper with schema versioning for forward compatibility
- Wire snapshot loading at startup and saving after every mutating action in `RdsService`
- Remove RDS from the "persistence not yet supported" warning in main.rs

## Test plan
- [x] `persistence_round_trip_parameter_group` — create parameter group, restart, verify it survives
- [x] `persistence_round_trip_subnet_group` — create subnet group with subnets, restart, verify it survives
- [x] `persistence_deletion_survives_restart` — create then delete parameter group, restart, verify it stays deleted
- [x] All 3 tests passing locally
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist RDS state across restarts, including DB instances, snapshots, subnet groups, and parameter groups. RDS now loads a snapshot on startup and saves after each mutating action, and the “persistence not yet supported” warning is removed.

- **New Features**
  - Added `Serialize`/`Deserialize` to `RdsState` and nested types; introduced `RdsSnapshot` with schema versioning.
  - Integrated `SnapshotStore` in `RdsService` to load on startup and save after mutating APIs; snapshot stored at `rds/snapshot.json`.
  - Added E2E tests for round-trip persistence and deletion durability; updated docs to list RDS under supported persistence.

- **Migration**
  - Run in persistent mode to enable RDS durability (e.g., set `FAKECLOUD_STORAGE_MODE=persistent` and `FAKECLOUD_DATA_PATH`).
  - Existing on-disk snapshots are validated against the expected schema; mismatches cause a fatal exit.

<sup>Written for commit bbee4685c8aab0898d37d5c753458849a3661562. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

