### PR TITLE
feat(s3,dynamodb): multi-account state isolation

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -456,14 +456,16 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .unwrap_or(&resource.logical_id);
 
-        let mut state = self.s3_state.write();
+        let mut __s3_mas = self.s3_state.write();
+        let state = __s3_mas.get_or_create(&self.account_id);
         let bucket = S3Bucket::new(bucket_name, &state.region, &state.account_id);
         state.buckets.insert(bucket_name.to_string(), bucket);
         Ok(bucket_name.to_string())
     }
 
     fn delete_s3_bucket(&self, physical_id: &str) -> Result<(), String> {
-        let mut state = self.s3_state.write();
+        let mut __s3_mas = self.s3_state.write();
+        let state = __s3_mas.get_or_create(&self.account_id);
         state.buckets.remove(physical_id);
         Ok(())
     }
@@ -670,7 +672,8 @@ impl ResourceProvisioner {
                     .unwrap_or(-1),
             });
 
-        let mut state = self.dynamodb_state.write();
+        let mut __ddb_mas = self.dynamodb_state.write();
+        let state = __ddb_mas.get_or_create(&self.account_id);
         let arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}",
             state.region, state.account_id, table_name
@@ -724,7 +727,8 @@ impl ResourceProvisioner {
     }
 
     fn delete_dynamodb_table(&self, physical_id: &str) -> Result<(), String> {
-        let mut state = self.dynamodb_state.write();
+        let mut __ddb_mas = self.dynamodb_state.write();
+        let state = __ddb_mas.get_or_create(&self.account_id);
         // physical_id is the ARN; find the table name
         let table_name = state
             .tables
@@ -925,16 +929,16 @@ mod tests {
             iam_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", "http://localhost:4566"),
             )),
