### PR TITLE
feat(sdk): add PHP SDK for introspection API

### DIFF
--- a/.github/workflows/sdk-php.yml
+++ b/.github/workflows/sdk-php.yml
@@ -1,0 +1,51 @@
+name: SDK PHP
+
+on:
+  push:
+    paths:
+      - "sdks/php/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    paths:
+      - "sdks/php/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+defaults:
+  run:
+    working-directory: sdks/php
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build fakecloud
+        run: cargo build --release
+        working-directory: .
+
+      - uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2
+        with:
+          php-version: "8.3"
+          extensions: curl, json
+          tools: composer
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit --testsuite unit
+
+      - name: Run E2E tests
+        run: |
+          ../../target/release/fakecloud &
+          sleep 2
+          vendor/bin/phpunit --testsuite e2e

--- a/.github/workflows/sdk-php.yml
+++ b/.github/workflows/sdk-php.yml
@@ -47,5 +47,10 @@ jobs:
       - name: Run E2E tests
         run: |
           ../../target/release/fakecloud &
-          sleep 2
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:4566/_fakecloud/health > /dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
           vendor/bin/phpunit --testsuite e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Local AWS cloud emulator. Part of the faisca project family.
 - FakeCloud is a local AWS emulator focused on high-fidelity behavior and AWS-compatible responses.
 - Current project state from prior work: 22 services, 1155 operations, with SES, Cognito User Pools, Docker-backed Lambda execution, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock (111 ops), and Bedrock Runtime already shipped.
 - The broader roadmap prioritizes services that LocalStack keeps behind paid tiers, especially ECR, ECS, ELB/ALB, CloudFront, CloudWatch Metrics, and EC2.
-- Introspection SDKs (Rust, Python, TypeScript, Go, Java) are already built and maintained for the `/_fakecloud/*` endpoints.
+- Introspection SDKs (Rust, Python, TypeScript, Go, PHP, Java) are already built and maintained for the `/_fakecloud/*` endpoints.
 
 ## Build And Run
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Thanks for your interest in contributing. This document covers the conventions a
 7. Update the `conformance-baseline.json` baseline.
 8. Add a service page to [`website/content/docs/services/<service>.md`](website/content/docs/services/).
 9. If the service is a market differentiator (paywalled by LocalStack, unique cross-service wiring, real infrastructure), update the README comparison table.
-10. Ship SDK helpers for TypeScript, Python, Go, Java, and Rust if the service exposes introspection or simulation endpoints that tests benefit from. SDK updates go in the same PR as the service — not as a follow-up.
+10. Ship SDK helpers for TypeScript, Python, Go, PHP, Java, and Rust if the service exposes introspection or simulation endpoints that tests benefit from. SDK updates go in the same PR as the service — not as a follow-up.
 
 ## Reporting bugs
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 - **Real cross-service wiring.** EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> S3/SNS/Lambda, and 15+ more integrations actually execute end-to-end.
 - **Real infrastructure for stateful services.** Lambda runs in Docker containers (13 runtimes). RDS runs real Postgres/MySQL/MariaDB. ElastiCache runs real Redis/Valkey.
 - **Single binary.** ~19 MB, ~10 MiB idle memory, ~500ms startup. No Docker required to run fakecloud itself (only to exercise the services that need real containers).
