### PR TITLE
feat(iam): implement ABAC for SQS, SNS, and IAM services

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement_abac.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement_abac.rs
@@ -9,6 +9,7 @@ mod helpers;
 use aws_credential_types::Credentials;
 use aws_sdk_iam::Client as IamClient;
 use aws_sdk_s3::Client as S3Client;
+use aws_sdk_sqs::Client as SqsClient;
 use aws_sdk_sts::Client as StsClient;
 use helpers::TestServer;
 
@@ -410,5 +411,163 @@ async fn s3_tag_keys_for_all_values_restricts_allowed_keys() {
     assert!(
         format!("{err:?}").contains("AccessDenied"),
         "expected AccessDenied for disallowed tag key"
+    );
+}
+
+// ======================================================================
+// SQS ABAC tests
+// ======================================================================
+
+#[tokio::test]
+async fn sqs_resource_tag_denies_when_queue_tag_mismatches() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_tagged_user(&server, "sqsuser", &[]).await;
+
+    // Allow all SQS, deny SendMessage unless ResourceTag/Env == dev
+    attach_inline_policy(
+        &server,
+        "sqsuser",
+        "AllowAll",
+        r#"{"Version":"2012-10-17","Statement":[
+            {"Effect":"Allow","Action":"sqs:*","Resource":"*"}
+        ]}"#,
+    )
+    .await;
+    attach_inline_policy(
+        &server,
+        "sqsuser",
+        "DenySendUnlessDev",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Deny",
+            "Action":"sqs:SendMessage",
+            "Resource":"*",
+            "Condition":{"StringNotEquals":{"aws:ResourceTag/Env":"dev"}}
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sqs = SqsClient::new(&cfg);
+
+    // Create a queue tagged Env=dev
+    let dev_queue = sqs
+        .create_queue()
+        .queue_name("dev-queue")
+        .tags("Env", "dev")
+        .send()
+        .await
+        .unwrap();
+    let dev_url = dev_queue.queue_url().unwrap();
+
+    // Create a queue tagged Env=prod
+    let prod_queue = sqs
+        .create_queue()
+        .queue_name("prod-queue")
+        .tags("Env", "prod")
+        .send()
+        .await
+        .unwrap();
+    let prod_url = prod_queue.queue_url().unwrap();
+
+    // SendMessage to dev queue: allowed
+    sqs.send_message()
+        .queue_url(dev_url)
+        .message_body("hello dev")
+        .send()
+        .await
+        .unwrap();
+
+    // SendMessage to prod queue: denied
+    let err = sqs
+        .send_message()
+        .queue_url(prod_url)
+        .message_body("hello prod")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for prod-tagged queue"
+    );
+}
+
+// ======================================================================
+// IAM resource tag ABAC tests
+// ======================================================================
+
+#[tokio::test]
+async fn iam_resource_tag_denies_get_user_without_matching_tag() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_tagged_user(&server, "iamadmin", &[]).await;
+
+    // Allow all IAM, deny GetUser unless ResourceTag/Team == ops
+    attach_inline_policy(
+        &server,
+        "iamadmin",
+        "AllowAll",
+        r#"{"Version":"2012-10-17","Statement":[
+            {"Effect":"Allow","Action":"iam:*","Resource":"*"}
+        ]}"#,
+    )
+    .await;
+    attach_inline_policy(
+        &server,
+        "iamadmin",
+        "DenyGetUserUnlessOps",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Deny",
+            "Action":"iam:GetUser",
+            "Resource":"*",
+            "Condition":{"StringNotEquals":{"aws:ResourceTag/Team":"ops"}}
+        }]}"#,
+    )
+    .await;
+
+    // Create two users: one with Team=ops, one with Team=dev
+    let boot_cfg = sdk_config_with(&server, "test", "test").await;
+    let boot_iam = IamClient::new(&boot_cfg);
+    boot_iam
+        .create_user()
+        .user_name("ops-user")
+        .tags(
+            aws_sdk_iam::types::Tag::builder()
+                .key("Team")
+                .value("ops")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    boot_iam
+        .create_user()
+        .user_name("dev-user")
+        .tags(
+            aws_sdk_iam::types::Tag::builder()
+                .key("Team")
+                .value("dev")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let iam = IamClient::new(&cfg);
+
+    // GetUser ops-user: allowed (Team=ops matches)
+    iam.get_user().user_name("ops-user").send().await.unwrap();
+
+    // GetUser dev-user: denied (Team=dev != ops)
+    let err = iam
+        .get_user()
+        .user_name("dev-user")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for dev-tagged user"
     );
 }

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -424,6 +424,107 @@ impl AwsService for IamService {
             resource: iam_action_resource(static_action, partition, account, request),
         })
     }
