### PR TITLE
feat(iam): implement NotPrincipal evaluation in resource policies

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -1507,3 +1507,125 @@ async fn sqs_send_message_attribute_condition_key() {
         "expected AccessDenied for no-attr send, got {err:?}"
     );
 }
+
+// ======================================================================
+// Phase 5: NotPrincipal
+//
+// Drive the evaluator's NotPrincipal path end-to-end via an S3 bucket
+// policy. The classic pattern is Deny + NotPrincipal: deny everyone
+// except a specific user. The named user is exempt from the deny;
+// everyone else is blocked.
+// ======================================================================
+
+#[tokio::test]
+async fn not_principal_deny_exempts_named_user() {
+    // Bucket policy:
+    //   1. Allow * for s3:GetObject (public read)
+    //   2. Deny NotPrincipal alice for s3:GetObject (block everyone except alice)
+    //
+    // Net effect: only alice can GetObject.
+    let server = start_strict().await;
+    let (alice_akid, alice_secret) = bootstrap_user(&server, "np_alice").await;
+    let (bob_akid, bob_secret) = bootstrap_user(&server, "np_bob").await;
+
+    let policy = serde_json::json!({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "PublicRead",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": ["arn:aws:s3:::np-bucket/*", "arn:aws:s3:::np-bucket"]
+            },
+            {
+                "Sid": "DenyEveryoneExceptAlice",
+                "Effect": "Deny",
+                "NotPrincipal": {"AWS": "arn:aws:iam::123456789012:user/np_alice"},
+                "Action": "s3:*",
+                "Resource": ["arn:aws:s3:::np-bucket/*", "arn:aws:s3:::np-bucket"]
+            }
+        ]
+    });
+
+    seed_bucket_with_policy(&server, "np-bucket", &policy.to_string()).await;
+
+    // Alice: Deny does NOT apply (she's the NotPrincipal), Allow applies -> success.
+    let alice_cfg = sdk_config_with(&server, &alice_akid, &alice_secret).await;
+    let alice_s3 = aws_sdk_s3::Client::new(&alice_cfg);
+    let resp = alice_s3
+        .get_object()
+        .bucket("np-bucket")
+        .key("readme.md")
+        .send()
+        .await
+        .unwrap();
+    let body = resp.body.collect().await.unwrap().into_bytes();
+    assert_eq!(body.as_ref(), b"hi");
+
+    // Bob: Deny applies (he's NOT the NotPrincipal) -> ExplicitDeny -> AccessDenied.
+    let bob_cfg = sdk_config_with(&server, &bob_akid, &bob_secret).await;
+    let bob_s3 = aws_sdk_s3::Client::new(&bob_cfg);
+    let err = bob_s3
+        .get_object()
+        .bucket("np-bucket")
+        .key("readme.md")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for bob, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn not_principal_allow_grants_only_non_named_user() {
+    // Bucket policy: Allow NotPrincipal for s3:GetObject — grants
+    // access to everyone EXCEPT the named user.
+    let server = start_strict().await;
+    let (alice_akid, alice_secret) = bootstrap_user(&server, "npa_alice").await;
+    let (bob_akid, bob_secret) = bootstrap_user(&server, "npa_bob").await;
+
+    let policy = serde_json::json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Sid": "AllowEveryoneExceptAlice",
+            "Effect": "Allow",
+            "NotPrincipal": {"AWS": "arn:aws:iam::123456789012:user/npa_alice"},
+            "Action": "s3:GetObject",
+            "Resource": ["arn:aws:s3:::npa-bucket/*", "arn:aws:s3:::npa-bucket"]
+        }]
+    });
+
+    seed_bucket_with_policy(&server, "npa-bucket", &policy.to_string()).await;
+
+    // Bob: Allow applies (he's NOT in the NotPrincipal list) -> success.
+    let bob_cfg = sdk_config_with(&server, &bob_akid, &bob_secret).await;
+    let bob_s3 = aws_sdk_s3::Client::new(&bob_cfg);
+    let resp = bob_s3
+        .get_object()
+        .bucket("npa-bucket")
+        .key("readme.md")
+        .send()
+        .await
+        .unwrap();
+    let body = resp.body.collect().await.unwrap().into_bytes();
+    assert_eq!(body.as_ref(), b"hi");
+
+    // Alice: Allow does NOT apply (she IS the NotPrincipal), no other
+    // grants -> ImplicitDeny -> AccessDenied.
+    let alice_cfg = sdk_config_with(&server, &alice_akid, &alice_secret).await;
+    let alice_s3 = aws_sdk_s3::Client::new(&alice_cfg);
+    let err = alice_s3
+        .get_object()
+        .bucket("npa-bucket")
+        .key("readme.md")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for alice, got {err:?}"
+    );
+}

--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -36,9 +36,7 @@
 //!
 //! **Not** implemented (returns implicit deny rather than guessing — these
 //! are tracked for future phases and documented on `/docs/reference/security`):
-//! - `NotPrincipal` (used in resource-based policies)
 //! - Service control policies
-//! - ABAC / tag conditions
 //!
 use std::collections::HashSet;
 
@@ -125,14 +123,16 @@ pub(crate) enum PrincipalPattern {
     /// Statement carried `Principal` naming the accepted principals.
     /// A request is accepted iff it matches at least one entry.
     Principal(Vec<PrincipalRef>),
-    /// Statement carried `NotPrincipal`. Full evaluation semantics for
-    /// `NotPrincipal` are intentionally **not** implemented in this
-    /// batch — they are subtle (cross-account root implications, deny
-    /// interactions) and deserve their own rollout. Statements with
-    /// this variant are skipped entirely at evaluation time with a
-    /// `fakecloud::iam::audit` debug log. Critically we do not fall
-    /// through to "matches everyone" — that would silently grant.
-    NotPrincipalSkipped,
+    /// Statement carried `NotPrincipal` naming the excluded principals.
+    /// A statement with `NotPrincipal` applies to all callers **except**
+    /// those matching any entry in the list — the inverse of `Principal`.
+    /// If the caller matches ANY entry, the statement does NOT apply.
+    /// If the caller matches NONE, the statement applies.
+    ///
+    /// An empty ref list (all entries were unrecognized principal types)
+    /// causes the statement to be skipped with a debug log — we never
+    /// silently grant by falling through to "matches everyone".
+    NotPrincipal(Vec<PrincipalRef>),
 }
 
 /// A single principal reference parsed from a statement's `Principal`
@@ -259,12 +259,8 @@ fn parse_statement(value: &Value) -> Option<ParsedStatement> {
         ResourceMatch::Implicit
     };
     let condition = obj.get("Condition").map(CompiledCondition::parse);
-    let principal = if obj.contains_key("NotPrincipal") {
-        tracing::debug!(
-            target: "fakecloud::iam::audit",
-            "statement has NotPrincipal; skipping (NotPrincipal evaluation is not implemented)"
-        );
-        PrincipalPattern::NotPrincipalSkipped
+    let principal = if let Some(np) = obj.get("NotPrincipal") {
+        PrincipalPattern::NotPrincipal(parse_principal(np))
     } else if let Some(p) = obj.get("Principal") {
         PrincipalPattern::Principal(parse_principal(p))
     } else {
@@ -577,13 +573,19 @@ fn evaluate_inner(
                         continue;
                     }
                 }
-                PrincipalPattern::NotPrincipalSkipped => {
-                    tracing::debug!(
-                        target: "fakecloud::iam::audit",
-                        action = %request.action,
-                        "NotPrincipal is not implemented; statement does not apply"
-                    );
-                    continue;
+                PrincipalPattern::NotPrincipal(refs) => {
+                    if refs.is_empty() {
+                        tracing::debug!(
+                            target: "fakecloud::iam::audit",
+                            action = %request.action,
+                            "NotPrincipal has no recognized principal types; statement does not apply"
+                        );
+                        continue;
+                    }
+                    // NotPrincipal: statement applies when caller does NOT match any entry.
+                    if principal_matches(refs, request.principal) {
+                        continue;
+                    }
                 }
             }
             if !action_matches(&statement.action, &request.action) {
@@ -2015,22 +2017,184 @@ mod tests {
     }
 
     #[test]
-    fn not_principal_statement_is_skipped_never_grants() {
-        // AWS's NotPrincipal semantics are not implemented in this
-        // batch. A statement carrying NotPrincipal must never silently
-        // grant — it's treated as "doesn't apply".
-        let p = principal_in(ACCT_A, "alice");
+    fn not_principal_deny_excludes_named_user() {
+        // NotPrincipal + Deny: deny everyone EXCEPT bob.
+        // Alice is not bob -> deny applies -> ExplicitDeny.
+        let alice = principal_in(ACCT_A, "alice");
+        let resource = json!({
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": "s3:GetObject",
+                    "Resource": "*"
+                },
+                {
+                    "Effect": "Deny",
+                    "NotPrincipal": {"AWS": format!("arn:aws:iam::{ACCT_A}:user/bob")},
+                    "Action": "s3:GetObject",
+                    "Resource": "*"
+                }
+            ]
+        });
+        assert_eq!(
+            eval_cross(None, Some(resource.clone()), &alice, ACCT_A),
+            Decision::ExplicitDeny
+        );
+
+        // Bob IS the named principal -> deny does NOT apply -> Allow from first statement.
+        let bob = principal_in(ACCT_A, "bob");
+        assert_eq!(
+            eval_cross(None, Some(resource), &bob, ACCT_A),
+            Decision::Allow
+        );
+    }
+
+    #[test]
+    fn not_principal_allow_excludes_named_user() {
+        // NotPrincipal + Allow: allow everyone EXCEPT bob.
+        // Alice is not bob -> allow applies.
+        let alice = principal_in(ACCT_A, "alice");
         let resource = json!({
             "Statement": [{
                 "Effect": "Allow",
-                "NotPrincipal": {"AWS": "arn:aws:iam::111111111111:user/bob"},
+                "NotPrincipal": {"AWS": format!("arn:aws:iam::{ACCT_A}:user/bob")},
                 "Action": "s3:GetObject",
                 "Resource": "*"
             }]
         });
         assert_eq!(
-            eval_cross(None, Some(resource), &p, ACCT_A),
+            eval_cross(None, Some(resource.clone()), &alice, ACCT_A),
+            Decision::Allow
+        );
+
+        // Bob IS the named principal -> allow does NOT apply -> ImplicitDeny.
+        let bob = principal_in(ACCT_A, "bob");
+        assert_eq!(
+            eval_cross(None, Some(resource), &bob, ACCT_A),
             Decision::ImplicitDeny
+        );
+    }
+
+    #[test]
+    fn not_principal_with_star_never_applies() {
+        // NotPrincipal: "*" matches everyone, so the statement never applies.
+        let alice = principal_in(ACCT_A, "alice");
+        let resource = json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "NotPrincipal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "*"
+            }]
+        });
+        assert_eq!(
+            eval_cross(None, Some(resource), &alice, ACCT_A),
+            Decision::ImplicitDeny
+        );
+    }
+
+    #[test]
+    fn not_principal_with_account_root() {
+        // NotPrincipal names account root. AwsAccountRoot matches
+        // any principal in that account, so alice (in ACCT_A) matches
+        // the NotPrincipal list and the statement does NOT apply.
+        let alice = principal_in(ACCT_A, "alice");
+        let resource = json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "NotPrincipal": {"AWS": format!("arn:aws:iam::{ACCT_A}:root")},
+                "Action": "s3:GetObject",
+                "Resource": "*"
+            }]
+        });
+        assert_eq!(
+            eval_cross(None, Some(resource.clone()), &alice, ACCT_A),
+            Decision::ImplicitDeny
+        );
+
+        // A user in a DIFFERENT account does NOT match ACCT_A root,
+        // so the Deny statement applies. With a Deny+NotPrincipal pattern
+        // this means the cross-account user gets denied.
+        let eve = principal_in(ACCT_B, "eve");
+        let resource_deny = json!({
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": "s3:GetObject",
+                    "Resource": "*"
+                },
+                {
+                    "Effect": "Deny",
+                    "NotPrincipal": {"AWS": format!("arn:aws:iam::{ACCT_A}:root")},
+                    "Action": "s3:GetObject",
+                    "Resource": "*"
+                }
+            ]
+        });
+        // Eve (ACCT_B) doesn't match ACCT_A root, so Deny applies.
+        assert_eq!(
+            eval_cross(None, Some(resource_deny.clone()), &eve, ACCT_A),
+            Decision::ExplicitDeny
+        );
+        // Alice (ACCT_A) matches ACCT_A root, so Deny does NOT apply -> Allow.
+        assert_eq!(
+            eval_cross(None, Some(resource_deny), &alice, ACCT_A),
+            Decision::Allow
+        );
+    }
+
+    #[test]
+    fn not_principal_with_unrecognized_type_safe_skips() {
+        // NotPrincipal with only Federated type (unrecognized) ->
+        // empty refs list -> statement skipped safely.
+        let alice = principal_in(ACCT_A, "alice");
+        let resource = json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "NotPrincipal": {"Federated": "cognito-identity.amazonaws.com"},
+                "Action": "s3:GetObject",
+                "Resource": "*"
+            }]
+        });
+        assert_eq!(
+            eval_cross(None, Some(resource), &alice, ACCT_A),
+            Decision::ImplicitDeny
+        );
+    }
+
+    #[test]
+    fn not_principal_with_multiple_entries() {
+        // NotPrincipal with multiple users. Statement applies only
+        // to callers matching NONE of the entries.
+        let alice = principal_in(ACCT_A, "alice");
+        let bob = principal_in(ACCT_A, "bob");
+        let charlie = principal_in(ACCT_A, "charlie");
+        let resource = json!({
+            "Statement": [{
+                "Effect": "Deny",
+                "NotPrincipal": {"AWS": [
+                    format!("arn:aws:iam::{ACCT_A}:user/alice"),
+                    format!("arn:aws:iam::{ACCT_A}:user/bob")
+                ]},
+                "Action": "s3:GetObject",
+                "Resource": "*"
+            }]
+        });
+        // Alice and bob are in the list -> deny does NOT apply
+        assert_eq!(
+            eval_cross(None, Some(resource.clone()), &alice, ACCT_A),
+            Decision::ImplicitDeny
+        );
+        assert_eq!(
+            eval_cross(None, Some(resource.clone()), &bob, ACCT_A),
+            Decision::ImplicitDeny
+        );
+        // Charlie is NOT in the list -> deny applies
+        assert_eq!(
+            eval_cross(None, Some(resource), &charlie, ACCT_A),
+            Decision::ExplicitDeny
         );
     }
 

--- a/website/content/docs/reference/security.md
+++ b/website/content/docs/reference/security.md
@@ -163,7 +163,9 @@ The resource's owning account is parsed from the ARN; S3 ARNs have an empty acco
 | `"Principal": {"AWS": [...]}` | List form — any entry matches |
 | `"Principal": {"Service": "events.amazonaws.com"}` | Matches an assumed-role principal whose ARN contains the service host (covers EventBridge -> SNS and similar service-linked role scenarios) |
 
-`NotPrincipal` is **not** evaluated — statements carrying it are skipped entirely with a `fakecloud::iam::audit` debug log and never silently grant. `Principal` types other than `AWS` / `Service` (`Federated`, `CanonicalUser`) fall through to "doesn't match" for the same reason.
+`NotPrincipal` is fully evaluated — a statement with `NotPrincipal` applies to all callers **except** those matching any entry in the list (the exact inverse of `Principal`). The classic AWS pattern `Deny` + `NotPrincipal` ("deny everyone except this user") works correctly. `NotPrincipal` entries with unrecognized principal types (`Federated`, `CanonicalUser`) are dropped from the match list; if all entries are unrecognized the statement is skipped with a `fakecloud::iam::audit` debug log and never silently grants.
+
+`Principal` types other than `AWS` / `Service` (`Federated`, `CanonicalUser`) fall through to "doesn't match" for the same reason.
 
 `Condition` blocks on resource-policy statements are evaluated with the same operator set and global condition keys as identity policies — the condition entry points are shared.
 
@@ -210,7 +212,6 @@ Key semantics:
 **Phase 5 — niche cleanup (planned).**
 
 - **KMS key policies.** KMS has a deny-by-default semantic (no policy means nothing is allowed, including the account root) that is materially different from S3 / SNS / Lambda's allow-on-match-or-fall-through, and lands behind its own migration decision before wiring it into the evaluator.
-- **`NotPrincipal`.** The inverse-principal matcher on resource-policy statements. Statements carrying it are currently skipped with a `fakecloud::iam::audit` debug log and never silently grant — the safe-fail semantics are deliberate and part of the no-gaming invariant.
 
 **Will not ship.**
 


### PR DESCRIPTION
## Summary

- Implement real `NotPrincipal` evaluation in the IAM policy evaluator, replacing the skip-with-debug-log stub
- A statement with `NotPrincipal` now applies to all callers **except** those matching any entry in the list — the exact inverse of `Principal` matching
- Empty refs (all unrecognized principal types) safely skip with a debug log, preserving the no-gaming invariant
- 6 unit tests + 2 E2E tests covering `Deny+NotPrincipal`, `Allow+NotPrincipal`, wildcard, account root, multiple entries, and unrecognized types

## Test plan

- [x] Unit tests: `cargo test -p fakecloud-iam --lib -- not_principal` (6 tests)
- [x] E2E tests: `cargo test -p fakecloud-e2e --test iam_enforcement -- not_principal` (2 tests)
- [x] Full IAM unit suite: 220 tests pass, 0 regressions
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements full `NotPrincipal` evaluation for resource policies in `fakecloud-iam`, enabling common allow/deny patterns and removing the skip stub. This closes a security gap and preserves no-silent-grant behavior.

- **New Features**
  - Evaluate `NotPrincipal` as the inverse of `Principal`: statements apply only when the caller does not match any entry.
  - Empty or unrecognized entries are dropped; if none remain, the statement is skipped with a `fakecloud::iam::audit` debug log.
  - Handles `*`, account root ARNs, and multiple entries as expected.
  - Added coverage: 6 unit tests + 2 E2E tests; updated docs to reflect the new behavior.

<sup>Written for commit 91105ccddbef934ce7fe6376e34cdc1c32c5b4b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

