### PR TITLE
feat(sqs,sns): multi-account state isolation + cross-account delivery

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -106,7 +106,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .unwrap_or(&resource.logical_id);
 
-        let mut state = self.sqs_state.write();
+        let mut __sqs_mas = self.sqs_state.write();
+        let state = __sqs_mas.get_or_create(&self.account_id);
         let queue_url = format!("{}/{}/{}", state.endpoint, state.account_id, queue_name);
         let arn = format!(
             "arn:aws:sqs:{}:{}:{}",
@@ -153,7 +154,8 @@ impl ResourceProvisioner {
     }
 
     fn delete_sqs_queue(&self, physical_id: &str) -> Result<(), String> {
-        let mut state = self.sqs_state.write();
+        let mut __sqs_mas = self.sqs_state.write();
+        let state = __sqs_mas.get_or_create(&self.account_id);
         if let Some(queue) = state.queues.remove(physical_id) {
             state.name_to_url.remove(&queue.queue_name);
         }
@@ -169,7 +171,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .unwrap_or(&resource.logical_id);
 
-        let mut state = self.sns_state.write();
+        let mut __sns_mas = self.sns_state.write();
+        let state = __sns_mas.get_or_create(&self.account_id);
         let topic_arn = format!(
             "arn:aws:sns:{}:{}:{}",
             state.region, state.account_id, topic_name
@@ -189,7 +192,8 @@ impl ResourceProvisioner {
     }
 
     fn delete_sns_topic(&self, physical_id: &str) -> Result<(), String> {
-        let mut state = self.sns_state.write();
+        let mut __sns_mas = self.sns_state.write();
+        let state = __sns_mas.get_or_create(&self.account_id);
         state.topics.remove(physical_id);
         // Also remove subscriptions for this topic
         state
@@ -215,7 +219,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .ok_or("SNS Subscription requires Endpoint")?;
 
-        let mut state = self.sns_state.write();
+        let mut __sns_mas = self.sns_state.write();
+        let state = __sns_mas.get_or_create(&self.account_id);
 
         // Validate that the topic exists
         if !state.topics.contains_key(topic_arn) {
@@ -240,7 +245,8 @@ impl ResourceProvisioner {
     }
 
     fn delete_sns_subscription(&self, physical_id: &str) -> Result<(), String> {
-        let mut state = self.sns_state.write();
+        let mut __sns_mas = self.sns_state.write();
+        let state = __sns_mas.get_or_create(&self.account_id);
         state.subscriptions.remove(physical_id);
         Ok(())
     }
@@ -912,16 +918,20 @@ mod tests {
 
     fn make_provisioner() -> ResourceProvisioner {
         ResourceProvisioner {
-            sqs_state: Arc::new(RwLock::new(fakecloud_sqs::state::SqsState::new(
-                "123456789012",
-                "us-east-1",
-                "http://localhost:4566",
-            ))),
-            sns_state: Arc::new(RwLock::new(fakecloud_sns::state::SnsState::new(
-                "123456789012",
-                "us-east-1",
-                "http://localhost:4566",
-            ))),
+            sqs_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+            )),
+            sns_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+            )),
             ssm_state: Arc::new(RwLock::new(fakecloud_ssm::state::SsmState::new(
                 "123456789012",
                 "us-east-1",

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -835,16 +835,20 @@ mod tests {
             "us-east-1",
         )));
         let deps = CloudFormationDeps {
-            sqs: Arc::new(RwLock::new(fakecloud_sqs::state::SqsState::new(
-                "123456789012",
-                "us-east-1",
-                "http://localhost:4566",
-            ))),
-            sns: Arc::new(RwLock::new(fakecloud_sns::state::SnsState::new(
-                "123456789012",
-                "us-east-1",
-                "http://localhost:4566",
-            ))),
+            sqs: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+            )),
+            sns: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+            )),
             ssm: Arc::new(RwLock::new(fakecloud_ssm::state::SsmState::new(
                 "123456789012",
                 "us-east-1",

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -101,13 +101,22 @@ async fn main() {
         ),
     ));
     let sqs_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_sqs::state::SqsState::new(&cli.account_id, &cli.region, &endpoint_url),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
     let sns_state = Arc::new(parking_lot::RwLock::new({
-        let mut s =
-            fakecloud_sns::state::SnsState::new(&cli.account_id, &cli.region, &endpoint_url);
-        s.seed_default_opted_out();
-        s
+        let mut mas: fakecloud_core::multi_account::MultiAccountState<
+            fakecloud_sns::state::SnsState,
+        > = fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        );
+        mas.default_mut().seed_default_opted_out();
+        mas
     }));
     let eb_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_eventbridge::state::EventBridgeState::new(&cli.account_id, &cli.region),
@@ -473,17 +482,31 @@ async fn main() {
                     match serde_json::from_slice::<fakecloud_sqs::state::SqsSnapshot>(&bytes) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_sqs::state::SQS_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_sqs::state::SQS_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "sqs persistence schema mismatch: on-disk={}, expected={}",
+                                    "sqs persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_sqs::state::SQS_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let queue_count = snapshot.state.queues.len();
-                            *sqs_state.write() = snapshot.state;
-                            tracing::info!(queues = queue_count, "loaded sqs persistence snapshot",);
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *sqs_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded sqs persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let queue_count = single_state.queues.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = sqs_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    queues = queue_count,
+                                    "loaded sqs persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse sqs persistence snapshot: {err}"
@@ -522,22 +545,31 @@ async fn main() {
                     match serde_json::from_slice::<fakecloud_sns::state::SnsSnapshot>(&bytes) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_sns::state::SNS_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_sns::state::SNS_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "sns persistence schema mismatch: on-disk={}, expected={}",
+                                    "sns persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_sns::state::SNS_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let topic_count = snapshot.state.topics.len();
-                            let sub_count = snapshot.state.subscriptions.len();
-                            *sns_state.write() = snapshot.state;
-                            tracing::info!(
-                                topics = topic_count,
-                                subscriptions = sub_count,
-                                "loaded sns persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *sns_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded sns persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let topic_count = single_state.topics.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = sns_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    topics = topic_count,
+                                    "loaded sns persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse sns persistence snapshot: {err}"
@@ -1981,7 +2013,8 @@ async fn main() {
             axum::routing::get({
                 let ss = sns_introspection_state;
                 move || async move {
-                    let state = ss.read();
+                    let mas = ss.read();
+                    let state = mas.default_ref();
                     let messages = state
                         .published
                         .iter()
@@ -2002,7 +2035,8 @@ async fn main() {
             axum::routing::get({
                 let ss = sqs_introspection_state;
                 move || async move {
-                    let state = ss.read();
+                    let mas = ss.read();
+                    let state = mas.default_ref();
                     let queues = state
                         .queues
                         .values()

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -37,14 +37,12 @@ impl ResetState {
                 self.iam.write().reset();
             }
             "sqs" => {
-                let mut s = self.sqs.write();
-                s.queues.clear();
-                s.name_to_url.clear();
+                self.sqs.write().reset();
             }
             "sns" => {
                 let mut s = self.sns.write();
                 s.reset();
-                s.seed_default_opted_out();
+                s.default_mut().seed_default_opted_out();
             }
             "events" | "eventbridge" => {
                 let mut eb = self.eb.write();
@@ -129,12 +127,11 @@ impl ResetState {
 
     pub(crate) fn reset(&self) -> axum::Json<types::ResetResponse> {
         self.iam.write().reset();
-        self.sqs.write().queues.clear();
-        self.sqs.write().name_to_url.clear();
+        self.sqs.write().reset();
         {
             let mut sns = self.sns.write();
             sns.reset();
-            sns.seed_default_opted_out();
+            sns.default_mut().seed_default_opted_out();
         }
         {
             let mut eb = self.eb.write();
@@ -242,14 +239,14 @@ mod tests {
                 ),
             )),
             sqs: Arc::new(parking_lot::RwLock::new(
-                fakecloud_sqs::state::SqsState::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",
                     "http://localhost:4566",
                 ),
             )),
             sns: Arc::new(parking_lot::RwLock::new(
-                fakecloud_sns::state::SnsState::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",
                     "http://localhost:4566",

--- a/crates/fakecloud-server/src/sqs_lambda_poller.rs
+++ b/crates/fakecloud-server/src/sqs_lambda_poller.rs
@@ -70,7 +70,11 @@ impl SqsLambdaPoller {
 
         for (queue_arn, function_arn, batch_size) in mappings {
             let messages = {
-                let mut sqs = self.sqs_state.write();
+                let mut sqs_mas = self.sqs_state.write();
+                // Parse account from queue ARN for multi-account routing
+                let default_acct = sqs_mas.default_account_id().to_string();
+                let acct = queue_arn.split(':').nth(4).unwrap_or(&default_acct);
+                let sqs = sqs_mas.get_or_create(acct);
                 let queue = sqs.queues.values_mut().find(|q| q.arn == queue_arn);
                 let queue = match queue {
                     Some(q) => q,

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -21,7 +21,12 @@ impl SnsDeliveryImpl {
 
 impl SnsDelivery for SnsDeliveryImpl {
     fn publish_to_topic(&self, topic_arn: &str, message: &str, subject: Option<&str>) {
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+
+        // Parse account from topic ARN (arn:aws:sns:region:ACCOUNT:name)
+        let default_id = accounts.default_account_id().to_string();
+        let target_account = topic_arn.split(':').nth(4).unwrap_or(&default_id);
+        let state = accounts.get_or_create(target_account);
 
         if !state.topics.contains_key(topic_arn) {
             tracing::warn!(topic_arn, "SNS delivery target topic not found");
@@ -138,7 +143,7 @@ impl SnsDelivery for SnsDeliveryImpl {
         }
 
         // Drop the lock before calling into SQS delivery
-        drop(state);
+        drop(accounts);
 
         // Wrap the message in SNS notification envelope (matches real AWS format)
         let sns_envelope = serde_json::json!({

--- a/crates/fakecloud-sns/src/resource_policy.rs
+++ b/crates/fakecloud-sns/src/resource_policy.rs
@@ -46,7 +46,9 @@ impl ResourcePolicyProvider for SnsResourcePolicyProvider {
         if !is_sns_topic_arn(resource_arn) {
             return None;
         }
-        let state = self.state.read();
+        let accts = self.state.read();
+        let acct = resource_arn.split(':').nth(4).unwrap_or("");
+        let state = accts.get(acct).unwrap_or_else(|| accts.default_ref());
         state
             .topics
             .get(resource_arn)
@@ -82,16 +84,21 @@ mod tests {
     use super::*;
     use crate::state::{SnsState, SnsTopic};
     use chrono::Utc;
+    use fakecloud_core::multi_account::MultiAccountState;
     use parking_lot::RwLock;
     use std::collections::HashMap;
 
     fn state_with_topic(arn: &str, policy: Option<&str>) -> SharedSnsState {
-        let mut s = SnsState::new("123456789012", "us-east-1", "http://localhost:4566");
+        let state = Arc::new(RwLock::new(MultiAccountState::<SnsState>::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4566",
+        )));
         let mut attrs = HashMap::new();
         if let Some(p) = policy {
             attrs.insert("Policy".to_string(), p.to_string());
         }
-        s.topics.insert(
+        state.write().default_mut().topics.insert(
             arn.to_string(),
             SnsTopic {
                 topic_arn: arn.to_string(),
@@ -102,7 +109,7 @@ mod tests {
                 created_at: Utc::now(),
             },
         );
-        Arc::new(RwLock::new(s))
+        state
     }
 
     #[test]

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -49,7 +49,8 @@ impl SnsService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = SnsSnapshot {
             schema_version: SNS_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            accounts: Some(self.state.read().clone()),
+            state: None,
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -224,7 +225,7 @@ impl AwsService for SnsService {
                 // evaluation and the actual ARN can't diverge even if
                 // the two sources ever drift (identified by cubic on
                 // PR #399).
-                let state = self.state.read();
+                let _accts = self.state.read(); let _empty = crate::state::SnsState::new(&request.account_id, &request.region, ""); let state = _accts.get(&request.account_id).unwrap_or(&_empty);
                 let partition = if request.region.starts_with("cn-") {
                     "aws-cn"
                 } else if request.region.starts_with("us-gov-") {
@@ -306,7 +307,9 @@ impl AwsService for SnsService {
         if resource_arn == "*" {
             return Some(std::collections::HashMap::new());
         }
-        let state = self.state.read();
+        let account_id = resource_arn.split(':').nth(4).unwrap_or("");
+        let _accts = self.state.read();
+        let state = _accts.get(account_id)?;
         let topic = state.topics.get(resource_arn)?;
         Some(topic.tags.iter().cloned().collect())
     }
@@ -498,7 +501,8 @@ impl SnsService {
         // Parse tags from request
         let tags = parse_tags(req);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let topic_arn = Arn::new("sns", &req.region, &state.account_id, &name).to_string();
 
         if !state.topics.contains_key(&topic_arn) {
@@ -565,7 +569,8 @@ impl SnsService {
 
     fn delete_topic(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let topic_arn = required(req, "TopicArn")?;
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.topics.remove(&topic_arn);
         state
             .subscriptions
@@ -585,7 +590,9 @@ impl SnsService {
     }
 
     fn list_topics(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
 
         // Filter topics by region
         let all_topics: Vec<&SnsTopic> = state
@@ -659,7 +666,9 @@ impl SnsService {
             }
         }
 
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
         let topic = state
             .topics
             .get(&topic_arn)
@@ -719,7 +728,8 @@ impl SnsService {
         let attr_name = required(req, "AttributeName")?;
         let attr_value = param(req, "AttributeValue").unwrap_or_default();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let topic = state
             .topics
             .get_mut(&topic_arn)
@@ -758,13 +768,16 @@ impl SnsService {
         let protocol = required(req, "Protocol")?;
         let endpoint = param(req, "Endpoint").unwrap_or_default();
 
-        let state_r = self.state.read();
+        let accts = self.state.read();
+        let state_r = accts
+            .get(&req.account_id)
+            .unwrap_or_else(|| accts.default_ref());
         let topic = state_r
             .topics
             .get(&topic_arn)
             .ok_or_else(|| not_found("Topic"))?;
         let is_fifo_topic = topic.is_fifo;
-        let account_id = state_r.account_id.clone();
+        let account_id = req.account_id.clone();
 
         // Validate application endpoint exists
         if protocol == "application" {
@@ -782,7 +795,7 @@ impl SnsService {
                 ));
             }
         }
-        drop(state_r);
+        drop(accts);
 
         // Validate SMS endpoint
         if protocol == "sms" {
@@ -836,7 +849,8 @@ impl SnsService {
         }
 
         // Check for duplicate subscription (same topic, protocol, endpoint)
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         for sub in state.subscriptions.values() {
             if sub.topic_arn == topic_arn && sub.protocol == protocol && sub.endpoint == endpoint {
                 return Ok(xml_resp(
@@ -906,7 +920,8 @@ impl SnsService {
         let topic_arn = required(req, "TopicArn")?;
         let token = required(req, "Token")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         // AWS accepts both the confirmation token and the subscription ARN as the Token parameter.
         // Confirming an already-confirmed subscription is a no-op (idempotent).
         let sub_arn = state
@@ -949,7 +964,11 @@ impl SnsService {
 
     fn unsubscribe(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let sub_arn = required(req, "SubscriptionArn")?;
-        self.state.write().subscriptions.remove(&sub_arn);
+        self.state
+            .write()
+            .get_or_create(&req.account_id)
+            .subscriptions
+            .remove(&sub_arn);
 
         Ok(xml_resp(
             &format!(
@@ -1041,7 +1060,8 @@ impl SnsService {
             );
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let topic = state
             .topics
             .get(&topic_arn)
@@ -1107,9 +1127,9 @@ impl SnsService {
         };
 
         let subscribers =
-            collect_topic_subscribers(&state, &topic_arn, &message_attributes, &message);
+            collect_topic_subscribers(state, &topic_arn, &message_attributes, &message);
         let endpoint = state.endpoint.clone();
-        drop(state);
+        drop(accounts);
 
         // Determine actual message content per protocol
         let sqs_message = if let Some(ref structure) = parsed_structure {
@@ -1266,7 +1286,9 @@ impl SnsService {
             .collect();
 
         {
-            let mut state = self.state.write();
+            let acct = ctx.topic_arn.split(':').nth(4).unwrap_or("");
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(acct);
             for (function_arn, _) in &lambda_payloads {
                 state
                     .lambda_invocations
@@ -1314,7 +1336,9 @@ impl SnsService {
         }
         let now = Utc::now();
         let subject_owned = ctx.subject.map(|s| s.to_string());
-        let mut state = self.state.write();
+        let acct = ctx.topic_arn.split(':').nth(4).unwrap_or("");
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(acct);
         for email_address in subs {
             tracing::info!(
                 email = %email_address,
@@ -1335,7 +1359,9 @@ impl SnsService {
         if subs.is_empty() {
             return;
         }
-        let mut state = self.state.write();
+        let acct = ctx.topic_arn.split(':').nth(4).unwrap_or("");
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(acct);
         for phone_number in subs {
             tracing::info!(
                 phone_number = %phone_number,
@@ -1351,14 +1377,16 @@ impl SnsService {
     fn publish_batch(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let topic_arn = required(req, "TopicArn")?;
 
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
         let topic = state
             .topics
             .get(&topic_arn)
             .ok_or_else(|| not_found("Topic"))?;
         let is_fifo = topic.is_fifo;
         let endpoint = state.endpoint.clone();
-        drop(state);
+        drop(_accts);
 
         // Parse batch entries: PublishBatchRequestEntries.member.N.*
         let mut entries = Vec::new();
@@ -1434,7 +1462,8 @@ impl SnsService {
             }
 
             let msg_id = uuid::Uuid::new_v4().to_string();
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
             state.published.push(PublishedMessage {
                 message_id: msg_id.clone(),
                 topic_arn: topic_arn.clone(),
@@ -1482,7 +1511,7 @@ impl SnsService {
                     (s.endpoint.clone(), raw)
                 })
                 .collect();
-            drop(state);
+            drop(accounts);
 
             // Build envelope attributes
             let mut envelope_attrs = serde_json::Map::new();
@@ -1606,7 +1635,8 @@ impl SnsService {
         }
 
         let msg_id = uuid::Uuid::new_v4().to_string();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state
             .sms_messages
             .push((phone.to_string(), message.clone()));
@@ -1644,7 +1674,9 @@ impl SnsService {
         message_attributes: &HashMap<String, MessageAttribute>,
         request_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let acct = endpoint_arn.split(':').nth(4).unwrap_or("");
+        let _accts = self.state.read();
+        let state = _accts.get(acct).unwrap_or_else(|| _accts.default_ref());
 
         // Find the platform endpoint
         let mut found_endpoint: Option<&PlatformEndpoint> = None;
@@ -1666,10 +1698,12 @@ impl SnsService {
                 "Endpoint is disabled",
             ));
         }
-        drop(state);
+        drop(_accts);
 
         let msg_id = uuid::Uuid::new_v4().to_string();
-        let mut state = self.state.write();
+        let acct = endpoint_arn.split(':').nth(4).unwrap_or("");
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(acct);
         // Store message on the endpoint
         for app in state.platform_applications.values_mut() {
             if let Some(ep) = app.endpoints.get_mut(endpoint_arn) {
@@ -1703,7 +1737,9 @@ impl SnsService {
     }
 
     fn list_subscriptions(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
 
         let all_subs: Vec<&SnsSubscription> = state.subscriptions.values().collect();
         let next_token = param(req, "NextToken")
@@ -1757,7 +1793,9 @@ impl SnsService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let topic_arn = required(req, "TopicArn")?;
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
 
         let all_subs: Vec<&SnsSubscription> = state
             .subscriptions
@@ -1816,7 +1854,9 @@ impl SnsService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let sub_arn = required(req, "SubscriptionArn")?;
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
         let sub = state
             .subscriptions
             .get(&sub_arn)
@@ -1903,7 +1943,8 @@ impl SnsService {
             validate_filter_policy(&attr_value)?;
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let sub = state
             .subscriptions
             .get_mut(&sub_arn)
@@ -1935,7 +1976,8 @@ impl SnsService {
         let resource_arn = required(req, "ResourceArn")?;
         let new_tags = parse_tags(req);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let topic = state.topics.get_mut(&resource_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -1982,7 +2024,8 @@ impl SnsService {
         let resource_arn = required(req, "ResourceArn")?;
         let tag_keys = parse_tag_keys(req);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let topic = state.topics.get_mut(&resource_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -2008,7 +2051,9 @@ impl SnsService {
 
     fn list_tags_for_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let resource_arn = required(req, "ResourceArn")?;
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
         let topic = state.topics.get(&resource_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -2078,7 +2123,8 @@ impl SnsService {
             }
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let account_id = state.account_id.clone();
         let topic = state
             .topics
@@ -2172,7 +2218,8 @@ impl SnsService {
         let topic_arn = required(req, "TopicArn")?;
         let label = required(req, "Label")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let topic = state
             .topics
             .get_mut(&topic_arn)
@@ -2212,7 +2259,8 @@ impl SnsService {
         let platform = required(req, "Platform")?;
         let attributes = parse_entries(req, "Attributes");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let arn = format!(
             "arn:aws:sns:{}:{}:app/{}/{}",
             req.region, state.account_id, platform, name
@@ -2250,7 +2298,11 @@ impl SnsService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let arn = required(req, "PlatformApplicationArn")?;
-        self.state.write().platform_applications.remove(&arn);
+        self.state
+            .write()
+            .get_or_create(&req.account_id)
+            .platform_applications
+            .remove(&arn);
 
         Ok(xml_resp(
             &format!(
@@ -2270,7 +2322,9 @@ impl SnsService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let arn = required(req, "PlatformApplicationArn")?;
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
         let app = state
             .platform_applications
             .get(&arn)
@@ -2308,7 +2362,8 @@ impl SnsService {
         let arn = required(req, "PlatformApplicationArn")?;
         let new_attrs = parse_entries(req, "Attributes");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let app = state
             .platform_applications
             .get_mut(&arn)
@@ -2332,7 +2387,9 @@ impl SnsService {
     }
 
     fn list_platform_applications(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
 
         let members: String = state
             .platform_applications
@@ -2381,7 +2438,8 @@ impl SnsService {
         let custom_user_data = param(req, "CustomUserData");
         let attrs = parse_entries(req, "Attributes");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let account_id = state.account_id.clone();
         let app = state
             .platform_applications
@@ -2487,7 +2545,8 @@ impl SnsService {
     fn delete_endpoint(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let endpoint_arn = required(req, "EndpointArn")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         for app in state.platform_applications.values_mut() {
             app.endpoints.remove(&endpoint_arn);
         }
@@ -2508,7 +2567,9 @@ impl SnsService {
     fn get_endpoint_attributes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let endpoint_arn = required(req, "EndpointArn")?;
 
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
         for app in state.platform_applications.values() {
             if let Some(ep) = app.endpoints.get(&endpoint_arn) {
                 let attrs: String = ep
@@ -2544,7 +2605,8 @@ impl SnsService {
         let endpoint_arn = required(req, "EndpointArn")?;
         let new_attrs = parse_entries(req, "Attributes");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         for app in state.platform_applications.values_mut() {
             if let Some(ep) = app.endpoints.get_mut(&endpoint_arn) {
                 for (k, v) in new_attrs {
@@ -2577,7 +2639,9 @@ impl SnsService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let app_arn = required(req, "PlatformApplicationArn")?;
 
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
         let app = state
             .platform_applications
             .get(&app_arn)
@@ -2629,7 +2693,8 @@ impl SnsService {
     fn set_sms_attributes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let attrs = parse_entries(req, "attributes");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         for (k, v) in attrs {
             state.sms_attributes.insert(k, v);
         }
@@ -2660,7 +2725,9 @@ impl SnsService {
             }
         }
 
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
 
         let attrs: String = state
             .sms_attributes
@@ -2708,7 +2775,9 @@ impl SnsService {
             ));
         }
 
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
         // Numbers ending in 99 are considered opted out by convention
         let is_opted_out =
             state.opted_out_numbers.contains(&phone_number) || phone_number.ends_with("99");
@@ -2733,7 +2802,9 @@ impl SnsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
         let members: String = state
             .opted_out_numbers
             .iter()
@@ -2761,7 +2832,8 @@ impl SnsService {
 
     fn opt_in_phone_number(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let phone_number = required(req, "phoneNumber")?;
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.opted_out_numbers.retain(|n| n != &phone_number);
 
         Ok(xml_resp(
@@ -3984,14 +4056,17 @@ mod tests {
     #[test]
     fn add_permission_with_invalid_policy_returns_error_not_panic() {
         use fakecloud_core::delivery::DeliveryBus;
+        use fakecloud_core::multi_account::MultiAccountState;
         use parking_lot::RwLock;
         use std::sync::Arc;
 
-        let state = Arc::new(RwLock::new(crate::state::SnsState::new(
-            "123456789012",
-            "us-east-1",
-            "http://localhost:4566",
-        )));
+        let state = Arc::new(RwLock::new(
+            MultiAccountState::<crate::state::SnsState>::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
         let delivery = Arc::new(DeliveryBus::new());
         let svc = SnsService::new(state.clone(), delivery);
 
@@ -3999,7 +4074,7 @@ mod tests {
         let topic_arn = "arn:aws:sns:us-east-1:123456789012:test-topic";
         {
             let mut s = state.write();
-            s.topics.insert(
+            s.default_mut().topics.insert(
                 topic_arn.to_string(),
                 crate::state::SnsTopic {
                     topic_arn: topic_arn.to_string(),
@@ -4052,14 +4127,17 @@ mod tests {
 
     fn make_sns() -> (SnsService, crate::state::SharedSnsState) {
         use fakecloud_core::delivery::DeliveryBus;
+        use fakecloud_core::multi_account::MultiAccountState;
         use parking_lot::RwLock;
         use std::sync::Arc;
 
-        let state = Arc::new(RwLock::new(crate::state::SnsState::new(
-            "123456789012",
-            "us-east-1",
-            "http://localhost:4566",
-        )));
+        let state = Arc::new(RwLock::new(
+            MultiAccountState::<crate::state::SnsState>::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
         let delivery = Arc::new(DeliveryBus::new());
         let svc = SnsService::new(state.clone(), delivery);
         (svc, state)
@@ -4234,14 +4312,17 @@ mod tests {
         // Get subscription ARN from state
         let sub_arn = {
             let s = state.read();
-            s.subscriptions.keys().next().unwrap().clone()
+            s.default_ref().subscriptions.keys().next().unwrap().clone()
         };
 
         let req = sns_request("Unsubscribe", vec![("SubscriptionArn", &sub_arn)]);
         assert_ok(&svc.unsubscribe(&req));
 
         let s = state.read();
-        assert!(s.subscriptions.is_empty(), "Subscription should be removed");
+        assert!(
+            s.default_ref().subscriptions.is_empty(),
+            "Subscription should be removed"
+        );
     }
 
     #[test]
@@ -4346,9 +4427,12 @@ mod tests {
         );
 
         let s = state.read();
-        assert_eq!(s.published.len(), 1);
-        assert_eq!(s.published[0].message, "Hello world");
-        assert_eq!(s.published[0].subject.as_deref(), Some("Test subject"));
+        assert_eq!(s.default_ref().published.len(), 1);
+        assert_eq!(s.default_ref().published[0].message, "Hello world");
+        assert_eq!(
+            s.default_ref().published[0].subject.as_deref(),
+            Some("Test subject")
+        );
     }
 
     #[test]
@@ -4403,9 +4487,9 @@ mod tests {
         assert_ok(&result);
 
         let s = state.read();
-        assert_eq!(s.sms_messages.len(), 1);
-        assert_eq!(s.sms_messages[0].0, "+15551234567");
-        assert_eq!(s.sms_messages[0].1, "SMS test");
+        assert_eq!(s.default_ref().sms_messages.len(), 1);
+        assert_eq!(s.default_ref().sms_messages[0].0, "+15551234567");
+        assert_eq!(s.default_ref().sms_messages[0].1, "SMS test");
     }
 
     #[test]
@@ -4444,7 +4528,7 @@ mod tests {
         );
 
         let s = state.read();
-        assert_eq!(s.published.len(), 2);
+        assert_eq!(s.default_ref().published.len(), 2);
     }
 
     #[test]
@@ -4486,7 +4570,7 @@ mod tests {
 
         let sub_arn = {
             let s = state.read();
-            s.subscriptions.keys().next().unwrap().clone()
+            s.default_ref().subscriptions.keys().next().unwrap().clone()
         };
 
         let req = sns_request(
@@ -4531,7 +4615,7 @@ mod tests {
 
         let sub_arn = {
             let s = state.read();
-            s.subscriptions.keys().next().unwrap().clone()
+            s.default_ref().subscriptions.keys().next().unwrap().clone()
         };
 
         // Set RawMessageDelivery to true
@@ -4547,7 +4631,7 @@ mod tests {
 
         // Verify in state
         let s = state.read();
-        let sub = s.subscriptions.get(&sub_arn).unwrap();
+        let sub = s.default_ref().subscriptions.get(&sub_arn).unwrap();
         assert_eq!(sub.attributes.get("RawMessageDelivery").unwrap(), "true");
     }
 
@@ -4568,7 +4652,7 @@ mod tests {
 
         let sub_arn = {
             let s = state.read();
-            s.subscriptions.keys().next().unwrap().clone()
+            s.default_ref().subscriptions.keys().next().unwrap().clone()
         };
 
         let req = sns_request(
@@ -4801,7 +4885,8 @@ mod tests {
         // Get the token from the pending subscription
         let token = {
             let s = state.read();
-            s.subscriptions
+            s.default_ref()
+                .subscriptions
                 .values()
                 .find(|sub| sub.topic_arn == topic_arn && !sub.confirmed)
                 .expect("should have a pending subscription")
@@ -4825,6 +4910,7 @@ mod tests {
         // Verify the subscription is now confirmed
         let s = state.read();
         let sub = s
+            .default_ref()
             .subscriptions
             .values()
             .find(|sub| sub.topic_arn == topic_arn)
@@ -4887,6 +4973,7 @@ mod tests {
         let (second_arn, second_token) = {
             let s = state.read();
             let sub = s
+                .default_ref()
                 .subscriptions
                 .values()
                 .find(|sub| sub.endpoint == "http://second.example.com/hook")
@@ -4912,7 +4999,7 @@ mod tests {
 
         // Verify only the second subscription is confirmed
         let s = state.read();
-        for sub in s.subscriptions.values() {
+        for sub in s.default_ref().subscriptions.values() {
             if sub.endpoint == "http://second.example.com/hook" {
                 assert!(sub.confirmed, "second subscription should be confirmed");
             } else {
@@ -4941,7 +5028,8 @@ mod tests {
         // Get the subscription ARN
         let sub_arn = {
             let s = state.read();
-            s.subscriptions
+            s.default_ref()
+                .subscriptions
                 .values()
                 .find(|sub| sub.topic_arn == topic_arn)
                 .expect("should have a subscription")
@@ -4960,6 +5048,7 @@ mod tests {
         // Verify the subscription is now confirmed
         let s = state.read();
         let sub = s
+            .default_ref()
             .subscriptions
             .values()
             .find(|sub| sub.topic_arn == topic_arn)
@@ -5033,6 +5122,7 @@ mod tests {
         {
             let s = state.read();
             let policy_str = s
+                .default_ref()
                 .topics
                 .get(topic_arn)
                 .unwrap()
@@ -5060,6 +5150,7 @@ mod tests {
         {
             let s = state.read();
             let policy_str = s
+                .default_ref()
                 .topics
                 .get(topic_arn)
                 .unwrap()
@@ -5136,7 +5227,7 @@ mod tests {
     #[test]
     fn check_phone_opted_out() {
         let (svc, state) = make_sns();
-        state.write().seed_default_opted_out();
+        state.write().default_mut().seed_default_opted_out();
 
         let req = sns_request(
             "CheckIfPhoneNumberIsOptedOut",
@@ -5154,7 +5245,7 @@ mod tests {
     #[test]
     fn list_phone_numbers_opted_out() {
         let (svc, state) = make_sns();
-        state.write().seed_default_opted_out();
+        state.write().default_mut().seed_default_opted_out();
 
         let req = sns_request("ListPhoneNumbersOptedOut", vec![]);
         let result = svc.list_phone_numbers_opted_out(&req);
@@ -5169,7 +5260,7 @@ mod tests {
     #[test]
     fn opt_in_phone_number() {
         let (svc, state) = make_sns();
-        state.write().seed_default_opted_out();
+        state.write().default_mut().seed_default_opted_out();
 
         let req = sns_request("OptInPhoneNumber", vec![("phoneNumber", "+15005550099")]);
         assert_ok(&svc.opt_in_phone_number(&req));
@@ -5177,7 +5268,9 @@ mod tests {
         // Verify removed from opted-out list
         let s = state.read();
         assert!(
-            !s.opted_out_numbers.contains(&"+15005550099".to_string()),
+            !s.default_ref()
+                .opted_out_numbers
+                .contains(&"+15005550099".to_string()),
             "Phone should no longer be opted out"
         );
     }
@@ -5198,11 +5291,11 @@ mod tests {
             ],
         )));
 
-        assert_eq!(state.read().subscriptions.len(), 1);
+        assert_eq!(state.read().default_ref().subscriptions.len(), 1);
 
         assert_ok(&svc.delete_topic(&sns_request("DeleteTopic", vec![("TopicArn", topic_arn)])));
         assert_eq!(
-            state.read().subscriptions.len(),
+            state.read().default_ref().subscriptions.len(),
             0,
             "Subscriptions should be removed with topic"
         );
@@ -5257,7 +5350,7 @@ mod tests {
         let (svc, state) = make_sns();
         let arn = create_app(&svc, "MyApp", "GCM");
         let s = state.read();
-        let app = s.platform_applications.get(&arn).unwrap();
+        let app = s.default_ref().platform_applications.get(&arn).unwrap();
         assert_eq!(app.name, "MyApp");
         assert_eq!(app.platform, "GCM");
         assert_eq!(
@@ -5305,7 +5398,8 @@ mod tests {
         svc.set_platform_application_attributes(&req).unwrap();
         let s = state.read();
         assert_eq!(
-            s.platform_applications
+            s.default_ref()
+                .platform_applications
                 .get(&arn)
                 .unwrap()
                 .attributes
@@ -5324,7 +5418,7 @@ mod tests {
             vec![("PlatformApplicationArn", arn.as_str())],
         );
         svc.delete_platform_application(&req).unwrap();
-        assert!(state.read().platform_applications.is_empty());
+        assert!(state.read().default_ref().platform_applications.is_empty());
     }
 
     fn create_endpoint(svc: &SnsService, app_arn: &str, token: &str) -> String {
@@ -5419,7 +5513,7 @@ mod tests {
         );
         svc.delete_endpoint(&del).unwrap();
         let s = state.read();
-        let app = s.platform_applications.get(&app_arn).unwrap();
+        let app = s.default_ref().platform_applications.get(&app_arn).unwrap();
         assert!(app.endpoints.is_empty());
     }
 

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -769,9 +769,10 @@ impl SnsService {
         let endpoint = param(req, "Endpoint").unwrap_or_default();
 
         let accts = self.state.read();
-        let state_r = accts
-            .get(&req.account_id)
-            .unwrap_or_else(|| accts.default_ref());
+        let state_r = match accts.get(&req.account_id) {
+            Some(s) => s,
+            None => return Err(not_found("Topic")),
+        };
         let topic = state_r
             .topics
             .get(&topic_arn)

--- a/crates/fakecloud-sns/src/simulation.rs
+++ b/crates/fakecloud-sns/src/simulation.rs
@@ -12,7 +12,8 @@ pub struct PendingConfirmation {
 
 /// List all subscriptions that are pending confirmation.
 pub fn list_pending_confirmations(state: &SharedSnsState) -> Vec<PendingConfirmation> {
-    let s = state.read();
+    let accts = state.read();
+    let s = accts.default_ref();
     s.subscriptions
         .values()
         .filter(|sub| !sub.confirmed)
@@ -29,7 +30,8 @@ pub fn list_pending_confirmations(state: &SharedSnsState) -> Vec<PendingConfirma
 /// Force-confirm a subscription by its ARN. Returns true if the
 /// subscription was found and confirmed (or was already confirmed).
 pub fn confirm_subscription(state: &SharedSnsState, subscription_arn: &str) -> bool {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.default_mut();
     match s.subscriptions.get_mut(subscription_arn) {
         Some(sub) => {
             sub.confirmed = true;
@@ -42,13 +44,13 @@ pub fn confirm_subscription(state: &SharedSnsState, subscription_arn: &str) -> b
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::SnsState;
+    use fakecloud_core::multi_account::MultiAccountState;
     use parking_lot::RwLock;
     use std::collections::HashMap;
     use std::sync::Arc;
 
     fn make_state() -> SharedSnsState {
-        Arc::new(RwLock::new(SnsState::new(
+        Arc::new(RwLock::new(MultiAccountState::new(
             "123456789012",
             "us-east-1",
             "http://localhost:4566",
@@ -63,7 +65,8 @@ mod tests {
         confirmed: bool,
     ) -> String {
         let sub_arn = format!("{}:{}", topic_arn, uuid::Uuid::new_v4());
-        let mut s = state.write();
+        let mut accts = state.write();
+        let s = accts.default_mut();
         s.subscriptions.insert(
             sub_arn.clone(),
             crate::state::SnsSubscription {
@@ -125,11 +128,11 @@ mod tests {
         let topic_arn = "arn:aws:sns:us-east-1:123456789012:my-topic";
         let sub_arn = add_subscription(&state, topic_arn, "http", "http://example.com/hook", false);
 
-        assert!(!state.read().subscriptions[&sub_arn].confirmed);
+        assert!(!state.read().default_ref().subscriptions[&sub_arn].confirmed);
 
         let result = confirm_subscription(&state, &sub_arn);
         assert!(result);
-        assert!(state.read().subscriptions[&sub_arn].confirmed);
+        assert!(state.read().default_ref().subscriptions[&sub_arn].confirmed);
     }
 
     #[test]

--- a/crates/fakecloud-sns/src/simulation.rs
+++ b/crates/fakecloud-sns/src/simulation.rs
@@ -13,32 +13,34 @@ pub struct PendingConfirmation {
 /// List all subscriptions that are pending confirmation.
 pub fn list_pending_confirmations(state: &SharedSnsState) -> Vec<PendingConfirmation> {
     let accts = state.read();
-    let s = accts.default_ref();
-    s.subscriptions
-        .values()
-        .filter(|sub| !sub.confirmed)
-        .map(|sub| PendingConfirmation {
-            subscription_arn: sub.subscription_arn.clone(),
-            topic_arn: sub.topic_arn.clone(),
-            protocol: sub.protocol.clone(),
-            endpoint: sub.endpoint.clone(),
-            token: sub.confirmation_token.clone(),
-        })
-        .collect()
+    let mut result = Vec::new();
+    for (_, acct_state) in accts.iter() {
+        for sub in acct_state.subscriptions.values() {
+            if !sub.confirmed {
+                result.push(PendingConfirmation {
+                    subscription_arn: sub.subscription_arn.clone(),
+                    topic_arn: sub.topic_arn.clone(),
+                    protocol: sub.protocol.clone(),
+                    endpoint: sub.endpoint.clone(),
+                    token: sub.confirmation_token.clone(),
+                });
+            }
+        }
+    }
+    result
 }
 
 /// Force-confirm a subscription by its ARN. Returns true if the
 /// subscription was found and confirmed (or was already confirmed).
 pub fn confirm_subscription(state: &SharedSnsState, subscription_arn: &str) -> bool {
     let mut accts = state.write();
-    let s = accts.default_mut();
-    match s.subscriptions.get_mut(subscription_arn) {
-        Some(sub) => {
+    for (_, acct_state) in accts.iter_mut() {
+        if let Some(sub) = acct_state.subscriptions.get_mut(subscription_arn) {
             sub.confirmed = true;
-            true
+            return true;
         }
-        None => false,
     }
+    false
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-sns/src/state.rs
+++ b/crates/fakecloud-sns/src/state.rs
@@ -140,14 +140,23 @@ impl SnsState {
     }
 }
 
-pub type SharedSnsState = Arc<RwLock<SnsState>>;
+pub type SharedSnsState = Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<SnsState>>>;
 
 /// On-disk snapshot envelope for SNS state. Versioned so format
 /// changes fail loudly on upgrade.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SnsSnapshot {
     pub schema_version: u32,
-    pub state: SnsState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<SnsState>>,
+    #[serde(default)]
+    pub state: Option<SnsState>,
 }
 
-pub const SNS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const SNS_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
+
+impl fakecloud_core::multi_account::AccountState for SnsState {
+    fn new_for_account(account_id: &str, region: &str, endpoint: &str) -> Self {
+        Self::new(account_id, region, endpoint)
+    }
+}

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -36,7 +36,12 @@ impl SqsDelivery for SqsDeliveryImpl {
         message_group_id: Option<&str>,
         message_dedup_id: Option<&str>,
     ) {
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+
+        // Parse account from queue ARN (arn:aws:sqs:region:ACCOUNT:name)
+        let default_id = accounts.default_account_id().to_string();
+        let target_account = queue_arn.split(':').nth(4).unwrap_or(&default_id);
+        let state = accounts.get_or_create(target_account);
 
         // Find queue by ARN
         let queue = state.queues.values_mut().find(|q| q.arn == queue_arn);

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -397,7 +397,8 @@ impl SqsService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = SqsSnapshot {
             schema_version: SQS_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            accounts: Some(self.state.read().clone()),
+            state: None,
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -585,7 +586,9 @@ impl AwsService for SqsService {
             return None;
         }
         let queue_name = parts[5];
-        let state = self.state.read();
+        let account_id = parts[4];
+        let _accts = self.state.read();
+        let state = _accts.get(account_id)?;
         let queue_url = state.name_to_url.get(queue_name)?;
         let queue = state.queues.get(queue_url)?;
         Some(queue.tags.clone())
@@ -1002,7 +1005,8 @@ impl SqsService {
             }
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if let Some(url) = state.name_to_url.get(&queue_name) {
             // Queue exists - check if attributes match
@@ -1100,7 +1104,7 @@ impl SqsService {
             .and_then(|s| parse_redrive_policy(s));
 
         if let Some(ref rp) = redrive_policy {
-            validate_redrive_policy_target(&state, rp, is_fifo)?;
+            validate_redrive_policy_target(state, rp, is_fifo)?;
         }
 
         // RedrivePolicy is already canonicalized to compact JSON above by
@@ -1170,8 +1174,9 @@ impl SqsService {
             .ok_or_else(|| missing_param("QueueUrl"))?
             .to_string();
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(&queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(&queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .remove(&resolved_url)
@@ -1189,7 +1194,9 @@ impl SqsService {
     fn list_queues(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = parse_body(req);
         let prefix = body["QueueNamePrefix"].as_str();
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SqsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
 
         let max_results = body["MaxResults"]
             .as_u64()
@@ -1237,7 +1244,9 @@ impl SqsService {
             .as_str()
             .ok_or_else(|| missing_param("QueueName"))?;
 
-        let state = self.state.read();
+        let _accts = self.state.read();
+        let _empty = crate::state::SqsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
         let url = state
             .name_to_url
             .get(queue_name)
@@ -1257,8 +1266,10 @@ impl SqsService {
             .as_str()
             .ok_or_else(|| missing_param("QueueUrl"))?;
 
-        let state = self.state.read();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let _accts = self.state.read();
+        let _empty = crate::state::SqsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get(&resolved_url)
@@ -1421,8 +1432,9 @@ impl SqsService {
 
         // --- Acquire write lock ONLY for queue validation + mutation ---
         let (message_id, sequence_number) = {
-            let mut state = self.state.write();
-            let resolved_url = resolve_queue_url(&queue_url, &state).ok_or_else(queue_not_found)?;
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            let resolved_url = resolve_queue_url(&queue_url, state).ok_or_else(queue_not_found)?;
             let queue = state
                 .queues
                 .get_mut(&resolved_url)
@@ -1558,8 +1570,10 @@ impl SqsService {
 
         // Resolve the queue URL (might be a name)
         let queue_url = {
-            let state = self.state.read();
-            resolve_queue_url(&queue_url_input, &state).ok_or_else(queue_not_found)?
+            let _accts = self.state.read();
+            let _empty = crate::state::SqsState::new(&req.account_id, &req.region, "");
+            let state = _accts.get(&req.account_id).unwrap_or(&_empty);
+            resolve_queue_url(&queue_url_input, state).ok_or_else(queue_not_found)?
         };
 
         let max_messages_raw = val_as_i64(&body["MaxNumberOfMessages"]);
@@ -1621,7 +1635,12 @@ impl SqsService {
         };
 
         loop {
-            let result = self.try_receive_messages(&queue_url, max_messages, visibility_timeout)?;
+            let result = self.try_receive_messages(
+                &req.account_id,
+                &queue_url,
+                max_messages,
+                visibility_timeout,
+            )?;
 
             if !result.is_empty() || deadline.is_none() {
                 return Ok(format_receive_response(
@@ -1650,12 +1669,14 @@ impl SqsService {
 
     fn try_receive_messages(
         &self,
+        account_id: &str,
         queue_url: &str,
         max_messages: usize,
         req_visibility_timeout: Option<i64>,
     ) -> Result<Vec<SqsMessage>, AwsServiceError> {
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -1858,8 +1879,9 @@ impl SqsService {
             .as_str()
             .ok_or_else(|| missing_param("ReceiptHandle"))?;
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -1896,8 +1918,9 @@ impl SqsService {
             .as_str()
             .ok_or_else(|| missing_param("QueueUrl"))?;
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -1925,8 +1948,9 @@ impl SqsService {
         let visibility_timeout = val_as_i64(&body["VisibilityTimeout"])
             .ok_or_else(|| missing_param("VisibilityTimeout"))?;
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -1998,8 +2022,9 @@ impl SqsService {
             .ok_or_else(|| missing_param("Entries"))?
             .clone();
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -2100,8 +2125,9 @@ impl SqsService {
             .as_str()
             .ok_or_else(|| missing_param("QueueUrl"))?;
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -2271,8 +2297,9 @@ impl SqsService {
             ));
         }
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(&queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(&queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -2336,8 +2363,9 @@ impl SqsService {
             }
         }
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -2400,8 +2428,10 @@ impl SqsService {
             .as_str()
             .ok_or_else(|| missing_param("QueueUrl"))?;
 
-        let state = self.state.read();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let _accts = self.state.read();
+        let _empty = crate::state::SqsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get(&resolved_url)
@@ -2432,8 +2462,9 @@ impl SqsService {
             ));
         }
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -2481,8 +2512,9 @@ impl SqsService {
             ));
         }
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -2592,8 +2624,9 @@ impl SqsService {
             }
         }
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -2680,8 +2713,9 @@ impl SqsService {
             .as_str()
             .ok_or_else(|| missing_param("Label"))?;
 
-        let mut state = self.state.write();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get_mut(&resolved_url)
@@ -2735,8 +2769,10 @@ impl SqsService {
             .as_str()
             .ok_or_else(|| missing_param("QueueUrl"))?;
 
-        let state = self.state.read();
-        let resolved_url = resolve_queue_url(queue_url, &state).ok_or_else(queue_not_found)?;
+        let _accts = self.state.read();
+        let _empty = crate::state::SqsState::new(&req.account_id, &req.region, "");
+        let state = _accts.get(&req.account_id).unwrap_or(&_empty);
+        let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
         let queue = state
             .queues
             .get(&resolved_url)
@@ -3232,11 +3268,13 @@ mod tests {
     }
 
     fn make_service() -> SqsService {
-        let state: SharedSqsState = Arc::new(RwLock::new(crate::state::SqsState::new(
-            "123456789012",
-            "us-east-1",
-            "http://localhost:4566",
-        )));
+        let state: SharedSqsState = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
         SqsService::new(state)
     }
 

--- a/crates/fakecloud-sqs/src/simulation.rs
+++ b/crates/fakecloud-sqs/src/simulation.rs
@@ -49,7 +49,14 @@ pub fn tick_expiration(state: &SharedSqsState) -> u64 {
 /// is a no-op returning 0.
 pub fn force_dlq(state: &SharedSqsState, queue_name: &str) -> u64 {
     let mut mas = state.write();
-    let state = mas.default_mut();
+
+    // Find which account owns this queue by name
+    let account_id = match mas.find_account(|s| s.name_to_url.contains_key(queue_name)) {
+        Some(id) => id.to_string(),
+        None => return 0,
+    };
+
+    let state = mas.get_or_create(&account_id);
 
     // Resolve queue URL from name
     let queue_url = match state.name_to_url.get(queue_name) {

--- a/crates/fakecloud-sqs/src/simulation.rs
+++ b/crates/fakecloud-sqs/src/simulation.rs
@@ -12,26 +12,28 @@ pub fn tick_expiration(state: &SharedSqsState) -> u64 {
     let mut total = 0u64;
     let now = Utc::now();
 
-    let mut state = state.write();
-    for queue in state.queues.values_mut() {
-        let retention_seconds: i64 = queue
-            .attributes
-            .get("MessageRetentionPeriod")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(345600); // default 4 days
+    let mut mas = state.write();
+    for (_, acct_state) in mas.iter_mut() {
+        for queue in acct_state.queues.values_mut() {
+            let retention_seconds: i64 = queue
+                .attributes
+                .get("MessageRetentionPeriod")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(345600); // default 4 days
 
-        let before = queue.messages.len() + queue.inflight.len();
+            let before = queue.messages.len() + queue.inflight.len();
 
-        queue
-            .messages
-            .retain(|m| (now - m.created_at).num_seconds() < retention_seconds);
-        queue
-            .inflight
-            .retain(|m| (now - m.created_at).num_seconds() < retention_seconds);
+            queue
+                .messages
+                .retain(|m| (now - m.created_at).num_seconds() < retention_seconds);
+            queue
+                .inflight
+                .retain(|m| (now - m.created_at).num_seconds() < retention_seconds);
 
-        let after = queue.messages.len() + queue.inflight.len();
-        total += (before - after) as u64;
-    }
+            let after = queue.messages.len() + queue.inflight.len();
+            total += (before - after) as u64;
+        }
+    } // end per-account loop
 
     total
 }
@@ -46,7 +48,8 @@ pub fn tick_expiration(state: &SharedSqsState) -> u64 {
 /// If the queue has no redrive policy, or the DLQ does not exist, this
 /// is a no-op returning 0.
 pub fn force_dlq(state: &SharedSqsState, queue_name: &str) -> u64 {
-    let mut state = state.write();
+    let mut mas = state.write();
+    let state = mas.default_mut();
 
     // Resolve queue URL from name
     let queue_url = match state.name_to_url.get(queue_name) {
@@ -117,12 +120,13 @@ mod tests {
     use super::*;
     use crate::state::{RedrivePolicy, SqsMessage, SqsQueue, SqsState};
     use chrono::Duration;
+    use fakecloud_core::multi_account::MultiAccountState;
     use parking_lot::RwLock;
     use std::collections::{HashMap, VecDeque};
     use std::sync::Arc;
 
     fn make_state() -> SharedSqsState {
-        Arc::new(RwLock::new(SqsState::new(
+        Arc::new(RwLock::new(MultiAccountState::<SqsState>::new(
             "123456789012",
             "us-east-1",
             "http://localhost:4566",
@@ -148,7 +152,8 @@ mod tests {
     }
 
     fn add_queue(state: &SharedSqsState, name: &str, retention: Option<&str>) -> String {
-        let mut s = state.write();
+        let mut accts = state.write();
+        let s = accts.default_mut();
         let url = format!("http://localhost:4566/123456789012/{name}");
         let arn = format!("arn:aws:sqs:us-east-1:123456789012:{name}");
         let mut attrs = HashMap::new();
@@ -182,16 +187,16 @@ mod tests {
         let url = add_queue(&state, "test-q", Some("60")); // 60s retention
 
         {
-            let mut s = state.write();
-            let q = s.queues.get_mut(&url).unwrap();
+            let mut accts = state.write();
+            let q = accts.default_mut().queues.get_mut(&url).unwrap();
             q.messages.push_back(make_message("old", 120, 0)); // 120s old > 60s retention
         }
 
         let expired = tick_expiration(&state);
         assert_eq!(expired, 1);
 
-        let s = state.read();
-        assert_eq!(s.queues[&url].messages.len(), 0);
+        let accts = state.read();
+        assert_eq!(accts.default_ref().queues[&url].messages.len(), 0);
     }
 
     #[test]
@@ -200,16 +205,16 @@ mod tests {
         let url = add_queue(&state, "test-q", Some("60")); // 60s retention
 
         {
-            let mut s = state.write();
-            let q = s.queues.get_mut(&url).unwrap();
+            let mut accts = state.write();
+            let q = accts.default_mut().queues.get_mut(&url).unwrap();
             q.messages.push_back(make_message("young", 10, 0)); // 10s old < 60s retention
         }
 
         let expired = tick_expiration(&state);
         assert_eq!(expired, 0);
 
-        let s = state.read();
-        assert_eq!(s.queues[&url].messages.len(), 1);
+        let accts = state.read();
+        assert_eq!(accts.default_ref().queues[&url].messages.len(), 1);
     }
 
     #[test]
@@ -219,14 +224,14 @@ mod tests {
         let src_url = add_queue(&state, "src-q", None);
 
         let dlq_arn = {
-            let s = state.read();
-            s.queues[&dlq_url].arn.clone()
+            let accts = state.read();
+            accts.default_ref().queues[&dlq_url].arn.clone()
         };
 
         // Set redrive policy on source
         {
-            let mut s = state.write();
-            let q = s.queues.get_mut(&src_url).unwrap();
+            let mut accts = state.write();
+            let q = accts.default_mut().queues.get_mut(&src_url).unwrap();
             q.redrive_policy = Some(RedrivePolicy {
                 dead_letter_target_arn: dlq_arn,
                 max_receive_count: 2,
@@ -238,7 +243,8 @@ mod tests {
         let moved = force_dlq(&state, "src-q");
         assert_eq!(moved, 1);
 
-        let s = state.read();
+        let accts = state.read();
+        let s = accts.default_ref();
         assert_eq!(s.queues[&src_url].messages.len(), 0);
         assert_eq!(s.queues[&dlq_url].messages.len(), 1);
         assert_eq!(s.queues[&dlq_url].messages[0].body, "over");
@@ -251,13 +257,13 @@ mod tests {
         let src_url = add_queue(&state, "src-q", None);
 
         let dlq_arn = {
-            let s = state.read();
-            s.queues[&dlq_url].arn.clone()
+            let accts = state.read();
+            accts.default_ref().queues[&dlq_url].arn.clone()
         };
 
         {
-            let mut s = state.write();
-            let q = s.queues.get_mut(&src_url).unwrap();
+            let mut accts = state.write();
+            let q = accts.default_mut().queues.get_mut(&src_url).unwrap();
             q.redrive_policy = Some(RedrivePolicy {
                 dead_letter_target_arn: dlq_arn,
                 max_receive_count: 3,
@@ -269,7 +275,8 @@ mod tests {
         let moved = force_dlq(&state, "src-q");
         assert_eq!(moved, 0);
 
-        let s = state.read();
+        let accts = state.read();
+        let s = accts.default_ref();
         assert_eq!(s.queues[&src_url].messages.len(), 1);
         assert_eq!(s.queues[&dlq_url].messages.len(), 0);
     }

--- a/crates/fakecloud-sqs/src/state.rs
+++ b/crates/fakecloud-sqs/src/state.rs
@@ -91,7 +91,7 @@ impl SqsState {
     }
 }
 
-pub type SharedSqsState = Arc<RwLock<SqsState>>;
+pub type SharedSqsState = Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<SqsState>>>;
 
 /// On-disk snapshot envelope for SQS. Mirrors the DynamoDB pattern: a
 /// versioned wrapper around the full [`SqsState`] so format changes fail
@@ -99,7 +99,16 @@ pub type SharedSqsState = Arc<RwLock<SqsState>>;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SqsSnapshot {
     pub schema_version: u32,
-    pub state: SqsState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<SqsState>>,
+    #[serde(default)]
+    pub state: Option<SqsState>,
 }
 
-pub const SQS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const SQS_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
+
+impl fakecloud_core::multi_account::AccountState for SqsState {
+    fn new_for_account(account_id: &str, region: &str, endpoint: &str) -> Self {
+        Self::new(account_id, region, endpoint)
+    }
+}


### PR DESCRIPTION
## Summary

Batch 3 of #381 (multi-account isolation). Wraps SQS and SNS state in `MultiAccountState<T>` and updates the delivery bus for cross-account message routing.

- SQS/SNS: all handlers use `get_or_create(&req.account_id)` for writes, read lock with fallback for reads
- **Delivery bus cross-account routing**: `SqsDeliveryImpl` and `SnsDeliveryImpl` parse the target account from the destination ARN (`arn:aws:sqs:region:ACCOUNT:name`), enabling SNS -> SQS fan-out across accounts
- SQS Lambda poller routes by queue ARN account
- Background tasks (expiration, DLQ simulation) iterate all accounts
- Snapshot schema v2 with v1 backward compat for both services
- Updated CloudFormation provisioner, reset handlers, introspection endpoints

## Test plan

- [x] All workspace unit tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` applied
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-account isolation for SQS and SNS with cross-account message delivery. Persists state as schema v2 with auto-migration from v1 and fixes account resolution in subscribe, DLQ, and confirmations.

- **New Features**
  - Wraps SQS/SNS state in `MultiAccountState`; per-account reads/writes via `get_or_create(account_id)`.
  - Cross-account routing by parsing account from ARNs; supports SNS → SQS fan-out, Lambda poller routes by queue ARN; CloudFormation and reset work on the target account; background tasks iterate all accounts; introspection uses the default account.
  - Persistence v2 for `fakecloud-sqs` and `fakecloud-sns`; v1 snapshots auto-load and migrate; snapshots newer than supported are rejected.

- **Bug Fixes**
  - `force_dlq` scans all accounts to find a queue by name.
  - `Subscribe` returns TopicNotFound for unknown accounts (no fallback to default).
  - `list_pending_confirmations` iterates all accounts.
  - `confirm_subscription` searches all accounts for the subscription ARN.

<sup>Written for commit 5f20e163576997cab2a5e1fbd36691489d7c85fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

