### PR TITLE
feat(bedrock): persist guardrails, models, jobs, policies, tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -101,7 +101,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -996,11 +996,11 @@ dependencies = [
  "hyper 0.14.32",
  "hyper 1.9.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.8",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -1439,7 +1439,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1479,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1633,7 +1633,7 @@ checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
  "digest 0.10.7",
- "rand 0.9.3",
+ "rand 0.9.4",
  "regex",
  "rustversion",
 ]
@@ -1924,7 +1924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2021,6 +2021,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "percent-encoding",
@@ -2028,6 +2029,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -2887,7 +2889,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3142,14 +3144,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -3467,9 +3469,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -3771,7 +3773,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3840,9 +3842,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3872,9 +3874,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -4160,7 +4162,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -4178,10 +4180,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -4244,9 +4246,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4260,7 +4262,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4303,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -4377,7 +4379,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.8",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
@@ -4385,7 +4387,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -4498,7 +4500,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4515,9 +4517,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4560,14 +4562,14 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.12",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4902,7 +4904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5039,7 +5041,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5157,9 +5159,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -5234,7 +5236,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -5531,9 +5533,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5737,9 +5739,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5779,7 +5781,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/fakecloud-bedrock/Cargo.toml
+++ b/crates/fakecloud-bedrock/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-core = { workspace = true }
 fakecloud-aws = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
