### PR TITLE
feat(s3): implement ABAC resource/request tag extraction

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement_abac.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement_abac.rs
@@ -1,14 +1,14 @@
 //! End-to-end tests for ABAC (attribute-based access control) tag conditions.
 //!
-//! Tests `aws:PrincipalTag/<key>` condition evaluation with
-//! `FAKECLOUD_IAM=strict`. The framework plumbs principal tags from
-//! IamState through to the condition evaluator; this file proves it
-//! works end-to-end with real aws-sdk-rust calls.
+//! Tests `aws:PrincipalTag/<key>`, `aws:ResourceTag/<key>`,
+//! `aws:RequestTag/<key>`, and `aws:TagKeys` condition evaluation with
+//! `FAKECLOUD_IAM=strict`.
 
 mod helpers;
 
 use aws_credential_types::Credentials;
 use aws_sdk_iam::Client as IamClient;
+use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sts::Client as StsClient;
 use helpers::TestServer;
 
@@ -183,5 +183,232 @@ async fn principal_tag_case_sensitive_key() {
     assert!(
         format!("{err:?}").contains("AccessDeniedException"),
         "expected AccessDeniedException — tag keys are case-sensitive"
+    );
+}
+
+// ======================================================================
+// aws:ResourceTag tests (S3)
+// ======================================================================
+
+#[tokio::test]
+async fn s3_resource_tag_allows_when_object_tag_matches() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_tagged_user(&server, "s3alice", &[]).await;
+
+    // Allow all S3, but deny GetObject unless ResourceTag/Environment == dev
+    attach_inline_policy(
+        &server,
+        "s3alice",
+        "AllowAll",
+        r#"{"Version":"2012-10-17","Statement":[
+            {"Effect":"Allow","Action":"s3:*","Resource":"*"}
+        ]}"#,
+    )
+    .await;
+    attach_inline_policy(
+        &server,
+        "s3alice",
+        "DenyGetUnlessDev",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Deny",
+            "Action":"s3:GetObject",
+            "Resource":"arn:aws:s3:::test-bucket/*",
+            "Condition":{"StringNotEquals":{"aws:ResourceTag/Environment":"dev"}}
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let s3 = S3Client::new(&cfg);
+
+    // Create bucket and put an object with tags
+    let boot_cfg = sdk_config_with(&server, "test", "test").await;
+    let boot_s3 = S3Client::new(&boot_cfg);
+    boot_s3
+        .create_bucket()
+        .bucket("test-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // Put object with Environment=dev tag
+    s3.put_object()
+        .bucket("test-bucket")
+        .key("dev-file.txt")
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"hello"))
+        .tagging("Environment=dev")
+        .send()
+        .await
+        .unwrap();
+
+    // Put object with Environment=prod tag
+    s3.put_object()
+        .bucket("test-bucket")
+        .key("prod-file.txt")
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"hello"))
+        .tagging("Environment=prod")
+        .send()
+        .await
+        .unwrap();
+
+    // GetObject on dev file: allowed (ResourceTag/Environment == dev)
+    s3.get_object()
+        .bucket("test-bucket")
+        .key("dev-file.txt")
+        .send()
+        .await
+        .unwrap();
+
+    // GetObject on prod file: denied (ResourceTag/Environment != dev)
+    let err = s3
+        .get_object()
+        .bucket("test-bucket")
+        .key("prod-file.txt")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for prod-tagged object, got {err:?}"
+    );
+}
+
+// ======================================================================
+// aws:RequestTag tests (S3)
+// ======================================================================
+
+#[tokio::test]
+async fn s3_request_tag_denies_put_with_wrong_tag() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_tagged_user(&server, "s3bob", &[]).await;
+
+    // Allow all S3, but deny PutObject unless RequestTag/CostCenter == 123
+    attach_inline_policy(
+        &server,
+        "s3bob",
+        "AllowAll",
+        r#"{"Version":"2012-10-17","Statement":[
+            {"Effect":"Allow","Action":"s3:*","Resource":"*"}
+        ]}"#,
+    )
+    .await;
+    attach_inline_policy(
+        &server,
+        "s3bob",
+        "DenyPutUnlessCC",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Deny",
+            "Action":"s3:PutObject",
+            "Resource":"arn:aws:s3:::tag-bucket/*",
+            "Condition":{"StringNotEquals":{"aws:RequestTag/CostCenter":"123"}}
+        }]}"#,
+    )
+    .await;
+
+    let boot_cfg = sdk_config_with(&server, "test", "test").await;
+    let boot_s3 = S3Client::new(&boot_cfg);
+    boot_s3
+        .create_bucket()
+        .bucket("tag-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let s3 = S3Client::new(&cfg);
+
+    // PutObject with CostCenter=123: allowed
+    s3.put_object()
+        .bucket("tag-bucket")
+        .key("good.txt")
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"ok"))
+        .tagging("CostCenter=123")
+        .send()
+        .await
+        .unwrap();
+
+    // PutObject with CostCenter=999: denied
+    let err = s3
+        .put_object()
+        .bucket("tag-bucket")
+        .key("bad.txt")
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"no"))
+        .tagging("CostCenter=999")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for wrong CostCenter"
+    );
+}
+
+// ======================================================================
+// aws:TagKeys tests (S3)
+// ======================================================================
+
+#[tokio::test]
+async fn s3_tag_keys_for_all_values_restricts_allowed_keys() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_tagged_user(&server, "s3carol", &[]).await;
+
+    // Allow all S3, but deny PutObject with tag keys outside the allowed set
+    attach_inline_policy(
+        &server,
+        "s3carol",
+        "AllowAll",
+        r#"{"Version":"2012-10-17","Statement":[
+            {"Effect":"Allow","Action":"s3:*","Resource":"*"}
+        ]}"#,
+    )
+    .await;
+    attach_inline_policy(
+        &server,
+        "s3carol",
+        "DenyBadTagKeys",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Deny",
+            "Action":"s3:PutObject",
+            "Resource":"arn:aws:s3:::keys-bucket/*",
+            "Condition":{"ForAnyValue:StringNotEquals":{"aws:TagKeys":["Environment","Team"]}}
+        }]}"#,
+    )
+    .await;
+
+    let boot_cfg = sdk_config_with(&server, "test", "test").await;
+    let boot_s3 = S3Client::new(&boot_cfg);
+    boot_s3
+        .create_bucket()
+        .bucket("keys-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let s3 = S3Client::new(&cfg);
+
+    // PutObject with allowed keys only: succeeds
+    s3.put_object()
+        .bucket("keys-bucket")
+        .key("ok.txt")
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"ok"))
+        .tagging("Environment=dev&Team=platform")
+        .send()
+        .await
+        .unwrap();
+
+    // PutObject with disallowed key "Secret": denied
+    let err = s3
+        .put_object()
+        .bucket("keys-bucket")
+        .key("bad.txt")
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"no"))
+        .tagging("Environment=dev&Secret=classified")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for disallowed tag key"
     );
 }

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -717,6 +717,21 @@ impl AwsService for S3Service {
     ) -> std::collections::BTreeMap<String, Vec<String>> {
         s3_condition_keys(action.action, &request.query_params)
     }
