### PR TITLE
feat(ci): add PHP SDK publish to Packagist via subtree split

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,8 +330,8 @@ jobs:
           git remote add php-mirror https://x-access-token:${MIRROR_TOKEN}@github.com/faiscadev/fakecloud-php.git
           git push php-mirror "${SHA}:refs/heads/main" --force
 
-          # Create version tag on mirror
-          git tag "v${TAG}" "${SHA}"
+          # Create version tag on mirror (-f because v${TAG} exists in this checkout)
+          git tag -f "v${TAG}" "${SHA}"
           git push php-mirror "v${TAG}" --force
         env:
           MIRROR_TOKEN: ${{ secrets.PHP_MIRROR_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,6 +297,45 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
 
+  publish-packagist:
+    name: Publish Packagist
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag matches composer.json version
+        working-directory: sdks/php
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          VERSION=$(php -r "echo json_decode(file_get_contents('composer.json'))->version ?? 'none';")
+          # composer.json version field is optional — skip check if absent
+          if [ "$VERSION" != "none" ] && [ "$TAG" != "$VERSION" ]; then
+            echo "::error::Tag v${TAG} does not match composer.json version ${VERSION}"
+            exit 1
+          fi
+
+      - name: Split and push to mirror repo
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Split sdks/php/ into its own branch with rewritten history
+          SHA=$(git subtree split --prefix=sdks/php)
+
+          # Push to mirror repo
+          git remote add php-mirror https://x-access-token:${MIRROR_TOKEN}@github.com/faiscadev/fakecloud-php.git
+          git push php-mirror "${SHA}:refs/heads/main" --force
+
+          # Create version tag on mirror
+          git tag "v${TAG}" "${SHA}"
+          git push php-mirror "v${TAG}" --force
+        env:
+          MIRROR_TOKEN: ${{ secrets.PHP_MIRROR_TOKEN }}
+
   publish-go:
     name: Publish Go module
     needs: check

--- a/crates/fakecloud-apigatewayv2/src/router.rs
+++ b/crates/fakecloud-apigatewayv2/src/router.rs
@@ -137,7 +137,7 @@ impl Router {
             .collect();
 
         // Sort by priority (highest first)
-        parsed_routes.sort_by(|a, b| b.1.priority.cmp(&a.1.priority));
+        parsed_routes.sort_by_key(|r| std::cmp::Reverse(r.1.priority));
 
         Self {
             routes: parsed_routes,

--- a/crates/fakecloud-bedrock/src/async_invoke.rs
+++ b/crates/fakecloud-bedrock/src/async_invoke.rs
@@ -124,7 +124,7 @@ pub fn list_async_invokes(
             }
         })
         .collect();
-    items.sort_by(|a, b| b.submit_time.cmp(&a.submit_time)); // Descending by default
+    items.sort_by_key(|i| std::cmp::Reverse(i.submit_time));
 
     let start = if let Some(token) = next_token {
         items

--- a/crates/fakecloud-cognito/src/service/misc.rs
+++ b/crates/fakecloud-cognito/src/service/misc.rs
@@ -215,7 +215,7 @@ impl CognitoService {
         })?;
 
         let mut devices: Vec<&Device> = user.devices.values().collect();
-        devices.sort_by(|a, b| a.device_create_date.cmp(&b.device_create_date));
+        devices.sort_by_key(|a| a.device_create_date);
 
         let start = pagination_token
             .and_then(|t| devices.iter().position(|d| d.device_key == t))
@@ -502,7 +502,7 @@ impl CognitoService {
             })?;
 
         let mut devices: Vec<&Device> = user.devices.values().collect();
-        devices.sort_by(|a, b| a.device_create_date.cmp(&b.device_create_date));
+        devices.sort_by_key(|a| a.device_create_date);
 
         let start = pagination_token
             .and_then(|t| devices.iter().position(|d| d.device_key == t))
@@ -890,7 +890,7 @@ impl CognitoService {
             .get(pool_id)
             .map(|m| m.values().collect())
             .unwrap_or_default();
-        jobs.sort_by(|a, b| a.creation_date.cmp(&b.creation_date));
+        jobs.sort_by_key(|a| a.creation_date);
 
         let start = pagination_token
             .and_then(|t| jobs.iter().position(|j| j.job_id == t))

--- a/crates/fakecloud-conformance/src/generators/negative.rs
+++ b/crates/fakecloud-conformance/src/generators/negative.rs
@@ -59,7 +59,7 @@ pub fn generate(
                     let mut input = build_required_input(model, input_shape_id, overrides);
                     if let Value::Object(ref mut obj) = input {
                         // Use a string shorter than min
-                        let short = "a".repeat((min as usize).saturating_sub(1).max(0));
+                        let short = "a".repeat((min as usize).saturating_sub(1));
                         obj.insert(member.name.clone(), Value::String(short));
                     }
                     variants.push(TestVariant {

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -343,7 +343,7 @@ impl DynamoTable {
             .iter()
             .map(|(k, &v)| (k.as_str(), v))
             .collect();
-        entries.sort_by(|a, b| b.1.cmp(&a.1));
+        entries.sort_by_key(|e| std::cmp::Reverse(e.1));
         entries.truncate(n);
         entries
     }

--- a/crates/fakecloud-iam/src/policy_validation.rs
+++ b/crates/fakecloud-iam/src/policy_validation.rs
@@ -644,10 +644,8 @@ fn validate_date_condition_values(val: &Value) -> Result<(), String> {
 
         for (_key, value) in inner {
             match value {
-                Value::String(s) => {
-                    if !is_valid_date_value(s) {
-                        return Err("The policy failed legacy parsing".to_string());
-                    }
+                Value::String(s) if !is_valid_date_value(s) => {
+                    return Err("The policy failed legacy parsing".to_string());
                 }
                 Value::Number(n) => {
                     // Check if the number is too large (> i64::MAX)

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -659,7 +659,7 @@ impl S3Store for DiskS3Store {
                         }
                     }
                     if !versioned.is_empty() {
-                        versioned.sort_by_key(|a| a.meta.last_modified);
+                        versioned.sort_by_key(|v| v.meta.last_modified);
                         if let Some(key) = key_name {
                             // Reconcile snap.objects with the newest version:
                             // a trailing delete marker hides any prior null or

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -870,7 +870,7 @@ impl SecretsManagerService {
                 true
             })
             .collect();
-        secrets.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        secrets.sort_by_key(|a| a.created_at);
 
         // Simple pagination with name-based token
         let start_idx = if let Some(token) = next_token {

--- a/crates/fakecloud-ssm/src/service/documents.rs
+++ b/crates/fakecloud-ssm/src/service/documents.rs
@@ -132,19 +132,15 @@ fn document_matches_list_filters(
             .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
             .unwrap_or_default();
         match key {
-            "Owner" => {
-                if values.contains(&"Self") && doc.owner != account_id {
-                    return false;
-                }
+            "Owner" if values.contains(&"Self") && doc.owner != account_id => {
+                return false;
             }
             "TargetType" => match &doc.target_type {
                 Some(tt) if values.contains(&tt.as_str()) => {}
                 _ => return false,
             },
-            "Name" => {
-                if !values.contains(&doc.name.as_str()) {
-                    return false;
-                }
+            "Name" if !values.contains(&doc.name.as_str()) => {
+                return false;
             }
             _ => {}
         }

--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -160,10 +160,8 @@ impl SsmService {
                             .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
                             .unwrap_or_default();
                         match key {
-                            "Name" => {
-                                if !values.iter().any(|v| *v == mw.name) {
-                                    return false;
-                                }
+                            "Name" if !values.iter().any(|v| *v == mw.name) => {
+                                return false;
                             }
                             "Enabled" => {
                                 let enabled_str = if mw.enabled { "true" } else { "false" };

--- a/crates/fakecloud-ssm/src/service/patches.rs
+++ b/crates/fakecloud-ssm/src/service/patches.rs
@@ -102,22 +102,19 @@ impl SsmService {
                             .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
                             .unwrap_or_default();
                         match key {
-                            "NAME_PREFIX" => {
-                                if !values.iter().any(|v| pb.name.starts_with(v)) {
+                            "NAME_PREFIX"
+                                if !values.iter().any(|v| pb.name.starts_with(v)) => {
                                     return false;
                                 }
-                            }
-                            "OWNER" => {
+                            "OWNER"
                                 // We don't track owner, but "Self" means user-created
-                                if values.contains(&"AWS") {
+                                if values.contains(&"AWS") => {
                                     return false;
                                 }
-                            }
-                            "OPERATING_SYSTEM" => {
-                                if !values.contains(&pb.operating_system.as_str()) {
+                            "OPERATING_SYSTEM"
+                                if !values.contains(&pb.operating_system.as_str()) => {
                                     return false;
                                 }
-                            }
                             _ => {}
                         }
                     }
@@ -383,10 +380,10 @@ impl SsmService {
                             .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
                             .unwrap_or_default();
                         match key {
-                            "NAME_PREFIX" => {
-                                if !values.iter().any(|v| pg.patch_group.starts_with(v)) {
-                                    return false;
-                                }
+                            "NAME_PREFIX"
+                                if !values.iter().any(|v| pg.patch_group.starts_with(v)) =>
+                            {
+                                return false;
                             }
                             "OPERATING_SYSTEM" => {
                                 if let Some(pb) = state.patch_baselines.get(&pg.baseline_id) {

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -524,7 +524,7 @@ impl StepFunctionsService {
             .collect();
 
         // Sort by start date descending (most recent first)
-        executions.sort_by(|a, b| b.start_date.cmp(&a.start_date));
+        executions.sort_by_key(|e| std::cmp::Reverse(e.start_date));
 
         let items: Vec<Value> = executions
             .iter()


### PR DESCRIPTION
## Summary

- Add `publish-packagist` job to release workflow
- On `v*` tag, runs `git subtree split --prefix=sdks/php` to extract PHP SDK into standalone history
- Force-pushes split to `faiscadev/fakecloud-php` mirror repo and creates version tag
- Mirror repo is already seeded with current PHP SDK content
- Packagist will be registered to watch `faiscadev/fakecloud-php` for auto-updates

## Setup required

- [ ] Create `PHP_MIRROR_TOKEN` repo secret — a PAT with `repo` scope for `faiscadev/fakecloud-php`
- [ ] Register `faiscadev/fakecloud-php` on [packagist.org/packages/submit](https://packagist.org/packages/submit)
- [ ] Enable Packagist GitHub webhook on `faiscadev/fakecloud-php` for auto-updates

## Test plan

- [ ] Verify `faiscadev/fakecloud-php` has correct content: `composer.json` at root, all source files
- [ ] Next release tag triggers subtree split + push successfully
- [ ] `composer require fakecloud/fakecloud` resolves after Packagist registration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Packagist publish step for the PHP SDK using `git subtree split` on `v*` tags to mirror `sdks/php` to `faiscadev/fakecloud-php`, force-tag the release, and trigger Packagist. Also resolves Rust 1.95 clippy lints by switching to `sort_by_key` (with `std::cmp::Reverse` where needed) and simplifying match guards.

- **New Features**
  - Adds `publish-packagist` job to the release workflow.
  - On `v*` tag: verify vs `composer.json` (if present), split `sdks/php`, push to mirror `main`, and force-create `v${TAG}` on the mirror to avoid tag collisions.
  - Packagist auto-releases from `faiscadev/fakecloud-php`.

- **Migration**
  - Create `PHP_MIRROR_TOKEN` secret with push access to `faiscadev/fakecloud-php`.
  - Register `faiscadev/fakecloud-php` on Packagist and enable the GitHub webhook.

<sup>Written for commit 7b9acb4d5bbb35e618cd98a4a5c85e73669fdd8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

