### PR TITLE
ci(codecov): enforce coverage ratchet — block PRs that decrease coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,12 +3,10 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1%
-        informational: true
+        threshold: 0%
     patch:
       default:
         target: auto
-        informational: true
 
 comment:
   layout: "reach, diff, flags, files"


### PR DESCRIPTION
## Summary
- Remove `informational: true` from codecov project and patch checks — they now fail PRs instead of just commenting
- Set threshold to 0% — any coverage decrease blocks merge
- `target: auto` continues using the current coverage as the baseline, so it ratchets forward automatically as we add tests

## Test plan
- [x] Verified codecov.yml syntax
- [x] No code changes — config only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a Codecov coverage ratchet: any decrease in project or patch coverage now fails the PR. Uses target: auto as a moving baseline and sets threshold to 0%; removed informational flags (config-only).

<sup>Written for commit 5a2232e334060f22d4fcf13707a443321612d4aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