+
+    fn resource_tags_for(
+        &self,
+        resource_arn: &str,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        s3_resource_tags(&self.state, resource_arn)
+    }
+
+    fn request_tags_from(
+        &self,
+        request: &AwsRequest,
+        action: &str,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        s3_request_tags(request, action)
+    }
 }
 
 /// Extract service-specific IAM condition keys from an S3 request.
@@ -743,6 +758,71 @@ fn s3_condition_keys(
         }
     }
     out
+}
+
+/// Look up resource tags for an S3 ARN.
+///
+/// Bucket-level ARN (`arn:aws:s3:::bucket`) -> bucket tags.
+/// Object-level ARN (`arn:aws:s3:::bucket/key`) -> object tags.
+/// `*` (ListBuckets) -> `Some(empty)` (no resource to tag).
+fn s3_resource_tags(
+    state: &SharedS3State,
+    resource_arn: &str,
+) -> Option<std::collections::HashMap<String, String>> {
+    if resource_arn == "*" {
+        return Some(std::collections::HashMap::new());
+    }
+    // S3 ARNs: arn:aws:s3:::bucket or arn:aws:s3:::bucket/key
+    let after_prefix = resource_arn.strip_prefix("arn:aws:s3:::")?;
+    let state = state.read();
+    if let Some(slash_pos) = after_prefix.find('/') {
+        // Object-level: bucket/key
+        let bucket_name = &after_prefix[..slash_pos];
+        let key = &after_prefix[slash_pos + 1..];
+        let bucket = state.buckets.get(bucket_name)?;
+        // Try current objects first, then versioned objects (latest version)
+        if let Some(obj) = bucket.objects.get(key) {
+            Some(obj.tags.clone())
+        } else if let Some(versions) = bucket.object_versions.get(key) {
+            versions.last().map(|v| v.tags.clone())
+        } else {
+            // Object doesn't exist yet (e.g. PutObject creating it)
+            Some(std::collections::HashMap::new())
+        }
+    } else {
+        // Bucket-level
+        let bucket = state.buckets.get(after_prefix)?;
+        Some(bucket.tags.clone())
+    }
+}
+
+/// Extract tags from an S3 request body/headers.
+///
+/// S3 sends tags via:
+/// - `x-amz-tagging` header (URL-encoded `key=value&...`) on PutObject
+/// - XML body on PutBucketTagging / PutObjectTagging
+fn s3_request_tags(
+    request: &AwsRequest,
+    action: &str,
+) -> Option<std::collections::HashMap<String, String>> {
+    match action {
+        "PutObject" | "CopyObject" | "CreateMultipartUpload" => {
+            // Tags come via x-amz-tagging header
+            if let Some(tagging) = request.headers.get("x-amz-tagging") {
+                let tags = parse_url_encoded_tags(tagging.to_str().unwrap_or(""));
+                Some(tags.into_iter().collect())
+            } else {
+                Some(std::collections::HashMap::new())
+            }
+        }
+        "PutBucketTagging" | "PutObjectTagging" => {
+            // Tags come in XML body
+            let body = std::str::from_utf8(&request.body).unwrap_or("");
+            let tags = parse_tagging_xml(body);
+            Some(tags.into_iter().collect())
+        }
+        _ => Some(std::collections::HashMap::new()),
+    }
 }
 
 /// Derive the IAM action name from an S3 REST request. Handles the