-- **First-party test SDKs** for TypeScript, Python, Go, Java, and Rust. Assert on what your code called without writing raw HTTP.
+- **First-party test SDKs** for TypeScript, Python, Go, PHP, Java, and Rust. Assert on what your code called without writing raw HTTP.
 - **Opt-in SigV4 verification and IAM enforcement.** Off by default so tests just work; turn on `--verify-sigv4` for real cryptographic signature checking and `--iam soft|strict` for identity-policy evaluation (Allow/Deny with Deny precedence, Action/Resource wildcards, user/group/role policies, `Condition` blocks with all 28 AWS operators against global keys like `aws:username` / `aws:SourceIp` / `aws:CurrentTime`, plus resource-based policies for S3 bucket, SNS topic, and Lambda function policies with AWS's cross-account combining semantics) across IAM, STS, SQS, SNS, and S3. See [the security docs](https://fakecloud.dev/docs/reference/security/).
 
 ## Supported services
@@ -86,7 +86,7 @@ Per-service docs and feature matrices: [fakecloud.dev/docs/services](https://fak
 | Startup time        | ~500ms                                             | ~3s                                                                            |
 | Idle memory         | ~10 MiB                                            | ~150 MiB                                                                       |
 | Install size        | ~19 MB binary                                      | ~1 GB Docker image                                                             |
-| Test assertion SDKs | TypeScript, Python, Go, Java, Rust                 | Python, Java                                                                   |
+| Test assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust            | Python, Java                                                                   |
 | Cognito User Pools  | 122 operations                                     | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | SES v2              | Full send + templates + DKIM + suppression         | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | SES inbound email   | Real receipt rule action execution                 | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) |
@@ -106,6 +106,8 @@ Normal AWS SDKs handle your application code. fakecloud's own SDKs let your test
 | TypeScript | `npm install fakecloud`                         |
 | Python     | `pip install fakecloud`                         |
 | Go         | `go get github.com/faiscadev/fakecloud/sdks/go` |
+| PHP        | `composer require fakecloud/fakecloud`          |
+| Java       | `dev.fakecloud:fakecloud` (Maven Central)       |
 | Rust       | `cargo add fakecloud-sdk`                       |
 
 ```ts
@@ -121,7 +123,7 @@ expect(emails).toHaveLength(1);
 await fc.reset();
 ```
 
-Full SDK reference for all four languages: [fakecloud.dev/docs/sdks](https://fakecloud.dev/docs/sdks).
+Full SDK reference for all six languages: [fakecloud.dev/docs/sdks](https://fakecloud.dev/docs/sdks).
 
 ## Use with AI coding tools
 

--- a/sdks/php/LICENSE
+++ b/sdks/php/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/sdks/php/README.md
+++ b/sdks/php/README.md
@@ -1,0 +1,226 @@
+# fakecloud
+
+PHP client SDK for [fakecloud](https://github.com/faiscadev/fakecloud) — a local AWS cloud emulator.
+
+Provides typed access to the fakecloud introspection and simulation API (`/_fakecloud/*` endpoints), letting you inspect emulator state and trigger time-based processors in tests.
+
+Requires **PHP 8.1+**. Uses the built-in `curl` extension and `json_decode`/`json_encode`. No external dependencies.
+
+## Installation
+
+```bash
+composer require fakecloud/fakecloud
+```
+
+## Quick start
+
+```php
+use FakeCloud\FakeCloud;
+
+$fc = new FakeCloud('http://localhost:4566');
+
+// Check server health
+$health = $fc->health();
+echo $health->version . ' ' . implode(', ', $health->services);
+
+// Reset all state between tests
+$fc->reset();
+
+// Inspect SES emails sent during a test
+$emails = $fc->ses()->getEmails()->emails;
+echo 'Sent ' . count($emails) . ' emails';
+
+// Inspect SNS messages
+$messages = $fc->sns()->getMessages()->messages;
+
+// Inspect SQS messages across all queues
+$queues = $fc->sqs()->getMessages()->queues;
+
+// Advance DynamoDB TTL processor
+$expired = $fc->dynamodb()->tickTtl()->expiredItems;
+
+// Advance S3 lifecycle processor
+$expiredObjects = $fc->s3()->tickLifecycle()->expiredObjects;
+```
+
+## API reference
+
+### `FakeCloud`
+
+```php
+$fc = new FakeCloud();                       // defaults to http://localhost:4566
+$fc = new FakeCloud('http://localhost:4566'); // explicit base URL
+```
+
+| Method                   | Description             |
+| ------------------------ | ----------------------- |
+| `health()`               | Server health check     |
+| `reset()`                | Reset all service state |
+| `resetService($service)` | Reset a single service  |
+
+### `$fc->lambda()`
+
+| Method                          | Description                          |
+| ------------------------------- | ------------------------------------ |
+| `getInvocations()`              | List recorded Lambda invocations     |
+| `getWarmContainers()`           | List warm (cached) Lambda containers |
+| `evictContainer($functionName)` | Evict a warm container               |
+
+### `$fc->ses()`
+
+| Method                 | Description                               |
+| ---------------------- | ----------------------------------------- |
+| `getEmails()`          | List all sent emails                      |
+| `simulateInbound($req)` | Simulate an inbound email (receipt rules) |
+
+### `$fc->sns()`
+
+| Method                       | Description                             |
+| ---------------------------- | --------------------------------------- |
+| `getMessages()`              | List all published messages             |
+| `getPendingConfirmations()`  | List subscriptions pending confirmation |
+| `confirmSubscription($req)`  | Confirm a pending subscription          |
+
+### `$fc->sqs()`
+
+| Method                  | Description                           |
+| ----------------------- | ------------------------------------- |
+| `getMessages()`         | List all messages across all queues   |
+| `tickExpiration()`      | Tick the message expiration processor |
+| `forceDlq($queueName)` | Force all messages to the queue's DLQ |
+
+### `$fc->events()`
+
+| Method           | Description                            |
+| ---------------- | -------------------------------------- |
+| `getHistory()`   | Get event history and delivery records |
+| `fireRule($req)` | Fire an EventBridge rule manually      |
+
+### `$fc->s3()`
+
+| Method                | Description                  |
+| --------------------- | ---------------------------- |
+| `getNotifications()`  | List S3 notification events  |
+| `tickLifecycle()`     | Tick the lifecycle processor |
+
+### `$fc->dynamodb()`
+
+| Method       | Description            |
+| ------------ | ---------------------- |
+| `tickTtl()`  | Tick the TTL processor |
+
+### `$fc->secretsmanager()`
+
+| Method            | Description                 |
+| ----------------- | --------------------------- |
+| `tickRotation()`  | Tick the rotation scheduler |
+
+### `$fc->cognito()`
+
+| Method                            | Description                          |
+| --------------------------------- | ------------------------------------ |
+| `getUserCodes($poolId, $username)` | Get confirmation codes for a user    |
+| `getConfirmationCodes()`          | List all confirmation codes          |
+| `confirmUser($req)`               | Confirm a user (bypass verification) |
+| `getTokens()`                     | List all active tokens               |
+| `expireTokens($req)`              | Expire tokens (optionally filtered)  |
+| `getAuthEvents()`                 | List auth events                     |
+
+### `$fc->rds()`
+
+| Method            | Description                              |
+| ----------------- | ---------------------------------------- |
+| `getInstances()`  | List RDS instances with runtime metadata |
+
+### `$fc->elasticache()`
+
+| Method                    | Description                         |
+| ------------------------- | ----------------------------------- |
+| `getClusters()`           | List ElastiCache cache clusters     |
+| `getReplicationGroups()`  | List ElastiCache replication groups |
+| `getServerlessCaches()`   | List ElastiCache serverless caches  |
+
+### `$fc->stepfunctions()`
+
+| Method             | Description                              |
+| ------------------ | ---------------------------------------- |
+| `getExecutions()`  | List all state machine execution history |
+
+### `$fc->apigatewayv2()`
+
+| Method           | Description                         |
+| ---------------- | ----------------------------------- |
+| `getRequests()`  | List all HTTP API requests received |
+
+### `$fc->bedrock()`
+
+| Method                              | Description                                                          |
+| ----------------------------------- | -------------------------------------------------------------------- |
+| `getInvocations()`                  | List recorded Bedrock runtime invocations                            |
+| `setModelResponse($modelId, $text)` | Configure a single canned response for a model                       |
+| `setResponseRules($modelId, $rules)` | Replace prompt-conditional response rules for a model               |
+| `clearResponseRules($modelId)`      | Clear all prompt-conditional response rules for a model              |
+| `queueFault($rule)`                 | Queue a fault rule for the next N calls                              |
+| `getFaults()`                       | List currently queued fault rules                                    |
+| `clearFaults()`                     | Clear all queued fault rules                                         |
+
+#### Full test loop — asserting on Bedrock calls
+
+```php
+use FakeCloud\FakeCloud;
+use FakeCloud\BedrockFaultRule;
+use FakeCloud\BedrockResponseRule;
+
+$fc = new FakeCloud();
+$modelId = 'anthropic.claude-3-haiku-20240307-v1:0';
+
+// beforeEach
+$fc->reset();
+
+// Prime prompt-conditional responses
+$fc->bedrock()->setResponseRules($modelId, [
+    new BedrockResponseRule('buy now', '{"label":"spam"}'),
+    new BedrockResponseRule(null, '{"label":"ham"}'), // catch-all
+]);
+
+classify('hello friend');           // user code calls Bedrock
+classify('buy now cheap pills');
+
+$invocations = $fc->bedrock()->getInvocations()->invocations;
+assert(count($invocations) === 2);
+assert(str_contains($invocations[0]->output, 'ham'));
+assert(str_contains($invocations[1]->output, 'spam'));
+```
+
+### Error handling
+
+All methods throw `FakeCloudError` (a `RuntimeException`) on non-2xx responses:
+
+```php
+use FakeCloud\FakeCloudError;
+use FakeCloud\ConfirmUserRequest;
+
+try {
+    $fc->cognito()->confirmUser(new ConfirmUserRequest('pool-1', 'nobody'));
+} catch (FakeCloudError $err) {
+    echo $err->status; // 404
+    echo $err->body;   // "user not found"
+}
+```
+
+## Local development
+
+```bash
+# Build fakecloud (from repo root)
+cargo build --release
+
+# Install PHP dependencies
+cd sdks/php
+composer install
+
+# Run unit tests
+vendor/bin/phpunit tests/ClientTest.php
+
+# Run E2E tests against the freshly-built binary
+vendor/bin/phpunit tests/E2ETest.php
+```

--- a/sdks/php/composer.json
+++ b/sdks/php/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "fakecloud/fakecloud",
+    "description": "PHP client SDK for fakecloud — a local AWS cloud emulator",
+    "type": "library",
+    "license": "AGPL-3.0-or-later",
+    "homepage": "https://github.com/faiscadev/fakecloud",
+    "keywords": ["fakecloud", "aws", "testing", "mock", "emulator", "localstack"],
+    "require": {
+        "php": ">=8.1",
+        "ext-curl": "*",
+        "ext-json": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0 || ^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "FakeCloud\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "FakeCloud\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/sdks/php/composer.json
+++ b/sdks/php/composer.json
@@ -16,7 +16,11 @@
     "autoload": {
         "psr-4": {
             "FakeCloud\\": "src/"
-        }
+        },
+        "files": [
+            "src/Types.php",
+            "src/FakeCloud.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/sdks/php/phpunit.xml
+++ b/sdks/php/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnWarning="true"
+         failOnRisky="true">
+    <testsuites>
+        <testsuite name="unit">
+            <file>tests/ClientTest.php</file>
+        </testsuite>
+        <testsuite name="e2e">
+            <file>tests/E2ETest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -326,16 +326,16 @@ final class CognitoClient
     {
         $payload = json_encode($req->toArray(), JSON_THROW_ON_ERROR);
         $response = $this->http->execute('POST', '/_fakecloud/cognito/confirm-user', $payload, 'application/json');
-        $parsed = ConfirmUserResponse::fromArray(json_decode($response['body'], true, 512, JSON_THROW_ON_ERROR));
 
         if ($response['status'] === 404) {
+            $parsed = ConfirmUserResponse::fromArray(json_decode($response['body'], true, 512, JSON_THROW_ON_ERROR));
             throw new FakeCloudError(404, $parsed->error ?? 'user not found');
         }
         if ($response['status'] < 200 || $response['status'] >= 300) {
             throw new FakeCloudError($response['status'], $response['body']);
         }
 
-        return $parsed;
+        return ConfirmUserResponse::fromArray(json_decode($response['body'], true, 512, JSON_THROW_ON_ERROR));
     }
 
     public function getTokens(): TokensResponse

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -1,0 +1,448 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeCloud;
+
+/**
+ * Top-level client for the fakecloud introspection and simulation API.
+ *
+ * ```php
+ * $fc = new FakeCloud('http://localhost:4566');
+ * $fc->reset();
+ * $emails = $fc->ses()->getEmails()->emails;
+ * ```
+ */
+final class FakeCloud
+{
+    private const DEFAULT_BASE_URL = 'http://localhost:4566';
+
+    private HttpTransport $http;
+    private LambdaClient $lambda;
+    private RdsClient $rds;
+    private ElastiCacheClient $elasticache;
+    private SesClient $ses;
+    private SnsClient $sns;
+    private SqsClient $sqs;
+    private EventsClient $events;
+    private S3Client $s3;
+    private DynamoDbClient $dynamodb;
+    private SecretsManagerClient $secretsmanager;
+    private CognitoClient $cognito;
+    private ApiGatewayV2Client $apigatewayv2;
+    private StepFunctionsClient $stepfunctions;
+    private BedrockClient $bedrock;
+
+    public function __construct(string $baseUrl = self::DEFAULT_BASE_URL)
+    {
+        $this->http = new HttpTransport($baseUrl);
+        $this->lambda = new LambdaClient($this->http);
+        $this->rds = new RdsClient($this->http);
+        $this->elasticache = new ElastiCacheClient($this->http);
+        $this->ses = new SesClient($this->http);
+        $this->sns = new SnsClient($this->http);
+        $this->sqs = new SqsClient($this->http);
+        $this->events = new EventsClient($this->http);
+        $this->s3 = new S3Client($this->http);
+        $this->dynamodb = new DynamoDbClient($this->http);
+        $this->secretsmanager = new SecretsManagerClient($this->http);
+        $this->cognito = new CognitoClient($this->http);
+        $this->apigatewayv2 = new ApiGatewayV2Client($this->http);
+        $this->stepfunctions = new StepFunctionsClient($this->http);
+        $this->bedrock = new BedrockClient($this->http);
+    }
+
+    public function baseUrl(): string
+    {
+        return $this->http->baseUrl();
+    }
+
+    // ── Health & Reset ─────────────────────────────────────────────
+
+    public function health(): HealthResponse
+    {
+        return HealthResponse::fromArray($this->http->get('/_fakecloud/health'));
+    }
+
+    public function reset(): ResetResponse
+    {
+        return ResetResponse::fromArray($this->http->postEmpty('/_reset'));
+    }
+
+    public function resetService(string $service): ResetServiceResponse
+    {
+        return ResetServiceResponse::fromArray(
+            $this->http->postEmpty('/_fakecloud/reset/' . HttpTransport::encodePath($service))
+        );
+    }
+
+    // ── Sub-client accessors ───────────────────────────────────────
+
+    public function lambda(): LambdaClient { return $this->lambda; }
+    public function rds(): RdsClient { return $this->rds; }
+    public function elasticache(): ElastiCacheClient { return $this->elasticache; }
+    public function ses(): SesClient { return $this->ses; }
+    public function sns(): SnsClient { return $this->sns; }
+    public function sqs(): SqsClient { return $this->sqs; }
+    public function events(): EventsClient { return $this->events; }
+    public function s3(): S3Client { return $this->s3; }
+    public function dynamodb(): DynamoDbClient { return $this->dynamodb; }
+    public function secretsmanager(): SecretsManagerClient { return $this->secretsmanager; }
+    public function cognito(): CognitoClient { return $this->cognito; }
+    public function apigatewayv2(): ApiGatewayV2Client { return $this->apigatewayv2; }
+    public function stepfunctions(): StepFunctionsClient { return $this->stepfunctions; }
+    public function bedrock(): BedrockClient { return $this->bedrock; }
+}
+
+// ── Sub-clients ────────────────────────────────────────────────
+
+final class LambdaClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getInvocations(): LambdaInvocationsResponse
+    {
+        return LambdaInvocationsResponse::fromArray(
+            $this->http->get('/_fakecloud/lambda/invocations')
+        );
+    }
+
+    public function getWarmContainers(): WarmContainersResponse
+    {
+        return WarmContainersResponse::fromArray(
+            $this->http->get('/_fakecloud/lambda/warm-containers')
+        );
+    }
+
+    public function evictContainer(string $functionName): EvictContainerResponse
+    {
+        return EvictContainerResponse::fromArray(
+            $this->http->postEmpty('/_fakecloud/lambda/' . HttpTransport::encodePath($functionName) . '/evict-container')
+        );
+    }
+}
+
+final class RdsClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getInstances(): RdsInstancesResponse
+    {
+        return RdsInstancesResponse::fromArray(
+            $this->http->get('/_fakecloud/rds/instances')
+        );
+    }
+}
+
+final class ElastiCacheClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getClusters(): ElastiCacheClustersResponse
+    {
+        return ElastiCacheClustersResponse::fromArray(
+            $this->http->get('/_fakecloud/elasticache/clusters')
+        );
+    }
+
+    public function getReplicationGroups(): ElastiCacheReplicationGroupsResponse
+    {
+        return ElastiCacheReplicationGroupsResponse::fromArray(
+            $this->http->get('/_fakecloud/elasticache/replication-groups')
+        );
+    }
+
+    public function getServerlessCaches(): ElastiCacheServerlessCachesResponse
+    {
+        return ElastiCacheServerlessCachesResponse::fromArray(
+            $this->http->get('/_fakecloud/elasticache/serverless-caches')
+        );
+    }
+}
+
+final class SesClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getEmails(): SesEmailsResponse
+    {
+        return SesEmailsResponse::fromArray(
+            $this->http->get('/_fakecloud/ses/emails')
+        );
+    }
+
+    public function simulateInbound(InboundEmailRequest $req): InboundEmailResponse
+    {
+        return InboundEmailResponse::fromArray(
+            $this->http->postJson('/_fakecloud/ses/inbound', $req->toArray())
+        );
+    }
+}
+
+final class SnsClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getMessages(): SnsMessagesResponse
+    {
+        return SnsMessagesResponse::fromArray(
+            $this->http->get('/_fakecloud/sns/messages')
+        );
+    }
+
+    public function getPendingConfirmations(): PendingConfirmationsResponse
+    {
+        return PendingConfirmationsResponse::fromArray(
+            $this->http->get('/_fakecloud/sns/pending-confirmations')
+        );
+    }
+
+    public function confirmSubscription(ConfirmSubscriptionRequest $req): ConfirmSubscriptionResponse
+    {
+        return ConfirmSubscriptionResponse::fromArray(
+            $this->http->postJson('/_fakecloud/sns/confirm-subscription', $req->toArray())
+        );
+    }
+}
+
+final class SqsClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getMessages(): SqsMessagesResponse
+    {
+        return SqsMessagesResponse::fromArray(
+            $this->http->get('/_fakecloud/sqs/messages')
+        );
+    }
+
+    public function tickExpiration(): ExpirationTickResponse
+    {
+        return ExpirationTickResponse::fromArray(
+            $this->http->postEmpty('/_fakecloud/sqs/expiration-processor/tick')
+        );
+    }
+
+    public function forceDlq(string $queueName): ForceDlqResponse
+    {
+        return ForceDlqResponse::fromArray(
+            $this->http->postEmpty('/_fakecloud/sqs/' . HttpTransport::encodePath($queueName) . '/force-dlq')
+        );
+    }
+}
+
+final class EventsClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getHistory(): EventHistoryResponse
+    {
+        return EventHistoryResponse::fromArray(
+            $this->http->get('/_fakecloud/events/history')
+        );
+    }
+
+    public function fireRule(FireRuleRequest $req): FireRuleResponse
+    {
+        return FireRuleResponse::fromArray(
+            $this->http->postJson('/_fakecloud/events/fire-rule', $req->toArray())
+        );
+    }
+}
+
+final class S3Client
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getNotifications(): S3NotificationsResponse
+    {
+        return S3NotificationsResponse::fromArray(
+            $this->http->get('/_fakecloud/s3/notifications')
+        );
+    }
+
+    public function tickLifecycle(): LifecycleTickResponse
+    {
+        return LifecycleTickResponse::fromArray(
+            $this->http->postEmpty('/_fakecloud/s3/lifecycle-processor/tick')
+        );
+    }
+}
+
+final class DynamoDbClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function tickTtl(): TtlTickResponse
+    {
+        return TtlTickResponse::fromArray(
+            $this->http->postEmpty('/_fakecloud/dynamodb/ttl-processor/tick')
+        );
+    }
+}
+
+final class SecretsManagerClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function tickRotation(): RotationTickResponse
+    {
+        return RotationTickResponse::fromArray(
+            $this->http->postEmpty('/_fakecloud/secretsmanager/rotation-scheduler/tick')
+        );
+    }
+}
+
+final class CognitoClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getUserCodes(string $poolId, string $username): UserConfirmationCodes
+    {
+        return UserConfirmationCodes::fromArray(
+            $this->http->get(
+                '/_fakecloud/cognito/confirmation-codes/'
+                . HttpTransport::encodePath($poolId)
+                . '/'
+                . HttpTransport::encodePath($username)
+            )
+        );
+    }
+
+    public function getConfirmationCodes(): ConfirmationCodesResponse
+    {
+        return ConfirmationCodesResponse::fromArray(
+            $this->http->get('/_fakecloud/cognito/confirmation-codes')
+        );
+    }
+
+    /**
+     * Force-confirm a user, bypassing the confirmation code flow.
+     *
+     * fakecloud returns a JSON body with an `error` field on 404 for unknown users,
+     * so we decode the body and surface it as a FakeCloudError.
+     */
+    public function confirmUser(ConfirmUserRequest $req): ConfirmUserResponse
+    {
+        $payload = json_encode($req->toArray(), JSON_THROW_ON_ERROR);
+        $response = $this->http->execute('POST', '/_fakecloud/cognito/confirm-user', $payload, 'application/json');
+        $parsed = ConfirmUserResponse::fromArray(json_decode($response['body'], true, 512, JSON_THROW_ON_ERROR));
+
+        if ($response['status'] === 404) {
+            throw new FakeCloudError(404, $parsed->error ?? 'user not found');
+        }
+        if ($response['status'] < 200 || $response['status'] >= 300) {
+            throw new FakeCloudError($response['status'], $response['body']);
+        }
+
+        return $parsed;
+    }
+
+    public function getTokens(): TokensResponse
+    {
+        return TokensResponse::fromArray(
+            $this->http->get('/_fakecloud/cognito/tokens')
+        );
+    }
+
+    public function expireTokens(ExpireTokensRequest $req): ExpireTokensResponse
+    {
+        return ExpireTokensResponse::fromArray(
+            $this->http->postJson('/_fakecloud/cognito/expire-tokens', $req->toArray())
+        );
+    }
+
+    public function getAuthEvents(): AuthEventsResponse
+    {
+        return AuthEventsResponse::fromArray(
+            $this->http->get('/_fakecloud/cognito/auth-events')
+        );
+    }
+}
+
+final class ApiGatewayV2Client
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getRequests(): ApiGatewayV2RequestsResponse
+    {
+        return ApiGatewayV2RequestsResponse::fromArray(
+            $this->http->get('/_fakecloud/apigatewayv2/requests')
+        );
+    }
+}
+
+final class StepFunctionsClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getExecutions(): StepFunctionsExecutionsResponse
+    {
+        return StepFunctionsExecutionsResponse::fromArray(
+            $this->http->get('/_fakecloud/stepfunctions/executions')
+        );
+    }
+}
+
+final class BedrockClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getInvocations(): BedrockInvocationsResponse
+    {
+        return BedrockInvocationsResponse::fromArray(
+            $this->http->get('/_fakecloud/bedrock/invocations')
+        );
+    }
+
+    public function setModelResponse(string $modelId, string $response): BedrockModelResponseConfig
+    {
+        return BedrockModelResponseConfig::fromArray(
+            $this->http->postText(
+                '/_fakecloud/bedrock/models/' . HttpTransport::encodePath($modelId) . '/response',
+                $response
+            )
+        );
+    }
+
+    /**
+     * @param BedrockResponseRule[] $rules
+     */
+    public function setResponseRules(string $modelId, array $rules): BedrockModelResponseConfig
+    {
+        return BedrockModelResponseConfig::fromArray(
+            $this->http->postJson(
+                '/_fakecloud/bedrock/models/' . HttpTransport::encodePath($modelId) . '/responses',
+                ['rules' => array_map(fn(BedrockResponseRule $r) => $r->toArray(), $rules)]
+            )
+        );
+    }
+
+    public function clearResponseRules(string $modelId): BedrockModelResponseConfig
+    {
+        return BedrockModelResponseConfig::fromArray(
+            $this->http->delete('/_fakecloud/bedrock/models/' . HttpTransport::encodePath($modelId) . '/responses')
+        );
+    }
+
+    public function queueFault(BedrockFaultRule $rule): BedrockStatusResponse
+    {
+        return BedrockStatusResponse::fromArray(
+            $this->http->postJson('/_fakecloud/bedrock/faults', $rule->toArray())
+        );
+    }
+
+    public function getFaults(): BedrockFaultsResponse
+    {
+        return BedrockFaultsResponse::fromArray(
+            $this->http->get('/_fakecloud/bedrock/faults')
+        );
+    }
+
+    public function clearFaults(): BedrockStatusResponse
+    {
+        return BedrockStatusResponse::fromArray(
+            $this->http->delete('/_fakecloud/bedrock/faults')
+        );
+    }
+}

