### PR TITLE
docs: update persistence docs now that all 21 services are persisted

### DIFF
--- a/crates/fakecloud-persistence/src/lib.rs
+++ b/crates/fakecloud-persistence/src/lib.rs
@@ -5,7 +5,6 @@ pub mod key_escape;
 pub mod s3;
 pub mod snapshot;
 pub mod version;
-pub mod warn;
 
 pub use config::{PersistenceConfig, StorageMode};
 pub use s3::{
@@ -15,4 +14,3 @@ pub use s3::{
     TagsSnapshot, UploadPartMeta,
 };
 pub use snapshot::{DiskSnapshotStore, MemorySnapshotStore, SnapshotStore};
-pub use warn::warn_unsupported;

--- a/crates/fakecloud-persistence/src/warn.rs
+++ b/crates/fakecloud-persistence/src/warn.rs
@@ -1,8 +1,0 @@
-/// Emit a one-shot warning that a given service does not yet honor
-/// `PersistenceConfig` and will continue to run purely in memory.
-pub fn warn_unsupported(service_name: &str) {
-    tracing::warn!(
-        service = service_name,
-        "persistence not yet supported, running in-memory"
-    );
-}

--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -6,7 +6,7 @@ weight = 2
 
 By default fakecloud keeps all state in memory: startup is instant, shutdown is a no-op, and tests can run in parallel without cross-contamination. That's what you want for CI and most dev workflows.
 
-For longer-running local environments where you want state to survive restarts, pass `--storage-mode=persistent --data-path=<dir>` to mirror supported services to disk.
+For longer-running local environments where you want state to survive restarts, pass `--storage-mode=persistent --data-path=<dir>` to mirror all service state to disk.
 
 ## Enabling persistent mode
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -66,7 +66,7 @@ fakecloud listens at `http://localhost:4566`.
 | `--region` | `FAKECLOUD_REGION` | `us-east-1` | AWS region to advertise |
 | `--account-id` | `FAKECLOUD_ACCOUNT_ID` | `123456789012` | AWS account ID |
 | `--log-level` | `FAKECLOUD_LOG` | `info` | Log level (trace, debug, info, warn, error) |
-| `--storage-mode` | `FAKECLOUD_STORAGE_MODE` | `memory` | `memory` (default) or `persistent` (mirror S3 state to `--data-path`) |
+| `--storage-mode` | `FAKECLOUD_STORAGE_MODE` | `memory` | `memory` (default) or `persistent` (mirror all state to `--data-path`) |
 | `--data-path` | `FAKECLOUD_DATA_PATH` | — | Directory to persist state to. Required when `--storage-mode=persistent`. |
 | `--s3-cache-size` | `FAKECLOUD_S3_CACHE_SIZE` | `268435456` | In-memory LRU cache for S3 object bodies in persistent mode. Default 256 MiB. |
 
@@ -74,20 +74,20 @@ fakecloud listens at `http://localhost:4566`.
 
 Default is `memory` mode — all state lives in RAM, startup is instant,
 shutdown is a no-op. Pass `--storage-mode=persistent --data-path=<dir>` to
-mirror supported services to disk and reload them on the next launch.
+mirror all service state to disk and reload on the next launch.
 
-S3 is the only service wired up today: buckets, objects, versions, delete
-markers, multipart uploads (resumable across restarts), and every bucket
-subresource are written to disk on every mutation and reloaded on startup.
-Other services emit `persistence not yet supported, running in-memory` at
-startup and continue to operate exactly as in memory mode.
+All 21 services are fully persisted: S3, SQS, SNS, EventBridge, IAM/STS,
+SSM, Secrets Manager, CloudWatch Logs, KMS, DynamoDB, Kinesis, SES,
+API Gateway v2, CloudFormation, Cognito, Lambda, Step Functions, RDS,
+ElastiCache, and Bedrock. State is written to disk on every mutation and
+reloaded on startup.
 
 The data directory is guarded by `fakecloud.version.toml`. A format mismatch
-fails startup loudly — there is no auto-migration. Object bodies stream
+fails startup loudly — there is no auto-migration. S3 object bodies stream
 straight to disk; a bounded LRU (`--s3-cache-size`, default 256 MiB) caches
 recent reads, and objects larger than `cache-size / 2` bypass the cache so a
-single large upload cannot evict everything. `/_fakecloud/s3/notifications`
-is intentionally in-memory only.
+single large upload cannot evict everything. Introspection buffers
+(`/_fakecloud/*/`) are intentionally not persisted — they reset on restart.
 
 ### Health check
 ```sh


### PR DESCRIPTION
## Summary
- Remove stale "S3 is the only service wired up today" claim from `llms-full.txt`, replace with complete list of all 21 persisted services
- Update "mirror supported services" -> "mirror all service state" in persistence.md and llms-full.txt
- Delete dead `warn_unsupported()` function and `warn.rs` module (no callers remain after #475, #477, #479)

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `grep -r warn_unsupported` returns zero results

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update persistence docs to reflect that all 21 services are fully persisted and clarify CLI text to “mirror all service state.” Also remove the outdated S3-only note.

- **Refactors**
  - Delete unused `warn_unsupported()` and `warn` module and remove its export from `fakecloud-persistence`.

<sup>Written for commit da74981e513c025405f7115ed4cf91367d76c041. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