-            s3_state: Arc::new(RwLock::new(fakecloud_s3::state::S3State::new(
+            s3_state: Arc::new(RwLock::new(fakecloud_core::multi_account::MultiAccountState::new(
                 "123456789012",
-                "us-east-1",
+                "us-east-1", "",
             ))),
             eventbridge_state: Arc::new(RwLock::new(
                 fakecloud_eventbridge::state::EventBridgeState::new("123456789012", "us-east-1"),
             )),
-            dynamodb_state: Arc::new(RwLock::new(fakecloud_dynamodb::state::DynamoDbState::new(
+            dynamodb_state: Arc::new(RwLock::new(fakecloud_core::multi_account::MultiAccountState::new(
                 "123456789012",
-                "us-east-1",
+                "us-east-1", "",
             ))),
             logs_state: Arc::new(RwLock::new(fakecloud_logs::state::LogsState::new(
                 "123456789012",

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -856,17 +856,23 @@ mod tests {
                     "",
                 ),
             )),
-            s3: Arc::new(RwLock::new(fakecloud_s3::state::S3State::new(
-                "123456789012",
-                "us-east-1",
-            ))),
+            s3: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
             eventbridge: Arc::new(RwLock::new(
                 fakecloud_eventbridge::state::EventBridgeState::new("123456789012", "us-east-1"),
             )),
-            dynamodb: Arc::new(RwLock::new(fakecloud_dynamodb::state::DynamoDbState::new(
-                "123456789012",
-                "us-east-1",
-            ))),
+            dynamodb: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
             logs: Arc::new(RwLock::new(fakecloud_logs::state::LogsState::new(
                 "123456789012",
                 "us-east-1",

--- a/crates/fakecloud-core/src/multi_account.rs
+++ b/crates/fakecloud-core/src/multi_account.rs
@@ -101,6 +101,19 @@ impl<T: AccountState> MultiAccountState<T> {
         );
     }
 
+    /// Find the first account whose state satisfies `predicate` and return
+    /// the account id. Useful for resolving globally-unique resources (e.g.
+    /// S3 bucket names) back to their owning account.
+    pub fn find_account<F>(&self, predicate: F) -> Option<&str>
+    where
+        F: Fn(&T) -> bool,
+    {
+        self.accounts
+            .iter()
+            .find(|(_, v)| predicate(v))
+            .map(|(k, _)| k.as_str())
+    }
+
     /// Number of accounts with state.
     pub fn account_count(&self) -> usize {
         self.accounts.len()

--- a/crates/fakecloud-core/src/multi_account.rs
+++ b/crates/fakecloud-core/src/multi_account.rs
@@ -14,6 +14,11 @@ use serde::{Deserialize, Serialize};
 pub trait AccountState: Sized {
     /// Create a fresh, empty state for the given account.
     fn new_for_account(account_id: &str, region: &str, endpoint: &str) -> Self;
+
+    /// Called after a new account state is created via [`MultiAccountState::get_or_create`],
+    /// with a reference to an existing sibling state. Services can override
+    /// this to propagate shared resources (e.g. body caches) to the new state.
+    fn inherit_from(&mut self, _sibling: &Self) {}
 }
 
 /// Account-partitioned state container.
@@ -46,12 +51,33 @@ impl<T: AccountState> MultiAccountState<T> {
     }
 
     /// Get or lazily create the state for `account_id`.
+    ///
+    /// When a new account is created, [`AccountState::inherit_from`] is called
+    /// with the default account's state so services can propagate shared
+    /// resources (e.g. body caches).
     pub fn get_or_create(&mut self, account_id: &str) -> &mut T {
         if !self.accounts.contains_key(account_id) {
-            self.accounts.insert(
-                account_id.to_string(),
-                T::new_for_account(account_id, &self.region, &self.endpoint),
-            );
+            let mut state = T::new_for_account(account_id, &self.region, &self.endpoint);
+            // Let the new state inherit shared resources from the default account.
+            if let Some(sibling) = self.accounts.get(&self.default_account_id) {
+                state.inherit_from(sibling);
+            }
+            self.accounts.insert(account_id.to_string(), state);
+        }
+        self.accounts.get_mut(account_id).unwrap()
+    }
+
+    /// Get or lazily create the state for `account_id`, then run `init` on
+    /// the newly created state. The callback is only invoked when the account
+    /// is freshly created, not on subsequent lookups.
+    pub fn get_or_create_with<F>(&mut self, account_id: &str, init: F) -> &mut T
+    where
+        F: FnOnce(&mut T),
+    {
+        if !self.accounts.contains_key(account_id) {
+            let mut state = T::new_for_account(account_id, &self.region, &self.endpoint);
+            init(&mut state);
+            self.accounts.insert(account_id.to_string(), state);
         }
         self.accounts.get_mut(account_id).unwrap()
     }

--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -37,7 +37,9 @@ impl DynamoDbService {
             })?
             .clone();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let mut responses: HashMap<String, Vec<Value>> = HashMap::new();
         let mut consumed_capacity: Vec<Value> = Vec::new();
 
@@ -114,7 +116,8 @@ impl DynamoDbService {
             })?
             .clone();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mut consumed_capacity: Vec<Value> = Vec::new();
         let mut item_collection_metrics: HashMap<String, Vec<Value>> = HashMap::new();
 
@@ -201,7 +204,9 @@ impl DynamoDbService {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let mut responses: Vec<Value> = Vec::new();
 
         for ti in transact_items {
@@ -259,7 +264,8 @@ impl DynamoDbService {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // First pass: validate all conditions
         let mut cancellation_reasons: Vec<Value> = Vec::new();

--- a/crates/fakecloud-dynamodb/src/service/global_tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/global_tables.rs
@@ -36,7 +36,8 @@ impl DynamoDbService {
             })
             .collect::<Vec<_>>();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if state.global_tables.contains_key(global_table_name) {
             return Err(AwsServiceError::aws_error(
@@ -86,7 +87,9 @@ impl DynamoDbService {
         let global_table_name = require_str(&body, "GlobalTableName")?;
         validate_string_length("globalTableName", global_table_name, 3, 255)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let gt = state.global_tables.get(global_table_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -117,7 +120,9 @@ impl DynamoDbService {
         let global_table_name = require_str(&body, "GlobalTableName")?;
         validate_string_length("globalTableName", global_table_name, 3, 255)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let gt = state.global_tables.get(global_table_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -159,7 +164,9 @@ impl DynamoDbService {
         validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, i64::MAX)?;
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let tables: Vec<Value> = state
             .global_tables
             .values()
@@ -188,7 +195,8 @@ impl DynamoDbService {
         validate_string_length("globalTableName", global_table_name, 3, 255)?;
         validate_required("replicaUpdates", &body["ReplicaUpdates"])?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let gt = state
             .global_tables
             .get_mut(global_table_name)
@@ -251,7 +259,9 @@ impl DynamoDbService {
             i64::MAX,
         )?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let gt = state.global_tables.get(global_table_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -26,7 +26,8 @@ impl DynamoDbService {
         // --- Acquire write lock ONLY for validation + mutation ---
         // Capture kinesis delivery info alongside the return value
         let (old_item, kinesis_info) = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
             let region = state.region.clone();
             let table = get_table_mut(&mut state.tables, table_name)?;
 
@@ -128,7 +129,9 @@ impl DynamoDbService {
 
         // --- Use a read lock for the lookup (allows concurrent GetItem calls) ---
         let (result, needs_insights) = {
-            let state = self.state.read();
+            let accounts = self.state.read();
+            let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
             let table = get_table(&state.tables, table_name)?;
             let needs_insights = table.contributor_insights_status == "ENABLED";
 
@@ -146,7 +149,8 @@ impl DynamoDbService {
 
         // Only acquire write lock if contributor insights tracking is enabled
         if needs_insights {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
             if let Some(table) = state.tables.get_mut(table_name) {
                 table.record_key_access(&key);
             }
@@ -188,7 +192,8 @@ impl DynamoDbService {
         let key = require_object(&body, "Key")?;
 
         let (result, kinesis_info) = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
             let region = state.region.clone();
             let table = get_table_mut(&mut state.tables, table_name)?;
 
@@ -275,7 +280,8 @@ impl DynamoDbService {
         let table_name = require_str(&body, "TableName")?;
         let key = require_object(&body, "Key")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let region = state.region.clone();
         let table = get_table_mut(&mut state.tables, table_name)?;
 
@@ -372,7 +378,7 @@ impl DynamoDbService {
         table.recalculate_stats();
 
         // Release the write lock (drop `state`)
-        drop(state);
+        drop(accounts);
 
         // Deliver to Kinesis destinations outside the lock
         if let Some((target, ev, keys, old_image, new_image)) = kinesis_info {

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -97,7 +97,8 @@ impl DynamoDbService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = DynamoDbSnapshot {
             schema_version: DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            accounts: Some(self.state.read().clone()),
+            state: None,
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -2355,7 +2356,8 @@ fn execute_partiql_select(
     let after_from = statement[from_pos + 4..].trim();
     let (table_name, rest) = parse_partiql_table_name(after_from);
 
-    let state = state.read();
+    let __mas = state.read();
+    let state = __mas.default_ref();
     let table = get_table(&state.tables, &table_name)?;
 
     let rest_upper = rest.trim().to_ascii_uppercase();
@@ -2402,7 +2404,8 @@ fn execute_partiql_insert(
     let value_str = rest.trim()[value_pos + 5..].trim();
     let item = parse_partiql_value_object(value_str, parameters)?;
 
-    let mut state = state.write();
+    let mut __mas = state.write();
+    let state = __mas.default_mut();
     let table = get_table_mut(&mut state.tables, &table_name)?;
     let key = extract_key(table, &item);
     if table.find_item_index(&key).is_some() {
@@ -2449,7 +2452,8 @@ fn execute_partiql_update(
         (after_set, "")
     };
 
-    let mut state = state.write();
+    let mut __mas = state.write();
+    let state = __mas.default_mut();
     let table = get_table_mut(&mut state.tables, &table_name)?;
 
     let matched_indices = if !where_clause.is_empty() {
@@ -2508,7 +2512,8 @@ fn execute_partiql_delete(
     }
     let where_clause = rest.trim()[5..].trim();
 
-    let mut state = state.write();
+    let mut __mas = state.write();
+    let state = __mas.default_mut();
     let table = get_table_mut(&mut state.tables, &table_name)?;
 
     let mut indices = find_partiql_where_indices(table, where_clause, parameters)?;
@@ -2917,10 +2922,9 @@ mod tests {
     use std::sync::Arc;
 
     fn make_service() -> DynamoDbService {
-        let state: SharedDynamoDbState = Arc::new(RwLock::new(crate::state::DynamoDbState::new(
-            "123456789012",
-            "us-east-1",
-        )));
+        let state: SharedDynamoDbState = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         DynamoDbService::new(state)
     }
 
@@ -3265,7 +3269,8 @@ mod tests {
         create_test_table(&svc);
 
         let table_arn = {
-            let state = svc.state.read();
+            let __mas = svc.state.read();
+            let state = __mas.default_ref();
             state.tables.get("test-table").unwrap().arn.clone()
         };
 
@@ -5810,7 +5815,12 @@ mod tests {
         create_test_table(&svc);
         let arn = {
             let s = svc.state.read();
-            s.tables.get("test-table").unwrap().arn.clone()
+            s.default_ref()
+                .tables
+                .get("test-table")
+                .unwrap()
+                .arn
+                .clone()
         };
 
         let req = make_request(

--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -17,7 +17,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
         let expr_attr_names = parse_expression_attribute_names(&body);
@@ -201,10 +203,11 @@ impl DynamoDbService {
             result["LastEvaluatedKey"] = json!(lek);
         }
 
-        drop(state);
+        drop(accounts);
 
         if !accessed_keys.is_empty() {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
             if let Some(table) = state.tables.get_mut(table_name) {
                 // Re-check insights status after acquiring write lock in case it
                 // was disabled between the read and write lock acquisitions.
@@ -226,7 +229,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
         let expr_attr_names = parse_expression_attribute_names(&body);
@@ -305,10 +310,11 @@ impl DynamoDbService {
             result["LastEvaluatedKey"] = json!(lek);
         }
 
-        drop(state);
+        drop(accounts);
 
         if !accessed_keys.is_empty() {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
             if let Some(table) = state.tables.get_mut(table_name) {
                 // Re-check insights status after acquiring write lock in case it
                 // was disabled between the read and write lock acquisitions.

--- a/crates/fakecloud-dynamodb/src/service/streams.rs
+++ b/crates/fakecloud-dynamodb/src/service/streams.rs
@@ -43,7 +43,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
         Self::ok_json(json!({
@@ -62,7 +64,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
         Self::ok_json(json!({
@@ -88,7 +92,8 @@ impl DynamoDbService {
             .as_str()
             .unwrap_or("MILLISECOND");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = get_table_mut(&mut state.tables, table_name)?;
 
         table.kinesis_destinations.push(KinesisDestination {
@@ -115,7 +120,8 @@ impl DynamoDbService {
         let table_name = require_str(&body, "TableName")?;
         let stream_arn = require_str(&body, "StreamArn")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = get_table_mut(&mut state.tables, table_name)?;
 
         if let Some(dest) = table
@@ -140,7 +146,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
         let destinations: Vec<Value> = table
@@ -173,7 +181,8 @@ impl DynamoDbService {
             .as_str()
             .unwrap_or("MILLISECOND");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = get_table_mut(&mut state.tables, table_name)?;
 
         if let Some(dest) = table
@@ -204,7 +213,9 @@ impl DynamoDbService {
         let table_name = require_str(&body, "TableName")?;
         let index_name = body["IndexName"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
         let top = table.top_contributors(10);
@@ -240,7 +251,8 @@ impl DynamoDbService {
         let action = require_str(&body, "ContributorInsightsAction")?;
         let index_name = body["IndexName"].as_str();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = get_table_mut(&mut state.tables, table_name)?;
 
         let status = match action {
@@ -279,7 +291,9 @@ impl DynamoDbService {
         validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 0, 100)?;
         let table_name = body["TableName"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let summaries: Vec<Value> = state
             .tables
             .values()

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -1201,11 +1201,12 @@ impl DynamoDbService {
             // Verify the target bucket exists before touching the store —
             // otherwise we would orphan artifacts on disk under a bucket
             // directory that no in-memory bucket references.
+            let s3_acct_id = req.account_id.as_str();
             if !s3_state
                 .read()
-                .default_ref()
-                .buckets
-                .contains_key(s3_bucket)
+                .get(s3_acct_id)
+                .map(|s| s.buckets.contains_key(s3_bucket))
+                .unwrap_or(false)
             {
                 export_failed = true;
                 failure_code = "S3NoSuchBucket";
@@ -1250,7 +1251,7 @@ impl DynamoDbService {
                 match body_ref_result {
                     Ok(body_ref) => {
                         let mut s3 = s3_state.write();
-                        let s3_acct = s3.default_mut();
+                        let s3_acct = s3.get_or_create(s3_acct_id);
                         if let Some(bucket) = s3_acct.buckets.get_mut(s3_bucket) {
                             let obj = fakecloud_s3::state::S3Object {
                                 key: s3_key.clone(),
@@ -1433,7 +1434,14 @@ impl DynamoDbService {
         let mut processed_size_bytes: i64 = 0;
         if let Some(ref s3_state) = self.s3_state {
             let s3_mas = s3_state.read();
-            let s3 = s3_mas.default_ref();
+            let s3_acct_id = req.account_id.as_str();
+            let s3 = s3_mas.get(s3_acct_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ImportConflictException",
+                    format!("S3 bucket does not exist: {s3_bucket}"),
+                )
+            })?;
             let bucket = s3.buckets.get(s3_bucket).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -141,7 +141,8 @@ impl DynamoDbService {
             (None, None)
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if state.tables.contains_key(&table_name) {
             return Err(AwsServiceError::aws_error(
@@ -216,7 +217,8 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         // Refuse if deletion protection is enabled (real AWS returns
         // ResourceInUseException with this message).
         if state
@@ -264,7 +266,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
         let table_desc = build_table_description(table);
@@ -288,7 +292,9 @@ impl DynamoDbService {
             .as_str()
             .map(|s| s.to_string());
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let mut names: Vec<&String> = state.tables.keys().collect();
         names.sort();
 
@@ -322,7 +328,8 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         // Snapshot region + account before taking a mutable borrow of
         // `state.tables` — we need them to mint a new stream ARN when the
         // caller flips stream_enabled from false to true mid-update.
@@ -552,7 +559,8 @@ impl DynamoDbService {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = get_table_mut(&mut state.tables, table_name)?;
 
         if enabled {
@@ -577,7 +585,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
         let status = if table.ttl_enabled {
@@ -606,7 +616,8 @@ impl DynamoDbService {
         let resource_arn = require_str(&body, "ResourceArn")?;
         validate_required("Tags", &body["Tags"])?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = find_table_by_arn_mut(&mut state.tables, resource_arn)?;
 
         fakecloud_core::tags::apply_tags(&mut table.tags, &body, "Tags", "Key", "Value").map_err(
@@ -627,7 +638,8 @@ impl DynamoDbService {
         let resource_arn = require_str(&body, "ResourceArn")?;
         validate_required("TagKeys", &body["TagKeys"])?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = find_table_by_arn_mut(&mut state.tables, resource_arn)?;
 
         fakecloud_core::tags::remove_tags(&mut table.tags, &body, "TagKeys").map_err(|f| {
@@ -648,7 +660,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let resource_arn = require_str(&body, "ResourceArn")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = find_table_by_arn(&state.tables, resource_arn)?;
 
         let tags = fakecloud_core::tags::tags_to_json(&table.tags, "Key", "Value");
@@ -666,7 +680,8 @@ impl DynamoDbService {
         let resource_arn = require_str(&body, "ResourceArn")?;
         let policy = require_str(&body, "Policy")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = find_table_by_arn_mut(&mut state.tables, resource_arn)?;
         table.resource_policy = Some(policy.to_string());
 
@@ -681,7 +696,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let resource_arn = require_str(&body, "ResourceArn")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = find_table_by_arn(&state.tables, resource_arn)?;
 
         match &table.resource_policy {
@@ -703,7 +720,8 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let resource_arn = require_str(&body, "ResourceArn")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = find_table_by_arn_mut(&mut state.tables, resource_arn)?;
         table.resource_policy = None;
 
@@ -717,7 +735,8 @@ impl DynamoDbService {
         let table_name = require_str(&body, "TableName")?;
         let backup_name = require_str(&body, "BackupName")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = get_table(&state.tables, table_name)?;
 
         let backup_arn = format!(
@@ -764,7 +783,8 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let backup_arn = require_str(&body, "BackupArn")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let backup = state.backups.remove(backup_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -809,7 +829,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let backup_arn = require_str(&body, "BackupArn")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let backup = state.backups.get(backup_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -867,7 +889,9 @@ impl DynamoDbService {
         )?;
         let table_name = body["TableName"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let summaries: Vec<Value> = state
             .backups
             .values()
@@ -899,7 +923,8 @@ impl DynamoDbService {
         let backup_arn = require_str(&body, "BackupArn")?;
         let target_table_name = require_str(&body, "TargetTableName")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let backup = state.backups.get(backup_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -974,7 +999,8 @@ impl DynamoDbService {
         let source_table_name = body["SourceTableName"].as_str();
         let source_table_arn = body["SourceTableArn"].as_str();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Resolve source table
         let source = if let Some(name) = source_table_name {
@@ -1069,7 +1095,8 @@ impl DynamoDbService {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let table = get_table_mut(&mut state.tables, table_name)?;
         table.pitr_enabled = enabled;
 
@@ -1093,7 +1120,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
         let status = if table.pitr_enabled {
@@ -1125,7 +1154,9 @@ impl DynamoDbService {
         let s3_prefix = body["S3Prefix"].as_str();
         let export_format = body["ExportFormat"].as_str().unwrap_or("DYNAMODB_JSON");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         // Verify table exists and get items
         let table = find_table_by_arn(&state.tables, table_arn)?;
         let items = table.items.clone();
@@ -1140,7 +1171,7 @@ impl DynamoDbService {
             uuid::Uuid::new_v4()
         );
 
-        drop(state);
+        drop(accounts);
 
         // Serialize items as JSON Lines and write to S3
         let mut json_lines = String::new();
@@ -1170,7 +1201,12 @@ impl DynamoDbService {
             // Verify the target bucket exists before touching the store —
             // otherwise we would orphan artifacts on disk under a bucket
             // directory that no in-memory bucket references.
-            if !s3_state.read().buckets.contains_key(s3_bucket) {
+            if !s3_state
+                .read()
+                .default_ref()
+                .buckets
+                .contains_key(s3_bucket)
+            {
                 export_failed = true;
                 failure_code = "S3NoSuchBucket";
                 failure_reason = format!("S3 bucket does not exist: {s3_bucket}");
@@ -1214,7 +1250,8 @@ impl DynamoDbService {
                 match body_ref_result {
                     Ok(body_ref) => {
                         let mut s3 = s3_state.write();
-                        if let Some(bucket) = s3.buckets.get_mut(s3_bucket) {
+                        let s3_acct = s3.default_mut();
+                        if let Some(bucket) = s3_acct.buckets.get_mut(s3_bucket) {
                             let obj = fakecloud_s3::state::S3Object {
                                 key: s3_key.clone(),
                                 body: body_ref,
@@ -1262,7 +1299,8 @@ impl DynamoDbService {
             billed_size_bytes: data_size,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.exports.insert(export_arn.clone(), export);
 
         let mut response = json!({
@@ -1291,7 +1329,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let export_arn = require_str(&body, "ExportArn")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let export = state.exports.get(export_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1323,7 +1363,9 @@ impl DynamoDbService {
         validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 1, 25)?;
         let table_arn = body["TableArn"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let summaries: Vec<Value> = state
             .exports
             .values()
@@ -1390,7 +1432,8 @@ impl DynamoDbService {
         let mut imported_items: Vec<HashMap<String, Value>> = Vec::new();
         let mut processed_size_bytes: i64 = 0;
         if let Some(ref s3_state) = self.s3_state {
-            let s3 = s3_state.read();
+            let s3_mas = s3_state.read();
+            let s3 = s3_mas.default_ref();
             let bucket = s3.buckets.get(s3_bucket).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -1442,7 +1485,8 @@ impl DynamoDbService {
             }
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if state.tables.contains_key(table_name) {
             return Err(AwsServiceError::aws_error(
@@ -1559,7 +1603,9 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let import_arn = require_str(&body, "ImportArn")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let import = state.imports.get(import_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1592,7 +1638,9 @@ impl DynamoDbService {
         validate_optional_range_i64("pageSize", body["PageSize"].as_i64(), 1, 25)?;
         let table_arn = body["TableArn"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let summaries: Vec<Value> = state
             .imports
             .values()

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -372,10 +372,15 @@ pub struct DynamoDbState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DynamoDbSnapshot {
     pub schema_version: u32,
-    pub state: DynamoDbState,
+    /// v2+: multi-account state.
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<DynamoDbState>>,
+    /// v1 compat: single-account state.
+    #[serde(default)]
+    pub state: Option<DynamoDbState>,
 }
 
-pub const DYNAMODB_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const DYNAMODB_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 impl DynamoDbState {
     pub fn new(account_id: &str, region: &str) -> Self {
@@ -399,4 +404,11 @@ impl DynamoDbState {
     }
 }
 
-pub type SharedDynamoDbState = Arc<RwLock<DynamoDbState>>;
+impl fakecloud_core::multi_account::AccountState for DynamoDbState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
+
+pub type SharedDynamoDbState =
+    Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<DynamoDbState>>>;

--- a/crates/fakecloud-dynamodb/src/ttl.rs
+++ b/crates/fakecloud-dynamodb/src/ttl.rs
@@ -16,43 +16,46 @@ pub fn process_ttl_expirations(state: &SharedDynamoDbState) -> usize {
 /// making it easy to test without time manipulation.
 pub fn process_ttl_expirations_at(state: &SharedDynamoDbState, now_epoch: i64) -> usize {
     let mut total_expired = 0;
-    let mut state = state.write();
+    let mut mas = state.write();
 
-    for table in state.tables.values_mut() {
-        if !table.ttl_enabled {
-            continue;
-        }
+    // Process TTL across all accounts
+    for (_, acct_state) in mas.iter_mut() {
+        for table in acct_state.tables.values_mut() {
+            if !table.ttl_enabled {
+                continue;
+            }
 
-        let ttl_attr = match &table.ttl_attribute {
-            Some(attr) => attr.clone(),
-            None => continue,
-        };
-
-        let before = table.items.len();
-        table.items.retain(|item| {
-            let av = match item.get(&ttl_attr) {
-                Some(v) => v,
-                None => return true, // no TTL attribute → keep
+            let ttl_attr = match &table.ttl_attribute {
+                Some(attr) => attr.clone(),
+                None => continue,
             };
 
-            // TTL attribute must be a Number ({"N": "..."})
-            let epoch = match av.as_object().and_then(|obj| obj.get("N")) {
-                Some(n) => match n.as_str().and_then(|s| s.parse::<i64>().ok()) {
+            let before = table.items.len();
+            table.items.retain(|item| {
+                let av = match item.get(&ttl_attr) {
                     Some(v) => v,
-                    None => return true, // non-numeric → keep
-                },
-                None => return true, // not a Number type → keep
-            };
+                    None => return true, // no TTL attribute → keep
+                };
 
-            // Keep if TTL is in the future (or exactly now)
-            epoch >= now_epoch
-        });
-        let removed = before - table.items.len();
-        if removed > 0 {
-            table.recalculate_stats();
+                // TTL attribute must be a Number ({"N": "..."})
+                let epoch = match av.as_object().and_then(|obj| obj.get("N")) {
+                    Some(n) => match n.as_str().and_then(|s| s.parse::<i64>().ok()) {
+                        Some(v) => v,
+                        None => return true, // non-numeric → keep
+                    },
+                    None => return true, // not a Number type → keep
+                };
+
+                // Keep if TTL is in the future (or exactly now)
+                epoch >= now_epoch
+            });
+            let removed = before - table.items.len();
+            if removed > 0 {
+                table.recalculate_stats();
+            }
+            total_expired += removed;
         }
-        total_expired += removed;
-    }
+    } // end per-account loop
 
     total_expired
 }
@@ -67,7 +70,9 @@ mod tests {
     use std::sync::Arc;
 
     fn make_state() -> SharedDynamoDbState {
-        Arc::new(RwLock::new(DynamoDbState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ))
     }
 
     fn make_table(name: &str, ttl_enabled: bool, ttl_attribute: Option<&str>) -> DynamoTable {
@@ -137,11 +142,15 @@ mod tests {
         table
             .items
             .push(make_item("a", Some(json!({"N": "999999"}))));
-        state.write().tables.insert("t1".to_string(), table);
+        state
+            .write()
+            .default_mut()
+            .tables
+            .insert("t1".to_string(), table);
 
         let count = process_ttl_expirations_at(&state, now);
         assert_eq!(count, 1);
-        assert_eq!(state.read().tables["t1"].items.len(), 0);
+        assert_eq!(state.read().default_ref().tables["t1"].items.len(), 0);
     }
 
     #[test]
@@ -154,11 +163,15 @@ mod tests {
         table
             .items
             .push(make_item("a", Some(json!({"N": "2000000"}))));
-        state.write().tables.insert("t1".to_string(), table);
+        state
+            .write()
+            .default_mut()
+            .tables
+            .insert("t1".to_string(), table);
 
         let count = process_ttl_expirations_at(&state, now);
         assert_eq!(count, 0);
-        assert_eq!(state.read().tables["t1"].items.len(), 1);
+        assert_eq!(state.read().default_ref().tables["t1"].items.len(), 1);
     }
 
     #[test]
@@ -170,11 +183,15 @@ mod tests {
         table
             .items
             .push(make_item("a", Some(json!({"N": "999999"}))));
-        state.write().tables.insert("t1".to_string(), table);
+        state
+            .write()
+            .default_mut()
+            .tables
+            .insert("t1".to_string(), table);
 
         let count = process_ttl_expirations_at(&state, now);
         assert_eq!(count, 0);
-        assert_eq!(state.read().tables["t1"].items.len(), 1);
+        assert_eq!(state.read().default_ref().tables["t1"].items.len(), 1);
     }
 
     #[test]
@@ -185,11 +202,15 @@ mod tests {
         let mut table = make_table("t1", true, Some("ttl"));
         // Item without the TTL attribute at all
         table.items.push(make_item("a", None));
-        state.write().tables.insert("t1".to_string(), table);
+        state
+            .write()
+            .default_mut()
+            .tables
+            .insert("t1".to_string(), table);
 
         let count = process_ttl_expirations_at(&state, now);
         assert_eq!(count, 0);
-        assert_eq!(state.read().tables["t1"].items.len(), 1);
+        assert_eq!(state.read().default_ref().tables["t1"].items.len(), 1);
     }
 
     #[test]
@@ -202,11 +223,15 @@ mod tests {
         table
             .items
             .push(make_item("a", Some(json!({"S": "not-a-number"}))));
-        state.write().tables.insert("t1".to_string(), table);
+        state
+            .write()
+            .default_mut()
+            .tables
+            .insert("t1".to_string(), table);
 
         let count = process_ttl_expirations_at(&state, now);
         assert_eq!(count, 0);
-        assert_eq!(state.read().tables["t1"].items.len(), 1);
+        assert_eq!(state.read().default_ref().tables["t1"].items.len(), 1);
     }
 
     #[test]
@@ -228,11 +253,15 @@ mod tests {
         table
             .items
             .push(make_item("string-ttl", Some(json!({"S": "oops"}))));
-        state.write().tables.insert("t1".to_string(), table);
+        state
+            .write()
+            .default_mut()
+            .tables
+            .insert("t1".to_string(), table);
 
         let count = process_ttl_expirations_at(&state, now);
         assert_eq!(count, 2);
-        assert_eq!(state.read().tables["t1"].items.len(), 3);
+        assert_eq!(state.read().default_ref().tables["t1"].items.len(), 3);
     }
 
     #[test]
@@ -249,10 +278,14 @@ mod tests {
             .push(make_item("b", Some(json!({"N": "2000000"}))));
         table.item_count = 2;
         table.size_bytes = 100;
-        state.write().tables.insert("t1".to_string(), table);
+        state
+            .write()
+            .default_mut()
+            .tables
+            .insert("t1".to_string(), table);
 
         process_ttl_expirations_at(&state, now);
         let s = state.read();
-        assert_eq!(s.tables["t1"].item_count, 1);
+        assert_eq!(s.default_ref().tables["t1"].item_count, 1);
     }
 }

--- a/crates/fakecloud-s3/src/inventory.rs
+++ b/crates/fakecloud-s3/src/inventory.rs
@@ -39,7 +39,9 @@ fn bucket_name_from_arn(arn: &str) -> Option<&str> {
 pub fn generate_inventory_report(state: &SharedS3State, source_bucket: &str, config_id: &str) {
     // Read the inventory config
     let config_xml = {
-        let st = state.read();
+        let mas = state.read();
+        let _empty_s3 = crate::state::S3State::new("", "");
+        let st = mas.default_ref();
         st.buckets
             .get(source_bucket)
             .and_then(|b| b.inventory_configs.get(config_id).cloned())
@@ -62,7 +64,9 @@ pub fn generate_inventory_report(state: &SharedS3State, source_bucket: &str, con
 
     // Collect object data from source bucket
     let rows: Vec<String> = {
-        let st = state.read();
+        let mas = state.read();
+        let _empty_s3 = crate::state::S3State::new("", "");
+        let st = mas.default_ref();
         let bucket = match st.buckets.get(source_bucket) {
             Some(b) => b,
             None => return,
@@ -120,7 +124,8 @@ pub fn generate_inventory_report(state: &SharedS3State, source_bucket: &str, con
         ..Default::default()
     };
 
-    let mut st = state.write();
+    let mut mas = state.write();
+    let st = mas.default_mut();
     if let Some(target) = st.buckets.get_mut(&dest_bucket_name) {
         target.objects.insert(report_key, report_object);
     }

--- a/crates/fakecloud-s3/src/lifecycle.rs
+++ b/crates/fakecloud-s3/src/lifecycle.rs
@@ -35,7 +35,8 @@ impl LifecycleProcessor {
 
         // Collect bucket names and their lifecycle configs (to avoid holding lock during processing)
         let bucket_configs: Vec<(String, String)> = {
-            let state = self.state.read();
+            let __mas = self.state.read();
+            let state = __mas.default_ref();
             state
                 .buckets
                 .values()
@@ -64,7 +65,8 @@ impl LifecycleProcessor {
     }
 
     fn process_rule(&self, bucket_name: &str, rule: &LifecycleRule, today: NaiveDate) {
-        let mut state = self.state.write();
+        let mut __mas = self.state.write();
+        let state = __mas.default_mut();
         let bucket = match state.buckets.get_mut(bucket_name) {
             Some(b) => b,
             None => return,

--- a/crates/fakecloud-s3/src/logging.rs
+++ b/crates/fakecloud-s3/src/logging.rs
@@ -80,7 +80,9 @@ pub fn maybe_write_access_log(
 ) {
     // Read logging config from the source bucket
     let logging_config_xml = {
-        let st = state.read();
+        let mas = state.read();
+        let _empty_s3 = crate::state::S3State::new("", "");
+        let st = mas.default_ref();
         st.buckets
             .get(source_bucket)
             .and_then(|b| b.logging_config.clone())
@@ -92,7 +94,9 @@ pub fn maybe_write_access_log(
     };
 
     let bucket_owner = {
-        let st = state.read();
+        let mas = state.read();
+        let _empty_s3 = crate::state::S3State::new("", "");
+        let st = mas.default_ref();
         st.buckets
             .get(source_bucket)
             .map(|b| b.acl_owner_id.clone())
@@ -125,7 +129,8 @@ pub fn maybe_write_access_log(
 
     let meta = object_meta_snapshot(&log_object);
     {
-        let mut st = state.write();
+        let mut mas = state.write();
+        let st = mas.default_mut();
         if let Some(target) = st.buckets.get_mut(&config.target_bucket) {
             target.objects.insert(log_key.clone(), log_object);
         } else {

--- a/crates/fakecloud-s3/src/logging.rs
+++ b/crates/fakecloud-s3/src/logging.rs
@@ -79,28 +79,31 @@ pub fn maybe_write_access_log(
     request: &AccessLogRequest<'_>,
 ) {
     // Read logging config from the source bucket
-    let logging_config_xml = {
+    let (logging_config_xml, bucket_owner) = {
         let mas = state.read();
-        let _empty_s3 = crate::state::S3State::new("", "");
-        let st = mas.default_ref();
-        st.buckets
+        let acct = match mas.find_account(|s| s.buckets.contains_key(source_bucket)) {
+            Some(a) => a,
+            None => return,
+        };
+        let st = match mas.get(acct) {
+            Some(s) => s,
+            None => return,
+        };
+        let config_xml = st
+            .buckets
             .get(source_bucket)
-            .and_then(|b| b.logging_config.clone())
+            .and_then(|b| b.logging_config.clone());
+        let owner = st
+            .buckets
+            .get(source_bucket)
+            .map(|b| b.acl_owner_id.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        (config_xml, owner)
     };
 
     let config = match logging_config_xml.and_then(|xml| parse_logging_config(&xml)) {
         Some(c) => c,
         None => return,
-    };
-
-    let bucket_owner = {
-        let mas = state.read();
-        let _empty_s3 = crate::state::S3State::new("", "");
-        let st = mas.default_ref();
-        st.buckets
-            .get(source_bucket)
-            .map(|b| b.acl_owner_id.clone())
-            .unwrap_or_else(|| "unknown".to_string())
     };
 
     let entry = format_access_log_entry(&bucket_owner, source_bucket, request);
@@ -130,10 +133,24 @@ pub fn maybe_write_access_log(
     let meta = object_meta_snapshot(&log_object);
     {
         let mut mas = state.write();
-        let st = mas.default_mut();
-        if let Some(target) = st.buckets.get_mut(&config.target_bucket) {
-            target.objects.insert(log_key.clone(), log_object);
+        let target_acct = mas
+            .find_account(|s| s.buckets.contains_key(&config.target_bucket))
+            .map(|a| a.to_string());
+        let inserted = if let Some(acct) = target_acct {
+            if let Some(st) = mas.get_mut(&acct) {
+                if let Some(target) = st.buckets.get_mut(&config.target_bucket) {
+                    target.objects.insert(log_key.clone(), log_object);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
         } else {
+            false
+        };
+        if !inserted {
             return;
         }
     }

--- a/crates/fakecloud-s3/src/resource_policy.rs
+++ b/crates/fakecloud-s3/src/resource_policy.rs
@@ -48,7 +48,8 @@ impl ResourcePolicyProvider for S3ResourcePolicyProvider {
             return None;
         }
         let bucket_name = parse_bucket_name(resource_arn)?;
-        let state = self.state.read();
+        let __mas = self.state.read();
+        let state = __mas.default_ref();
         state
             .buckets
             .get(bucket_name)
@@ -84,11 +85,13 @@ mod tests {
     use parking_lot::RwLock;
 
     fn state_with_bucket(name: &str, policy: Option<&str>) -> SharedS3State {
-        let mut s = S3State::new("123456789012", "us-east-1");
+        let mut mas: fakecloud_core::multi_account::MultiAccountState<S3State> =
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", "");
+        let s = mas.get_or_create("123456789012");
         let mut b = S3Bucket::new(name, "us-east-1", "owner");
         b.policy = policy.map(|p| p.to_string());
         s.buckets.insert(name.to_string(), b);
-        Arc::new(RwLock::new(s))
+        Arc::new(RwLock::new(mas))
     }
 
     #[test]

--- a/crates/fakecloud-s3/src/resource_policy.rs
+++ b/crates/fakecloud-s3/src/resource_policy.rs
@@ -48,8 +48,9 @@ impl ResourcePolicyProvider for S3ResourcePolicyProvider {
             return None;
         }
         let bucket_name = parse_bucket_name(resource_arn)?;
-        let __mas = self.state.read();
-        let state = __mas.default_ref();
+        let mas = self.state.read();
+        let acct = mas.find_account(|s| s.buckets.contains_key(bucket_name))?;
+        let state = mas.get(acct)?;
         state
             .buckets
             .get(bucket_name)

--- a/crates/fakecloud-s3/src/service/acl.rs
+++ b/crates/fakecloud-s3/src/service/acl.rs
@@ -13,11 +13,14 @@ use super::{
 impl S3Service {
     pub(super) fn get_object_acl(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -31,6 +34,7 @@ impl S3Service {
 
     pub(super) fn put_object_acl(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -41,7 +45,8 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)

--- a/crates/fakecloud-s3/src/service/buckets.rs
+++ b/crates/fakecloud-s3/src/service/buckets.rs
@@ -12,8 +12,15 @@ use super::{
 };
 
 impl S3Service {
-    pub(super) fn list_buckets(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    pub(super) fn list_buckets(
+        &self,
+        _account_id: &str,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let account_id = req.account_id.as_str();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let mut buckets_xml = String::new();
         let mut sorted: Vec<_> = state.buckets.values().collect();
         sorted.sort_by_key(|b| &b.name);
@@ -37,6 +44,7 @@ impl S3Service {
 
     pub(super) fn create_bucket(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -121,7 +129,8 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .unwrap_or("private");
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         if let Some(existing) = state.buckets.get(bucket) {
             // In us-east-1, re-creating same bucket in same region is idempotent (returns 200)
             if existing.region == requested_region && requested_region == "us-east-1" {
@@ -197,10 +206,12 @@ impl S3Service {
 
     pub(super) fn delete_bucket(
         &self,
+        account_id: &str,
         _req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get(bucket)
@@ -228,8 +239,14 @@ impl S3Service {
         })
     }
 
-    pub(super) fn head_bucket(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    pub(super) fn head_bucket(
+        &self,
+        account_id: &str,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         if !state.buckets.contains_key(bucket) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -245,8 +262,14 @@ impl S3Service {
         })
     }
 
-    pub(super) fn get_bucket_location(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    pub(super) fn get_bucket_location(
+        &self,
+        account_id: &str,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)

--- a/crates/fakecloud-s3/src/service/buckets.rs
+++ b/crates/fakecloud-s3/src/service/buckets.rs
@@ -14,10 +14,9 @@ use super::{
 impl S3Service {
     pub(super) fn list_buckets(
         &self,
-        _account_id: &str,
-        req: &AwsRequest,
+        account_id: &str,
+        _req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let account_id = req.account_id.as_str();
         let accts = self.state.read();
         let __empty = crate::state::S3State::new(account_id, "us-east-1");
         let state = accts.get(account_id).unwrap_or(&__empty);
@@ -37,7 +36,7 @@ impl S3Service {
              <Owner><ID>{account}</ID><DisplayName>{account}</DisplayName></Owner>\
              <Buckets>{buckets_xml}</Buckets>\
              </ListAllMyBucketsResult>",
-            account = req.account_id,
+            account = account_id,
         );
         Ok(s3_xml(StatusCode::OK, body))
     }

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -20,11 +20,13 @@ impl S3Service {
 
     pub(super) fn put_bucket_encryption(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -48,9 +50,12 @@ impl S3Service {
 
     pub(super) fn get_bucket_encryption(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -68,9 +73,11 @@ impl S3Service {
 
     pub(super) fn delete_bucket_encryption(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -86,6 +93,7 @@ impl S3Service {
 
     pub(super) fn put_bucket_lifecycle(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -97,7 +105,8 @@ impl S3Service {
         // If there are no <Rule> elements at all, treat as deleting the configuration
         let has_rules = body_str.contains("<Rule>");
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -118,9 +127,12 @@ impl S3Service {
 
     pub(super) fn get_bucket_lifecycle(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -138,9 +150,11 @@ impl S3Service {
 
     pub(super) fn delete_bucket_lifecycle(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -156,6 +170,7 @@ impl S3Service {
 
     pub(super) fn put_bucket_policy(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -167,7 +182,8 @@ impl S3Service {
                 "This policy contains invalid Json",
             ));
         }
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -179,8 +195,14 @@ impl S3Service {
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
-    pub(super) fn get_bucket_policy(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    pub(super) fn get_bucket_policy(
+        &self,
+        account_id: &str,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -203,9 +225,11 @@ impl S3Service {
 
     pub(super) fn delete_bucket_policy(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -221,6 +245,7 @@ impl S3Service {
 
     pub(super) fn put_bucket_cors(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -258,7 +283,8 @@ impl S3Service {
             }
         }
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -270,8 +296,14 @@ impl S3Service {
         Ok(empty_response(StatusCode::OK))
     }
 
-    pub(super) fn get_bucket_cors(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    pub(super) fn get_bucket_cors(
+        &self,
+        account_id: &str,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -287,8 +319,13 @@ impl S3Service {
         }
     }
 
-    pub(super) fn delete_bucket_cors(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+    pub(super) fn delete_bucket_cors(
+        &self,
+        account_id: &str,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -304,11 +341,13 @@ impl S3Service {
 
     pub(super) fn put_bucket_notification(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -330,9 +369,12 @@ impl S3Service {
 
     pub(super) fn get_bucket_notification(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -357,11 +399,13 @@ impl S3Service {
 
     pub(super) fn put_bucket_logging(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -373,8 +417,14 @@ impl S3Service {
         Ok(empty_response(StatusCode::OK))
     }
 
-    pub(super) fn get_bucket_logging(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    pub(super) fn get_bucket_logging(
+        &self,
+        account_id: &str,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -393,11 +443,13 @@ impl S3Service {
 
     pub(super) fn put_bucket_website(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -409,8 +461,14 @@ impl S3Service {
         Ok(empty_response(StatusCode::OK))
     }
 
-    pub(super) fn get_bucket_website(&self, bucket: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    pub(super) fn get_bucket_website(
+        &self,
+        account_id: &str,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -428,9 +486,11 @@ impl S3Service {
 
     pub(super) fn delete_bucket_website(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -446,6 +506,7 @@ impl S3Service {
 
     pub(super) fn put_bucket_accelerate(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -458,7 +519,8 @@ impl S3Service {
         }
         let body_str = std::str::from_utf8(&req.body).unwrap_or("");
         let status = extract_xml_value(body_str, "Status");
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -487,9 +549,12 @@ impl S3Service {
 
     pub(super) fn get_bucket_accelerate(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -511,6 +576,7 @@ impl S3Service {
 
     pub(super) fn put_public_access_block(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -527,7 +593,8 @@ impl S3Service {
                 "Must specify at least one configuration.",
             ));
         }
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -541,9 +608,12 @@ impl S3Service {
 
     pub(super) fn get_public_access_block(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -578,9 +648,11 @@ impl S3Service {
 
     pub(super) fn delete_public_access_block(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -596,6 +668,7 @@ impl S3Service {
 
     pub(super) fn put_object_lock_config(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -619,7 +692,8 @@ impl S3Service {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -643,10 +717,13 @@ impl S3Service {
 
     pub(super) fn get_bucket_tagging(
         &self,
+        account_id: &str,
         _req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -677,6 +754,7 @@ impl S3Service {
 
     pub(super) fn put_bucket_tagging(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -686,7 +764,8 @@ impl S3Service {
         // Validate tags: no duplicate keys
         validate_tags(&tags)?;
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -709,10 +788,12 @@ impl S3Service {
 
     pub(super) fn delete_bucket_tagging(
         &self,
+        account_id: &str,
         _req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -733,10 +814,13 @@ impl S3Service {
 
     pub(super) fn get_bucket_acl(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -748,6 +832,7 @@ impl S3Service {
 
     pub(super) fn put_bucket_acl(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -758,7 +843,8 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -793,13 +879,15 @@ impl S3Service {
 
     pub(super) fn put_bucket_versioning(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("");
         let status_val = extract_xml_value(body_str, "Status").unwrap_or_default();
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -821,9 +909,12 @@ impl S3Service {
 
     pub(super) fn get_bucket_versioning(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -842,9 +933,12 @@ impl S3Service {
     }
     pub(super) fn get_object_lock_configuration(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -861,11 +955,13 @@ impl S3Service {
 
     pub(super) fn put_bucket_replication(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -891,9 +987,12 @@ impl S3Service {
 
     pub(super) fn get_bucket_replication(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -911,9 +1010,11 @@ impl S3Service {
 
     pub(super) fn delete_bucket_replication(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -927,11 +1028,13 @@ impl S3Service {
 
     pub(super) fn put_bucket_ownership_controls(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -945,9 +1048,12 @@ impl S3Service {
 
     pub(super) fn get_bucket_ownership_controls(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -965,9 +1071,11 @@ impl S3Service {
 
     pub(super) fn delete_bucket_ownership_controls(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -981,6 +1089,7 @@ impl S3Service {
 
     pub(super) fn put_bucket_inventory(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -990,7 +1099,8 @@ impl S3Service {
             .or_else(|| req.query_params.get("id").cloned())
             .unwrap_or_default();
         let payload = {
-            let mut state = self.state.write();
+            let mut accts = self.state.write();
+            let state = accts.get_or_create(account_id);
             let b = state
                 .buckets
                 .get_mut(bucket)
@@ -1011,11 +1121,14 @@ impl S3Service {
 
     pub(super) fn get_bucket_inventory(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let inv_id = req.query_params.get("id").cloned().unwrap_or_default();
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -1032,9 +1145,12 @@ impl S3Service {
 
     pub(super) fn list_bucket_inventory_configurations(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -1058,11 +1174,13 @@ impl S3Service {
 
     pub(super) fn delete_bucket_inventory(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let inv_id = req.query_params.get("id").cloned().unwrap_or_default();
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)

--- a/crates/fakecloud-s3/src/service/lock.rs
+++ b/crates/fakecloud-s3/src/service/lock.rs
@@ -13,6 +13,7 @@ use super::{
 impl S3Service {
     pub(super) fn put_object_retention(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -23,7 +24,8 @@ impl S3Service {
         let retain_until = extract_xml_value(body_str, "RetainUntilDate")
             .and_then(|s| s.parse::<DateTime<Utc>>().ok());
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -103,11 +105,14 @@ impl S3Service {
 
     pub(super) fn get_object_retention(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -137,6 +142,7 @@ impl S3Service {
 
     pub(super) fn put_object_legal_hold(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -145,7 +151,8 @@ impl S3Service {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("");
         let status = extract_xml_value(body_str, "Status");
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -217,11 +224,14 @@ impl S3Service {
 
     pub(super) fn get_object_legal_hold(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -132,6 +132,8 @@ impl AwsService for S3Service {
             None
         };
 
+        let account_id = req.account_id.as_str();
+
         // Multipart upload operations (checked before main match)
         if let Some(b) = bucket {
             // POST /{bucket}/{key}?uploads — CreateMultipartUpload
@@ -139,7 +141,7 @@ impl AwsService for S3Service {
                 && key.is_some()
                 && req.query_params.contains_key("uploads")
             {
-                return self.create_multipart_upload(&req, b, key.as_deref().unwrap());
+                return self.create_multipart_upload(account_id, &req, b, key.as_deref().unwrap());
             }
 
             // POST /{bucket}/{key}?restore
@@ -147,13 +149,14 @@ impl AwsService for S3Service {
                 && key.is_some()
                 && req.query_params.contains_key("restore")
             {
-                return self.restore_object(&req, b, key.as_deref().unwrap());
+                return self.restore_object(account_id, &req, b, key.as_deref().unwrap());
             }
 
             // POST /{bucket}/{key}?uploadId=X — CompleteMultipartUpload
             if req.method == Method::POST && key.is_some() {
                 if let Some(upload_id) = req.query_params.get("uploadId").cloned() {
                     return self.complete_multipart_upload(
+                        account_id,
                         &req,
                         b,
                         key.as_deref().unwrap(),
@@ -171,6 +174,7 @@ impl AwsService for S3Service {
                     if let Ok(part_number) = part_num_str.parse::<i64>() {
                         if req.headers.contains_key("x-amz-copy-source") {
                             return self.upload_part_copy(
+                                account_id,
                                 &req,
                                 b,
                                 key.as_deref().unwrap(),
@@ -179,6 +183,7 @@ impl AwsService for S3Service {
                             );
                         }
                         return self.upload_part(
+                            account_id,
                             &req,
                             b,
                             key.as_deref().unwrap(),
@@ -192,7 +197,12 @@ impl AwsService for S3Service {
             // DELETE /{bucket}/{key}?uploadId=X — AbortMultipartUpload
             if req.method == Method::DELETE && key.is_some() {
                 if let Some(upload_id) = req.query_params.get("uploadId").cloned() {
-                    return self.abort_multipart_upload(b, key.as_deref().unwrap(), &upload_id);
+                    return self.abort_multipart_upload(
+                        account_id,
+                        b,
+                        key.as_deref().unwrap(),
+                        &upload_id,
+                    );
                 }
             }
 
@@ -201,13 +211,19 @@ impl AwsService for S3Service {
                 && key.is_none()
                 && req.query_params.contains_key("uploads")
             {
-                return self.list_multipart_uploads(b);
+                return self.list_multipart_uploads(account_id, b);
             }
 
             // GET /{bucket}/{key}?uploadId=X — ListParts
             if req.method == Method::GET && key.is_some() {
                 if let Some(upload_id) = req.query_params.get("uploadId").cloned() {
-                    return self.list_parts(&req, b, key.as_deref().unwrap(), &upload_id);
+                    return self.list_parts(
+                        account_id,
+                        &req,
+                        b,
+                        key.as_deref().unwrap(),
+                        &upload_id,
+                    );
                 }
             }
         }
@@ -216,7 +232,9 @@ impl AwsService for S3Service {
         if req.method == Method::OPTIONS {
             if let Some(b_name) = bucket {
                 let cors_config = {
-                    let state = self.state.read();
+                    let accounts = self.state.read();
+                    let _empty_s3 = crate::state::S3State::new(&req.account_id, &req.region);
+                    let state = accounts.get(&req.account_id).unwrap_or(&_empty_s3);
                     state
                         .buckets
                         .get(b_name)
@@ -304,119 +322,121 @@ impl AwsService for S3Service {
 
         let mut result = match (&req.method, bucket, key.as_deref()) {
             // ListBuckets: GET /
-            (&Method::GET, None, None) => self.list_buckets(&req),
+            (&Method::GET, None, None) => self.list_buckets(account_id, &req),
 
             // Bucket-level operations (no key)
             (&Method::PUT, Some(b), None) => {
                 if req.query_params.contains_key("tagging") {
-                    self.put_bucket_tagging(&req, b)
+                    self.put_bucket_tagging(account_id, &req, b)
                 } else if req.query_params.contains_key("acl") {
-                    self.put_bucket_acl(&req, b)
+                    self.put_bucket_acl(account_id, &req, b)
                 } else if req.query_params.contains_key("versioning") {
-                    self.put_bucket_versioning(&req, b)
+                    self.put_bucket_versioning(account_id, &req, b)
                 } else if req.query_params.contains_key("cors") {
-                    self.put_bucket_cors(&req, b)
+                    self.put_bucket_cors(account_id, &req, b)
                 } else if req.query_params.contains_key("notification") {
-                    self.put_bucket_notification(&req, b)
+                    self.put_bucket_notification(account_id, &req, b)
                 } else if req.query_params.contains_key("website") {
-                    self.put_bucket_website(&req, b)
+                    self.put_bucket_website(account_id, &req, b)
                 } else if req.query_params.contains_key("accelerate") {
-                    self.put_bucket_accelerate(&req, b)
+                    self.put_bucket_accelerate(account_id, &req, b)
                 } else if req.query_params.contains_key("publicAccessBlock") {
-                    self.put_public_access_block(&req, b)
+                    self.put_public_access_block(account_id, &req, b)
                 } else if req.query_params.contains_key("encryption") {
-                    self.put_bucket_encryption(&req, b)
+                    self.put_bucket_encryption(account_id, &req, b)
                 } else if req.query_params.contains_key("lifecycle") {
-                    self.put_bucket_lifecycle(&req, b)
+                    self.put_bucket_lifecycle(account_id, &req, b)
                 } else if req.query_params.contains_key("logging") {
-                    self.put_bucket_logging(&req, b)
+                    self.put_bucket_logging(account_id, &req, b)
                 } else if req.query_params.contains_key("policy") {
-                    self.put_bucket_policy(&req, b)
+                    self.put_bucket_policy(account_id, &req, b)
                 } else if req.query_params.contains_key("object-lock") {
-                    self.put_object_lock_config(&req, b)
+                    self.put_object_lock_config(account_id, &req, b)
                 } else if req.query_params.contains_key("replication") {
-                    self.put_bucket_replication(&req, b)
+                    self.put_bucket_replication(account_id, &req, b)
                 } else if req.query_params.contains_key("ownershipControls") {
-                    self.put_bucket_ownership_controls(&req, b)
+                    self.put_bucket_ownership_controls(account_id, &req, b)
                 } else if req.query_params.contains_key("inventory") {
-                    self.put_bucket_inventory(&req, b)
+                    self.put_bucket_inventory(account_id, &req, b)
                 } else {
-                    self.create_bucket(&req, b)
+                    self.create_bucket(account_id, &req, b)
                 }
             }
             (&Method::DELETE, Some(b), None) => {
                 if req.query_params.contains_key("tagging") {
-                    self.delete_bucket_tagging(&req, b)
+                    self.delete_bucket_tagging(account_id, &req, b)
                 } else if req.query_params.contains_key("cors") {
-                    self.delete_bucket_cors(b)
+                    self.delete_bucket_cors(account_id, b)
                 } else if req.query_params.contains_key("website") {
-                    self.delete_bucket_website(b)
+                    self.delete_bucket_website(account_id, b)
                 } else if req.query_params.contains_key("publicAccessBlock") {
-                    self.delete_public_access_block(b)
+                    self.delete_public_access_block(account_id, b)
                 } else if req.query_params.contains_key("encryption") {
-                    self.delete_bucket_encryption(b)
+                    self.delete_bucket_encryption(account_id, b)
                 } else if req.query_params.contains_key("lifecycle") {
-                    self.delete_bucket_lifecycle(b)
+                    self.delete_bucket_lifecycle(account_id, b)
                 } else if req.query_params.contains_key("policy") {
-                    self.delete_bucket_policy(b)
+                    self.delete_bucket_policy(account_id, b)
                 } else if req.query_params.contains_key("replication") {
-                    self.delete_bucket_replication(b)
+                    self.delete_bucket_replication(account_id, b)
                 } else if req.query_params.contains_key("ownershipControls") {
-                    self.delete_bucket_ownership_controls(b)
+                    self.delete_bucket_ownership_controls(account_id, b)
                 } else if req.query_params.contains_key("inventory") {
-                    self.delete_bucket_inventory(&req, b)
+                    self.delete_bucket_inventory(account_id, &req, b)
                 } else {
-                    self.delete_bucket(&req, b)
+                    self.delete_bucket(account_id, &req, b)
                 }
             }
-            (&Method::HEAD, Some(b), None) => self.head_bucket(b),
+            (&Method::HEAD, Some(b), None) => self.head_bucket(account_id, b),
             (&Method::GET, Some(b), None) => {
                 if req.query_params.contains_key("tagging") {
-                    self.get_bucket_tagging(&req, b)
+                    self.get_bucket_tagging(account_id, &req, b)
                 } else if req.query_params.contains_key("location") {
-                    self.get_bucket_location(b)
+                    self.get_bucket_location(account_id, b)
                 } else if req.query_params.contains_key("acl") {
-                    self.get_bucket_acl(&req, b)
+                    self.get_bucket_acl(account_id, &req, b)
                 } else if req.query_params.contains_key("versioning") {
-                    self.get_bucket_versioning(b)
+                    self.get_bucket_versioning(account_id, b)
                 } else if req.query_params.contains_key("versions") {
-                    self.list_object_versions(&req, b)
+                    self.list_object_versions(account_id, &req, b)
                 } else if req.query_params.contains_key("object-lock") {
-                    self.get_object_lock_configuration(b)
+                    self.get_object_lock_configuration(account_id, b)
                 } else if req.query_params.contains_key("cors") {
-                    self.get_bucket_cors(b)
+                    self.get_bucket_cors(account_id, b)
                 } else if req.query_params.contains_key("notification") {
-                    self.get_bucket_notification(b)
+                    self.get_bucket_notification(account_id, b)
                 } else if req.query_params.contains_key("website") {
-                    self.get_bucket_website(b)
+                    self.get_bucket_website(account_id, b)
                 } else if req.query_params.contains_key("accelerate") {
-                    self.get_bucket_accelerate(b)
+                    self.get_bucket_accelerate(account_id, b)
                 } else if req.query_params.contains_key("publicAccessBlock") {
-                    self.get_public_access_block(b)
+                    self.get_public_access_block(account_id, b)
                 } else if req.query_params.contains_key("encryption") {
-                    self.get_bucket_encryption(b)
+                    self.get_bucket_encryption(account_id, b)
                 } else if req.query_params.contains_key("lifecycle") {
-                    self.get_bucket_lifecycle(b)
+                    self.get_bucket_lifecycle(account_id, b)
                 } else if req.query_params.contains_key("logging") {
-                    self.get_bucket_logging(b)
+                    self.get_bucket_logging(account_id, b)
                 } else if req.query_params.contains_key("policy") {
-                    self.get_bucket_policy(b)
+                    self.get_bucket_policy(account_id, b)
                 } else if req.query_params.contains_key("replication") {
-                    self.get_bucket_replication(b)
+                    self.get_bucket_replication(account_id, b)
                 } else if req.query_params.contains_key("ownershipControls") {
-                    self.get_bucket_ownership_controls(b)
+                    self.get_bucket_ownership_controls(account_id, b)
                 } else if req.query_params.contains_key("inventory") {
                     if req.query_params.contains_key("id") {
-                        self.get_bucket_inventory(&req, b)
+                        self.get_bucket_inventory(account_id, &req, b)
                     } else {
-                        self.list_bucket_inventory_configurations(b)
+                        self.list_bucket_inventory_configurations(account_id, b)
                     }
                 } else if req.query_params.get("list-type").map(|s| s.as_str()) == Some("2") {
-                    self.list_objects_v2(&req, b)
+                    self.list_objects_v2(account_id, &req, b)
                 } else if req.query_params.is_empty() {
                     // If bucket has website config and no query params, serve index document
                     let website_config = {
-                        let state = self.state.read();
+                        let accounts = self.state.read();
+                        let _empty_s3 = crate::state::S3State::new(&req.account_id, &req.region);
+                        let state = accounts.get(&req.account_id).unwrap_or(&_empty_s3);
                         state
                             .buckets
                             .get(b)
@@ -432,47 +452,47 @@ impl AwsService for S3Service {
                                 Some(inner[s..e].trim().to_string())
                             })
                         }) {
-                            self.serve_website_object(&req, b, &index_doc, config)
+                            self.serve_website_object(account_id, &req, b, &index_doc, config)
                         } else {
-                            self.list_objects_v1(&req, b)
+                            self.list_objects_v1(account_id, &req, b)
                         }
                     } else {
-                        self.list_objects_v1(&req, b)
+                        self.list_objects_v1(account_id, &req, b)
                     }
                 } else {
-                    self.list_objects_v1(&req, b)
+                    self.list_objects_v1(account_id, &req, b)
                 }
             }
 
             // Object-level operations
             (&Method::PUT, Some(b), Some(k)) => {
                 if req.query_params.contains_key("tagging") {
-                    self.put_object_tagging(&req, b, k)
+                    self.put_object_tagging(account_id, &req, b, k)
                 } else if req.query_params.contains_key("acl") {
-                    self.put_object_acl(&req, b, k)
+                    self.put_object_acl(account_id, &req, b, k)
                 } else if req.query_params.contains_key("retention") {
-                    self.put_object_retention(&req, b, k)
+                    self.put_object_retention(account_id, &req, b, k)
                 } else if req.query_params.contains_key("legal-hold") {
-                    self.put_object_legal_hold(&req, b, k)
+                    self.put_object_legal_hold(account_id, &req, b, k)
                 } else if req.headers.contains_key("x-amz-copy-source") {
-                    self.copy_object(&req, b, k)
+                    self.copy_object(account_id, &req, b, k)
                 } else {
-                    self.put_object(&req, b, k)
+                    self.put_object(account_id, &req, b, k)
                 }
             }
             (&Method::GET, Some(b), Some(k)) => {
                 if req.query_params.contains_key("tagging") {
-                    self.get_object_tagging(&req, b, k)
+                    self.get_object_tagging(account_id, &req, b, k)
                 } else if req.query_params.contains_key("acl") {
-                    self.get_object_acl(&req, b, k)
+                    self.get_object_acl(account_id, &req, b, k)
                 } else if req.query_params.contains_key("retention") {
-                    self.get_object_retention(&req, b, k)
+                    self.get_object_retention(account_id, &req, b, k)
                 } else if req.query_params.contains_key("legal-hold") {
-                    self.get_object_legal_hold(&req, b, k)
+                    self.get_object_legal_hold(account_id, &req, b, k)
                 } else if req.query_params.contains_key("attributes") {
-                    self.get_object_attributes(&req, b, k)
+                    self.get_object_attributes(account_id, &req, b, k)
                 } else {
-                    let result = self.get_object(&req, b, k);
+                    let result = self.get_object(account_id, &req, b, k);
                     // If object not found and bucket has website config, serve error document
                     let is_not_found = matches!(
                         &result,
@@ -480,7 +500,10 @@ impl AwsService for S3Service {
                     );
                     if is_not_found {
                         let website_config = {
-                            let state = self.state.read();
+                            let accounts = self.state.read();
+                            let _empty_s3 =
+                                crate::state::S3State::new(&req.account_id, &req.region);
+                            let state = accounts.get(&req.account_id).unwrap_or(&_empty_s3);
                             state
                                 .buckets
                                 .get(b)
@@ -497,7 +520,7 @@ impl AwsService for S3Service {
                                 })
                                 .or_else(|| extract_xml_value(config, "Key"))
                             {
-                                return self.serve_website_error(&req, b, &error_key);
+                                return self.serve_website_error(account_id, &req, b, &error_key);
                             }
                         }
                     }
@@ -506,16 +529,16 @@ impl AwsService for S3Service {
             }
             (&Method::DELETE, Some(b), Some(k)) => {
                 if req.query_params.contains_key("tagging") {
-                    self.delete_object_tagging(b, k)
+                    self.delete_object_tagging(account_id, b, k)
                 } else {
-                    self.delete_object(&req, b, k)
+                    self.delete_object(account_id, &req, b, k)
                 }
             }
-            (&Method::HEAD, Some(b), Some(k)) => self.head_object(&req, b, k),
+            (&Method::HEAD, Some(b), Some(k)) => self.head_object(account_id, &req, b, k),
 
             // POST /{bucket}?delete — batch delete
             (&Method::POST, Some(b), None) if req.query_params.contains_key("delete") => {
-                self.delete_objects(&req, b)
+                self.delete_objects(account_id, &req, b)
             }
 
             _ => Err(AwsServiceError::aws_error(
@@ -528,7 +551,9 @@ impl AwsService for S3Service {
         // Apply CORS headers to the response if Origin was present
         if let (Some(ref origin), Some(b_name)) = (&origin_header, bucket) {
             let cors_config = {
-                let state = self.state.read();
+                let accounts = self.state.read();
+                let _empty_s3 = crate::state::S3State::new(&req.account_id, &req.region);
+                let state = accounts.get(&req.account_id).unwrap_or(&_empty_s3);
                 state
                     .buckets
                     .get(b_name)
@@ -774,7 +799,13 @@ fn s3_resource_tags(
     }
     // S3 ARNs: arn:aws:s3:::bucket or arn:aws:s3:::bucket/key
     let after_prefix = resource_arn.strip_prefix("arn:aws:s3:::")?;
-    let state = state.read();
+    let mas = state.read();
+    // S3 bucket names are globally unique; scan all accounts to find the bucket
+    let bucket_name = after_prefix.split('/').next().unwrap_or(after_prefix);
+    let state = mas
+        .find_account(|s| s.buckets.contains_key(bucket_name))
+        .and_then(|id| mas.get(id))
+        .or_else(|| Some(mas.default_ref()))?;
     if let Some(slash_pos) = after_prefix.find('/') {
         // Object-level: bucket/key
         let bucket_name = &after_prefix[..slash_pos];
@@ -2763,7 +2794,7 @@ mod tests {
     // running Axum router.
     // ────────────────────────────────────────────────────────────────
 
-    use crate::state::{S3Bucket, S3Object, S3State};
+    use crate::state::{S3Bucket, S3Object};
     use bytes::Bytes;
     use fakecloud_core::delivery::DeliveryBus;
     use fakecloud_core::service::{AwsRequest, AwsServiceError};
@@ -2773,19 +2804,23 @@ mod tests {
     use std::sync::Arc;
 
     fn make_service() -> S3Service {
-        let state: SharedS3State = Arc::new(RwLock::new(S3State::new("123456789012", "us-east-1")));
+        let state: SharedS3State = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         S3Service::new(state, Arc::new(DeliveryBus::new()))
     }
 
     fn seed_bucket(svc: &S3Service, name: &str) {
-        let mut state = svc.state.write();
+        let mut mas = svc.state.write();
+        let state = mas.default_mut();
         state
             .buckets
             .insert(name.to_string(), S3Bucket::new(name, "us-east-1", "owner"));
     }
 
     fn seed_object(svc: &S3Service, bucket: &str, key: &str, body: &[u8]) {
-        let mut state = svc.state.write();
+        let mut mas = svc.state.write();
+        let state = mas.default_mut();
         let b = state.buckets.get_mut(bucket).expect("bucket seeded");
         let mut obj = S3Object {
             key: key.to_string(),
@@ -2860,8 +2895,9 @@ mod tests {
         seed_bucket(&svc, "b");
         seed_object(&svc, "b", "k", b"hello");
         {
-            let mut state = svc.state.write();
-            let obj = state
+            let mut mas = svc.state.write();
+            let obj = mas
+                .default_mut()
                 .buckets
                 .get_mut("b")
                 .unwrap()
@@ -2873,7 +2909,9 @@ mod tests {
         }
 
         let req = make_request(Method::GET, "/b/k", &[("tagging", "")], b"");
-        let resp = svc.get_object_tagging(&req, "b", "k").unwrap();
+        let resp = svc
+            .get_object_tagging("123456789012", &req, "b", "k")
+            .unwrap();
         assert_eq!(resp.status, StatusCode::OK);
         let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body.contains("<Tag><Key>env</Key><Value>prod</Value></Tag>"));
@@ -2884,7 +2922,10 @@ mod tests {
     fn get_object_tagging_missing_bucket_errors() {
         let svc = make_service();
         let req = make_request(Method::GET, "/nope/k", &[("tagging", "")], b"");
-        assert_aws_err(svc.get_object_tagging(&req, "nope", "k"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_object_tagging("123456789012", &req, "nope", "k"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
@@ -2895,7 +2936,10 @@ mod tests {
 
         let xml = r#"<Tagging><TagSet><Tag><Key>aws:internal</Key><Value>v</Value></Tag></TagSet></Tagging>"#;
         let req = make_request(Method::PUT, "/b/k", &[("tagging", "")], xml.as_bytes());
-        assert_aws_err(svc.put_object_tagging(&req, "b", "k"), "InvalidTag");
+        assert_aws_err(
+            svc.put_object_tagging("123456789012", &req, "b", "k"),
+            "InvalidTag",
+        );
     }
 
     #[test]
@@ -2910,7 +2954,10 @@ mod tests {
         }
         xml.push_str("</TagSet></Tagging>");
         let req = make_request(Method::PUT, "/b/k", &[("tagging", "")], xml.as_bytes());
-        assert_aws_err(svc.put_object_tagging(&req, "b", "k"), "BadRequest");
+        assert_aws_err(
+            svc.put_object_tagging("123456789012", &req, "b", "k"),
+            "BadRequest",
+        );
     }
 
     #[test]
@@ -2925,7 +2972,10 @@ mod tests {
             &[("tagging", "")],
             xml.as_bytes(),
         );
-        assert_aws_err(svc.put_object_tagging(&req, "b", "missing"), "NoSuchKey");
+        assert_aws_err(
+            svc.put_object_tagging("123456789012", &req, "b", "missing"),
+            "NoSuchKey",
+        );
     }
 
     #[test]
@@ -2934,8 +2984,9 @@ mod tests {
         seed_bucket(&svc, "b");
         seed_object(&svc, "b", "k", b"x");
         {
-            let mut state = svc.state.write();
-            let obj = state
+            let mut mas = svc.state.write();
+            let obj = mas
+                .default_mut()
                 .buckets
                 .get_mut("b")
                 .unwrap()
@@ -2948,10 +2999,13 @@ mod tests {
         let xml =
             r#"<Tagging><TagSet><Tag><Key>new</Key><Value>here</Value></Tag></TagSet></Tagging>"#;
         let req = make_request(Method::PUT, "/b/k", &[("tagging", "")], xml.as_bytes());
-        let resp = svc.put_object_tagging(&req, "b", "k").unwrap();
+        let resp = svc
+            .put_object_tagging("123456789012", &req, "b", "k")
+            .unwrap();
         assert_eq!(resp.status, StatusCode::OK);
 
-        let state = svc.state.read();
+        let __mas = svc.state.read();
+        let state = __mas.default_ref();
         let tags = &state
             .buckets
             .get("b")
@@ -2970,8 +3024,9 @@ mod tests {
         seed_bucket(&svc, "b");
         seed_object(&svc, "b", "k", b"x");
         {
-            let mut state = svc.state.write();
-            let obj = state
+            let mut mas = svc.state.write();
+            let obj = mas
+                .default_mut()
                 .buckets
                 .get_mut("b")
                 .unwrap()
@@ -2981,9 +3036,10 @@ mod tests {
             obj.tags.insert("env".to_string(), "prod".to_string());
         }
 
-        let resp = svc.delete_object_tagging("b", "k").unwrap();
+        let resp = svc.delete_object_tagging("123456789012", "b", "k").unwrap();
         assert_eq!(resp.status, StatusCode::NO_CONTENT);
-        let state = svc.state.read();
+        let __mas = svc.state.read();
+        let state = __mas.default_ref();
         assert!(state
             .buckets
             .get("b")
@@ -2999,7 +3055,10 @@ mod tests {
     fn delete_object_tagging_missing_key_errors() {
         let svc = make_service();
         seed_bucket(&svc, "b");
-        assert_aws_err(svc.delete_object_tagging("b", "gone"), "NoSuchKey");
+        assert_aws_err(
+            svc.delete_object_tagging("123456789012", "b", "gone"),
+            "NoSuchKey",
+        );
     }
 
     // ── Multipart (service/multipart.rs) ─────────────────────────────
@@ -3011,7 +3070,9 @@ mod tests {
             &[("uploads", "")],
             b"",
         );
-        let resp = svc.create_multipart_upload(&req, bucket, key).unwrap();
+        let resp = svc
+            .create_multipart_upload("123456789012", &req, bucket, key)
+            .unwrap();
         let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         let start = body.find("<UploadId>").unwrap() + "<UploadId>".len();
         let end = body.find("</UploadId>").unwrap();
@@ -3023,7 +3084,8 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "b");
         let upload_id = initiate_mpu(&svc, "b", "big.bin");
-        let state = svc.state.read();
+        let __mas = svc.state.read();
+        let state = __mas.default_ref();
         assert!(state
             .buckets
             .get("b")
@@ -3041,7 +3103,7 @@ mod tests {
         req.headers
             .insert("x-amz-grant-read", "id=owner".parse().unwrap());
         assert_aws_err(
-            svc.create_multipart_upload(&req, "b", "k"),
+            svc.create_multipart_upload("123456789012", &req, "b", "k"),
             "InvalidRequest",
         );
     }
@@ -3051,7 +3113,7 @@ mod tests {
         let svc = make_service();
         let req = make_request(Method::POST, "/ghost/k", &[("uploads", "")], b"");
         assert_aws_err(
-            svc.create_multipart_upload(&req, "ghost", "k"),
+            svc.create_multipart_upload("123456789012", &req, "ghost", "k"),
             "NoSuchBucket",
         );
     }
@@ -3065,14 +3127,14 @@ mod tests {
         // part_number < 1 is masked as NoSuchUpload (matching AWS behavior).
         let req = make_request(Method::PUT, "/b/k", &[("partNumber", "0")], b"body");
         assert_aws_err(
-            svc.upload_part(&req, "b", "k", &upload_id, 0),
+            svc.upload_part("123456789012", &req, "b", "k", &upload_id, 0),
             "NoSuchUpload",
         );
 
         // part_number > 10000 returns InvalidArgument.
         let req2 = make_request(Method::PUT, "/b/k", &[("partNumber", "10001")], b"body");
         assert_aws_err(
-            svc.upload_part(&req2, "b", "k", &upload_id, 10_001),
+            svc.upload_part("123456789012", &req2, "b", "k", &upload_id, 10_001),
             "InvalidArgument",
         );
     }
@@ -3083,7 +3145,7 @@ mod tests {
         seed_bucket(&svc, "b");
         let req = make_request(Method::PUT, "/b/k", &[("partNumber", "1")], b"body");
         assert_aws_err(
-            svc.upload_part(&req, "b", "k", "not-an-upload", 1),
+            svc.upload_part("123456789012", &req, "b", "k", "not-an-upload", 1),
             "NoSuchUpload",
         );
     }
@@ -3098,7 +3160,9 @@ mod tests {
         // only applies to non-last parts, so a single part of any size works.
         let part_body = b"hello";
         let req = make_request(Method::PUT, "/b/k", &[("partNumber", "1")], part_body);
-        let resp = svc.upload_part(&req, "b", "k", &upload_id, 1).unwrap();
+        let resp = svc
+            .upload_part("123456789012", &req, "b", "k", &upload_id, 1)
+            .unwrap();
         let etag = resp
             .headers
             .get("etag")
@@ -3117,11 +3181,12 @@ mod tests {
             complete_xml.as_bytes(),
         );
         let resp = svc
-            .complete_multipart_upload(&complete_req, "b", "k", &upload_id)
+            .complete_multipart_upload("123456789012", &complete_req, "b", "k", &upload_id)
             .unwrap();
         assert_eq!(resp.status, StatusCode::OK);
 
-        let state = svc.state.read();
+        let __mas = svc.state.read();
+        let state = __mas.default_ref();
         let bucket = state.buckets.get("b").unwrap();
         let obj = bucket.objects.get("k").expect("object materialized");
         assert_eq!(obj.size, part_body.len() as u64);
@@ -3142,12 +3207,14 @@ mod tests {
                 &[("partNumber", &n.to_string())],
                 body.as_bytes(),
             );
-            svc.upload_part(&req, "b", "k", &upload_id, n).unwrap();
+            svc.upload_part("123456789012", &req, "b", "k", &upload_id, n)
+                .unwrap();
         }
 
         // Grab the etags from state.
         let (etag1, etag2) = {
-            let state = svc.state.read();
+            let __mas = svc.state.read();
+            let state = __mas.default_ref();
             let parts = &state
                 .buckets
                 .get("b")
@@ -3172,7 +3239,7 @@ mod tests {
             complete_xml.as_bytes(),
         );
         assert_aws_err(
-            svc.complete_multipart_upload(&complete_req, "b", "k", &upload_id),
+            svc.complete_multipart_upload("123456789012", &complete_req, "b", "k", &upload_id),
             "EntityTooSmall",
         );
     }
@@ -3182,9 +3249,12 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "b");
         let upload_id = initiate_mpu(&svc, "b", "k");
-        let resp = svc.abort_multipart_upload("b", "k", &upload_id).unwrap();
+        let resp = svc
+            .abort_multipart_upload("123456789012", "b", "k", &upload_id)
+            .unwrap();
         assert_eq!(resp.status, StatusCode::NO_CONTENT);
-        let state = svc.state.read();
+        let __mas = svc.state.read();
+        let state = __mas.default_ref();
         assert!(!state
             .buckets
             .get("b")
@@ -3198,7 +3268,7 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "b");
         assert_aws_err(
-            svc.abort_multipart_upload("b", "k", "no-such"),
+            svc.abort_multipart_upload("123456789012", "b", "k", "no-such"),
             "NoSuchUpload",
         );
     }
@@ -3209,7 +3279,7 @@ mod tests {
         seed_bucket(&svc, "b");
         let u1 = initiate_mpu(&svc, "b", "a");
         let u2 = initiate_mpu(&svc, "b", "b");
-        let resp = svc.list_multipart_uploads("b").unwrap();
+        let resp = svc.list_multipart_uploads("123456789012", "b").unwrap();
         let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body.contains(&u1));
         assert!(body.contains(&u2));
@@ -3221,10 +3291,13 @@ mod tests {
         seed_bucket(&svc, "b");
         let upload_id = initiate_mpu(&svc, "b", "k");
         let req = make_request(Method::PUT, "/b/k", &[("partNumber", "1")], b"data");
-        svc.upload_part(&req, "b", "k", &upload_id, 1).unwrap();
+        svc.upload_part("123456789012", &req, "b", "k", &upload_id, 1)
+            .unwrap();
 
         let list_req = make_request(Method::GET, "/b/k", &[("uploadId", &upload_id)], b"");
-        let resp = svc.list_parts(&list_req, "b", "k", &upload_id).unwrap();
+        let resp = svc
+            .list_parts("123456789012", &list_req, "b", "k", &upload_id)
+            .unwrap();
         let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body.contains("<PartNumber>1</PartNumber>"));
     }
@@ -3238,19 +3311,21 @@ mod tests {
 
         let xml = r#"<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>AES256</SSEAlgorithm></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>"#;
         let req = make_request(Method::PUT, "/b", &[("encryption", "")], xml.as_bytes());
-        let resp = svc.put_bucket_encryption(&req, "b").unwrap();
+        let resp = svc
+            .put_bucket_encryption("123456789012", &req, "b")
+            .unwrap();
         assert_eq!(resp.status, StatusCode::OK);
 
         // Normalized body should include BucketKeyEnabled=false.
-        let get = svc.get_bucket_encryption("b").unwrap();
+        let get = svc.get_bucket_encryption("123456789012", "b").unwrap();
         let body = std::str::from_utf8(get.body.expect_bytes()).unwrap();
         assert!(body.contains("AES256"));
         assert!(body.contains("<BucketKeyEnabled>false</BucketKeyEnabled>"));
 
-        let del = svc.delete_bucket_encryption("b").unwrap();
+        let del = svc.delete_bucket_encryption("123456789012", "b").unwrap();
         assert_eq!(del.status, StatusCode::NO_CONTENT);
         assert_aws_err(
-            svc.get_bucket_encryption("b"),
+            svc.get_bucket_encryption("123456789012", "b"),
             "ServerSideEncryptionConfigurationNotFoundError",
         );
     }
@@ -3260,7 +3335,10 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "b");
         let req = make_request(Method::PUT, "/b", &[("policy", "")], b"not-json");
-        assert_aws_err(svc.put_bucket_policy(&req, "b"), "MalformedPolicy");
+        assert_aws_err(
+            svc.put_bucket_policy("123456789012", &req, "b"),
+            "MalformedPolicy",
+        );
     }
 
     #[test]
@@ -3270,15 +3348,20 @@ mod tests {
 
         let body = br#"{"Version":"2012-10-17","Statement":[]}"#;
         let put_req = make_request(Method::PUT, "/b", &[("policy", "")], body);
-        let resp = svc.put_bucket_policy(&put_req, "b").unwrap();
+        let resp = svc
+            .put_bucket_policy("123456789012", &put_req, "b")
+            .unwrap();
         assert_eq!(resp.status, StatusCode::NO_CONTENT);
 
-        let get = svc.get_bucket_policy("b").unwrap();
+        let get = svc.get_bucket_policy("123456789012", "b").unwrap();
         assert_eq!(get.body.expect_bytes(), body);
 
-        let del = svc.delete_bucket_policy("b").unwrap();
+        let del = svc.delete_bucket_policy("123456789012", "b").unwrap();
         assert_eq!(del.status, StatusCode::NO_CONTENT);
-        assert_aws_err(svc.get_bucket_policy("b"), "NoSuchBucketPolicy");
+        assert_aws_err(
+            svc.get_bucket_policy("123456789012", "b"),
+            "NoSuchBucketPolicy",
+        );
     }
 
     #[test]
@@ -3286,7 +3369,8 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "b");
         {
-            let mut state = svc.state.write();
+            let mut __mas = svc.state.write();
+            let state = __mas.default_mut();
             state.buckets.get_mut("b").unwrap().lifecycle_config = Some("placeholder".to_string());
         }
         let req = make_request(
@@ -3295,8 +3379,9 @@ mod tests {
             &[("lifecycle", "")],
             b"<LifecycleConfiguration></LifecycleConfiguration>",
         );
-        svc.put_bucket_lifecycle(&req, "b").unwrap();
-        let state = svc.state.read();
+        svc.put_bucket_lifecycle("123456789012", &req, "b").unwrap();
+        let __mas = svc.state.read();
+        let state = __mas.default_ref();
         assert!(state.buckets.get("b").unwrap().lifecycle_config.is_none());
     }
 
@@ -3306,13 +3391,16 @@ mod tests {
         seed_bucket(&svc, "b");
         let xml = br#"<CORSConfiguration><CORSRule><AllowedMethod>GET</AllowedMethod><AllowedOrigin>*</AllowedOrigin></CORSRule></CORSConfiguration>"#;
         let req = make_request(Method::PUT, "/b", &[("cors", "")], xml);
-        svc.put_bucket_cors(&req, "b").unwrap();
-        let got = svc.get_bucket_cors("b").unwrap();
+        svc.put_bucket_cors("123456789012", &req, "b").unwrap();
+        let got = svc.get_bucket_cors("123456789012", "b").unwrap();
         assert!(std::str::from_utf8(got.body.expect_bytes())
             .unwrap()
             .contains("CORSConfiguration"));
-        svc.delete_bucket_cors("b").unwrap();
-        assert_aws_err(svc.get_bucket_cors("b"), "NoSuchCORSConfiguration");
+        svc.delete_bucket_cors("123456789012", "b").unwrap();
+        assert_aws_err(
+            svc.get_bucket_cors("123456789012", "b"),
+            "NoSuchCORSConfiguration",
+        );
     }
 
     #[test]
@@ -3325,16 +3413,18 @@ mod tests {
             &[("versioning", "")],
             b"<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>",
         );
-        svc.put_bucket_versioning(&req, "b").unwrap();
+        svc.put_bucket_versioning("123456789012", &req, "b")
+            .unwrap();
 
-        let state = svc.state.read();
+        let __mas = svc.state.read();
+        let state = __mas.default_ref();
         assert_eq!(
             state.buckets.get("b").unwrap().versioning.as_deref(),
             Some("Enabled")
         );
-        drop(state);
+        drop(__mas);
 
-        let resp = svc.get_bucket_versioning("b").unwrap();
+        let resp = svc.get_bucket_versioning("123456789012", "b").unwrap();
         let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body.contains("<Status>Enabled</Status>"));
     }
@@ -3349,15 +3439,21 @@ mod tests {
             &[("tagging", "")],
             br#"<Tagging><TagSet><Tag><Key>env</Key><Value>prod</Value></Tag></TagSet></Tagging>"#,
         );
-        svc.put_bucket_tagging(&req, "b").unwrap();
+        svc.put_bucket_tagging("123456789012", &req, "b").unwrap();
         let get_req = make_request(Method::GET, "/b", &[("tagging", "")], b"");
-        let got = svc.get_bucket_tagging(&get_req, "b").unwrap();
+        let got = svc
+            .get_bucket_tagging("123456789012", &get_req, "b")
+            .unwrap();
         assert!(std::str::from_utf8(got.body.expect_bytes())
             .unwrap()
             .contains("<Key>env</Key>"));
         let del_req = make_request(Method::DELETE, "/b", &[("tagging", "")], b"");
-        svc.delete_bucket_tagging(&del_req, "b").unwrap();
-        assert_aws_err(svc.get_bucket_tagging(&get_req, "b"), "NoSuchTagSet");
+        svc.delete_bucket_tagging("123456789012", &del_req, "b")
+            .unwrap();
+        assert_aws_err(
+            svc.get_bucket_tagging("123456789012", &get_req, "b"),
+            "NoSuchTagSet",
+        );
     }
 
     #[test]
@@ -3370,7 +3466,10 @@ mod tests {
             &[("accelerate", "")],
             b"<AccelerateConfiguration><Status>Bogus</Status></AccelerateConfiguration>",
         );
-        assert_aws_err(svc.put_bucket_accelerate(&req, "b"), "MalformedXML");
+        assert_aws_err(
+            svc.put_bucket_accelerate("123456789012", &req, "b"),
+            "MalformedXML",
+        );
     }
 
     #[test]
@@ -3383,8 +3482,9 @@ mod tests {
             &[("accelerate", "")],
             b"<AccelerateConfiguration><Status>Enabled</Status></AccelerateConfiguration>",
         );
-        svc.put_bucket_accelerate(&req, "b").unwrap();
-        let got = svc.get_bucket_accelerate("b").unwrap();
+        svc.put_bucket_accelerate("123456789012", &req, "b")
+            .unwrap();
+        let got = svc.get_bucket_accelerate("123456789012", "b").unwrap();
         assert!(std::str::from_utf8(got.body.expect_bytes())
             .unwrap()
             .contains("<Status>Enabled</Status>"));
@@ -3396,14 +3496,15 @@ mod tests {
         seed_bucket(&svc, "b");
         let body = br#"<PublicAccessBlockConfiguration><BlockPublicAcls>true</BlockPublicAcls><IgnorePublicAcls>true</IgnorePublicAcls><BlockPublicPolicy>true</BlockPublicPolicy><RestrictPublicBuckets>true</RestrictPublicBuckets></PublicAccessBlockConfiguration>"#;
         let req = make_request(Method::PUT, "/b", &[("publicAccessBlock", "")], body);
-        svc.put_public_access_block(&req, "b").unwrap();
-        let got = svc.get_public_access_block("b").unwrap();
+        svc.put_public_access_block("123456789012", &req, "b")
+            .unwrap();
+        let got = svc.get_public_access_block("123456789012", "b").unwrap();
         assert!(std::str::from_utf8(got.body.expect_bytes())
             .unwrap()
             .contains("<BlockPublicAcls>true</BlockPublicAcls>"));
-        svc.delete_public_access_block("b").unwrap();
+        svc.delete_public_access_block("123456789012", "b").unwrap();
         assert_aws_err(
-            svc.get_public_access_block("b"),
+            svc.get_public_access_block("123456789012", "b"),
             "NoSuchPublicAccessBlockConfiguration",
         );
     }
@@ -3418,20 +3519,26 @@ mod tests {
             &[("website", "")],
             b"<WebsiteConfiguration><IndexDocument><Suffix>index.html</Suffix></IndexDocument></WebsiteConfiguration>",
         );
-        svc.put_bucket_website(&req, "b").unwrap();
-        let got = svc.get_bucket_website("b").unwrap();
+        svc.put_bucket_website("123456789012", &req, "b").unwrap();
+        let got = svc.get_bucket_website("123456789012", "b").unwrap();
         assert!(std::str::from_utf8(got.body.expect_bytes())
             .unwrap()
             .contains("<Suffix>index.html</Suffix>"));
-        svc.delete_bucket_website("b").unwrap();
-        assert_aws_err(svc.get_bucket_website("b"), "NoSuchWebsiteConfiguration");
+        svc.delete_bucket_website("123456789012", "b").unwrap();
+        assert_aws_err(
+            svc.get_bucket_website("123456789012", "b"),
+            "NoSuchWebsiteConfiguration",
+        );
     }
 
     #[test]
     fn bucket_replication_requires_existing_bucket() {
         let svc = make_service();
         let req = make_request(Method::PUT, "/nope", &[("replication", "")], b"<x/>");
-        assert_aws_err(svc.put_bucket_replication(&req, "nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.put_bucket_replication("123456789012", &req, "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
@@ -3444,14 +3551,18 @@ mod tests {
             &[("ownershipControls", "")],
             b"<OwnershipControls><Rule><ObjectOwnership>BucketOwnerEnforced</ObjectOwnership></Rule></OwnershipControls>",
         );
-        svc.put_bucket_ownership_controls(&req, "b").unwrap();
-        let got = svc.get_bucket_ownership_controls("b").unwrap();
+        svc.put_bucket_ownership_controls("123456789012", &req, "b")
+            .unwrap();
+        let got = svc
+            .get_bucket_ownership_controls("123456789012", "b")
+            .unwrap();
         assert!(std::str::from_utf8(got.body.expect_bytes())
             .unwrap()
             .contains("BucketOwnerEnforced"));
-        svc.delete_bucket_ownership_controls("b").unwrap();
+        svc.delete_bucket_ownership_controls("123456789012", "b")
+            .unwrap();
         assert_aws_err(
-            svc.get_bucket_ownership_controls("b"),
+            svc.get_bucket_ownership_controls("123456789012", "b"),
             "OwnershipControlsNotFoundError",
         );
     }
@@ -3462,7 +3573,10 @@ mod tests {
     fn get_object_nonexistent_bucket() {
         let svc = make_service();
         let req = make_request(Method::GET, "/no-bucket/key", &[], b"");
-        assert_aws_err(svc.get_object(&req, "no-bucket", "key"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_object("123456789012", &req, "no-bucket", "key"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
@@ -3470,7 +3584,10 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "b");
         let req = make_request(Method::GET, "/b/missing", &[], b"");
-        assert_aws_err(svc.get_object(&req, "b", "missing"), "NoSuchKey");
+        assert_aws_err(
+            svc.get_object("123456789012", &req, "b", "missing"),
+            "NoSuchKey",
+        );
     }
 
     #[test]
@@ -3479,7 +3596,10 @@ mod tests {
         seed_bucket(&svc, "b");
         let long_key = "x".repeat(1025);
         let req = make_request(Method::PUT, &format!("/b/{long_key}"), &[], b"data");
-        assert_aws_err(svc.put_object(&req, "b", &long_key), "KeyTooLongError");
+        assert_aws_err(
+            svc.put_object("123456789012", &req, "b", &long_key),
+            "KeyTooLongError",
+        );
     }
 
     #[test]
@@ -3489,7 +3609,10 @@ mod tests {
         let mut req = make_request(Method::PUT, "/b/tagged", &[], b"data");
         req.headers
             .insert("x-amz-tagging", "aws:reserved=nope".parse().unwrap());
-        assert_aws_err(svc.put_object(&req, "b", "tagged"), "InvalidTag");
+        assert_aws_err(
+            svc.put_object("123456789012", &req, "b", "tagged"),
+            "InvalidTag",
+        );
     }
 
     #[test]
@@ -3501,7 +3624,10 @@ mod tests {
             .insert("x-amz-acl", "public-read".parse().unwrap());
         req.headers
             .insert("x-amz-grant-read", "id=abc123".parse().unwrap());
-        assert_aws_err(svc.put_object(&req, "b", "conflict"), "InvalidRequest");
+        assert_aws_err(
+            svc.put_object("123456789012", &req, "b", "conflict"),
+            "InvalidRequest",
+        );
     }
 
     #[test]
@@ -3509,21 +3635,30 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "b");
         let req = make_request(Method::HEAD, "/b/missing", &[], b"");
-        assert_aws_err(svc.head_object(&req, "b", "missing"), "NoSuchKey");
+        assert_aws_err(
+            svc.head_object("123456789012", &req, "b", "missing"),
+            "NoSuchKey",
+        );
     }
 
     #[test]
     fn head_object_nonexistent_bucket() {
         let svc = make_service();
         let req = make_request(Method::HEAD, "/nope/key", &[], b"");
-        assert_aws_err(svc.head_object(&req, "nope", "key"), "NoSuchBucket");
+        assert_aws_err(
+            svc.head_object("123456789012", &req, "nope", "key"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn delete_object_nonexistent_bucket() {
         let svc = make_service();
         let req = make_request(Method::DELETE, "/nope/key", &[], b"");
-        assert_aws_err(svc.delete_object(&req, "nope", "key"), "NoSuchBucket");
+        assert_aws_err(
+            svc.delete_object("123456789012", &req, "nope", "key"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
@@ -3534,7 +3669,10 @@ mod tests {
         let mut req = make_request(Method::PUT, "/dst-b/copied", &[], b"");
         req.headers
             .insert("x-amz-copy-source", "src-b/nonexistent".parse().unwrap());
-        assert_aws_err(svc.copy_object(&req, "dst-b", "copied"), "NoSuchKey");
+        assert_aws_err(
+            svc.copy_object("123456789012", &req, "dst-b", "copied"),
+            "NoSuchKey",
+        );
     }
 
     #[test]
@@ -3544,14 +3682,20 @@ mod tests {
         let mut req = make_request(Method::PUT, "/dst-b2/copied", &[], b"");
         req.headers
             .insert("x-amz-copy-source", "nope-bucket/key".parse().unwrap());
-        assert_aws_err(svc.copy_object(&req, "dst-b2", "copied"), "NoSuchBucket");
+        assert_aws_err(
+            svc.copy_object("123456789012", &req, "dst-b2", "copied"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn list_objects_v2_nonexistent_bucket() {
         let svc = make_service();
         let req = make_request(Method::GET, "/nope", &[("list-type", "2")], b"");
-        assert_aws_err(svc.list_objects_v2(&req, "nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.list_objects_v2("123456789012", &req, "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
@@ -3564,21 +3708,30 @@ mod tests {
             &[("list-type", "2"), ("continuation-token", "")],
             b"",
         );
-        assert_aws_err(svc.list_objects_v2(&req, "b"), "InvalidArgument");
+        assert_aws_err(
+            svc.list_objects_v2("123456789012", &req, "b"),
+            "InvalidArgument",
+        );
     }
 
     #[test]
     fn list_objects_v1_nonexistent_bucket() {
         let svc = make_service();
         let req = make_request(Method::GET, "/nope", &[], b"");
-        assert_aws_err(svc.list_objects_v1(&req, "nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.list_objects_v1("123456789012", &req, "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn list_object_versions_nonexistent_bucket() {
         let svc = make_service();
         let req = make_request(Method::GET, "/nope", &[("versions", "")], b"");
-        assert_aws_err(svc.list_object_versions(&req, "nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.list_object_versions("123456789012", &req, "nope"),
+            "NoSuchBucket",
+        );
     }
 
     // ── Error branch tests: multipart operations ──
@@ -3588,7 +3741,7 @@ mod tests {
         let svc = make_service();
         let req = make_request(Method::POST, "/nope/key", &[("uploads", "")], b"");
         assert_aws_err(
-            svc.create_multipart_upload(&req, "nope", "key"),
+            svc.create_multipart_upload("123456789012", &req, "nope", "key"),
             "NoSuchBucket",
         );
     }
@@ -3604,7 +3757,7 @@ mod tests {
             b"data",
         );
         assert_aws_err(
-            svc.upload_part(&req, "b", "key", "bogus", 1),
+            svc.upload_part("123456789012", &req, "b", "key", "bogus", 1),
             "NoSuchUpload",
         );
     }
@@ -3620,7 +3773,7 @@ mod tests {
             b"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>\"abc\"</ETag></Part></CompleteMultipartUpload>",
         );
         assert_aws_err(
-            svc.complete_multipart_upload(&req, "b", "key", "bogus"),
+            svc.complete_multipart_upload("123456789012", &req, "b", "key", "bogus"),
             "NoSuchUpload",
         );
     }
@@ -3630,7 +3783,7 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "b");
         assert_aws_err(
-            svc.abort_multipart_upload("b", "key", "bogus"),
+            svc.abort_multipart_upload("123456789012", "b", "key", "bogus"),
             "NoSuchUpload",
         );
     }
@@ -3640,7 +3793,10 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "b");
         let req = make_request(Method::GET, "/b/key", &[("uploadId", "bogus")], b"");
-        assert_aws_err(svc.list_parts(&req, "b", "key", "bogus"), "NoSuchUpload");
+        assert_aws_err(
+            svc.list_parts("123456789012", &req, "b", "key", "bogus"),
+            "NoSuchUpload",
+        );
     }
 
     // ── Error branch tests: config operations ──
@@ -3649,13 +3805,19 @@ mod tests {
     fn get_bucket_acl_nonexistent() {
         let svc = make_service();
         let req = make_request(Method::GET, "/nope", &[("acl", "")], b"");
-        assert_aws_err(svc.get_bucket_acl(&req, "nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_bucket_acl("123456789012", &req, "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_bucket_versioning_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_bucket_versioning("nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_bucket_versioning("123456789012", "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
@@ -3667,43 +3829,64 @@ mod tests {
             &[("versioning", "")],
             b"<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>",
         );
-        assert_aws_err(svc.put_bucket_versioning(&req, "nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.put_bucket_versioning("123456789012", &req, "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_bucket_location_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_bucket_location("nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_bucket_location("123456789012", "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_bucket_lifecycle_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_bucket_lifecycle("nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_bucket_lifecycle("123456789012", "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_bucket_notification_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_bucket_notification("nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_bucket_notification("123456789012", "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_bucket_encryption_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_bucket_encryption("nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_bucket_encryption("123456789012", "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_bucket_logging_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_bucket_logging("nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_bucket_logging("123456789012", "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_object_lock_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_object_lock_configuration("nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_object_lock_configuration("123456789012", "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
@@ -3711,7 +3894,10 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "b");
         let req = make_request(Method::GET, "/b/missing", &[("attributes", "")], b"");
-        assert_aws_err(svc.get_object_attributes(&req, "b", "missing"), "NoSuchKey");
+        assert_aws_err(
+            svc.get_object_attributes("123456789012", &req, "b", "missing"),
+            "NoSuchKey",
+        );
     }
 
     #[test]
@@ -3719,7 +3905,7 @@ mod tests {
         let svc = make_service();
         let req = make_request(Method::GET, "/nope/key", &[("attributes", "")], b"");
         assert_aws_err(
-            svc.get_object_attributes(&req, "nope", "key"),
+            svc.get_object_attributes("123456789012", &req, "nope", "key"),
             "NoSuchBucket",
         );
     }
@@ -3733,38 +3919,53 @@ mod tests {
             &[("restore", "")],
             b"<RestoreRequest><Days>1</Days></RestoreRequest>",
         );
-        assert_aws_err(svc.restore_object(&req, "nope", "key"), "NoSuchBucket");
+        assert_aws_err(
+            svc.restore_object("123456789012", &req, "nope", "key"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_public_access_block_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_public_access_block("nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_public_access_block("123456789012", "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_bucket_policy_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_bucket_policy("nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_bucket_policy("123456789012", "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_bucket_cors_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_bucket_cors("nope"), "NoSuchBucket");
+        assert_aws_err(svc.get_bucket_cors("123456789012", "nope"), "NoSuchBucket");
     }
 
     #[test]
     fn get_bucket_tagging_nonexistent() {
         let svc = make_service();
         let req = make_request(Method::GET, "/nope", &[("tagging", "")], b"");
-        assert_aws_err(svc.get_bucket_tagging(&req, "nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_bucket_tagging("123456789012", &req, "nope"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
     fn get_bucket_website_nonexistent() {
         let svc = make_service();
-        assert_aws_err(svc.get_bucket_website("nope"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_bucket_website("123456789012", "nope"),
+            "NoSuchBucket",
+        );
     }
 
     // ── Object lock (lock.rs - 0% coverage) ──
@@ -3782,7 +3983,7 @@ mod tests {
             &[("retention", "")],
             body,
         );
-        svc.put_object_retention(&req, "lock-b", "retained.txt")
+        svc.put_object_retention("123456789012", &req, "lock-b", "retained.txt")
             .unwrap();
 
         let req = make_request(
@@ -3792,7 +3993,7 @@ mod tests {
             b"",
         );
         let resp = svc
-            .get_object_retention(&req, "lock-b", "retained.txt")
+            .get_object_retention("123456789012", &req, "lock-b", "retained.txt")
             .unwrap();
         let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body_str.contains("GOVERNANCE"));
@@ -3803,7 +4004,7 @@ mod tests {
         let svc = make_service();
         let req = make_request(Method::GET, "/nope/key", &[("retention", "")], b"");
         assert_aws_err(
-            svc.get_object_retention(&req, "nope", "key"),
+            svc.get_object_retention("123456789012", &req, "nope", "key"),
             "NoSuchBucket",
         );
     }
@@ -3814,7 +4015,7 @@ mod tests {
         seed_bucket(&svc, "lock-b2");
         let req = make_request(Method::GET, "/lock-b2/missing", &[("retention", "")], b"");
         assert_aws_err(
-            svc.get_object_retention(&req, "lock-b2", "missing"),
+            svc.get_object_retention("123456789012", &req, "lock-b2", "missing"),
             "NoSuchKey",
         );
     }
@@ -3827,12 +4028,12 @@ mod tests {
 
         let body = b"<LegalHold><Status>ON</Status></LegalHold>";
         let req = make_request(Method::PUT, "/hold-b/held.txt", &[("legal-hold", "")], body);
-        svc.put_object_legal_hold(&req, "hold-b", "held.txt")
+        svc.put_object_legal_hold("123456789012", &req, "hold-b", "held.txt")
             .unwrap();
 
         let req = make_request(Method::GET, "/hold-b/held.txt", &[("legal-hold", "")], b"");
         let resp = svc
-            .get_object_legal_hold(&req, "hold-b", "held.txt")
+            .get_object_legal_hold("123456789012", &req, "hold-b", "held.txt")
             .unwrap();
         let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body_str.contains("ON"));
@@ -3843,7 +4044,7 @@ mod tests {
         let svc = make_service();
         let req = make_request(Method::GET, "/nope/key", &[("legal-hold", "")], b"");
         assert_aws_err(
-            svc.get_object_legal_hold(&req, "nope", "key"),
+            svc.get_object_legal_hold("123456789012", &req, "nope", "key"),
             "NoSuchBucket",
         );
     }
@@ -3857,7 +4058,9 @@ mod tests {
         seed_object(&svc, "acl-b", "file.txt", b"data");
 
         let req = make_request(Method::GET, "/acl-b/file.txt", &[("acl", "")], b"");
-        let resp = svc.get_object_acl(&req, "acl-b", "file.txt").unwrap();
+        let resp = svc
+            .get_object_acl("123456789012", &req, "acl-b", "file.txt")
+            .unwrap();
         let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body_str.contains("AccessControlPolicy"));
     }
@@ -3866,7 +4069,10 @@ mod tests {
     fn get_object_acl_nonexistent_bucket() {
         let svc = make_service();
         let req = make_request(Method::GET, "/nope/key", &[("acl", "")], b"");
-        assert_aws_err(svc.get_object_acl(&req, "nope", "key"), "NoSuchBucket");
+        assert_aws_err(
+            svc.get_object_acl("123456789012", &req, "nope", "key"),
+            "NoSuchBucket",
+        );
     }
 
     #[test]
@@ -3874,7 +4080,10 @@ mod tests {
         let svc = make_service();
         seed_bucket(&svc, "acl-b2");
         let req = make_request(Method::GET, "/acl-b2/missing", &[("acl", "")], b"");
-        assert_aws_err(svc.get_object_acl(&req, "acl-b2", "missing"), "NoSuchKey");
+        assert_aws_err(
+            svc.get_object_acl("123456789012", &req, "acl-b2", "missing"),
+            "NoSuchKey",
+        );
     }
 
     #[test]
@@ -3885,6 +4094,7 @@ mod tests {
 
         let acl_xml = b"<AccessControlPolicy><Owner><ID>owner</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"CanonicalUser\"><ID>owner</ID></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>";
         let req = make_request(Method::PUT, "/acl-put-b/file.txt", &[("acl", "")], acl_xml);
-        svc.put_object_acl(&req, "acl-put-b", "file.txt").unwrap();
+        svc.put_object_acl("123456789012", &req, "acl-put-b", "file.txt")
+            .unwrap();
     }
 }

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -20,6 +20,7 @@ use super::{
 impl S3Service {
     pub(super) fn create_multipart_upload(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -78,7 +79,8 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_uppercase());
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -147,6 +149,7 @@ impl S3Service {
 
     pub(super) fn upload_part(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -173,7 +176,8 @@ impl S3Service {
         let data = req.body.clone();
         let etag = compute_md5(&data);
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -226,6 +230,7 @@ impl S3Service {
 
     pub(super) fn upload_part_copy(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -271,7 +276,8 @@ impl S3Service {
             .get("x-amz-copy-source-range")
             .and_then(|v| v.to_str().ok());
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let src_body_ref = {
             let sb = state
                 .buckets
@@ -348,6 +354,7 @@ impl S3Service {
 
     pub(super) fn complete_multipart_upload(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -371,7 +378,8 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let (upload, already_has_object) = {
             let b = state
                 .buckets
@@ -608,11 +616,13 @@ impl S3Service {
 
     pub(super) fn abort_multipart_upload(
         &self,
+        account_id: &str,
         bucket: &str,
         key: &str,
         upload_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -644,9 +654,12 @@ impl S3Service {
 
     pub(super) fn list_multipart_uploads(
         &self,
+        account_id: &str,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -685,6 +698,7 @@ impl S3Service {
 
     pub(super) fn list_parts(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -741,7 +755,9 @@ impl S3Service {
             ));
         }
 
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)

--- a/crates/fakecloud-s3/src/service/notifications.rs
+++ b/crates/fakecloud-s3/src/service/notifications.rs
@@ -654,10 +654,9 @@ pub(crate) fn deliver_notifications(
     let eventbridge_enabled = s3_state
         .and_then(|st| {
             let mas = st.read();
-            let state = mas.default_ref();
-            state
-                .buckets
-                .get(bucket_name)
+            let acct = mas.find_account(|s| s.buckets.contains_key(bucket_name))?;
+            mas.get(acct)
+                .and_then(|s| s.buckets.get(bucket_name))
                 .map(|b| b.eventbridge_enabled)
         })
         .unwrap_or(false);
@@ -737,16 +736,20 @@ pub(crate) fn deliver_notifications(
     // Record notification event for introspection only if at least one target matched
     if delivered {
         if let Some(state) = s3_state {
-            state
-                .write()
-                .default_mut()
-                .notification_events
-                .push(S3NotificationEvent {
-                    bucket: bucket_name.to_string(),
-                    key: key.to_string(),
-                    event_type: s3_event_name,
-                    timestamp: Utc::now(),
-                });
+            let mut mas = state.write();
+            let owner_acct = mas
+                .find_account(|s| s.buckets.contains_key(bucket_name))
+                .map(|a| a.to_string());
+            if let Some(acct) = owner_acct {
+                if let Some(acct_state) = mas.get_mut(&acct) {
+                    acct_state.notification_events.push(S3NotificationEvent {
+                        bucket: bucket_name.to_string(),
+                        key: key.to_string(),
+                        event_type: s3_event_name,
+                        timestamp: Utc::now(),
+                    });
+                }
+            }
         }
     }
 }

--- a/crates/fakecloud-s3/src/service/notifications.rs
+++ b/crates/fakecloud-s3/src/service/notifications.rs
@@ -653,7 +653,8 @@ pub(crate) fn deliver_notifications(
     // Deliver to EventBridge if enabled for this bucket
     let eventbridge_enabled = s3_state
         .and_then(|st| {
-            let state = st.read();
+            let mas = st.read();
+            let state = mas.default_ref();
             state
                 .buckets
                 .get(bucket_name)
@@ -736,12 +737,16 @@ pub(crate) fn deliver_notifications(
     // Record notification event for introspection only if at least one target matched
     if delivered {
         if let Some(state) = s3_state {
-            state.write().notification_events.push(S3NotificationEvent {
-                bucket: bucket_name.to_string(),
-                key: key.to_string(),
-                event_type: s3_event_name,
-                timestamp: Utc::now(),
-            });
+            state
+                .write()
+                .default_mut()
+                .notification_events
+                .push(S3NotificationEvent {
+                    bucket: bucket_name.to_string(),
+                    key: key.to_string(),
+                    event_type: s3_event_name,
+                    timestamp: Utc::now(),
+                });
         }
     }
 }

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -22,10 +22,13 @@ use super::{
 impl S3Service {
     pub(super) fn list_objects_v1(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -173,10 +176,13 @@ impl S3Service {
 
     pub(super) fn list_objects_v2(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -368,10 +374,13 @@ impl S3Service {
 
     pub(super) fn list_object_versions(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -585,6 +594,7 @@ impl S3Service {
 
     pub(super) fn put_object(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -667,7 +677,9 @@ impl S3Service {
             notification_config,
             region,
         ) = {
-            let state = self.state.read();
+            let accts = self.state.read();
+            let __empty = crate::state::S3State::new(account_id, "us-east-1");
+            let state = accts.get(account_id).unwrap_or(&__empty);
             let b = state
                 .buckets
                 .get(bucket)
@@ -954,7 +966,8 @@ impl S3Service {
 
         // --- Write lock phase: insert object and handle versioning/replication ---
         {
-            let mut state = self.state.write();
+            let mut accts = self.state.write();
+            let state = accts.get_or_create(account_id);
             let b = state
                 .buckets
                 .get_mut(bucket)
@@ -1027,7 +1040,7 @@ impl S3Service {
                 }
             }
             // Replicate (in-memory copy) then persist replicas via the store.
-            replicate_through_store(&mut state, &self.store, bucket, key)
+            replicate_through_store(state, &self.store, bucket, key)
                 .map_err(super::persistence_error)?;
         } // write lock dropped
 
@@ -1101,11 +1114,14 @@ impl S3Service {
 
     pub(super) fn get_object(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -1244,12 +1260,12 @@ impl S3Service {
                     }
                     RangeResult::Ignored => {
                         headers.insert("content-length", total_size.to_string().parse().unwrap());
-                        response_body = full_body_response(&state, &obj.body)?;
+                        response_body = full_body_response(state, &obj.body)?;
                     }
                 }
             } else {
                 headers.insert("content-length", total_size.to_string().parse().unwrap());
-                response_body = full_body_response(&state, &obj.body)?;
+                response_body = full_body_response(state, &obj.body)?;
             }
         } else if let Some(part_num_str) = req.query_params.get("partNumber") {
             if let Ok(part_num) = part_num_str.parse::<u32>() {
@@ -1293,11 +1309,11 @@ impl S3Service {
                 response_status = StatusCode::PARTIAL_CONTENT;
             } else {
                 headers.insert("content-length", total_size.to_string().parse().unwrap());
-                response_body = full_body_response(&state, &obj.body)?;
+                response_body = full_body_response(state, &obj.body)?;
             }
         } else {
             headers.insert("content-length", total_size.to_string().parse().unwrap());
-            response_body = full_body_response(&state, &obj.body)?;
+            response_body = full_body_response(state, &obj.body)?;
         }
         // Only include checksum headers for full (non-range) responses
         if !is_range_request {
@@ -1323,12 +1339,13 @@ impl S3Service {
     /// Serve a website object (index or error document) from the bucket.
     pub(super) fn serve_website_object(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
         website_config: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let result = self.get_object(req, bucket, key);
+        let result = self.get_object(account_id, req, bucket, key);
         if result.is_err() {
             // If index doc doesn't exist either, try error document
             if let Some(error_key) = extract_xml_value(website_config, "ErrorDocument")
@@ -1341,7 +1358,7 @@ impl S3Service {
                 })
                 .or_else(|| extract_xml_value(website_config, "Key"))
             {
-                return self.serve_website_error(req, bucket, &error_key);
+                return self.serve_website_error(account_id, req, bucket, &error_key);
             }
         }
         result
@@ -1350,11 +1367,12 @@ impl S3Service {
     /// Serve the website error document with a 404 status.
     pub(super) fn serve_website_error(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         error_key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        match self.get_object(req, bucket, error_key) {
+        match self.get_object(account_id, req, bucket, error_key) {
             Ok(mut resp) => {
                 resp.status = StatusCode::NOT_FOUND;
                 Ok(resp)
@@ -1365,6 +1383,7 @@ impl S3Service {
 
     pub(super) fn delete_object(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -1376,7 +1395,8 @@ impl S3Service {
             .map(|s| s.to_string());
         let version_id_param = req.query_params.get("versionId").cloned();
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let region = state.region.clone();
         let b = state
             .buckets
@@ -1567,7 +1587,7 @@ impl S3Service {
             let bucket_name = bucket.to_string();
             let obj_key = key.to_string();
             let region = region.clone();
-            drop(state);
+            drop(accts);
             if let Some(ref config) = notification_config {
                 deliver_notifications(
                     &self.delivery,
@@ -1601,7 +1621,7 @@ impl S3Service {
         self.store
             .delete_object(bucket, key, None)
             .map_err(super::persistence_error)?;
-        drop(state);
+        drop(accts);
 
         // Deliver S3 event notifications
         if let Some(ref config) = notification_config {
@@ -1630,11 +1650,14 @@ impl S3Service {
 
     pub(super) fn head_object(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -1835,6 +1858,7 @@ impl S3Service {
 
     pub(super) fn copy_object(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         dest_bucket: &str,
         dest_key: &str,
@@ -1940,7 +1964,8 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_uppercase());
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
 
         // Resolve source object, possibly a specific version
         let (src_obj, src_version_id_actual) = {
@@ -2253,10 +2278,10 @@ impl S3Service {
         let region = state.region.clone();
 
         // Replicate object if replication is configured on the destination bucket
-        replicate_through_store(&mut state, &self.store, dest_bucket, dest_key)
+        replicate_through_store(state, &self.store, dest_bucket, dest_key)
             .map_err(super::persistence_error)?;
 
-        drop(state);
+        drop(accts);
 
         let body = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
@@ -2295,6 +2320,7 @@ impl S3Service {
 
     pub(super) fn delete_objects(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -2309,7 +2335,8 @@ impl S3Service {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -2447,11 +2474,14 @@ impl S3Service {
 
     pub(super) fn get_object_attributes(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -2536,11 +2566,13 @@ impl S3Service {
 
     pub(super) fn restore_object(
         &self,
+        account_id: &str,
         _req: &AwsRequest,
         bucket: &str,
         key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)

--- a/crates/fakecloud-s3/src/service/tags.rs
+++ b/crates/fakecloud-s3/src/service/tags.rs
@@ -13,11 +13,14 @@ use super::{
 impl S3Service {
     pub(super) fn get_object_tagging(
         &self,
+        account_id: &str,
         _req: &AwsRequest,
         bucket: &str,
         key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
         let b = state
             .buckets
             .get(bucket)
@@ -42,6 +45,7 @@ impl S3Service {
 
     pub(super) fn put_object_tagging(
         &self,
+        account_id: &str,
         req: &AwsRequest,
         bucket: &str,
         key: &str,
@@ -71,7 +75,8 @@ impl S3Service {
 
         let version_id = req.query_params.get("versionId").map(|s| s.to_string());
 
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)
@@ -189,10 +194,12 @@ impl S3Service {
 
     pub(super) fn delete_object_tagging(
         &self,
+        account_id: &str,
         bucket: &str,
         key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
         let b = state
             .buckets
             .get_mut(bucket)

--- a/crates/fakecloud-s3/src/simulation.rs
+++ b/crates/fakecloud-s3/src/simulation.rs
@@ -19,7 +19,8 @@ struct BucketSnapshot {
 pub fn tick_lifecycle(state: &SharedS3State) -> LifecycleTickResult {
     // Snapshot object counts and storage classes before processing
     let (buckets_with_lifecycle, before_snapshot) = {
-        let s = state.read();
+        let __mas = state.read();
+        let s = __mas.default_ref();
         let mut count = 0u64;
         let mut snapshot: Vec<BucketSnapshot> = Vec::new();
         for bucket in s.buckets.values() {
@@ -48,7 +49,8 @@ pub fn tick_lifecycle(state: &SharedS3State) -> LifecycleTickResult {
     let mut expired_objects = 0u64;
     let mut transitioned_objects = 0u64;
 
-    let s = state.read();
+    let __mas = state.read();
+    let s = __mas.default_ref();
     for snap in &before_snapshot {
         let bucket = match s.buckets.get(&snap.name) {
             Some(b) => b,
@@ -81,14 +83,16 @@ pub fn tick_lifecycle(state: &SharedS3State) -> LifecycleTickResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{S3Bucket, S3Object, S3State};
+    use crate::state::{S3Bucket, S3Object};
     use bytes::Bytes;
     use chrono::{Duration, Utc};
     use parking_lot::RwLock;
     use std::sync::Arc;
 
     fn make_state() -> SharedS3State {
-        Arc::new(RwLock::new(S3State::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ))
     }
 
     fn make_object(key: &str, age_days: i64) -> S3Object {
@@ -109,7 +113,8 @@ mod tests {
         let state = make_state();
 
         {
-            let mut s = state.write();
+            let mut __mas = state.write();
+            let s = __mas.default_mut();
             let mut bucket = S3Bucket::new("test-bucket", "us-east-1", "123456789012");
             bucket.lifecycle_config = Some(
                 r#"<LifecycleConfiguration>
@@ -135,7 +140,8 @@ mod tests {
         assert_eq!(result.expired_objects, 1);
         assert_eq!(result.transitioned_objects, 0);
 
-        let s = state.read();
+        let __mas = state.read();
+        let s = __mas.default_ref();
         let bucket = s.buckets.get("test-bucket").unwrap();
         assert_eq!(bucket.objects.len(), 1);
         assert!(bucket.objects.contains_key("new-file.txt"));
@@ -146,7 +152,8 @@ mod tests {
         let state = make_state();
 
         {
-            let mut s = state.write();
+            let mut __mas = state.write();
+            let s = __mas.default_mut();
             let mut bucket = S3Bucket::new("trans-bucket", "us-east-1", "123456789012");
             bucket.lifecycle_config = Some(
                 r#"<LifecycleConfiguration>
@@ -172,7 +179,8 @@ mod tests {
         assert_eq!(result.expired_objects, 0);
         assert_eq!(result.transitioned_objects, 1);
 
-        let s = state.read();
+        let __mas = state.read();
+        let s = __mas.default_ref();
         let obj = s.buckets["trans-bucket"]
             .objects
             .get("old-file.txt")
@@ -185,7 +193,8 @@ mod tests {
         let state = make_state();
 
         {
-            let mut s = state.write();
+            let mut __mas = state.write();
+            let s = __mas.default_mut();
             let bucket = S3Bucket::new("empty-bucket", "us-east-1", "123456789012");
             s.buckets.insert("empty-bucket".to_string(), bucket);
         }

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -255,6 +255,12 @@ impl fakecloud_core::multi_account::AccountState for S3State {
     fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
         Self::new(account_id, region)
     }
+
+    fn inherit_from(&mut self, sibling: &Self) {
+        if let Some(cache) = &sibling.body_cache {
+            self.body_cache = Some(cache.clone());
+        }
+    }
 }
 
 pub type SharedS3State = Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<S3State>>>;

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -251,7 +251,13 @@ impl S3State {
     }
 }
 
-pub type SharedS3State = Arc<RwLock<S3State>>;
+impl fakecloud_core::multi_account::AccountState for S3State {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
+
+pub type SharedS3State = Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<S3State>>>;
 
 /// Construct a memory-backed [`BodyRef`] from [`Bytes`].
 pub fn memory_body(bytes: Bytes) -> BodyRef {

--- a/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
+++ b/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
@@ -88,7 +88,8 @@ impl DynamoDbStreamsLambdaPoller {
 
             // Read stream records from DynamoDB
             let records = {
-                let dynamodb = self.dynamodb_state.read();
+                let dynamodb_mas = self.dynamodb_state.read();
+                let dynamodb = dynamodb_mas.default_ref();
                 let table = match dynamodb.tables.get(table_name) {
                     Some(t) => t,
                     None => continue,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -116,7 +116,11 @@ async fn main() {
         fakecloud_ssm::state::SsmState::new(&cli.account_id, &cli.region),
     ));
     let dynamodb_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_dynamodb::state::DynamoDbState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
     let lambda_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_lambda::state::LambdaState::new(&cli.account_id, &cli.region),
@@ -140,10 +144,13 @@ async fn main() {
     let secretsmanager_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_secretsmanager::state::SecretsManagerState::new(&cli.account_id, &cli.region),
     ));
-    let s3_state = Arc::new(parking_lot::RwLock::new(fakecloud_s3::state::S3State::new(
-        &cli.account_id,
-        &cli.region,
-    )));
+    let s3_state = Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
+    ));
     let logs_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_logs::state::LogsState::new(&cli.account_id, &cli.region),
     ));
@@ -1006,7 +1013,11 @@ async fn main() {
                             "failed to hydrate s3 persistence snapshot: {err}"
                         )),
                     };
-                    *s3_state.write() = hydrated;
+                    {
+                        let account_id = hydrated.account_id.clone();
+                        let mut mas = s3_state.write();
+                        *mas.get_or_create(&account_id) = hydrated;
+                    }
                     tracing::info!(
                         buckets = bucket_count,
                         objects = object_count,
@@ -1027,7 +1038,7 @@ async fn main() {
     if let Some(ref cache) = shared_body_cache {
         // Share the cache between the S3Store and S3State so read_body honors
         // the persistent LRU on every read site, not just open_object_body.
-        s3_state.write().set_body_cache(cache.clone());
+        s3_state.write().default_mut().set_body_cache(cache.clone());
     }
     registry.register(Arc::new(
         S3Service::with_store(s3_state.clone(), delivery_for_s3, s3_store.clone())
@@ -1052,20 +1063,31 @@ async fn main() {
                     ) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_dynamodb::state::DYNAMODB_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_dynamodb::state::DYNAMODB_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "dynamodb persistence schema mismatch: on-disk={}, expected={}",
+                                    "dynamodb persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_dynamodb::state::DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let table_count = snapshot.state.tables.len();
-                            *dynamodb_state_for_register.write() = snapshot.state;
-                            tracing::info!(
-                                tables = table_count,
-                                "loaded dynamodb persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *dynamodb_state_for_register.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded dynamodb persistence snapshot (multi-account)",
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let table_count = single_state.tables.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = dynamodb_state_for_register.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    tables = table_count,
+                                    "loaded dynamodb persistence snapshot (migrated from v1)",
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse dynamodb persistence snapshot: {err}"
@@ -1804,7 +1826,8 @@ async fn main() {
                                     storage_class: "STANDARD".to_string(),
                                     ..Default::default()
                                 };
-                                let mut state = s3_for_inbound.write();
+                                let mut mas = s3_for_inbound.write();
+                                let state = mas.default_mut();
                                 if let Some(bucket) = state.buckets.get_mut(bucket_name) {
                                     tracing::info!(
                                         bucket = %bucket_name,
@@ -1814,7 +1837,7 @@ async fn main() {
                                     let meta =
                                         fakecloud_s3::persistence::object_meta_snapshot(&obj);
                                     bucket.objects.insert(key.clone(), obj);
-                                    drop(state);
+                                    drop(mas);
                                     if let Err(err) = s3_store_for_inbound.put_object(
                                         bucket_name,
                                         &key,
@@ -2136,7 +2159,8 @@ async fn main() {
             axum::routing::get({
                 let ss = s3_introspection_state;
                 move || async move {
-                    let state = ss.read();
+                    let mas = ss.read();
+                    let state = mas.default_ref();
                     let notifications = state
                         .notification_events
                         .iter()

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -262,7 +262,11 @@ mod tests {
                 fakecloud_ssm::state::SsmState::new("123456789012", "us-east-1"),
             )),
             dynamodb: Arc::new(parking_lot::RwLock::new(
-                fakecloud_dynamodb::state::DynamoDbState::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
             )),
             lambda: Arc::new(parking_lot::RwLock::new(
                 fakecloud_lambda::state::LambdaState::new("123456789012", "us-east-1"),
@@ -273,10 +277,13 @@ mod tests {
                     "us-east-1",
                 ),
             )),
-            s3: Arc::new(parking_lot::RwLock::new(fakecloud_s3::state::S3State::new(
-                "123456789012",
-                "us-east-1",
-            ))),
+            s3: Arc::new(parking_lot::RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+            )),
             logs: Arc::new(parking_lot::RwLock::new(
                 fakecloud_logs::state::LogsState::new("123456789012", "us-east-1"),
             )),

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1226,7 +1226,8 @@ fn invoke_dynamodb_get_item(
 
     let key_map: HashMap<String, Value> = key.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
-    let state = ddb.read();
+    let __mas = ddb.read();
+    let state = __mas.default_ref();
     let table = state.tables.get(table_name).ok_or_else(|| {
         (
             "States.TaskFailed".to_string(),
@@ -1279,7 +1280,8 @@ fn invoke_dynamodb_put_item(
     let item_map: HashMap<String, Value> =
         item.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
-    let mut state = ddb.write();
+    let mut __mas = ddb.write();
+    let state = __mas.default_mut();
     let table = state.tables.get_mut(table_name).ok_or_else(|| {
         (
             "States.TaskFailed".to_string(),
@@ -1328,7 +1330,8 @@ fn invoke_dynamodb_delete_item(
 
     let key_map: HashMap<String, Value> = key.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
-    let mut state = ddb.write();
+    let mut __mas = ddb.write();
+    let state = __mas.default_mut();
     let table = state.tables.get_mut(table_name).ok_or_else(|| {
         (
             "States.TaskFailed".to_string(),
@@ -1375,7 +1378,8 @@ fn invoke_dynamodb_update_item(
 
     let key_map: HashMap<String, Value> = key.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
-    let mut state = ddb.write();
+    let mut __mas = ddb.write();
+    let state = __mas.default_mut();
     let table = state.tables.get_mut(table_name).ok_or_else(|| {
         (
             "States.TaskFailed".to_string(),


### PR DESCRIPTION
## Summary

Batch 2 of #381 (multi-account isolation). Wraps S3 and DynamoDB state in `MultiAccountState<T>` so each account gets isolated storage.

- S3: all handlers receive `account_id` parameter, background tasks use default account, resource tag lookup scans all accounts for bucket owner
- DynamoDB: all handlers use `get_or_create`/read-lock pattern, TTL processor iterates all accounts, snapshot v2 with v1 backward compat
- Updated cross-service references: CloudFormation provisioner, StepFunctions interpreter, DynamoDB Streams poller
- Added `find_account()` helper to `MultiAccountState` for scanning all accounts

## Test plan

- [x] All workspace unit tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` applied
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-account state isolation for S3 and DynamoDB so each account has its own storage. Also improves cross-account lookups to correctly resolve bucket owners and route notifications.

- **New Features**
  - `fakecloud-s3` and `fakecloud-dynamodb` now use `MultiAccountState` for per-account isolation.
  - `fakecloud-core`: added `find_account()` and `AccountState::inherit_from`; new S3 accounts inherit `body_cache`.
  - S3: all handlers take `account_id`; lifecycle, inventory, and access logging run on the default account; bucket-owner and resource-policy lookups scan all accounts; `list_buckets` uses `account_id`; notification events are stored in the bucket owner’s account.
  - DynamoDB: writes use `get_or_create(&req.account_id)`; read-only paths use empty fallbacks; TTL runs across all accounts; snapshots upgraded to v2 with v1 compat; PartiQL helpers use the default account; export/import uses `req.account_id` for S3 access.
  - Cross-service updates: CloudFormation provisioner, StepFunctions interpreter, and DynamoDB Streams poller now use the default account or `get_or_create` as needed.

- **Migration**
  - Initialize `MultiAccountState` for S3 and DynamoDB in `fakecloud-server` and update `SharedS3State`/`SharedDynamoDbState` types.
  - Pass `account_id` to S3 handlers; DynamoDB writes call `get_or_create(&req.account_id)`; read paths may use default/empty fallbacks.
  - Snapshot files now write v2; loading v1 continues to work without changes.

<sup>Written for commit 4091a30d5be6fd7b0667c679edf3fc2a7138b706. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

