### PR TITLE
test(lambda,sns): error-branch tests for Lambda and SNS handlers

### DIFF
--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1514,4 +1514,122 @@ mod tests {
             "arn:aws:lambda:us-east-1:123456789012:function:newfn"
         );
     }
+
+    // ── Error branch tests ──
+
+    #[tokio::test]
+    async fn create_function_duplicate_returns_conflict() {
+        let svc = LambdaService::new(make_state());
+        seed_function(&svc, "dup-fn").await;
+
+        let body = json!({
+            "FunctionName": "dup-fn",
+            "Runtime": "python3.12",
+            "Role": "arn:aws:iam::123456789012:role/r",
+            "Handler": "index.handler",
+            "Code": {"ZipFile": "UEsDBBQ="},
+        });
+        let req = make_request(Method::POST, "/2015-03-31/functions", &body.to_string());
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected ResourceConflictException"),
+        };
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn get_function_not_found() {
+        let svc = LambdaService::new(make_state());
+        let req = make_request(Method::GET, "/2015-03-31/functions/nope", "");
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_function_not_found() {
+        let svc = LambdaService::new(make_state());
+        let req = make_request(Method::DELETE, "/2015-03-31/functions/nope", "");
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_event_source_mapping_not_found() {
+        let svc = LambdaService::new(make_state());
+        let req = make_request(
+            Method::GET,
+            "/2015-03-31/event-source-mappings/nonexistent",
+            "",
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_event_source_mapping_not_found() {
+        let svc = LambdaService::new(make_state());
+        let req = make_request(
+            Method::DELETE,
+            "/2015-03-31/event-source-mappings/nonexistent",
+            "",
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_policy_on_missing_function() {
+        let svc = LambdaService::new(make_state());
+        let req = make_request(Method::GET, "/2015-03-31/functions/nope/policy", "");
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn remove_permission_on_missing_function() {
+        let svc = LambdaService::new(make_state());
+        let req = make_request(
+            Method::DELETE,
+            "/2015-03-31/functions/nope/policy/stmt1",
+            "",
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn publish_version_on_missing_function() {
+        let svc = LambdaService::new(make_state());
+        let req = make_request(Method::POST, "/2015-03-31/functions/nope/versions", "{}");
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn unknown_route_returns_error() {
+        let svc = LambdaService::new(make_state());
+        let req = make_request(Method::POST, "/unknown/route", "{}");
+        assert!(svc.handle(req).await.is_err());
+    }
 }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -5435,4 +5435,206 @@ mod tests {
         );
         assert!(svc.get_endpoint_attributes(&req).is_err());
     }
+
+    // ── Error branch tests ──
+
+    #[test]
+    fn get_topic_attributes_not_found() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "GetTopicAttributes",
+            vec![("TopicArn", "arn:aws:sns:us-east-1:123456789012:nonexistent")],
+        );
+        assert!(svc.get_topic_attributes(&req).is_err());
+    }
+
+    #[test]
+    fn delete_topic_not_found() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "DeleteTopic",
+            vec![("TopicArn", "arn:aws:sns:us-east-1:123456789012:nonexistent")],
+        );
+        // DeleteTopic returns success even for nonexistent topics (AWS behavior)
+        assert!(svc.delete_topic(&req).is_ok());
+    }
+
+    #[test]
+    fn subscribe_to_nonexistent_topic() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "Subscribe",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:nope"),
+                ("Protocol", "email"),
+                ("Endpoint", "test@example.com"),
+            ],
+        );
+        assert!(svc.subscribe(&req).is_err());
+    }
+
+    #[test]
+    fn unsubscribe_nonexistent_is_noop() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "Unsubscribe",
+            vec![(
+                "SubscriptionArn",
+                "arn:aws:sns:us-east-1:123456789012:topic:nonexistent-sub",
+            )],
+        );
+        // AWS returns success for nonexistent subscriptions
+        assert!(svc.unsubscribe(&req).is_ok());
+    }
+
+    #[test]
+    fn set_topic_attributes_not_found() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "SetTopicAttributes",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:nope"),
+                ("AttributeName", "DisplayName"),
+                ("AttributeValue", "My Topic"),
+            ],
+        );
+        assert!(svc.set_topic_attributes(&req).is_err());
+    }
+
+    #[test]
+    fn publish_to_nonexistent_topic() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:nope"),
+                ("Message", "hello"),
+            ],
+        );
+        assert!(svc.publish(&req).is_err());
+    }
+
+    #[test]
+    fn get_subscription_attributes_not_found() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "GetSubscriptionAttributes",
+            vec![(
+                "SubscriptionArn",
+                "arn:aws:sns:us-east-1:123456789012:topic:bad-sub",
+            )],
+        );
+        assert!(svc.get_subscription_attributes(&req).is_err());
+    }
+
+    #[test]
+    fn set_subscription_attributes_not_found() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "SetSubscriptionAttributes",
+            vec![
+                (
+                    "SubscriptionArn",
+                    "arn:aws:sns:us-east-1:123456789012:topic:bad-sub",
+                ),
+                ("AttributeName", "FilterPolicy"),
+                ("AttributeValue", "{}"),
+            ],
+        );
+        assert!(svc.set_subscription_attributes(&req).is_err());
+    }
+
+    #[test]
+    fn tag_resource_nonexistent_topic() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "TagResource",
+            vec![
+                ("ResourceArn", "arn:aws:sns:us-east-1:123456789012:nope"),
+                ("Tags.member.1.Key", "env"),
+                ("Tags.member.1.Value", "prod"),
+            ],
+        );
+        assert!(svc.tag_resource(&req).is_err());
+    }
+
+    #[test]
+    fn untag_resource_nonexistent_topic() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "UntagResource",
+            vec![
+                ("ResourceArn", "arn:aws:sns:us-east-1:123456789012:nope"),
+                ("TagKeys.member.1", "env"),
+            ],
+        );
+        assert!(svc.untag_resource(&req).is_err());
+    }
+
+    #[test]
+    fn list_tags_nonexistent_topic() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "ListTagsForResource",
+            vec![("ResourceArn", "arn:aws:sns:us-east-1:123456789012:nope")],
+        );
+        assert!(svc.list_tags_for_resource(&req).is_err());
+    }
+
+    #[test]
+    fn create_topic_duplicate_returns_existing_arn() {
+        let (svc, _) = make_sns();
+        let req = sns_request("CreateTopic", vec![("Name", "dup-topic")]);
+        let resp1 = svc.create_topic(&req).unwrap();
+
+        let req = sns_request("CreateTopic", vec![("Name", "dup-topic")]);
+        let resp2 = svc.create_topic(&req).unwrap();
+
+        // Should return same ARN (idempotent)
+        let body1 = std::str::from_utf8(resp1.body.expect_bytes()).unwrap();
+        let body2 = std::str::from_utf8(resp2.body.expect_bytes()).unwrap();
+        assert_eq!(body1, body2);
+    }
+
+    #[test]
+    fn confirm_subscription_not_found() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "ConfirmSubscription",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:nope"),
+                ("Token", "fake-token"),
+            ],
+        );
+        assert!(svc.confirm_subscription(&req).is_err());
+    }
+
+    #[test]
+    fn get_platform_application_attributes_not_found() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "GetPlatformApplicationAttributes",
+            vec![(
+                "PlatformApplicationArn",
+                "arn:aws:sns:us-east-1:123456789012:app/GCM/ghost",
+            )],
+        );
+        assert!(svc.get_platform_application_attributes(&req).is_err());
+    }
+
+    #[test]
+    fn create_platform_endpoint_app_not_found() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "CreatePlatformEndpoint",
+            vec![
+                (
+                    "PlatformApplicationArn",
+                    "arn:aws:sns:us-east-1:123456789012:app/GCM/ghost",
+                ),
+                ("Token", "device-token"),
+            ],
+        );
+        assert!(svc.create_platform_endpoint(&req).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- Add 24 error-branch tests across Lambda and SNS services
- Lambda (+9 tests): duplicate function conflict, not-found errors for get/delete function, event source mappings, policy, versions, unknown route
- SNS (+15 tests): not-found errors for topics, subscriptions, tags, platform applications; idempotent create topic; noop unsubscribe/delete
- Lambda total: 40 (up from 31), SNS total: 86 (up from 71)

## Test plan
- [x] `cargo test -p fakecloud-lambda` — 40 tests pass
- [x] `cargo test -p fakecloud-sns` — 86 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added 24 error-path tests to `fakecloud-lambda` (+9, 31→40) and `fakecloud-sns` (+15, 71→86) to improve handler coverage and align error semantics with AWS. Tests cover duplicate Lambda function conflict, not-found routes (functions, event source mappings, policy/permission, versions), SNS idempotent `CreateTopic`, noop `Unsubscribe`/`DeleteTopic`, and not-found for topics, subscriptions, tags, and platform apps/endpoints.

<sup>Written for commit efe2822d14df5753694dbe7e975fb41eaa33024b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