--- a/sdks/php/src/FakeCloudError.php
+++ b/sdks/php/src/FakeCloudError.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeCloud;
+
+use RuntimeException;
+
+final class FakeCloudError extends RuntimeException
+{
+    public function __construct(
+        public readonly int $status,
+        public readonly string $body,
+    ) {
+        parent::__construct("fakecloud API error ({$status}): {$body}");
+    }
+}

--- a/sdks/php/src/HttpTransport.php
+++ b/sdks/php/src/HttpTransport.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeCloud;
+
+/**
+ * Shared HTTP + JSON machinery for every sub-client.
+ *
+ * @internal Not part of the public API.
+ */
+final class HttpTransport
+{
+    private string $baseUrl;
+
+    public function __construct(string $baseUrl)
+    {
+        $this->baseUrl = rtrim($baseUrl, '/');
+    }
+
+    public function baseUrl(): string
+    {
+        return $this->baseUrl;
+    }
+
+    public static function encodePath(string $segment): string
+    {
+        return rawurlencode($segment);
+    }
+
+    public function get(string $path): array
+    {
+        return $this->send('GET', $path);
+    }
+
+    public function postEmpty(string $path): array
+    {
+        return $this->send('POST', $path);
+    }
+
+    public function postJson(string $path, array $body): array
+    {
+        $payload = json_encode($body, JSON_THROW_ON_ERROR);
+        return $this->send('POST', $path, $payload, 'application/json');
+    }
+
+    public function postText(string $path, string $body): array
+    {
+        return $this->send('POST', $path, $body, 'text/plain');
+    }
+
+    public function delete(string $path): array
+    {
+        return $this->send('DELETE', $path);
+    }
+
+    /**
+     * Execute a request and return the raw response body + status code.
+     * Used by CognitoClient for special error handling.
+     *
+     * @return array{body: string, status: int}
+     */
+    public function execute(string $method, string $path, ?string $body = null, ?string $contentType = null): array
+    {
+        $ch = curl_init($this->baseUrl . $path);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+
+        $headers = [];
+        if ($contentType !== null) {
+            $headers[] = "Content-Type: {$contentType}";
+        }
+        if ($body !== null) {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+        }
+        if ($headers !== []) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        }
+
+        $responseBody = curl_exec($ch);
+        if ($responseBody === false) {
+            $error = curl_error($ch);
+            curl_close($ch);
+            throw new FakeCloudError(-1, "network error: {$error}");
+        }
+
+        $status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return ['body' => $responseBody, 'status' => $status];
+    }
+
+    private function send(string $method, string $path, ?string $body = null, ?string $contentType = null): array
+    {
+        $response = $this->execute($method, $path, $body, $contentType);
+
+        if ($response['status'] < 200 || $response['status'] >= 300) {
+            throw new FakeCloudError($response['status'], $response['body']);
+        }
+
+        $decoded = json_decode($response['body'], true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
+    }
+}