+
+    fn resource_tags_for(
+        &self,
+        resource_arn: &str,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        iam_resource_tags(&self.state, resource_arn)
+    }
+
+    fn request_tags_from(
+        &self,
+        request: &AwsRequest,
+        action: &str,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        iam_request_tags(request, action)
+    }
+}
+
+/// Look up resource tags for an IAM ARN.
+///
+/// IAM ARN formats:
+/// - `arn:{p}:iam::{account}:user/{path/}name`
+/// - `arn:{p}:iam::{account}:role/{path/}name`
+/// - `arn:{p}:iam::{account}:policy/{path/}name`
+/// - `arn:{p}:iam::{account}:instance-profile/{path/}name`
+/// - `*` for account-level operations
+fn iam_resource_tags(
+    state: &SharedIamState,
+    resource_arn: &str,
+) -> Option<std::collections::HashMap<String, String>> {
+    if resource_arn == "*" {
+        return Some(std::collections::HashMap::new());
+    }
+    // Parse the resource segment after the 6th colon
+    let parts: Vec<&str> = resource_arn.split(':').collect();
+    if parts.len() < 6 {
+        return None;
+    }
+    let resource = parts[5];
+    let state = state.read();
+    if let Some(rest) = resource.strip_prefix("user/") {
+        let name = rest.rsplit('/').next().unwrap_or(rest);
+        state
+            .users
+            .get(name)
+            .map(|u| tags_to_hashmap_or_empty(&u.tags))
+    } else if let Some(rest) = resource.strip_prefix("role/") {
+        let name = rest.rsplit('/').next().unwrap_or(rest);
+        state
+            .roles
+            .get(name)
+            .map(|r| tags_to_hashmap_or_empty(&r.tags))
+    } else if resource.starts_with("policy/") {
+        // Policies are keyed by full ARN
+        state
+            .policies
+            .get(resource_arn)
+            .map(|p| tags_to_hashmap_or_empty(&p.tags))
+    } else if let Some(rest) = resource.strip_prefix("instance-profile/") {
+        let name = rest.rsplit('/').next().unwrap_or(rest);
+        state
+            .instance_profiles
+            .get(name)
+            .map(|ip| tags_to_hashmap_or_empty(&ip.tags))
+    } else {
+        Some(std::collections::HashMap::new())
+    }
+}
+
+fn tags_to_hashmap_or_empty(tags: &[Tag]) -> std::collections::HashMap<String, String> {
+    tags.iter()
+        .map(|t| (t.key.clone(), t.value.clone()))
+        .collect()
+}
+
+/// Extract request tags from IAM operations that accept tags.
+fn iam_request_tags(
+    request: &AwsRequest,
+    action: &str,
+) -> Option<std::collections::HashMap<String, String>> {
+    const TAG_ACTIONS: &[&str] = &[
+        "CreateUser",
+        "TagUser",
+        "CreateRole",
+        "TagRole",
+        "CreatePolicy",
+        "TagPolicy",
+        "CreateInstanceProfile",
+        "TagInstanceProfile",
+        "CreateOpenIDConnectProvider",
+        "TagOpenIDConnectProvider",
+        "CreateSAMLProvider",
+        "TagSAMLProvider",
+        "UploadServerCertificate",
+        "TagServerCertificate",
+    ];
+    if TAG_ACTIONS.contains(&action) {
+        let tags = parse_tags(&request.query_params);
+        Some(tags.into_iter().map(|t| (t.key, t.value)).collect())
+    } else {
+        Some(std::collections::HashMap::new())
+    }
 }
 
 /// Derive the fully-qualified IAM resource ARN for a given action +

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -298,6 +298,32 @@ impl AwsService for SnsService {
         }
         out
     }
