### PR TITLE
feat(elasticache): persist clusters, replication groups, users, subnet groups, tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,11 +2229,15 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "form_urlencoded",
  "http 1.4.0",
  "parking_lot",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/fakecloud-e2e/tests/elasticache_persistence.rs
+++ b/crates/fakecloud-e2e/tests/elasticache_persistence.rs
@@ -1,0 +1,190 @@
+mod helpers;
+
+use helpers::TestServer;
+
+/// Users and user groups survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_user_and_group() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user()
+        .user_id("persist-user")
+        .user_name("persist-user")
+        .engine("redis")
+        .access_string("on ~* +@all")
+        .no_password_required(true)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_user_group()
+        .user_group_id("persist-group")
+        .engine("redis")
+        .user_ids("default")
+        .user_ids("persist-user")
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.elasticache_client().await;
+
+    // User survives
+    let users = client
+        .describe_users()
+        .user_id("persist-user")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(users.users().len(), 1);
+    assert_eq!(users.users()[0].user_id(), Some("persist-user"));
+
+    // User group survives
+    let groups = client
+        .describe_user_groups()
+        .user_group_id("persist-group")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(groups.user_groups().len(), 1);
+    let group = &groups.user_groups()[0];
+    assert_eq!(group.user_group_id(), Some("persist-group"));
+    assert!(group.user_ids().contains(&"persist-user".to_string()));
+    assert!(group.user_ids().contains(&"default".to_string()));
+}
+
+/// Subnet groups survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_subnet_group() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("persist-sg")
+        .cache_subnet_group_description("Persistence test subnet group")
+        .subnet_ids("subnet-aaa")
+        .subnet_ids("subnet-bbb")
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.elasticache_client().await;
+
+    let groups = client
+        .describe_cache_subnet_groups()
+        .cache_subnet_group_name("persist-sg")
+        .send()
+        .await
+        .unwrap();
+    let sgs = groups.cache_subnet_groups();
+    assert_eq!(sgs.len(), 1);
+    assert_eq!(sgs[0].cache_subnet_group_name(), Some("persist-sg"));
+    assert_eq!(
+        sgs[0].cache_subnet_group_description(),
+        Some("Persistence test subnet group")
+    );
+}
+
+/// Tags survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user()
+        .user_id("tagged-user")
+        .user_name("tagged-user")
+        .engine("redis")
+        .access_string("on ~* +@all")
+        .no_password_required(true)
+        .send()
+        .await
+        .unwrap();
+
+    // Get the ARN
+    let users = client
+        .describe_users()
+        .user_id("tagged-user")
+        .send()
+        .await
+        .unwrap();
+    let arn = users.users()[0].arn().unwrap().to_string();
+
+    client
+        .add_tags_to_resource()
+        .resource_name(&arn)
+        .tags(
+            aws_sdk_elasticache::types::Tag::builder()
+                .key("env")
+                .value("prod")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.elasticache_client().await;
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_name(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags
+        .tag_list()
+        .iter()
+        .any(|t| t.key() == Some("env") && t.value() == Some("prod")));
+}
+
+/// Deletion survives a restart.
+#[tokio::test]
+async fn persistence_deletion_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user()
+        .user_id("doomed-user")
+        .user_name("doomed-user")
+        .engine("redis")
+        .access_string("on ~* +@all")
+        .no_password_required(true)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_user()
+        .user_id("doomed-user")
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.elasticache_client().await;
+
+    let users = client.describe_users().send().await.unwrap();
+    assert!(
+        !users
+            .users()
+            .iter()
+            .any(|u| u.user_id() == Some("doomed-user")),
+        "deleted user should not reappear"
+    );
+}