--- a/sdks/php/src/HttpTransport.php
+++ b/sdks/php/src/HttpTransport.php
@@ -65,6 +65,7 @@ final class HttpTransport
         $ch = curl_init($this->baseUrl . $path);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
 
         $headers = [];

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -1,0 +1,1182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeCloud;
+
+// ── Health & Reset ─────────────────────────────────────────────
+
+final class HealthResponse
+{
+    public function __construct(
+        public readonly string $status,
+        public readonly string $version,
+        /** @var string[] */
+        public readonly array $services,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['status'], $data['version'], $data['services']);
+    }
+}
+
+final class ResetResponse
+{
+    public function __construct(
+        public readonly string $status,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['status']);
+    }
+}
+
+final class ResetServiceResponse
+{
+    public function __construct(
+        public readonly string $reset,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['reset']);
+    }
+}
+
+// ── RDS ────────────────────────────────────────────────────────
+
+final class RdsTag
+{
+    public function __construct(
+        public readonly string $key,
+        public readonly string $value,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['key'], $data['value']);
+    }
+}
+
+final class RdsInstance
+{
+    public function __construct(
+        public readonly string $dbInstanceIdentifier,
+        public readonly string $dbInstanceArn,
+        public readonly string $dbInstanceClass,
+        public readonly string $engine,
+        public readonly string $engineVersion,
+        public readonly string $dbInstanceStatus,
+        public readonly string $masterUsername,
+        public readonly ?string $dbName,
+        public readonly ?string $endpointAddress,
+        public readonly int $port,
+        public readonly int $allocatedStorage,
+        public readonly bool $publiclyAccessible,
+        public readonly bool $deletionProtection,
+        public readonly string $createdAt,
+        public readonly string $dbiResourceId,
+        public readonly ?string $containerId,
+        public readonly ?int $hostPort,
+        /** @var RdsTag[] */
+        public readonly array $tags,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['dbInstanceIdentifier'],
+            $data['dbInstanceArn'],
+            $data['dbInstanceClass'],
+            $data['engine'],
+            $data['engineVersion'],
+            $data['dbInstanceStatus'],
+            $data['masterUsername'],
+            $data['dbName'] ?? null,
+            $data['endpointAddress'] ?? null,
+            $data['port'],
+            $data['allocatedStorage'],
+            $data['publiclyAccessible'],
+            $data['deletionProtection'],
+            $data['createdAt'],
+            $data['dbiResourceId'],
+            $data['containerId'] ?? null,
+            $data['hostPort'] ?? null,
+            array_map(RdsTag::fromArray(...), $data['tags'] ?? []),
+        );
+    }
+}
+
+final class RdsInstancesResponse
+{
+    public function __construct(
+        /** @var RdsInstance[] */
+        public readonly array $instances,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(RdsInstance::fromArray(...), $data['instances']));
+    }
+}
+
+// ── ElastiCache ────────────────────────────────────────────────
+
+final class ElastiCacheCluster
+{
+    public function __construct(
+        public readonly string $cacheClusterId,
+        public readonly string $cacheClusterStatus,
+        public readonly string $engine,
+        public readonly string $engineVersion,
+        public readonly string $cacheNodeType,
+        public readonly int $numCacheNodes,
+        public readonly ?string $replicationGroupId,
+        public readonly ?int $port,
+        public readonly ?int $hostPort,
+        public readonly ?string $containerId,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['cacheClusterId'],
+            $data['cacheClusterStatus'],
+            $data['engine'],
+            $data['engineVersion'],
+            $data['cacheNodeType'],
+            $data['numCacheNodes'],
+            $data['replicationGroupId'] ?? null,
+            $data['port'] ?? null,
+            $data['hostPort'] ?? null,
+            $data['containerId'] ?? null,
+        );
+    }
+}
+
+final class ElastiCacheClustersResponse
+{
+    public function __construct(
+        /** @var ElastiCacheCluster[] */
+        public readonly array $clusters,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(ElastiCacheCluster::fromArray(...), $data['clusters']));
+    }
+}
+
+final class ElastiCacheReplicationGroup
+{
+    public function __construct(
+        public readonly string $replicationGroupId,
+        public readonly string $status,
+        public readonly string $description,
+        /** @var string[] */
+        public readonly array $memberClusters,
+        public readonly bool $automaticFailover,
+        public readonly bool $multiAz,
+        public readonly string $engine,
+        public readonly string $engineVersion,
+        public readonly string $cacheNodeType,
+        public readonly int $numCacheClusters,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['replicationGroupId'],
+            $data['status'],
+            $data['description'],
+            $data['memberClusters'],
+            $data['automaticFailover'],
+            $data['multiAz'],
+            $data['engine'],
+            $data['engineVersion'],
+            $data['cacheNodeType'],
+            $data['numCacheClusters'],
+        );
+    }
+}
+
+final class ElastiCacheReplicationGroupsResponse
+{
+    public function __construct(
+        /** @var ElastiCacheReplicationGroup[] */
+        public readonly array $replicationGroups,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(ElastiCacheReplicationGroup::fromArray(...), $data['replicationGroups']));
+    }
+}
+
+final class ElastiCacheServerlessCache
+{
+    public function __construct(
+        public readonly string $serverlessCacheName,
+        public readonly string $status,
+        public readonly string $engine,
+        public readonly string $engineVersion,
+        public readonly ?string $cacheNodeType,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['serverlessCacheName'],
+            $data['status'],
+            $data['engine'],
+            $data['engineVersion'],
+            $data['cacheNodeType'] ?? null,
+        );
+    }
+}
+
+final class ElastiCacheServerlessCachesResponse
+{
+    public function __construct(
+        /** @var ElastiCacheServerlessCache[] */
+        public readonly array $serverlessCaches,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(ElastiCacheServerlessCache::fromArray(...), $data['serverlessCaches']));
+    }
+}
+
+// ── Lambda ─────────────────────────────────────────────────────
+
+final class LambdaInvocation
+{
+    public function __construct(
+        public readonly string $functionArn,
+        public readonly string $payload,
+        public readonly string $source,
+        public readonly string $timestamp,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['functionArn'], $data['payload'], $data['source'], $data['timestamp']);
+    }
+}
+
+final class LambdaInvocationsResponse
+{
+    public function __construct(
+        /** @var LambdaInvocation[] */
+        public readonly array $invocations,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(LambdaInvocation::fromArray(...), $data['invocations']));
+    }
+}
+
+final class WarmContainer
+{
+    public function __construct(
+        public readonly string $functionName,
+        public readonly string $runtime,
+        public readonly string $containerId,
+        public readonly int $lastUsedSecsAgo,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['functionName'], $data['runtime'], $data['containerId'], $data['lastUsedSecsAgo']);
+    }
+}
+
+final class WarmContainersResponse
+{
+    public function __construct(
+        /** @var WarmContainer[] */
+        public readonly array $containers,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(WarmContainer::fromArray(...), $data['containers']));
+    }
+}
+
+final class EvictContainerResponse
+{
+    public function __construct(
+        public readonly bool $evicted,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['evicted']);
+    }
+}
+
+// ── SES ────────────────────────────────────────────────────────
+
+final class SentEmail
+{
+    public function __construct(
+        public readonly string $messageId,
+        public readonly string $from,
+        /** @var string[] */
+        public readonly array $to,
+        /** @var string[] */
+        public readonly array $cc,
+        /** @var string[] */
+        public readonly array $bcc,
+        public readonly ?string $subject,
+        public readonly ?string $htmlBody,
+        public readonly ?string $textBody,
+        public readonly ?string $rawData,
+        public readonly ?string $templateName,
+        public readonly ?string $templateData,
+        public readonly string $timestamp,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['messageId'],
+            $data['from'],
+            $data['to'] ?? [],
+            $data['cc'] ?? [],
+            $data['bcc'] ?? [],
+            $data['subject'] ?? null,
+            $data['htmlBody'] ?? null,
+            $data['textBody'] ?? null,
+            $data['rawData'] ?? null,
+            $data['templateName'] ?? null,
+            $data['templateData'] ?? null,
+            $data['timestamp'],
+        );
+    }
+}
+
+final class SesEmailsResponse
+{
+    public function __construct(
+        /** @var SentEmail[] */
+        public readonly array $emails,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(SentEmail::fromArray(...), $data['emails']));
+    }
+}
+
+final class InboundEmailRequest
+{
+    public function __construct(
+        public readonly string $from,
+        /** @var string[] */
+        public readonly array $to,
+        public readonly string $subject,
+        public readonly string $body,
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'from' => $this->from,
+            'to' => $this->to,
+            'subject' => $this->subject,
+            'body' => $this->body,
+        ];
+    }
+}
+
+final class InboundActionExecuted
+{
+    public function __construct(
+        public readonly string $rule,
+        public readonly string $actionType,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['rule'], $data['actionType']);
+    }
+}
+
+final class InboundEmailResponse
+{
+    public function __construct(
+        public readonly string $messageId,
+        /** @var string[] */
+        public readonly array $matchedRules,
+        /** @var InboundActionExecuted[] */
+        public readonly array $actionsExecuted,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['messageId'],
+            $data['matchedRules'],
+            array_map(InboundActionExecuted::fromArray(...), $data['actionsExecuted']),
+        );
+    }
+}
+
+// ── SNS ────────────────────────────────────────────────────────
+
+final class SnsMessage
+{
+    public function __construct(
+        public readonly string $messageId,
+        public readonly string $topicArn,
+        public readonly string $message,
+        public readonly ?string $subject,
+        public readonly string $timestamp,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['messageId'], $data['topicArn'], $data['message'], $data['subject'] ?? null, $data['timestamp']);
+    }
+}
+
+final class SnsMessagesResponse
+{
+    public function __construct(
+        /** @var SnsMessage[] */
+        public readonly array $messages,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(SnsMessage::fromArray(...), $data['messages']));
+    }
+}
+
+final class PendingConfirmation
+{
+    public function __construct(
+        public readonly string $subscriptionArn,
+        public readonly string $topicArn,
+        public readonly string $protocol,
+        public readonly string $endpoint,
+        public readonly string $token,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['subscriptionArn'], $data['topicArn'], $data['protocol'], $data['endpoint'], $data['token']);
+    }
+}
+
+final class PendingConfirmationsResponse
+{
+    public function __construct(
+        /** @var PendingConfirmation[] */
+        public readonly array $pendingConfirmations,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(PendingConfirmation::fromArray(...), $data['pendingConfirmations']));
+    }
+}
+
+final class ConfirmSubscriptionRequest
+{
+    public function __construct(
+        public readonly string $subscriptionArn,
+    ) {}
+
+    public function toArray(): array
+    {
+        return ['subscriptionArn' => $this->subscriptionArn];
+    }
+}
+
+final class ConfirmSubscriptionResponse
+{
+    public function __construct(
+        public readonly bool $confirmed,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['confirmed']);
+    }
+}
+
+// ── SQS ────────────────────────────────────────────────────────
+
+final class SqsMessageInfo
+{
+    public function __construct(
+        public readonly string $messageId,
+        public readonly string $body,
+        public readonly int $receiveCount,
+        public readonly bool $inFlight,
+        public readonly string $createdAt,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['messageId'], $data['body'], $data['receiveCount'], $data['inFlight'], $data['createdAt']);
+    }
+}
+
+final class SqsQueueMessages
+{
+    public function __construct(
+        public readonly string $queueUrl,
+        public readonly string $queueName,
+        /** @var SqsMessageInfo[] */
+        public readonly array $messages,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['queueUrl'],
+            $data['queueName'],
+            array_map(SqsMessageInfo::fromArray(...), $data['messages']),
+        );
+    }
+}
+
+final class SqsMessagesResponse
+{
+    public function __construct(
+        /** @var SqsQueueMessages[] */
+        public readonly array $queues,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(SqsQueueMessages::fromArray(...), $data['queues']));
+    }
+}
+
+final class ExpirationTickResponse
+{
+    public function __construct(
+        public readonly int $expiredMessages,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['expiredMessages']);
+    }
+}
+
+final class ForceDlqResponse
+{
+    public function __construct(
+        public readonly int $movedMessages,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['movedMessages']);
+    }
+}
+
+// ── EventBridge ────────────────────────────────────────────────
+
+final class EventBridgeEvent
+{
+    public function __construct(
+        public readonly string $eventId,
+        public readonly string $source,
+        public readonly string $detailType,
+        public readonly string $detail,
+        public readonly string $busName,
+        public readonly string $timestamp,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['eventId'], $data['source'], $data['detailType'], $data['detail'], $data['busName'], $data['timestamp']);
+    }
+}
+
+final class EventBridgeLambdaDelivery
+{
+    public function __construct(
+        public readonly string $functionArn,
+        public readonly string $payload,
+        public readonly string $timestamp,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['functionArn'], $data['payload'], $data['timestamp']);
+    }
+}
+
+final class EventBridgeLogDelivery
+{
+    public function __construct(
+        public readonly string $logGroupArn,
+        public readonly string $payload,
+        public readonly string $timestamp,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['logGroupArn'], $data['payload'], $data['timestamp']);
+    }
+}
+
+final class EventBridgeDeliveries
+{
+    public function __construct(
+        /** @var EventBridgeLambdaDelivery[] */
+        public readonly array $lambda,
+        /** @var EventBridgeLogDelivery[] */
+        public readonly array $logs,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            array_map(EventBridgeLambdaDelivery::fromArray(...), $data['lambda'] ?? []),
+            array_map(EventBridgeLogDelivery::fromArray(...), $data['logs'] ?? []),
+        );
+    }
+}
+
+final class EventHistoryResponse
+{
+    public function __construct(
+        /** @var EventBridgeEvent[] */
+        public readonly array $events,
+        public readonly EventBridgeDeliveries $deliveries,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            array_map(EventBridgeEvent::fromArray(...), $data['events']),
+            EventBridgeDeliveries::fromArray($data['deliveries']),
+        );
+    }
+}
+
+final class FireRuleRequest
+{
+    public function __construct(
+        public readonly string $ruleName,
+        public readonly ?string $busName = null,
+    ) {}
+
+    public function toArray(): array
+    {
+        $data = ['ruleName' => $this->ruleName];
+        if ($this->busName !== null) {
+            $data['busName'] = $this->busName;
+        }
+        return $data;
+    }
+}
+
+final class FireRuleTarget
+{
+    public function __construct(
+        public readonly string $type,
+        public readonly string $arn,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['type'], $data['arn']);
+    }
+}
+
+final class FireRuleResponse
+{
+    public function __construct(
+        /** @var FireRuleTarget[] */
+        public readonly array $targets,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(FireRuleTarget::fromArray(...), $data['targets']));
+    }
+}
+
+// ── S3 ─────────────────────────────────────────────────────────
+
+final class S3Notification
+{
+    public function __construct(
+        public readonly string $bucket,
+        public readonly string $key,
+        public readonly string $eventType,
+        public readonly string $timestamp,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['bucket'], $data['key'], $data['eventType'], $data['timestamp']);
+    }
+}
+
+final class S3NotificationsResponse
+{
+    public function __construct(
+        /** @var S3Notification[] */
+        public readonly array $notifications,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(S3Notification::fromArray(...), $data['notifications']));
+    }
+}
+
+final class LifecycleTickResponse
+{
+    public function __construct(
+        public readonly int $processedBuckets,
+        public readonly int $expiredObjects,
+        public readonly int $transitionedObjects,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['processedBuckets'], $data['expiredObjects'], $data['transitionedObjects']);
+    }
+}
+
+// ── DynamoDB ───────────────────────────────────────────────────
+
+final class TtlTickResponse
+{
+    public function __construct(
+        public readonly int $expiredItems,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['expiredItems']);
+    }
+}
+
+// ── SecretsManager ─────────────────────────────────────────────
+
+final class RotationTickResponse
+{
+    public function __construct(
+        /** @var string[] */
+        public readonly array $rotatedSecrets,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['rotatedSecrets']);
+    }
+}
+
+// ── Cognito ────────────────────────────────────────────────────
+
+final class UserConfirmationCodes
+{
+    public function __construct(
+        public readonly ?string $confirmationCode,
+        /** @var array<string, mixed> */
+        public readonly array $attributeVerificationCodes,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['confirmationCode'] ?? null, $data['attributeVerificationCodes'] ?? []);
+    }
+}
+
+final class ConfirmationCode
+{
+    public function __construct(
+        public readonly string $poolId,
+        public readonly string $username,
+        public readonly string $code,
+        public readonly string $type,
+        public readonly ?string $attribute,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['poolId'], $data['username'], $data['code'], $data['type'], $data['attribute'] ?? null);
+    }
+}
+
+final class ConfirmationCodesResponse
+{
+    public function __construct(
+        /** @var ConfirmationCode[] */
+        public readonly array $codes,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(ConfirmationCode::fromArray(...), $data['codes']));
+    }
+}
+
+final class ConfirmUserRequest
+{
+    public function __construct(
+        public readonly string $userPoolId,
+        public readonly string $username,
+    ) {}
+
+    public function toArray(): array
+    {
+        return ['userPoolId' => $this->userPoolId, 'username' => $this->username];
+    }
+}
+
+final class ConfirmUserResponse
+{
+    public function __construct(
+        public readonly bool $confirmed,
+        public readonly ?string $error,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['confirmed'], $data['error'] ?? null);
+    }
+}
+
+final class TokenInfo
+{
+    public function __construct(
+        public readonly string $type,
+        public readonly string $username,
+        public readonly string $poolId,
+        public readonly string $clientId,
+        public readonly int $issuedAt,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['type'], $data['username'], $data['poolId'], $data['clientId'], $data['issuedAt']);
+    }
+}
+
+final class TokensResponse
+{
+    public function __construct(
+        /** @var TokenInfo[] */
+        public readonly array $tokens,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(TokenInfo::fromArray(...), $data['tokens']));
+    }
+}
+
+final class ExpireTokensRequest
+{
+    public function __construct(
+        public readonly ?string $userPoolId = null,
+        public readonly ?string $username = null,
+    ) {}
+
+    public function toArray(): array
+    {
+        $data = [];
+        if ($this->userPoolId !== null) {
+            $data['userPoolId'] = $this->userPoolId;
+        }
+        if ($this->username !== null) {
+            $data['username'] = $this->username;
+        }
+        return $data;
+    }
+}
+
+final class ExpireTokensResponse
+{
+    public function __construct(
+        public readonly int $expiredTokens,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['expiredTokens']);
+    }
+}
+
+final class AuthEvent
+{
+    public function __construct(
+        public readonly string $eventType,
+        public readonly string $username,
+        public readonly string $userPoolId,
+        public readonly string $clientId,
+        public readonly int $timestamp,
+        public readonly bool $success,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['eventType'], $data['username'], $data['userPoolId'], $data['clientId'], $data['timestamp'], $data['success']);
+    }
+}
+
+final class AuthEventsResponse
+{
+    public function __construct(
+        /** @var AuthEvent[] */
+        public readonly array $events,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(AuthEvent::fromArray(...), $data['events']));
+    }
+}
+
+// ── Step Functions ─────────────────────────────────────────────
+
+final class StepFunctionsExecution
+{
+    public function __construct(
+        public readonly string $executionArn,
+        public readonly string $stateMachineArn,
+        public readonly string $name,
+        public readonly string $status,
+        public readonly string $startDate,
+        public readonly ?string $input,
+        public readonly ?string $output,
+        public readonly ?string $stopDate,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['executionArn'],
+            $data['stateMachineArn'],
+            $data['name'],
+            $data['status'],
+            $data['startDate'],
+            $data['input'] ?? null,
+            $data['output'] ?? null,
+            $data['stopDate'] ?? null,
+        );
+    }
+}
+
+final class StepFunctionsExecutionsResponse
+{
+    public function __construct(
+        /** @var StepFunctionsExecution[] */
+        public readonly array $executions,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(StepFunctionsExecution::fromArray(...), $data['executions']));
+    }
+}
+
+// ── Bedrock ────────────────────────────────────────────────────
+
+final class BedrockInvocation
+{
+    public function __construct(
+        public readonly string $modelId,
+        public readonly string $input,
+        public readonly ?string $output,
+        public readonly string $timestamp,
+        public readonly ?string $error,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['modelId'], $data['input'], $data['output'] ?? null, $data['timestamp'], $data['error'] ?? null);
+    }
+}
+
+final class BedrockInvocationsResponse
+{
+    public function __construct(
+        /** @var BedrockInvocation[] */
+        public readonly array $invocations,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(BedrockInvocation::fromArray(...), $data['invocations']));
+    }
+}
+
+final class BedrockModelResponseConfig
+{
+    public function __construct(
+        public readonly string $status,
+        public readonly string $modelId,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['status'], $data['modelId']);
+    }
+}
+
+final class BedrockResponseRule
+{
+    public function __construct(
+        public readonly ?string $promptContains,
+        public readonly string $response,
+    ) {}
+
+    public function toArray(): array
+    {
+        $data = ['response' => $this->response];
+        if ($this->promptContains !== null) {
+            $data['promptContains'] = $this->promptContains;
+        }
+        return $data;
+    }
+}
+
+final class BedrockFaultRule
+{
+    public function __construct(
+        public readonly string $errorType,
+        public readonly ?string $message = null,
+        public readonly ?int $httpStatus = null,
+        public readonly ?int $count = null,
+        public readonly ?string $modelId = null,
+        public readonly ?string $operation = null,
+    ) {}
+
+    public function toArray(): array
+    {
+        $data = ['errorType' => $this->errorType];
+        if ($this->message !== null) {
+            $data['message'] = $this->message;
+        }
+        if ($this->httpStatus !== null) {
+            $data['httpStatus'] = $this->httpStatus;
+        }
+        if ($this->count !== null) {
+            $data['count'] = $this->count;
+        }
+        if ($this->modelId !== null) {
+            $data['modelId'] = $this->modelId;
+        }
+        if ($this->operation !== null) {
+            $data['operation'] = $this->operation;
+        }
+        return $data;
+    }
+}
+
+final class BedrockFaultRuleState
+{
+    public function __construct(
+        public readonly string $errorType,
+        public readonly ?string $message,
+        public readonly int $httpStatus,
+        public readonly int $remaining,
+        public readonly ?string $modelId,
+        public readonly ?string $operation,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['errorType'],
+            $data['message'] ?? null,
+            $data['httpStatus'],
+            $data['remaining'],
+            $data['modelId'] ?? null,
+            $data['operation'] ?? null,
+        );
+    }
+}
+
+final class BedrockFaultsResponse
+{
+    public function __construct(
+        /** @var BedrockFaultRuleState[] */
+        public readonly array $faults,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(BedrockFaultRuleState::fromArray(...), $data['faults']));
+    }
+}
+
+final class BedrockStatusResponse
+{
+    public function __construct(
+        public readonly string $status,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['status']);
+    }
+}
+
+// ── API Gateway v2 ─────────────────────────────────────────────
+
+final class ApiGatewayV2Request
+{
+    public function __construct(
+        public readonly string $requestId,
+        public readonly string $apiId,
+        public readonly string $stage,
+        public readonly string $method,
+        public readonly string $path,
+        /** @var array<string, string> */
+        public readonly array $headers,
+        /** @var array<string, string> */
+        public readonly array $queryParams,
+        public readonly ?string $body,
+        public readonly string $timestamp,
+        public readonly int $statusCode,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['requestId'],
+            $data['apiId'],
+            $data['stage'],
+            $data['method'],
+            $data['path'],
+            $data['headers'] ?? [],
+            $data['queryParams'] ?? [],
+            $data['body'] ?? null,
+            $data['timestamp'],
+            $data['statusCode'],
+        );
+    }
+}
+
+final class ApiGatewayV2RequestsResponse
+{
+    public function __construct(
+        /** @var ApiGatewayV2Request[] */
+        public readonly array $requests,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(ApiGatewayV2Request::fromArray(...), $data['requests']));
+    }
+}