+
+    fn resource_tags_for(
+        &self,
+        resource_arn: &str,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        if resource_arn == "*" {
+            return Some(std::collections::HashMap::new());
+        }
+        let state = self.state.read();
+        let topic = state.topics.get(resource_arn)?;
+        Some(topic.tags.iter().cloned().collect())
+    }
+
+    fn request_tags_from(
+        &self,
+        request: &AwsRequest,
+        action: &str,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        match action {
+            "CreateTopic" | "TagResource" => {
+                let tags = parse_tags(request);
+                Some(tags.into_iter().collect())
+            }
+            _ => Some(std::collections::HashMap::new()),
+        }
+    }
 }
 
 const SNS_SUPPORTED_ACTIONS: &[&str] = &[

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -571,6 +571,50 @@ impl AwsService for SqsService {
         }
         out
     }
+
+    fn resource_tags_for(
+        &self,
+        resource_arn: &str,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        if resource_arn == "*" {
+            return Some(std::collections::HashMap::new());
+        }
+        // SQS ARN: arn:{partition}:sqs:{region}:{account}:{queue-name}
+        let parts: Vec<&str> = resource_arn.split(':').collect();
+        if parts.len() < 6 {
+            return None;
+        }
+        let queue_name = parts[5];
+        let state = self.state.read();
+        let queue_url = state.name_to_url.get(queue_name)?;
+        let queue = state.queues.get(queue_url)?;
+        Some(queue.tags.clone())
+    }
+
+    fn request_tags_from(
+        &self,
+        request: &AwsRequest,
+        action: &str,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        match action {
+            "CreateQueue" | "TagQueue" => {
+                let body = parse_body(request);
+                let mut tags = std::collections::HashMap::new();
+                // Both CreateQueue and TagQueue send tags as JSON objects
+                for field in &["tags", "Tags"] {
+                    if let Some(obj) = body[field].as_object() {
+                        for (k, v) in obj {
+                            if let Some(val) = v.as_str() {
+                                tags.insert(k.clone(), val.to_string());
+                            }
+                        }
+                    }
+                }
+                Some(tags)
+            }
+            _ => Some(std::collections::HashMap::new()),
+        }
+    }
 }
 
 /// Build the SQS resource ARN for an incoming action. Returns `*` for


### PR DESCRIPTION
## Summary

- Implement `resource_tags_for` and `request_tags_from` for SQS, SNS, and IAM services
- SQS: queue tag lookup by ARN, request tag extraction from CreateQueue/TagQueue JSON
- SNS: topic tag lookup by ARN (Vec to HashMap conversion), request tags from query params
- IAM: user/role/policy/instance-profile tag lookup from ARN parsing, request tags from Tag* operations
- STS left with trait defaults (no taggable resources)
- E2E tests for SQS ResourceTag and IAM ResourceTag conditions

## Test plan

- [x] E2E: SQS SendMessage denied on prod-tagged queue, allowed on dev-tagged
- [x] E2E: IAM GetUser denied on dev-tagged user, allowed on ops-tagged
- [x] All 9 ABAC E2E tests pass
- [x] All workspace lib tests pass (zero regressions)
- [x] cargo clippy clean, cargo fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements ABAC for SQS, SNS, and IAM so policies can evaluate `aws:ResourceTag` conditions using resource and request tags.

- **New Features**
  - `fakecloud-sqs`: parse queue ARN, fetch tags via `name_to_url`; extract tags from `CreateQueue`/`TagQueue` JSON (`tags`/`Tags` objects).
  - `fakecloud-sns`: look up topic tags by ARN; extract tags from query params for `CreateTopic`/`TagResource`.
  - `fakecloud-iam`: resolve tags for `user/`, `role/`, `policy/`, and `instance-profile/` ARNs; extract tags from `Create*`/`Tag*` operations via query params.
  - `fakecloud-sts`: no changes (no taggable resources).
  - E2E: SQS `SendMessage` denied on prod-tagged queue, allowed on dev-tagged; IAM `GetUser` denied on dev-tagged user, allowed on ops-tagged.

<sup>Written for commit 1f080e325281083fcd4b41d8d6ce5719c94cc2f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

