### PR TITLE
test(ssm,s3): unit tests for SSM tags, S3 object lock and ACL (0% -> covered)

### DIFF
--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -3766,4 +3766,125 @@ mod tests {
         let svc = make_service();
         assert_aws_err(svc.get_bucket_website("nope"), "NoSuchBucket");
     }
+
+    // ── Object lock (lock.rs - 0% coverage) ──
+
+    #[test]
+    fn put_and_get_object_retention() {
+        let svc = make_service();
+        seed_bucket(&svc, "lock-b");
+        seed_object(&svc, "lock-b", "retained.txt", b"data");
+
+        let body = b"<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate></Retention>";
+        let req = make_request(
+            Method::PUT,
+            "/lock-b/retained.txt",
+            &[("retention", "")],
+            body,
+        );
+        svc.put_object_retention(&req, "lock-b", "retained.txt")
+            .unwrap();
+
+        let req = make_request(
+            Method::GET,
+            "/lock-b/retained.txt",
+            &[("retention", "")],
+            b"",
+        );
+        let resp = svc
+            .get_object_retention(&req, "lock-b", "retained.txt")
+            .unwrap();
+        let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body_str.contains("GOVERNANCE"));
+    }
+
+    #[test]
+    fn get_object_retention_nonexistent_bucket() {
+        let svc = make_service();
+        let req = make_request(Method::GET, "/nope/key", &[("retention", "")], b"");
+        assert_aws_err(
+            svc.get_object_retention(&req, "nope", "key"),
+            "NoSuchBucket",
+        );
+    }
+
+    #[test]
+    fn get_object_retention_nonexistent_key() {
+        let svc = make_service();
+        seed_bucket(&svc, "lock-b2");
+        let req = make_request(Method::GET, "/lock-b2/missing", &[("retention", "")], b"");
+        assert_aws_err(
+            svc.get_object_retention(&req, "lock-b2", "missing"),
+            "NoSuchKey",
+        );
+    }
+
+    #[test]
+    fn put_and_get_object_legal_hold() {
+        let svc = make_service();
+        seed_bucket(&svc, "hold-b");
+        seed_object(&svc, "hold-b", "held.txt", b"data");
+
+        let body = b"<LegalHold><Status>ON</Status></LegalHold>";
+        let req = make_request(Method::PUT, "/hold-b/held.txt", &[("legal-hold", "")], body);
+        svc.put_object_legal_hold(&req, "hold-b", "held.txt")
+            .unwrap();
+
+        let req = make_request(Method::GET, "/hold-b/held.txt", &[("legal-hold", "")], b"");
+        let resp = svc
+            .get_object_legal_hold(&req, "hold-b", "held.txt")
+            .unwrap();
+        let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body_str.contains("ON"));
+    }
+
+    #[test]
+    fn get_object_legal_hold_nonexistent() {
+        let svc = make_service();
+        let req = make_request(Method::GET, "/nope/key", &[("legal-hold", "")], b"");
+        assert_aws_err(
+            svc.get_object_legal_hold(&req, "nope", "key"),
+            "NoSuchBucket",
+        );
+    }
+
+    // ── Object ACL (acl.rs - 0% coverage) ──
+
+    #[test]
+    fn get_object_acl_default() {
+        let svc = make_service();
+        seed_bucket(&svc, "acl-b");
+        seed_object(&svc, "acl-b", "file.txt", b"data");
+
+        let req = make_request(Method::GET, "/acl-b/file.txt", &[("acl", "")], b"");
+        let resp = svc.get_object_acl(&req, "acl-b", "file.txt").unwrap();
+        let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body_str.contains("AccessControlPolicy"));
+    }
+
+    #[test]
+    fn get_object_acl_nonexistent_bucket() {
+        let svc = make_service();
+        let req = make_request(Method::GET, "/nope/key", &[("acl", "")], b"");
+        assert_aws_err(svc.get_object_acl(&req, "nope", "key"), "NoSuchBucket");
+    }
+
+    #[test]
+    fn get_object_acl_nonexistent_key() {
+        let svc = make_service();
+        seed_bucket(&svc, "acl-b2");
+        let req = make_request(Method::GET, "/acl-b2/missing", &[("acl", "")], b"");
+        assert_aws_err(svc.get_object_acl(&req, "acl-b2", "missing"), "NoSuchKey");
+    }
+
+    #[test]
+    fn put_object_acl() {
+        let svc = make_service();
+        seed_bucket(&svc, "acl-put-b");
+        seed_object(&svc, "acl-put-b", "file.txt", b"data");
+
+        let acl_xml = b"<AccessControlPolicy><Owner><ID>owner</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"CanonicalUser\"><ID>owner</ID></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>";
+        let req = make_request(Method::PUT, "/acl-put-b/file.txt", &[("acl", "")], acl_xml);
+        svc.put_object_acl(&req, "acl-put-b", "file.txt").unwrap();
+    }
 }

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -3125,4 +3125,118 @@ mod tests {
         );
         expect_err_code(svc.update_ops_item(&req), "OpsItemNotFoundException");
     }