--- a/sdks/php/tests/ClientTest.php
+++ b/sdks/php/tests/ClientTest.php
@@ -1,0 +1,516 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeCloud\Tests;
+
+use FakeCloud\ApiGatewayV2Request;
+use FakeCloud\ApiGatewayV2RequestsResponse;
+use FakeCloud\AuthEvent;
+use FakeCloud\AuthEventsResponse;
+use FakeCloud\BedrockFaultRule;
+use FakeCloud\BedrockFaultRuleState;
+use FakeCloud\BedrockFaultsResponse;
+use FakeCloud\BedrockInvocation;
+use FakeCloud\BedrockInvocationsResponse;
+use FakeCloud\BedrockModelResponseConfig;
+use FakeCloud\BedrockResponseRule;
+use FakeCloud\BedrockStatusResponse;
+use FakeCloud\ConfirmationCode;
+use FakeCloud\ConfirmationCodesResponse;
+use FakeCloud\ConfirmSubscriptionRequest;
+use FakeCloud\ConfirmSubscriptionResponse;
+use FakeCloud\ConfirmUserRequest;
+use FakeCloud\ConfirmUserResponse;
+use FakeCloud\ElastiCacheCluster;
+use FakeCloud\ElastiCacheClustersResponse;
+use FakeCloud\ElastiCacheReplicationGroup;
+use FakeCloud\ElastiCacheReplicationGroupsResponse;
+use FakeCloud\ElastiCacheServerlessCache;
+use FakeCloud\ElastiCacheServerlessCachesResponse;
+use FakeCloud\EventBridgeDeliveries;
+use FakeCloud\EventBridgeEvent;
+use FakeCloud\EventHistoryResponse;
+use FakeCloud\EvictContainerResponse;
+use FakeCloud\ExpirationTickResponse;
+use FakeCloud\ExpireTokensRequest;
+use FakeCloud\ExpireTokensResponse;
+use FakeCloud\FakeCloud;
+use FakeCloud\FakeCloudError;
+use FakeCloud\FireRuleRequest;
+use FakeCloud\FireRuleResponse;
+use FakeCloud\FireRuleTarget;
+use FakeCloud\ForceDlqResponse;
+use FakeCloud\HealthResponse;
+use FakeCloud\HttpTransport;
+use FakeCloud\InboundEmailRequest;
+use FakeCloud\InboundEmailResponse;
+use FakeCloud\LambdaInvocation;
+use FakeCloud\LambdaInvocationsResponse;
+use FakeCloud\LifecycleTickResponse;
+use FakeCloud\PendingConfirmation;
+use FakeCloud\PendingConfirmationsResponse;
+use FakeCloud\RdsInstance;
+use FakeCloud\RdsInstancesResponse;
+use FakeCloud\RdsTag;
+use FakeCloud\ResetResponse;
+use FakeCloud\ResetServiceResponse;
+use FakeCloud\RotationTickResponse;
+use FakeCloud\S3Notification;
+use FakeCloud\S3NotificationsResponse;
+use FakeCloud\SentEmail;
+use FakeCloud\SesEmailsResponse;
+use FakeCloud\SnsMessage;
+use FakeCloud\SnsMessagesResponse;
+use FakeCloud\SqsMessageInfo;
+use FakeCloud\SqsMessagesResponse;
+use FakeCloud\SqsQueueMessages;
+use FakeCloud\StepFunctionsExecution;
+use FakeCloud\StepFunctionsExecutionsResponse;
+use FakeCloud\TokenInfo;
+use FakeCloud\TokensResponse;
+use FakeCloud\TtlTickResponse;
+use FakeCloud\UserConfirmationCodes;
+use FakeCloud\WarmContainer;
+use FakeCloud\WarmContainersResponse;
+use PHPUnit\Framework\TestCase;
+
+final class ClientTest extends TestCase
+{
+    public function testDefaultBaseUrl(): void
+    {
+        $fc = new FakeCloud();
+        $this->assertSame('http://localhost:4566', $fc->baseUrl());
+    }
+
+    public function testCustomBaseUrl(): void
+    {
+        $fc = new FakeCloud('http://custom:1234');
+        $this->assertSame('http://custom:1234', $fc->baseUrl());
+    }
+
+    public function testTrailingSlashStripped(): void
+    {
+        $fc = new FakeCloud('http://localhost:4566///');
+        $this->assertSame('http://localhost:4566', $fc->baseUrl());
+    }
+
+    public function testEncodePath(): void
+    {
+        $this->assertSame('hello%20world', HttpTransport::encodePath('hello world'));
+        $this->assertSame('a%2Fb', HttpTransport::encodePath('a/b'));
+        $this->assertSame('simple', HttpTransport::encodePath('simple'));
+    }
+
+    // ── Type deserialization ───────────────────────────────────────
+
+    public function testHealthResponseFromArray(): void
+    {
+        $resp = HealthResponse::fromArray([
+            'status' => 'ok',
+            'version' => '0.9.2',
+            'services' => ['s3', 'sqs'],
+        ]);
+        $this->assertSame('ok', $resp->status);
+        $this->assertSame('0.9.2', $resp->version);
+        $this->assertSame(['s3', 'sqs'], $resp->services);
+    }
+
+    public function testResetResponseFromArray(): void
+    {
+        $resp = ResetResponse::fromArray(['status' => 'ok']);
+        $this->assertSame('ok', $resp->status);
+    }
+
+    public function testResetServiceResponseFromArray(): void
+    {
+        $resp = ResetServiceResponse::fromArray(['reset' => 'sqs']);
+        $this->assertSame('sqs', $resp->reset);
+    }
+
+    public function testLambdaInvocationsResponseFromArray(): void
+    {
+        $resp = LambdaInvocationsResponse::fromArray([
+            'invocations' => [
+                ['functionArn' => 'arn:aws:lambda:us-east-1:123:function:my-fn', 'payload' => '{}', 'source' => 'sdk', 'timestamp' => '2026-01-01T00:00:00Z'],
+            ],
+        ]);
+        $this->assertCount(1, $resp->invocations);
+        $this->assertSame('my-fn', basename($resp->invocations[0]->functionArn));
+    }
+
+    public function testWarmContainersResponseFromArray(): void
+    {
+        $resp = WarmContainersResponse::fromArray([
+            'containers' => [
+                ['functionName' => 'fn1', 'runtime' => 'nodejs20.x', 'containerId' => 'abc123', 'lastUsedSecsAgo' => 42],
+            ],
+        ]);
+        $this->assertCount(1, $resp->containers);
+        $this->assertSame(42, $resp->containers[0]->lastUsedSecsAgo);
+    }
+
+    public function testEvictContainerResponseFromArray(): void
+    {
+        $resp = EvictContainerResponse::fromArray(['evicted' => true]);
+        $this->assertTrue($resp->evicted);
+    }
+
+    public function testSesEmailsResponseFromArray(): void
+    {
+        $resp = SesEmailsResponse::fromArray([
+            'emails' => [
+                [
+                    'messageId' => 'msg-1',
+                    'from' => 'a@b.com',
+                    'to' => ['c@d.com'],
+                    'cc' => [],
+                    'bcc' => [],
+                    'subject' => 'Hello',
+                    'htmlBody' => '<b>hi</b>',
+                    'textBody' => 'hi',
+                    'rawData' => null,
+                    'templateName' => null,
+                    'templateData' => null,
+                    'timestamp' => '2026-01-01T00:00:00Z',
+                ],
+            ],
+        ]);
+        $this->assertCount(1, $resp->emails);
+        $this->assertSame('Hello', $resp->emails[0]->subject);
+    }
+
+    public function testInboundEmailRequestToArray(): void
+    {
+        $req = new InboundEmailRequest('a@b.com', ['c@d.com'], 'Test', 'Body');
+        $this->assertSame([
+            'from' => 'a@b.com',
+            'to' => ['c@d.com'],
+            'subject' => 'Test',
+            'body' => 'Body',
+        ], $req->toArray());
+    }
+
+    public function testSnsMessagesResponseFromArray(): void
+    {
+        $resp = SnsMessagesResponse::fromArray([
+            'messages' => [
+                ['messageId' => 'm1', 'topicArn' => 'arn:aws:sns:us-east-1:123:topic', 'message' => 'hello', 'subject' => null, 'timestamp' => '2026-01-01T00:00:00Z'],
+            ],
+        ]);
+        $this->assertCount(1, $resp->messages);
+        $this->assertNull($resp->messages[0]->subject);
+    }
+
+    public function testSqsMessagesResponseFromArray(): void
+    {
+        $resp = SqsMessagesResponse::fromArray([
+            'queues' => [
+                [
+                    'queueUrl' => 'http://localhost:4566/queue/test-queue',
+                    'queueName' => 'test-queue',
+                    'messages' => [
+                        ['messageId' => 'm1', 'body' => 'hi', 'receiveCount' => 0, 'inFlight' => false, 'createdAt' => '2026-01-01T00:00:00Z'],
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertCount(1, $resp->queues);
+        $this->assertSame('test-queue', $resp->queues[0]->queueName);
+        $this->assertCount(1, $resp->queues[0]->messages);
+    }
+
+    public function testEventHistoryResponseFromArray(): void
+    {
+        $resp = EventHistoryResponse::fromArray([
+            'events' => [
+                ['eventId' => 'e1', 'source' => 'my.app', 'detailType' => 'OrderPlaced', 'detail' => '{}', 'busName' => 'default', 'timestamp' => '2026-01-01T00:00:00Z'],
+            ],
+            'deliveries' => ['lambda' => [], 'logs' => []],
+        ]);
+        $this->assertCount(1, $resp->events);
+        $this->assertEmpty($resp->deliveries->lambda);
+    }
+
+    public function testFireRuleRequestToArray(): void
+    {
+        $req = new FireRuleRequest('my-rule');
+        $this->assertSame(['ruleName' => 'my-rule'], $req->toArray());
+
+        $req2 = new FireRuleRequest('my-rule', 'custom-bus');
+        $this->assertSame(['ruleName' => 'my-rule', 'busName' => 'custom-bus'], $req2->toArray());
+    }
+
+    public function testRdsInstancesResponseFromArray(): void
+    {
+        $resp = RdsInstancesResponse::fromArray([
+            'instances' => [
+                [
+                    'dbInstanceIdentifier' => 'test-db',
+                    'dbInstanceArn' => 'arn:aws:rds:us-east-1:123:db:test-db',
+                    'dbInstanceClass' => 'db.t3.micro',
+                    'engine' => 'postgres',
+                    'engineVersion' => '15.4',
+                    'dbInstanceStatus' => 'available',
+                    'masterUsername' => 'admin',
+                    'dbName' => 'testdb',
+                    'endpointAddress' => 'localhost',
+                    'port' => 5432,
+                    'allocatedStorage' => 20,
+                    'publiclyAccessible' => false,
+                    'deletionProtection' => false,
+                    'createdAt' => '2026-01-01T00:00:00Z',
+                    'dbiResourceId' => 'db-ABC123',
+                    'containerId' => 'ctr-123',
+                    'hostPort' => 55432,
+                    'tags' => [['key' => 'env', 'value' => 'test']],
+                ],
+            ],
+        ]);
+        $this->assertCount(1, $resp->instances);
+        $this->assertSame('test-db', $resp->instances[0]->dbInstanceIdentifier);
+        $this->assertCount(1, $resp->instances[0]->tags);
+        $this->assertSame('env', $resp->instances[0]->tags[0]->key);
+    }
+
+    public function testElastiCacheResponsesFromArray(): void
+    {
+        $clusters = ElastiCacheClustersResponse::fromArray([
+            'clusters' => [
+                ['cacheClusterId' => 'c1', 'cacheClusterStatus' => 'available', 'engine' => 'redis', 'engineVersion' => '7.0', 'cacheNodeType' => 'cache.t3.micro', 'numCacheNodes' => 1, 'replicationGroupId' => null, 'port' => 6379, 'hostPort' => 56379, 'containerId' => 'ctr'],
+            ],
+        ]);
+        $this->assertCount(1, $clusters->clusters);
+
+        $replGroups = ElastiCacheReplicationGroupsResponse::fromArray([
+            'replicationGroups' => [
+                ['replicationGroupId' => 'rg1', 'status' => 'available', 'description' => 'test', 'memberClusters' => ['c1'], 'automaticFailover' => true, 'multiAz' => false, 'engine' => 'redis', 'engineVersion' => '7.0', 'cacheNodeType' => 'cache.t3.micro', 'numCacheClusters' => 1],
+            ],
+        ]);
+        $this->assertCount(1, $replGroups->replicationGroups);
+
+        $serverless = ElastiCacheServerlessCachesResponse::fromArray([
+            'serverlessCaches' => [
+                ['serverlessCacheName' => 'sc1', 'status' => 'available', 'engine' => 'redis', 'engineVersion' => '7.0', 'cacheNodeType' => null],
+            ],
+        ]);
+        $this->assertCount(1, $serverless->serverlessCaches);
+    }
+
+    public function testCognitoTypesFromArray(): void
+    {
+        $codes = UserConfirmationCodes::fromArray(['confirmationCode' => '123456', 'attributeVerificationCodes' => ['email' => '654321']]);
+        $this->assertSame('123456', $codes->confirmationCode);
+
+        $allCodes = ConfirmationCodesResponse::fromArray([
+            'codes' => [
+                ['poolId' => 'pool-1', 'username' => 'user1', 'code' => '123', 'type' => 'signup', 'attribute' => null],
+            ],
+        ]);
+        $this->assertCount(1, $allCodes->codes);
+
+        $confirmResp = ConfirmUserResponse::fromArray(['confirmed' => true, 'error' => null]);
+        $this->assertTrue($confirmResp->confirmed);
+
+        $tokens = TokensResponse::fromArray([
+            'tokens' => [
+                ['type' => 'access', 'username' => 'user1', 'poolId' => 'pool-1', 'clientId' => 'client-1', 'issuedAt' => 1700000000],
+            ],
+        ]);
+        $this->assertCount(1, $tokens->tokens);
+
+        $expireResp = ExpireTokensResponse::fromArray(['expiredTokens' => 5]);
+        $this->assertSame(5, $expireResp->expiredTokens);
+
+        $events = AuthEventsResponse::fromArray([
+            'events' => [
+                ['eventType' => 'SignIn', 'username' => 'user1', 'userPoolId' => 'pool-1', 'clientId' => 'client-1', 'timestamp' => 1700000000, 'success' => true],
+            ],
+        ]);
+        $this->assertCount(1, $events->events);
+    }
+
+    public function testStepFunctionsResponseFromArray(): void
+    {
+        $resp = StepFunctionsExecutionsResponse::fromArray([
+            'executions' => [
+                ['executionArn' => 'arn:exec', 'stateMachineArn' => 'arn:sm', 'name' => 'exec-1', 'status' => 'SUCCEEDED', 'startDate' => '2026-01-01T00:00:00Z', 'input' => '{}', 'output' => '{"result":1}', 'stopDate' => '2026-01-01T00:00:01Z'],
+            ],
+        ]);
+        $this->assertCount(1, $resp->executions);
+        $this->assertSame('SUCCEEDED', $resp->executions[0]->status);
+    }
+
+    public function testApiGatewayV2ResponseFromArray(): void
+    {
+        $resp = ApiGatewayV2RequestsResponse::fromArray([
+            'requests' => [
+                ['requestId' => 'r1', 'apiId' => 'api1', 'stage' => '$default', 'method' => 'GET', 'path' => '/hello', 'headers' => ['host' => 'localhost'], 'queryParams' => ['q' => 'test'], 'body' => null, 'timestamp' => '2026-01-01T00:00:00Z', 'statusCode' => 200],
+            ],
+        ]);
+        $this->assertCount(1, $resp->requests);
+        $this->assertSame(200, $resp->requests[0]->statusCode);
+    }
+
+    public function testBedrockTypesFromArray(): void
+    {
+        $invocations = BedrockInvocationsResponse::fromArray([
+            'invocations' => [
+                ['modelId' => 'anthropic.claude-3', 'input' => 'hi', 'output' => 'hello', 'timestamp' => '2026-01-01T00:00:00Z', 'error' => null],
+            ],
+        ]);
+        $this->assertCount(1, $invocations->invocations);
+
+        $config = BedrockModelResponseConfig::fromArray(['status' => 'ok', 'modelId' => 'test-model']);
+        $this->assertSame('ok', $config->status);
+
+        $faults = BedrockFaultsResponse::fromArray([
+            'faults' => [
+                ['errorType' => 'ThrottlingException', 'message' => 'too fast', 'httpStatus' => 429, 'remaining' => 3, 'modelId' => null, 'operation' => null],
+            ],
+        ]);
+        $this->assertCount(1, $faults->faults);
+        $this->assertSame(3, $faults->faults[0]->remaining);
+    }
+
+    public function testBedrockFaultRuleToArray(): void
+    {
+        $rule = new BedrockFaultRule('ThrottlingException');
+        $this->assertSame(['errorType' => 'ThrottlingException'], $rule->toArray());
+
+        $rule2 = new BedrockFaultRule('ThrottlingException', 'too fast', 429, 3, 'model-1', 'InvokeModel');
+        $expected = [
+            'errorType' => 'ThrottlingException',
+            'message' => 'too fast',
+            'httpStatus' => 429,
+            'count' => 3,
+            'modelId' => 'model-1',
+            'operation' => 'InvokeModel',
+        ];
+        $this->assertSame($expected, $rule2->toArray());
+    }
+
+    public function testBedrockResponseRuleToArray(): void
+    {
+        $rule = new BedrockResponseRule('buy now', '{"label":"spam"}');
+        $this->assertSame(['response' => '{"label":"spam"}', 'promptContains' => 'buy now'], $rule->toArray());
+
+        $catchAll = new BedrockResponseRule(null, '{"label":"ham"}');
+        $this->assertSame(['response' => '{"label":"ham"}'], $catchAll->toArray());
+    }
+
+    public function testExpireTokensRequestToArray(): void
+    {
+        $req = new ExpireTokensRequest();
+        $this->assertSame([], $req->toArray());
+
+        $req2 = new ExpireTokensRequest('pool-1', 'user1');
+        $this->assertSame(['userPoolId' => 'pool-1', 'username' => 'user1'], $req2->toArray());
+    }
+
+    public function testConfirmSubscriptionRequestToArray(): void
+    {
+        $req = new ConfirmSubscriptionRequest('arn:sub');
+        $this->assertSame(['subscriptionArn' => 'arn:sub'], $req->toArray());
+    }
+
+    public function testConfirmUserRequestToArray(): void
+    {
+        $req = new ConfirmUserRequest('pool-1', 'user1');
+        $this->assertSame(['userPoolId' => 'pool-1', 'username' => 'user1'], $req->toArray());
+    }
+
+    public function testFakeCloudErrorMessage(): void
+    {
+        $err = new FakeCloudError(404, 'not found');
+        $this->assertSame(404, $err->status);
+        $this->assertSame('not found', $err->body);
+        $this->assertSame('fakecloud API error (404): not found', $err->getMessage());
+    }
+
+    public function testSubClientAccessors(): void
+    {
+        $fc = new FakeCloud();
+        $this->assertInstanceOf(\FakeCloud\LambdaClient::class, $fc->lambda());
+        $this->assertInstanceOf(\FakeCloud\RdsClient::class, $fc->rds());
+        $this->assertInstanceOf(\FakeCloud\ElastiCacheClient::class, $fc->elasticache());
+        $this->assertInstanceOf(\FakeCloud\SesClient::class, $fc->ses());
+        $this->assertInstanceOf(\FakeCloud\SnsClient::class, $fc->sns());
+        $this->assertInstanceOf(\FakeCloud\SqsClient::class, $fc->sqs());
+        $this->assertInstanceOf(\FakeCloud\EventsClient::class, $fc->events());
+        $this->assertInstanceOf(\FakeCloud\S3Client::class, $fc->s3());
+        $this->assertInstanceOf(\FakeCloud\DynamoDbClient::class, $fc->dynamodb());
+        $this->assertInstanceOf(\FakeCloud\SecretsManagerClient::class, $fc->secretsmanager());
+        $this->assertInstanceOf(\FakeCloud\CognitoClient::class, $fc->cognito());
+        $this->assertInstanceOf(\FakeCloud\ApiGatewayV2Client::class, $fc->apigatewayv2());
+        $this->assertInstanceOf(\FakeCloud\StepFunctionsClient::class, $fc->stepfunctions());
+        $this->assertInstanceOf(\FakeCloud\BedrockClient::class, $fc->bedrock());
+    }
+
+    public function testTickerResponsesFromArray(): void
+    {
+        $ttl = TtlTickResponse::fromArray(['expiredItems' => 10]);
+        $this->assertSame(10, $ttl->expiredItems);
+
+        $rotation = RotationTickResponse::fromArray(['rotatedSecrets' => ['secret-1', 'secret-2']]);
+        $this->assertSame(['secret-1', 'secret-2'], $rotation->rotatedSecrets);
+
+        $expiration = ExpirationTickResponse::fromArray(['expiredMessages' => 3]);
+        $this->assertSame(3, $expiration->expiredMessages);
+
+        $dlq = ForceDlqResponse::fromArray(['movedMessages' => 5]);
+        $this->assertSame(5, $dlq->movedMessages);
+
+        $lifecycle = LifecycleTickResponse::fromArray(['processedBuckets' => 2, 'expiredObjects' => 4, 'transitionedObjects' => 1]);
+        $this->assertSame(2, $lifecycle->processedBuckets);
+        $this->assertSame(4, $lifecycle->expiredObjects);
+        $this->assertSame(1, $lifecycle->transitionedObjects);
+    }
+
+    public function testS3NotificationsFromArray(): void
+    {
+        $resp = S3NotificationsResponse::fromArray([
+            'notifications' => [
+                ['bucket' => 'my-bucket', 'key' => 'file.txt', 'eventType' => 's3:ObjectCreated:Put', 'timestamp' => '2026-01-01T00:00:00Z'],
+            ],
+        ]);
+        $this->assertCount(1, $resp->notifications);
+        $this->assertSame('my-bucket', $resp->notifications[0]->bucket);
+    }
+
+    public function testPendingConfirmationsFromArray(): void
+    {
+        $resp = PendingConfirmationsResponse::fromArray([
+            'pendingConfirmations' => [
+                ['subscriptionArn' => 'arn:sub', 'topicArn' => 'arn:topic', 'protocol' => 'https', 'endpoint' => 'https://example.com', 'token' => 'tok-123'],
+            ],
+        ]);
+        $this->assertCount(1, $resp->pendingConfirmations);
+        $this->assertSame('tok-123', $resp->pendingConfirmations[0]->token);
+    }
+
+    public function testInboundEmailResponseFromArray(): void
+    {
+        $resp = InboundEmailResponse::fromArray([
+            'messageId' => 'msg-1',
+            'matchedRules' => ['rule-1'],
+            'actionsExecuted' => [
+                ['rule' => 'rule-1', 'actionType' => 'Lambda'],
+            ],
+        ]);
+        $this->assertSame('msg-1', $resp->messageId);
+        $this->assertCount(1, $resp->actionsExecuted);
+    }
+
+    public function testUnknownFieldsIgnored(): void
+    {
+        // Forward compatibility: extra fields should not cause errors
+        $resp = HealthResponse::fromArray([
+            'status' => 'ok',
+            'version' => '1.0.0',
+            'services' => [],
+            'newFieldFromFuture' => 'value',
+        ]);
+        $this->assertSame('ok', $resp->status);
+    }
+}

--- a/sdks/php/tests/ClientTest.php
+++ b/sdks/php/tests/ClientTest.php
@@ -136,7 +136,7 @@ final class ClientTest extends TestCase
             ],
         ]);
         $this->assertCount(1, $resp->invocations);
-        $this->assertSame('my-fn', basename($resp->invocations[0]->functionArn));
+        $this->assertStringEndsWith(':my-fn', $resp->invocations[0]->functionArn);
     }
 
     public function testWarmContainersResponseFromArray(): void

--- a/sdks/php/tests/E2ETest.php
+++ b/sdks/php/tests/E2ETest.php
@@ -1,0 +1,390 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeCloud\Tests;
+
+use FakeCloud\BedrockFaultRule;
+use FakeCloud\BedrockResponseRule;
+use FakeCloud\ConfirmUserRequest;
+use FakeCloud\FakeCloud;
+use FakeCloud\FakeCloudError;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * E2E tests that require a running fakecloud server.
+ *
+ * Start the server before running:
+ *   cargo run -- --port 4566
+ *
+ * Then run:
+ *   vendor/bin/phpunit tests/E2ETest.php
+ *
+ * Set FAKECLOUD_ENDPOINT to override the base URL (default: http://localhost:4566).
+ */
+final class E2ETest extends TestCase
+{
+    private FakeCloud $fc;
+    private string $endpoint;
+
+    protected function setUp(): void
+    {
+        $this->endpoint = getenv('FAKECLOUD_ENDPOINT') ?: 'http://localhost:4566';
+
+        // Quick health check — skip if server not reachable
+        $ch = curl_init($this->endpoint . '/_fakecloud/health');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 2);
+        $result = curl_exec($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        if ($result === false || $code !== 200) {
+            $this->markTestSkipped('fakecloud server not reachable at ' . $this->endpoint);
+        }
+
+        $this->fc = new FakeCloud($this->endpoint);
+        $this->fc->reset();
+    }
+
+    // ── Health ─────────────────────────────────────────────────────
+
+    public function testHealthReturnsServerStatus(): void
+    {
+        $health = $this->fc->health();
+        $this->assertSame('ok', $health->status);
+        $this->assertNotEmpty($health->version);
+        $this->assertNotEmpty($health->services);
+    }
+
+    // ── Reset ──────────────────────────────────────────────────────
+
+    public function testResetClearsState(): void
+    {
+        // Create a queue via AWS SDK
+        $this->awsSqs('CreateQueue', ['QueueName' => 'reset-test']);
+
+        // Verify queue exists
+        $queues = $this->fc->sqs()->getMessages();
+        // After reset, should be empty
+        $this->fc->reset();
+        $queuesAfter = $this->fc->sqs()->getMessages();
+        $this->assertEmpty($queuesAfter->queues);
+    }
+
+    public function testResetServiceClearsOneService(): void
+    {
+        $result = $this->fc->resetService('sqs');
+        $this->assertSame('sqs', $result->reset);
+    }
+
+    // ── SQS ────────────────────────────────────────────────────────
+
+    public function testSqsGetMessages(): void
+    {
+        $this->awsSqs('CreateQueue', ['QueueName' => 'php-test-queue']);
+        $queueUrl = $this->endpoint . '/000000000000/php-test-queue';
+        $this->awsSqs('SendMessage', [
+            'QueueUrl' => $queueUrl,
+            'MessageBody' => 'hello from php',
+        ]);
+
+        $result = $this->fc->sqs()->getMessages();
+        $this->assertNotEmpty($result->queues);
+        $queue = $this->findQueue($result->queues, 'php-test-queue');
+        $this->assertNotNull($queue);
+        $this->assertCount(1, $queue->messages);
+        $this->assertSame('hello from php', $queue->messages[0]->body);
+    }
+
+    // ── SNS ────────────────────────────────────────────────────────
+
+    public function testSnsGetMessages(): void
+    {
+        $topicArn = $this->awsSns('CreateTopic', ['Name' => 'php-test-topic'])['CreateTopicResponse']['CreateTopicResult']['TopicArn'];
+        $this->awsSns('Publish', [
+            'TopicArn' => $topicArn,
+            'Message' => 'hello sns from php',
+            'Subject' => 'test subject',
+        ]);
+
+        $result = $this->fc->sns()->getMessages();
+        $this->assertNotEmpty($result->messages);
+        $this->assertSame('hello sns from php', $result->messages[0]->message);
+    }
+
+    public function testSnsPendingConfirmations(): void
+    {
+        $topicArn = $this->awsSns('CreateTopic', ['Name' => 'php-confirm-topic'])['CreateTopicResponse']['CreateTopicResult']['TopicArn'];
+        $this->awsSns('Subscribe', [
+            'TopicArn' => $topicArn,
+            'Protocol' => 'https',
+            'Endpoint' => 'https://example.com/php-webhook',
+        ]);
+
+        $result = $this->fc->sns()->getPendingConfirmations();
+        $found = false;
+        foreach ($result->pendingConfirmations as $pc) {
+            if ($pc->endpoint === 'https://example.com/php-webhook') {
+                $found = true;
+                $this->assertSame('https', $pc->protocol);
+            }
+        }
+        $this->assertTrue($found, 'Expected pending confirmation not found');
+    }
+
+    // ── SES ────────────────────────────────────────────────────────
+
+    public function testSesGetEmails(): void
+    {
+        $this->awsSesV2('CreateEmailIdentity', ['EmailIdentity' => 'php@example.com']);
+        $this->awsSesV2('SendEmail', [
+            'FromEmailAddress' => 'php@example.com',
+            'Destination' => ['ToAddresses' => ['to@example.com']],
+            'Content' => [
+                'Simple' => [
+                    'Subject' => ['Data' => 'PHP test email'],
+                    'Body' => ['Text' => ['Data' => 'Hello from PHP']],
+                ],
+            ],
+        ]);
+
+        $result = $this->fc->ses()->getEmails();
+        $this->assertNotEmpty($result->emails);
+        $found = false;
+        foreach ($result->emails as $email) {
+            if ($email->subject === 'PHP test email') {
+                $found = true;
+                $this->assertSame('php@example.com', $email->from);
+            }
+        }
+        $this->assertTrue($found, 'Expected email not found');
+    }
+
+    // ── EventBridge ────────────────────────────────────────────────
+
+    public function testEventsGetHistory(): void
+    {
+        $this->awsEventBridge('PutEvents', [
+            'Entries' => [
+                [
+                    'Source' => 'php.test',
+                    'DetailType' => 'PhpTestEvent',
+                    'Detail' => '{"key":"value"}',
+                ],
+            ],
+        ]);
+
+        $result = $this->fc->events()->getHistory();
+        $found = false;
+        foreach ($result->events as $event) {
+            if ($event->source === 'php.test') {
+                $found = true;
+                $this->assertSame('PhpTestEvent', $event->detailType);
+            }
+        }
+        $this->assertTrue($found, 'Expected event not found');
+    }
+
+    // ── DynamoDB ───────────────────────────────────────────────────
+
+    public function testDynamodbTickTtl(): void
+    {
+        $this->awsDynamoDB('CreateTable', [
+            'TableName' => 'php-ttl-table',
+            'KeySchema' => [['AttributeName' => 'pk', 'KeyType' => 'HASH']],
+            'AttributeDefinitions' => [['AttributeName' => 'pk', 'AttributeType' => 'S']],
+            'BillingMode' => 'PAY_PER_REQUEST',
+        ]);
+        $this->awsDynamoDB('UpdateTimeToLive', [
+            'TableName' => 'php-ttl-table',
+            'TimeToLiveSpecification' => ['AttributeName' => 'ttl', 'Enabled' => true],
+        ]);
+        $this->awsDynamoDB('PutItem', [
+            'TableName' => 'php-ttl-table',
+            'Item' => [
+                'pk' => ['S' => 'item-1'],
+                'ttl' => ['N' => '0'],
+            ],
+        ]);
+
+        $result = $this->fc->dynamodb()->tickTtl();
+        $this->assertGreaterThanOrEqual(1, $result->expiredItems);
+    }
+
+    // ── Bedrock ────────────────────────────────────────────────────
+
+    public function testBedrockResponseRulesRoundTrip(): void
+    {
+        $modelId = 'anthropic.claude-3-haiku-20240307-v1:0';
+        $set = $this->fc->bedrock()->setResponseRules($modelId, [
+            new BedrockResponseRule('spam:', '{"label":"spam"}'),
+            new BedrockResponseRule(null, '{"label":"ham"}'),
+        ]);
+        $this->assertSame('ok', $set->status);
+        $this->assertSame($modelId, $set->modelId);
+
+        $cleared = $this->fc->bedrock()->clearResponseRules($modelId);
+        $this->assertSame('ok', $cleared->status);
+    }
+
+    public function testBedrockFaultsRoundTrip(): void
+    {
+        $queued = $this->fc->bedrock()->queueFault(
+            new BedrockFaultRule('ThrottlingException', 'Rate exceeded', 429, 2, null, 'InvokeModel')
+        );
+        $this->assertSame('ok', $queued->status);
+
+        $list = $this->fc->bedrock()->getFaults();
+        $this->assertCount(1, $list->faults);
+        $this->assertSame('ThrottlingException', $list->faults[0]->errorType);
+        $this->assertSame(2, $list->faults[0]->remaining);
+
+        $cleared = $this->fc->bedrock()->clearFaults();
+        $this->assertSame('ok', $cleared->status);
+        $this->assertEmpty($this->fc->bedrock()->getFaults()->faults);
+    }
+
+    public function testBedrockGetInvocations(): void
+    {
+        $result = $this->fc->bedrock()->getInvocations();
+        $this->assertIsArray($result->invocations);
+    }
+
+    // ── S3 ─────────────────────────────────────────────────────────
+
+    public function testS3GetNotifications(): void
+    {
+        $result = $this->fc->s3()->getNotifications();
+        $this->assertIsArray($result->notifications);
+    }
+
+    // ── Cognito ────────────────────────────────────────────────────
+
+    public function testCognitoConfirmUserNotFoundThrows(): void
+    {
+        // Create pool so we have a valid pool ID
+        $poolId = $this->createCognitoPool();
+
+        $this->expectException(FakeCloudError::class);
+        $this->fc->cognito()->confirmUser(new ConfirmUserRequest($poolId, 'nobody-here'));
+    }
+
+    // ── Helpers: raw AWS API calls via curl ────────────────────────
+
+    private function awsSqs(string $action, array $params): array
+    {
+        $params['Action'] = $action;
+        $params['Version'] = '2012-11-05';
+        $ch = curl_init($this->endpoint);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/x-www-form-urlencoded',
+            'Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260101/us-east-1/sqs/aws4_request, SignedHeaders=host, Signature=dummy',
+        ]);
+        $result = curl_exec($ch);
+        curl_close($ch);
+        return json_decode($result, true) ?: [];
+    }
+
+    private function awsSns(string $action, array $params): array
+    {
+        $params['Action'] = $action;
+        $params['Version'] = '2010-03-31';
+        $ch = curl_init($this->endpoint);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/x-www-form-urlencoded',
+            'Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260101/us-east-1/sns/aws4_request, SignedHeaders=host, Signature=dummy',
+        ]);
+        $result = curl_exec($ch);
+        curl_close($ch);
+
+        // SNS returns XML, parse it
+        $xml = simplexml_load_string($result);
+        return json_decode(json_encode($xml), true) ?: [];
+    }
+
+    private function awsSesV2(string $action, array $params): array
+    {
+        $path = match ($action) {
+            'CreateEmailIdentity' => '/v2/email/identities',
+            'SendEmail' => '/v2/email/outbound-emails',
+            default => throw new \RuntimeException("Unknown SES v2 action: {$action}"),
+        };
+        $ch = curl_init($this->endpoint . $path);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($params));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260101/us-east-1/ses/aws4_request, SignedHeaders=host, Signature=dummy',
+        ]);
+        $result = curl_exec($ch);
+        curl_close($ch);
+        return json_decode($result, true) ?: [];
+    }
+
+    private function awsEventBridge(string $action, array $params): array
+    {
+        $ch = curl_init($this->endpoint);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($params));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/x-amz-json-1.1',
+            'X-Amz-Target: AWSEvents.' . $action,
+            'Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260101/us-east-1/events/aws4_request, SignedHeaders=host, Signature=dummy',
+        ]);
+        $result = curl_exec($ch);
+        curl_close($ch);
+        return json_decode($result, true) ?: [];
+    }
+
+    private function awsDynamoDB(string $action, array $params): array
+    {
+        $ch = curl_init($this->endpoint);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($params));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/x-amz-json-1.0',
+            'X-Amz-Target: DynamoDB_20120810.' . $action,
+            'Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260101/us-east-1/dynamodb/aws4_request, SignedHeaders=host, Signature=dummy',
+        ]);
+        $result = curl_exec($ch);
+        curl_close($ch);
+        return json_decode($result, true) ?: [];
+    }
+
+    private function createCognitoPool(): string
+    {
+        $ch = curl_init($this->endpoint);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode(['PoolName' => 'php-test-pool']));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/x-amz-json-1.1',
+            'X-Amz-Target: AWSCognitoIdentityProviderService.CreateUserPool',
+            'Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260101/us-east-1/cognito-idp/aws4_request, SignedHeaders=host, Signature=dummy',
+        ]);
+        $result = curl_exec($ch);
+        curl_close($ch);
+        $data = json_decode($result, true);
+        return $data['UserPool']['Id'];
+    }
+
+    /** @param \FakeCloud\SqsQueueMessages[] $queues */
+    private function findQueue(array $queues, string $name): ?\FakeCloud\SqsQueueMessages
+    {
+        foreach ($queues as $q) {
+            if ($q->queueName === $name) {
+                return $q;
+            }
+        }
+        return null;
+    }
+}