@@ -21,6 +22,8 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 regex = { workspace = true }
 percent-encoding = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -1,19 +1,118 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use http::{Method, StatusCode};
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::models;
-use crate::state::SharedBedrockState;
+use crate::state::{BedrockSnapshot, SharedBedrockState, BEDROCK_SNAPSHOT_SCHEMA_VERSION};
 
 pub struct BedrockService {
     state: SharedBedrockState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
+}
+
+fn is_read_only_action(action: &str) -> bool {
+    matches!(
+        action,
+        "ListFoundationModels"
+            | "GetFoundationModel"
+            | "ListTagsForResource"
+            | "GetGuardrail"
+            | "ListGuardrails"
+            | "GetCustomModel"
+            | "ListCustomModels"
+            | "GetCustomModelDeployment"
+            | "ListCustomModelDeployments"
+            | "GetModelImportJob"
+            | "ListModelImportJobs"
+            | "GetImportedModel"
+            | "ListImportedModels"
+            | "GetModelCopyJob"
+            | "ListModelCopyJobs"
+            | "GetModelInvocationJob"
+            | "ListModelInvocationJobs"
+            | "GetEvaluationJob"
+            | "ListEvaluationJobs"
+            | "GetInferenceProfile"
+            | "ListInferenceProfiles"
+            | "GetPromptRouter"
+            | "ListPromptRouters"
+            | "GetResourcePolicy"
+            | "GetMarketplaceModelEndpoint"
+            | "ListMarketplaceModelEndpoints"
+            | "ListFoundationModelAgreementOffers"
+            | "GetFoundationModelAvailability"
+            | "GetUseCaseForModelAccess"
+            | "ListEnforcedGuardrailsConfiguration"
+            | "GetAutomatedReasoningPolicy"
+            | "ListAutomatedReasoningPolicies"
+            | "ExportAutomatedReasoningPolicyVersion"
+            | "GetAutomatedReasoningPolicyTestCase"
+            | "ListAutomatedReasoningPolicyTestCases"
+            | "GetAutomatedReasoningPolicyBuildWorkflow"
+            | "ListAutomatedReasoningPolicyBuildWorkflows"
+            | "GetAutomatedReasoningPolicyBuildWorkflowResultAssets"
+            | "GetAutomatedReasoningPolicyTestResult"
+            | "ListAutomatedReasoningPolicyTestResults"
+            | "GetAutomatedReasoningPolicyAnnotations"
+            | "GetAutomatedReasoningPolicyNextScenario"
+            | "GetModelCustomizationJob"
+            | "ListModelCustomizationJobs"
+            | "GetProvisionedModelThroughput"
+            | "ListProvisionedModelThroughputs"
+            | "GetModelInvocationLoggingConfiguration"
+            | "GetAsyncInvoke"
+            | "ListAsyncInvokes"
+            | "InvokeModel"
+            | "InvokeModelWithResponseStream"
+            | "InvokeModelWithBidirectionalStream"
+            | "Converse"
+            | "ConverseStream"
+            | "CountTokens"
+            | "ApplyGuardrail"
+    )
 }
 
 impl BedrockService {
     pub fn new(state: SharedBedrockState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = BedrockSnapshot {
+            schema_version: BEDROCK_SNAPSHOT_SCHEMA_VERSION,
+            state: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write bedrock snapshot"),
+            Err(err) => tracing::error!(%err, "bedrock snapshot task panicked"),
+        }
     }
 
     fn resolve_action(req: &AwsRequest) -> Option<(&str, Option<String>, Option<String>)> {
@@ -751,9 +850,10 @@ impl AwsService for BedrockService {
                 action: format!("{} {}", req.method, req.raw_path),
             })?;
 
+        let mutates = !is_read_only_action(action);
         let body = req.json_body();
 
-        match action {
+        let result = match action {
             "ListFoundationModels" => self.list_foundation_models(&req),
             "GetFoundationModel" => {
                 self.get_foundation_model(&req, &resource_id.unwrap_or_default())
@@ -1361,7 +1461,11 @@ impl AwsService for BedrockService {
                 service: "bedrock".to_string(),
                 action: action.to_string(),
             }),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -6,6 +6,63 @@ use parking_lot::RwLock;
 
 pub type SharedBedrockState = Arc<RwLock<BedrockState>>;
 
+pub const BEDROCK_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct BedrockSnapshot {
+    pub schema_version: u32,
+    pub state: BedrockState,
+}
+
+/// Serialize/deserialize `HashMap<(String, String), V>` as `Vec<(String, String, V)>`.
+mod tuple2_map_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::collections::HashMap;
+
+    pub fn serialize<V: Serialize, S: Serializer>(
+        map: &HashMap<(String, String), V>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        let entries: Vec<(&String, &String, &V)> =
+            map.iter().map(|((a, b), v)| (a, b, v)).collect();
+        entries.serialize(s)
+    }
+
+    pub fn deserialize<'de, V: Deserialize<'de>, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<HashMap<(String, String), V>, D::Error> {
+        let entries: Vec<(String, String, V)> = Vec::deserialize(d)?;
+        Ok(entries.into_iter().map(|(a, b, v)| ((a, b), v)).collect())
+    }
+}
+
+/// Serialize/deserialize `HashMap<(String, String, String), V>` as `Vec<(String, String, String, V)>`.
+#[allow(clippy::type_complexity)]
+mod tuple3_map_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::collections::HashMap;
+
+    pub fn serialize<V: Serialize, S: Serializer>(
+        map: &HashMap<(String, String, String), V>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        let entries: Vec<(&String, &String, &String, &V)> =
+            map.iter().map(|((a, b, c), v)| (a, b, c, v)).collect();
+        entries.serialize(s)
+    }
+
+    pub fn deserialize<'de, V: Deserialize<'de>, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<HashMap<(String, String, String), V>, D::Error> {
+        let entries: Vec<(String, String, String, V)> = Vec::deserialize(d)?;
+        Ok(entries
+            .into_iter()
+            .map(|(a, b, c, v)| ((a, b, c), v))
+            .collect())
+    }
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct BedrockState {
     pub account_id: String,
     pub region: String,
@@ -14,6 +71,7 @@ pub struct BedrockState {
     /// Guardrails keyed by guardrail ID.
     pub guardrails: HashMap<String, Guardrail>,
     /// Guardrail versions keyed by (guardrail_id, version).
+    #[serde(with = "tuple2_map_serde")]
     pub guardrail_versions: HashMap<(String, String), GuardrailVersion>,
     /// Model customization jobs keyed by job ARN.
     pub customization_jobs: HashMap<String, CustomizationJob>,
@@ -22,14 +80,16 @@ pub struct BedrockState {
     /// Model invocation logging configuration.
     pub logging_config: Option<LoggingConfig>,
     /// All model invocations recorded for introspection.
+    #[serde(skip)]
     pub invocations: Vec<ModelInvocation>,
     /// Custom responses configured per model ID via simulation endpoint.
+    #[serde(skip)]
     pub custom_responses: HashMap<String, String>,
-    /// Prompt-conditional response rules per model ID. Evaluated in order;
-    /// the first rule whose `prompt_contains` matches wins.
+    /// Prompt-conditional response rules per model ID.
+    #[serde(skip)]
     pub response_rules: HashMap<String, Vec<ResponseRule>>,
-    /// Queued fault-injection rules. Consumed in order; rules with filters
-    /// only trigger when both `model_id` and `operation` match.
+    /// Queued fault-injection rules.
+    #[serde(skip)]
     pub fault_rules: Vec<FaultRule>,
     /// Async invocations keyed by invocation ARN.
     pub async_invocations: HashMap<String, AsyncInvocation>,
@@ -64,12 +124,16 @@ pub struct BedrockState {
     /// Automated reasoning policies keyed by policy ARN.
     pub automated_reasoning_policies: HashMap<String, AutomatedReasoningPolicy>,
     /// Automated reasoning test cases keyed by (policy_arn, test_case_id).
+    #[serde(with = "tuple2_map_serde")]
     pub automated_reasoning_test_cases: HashMap<(String, String), AutomatedReasoningTestCase>,
     /// Automated reasoning build workflows keyed by (policy_arn, workflow_id).
+    #[serde(with = "tuple2_map_serde")]
     pub ar_build_workflows: HashMap<(String, String), AutomatedReasoningBuildWorkflow>,
     /// Automated reasoning test results keyed by (policy_arn, workflow_id, test_case_id).
+    #[serde(with = "tuple3_map_serde")]
     pub ar_test_results: HashMap<(String, String, String), serde_json::Value>,
     /// Automated reasoning annotations keyed by (policy_arn, workflow_id).
+    #[serde(with = "tuple2_map_serde")]
     pub ar_annotations: HashMap<(String, String), serde_json::Value>,
 }
 
@@ -145,7 +209,7 @@ impl BedrockState {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct Guardrail {
     pub guardrail_id: String,
     pub guardrail_arn: String,
@@ -164,7 +228,7 @@ pub struct Guardrail {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct GuardrailVersion {
     pub guardrail_id: String,
     pub guardrail_arn: String,
@@ -181,7 +245,7 @@ pub struct GuardrailVersion {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct CustomizationJob {
     pub job_arn: String,
     pub job_name: String,
@@ -196,7 +260,7 @@ pub struct CustomizationJob {
     pub last_modified_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProvisionedThroughput {
     pub provisioned_model_id: String,
     pub provisioned_model_arn: String,
@@ -210,7 +274,7 @@ pub struct ProvisionedThroughput {
     pub last_modified_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct LoggingConfig {
     pub cloud_watch_config: Option<serde_json::Value>,
     pub s3_config: Option<serde_json::Value>,
@@ -219,7 +283,7 @@ pub struct LoggingConfig {
     pub embedding_data_delivery_enabled: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ResponseRule {
     /// Substring to look for in the extracted prompt text. `None` or empty
     /// matches any prompt.
@@ -228,7 +292,7 @@ pub struct ResponseRule {
     pub response: String,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ModelInvocation {
     pub model_id: String,
     pub input: String,
@@ -239,7 +303,7 @@ pub struct ModelInvocation {
     pub error: Option<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct FaultRule {
     pub error_type: String,
     pub message: String,
@@ -249,7 +313,7 @@ pub struct FaultRule {
     pub operation: Option<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct AsyncInvocation {
     pub invocation_arn: String,
     pub model_arn: String,
@@ -262,7 +326,7 @@ pub struct AsyncInvocation {
     pub end_time: Option<DateTime<Utc>>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct CustomModel {
     pub model_arn: String,
     pub model_name: String,
@@ -273,7 +337,7 @@ pub struct CustomModel {
     pub creation_time: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct CustomModelDeployment {
     pub deployment_arn: String,
     pub deployment_name: String,
@@ -284,7 +348,7 @@ pub struct CustomModelDeployment {
     pub last_updated_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ModelImportJob {
     pub job_arn: String,
     pub job_name: String,
@@ -297,7 +361,7 @@ pub struct ModelImportJob {
     pub last_modified_time: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ImportedModel {
     pub model_arn: String,
     pub model_name: String,
@@ -306,7 +370,7 @@ pub struct ImportedModel {
     pub creation_time: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ModelCopyJob {
     pub job_arn: String,
     pub source_model_arn: String,
@@ -316,7 +380,7 @@ pub struct ModelCopyJob {
     pub creation_time: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ModelInvocationJob {
     pub job_arn: String,
     pub job_name: String,
@@ -330,7 +394,7 @@ pub struct ModelInvocationJob {
     pub end_time: Option<DateTime<Utc>>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct EvaluationJob {
     pub job_arn: String,
     pub job_name: String,
@@ -345,7 +409,7 @@ pub struct EvaluationJob {
     pub last_modified_time: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct InferenceProfile {
     pub inference_profile_arn: String,
     pub inference_profile_name: String,
@@ -357,7 +421,7 @@ pub struct InferenceProfile {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct PromptRouter {
     pub prompt_router_arn: String,
     pub prompt_router_name: String,
@@ -371,7 +435,7 @@ pub struct PromptRouter {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct MarketplaceModelEndpoint {
     pub endpoint_arn: String,
     pub endpoint_name: String,
@@ -382,14 +446,14 @@ pub struct MarketplaceModelEndpoint {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct FoundationModelAgreement {
     pub agreement_id: String,
     pub model_id: String,
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct AutomatedReasoningPolicy {
     pub policy_arn: String,
     pub policy_name: String,
@@ -402,7 +466,7 @@ pub struct AutomatedReasoningPolicy {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct AutomatedReasoningBuildWorkflow {
     pub workflow_id: String,
     pub policy_arn: String,
@@ -412,7 +476,7 @@ pub struct AutomatedReasoningBuildWorkflow {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct AutomatedReasoningTestCase {
     pub test_case_id: String,
     pub policy_arn: String,

--- a/crates/fakecloud-e2e/tests/bedrock_persistence.rs
+++ b/crates/fakecloud-e2e/tests/bedrock_persistence.rs
@@ -1,0 +1,128 @@
+mod helpers;
+
+use aws_sdk_bedrock::types::Tag;
+use helpers::TestServer;
+
+/// Guardrails and their versions survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_guardrail() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.bedrock_client().await;
+
+    let created = client
+        .create_guardrail()
+        .name("persist-guard")
+        .description("Persistence test guardrail")
+        .blocked_input_messaging("blocked")
+        .blocked_outputs_messaging("blocked")
+        .send()
+        .await
+        .unwrap();
+    let guardrail_id = created.guardrail_id().to_string();
+
+    // Create a version
+    client
+        .create_guardrail_version()
+        .guardrail_identifier(&guardrail_id)
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.bedrock_client().await;
+
+    // Guardrail survives
+    let got = client
+        .get_guardrail()
+        .guardrail_identifier(&guardrail_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.name(), "persist-guard");
+    assert_eq!(got.description(), Some("Persistence test guardrail"));
+
+    // List should include it
+    let list = client.list_guardrails().send().await.unwrap();
+    assert!(list
+        .guardrails()
+        .iter()
+        .any(|g| g.name() == "persist-guard"));
+}
+
+/// Tags survive a restart.
+#[tokio::test]
+async fn persistence_round_trip_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.bedrock_client().await;
+
+    let created = client
+        .create_guardrail()
+        .name("tagged-guard")
+        .blocked_input_messaging("blocked")
+        .blocked_outputs_messaging("blocked")
+        .send()
+        .await
+        .unwrap();
+    let guardrail_arn = created.guardrail_arn().to_string();
+
+    client
+        .tag_resource()
+        .resource_arn(&guardrail_arn)
+        .tags(Tag::builder().key("env").value("prod").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.bedrock_client().await;
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(&guardrail_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags
+        .tags()
+        .iter()
+        .any(|t: &Tag| t.key() == "env" && t.value() == "prod"));
+}
+
+/// Deletion survives a restart.
+#[tokio::test]
+async fn persistence_deletion_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.bedrock_client().await;
+
+    let created = client
+        .create_guardrail()
+        .name("doomed-guard")
+        .blocked_input_messaging("blocked")
+        .blocked_outputs_messaging("blocked")
+        .send()
+        .await
+        .unwrap();
+    let guardrail_id = created.guardrail_id().to_string();
+
+    client
+        .delete_guardrail()
+        .guardrail_identifier(&guardrail_id)
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.bedrock_client().await;
+
+    let list = client.list_guardrails().send().await.unwrap();
+    assert!(
+        !list.guardrails().iter().any(|g| g.name() == "doomed-guard"),
+        "deleted guardrail should not reappear"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -381,9 +381,6 @@ async fn main() {
     };
 
     // Register services
-    if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
-        fakecloud_persistence::warn_unsupported("bedrock");
-    }
     let mut registry = ServiceRegistry::new();
     let cloudformation_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -1517,7 +1514,58 @@ async fn main() {
         apigw_service = apigw_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(apigw_service));
-    registry.register(Arc::new(BedrockService::new(bedrock_state.clone())));
+    let bedrock_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("bedrock").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_bedrock::state::BedrockSnapshot>(
+                        &bytes,
+                    ) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                != fakecloud_bedrock::state::BEDROCK_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "bedrock persistence schema mismatch: on-disk={}, expected={}",
+                                    snapshot.schema_version,
+                                    fakecloud_bedrock::state::BEDROCK_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let guardrail_count = snapshot.state.guardrails.len();
+                            *bedrock_state.write() = snapshot.state;
+                            tracing::info!(
+                                guardrails = guardrail_count,
+                                "loaded bedrock persistence snapshot",
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse bedrock persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no bedrock persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read bedrock persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut bedrock_service = BedrockService::new(bedrock_state.clone());
+    if let Some(store) = bedrock_snapshot_store {
+        bedrock_service = bedrock_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(bedrock_service));
 
     // Spawn background tasks
     let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state.clone());

--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -41,7 +41,7 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 - **Step Functions** — state machines, definitions, executions, execution history events, tags.
 - **RDS** — DB instances (configuration, credentials, tags), DB snapshots (including dump data), subnet groups, parameter groups.
 - **ElastiCache** — cache clusters, replication groups, global replication groups, subnet groups, parameter groups, users, user groups, snapshots, serverless caches and snapshots, reserved cache nodes, tags.
-- **Every other service** emits `persistence not yet supported, running in-memory` at startup and continues to operate exactly as in memory mode. Your tests don't break — you just don't get cross-restart durability for those services yet.
+- **Bedrock** — guardrails, guardrail versions, customization jobs, provisioned throughputs, logging config, async invocations, custom models, deployments, model import/copy/invocation jobs, evaluation jobs, inference profiles, prompt routers, resource policies, marketplace endpoints, foundation model agreements, automated reasoning policies/test cases/workflows, tags. The `/_fakecloud/bedrock/invocations` introspection buffer and simulation config (custom responses, response rules, fault rules) reset on restart.
 
 ## Version compatibility
 


### PR DESCRIPTION
## Summary
- Add `Serialize`/`Deserialize` to `BedrockState` and all nested types
- Solve the tuple-key Serde blocker with custom serde modules for 5 HashMaps (`guardrail_versions`, `automated_reasoning_test_cases`, `ar_build_workflows`, `ar_test_results`, `ar_annotations`) — serialized as Vec of tuples
- Skip introspection (`invocations`) and simulation config (`custom_responses`, `response_rules`, `fault_rules`) — these reset on restart
- Wire snapshot loading at startup and saving after every mutating action
- Remove bedrock from the "persistence not yet supported" warning (the warning loop is now gone entirely)

## Test plan
- [x] `persistence_round_trip_guardrail` — create guardrail + version, restart, verify both survive
- [x] `persistence_round_trip_tags` — tag a guardrail, restart, verify tags survive
- [x] `persistence_deletion_survives_restart` — create then delete guardrail, restart, verify it stays deleted
- [x] All 3 tests passing locally
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Bedrock data to disk and restore it on startup, so guardrails, models, jobs, policies, and tags survive restarts. Snapshots are versioned and saved after each successful mutation.

- **New Features**
  - Added `Serialize`/`Deserialize` to `BedrockState` and nested types; tuple-key maps use custom serde; skipped fields: `invocations`, `custom_responses`, `response_rules`, `fault_rules`.
  - `BedrockService` integrates with a `SnapshotStore`; saves snapshots only for mutating actions that succeed (read-only actions are whitelisted); writes run under a lock in `spawn_blocking`.
  - Server loads `bedrock/snapshot.json` on boot, validates schema via `BedrockSnapshot`, logs status, and removes the Bedrock persistence warning.
  - E2E tests verify guardrail+version, tags, and deletions persist across restart; docs list Bedrock persistence.

- **Dependencies**
  - `fakecloud-bedrock`: add `fakecloud-persistence`, `tokio`, `tracing`.

<sup>Written for commit 1a0575b59520f74cb84e9d01c6a3adc01df11c2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