### PR DESCRIPTION
## Summary

- Implement `resource_tags_for` for S3: parses bucket and object ARNs, returns tags from S3State
- Implement `request_tags_from` for S3: extracts tags from `x-amz-tagging` header (PutObject) and XML body (PutBucketTagging/PutObjectTagging)
- E2E tests covering `aws:ResourceTag/<key>`, `aws:RequestTag/<key>`, and `aws:TagKeys` with S3 operations under `FAKECLOUD_IAM=strict`

## Test plan

- [x] E2E: ResourceTag deny on GetObject with non-matching tag
- [x] E2E: RequestTag deny on PutObject with wrong tag value
- [x] E2E: TagKeys deny on PutObject with disallowed tag keys (ForAnyValue:StringNotEquals)
- [x] All existing tests pass (zero regressions)
- [x] cargo clippy clean, cargo fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add S3 ABAC support for tag-based IAM conditions. We now extract resource and request tags so policies using aws:ResourceTag, aws:RequestTag, and aws:TagKeys work under FAKECLOUD_IAM=strict.

- **New Features**
  - `resource_tags_for` in `fakecloud-s3`: parses bucket/object ARNs and returns tags from state; handles current and versioned objects; returns empty for new objects and `*`.
  - `request_tags_from` in `fakecloud-s3`: extracts tags from `x-amz-tagging` on PutObject/CopyObject/CreateMultipartUpload and from XML on PutBucketTagging/PutObjectTagging.
  - E2E in `fakecloud-e2e`: validates S3 tag conditions (allow/deny GetObject based on object tag, deny PutObject with wrong request tag, restrict tag keys).

<sup>Written for commit 80529225f67ae4bcbe709b46e460316fdb37a084. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