--- a/sdks/php/tests/E2ETest.php
+++ b/sdks/php/tests/E2ETest.php
@@ -100,7 +100,8 @@ final class E2ETest extends TestCase
 
     public function testSnsGetMessages(): void
     {
-        $topicArn = $this->awsSns('CreateTopic', ['Name' => 'php-test-topic'])['CreateTopicResponse']['CreateTopicResult']['TopicArn'];
+        $xml = $this->awsSns('CreateTopic', ['Name' => 'php-test-topic']);
+        $topicArn = $this->extractXmlValue($xml, 'TopicArn');
         $this->awsSns('Publish', [
             'TopicArn' => $topicArn,
             'Message' => 'hello sns from php',
@@ -114,7 +115,8 @@ final class E2ETest extends TestCase
 
     public function testSnsPendingConfirmations(): void
     {
-        $topicArn = $this->awsSns('CreateTopic', ['Name' => 'php-confirm-topic'])['CreateTopicResponse']['CreateTopicResult']['TopicArn'];
+        $xml = $this->awsSns('CreateTopic', ['Name' => 'php-confirm-topic']);
+        $topicArn = $this->extractXmlValue($xml, 'TopicArn');
         $this->awsSns('Subscribe', [
             'TopicArn' => $topicArn,
             'Protocol' => 'https',
@@ -288,7 +290,7 @@ final class E2ETest extends TestCase
         return json_decode($result, true) ?: [];
     }
 
-    private function awsSns(string $action, array $params): array
+    private function awsSns(string $action, array $params): string
     {
         $params['Action'] = $action;
         $params['Version'] = '2010-03-31';
@@ -302,10 +304,13 @@ final class E2ETest extends TestCase
         ]);
         $result = curl_exec($ch);
         curl_close($ch);
+        return $result;
+    }
 
-        // SNS returns XML, parse it
-        $xml = simplexml_load_string($result);
-        return json_decode(json_encode($xml), true) ?: [];
+    private function extractXmlValue(string $xml, string $tag): string
+    {
+        preg_match("/<{$tag}>([^<]+)<\/{$tag}>/", $xml, $matches);
+        return $matches[1] ?? '';
     }
 
     private function awsSesV2(string $action, array $params): array

--- a/website/content/docs/getting-started/sdk-setup.md
+++ b/website/content/docs/getting-started/sdk-setup.md
@@ -1,10 +1,10 @@
 +++
 title = "SDK setup"
-description = "Install the first-party fakecloud SDK in TypeScript, Python, Go, Java, or Rust."
+description = "Install the first-party fakecloud SDK in TypeScript, Python, Go, PHP, Java, or Rust."
 weight = 3
 +++
 
-fakecloud ships first-party SDKs for test assertions in five languages. They wrap the `/_fakecloud/*` introspection and configuration endpoints into ergonomic helpers.
+fakecloud ships first-party SDKs for test assertions in six languages. They wrap the `/_fakecloud/*` introspection and configuration endpoints into ergonomic helpers.
 
 These SDKs are **not** the AWS SDK. Your application code still uses the normal AWS SDK (boto3, aws-sdk-js, etc.) to talk to fakecloud over the standard AWS wire protocol. The fakecloud SDK is what your tests use to assert on what happened and configure simulation behavior.
 
@@ -62,6 +62,21 @@ fc.Reset()
 emails, _ := fc.SES.GetEmails()
 ```
 
+## PHP
+
+```sh
+composer require fakecloud/fakecloud
+```
+
+```php
+use FakeCloud\FakeCloud;
+
+$fc = new FakeCloud(); // defaults to http://localhost:4566
+
+$fc->reset();
+$emails = $fc->ses()->getEmails()->emails;
+```
+
 ## Java
 
 ```kotlin
@@ -93,7 +108,7 @@ let invocations = fc.bedrock().get_invocations().await?;
 
 ## What each SDK covers
 
-All five SDKs wrap the same core surface:
+All six SDKs wrap the same core surface:
 
 - **Reset:** `reset()` / `reset(service)` — clear state between tests
 - **Per-service introspection:** getters for recorded messages, emails, invocations, etc.

--- a/website/content/docs/sdks/_index.md
+++ b/website/content/docs/sdks/_index.md
@@ -1,13 +1,13 @@
 +++
 title = "SDK reference"
-description = "First-party fakecloud SDKs for TypeScript, Python, Go, Java, and Rust."
+description = "First-party fakecloud SDKs for TypeScript, Python, Go, PHP, Java, and Rust."
 sort_by = "weight"
 weight = 6
 template = "docs.html"
 page_template = "docs-page.html"
 +++
 
-fakecloud ships first-party SDKs in five languages for test assertions and simulation control. Each SDK wraps the `/_fakecloud/*` introspection and configuration endpoints into ergonomic helpers that fit the language's testing idioms.
+fakecloud ships first-party SDKs in six languages for test assertions and simulation control. Each SDK wraps the `/_fakecloud/*` introspection and configuration endpoints into ergonomic helpers that fit the language's testing idioms.
 
 These SDKs are **not** the AWS SDK. Your application code still talks to fakecloud through the normal AWS SDK (boto3, aws-sdk-js, aws-sdk-rust, etc.) — the fakecloud SDK is what your tests use to assert on what happened.
 
@@ -18,12 +18,13 @@ These SDKs are **not** the AWS SDK. Your application code still talks to fakeclo
 | TypeScript | `npm install fakecloud`                         | [TypeScript SDK](/docs/sdks/typescript/) |
 | Python     | `pip install fakecloud`                         | [Python SDK](/docs/sdks/python/) |
 | Go         | `go get github.com/faiscadev/fakecloud/sdks/go` | [Go SDK](/docs/sdks/go/) |
+| PHP        | `composer require fakecloud/fakecloud`          | [PHP SDK](/docs/sdks/php/) |
 | Java       | `dev.fakecloud:fakecloud:0.1.0`                 | [Java SDK](/docs/sdks/java/) |
 | Rust       | `cargo add fakecloud-sdk`                       | [Rust SDK](/docs/sdks/rust/) |
 
 ## Common surface
 
-All five SDKs cover the same core surface:
+All six SDKs cover the same core surface:
 
 - **Reset:** `reset()` and `resetService(service)` to clear state between tests
 - **Health:** verify fakecloud is reachable
@@ -31,4 +32,4 @@ All five SDKs cover the same core surface:
 - **Simulation and processor ticks:** drive time-dependent behavior on demand (TTL expiration, secret rotation, S3 lifecycle)
 - **Bedrock test harness:** response configuration, fault injection, call history
 
-The method names differ across languages to match each language's idiom (camelCase for TS/JS and Java, snake_case for Python, PascalCase for Go, snake_case for Rust), but the behavior is the same.
+The method names differ across languages to match each language's idiom (camelCase for TS/JS, Java, and PHP, snake_case for Python, PascalCase for Go, snake_case for Rust), but the behavior is the same.

--- a/website/content/docs/sdks/php.md
+++ b/website/content/docs/sdks/php.md
@@ -1,0 +1,110 @@
++++
+title = "PHP SDK"
+description = "Install and use the fakecloud SDK for PHP tests (PHPUnit, Pest, Laravel, Symfony)."
+weight = 4
++++
+
+## Install
+
+```bash
+composer require fakecloud/fakecloud
+```
+
+Requires PHP 8.1+. Uses the built-in `curl` extension and `json_decode`/`json_encode`. No external dependencies.
+
+## Initialize
+
+```php
+use FakeCloud\FakeCloud;
+
+$fc = new FakeCloud();                         // defaults to http://localhost:4566
+$fc = new FakeCloud('http://localhost:5000');   // explicit base URL
+```
+
+## Top-level
+
+| Method                   | Description             |
+| ------------------------ | ----------------------- |
+| `health()`               | Server health check     |
+| `reset()`                | Reset all service state |
+| `resetService($service)` | Reset a single service  |
+
+## `$fc->bedrock()`
+
+| Method                                | Description                                                          |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| `getInvocations()`                    | List recorded Bedrock runtime invocations                            |
+| `setModelResponse($modelId, $text)`   | Configure a single canned response for a model                       |
+| `setResponseRules($modelId, $rules)`  | Replace prompt-conditional response rules for a model                |
+| `clearResponseRules($modelId)`        | Clear all prompt-conditional response rules for a model              |
+| `queueFault($rule)`                   | Queue a fault rule for the next N calls                              |
+| `getFaults()`                         | List currently queued fault rules                                    |
+| `clearFaults()`                       | Clear all queued fault rules                                         |
+
+## `$fc->lambda()`, `$fc->ses()`, `$fc->sns()`, `$fc->sqs()`, `$fc->events()`, `$fc->s3()`, `$fc->dynamodb()`, `$fc->secretsmanager()`, `$fc->cognito()`, `$fc->stepfunctions()`, `$fc->rds()`, `$fc->elasticache()`, `$fc->apigatewayv2()`
+
+Each sub-client mirrors the Java SDK method list 1:1. See the
+[SDK README](https://github.com/faiscadev/fakecloud/blob/main/sdks/php/README.md)
+for the full, always-current surface.
+
+## Error handling
+
+All methods throw `FakeCloudError` (a `RuntimeException`) on non-2xx responses:
+
+```php
+use FakeCloud\FakeCloudError;
+use FakeCloud\ConfirmUserRequest;
+
+try {
+    $fc->cognito()->confirmUser(new ConfirmUserRequest('pool-1', 'nobody'));
+} catch (FakeCloudError $err) {
+    echo $err->status; // 404
+    echo $err->body;   // error body from fakecloud
+}
+```
+
+## Example: full test loop
+
+```php
+use FakeCloud\FakeCloud;
+use FakeCloud\BedrockFaultRule;
+use FakeCloud\BedrockResponseRule;
+
+$fc = new FakeCloud();
+$modelId = 'anthropic.claude-3-haiku-20240307-v1:0';
+
+// PHPUnit setUp
+$fc->reset();
+
+// Test: classifier branches on spam vs ham
+$fc->bedrock()->setResponseRules($modelId, [
+    new BedrockResponseRule('buy now', '{"label":"spam"}'),
+    new BedrockResponseRule(null, '{"label":"ham"}'),
+]);
+
+classify('hello friend');
+classify('buy now cheap pills');
+
+$invocations = $fc->bedrock()->getInvocations()->invocations;
+$this->assertCount(2, $invocations);
+$this->assertStringContainsString('ham', $invocations[0]->output);
+$this->assertStringContainsString('spam', $invocations[1]->output);
+
+// Test: retries on throttling
+$fc->reset();
+$fc->bedrock()->queueFault(
+    new BedrockFaultRule('ThrottlingException', 'Rate exceeded', 429, 1)
+);
+
+classify('hello');
+
+$invocations = $fc->bedrock()->getInvocations()->invocations;
+$this->assertCount(2, $invocations);
+$this->assertStringContainsString('ThrottlingException', $invocations[0]->error);
+$this->assertNull($invocations[1]->error);
+```
+
+## Source
+
+- [`sdks/php`](https://github.com/faiscadev/fakecloud/tree/main/sdks/php)
+- [Source README](https://github.com/faiscadev/fakecloud/blob/main/sdks/php/README.md) — always-current method list


### PR DESCRIPTION
## Summary

- New PHP SDK at `sdks/php/` wrapping all `/_fakecloud/*` introspection endpoints
- Zero dependencies — uses built-in `curl` + `json_decode`, requires PHP 8.1+
- 14 service sub-clients matching existing SDKs 1:1: Lambda, SES, SNS, SQS, EventBridge, S3, DynamoDB, Secrets Manager, Cognito, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock
- Full type coverage with readonly classes and `fromArray()` deserialization
- Unit tests for all type serialization/deserialization
- E2E tests against running fakecloud server
- CI workflow (`.github/workflows/sdk-php.yml`)
- Documentation: README, website SDK page, SDK reference index, getting-started guide

## Test plan

- [ ] Unit tests pass: `cd sdks/php && composer install && vendor/bin/phpunit --testsuite unit`
- [ ] E2E tests pass against running fakecloud: `vendor/bin/phpunit --testsuite e2e`
- [ ] CI workflow runs both unit and E2E suites
- [ ] All 14 sub-clients match Java SDK method-for-method

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a zero‑dependency PHP SDK (`fakecloud/fakecloud`) for the `/_fakecloud/*` introspection API with typed models, 14 service clients, tests, CI, and docs. Also hardens HTTP handling, fixes SNS E2E XML parsing, and improves CI reliability.

- **New Features**
  - New SDK at `sdks/php/` for `/_fakecloud/*`; PHP 8.1+; uses built‑in `curl` and `json_decode`.
  - 14 service sub‑clients matching other SDKs 1:1.
  - Readonly, typed responses with `fromArray()`; unit/E2E tests; CI workflow and PHP docs pages.

- **Bug Fixes**
  - Composer `autoload.files` entries for multi‑class `src/Types.php` and `src/FakeCloud.php` to ensure PSR‑4 autoloading works.
  - HTTP: validate status before parsing body in `CognitoClient::confirmUser`; add `CURLOPT_TIMEOUT` (30s) to avoid hangs.
  - CI: replace fixed sleep with health‑check polling to stabilize test runs.
  - Tests: fix Lambda ARN assertion (use suffix check); fix SNS E2E XML parsing by extracting `TopicArn` via regex to handle namespaces.

<sup>Written for commit 3bce04153144eb038b88df9d56d0247063b46481. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