+
+    // ── Tag operations (tags.rs - 0% coverage) ──
+
+    #[test]
+    fn add_and_list_tags_for_parameter() {
+        let svc = make_service();
+        let req = make_request(
+            "PutParameter",
+            json!({"Name": "/tagged/param", "Value": "v", "Type": "String"}),
+        );
+        svc.put_parameter(&req).unwrap();
+
+        let req = make_request(
+            "AddTagsToResource",
+            json!({
+                "ResourceType": "Parameter",
+                "ResourceId": "/tagged/param",
+                "Tags": [{"Key": "env", "Value": "prod"}, {"Key": "team", "Value": "be"}],
+            }),
+        );
+        svc.add_tags_to_resource(&req).unwrap();
+
+        let req = make_request(
+            "ListTagsForResource",
+            json!({"ResourceType": "Parameter", "ResourceId": "/tagged/param"}),
+        );
+        let resp = svc.list_tags_for_resource(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["TagList"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn remove_tags_from_parameter() {
+        let svc = make_service();
+        let req = make_request(
+            "PutParameter",
+            json!({"Name": "/rm-tag", "Value": "v", "Type": "String"}),
+        );
+        svc.put_parameter(&req).unwrap();
+
+        svc.add_tags_to_resource(&make_request(
+            "AddTagsToResource",
+            json!({
+                "ResourceType": "Parameter",
+                "ResourceId": "/rm-tag",
+                "Tags": [{"Key": "env", "Value": "prod"}],
+            }),
+        ))
+        .unwrap();
+
+        svc.remove_tags_from_resource(&make_request(
+            "RemoveTagsFromResource",
+            json!({"ResourceType": "Parameter", "ResourceId": "/rm-tag", "TagKeys": ["env"]}),
+        ))
+        .unwrap();
+
+        let resp = svc
+            .list_tags_for_resource(&make_request(
+                "ListTagsForResource",
+                json!({"ResourceType": "Parameter", "ResourceId": "/rm-tag"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["TagList"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn tags_invalid_resource_type() {
+        let svc = make_service();
+        expect_err_code(
+            svc.add_tags_to_resource(&make_request(
+                "AddTagsToResource",
+                json!({"ResourceType": "Bogus", "ResourceId": "x", "Tags": [{"Key": "k", "Value": "v"}]}),
+            )),
+            "InvalidResourceType",
+        );
+    }
+
+    #[test]
+    fn tags_invalid_resource_id() {
+        let svc = make_service();
+        expect_err_code(
+            svc.add_tags_to_resource(&make_request(
+                "AddTagsToResource",
+                json!({"ResourceType": "Parameter", "ResourceId": "/nonexistent", "Tags": [{"Key": "k", "Value": "v"}]}),
+            )),
+            "InvalidResourceId",
+        );
+    }
+
+    #[test]
+    fn tags_on_document() {
+        let svc = make_service();
+        svc.create_document(&make_request(
+            "CreateDocument",
+            json!({"Name": "TagDoc", "Content": "{\"schemaVersion\":\"2.2\",\"mainSteps\":[]}", "DocumentType": "Command"}),
+        ))
+        .unwrap();
+
+        svc.add_tags_to_resource(&make_request(
+            "AddTagsToResource",
+            json!({"ResourceType": "Document", "ResourceId": "TagDoc", "Tags": [{"Key": "p", "Value": "t"}]}),
+        ))
+        .unwrap();
+
+        let resp = svc
+            .list_tags_for_resource(&make_request(
+                "ListTagsForResource",
+                json!({"ResourceType": "Document", "ResourceId": "TagDoc"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["TagList"].as_array().unwrap().len(), 1);
+    }
 }


### PR DESCRIPTION
## Summary
- SSM tags.rs (210 lines, 0%): add 5 tests covering add/list/remove tags on parameters and documents, invalid resource type/ID errors
- S3 lock.rs (347 lines, 0%) + acl.rs (110 lines, 0%): add 9 tests covering object retention CRUD, legal hold CRUD, object ACL get/put, error branches for nonexistent resources
- SSM total: 109 (up from 104), S3 total: 131 (up from 122)

## Test plan
- [x] `cargo test -p fakecloud-ssm` — 109 tests pass
- [x] `cargo test -p fakecloud-s3` — 131 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests covering SSM tag operations and S3 object lock and ACL, bringing previously untested paths under coverage. SSM: add/list/remove tags on parameters, tags on documents, invalid resource type/ID; S3: object retention and legal hold put/get, object ACL get/put, and errors for missing bucket/key (+5 tests to 109 in `fakecloud-ssm`, +9 to 131 in `fakecloud-s3`).

<sup>Written for commit f4bc7accdfebb430b7f5447b23ba5b51f4b3aa5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