--- a/crates/fakecloud-elasticache/Cargo.toml
+++ b/crates/fakecloud-elasticache/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
@@ -17,6 +18,9 @@ parking_lot = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 form_urlencoded = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -3,19 +3,21 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use http::StatusCode;
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_aws::xml::xml_escape;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::runtime::{ElastiCacheRuntime, RuntimeError};
 use crate::state::{
     default_engine_versions, default_parameters_for_family, CacheCluster, CacheEngineVersion,
-    CacheParameterGroup, CacheSnapshot, CacheSubnetGroup, ElastiCacheState, ElastiCacheUser,
-    ElastiCacheUserGroup, EngineDefaultParameter, GlobalReplicationGroup,
+    CacheParameterGroup, CacheSnapshot, CacheSubnetGroup, ElastiCacheSnapshot, ElastiCacheState,
+    ElastiCacheUser, ElastiCacheUserGroup, EngineDefaultParameter, GlobalReplicationGroup,
     GlobalReplicationGroupMember, RecurringCharge, ReplicationGroup, ReservedCacheNode,
     ReservedCacheNodesOffering, ServerlessCache, ServerlessCacheDataStorage,
     ServerlessCacheEcpuPerSecond, ServerlessCacheEndpoint, ServerlessCacheSnapshot,
-    ServerlessCacheUsageLimits, SharedElastiCacheState,
+    ServerlessCacheUsageLimits, SharedElastiCacheState, ELASTICACHE_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const ELASTICACHE_NS: &str = "http://elasticache.amazonaws.com/doc/2015-02-02/";
@@ -86,6 +88,8 @@ const SUPPORTED_ACTIONS: &[&str] = &[
 pub struct ElastiCacheService {
     state: SharedElastiCacheState,
     runtime: Option<Arc<ElastiCacheRuntime>>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl ElastiCacheService {
@@ -93,6 +97,8 @@ impl ElastiCacheService {
         Self {
             state,
             runtime: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -100,6 +106,54 @@ impl ElastiCacheService {
         self.runtime = Some(runtime);
         self
     }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = ElastiCacheSnapshot {
+            schema_version: ELASTICACHE_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write elasticache snapshot"),
+            Err(err) => tracing::error!(%err, "elasticache snapshot task panicked"),
+        }
+    }
+}
+
+fn is_mutating_action(action: &str) -> bool {
+    !matches!(
+        action,
+        "DescribeCacheClusters"
+            | "DescribeCacheEngineVersions"
+            | "DescribeGlobalReplicationGroups"
+            | "DescribeCacheParameterGroups"
+            | "DescribeReservedCacheNodes"
+            | "DescribeReservedCacheNodesOfferings"
+            | "DescribeCacheSubnetGroups"
+            | "DescribeEngineDefaultParameters"
+            | "DescribeReplicationGroups"
+            | "DescribeServerlessCaches"
+            | "DescribeServerlessCacheSnapshots"
+            | "DescribeSnapshots"
+            | "DescribeUserGroups"
+            | "DescribeUsers"
+            | "ListTagsForResource"
+    )
 }
 
 #[async_trait]
@@ -109,7 +163,8 @@ impl AwsService for ElastiCacheService {
     }
 
     async fn handle(&self, request: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match request.action.as_str() {
+        let mutates = is_mutating_action(request.action.as_str());
+        let result = match request.action.as_str() {
             "AddTagsToResource" => self.add_tags_to_resource(&request),
             "CreateCacheCluster" => self.create_cache_cluster(&request).await,
             "CreateGlobalReplicationGroup" => self.create_global_replication_group(&request),
@@ -164,7 +219,11 @@ impl AwsService for ElastiCacheService {
                 self.service_name(),
                 &request.action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -6,7 +6,7 @@ use parking_lot::RwLock;
 
 pub type SharedElastiCacheState = Arc<RwLock<ElastiCacheState>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CacheEngineVersion {
     pub engine: String,
     pub engine_version: String,
@@ -15,7 +15,7 @@ pub struct CacheEngineVersion {
     pub cache_engine_version_description: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CacheParameterGroup {
     pub cache_parameter_group_name: String,
     pub cache_parameter_group_family: String,
@@ -24,7 +24,7 @@ pub struct CacheParameterGroup {
     pub arn: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EngineDefaultParameter {
     pub parameter_name: String,
     pub parameter_value: String,
@@ -36,7 +36,7 @@ pub struct EngineDefaultParameter {
     pub minimum_engine_version: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CacheSubnetGroup {
     pub cache_subnet_group_name: String,
     pub cache_subnet_group_description: String,
@@ -45,13 +45,13 @@ pub struct CacheSubnetGroup {
     pub arn: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RecurringCharge {
     pub recurring_charge_amount: f64,
     pub recurring_charge_frequency: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ReservedCacheNode {
     pub reserved_cache_node_id: String,
     pub reserved_cache_nodes_offering_id: String,
@@ -68,7 +68,7 @@ pub struct ReservedCacheNode {
     pub reservation_arn: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ReservedCacheNodesOffering {
     pub reserved_cache_nodes_offering_id: String,
     pub cache_node_type: String,
@@ -80,7 +80,7 @@ pub struct ReservedCacheNodesOffering {
     pub recurring_charges: Vec<RecurringCharge>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CacheCluster {
     pub cache_cluster_id: String,
     pub cache_node_type: String,
@@ -100,7 +100,7 @@ pub struct CacheCluster {
     pub replication_group_id: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ReplicationGroup {
     pub replication_group_id: String,
     pub description: String,
@@ -123,7 +123,7 @@ pub struct ReplicationGroup {
     pub snapshot_window: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GlobalReplicationGroupMember {
     pub replication_group_id: String,
     pub replication_group_region: String,
@@ -132,7 +132,7 @@ pub struct GlobalReplicationGroupMember {
     pub status: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GlobalReplicationGroup {
     pub global_replication_group_id: String,
     pub global_replication_group_description: String,
@@ -145,7 +145,7 @@ pub struct GlobalReplicationGroup {
     pub arn: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ElastiCacheUser {
     pub user_id: String,
     pub user_name: String,
@@ -159,7 +159,7 @@ pub struct ElastiCacheUser {
     pub user_group_ids: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ElastiCacheUserGroup {
     pub user_group_id: String,
     pub engine: String,
@@ -171,13 +171,13 @@ pub struct ElastiCacheUserGroup {
     pub replication_groups: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UserGroupPendingChanges {
     pub user_ids_to_add: Vec<String>,
     pub user_ids_to_remove: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CacheSnapshot {
     pub snapshot_name: String,
     pub replication_group_id: String,
@@ -192,32 +192,32 @@ pub struct CacheSnapshot {
     pub snapshot_source: String,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ServerlessCacheUsageLimits {
     pub data_storage: Option<ServerlessCacheDataStorage>,
     pub ecpu_per_second: Option<ServerlessCacheEcpuPerSecond>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ServerlessCacheDataStorage {
     pub maximum: Option<i32>,
     pub minimum: Option<i32>,
     pub unit: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ServerlessCacheEcpuPerSecond {
     pub maximum: Option<i32>,
     pub minimum: Option<i32>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ServerlessCacheEndpoint {
     pub address: String,
     pub port: u16,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ServerlessCache {
     pub serverless_cache_name: String,
     pub description: String,
@@ -240,7 +240,7 @@ pub struct ServerlessCache {
     pub host_port: u16,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ServerlessCacheSnapshot {
     pub serverless_cache_snapshot_name: String,
     pub arn: String,
@@ -255,7 +255,7 @@ pub struct ServerlessCacheSnapshot {
     pub major_engine_version: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ElastiCacheState {
     pub account_id: String,
     pub region: String,
@@ -624,6 +624,14 @@ fn default_users(account_id: &str, region: &str) -> HashMap<String, ElastiCacheU
         },
     );
     map
+}
+
+pub const ELASTICACHE_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ElastiCacheSnapshot {
+    pub schema_version: u32,
+    pub state: ElastiCacheState,
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -382,9 +382,7 @@ async fn main() {
 
     // Register services
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
-        for service in ["bedrock"] {
-            fakecloud_persistence::warn_unsupported(service);
-        }
+        fakecloud_persistence::warn_unsupported("bedrock");
     }
     let mut registry = ServiceRegistry::new();
     let cloudformation_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -382,7 +382,7 @@ async fn main() {
 
     // Register services
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
-        for service in ["elasticache", "bedrock"] {
+        for service in ["bedrock"] {
             fakecloud_persistence::warn_unsupported(service);
         }
     }
@@ -1314,9 +1314,59 @@ async fn main() {
         rds_service = rds_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(rds_service));
+    let elasticache_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("elasticache").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_elasticache::state::ElastiCacheSnapshot>(
+                        &bytes,
+                    ) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_elasticache::state::ELASTICACHE_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "elasticache persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_elasticache::state::ELASTICACHE_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let cluster_count = snapshot.state.cache_clusters.len();
+                            *elasticache_state.write() = snapshot.state;
+                            tracing::info!(
+                                clusters = cluster_count,
+                                "loaded elasticache persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse elasticache persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no elasticache persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read elasticache persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
     let mut elasticache_service = ElastiCacheService::new(elasticache_state);
     if let Some(ref rt) = elasticache_runtime {
         elasticache_service = elasticache_service.with_runtime(rt.clone());
+    }
+    if let Some(store) = elasticache_snapshot_store {
+        elasticache_service = elasticache_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(elasticache_service));
     let mut sfn_service = StepFunctionsService::new(stepfunctions_state.clone());

--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -40,6 +40,7 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 - **Lambda** — functions (code zips, configuration, resource policies), event source mappings. The `/_fakecloud/lambda/invocations` introspection buffer resets on restart; containers are rebuilt from the persisted code zip on first Invoke.
 - **Step Functions** — state machines, definitions, executions, execution history events, tags.
 - **RDS** — DB instances (configuration, credentials, tags), DB snapshots (including dump data), subnet groups, parameter groups.
+- **ElastiCache** — cache clusters, replication groups, global replication groups, subnet groups, parameter groups, users, user groups, snapshots, serverless caches and snapshots, reserved cache nodes, tags.
 - **Every other service** emits `persistence not yet supported, running in-memory` at startup and continues to operate exactly as in memory mode. Your tests don't break — you just don't get cross-restart durability for those services yet.
 
 ## Version compatibility


### PR DESCRIPTION
## Summary
- Add `Serialize`/`Deserialize` to `ElastiCacheState` and all 21 nested types
- Add `ElastiCacheSnapshot` wrapper with schema versioning
- Wire snapshot loading at startup and saving after every mutating action
- Use exclude-list pattern for `is_mutating_action` (all Describe*/List* are read-only, everything else mutates)
- Remove ElastiCache from the "persistence not yet supported" warning

## Test plan
- [x] `persistence_round_trip_user_and_group` — create user + user group, restart, verify both survive
- [x] `persistence_round_trip_subnet_group` — create subnet group, restart, verify it survives
- [x] `persistence_round_trip_tags` — tag a user, restart, verify tags survive
- [x] `persistence_deletion_survives_restart` — create then delete user, restart, verify it stays deleted
- [x] All 4 tests passing locally
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add on-disk persistence for ElastiCache so state survives restarts. Uses a versioned snapshot saved after each successful mutating API call in persistent mode, and includes a minor clippy cleanup.

- **New Features**
  - Persist full ElastiCache state across restarts (clusters, replication groups, global replication groups, parameter groups, users, user groups, subnet groups, snapshots, serverless caches and snapshots, reserved nodes, tags).
  - Versioned `ElastiCacheSnapshot` saved via `SnapshotStore`; loaded on boot and saved after successful mutations.
  - Read-only APIs excluded via a denylist (Describe* and ListTagsForResource); all others trigger saves.
  - Updated docs and added E2E tests (users, user groups, subnet groups, tags; deletions survive). Removed ElastiCache from the unsupported persistence warning.

- **Migration**
  - On snapshot schema mismatch, the server exits with an error; delete `elasticache/snapshot.json` to reset.

<sup>Written for commit 8b895cdabc98661c46a725a0ba5f5a1ac4bd3a2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

