### PR TITLE
feat(iam): add ABAC framework + PrincipalTag condition support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,6 +2027,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tokio",
  "uuid",
 ]
 

--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -10,7 +10,7 @@
 //! `/docs/reference/security` (added in a later batch) for the user-facing
 //! contract.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::net::IpAddr;
 use std::str::FromStr;
@@ -92,6 +92,10 @@ pub struct Principal {
     /// `AssumeRole`'s `SourceIdentity` parameter. Reserved for later
     /// batches that wire session policies and auditing.
     pub source_identity: Option<String>,
+    /// Tags on the calling principal (IAM user or assumed role).
+    /// Populated at credential-resolution time from `IamState`.
+    /// Used for `aws:PrincipalTag/<key>` condition evaluation.
+    pub tags: Option<HashMap<String, String>>,
 }
 
 impl Principal {
@@ -233,8 +237,18 @@ pub struct ConditionContext {
     /// `aws:RequestedRegion` — region extracted from SigV4 / config.
     pub aws_requested_region: Option<String>,
     /// Service-specific keys (`s3:prefix`, `sqs:MessageAttribute`, …).
-    /// Reserved; empty in the initial Phase 2 rollout.
     pub service_keys: BTreeMap<String, Vec<String>>,
+    /// `aws:ResourceTag/<key>` — tags on the target resource.
+    /// Populated by [`crate::service::AwsService::resource_tags_for`].
+    /// `None` means the service doesn't expose resource tags for ABAC.
+    pub resource_tags: Option<HashMap<String, String>>,
+    /// `aws:RequestTag/<key>` — tags sent in the request body/headers.
+    /// Populated by [`crate::service::AwsService::request_tags_from`].
+    /// Also drives `aws:TagKeys` (the list of request tag keys).
+    pub request_tags: Option<HashMap<String, String>>,
+    /// `aws:PrincipalTag/<key>` — tags on the calling IAM user or role.
+    /// Populated from [`Principal::tags`] at dispatch time.
+    pub principal_tags: Option<HashMap<String, String>>,
 }
 
 impl ConditionContext {
@@ -245,6 +259,44 @@ impl ConditionContext {
     pub fn lookup(&self, key: &str) -> Option<Vec<String>> {
         let lower = key.to_ascii_lowercase();
         let one = |s: &str| Some(vec![s.to_string()]);
+
+        // ABAC tag-based keys: case-insensitive prefix, case-sensitive
+        // tag key (the part after the slash). AWS treats "Environment"
+        // and "environment" as distinct tag keys.
+        //
+        // Prefix lengths: "aws:resourcetag/" = 16, "aws:requesttag/" = 15,
+        //                 "aws:principaltag/" = 17
+        if lower.starts_with("aws:resourcetag/") {
+            let tag_key = &key[16..]; // preserve original case
+            return self
+                .resource_tags
+                .as_ref()
+                .and_then(|tags| tags.get(tag_key))
+                .map(|v| vec![v.clone()]);
+        }
+        if lower.starts_with("aws:requesttag/") {
+            let tag_key = &key[15..];
+            return self
+                .request_tags
+                .as_ref()
+                .and_then(|tags| tags.get(tag_key))
+                .map(|v| vec![v.clone()]);
+        }
+        if lower.starts_with("aws:principaltag/") {
+            let tag_key = &key[17..];
+            return self
+                .principal_tags
+                .as_ref()
+                .and_then(|tags| tags.get(tag_key))
+                .map(|v| vec![v.clone()]);
+        }
+        if lower == "aws:tagkeys" {
+            return self
+                .request_tags
+                .as_ref()
+                .map(|tags| tags.keys().cloned().collect());
+        }
+
         match lower.as_str() {
             "aws:username" => self.aws_username.as_deref().and_then(one),
             "aws:userid" => self.aws_userid.as_deref().and_then(one),
@@ -595,6 +647,7 @@ mod tests {
             account_id: "123456789012".to_string(),
             principal_type: PrincipalType::Unknown,
             source_identity: None,
+            tags: None,
         };
         assert!(!p.is_root());
     }
@@ -607,6 +660,7 @@ mod tests {
             account_id: "123456789012".to_string(),
             principal_type: PrincipalType::Root,
             source_identity: None,
+            tags: None,
         };
         assert!(p.is_root());
 
@@ -616,6 +670,7 @@ mod tests {
             account_id: "123456789012".to_string(),
             principal_type: PrincipalType::User,
             source_identity: None,
+            tags: None,
         };
         assert!(!user.is_root());
     }
@@ -631,6 +686,7 @@ mod tests {
                 account_id: "123456789012".into(),
                 principal_type: PrincipalType::User,
                 source_identity: None,
+                tags: None,
             },
             session_policies: Vec::new(),
         };
@@ -767,5 +823,108 @@ mod tests {
             arc.resource_policy("s3", "arn:aws:s3:::b").as_deref(),
             Some("doc")
         );
+    }
+
+    // --- ABAC tag condition key lookup ------------------------------------
+
+    fn abac_context() -> ConditionContext {
+        ConditionContext {
+            resource_tags: Some(
+                [("Environment", "prod"), ("CostCenter", "42")]
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+            request_tags: Some(
+                [("Project", "web"), ("Team", "platform")]
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+            principal_tags: Some(
+                [("Department", "eng"), ("Role", "developer")]
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn lookup_resource_tag_case_sensitive_key() {
+        let ctx = abac_context();
+        assert_eq!(
+            ctx.lookup("aws:ResourceTag/Environment"),
+            Some(vec!["prod".to_string()])
+        );
+        // Different case -> different tag key -> None
+        assert_eq!(ctx.lookup("aws:ResourceTag/environment"), None);
+    }
+
+    #[test]
+    fn lookup_resource_tag_prefix_case_insensitive() {
+        let ctx = abac_context();
+        // Prefix is case-insensitive per AWS
+        assert_eq!(
+            ctx.lookup("AWS:resourcetag/Environment"),
+            Some(vec!["prod".to_string()])
+        );
+        assert_eq!(
+            ctx.lookup("Aws:RESOURCETAG/CostCenter"),
+            Some(vec!["42".to_string()])
+        );
+    }
+
+    #[test]
+    fn lookup_request_tag() {
+        let ctx = abac_context();
+        assert_eq!(
+            ctx.lookup("aws:RequestTag/Project"),
+            Some(vec!["web".to_string()])
+        );
+        assert_eq!(ctx.lookup("aws:RequestTag/project"), None);
+    }
+
+    #[test]
+    fn lookup_principal_tag() {
+        let ctx = abac_context();
+        assert_eq!(
+            ctx.lookup("aws:PrincipalTag/Department"),
+            Some(vec!["eng".to_string()])
+        );
+        assert_eq!(ctx.lookup("aws:PrincipalTag/department"), None);
+    }
+
+    #[test]
+    fn lookup_tag_keys_returns_all_request_tag_keys() {
+        let ctx = abac_context();
+        let mut keys = ctx.lookup("aws:TagKeys").unwrap();
+        keys.sort();
+        assert_eq!(keys, vec!["Project", "Team"]);
+    }
+
+    #[test]
+    fn lookup_tag_keys_case_insensitive() {
+        let ctx = abac_context();
+        assert!(ctx.lookup("AWS:TAGKEYS").is_some());
+        assert!(ctx.lookup("aws:tagkeys").is_some());
+    }
+
+    #[test]
+    fn lookup_tag_none_when_field_not_set() {
+        let ctx = ConditionContext::default();
+        assert_eq!(ctx.lookup("aws:ResourceTag/Foo"), None);
+        assert_eq!(ctx.lookup("aws:RequestTag/Foo"), None);
+        assert_eq!(ctx.lookup("aws:PrincipalTag/Foo"), None);
+        assert_eq!(ctx.lookup("aws:TagKeys"), None);
+    }
+
+    #[test]
+    fn lookup_tag_missing_key_returns_none() {
+        let ctx = abac_context();
+        assert_eq!(ctx.lookup("aws:ResourceTag/NonExistent"), None);
+        assert_eq!(ctx.lookup("aws:RequestTag/NonExistent"), None);
+        assert_eq!(ctx.lookup("aws:PrincipalTag/NonExistent"), None);
     }
 }

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -305,6 +305,31 @@ pub async fn dispatch(
                         );
                         condition_context.service_keys =
                             service.iam_condition_keys_for(&aws_request, &iam_action);
+
+                        // ABAC: populate tag-based condition keys.
+                        // aws:ResourceTag/*
+                        match service.resource_tags_for(&iam_action.resource) {
+                            Some(tags) => condition_context.resource_tags = Some(tags),
+                            None => tracing::debug!(
+                                target: "fakecloud::iam::audit",
+                                service = %detected.service,
+                                resource = %iam_action.resource,
+                                "service does not expose resource tags for ABAC; skipping aws:ResourceTag/* evaluation"
+                            ),
+                        }
+                        // aws:RequestTag/* + aws:TagKeys
+                        match service.request_tags_from(&aws_request, iam_action.action) {
+                            Some(tags) => condition_context.request_tags = Some(tags),
+                            None => tracing::debug!(
+                                target: "fakecloud::iam::audit",
+                                service = %detected.service,
+                                action = %iam_action.action_string(),
+                                "service does not expose request tags for ABAC; skipping aws:RequestTag/* / aws:TagKeys evaluation"
+                            ),
+                        }
+                        // aws:PrincipalTag/*
+                        condition_context.principal_tags = principal.tags.clone();
+
                         // Phase 2: fetch the resource-based policy (if
                         // any) attached to the target resource and
                         // pass it to the evaluator alongside the
@@ -620,6 +645,9 @@ fn build_condition_context(
         aws_secure_transport: Some(secure_transport),
         aws_requested_region: Some(region.to_string()),
         service_keys: Default::default(),
+        resource_tags: None,
+        request_tags: None,
+        principal_tags: None,
     }
 }
 
@@ -691,6 +719,7 @@ mod tests {
             account_id: "123456789012".into(),
             principal_type: PrincipalType::User,
             source_identity: None,
+            tags: None,
         };
         assert_eq!(aws_username_from_principal(&p), Some("alice".into()));
     }
@@ -703,6 +732,7 @@ mod tests {
             account_id: "123456789012".into(),
             principal_type: PrincipalType::AssumedRole,
             source_identity: None,
+            tags: None,
         };
         assert_eq!(aws_username_from_principal(&p), None);
     }
@@ -725,6 +755,7 @@ mod tests {
             account_id: "123456789012".into(),
             principal_type: PrincipalType::User,
             source_identity: None,
+            tags: None,
         };
         let addr: SocketAddr = "10.0.0.1:54321".parse().unwrap();
         let ctx = build_condition_context(&p, Some(addr), "us-east-1", false);

--- a/crates/fakecloud-core/src/service.rs
+++ b/crates/fakecloud-core/src/service.rs
@@ -345,6 +345,41 @@ pub trait AwsService: Send + Sync {
     ) -> BTreeMap<String, Vec<String>> {
         BTreeMap::new()
     }
+
+    /// Return the tags on the resource identified by `resource_arn`.
+    ///
+    /// Called at dispatch time when IAM enforcement is enabled, right
+    /// after [`AwsService::iam_action_for`]. The returned map populates
+    /// `aws:ResourceTag/<key>` condition keys so policies can gate
+    /// access based on the target resource's tags.
+    ///
+    /// Return `None` to signal that this service does not (yet) support
+    /// resource-tag ABAC — dispatch will emit a debug audit log and
+    /// skip `aws:ResourceTag/*` evaluation. Return `Some(empty map)`
+    /// when the resource exists but has no tags.
+    fn resource_tags_for(
+        &self,
+        _resource_arn: &str,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        None
+    }
+
+    /// Extract tags being sent in the request (e.g. on CreateQueue,
+    /// PutObject with `x-amz-tagging`, TagResource).
+    ///
+    /// The returned map populates `aws:RequestTag/<key>` and
+    /// `aws:TagKeys` condition keys. Return `None` when the service
+    /// does not (yet) support request-tag extraction — dispatch skips
+    /// `aws:RequestTag/*` / `aws:TagKeys` evaluation with a debug log.
+    /// Return `Some(empty map)` when the request legitimately carries
+    /// no tags.
+    fn request_tags_from(
+        &self,
+        _request: &AwsRequest,
+        _action: &str,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-e2e/tests/iam_enforcement_abac.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement_abac.rs
@@ -1,0 +1,187 @@
+//! End-to-end tests for ABAC (attribute-based access control) tag conditions.
+//!
+//! Tests `aws:PrincipalTag/<key>` condition evaluation with
+//! `FAKECLOUD_IAM=strict`. The framework plumbs principal tags from
+//! IamState through to the condition evaluator; this file proves it
+//! works end-to-end with real aws-sdk-rust calls.
+
+mod helpers;
+
+use aws_credential_types::Credentials;
+use aws_sdk_iam::Client as IamClient;
+use aws_sdk_sts::Client as StsClient;
+use helpers::TestServer;
+
+async fn start_strict() -> TestServer {
+    TestServer::start_with_env(&[
+        ("FAKECLOUD_IAM", "strict"),
+        ("FAKECLOUD_VERIFY_SIGV4", "true"),
+    ])
+    .await
+}
+
+async fn sdk_config_with(server: &TestServer, akid: &str, secret: &str) -> aws_config::SdkConfig {
+    aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(akid, secret, None, None, "fakecloud-abac"))
+        .load()
+        .await
+}
+
+async fn bootstrap_tagged_user(
+    server: &TestServer,
+    name: &str,
+    tags: &[(&str, &str)],
+) -> (String, String) {
+    let boot = sdk_config_with(server, "test", "test").await;
+    let iam = IamClient::new(&boot);
+    let mut req = iam.create_user().user_name(name);
+    for (k, v) in tags {
+        req = req.tags(
+            aws_sdk_iam::types::Tag::builder()
+                .key(*k)
+                .value(*v)
+                .build()
+                .unwrap(),
+        );
+    }
+    req.send().await.unwrap();
+    let ak = iam
+        .create_access_key()
+        .user_name(name)
+        .send()
+        .await
+        .unwrap();
+    let key = ak.access_key().unwrap();
+    (
+        key.access_key_id().to_string(),
+        key.secret_access_key().to_string(),
+    )
+}
+
+async fn attach_inline_policy(server: &TestServer, user: &str, name: &str, document: &str) {
+    let boot = sdk_config_with(server, "test", "test").await;
+    IamClient::new(&boot)
+        .put_user_policy()
+        .user_name(user)
+        .policy_name(name)
+        .policy_document(document)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ======================================================================
+// aws:PrincipalTag tests
+// ======================================================================
+
+#[tokio::test]
+async fn principal_tag_condition_allows_matching_user() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_tagged_user(&server, "alice", &[("Team", "platform")]).await;
+
+    // Policy: allow sts:GetCallerIdentity only if PrincipalTag/Team == platform
+    attach_inline_policy(
+        &server,
+        "alice",
+        "AllowIfPlatform",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Action":"sts:GetCallerIdentity",
+            "Resource":"*",
+            "Condition":{"StringEquals":{"aws:PrincipalTag/Team":"platform"}}
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sts = StsClient::new(&cfg);
+    let identity = sts.get_caller_identity().send().await.unwrap();
+    assert!(identity.arn().unwrap().contains("user/alice"));
+}
+
+#[tokio::test]
+async fn principal_tag_condition_denies_non_matching_user() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_tagged_user(&server, "bob", &[("Team", "backend")]).await;
+
+    // Policy: allow sts:GetCallerIdentity only if PrincipalTag/Team == platform
+    attach_inline_policy(
+        &server,
+        "bob",
+        "AllowIfPlatform",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Action":"sts:GetCallerIdentity",
+            "Resource":"*",
+            "Condition":{"StringEquals":{"aws:PrincipalTag/Team":"platform"}}
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sts = StsClient::new(&cfg);
+    let err = sts.get_caller_identity().send().await.unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDeniedException"),
+        "expected AccessDeniedException"
+    );
+}
+
+#[tokio::test]
+async fn principal_tag_condition_denies_user_with_no_tags() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_tagged_user(&server, "carol", &[]).await;
+
+    // Policy requires PrincipalTag/Team == platform, but carol has no tags
+    attach_inline_policy(
+        &server,
+        "carol",
+        "AllowIfPlatform",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Action":"sts:GetCallerIdentity",
+            "Resource":"*",
+            "Condition":{"StringEquals":{"aws:PrincipalTag/Team":"platform"}}
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sts = StsClient::new(&cfg);
+    let err = sts.get_caller_identity().send().await.unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDeniedException"),
+        "expected AccessDeniedException"
+    );
+}
+
+#[tokio::test]
+async fn principal_tag_case_sensitive_key() {
+    let server = start_strict().await;
+    // User has tag "team" (lowercase), but policy checks "Team" (titlecase)
+    let (akid, secret) = bootstrap_tagged_user(&server, "dave", &[("team", "platform")]).await;
+
+    attach_inline_policy(
+        &server,
+        "dave",
+        "AllowIfPlatform",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Action":"sts:GetCallerIdentity",
+            "Resource":"*",
+            "Condition":{"StringEquals":{"aws:PrincipalTag/Team":"platform"}}
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sts = StsClient::new(&cfg);
+    // Tag key mismatch: "team" != "Team" -> condition fails -> denied
+    let err = sts.get_caller_identity().send().await.unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDeniedException"),
+        "expected AccessDeniedException — tag keys are case-sensitive"
+    );
+}

--- a/crates/fakecloud-iam/src/condition.rs
+++ b/crates/fakecloud-iam/src/condition.rs
@@ -833,9 +833,11 @@ mod tests {
     #[test]
     fn for_all_values_every_context_must_match() {
         let mut ctx = ctx_user("alice");
-        ctx.service_keys.insert(
-            "aws:tagkeys".to_string(),
-            vec!["env".to_string(), "team".to_string()],
+        ctx.request_tags = Some(
+            [("env", "dev"), ("team", "platform")]
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
         );
         let b = compile(json!({
             "ForAllValues:StringEquals": {
@@ -843,9 +845,11 @@ mod tests {
             }
         }));
         assert!(b.matches(&ctx));
-        ctx.service_keys.insert(
-            "aws:tagkeys".to_string(),
-            vec!["env".to_string(), "rogue".to_string()],
+        ctx.request_tags = Some(
+            [("env", "dev"), ("rogue", "x")]
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
         );
         assert!(!b.matches(&ctx));
     }
@@ -853,9 +857,11 @@ mod tests {
     #[test]
     fn for_any_value_some_context_matches() {
         let mut ctx = ctx_user("alice");
-        ctx.service_keys.insert(
-            "aws:tagkeys".to_string(),
-            vec!["env".to_string(), "rogue".to_string()],
+        ctx.request_tags = Some(
+            [("env", "dev"), ("rogue", "x")]
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
         );
         let b = compile(json!({
             "ForAnyValue:StringEquals": { "aws:TagKeys": "env" }

--- a/crates/fakecloud-iam/src/credential_resolver.rs
+++ b/crates/fakecloud-iam/src/credential_resolver.rs
@@ -48,6 +48,7 @@ impl CredentialResolver for IamCredentialResolver {
                 account_id: lookup.account_id,
                 principal_type,
                 source_identity: None,
+                tags: lookup.principal_tags,
             },
             session_policies: lookup.session_policies,
         })
@@ -136,5 +137,121 @@ mod tests {
             PrincipalType::AssumedRole
         );
         assert_eq!(resolved.session_token.as_deref(), Some("temp-token"));
+    }
+
+    #[test]
+    fn resolves_iam_user_tags_for_principal() {
+        use crate::state::Tag;
+        let mut state = IamState::new("123456789012");
+        state.users.insert(
+            "bob".to_string(),
+            IamUser {
+                user_name: "bob".into(),
+                user_id: "AIDABOB".into(),
+                arn: "arn:aws:iam::123456789012:user/bob".into(),
+                path: "/".into(),
+                created_at: Utc::now(),
+                tags: vec![
+                    Tag {
+                        key: "Team".into(),
+                        value: "platform".into(),
+                    },
+                    Tag {
+                        key: "Environment".into(),
+                        value: "prod".into(),
+                    },
+                ],
+                permissions_boundary: None,
+            },
+        );
+        state.access_keys.insert(
+            "bob".to_string(),
+            vec![IamAccessKey {
+                access_key_id: "FKIABOB".into(),
+                secret_access_key: "bob-secret".into(),
+                user_name: "bob".into(),
+                status: "Active".into(),
+                created_at: Utc::now(),
+            }],
+        );
+        let resolver = IamCredentialResolver::new(Arc::new(RwLock::new(state)));
+        let resolved = resolver.resolve("FKIABOB").unwrap();
+        let tags = resolved.principal.tags.as_ref().unwrap();
+        assert_eq!(tags.get("Team").map(|s| s.as_str()), Some("platform"));
+        assert_eq!(tags.get("Environment").map(|s| s.as_str()), Some("prod"));
+    }
+
+    #[test]
+    fn resolves_assumed_role_tags_for_principal() {
+        use crate::state::{IamRole, StsTempCredential, Tag};
+        let mut state = IamState::new("123456789012");
+        state.roles.insert(
+            "ops".to_string(),
+            IamRole {
+                role_name: "ops".into(),
+                role_id: "AROAOPS".into(),
+                arn: "arn:aws:iam::123456789012:role/ops".into(),
+                path: "/".into(),
+                assume_role_policy_document: "{}".into(),
+                created_at: Utc::now(),
+                tags: vec![Tag {
+                    key: "Department".into(),
+                    value: "engineering".into(),
+                }],
+                max_session_duration: 3600,
+                permissions_boundary: None,
+                description: None,
+            },
+        );
+        state.sts_temp_credentials.insert(
+            "FSIAOPS".to_string(),
+            StsTempCredential {
+                access_key_id: "FSIAOPS".into(),
+                secret_access_key: "ops-secret".into(),
+                session_token: "ops-token".into(),
+                principal_arn: "arn:aws:sts::123456789012:assumed-role/ops/session".into(),
+                user_id: "AROAOPS:session".into(),
+                account_id: "123456789012".into(),
+                expiration: Utc::now() + chrono::Duration::minutes(30),
+                session_policies: Vec::new(),
+            },
+        );
+        let resolver = IamCredentialResolver::new(Arc::new(RwLock::new(state)));
+        let resolved = resolver.resolve("FSIAOPS").unwrap();
+        let tags = resolved.principal.tags.as_ref().unwrap();
+        assert_eq!(
+            tags.get("Department").map(|s| s.as_str()),
+            Some("engineering")
+        );
+    }
+
+    #[test]
+    fn no_tags_yields_none() {
+        let mut state = IamState::new("123456789012");
+        state.users.insert(
+            "empty".to_string(),
+            IamUser {
+                user_name: "empty".into(),
+                user_id: "AIDAEMPTY".into(),
+                arn: "arn:aws:iam::123456789012:user/empty".into(),
+                path: "/".into(),
+                created_at: Utc::now(),
+                tags: Vec::new(),
+                permissions_boundary: None,
+            },
+        );
+        state.access_keys.insert(
+            "empty".to_string(),
+            vec![IamAccessKey {
+                access_key_id: "FKIAEMPTY".into(),
+                secret_access_key: "s".into(),
+                user_name: "empty".into(),
+                status: "Active".into(),
+                created_at: Utc::now(),
+            }],
+        );
+        let resolver = IamCredentialResolver::new(Arc::new(RwLock::new(state)));
+        let resolved = resolver.resolve("FKIAEMPTY").unwrap();
+        assert!(resolved.principal.tags.is_none());
     }
 }

--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -925,6 +925,7 @@ mod tests {
             account_id: "123456789012".into(),
             principal_type: PrincipalType::User,
             source_identity: None,
+            tags: None,
         }
     }
 
@@ -1597,6 +1598,7 @@ mod tests {
             account_id: "123456789012".to_string(),
             principal_type: PrincipalType::User,
             source_identity: None,
+            tags: None,
         };
         let docs = collect_identity_policies(&state, &principal);
         assert_eq!(docs.len(), 1, "pathed user's inline policy was missed");
@@ -1731,6 +1733,7 @@ mod tests {
             account_id: "123456789012".into(),
             principal_type: PrincipalType::Root,
             source_identity: None,
+            tags: None,
         };
         // Root short-circuits via Principal::is_root in dispatch; here we
         // just assert collect_identity_policies doesn't synthesize a
@@ -1750,6 +1753,7 @@ mod tests {
             account_id: account.into(),
             principal_type: PrincipalType::User,
             source_identity: None,
+            tags: None,
         }
     }
 
@@ -1760,6 +1764,7 @@ mod tests {
             account_id: account.into(),
             principal_type: PrincipalType::AssumedRole,
             source_identity: None,
+            tags: None,
         }
     }
 

--- a/crates/fakecloud-iam/src/policy_evaluator.rs
+++ b/crates/fakecloud-iam/src/policy_evaluator.rs
@@ -121,6 +121,7 @@ mod tests {
             account_id: "123456789012".to_string(),
             principal_type: PrincipalType::User,
             source_identity: None,
+            tags: None,
         }
     }
 
@@ -387,6 +388,7 @@ mod tests {
             account_id: "123456789012".into(),
             principal_type: PrincipalType::AssumedRole,
             source_identity: None,
+            tags: None,
         };
         let eval = IamPolicyEvaluatorImpl::new(state);
         assert_eq!(

--- a/crates/fakecloud-iam/src/state.rs
+++ b/crates/fakecloud-iam/src/state.rs
@@ -234,6 +234,22 @@ pub struct SecretLookup {
     /// Session policies from the STS call that minted this credential.
     /// Empty for IAM user access keys.
     pub session_policies: Vec<String>,
+    /// Tags on the principal (IAM user or assumed role) for
+    /// `aws:PrincipalTag/<key>` condition evaluation.
+    pub principal_tags: Option<HashMap<String, String>>,
+}
+
+/// Convert a `Vec<Tag>` to a `HashMap<String, String>`.
+/// Returns `None` when the input is empty (no tags to evaluate).
+pub fn tags_to_hashmap(tags: &[Tag]) -> Option<HashMap<String, String>> {
+    if tags.is_empty() {
+        return None;
+    }
+    Some(
+        tags.iter()
+            .map(|t| (t.key.clone(), t.value.clone()))
+            .collect(),
+    )
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -351,6 +367,7 @@ impl IamState {
                             user_id: user.user_id.clone(),
                             account_id: self.account_id.clone(),
                             session_policies: Vec::new(),
+                            principal_tags: tags_to_hashmap(&user.tags),
                         });
                     }
                 }
@@ -362,6 +379,7 @@ impl IamState {
         let now = Utc::now();
         if let Some(temp) = self.sts_temp_credentials.get(access_key_id) {
             if temp.expiration > now {
+                let principal_tags = self.resolve_role_tags(&temp.principal_arn);
                 return Some(SecretLookup {
                     secret_access_key: temp.secret_access_key.clone(),
                     session_token: Some(temp.session_token.clone()),
@@ -369,6 +387,7 @@ impl IamState {
                     user_id: temp.user_id.clone(),
                     account_id: temp.account_id.clone(),
                     session_policies: temp.session_policies.clone(),
+                    principal_tags,
                 });
             }
             self.sts_temp_credentials.remove(access_key_id);
@@ -391,6 +410,7 @@ impl IamState {
                             user_id: user.user_id.clone(),
                             account_id: self.account_id.clone(),
                             session_policies: Vec::new(),
+                            principal_tags: tags_to_hashmap(&user.tags),
                         });
                     }
                 }
@@ -402,6 +422,7 @@ impl IamState {
         if temp.expiration <= now {
             return None;
         }
+        let principal_tags = self.resolve_role_tags(&temp.principal_arn);
         Some(SecretLookup {
             secret_access_key: temp.secret_access_key.clone(),
             session_token: Some(temp.session_token.clone()),
@@ -409,7 +430,26 @@ impl IamState {
             user_id: temp.user_id.clone(),
             account_id: temp.account_id.clone(),
             session_policies: temp.session_policies.clone(),
+            principal_tags,
         })
+    }
+
+    /// Resolve role tags from an assumed-role principal ARN.
+    /// ARN format: `arn:aws:sts::<account>:assumed-role/<role-name>/<session>`
+    /// Looks up the role by name and returns its tags.
+    fn resolve_role_tags(&self, principal_arn: &str) -> Option<HashMap<String, String>> {
+        // assumed-role ARNs: arn:aws:sts::<account>:assumed-role/<role>/<session>
+        let parts: Vec<&str> = principal_arn.split(':').collect();
+        if parts.len() < 6 {
+            return None;
+        }
+        let resource = parts[5];
+        if let Some(rest) = resource.strip_prefix("assumed-role/") {
+            let role_name = rest.split('/').next()?;
+            let role = self.roles.get(role_name)?;
+            return tags_to_hashmap(&role.tags);
+        }
+        None
     }
 }
 


### PR DESCRIPTION
## Summary

- Add ABAC (attribute-based access control) framework for tag-based IAM condition evaluation (Phase 4 Batch 1)
- Implement `aws:PrincipalTag/<key>` condition key end-to-end: tags flow from IamState through credential resolution into condition evaluation
- Add `resource_tags_for()` and `request_tags_from()` hooks to AwsService trait for per-service ABAC rollout (return None by default, no behavior change)
- Extend `ConditionContext::lookup()` with prefix matching for `aws:ResourceTag/<key>`, `aws:RequestTag/<key>`, `aws:PrincipalTag/<key>`, and `aws:TagKeys` — case-insensitive prefix, case-sensitive tag key per AWS semantics

## Test plan

- [x] Unit tests for ConditionContext ABAC lookup (case sensitivity, missing keys, all four families)
- [x] Unit tests for credential resolver tag plumbing (IAM user tags, assumed role tags, no-tags case)
- [x] E2E: PrincipalTag condition allows matching user
- [x] E2E: PrincipalTag condition denies non-matching user
- [x] E2E: PrincipalTag condition denies user with no tags
- [x] E2E: PrincipalTag tag key is case-sensitive
- [x] All existing tests pass (zero regressions)
- [x] cargo clippy clean, cargo fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ABAC framework for tag-based IAM conditions and full support for `aws:PrincipalTag/<key>`. This enables tag-driven policy checks with correct AWS semantics.

- **New Features**
  - Support `aws:ResourceTag/<key>`, `aws:RequestTag/<key>`, `aws:PrincipalTag/<key>`, and `aws:TagKeys` in condition lookup (prefix is case-insensitive; tag keys are case-sensitive).
  - Principal tags are resolved from `IamState` (IAM users and assumed roles) and carried through dispatch into evaluation.
  - New per-service hooks `resource_tags_for()` and `request_tags_from()` allow gradual ABAC rollout; defaults return `None`. Added unit and E2E tests for `PrincipalTag`.

- **Migration**
  - No behavior change by default. Implement `AwsService::resource_tags_for` and `AwsService::request_tags_from` to enable `ResourceTag`/`RequestTag` evaluation.
  - `PrincipalTag` works automatically when principal tags exist in state; no service changes required.

<sup>Written for commit 82e091029e334670185225b53e93bc16ae03628a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

