### PR TITLE
test(cognito,ssm): deep coverage for misc handlers and parameter operations

### DIFF
--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -5590,4 +5590,213 @@ mod tests {
         let err = expect_err(block_on(svc.initiate_auth(&req)));
         assert_eq!(err.code(), "NotAuthorizedException");
     }
+
+    // ── Helper: auth and get token ──
+
+    fn auth_get_token(
+        svc: &CognitoService,
+        pool_id: &str,
+        client_id: &str,
+        username: &str,
+        password: &str,
+    ) -> String {
+        let body = json!({
+            "UserPoolId": pool_id,
+            "ClientId": client_id,
+            "AuthFlow": "ADMIN_NO_SRP_AUTH",
+            "AuthParameters": {"USERNAME": username, "PASSWORD": password},
+        });
+        let resp =
+            block_on(svc.admin_initiate_auth(&make_req("AdminInitiateAuth", &body.to_string())))
+                .unwrap();
+        let b = resp_json(&resp);
+        b["AuthenticationResult"]["AccessToken"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    // ── cognito/misc.rs coverage ──
+
+    #[test]
+    fn revoke_token_invalid() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+
+        let body = json!({"Token": "invalid-refresh-token", "ClientId": client_id});
+        let req = make_req("RevokeToken", &body.to_string());
+        // RevokeToken should handle gracefully
+        let _ = svc.revoke_token(&req);
+    }
+
+    #[test]
+    fn get_tokens_from_refresh_token_invalid() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+
+        let body = json!({
+            "ClientId": client_id,
+            "AuthFlow": "REFRESH_TOKEN_AUTH",
+            "AuthParameters": {"REFRESH_TOKEN": "invalid-token"},
+        });
+        let req = make_req("InitiateAuth", &body.to_string());
+        let err = expect_err(block_on(svc.initiate_auth(&req)));
+        assert_eq!(err.code(), "NotAuthorizedException");
+    }
+
+    #[test]
+    fn get_csv_header() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+
+        let body = json!({"UserPoolId": pool_id});
+        let req = make_req("GetCSVHeader", &body.to_string());
+        let resp = svc.get_csv_header(&req).unwrap();
+        let b = resp_json(&resp);
+        assert!(b["CSVHeader"].as_array().is_some());
+        assert!(b["UserPoolId"].as_str().is_some());
+    }
+
+    #[test]
+    fn start_and_stop_user_import_job() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+
+        // Create import job
+        let body = json!({
+            "UserPoolId": pool_id,
+            "JobName": "import-1",
+            "CloudWatchLogsRoleArn": "arn:aws:iam::123456789012:role/CognitoImport",
+        });
+        let req = make_req("CreateUserImportJob", &body.to_string());
+        let resp = svc.create_user_import_job(&req).unwrap();
+        let b = resp_json(&resp);
+        let job_id = b["UserImportJob"]["JobId"].as_str().unwrap().to_string();
+
+        // Start
+        let body = json!({"UserPoolId": pool_id, "JobId": job_id});
+        let req = make_req("StartUserImportJob", &body.to_string());
+        svc.start_user_import_job(&req).unwrap();
+
+        // Stop
+        let body = json!({"UserPoolId": pool_id, "JobId": job_id});
+        let req = make_req("StopUserImportJob", &body.to_string());
+        svc.stop_user_import_job(&req).unwrap();
+    }
+
+    #[test]
+    fn confirm_device_and_list() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+        admin_create_user_helper(&svc, &pool_id, "devuser");
+        set_user_password(&svc, &pool_id, "devuser", "Password1!");
+        let token = auth_get_token(&svc, &pool_id, &client_id, "devuser", "Password1!");
+
+        // ConfirmDevice
+        let body = json!({
+            "AccessToken": token,
+            "DeviceKey": "us-east-1_device-abc",
+            "DeviceName": "My Phone",
+        });
+        let req = make_req("ConfirmDevice", &body.to_string());
+        svc.confirm_device(&req).unwrap();
+
+        // ListDevices
+        let body = json!({"AccessToken": token});
+        let req = make_req("ListDevices", &body.to_string());
+        let resp = svc.list_devices(&req).unwrap();
+        let b = resp_json(&resp);
+        assert!(!b["Devices"].as_array().unwrap().is_empty());
+
+        // GetDevice
+        let body = json!({"AccessToken": token, "DeviceKey": "us-east-1_device-abc"});
+        let req = make_req("GetDevice", &body.to_string());
+        let resp = svc.get_device(&req).unwrap();
+        let b = resp_json(&resp);
+        assert_eq!(b["Device"]["DeviceKey"], "us-east-1_device-abc");
+
+        // UpdateDeviceStatus
+        let body = json!({
+            "AccessToken": token,
+            "DeviceKey": "us-east-1_device-abc",
+            "DeviceRememberedStatus": "remembered",
+        });
+        let req = make_req("UpdateDeviceStatus", &body.to_string());
+        svc.update_device_status(&req).unwrap();
+
+        // ForgetDevice
+        let body = json!({"AccessToken": token, "DeviceKey": "us-east-1_device-abc"});
+        let req = make_req("ForgetDevice", &body.to_string());
+        svc.forget_device(&req).unwrap();
+    }
+
+    #[test]
+    fn update_user_pool_domain() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+
+        svc.create_user_pool_domain(&make_req(
+            "CreateUserPoolDomain",
+            &json!({"UserPoolId": pool_id, "Domain": "upd-domain"}).to_string(),
+        ))
+        .unwrap();
+
+        let body = json!({
+            "UserPoolId": pool_id,
+            "Domain": "upd-domain",
+            "CustomDomainConfig": {"CertificateArn": "arn:aws:acm:us-east-1:123:cert/abc"},
+        });
+        let req = make_req("UpdateUserPoolDomain", &body.to_string());
+        svc.update_user_pool_domain(&req).unwrap();
+    }
+
+    #[test]
+    fn device_operations_invalid_token() {
+        let (svc, _) = make_svc();
+
+        let body = json!({"AccessToken": "bad", "DeviceKey": "dk"});
+        let req = make_req("GetDevice", &body.to_string());
+        let err = expect_err(svc.get_device(&req));
+        assert_eq!(err.code(), "NotAuthorizedException");
+
+        let body = json!({"AccessToken": "bad"});
+        let req = make_req("ListDevices", &body.to_string());
+        let err = expect_err(svc.list_devices(&req));
+        assert_eq!(err.code(), "NotAuthorizedException");
+
+        let body = json!({"AccessToken": "bad", "DeviceKey": "dk"});
+        let req = make_req("ForgetDevice", &body.to_string());
+        let err = expect_err(svc.forget_device(&req));
+        assert_eq!(err.code(), "NotAuthorizedException");
+    }
+
+    #[test]
+    fn admin_update_device_status() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+        admin_create_user_helper(&svc, &pool_id, "admdev");
+        set_user_password(&svc, &pool_id, "admdev", "Password1!");
+        let token = auth_get_token(&svc, &pool_id, &client_id, "admdev", "Password1!");
+
+        // Confirm a device first
+        svc.confirm_device(&make_req(
+            "ConfirmDevice",
+            &json!({"AccessToken": token, "DeviceKey": "dk-1"}).to_string(),
+        ))
+        .unwrap();
+
+        // AdminUpdateDeviceStatus
+        let body = json!({
+            "UserPoolId": pool_id,
+            "Username": "admdev",
+            "DeviceKey": "dk-1",
+            "DeviceRememberedStatus": "not_remembered",
+        });
+        let req = make_req("AdminUpdateDeviceStatus", &body.to_string());
+        svc.admin_update_device_status(&req).unwrap();
+    }
 }

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -3239,4 +3239,209 @@ mod tests {
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["TagList"].as_array().unwrap().len(), 1);
     }
+
+    // ── Parameter deep coverage ──
+
+    #[test]
+    fn describe_parameters_with_filters() {
+        let svc = make_service();
+        for name in &["/app/db-host", "/app/db-port", "/other/key"] {
+            svc.put_parameter(&make_request(
+                "PutParameter",
+                json!({"Name": name, "Value": "v", "Type": "String"}),
+            ))
+            .unwrap();
+        }
+
+        // Filter by path
+        let req = make_request(
+            "DescribeParameters",
+            json!({"ParameterFilters": [{"Key": "Name", "Option": "BeginsWith", "Values": ["/app/"]}]}),
+        );
+        let resp = svc.describe_parameters(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameters"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn describe_parameters_empty() {
+        let svc = make_service();
+        let req = make_request("DescribeParameters", json!({}));
+        let resp = svc.describe_parameters(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["Parameters"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn get_parameters_by_path_recursive() {
+        let svc = make_service();
+        for name in &["/a/b/c", "/a/b/d", "/a/e"] {
+            svc.put_parameter(&make_request(
+                "PutParameter",
+                json!({"Name": name, "Value": "v", "Type": "String"}),
+            ))
+            .unwrap();
+        }
+
+        // Non-recursive: only direct children of /a
+        let req = make_request(
+            "GetParametersByPath",
+            json!({"Path": "/a", "Recursive": false}),
+        );
+        let resp = svc.get_parameters_by_path(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameters"].as_array().unwrap().len(), 1); // only /a/e
+
+        // Recursive: all under /a
+        let req = make_request(
+            "GetParametersByPath",
+            json!({"Path": "/a", "Recursive": true}),
+        );
+        let resp = svc.get_parameters_by_path(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameters"].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn label_unlabel_and_get_by_label() {
+        let svc = make_service();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/labeled", "Value": "v1", "Type": "String"}),
+        ))
+        .unwrap();
+
+        // Label version 1
+        let req = make_request(
+            "LabelParameterVersion",
+            json!({"Name": "/labeled", "Labels": ["prod"], "ParameterVersion": 1}),
+        );
+        svc.label_parameter_version(&req).unwrap();
+
+        // Get by label
+        let req = make_request("GetParameter", json!({"Name": "/labeled:prod"}));
+        let resp = svc.get_parameter(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameter"]["Value"], "v1");
+
+        // Unlabel
+        let req = make_request(
+            "UnlabelParameterVersion",
+            json!({"Name": "/labeled", "Labels": ["prod"], "ParameterVersion": 1}),
+        );
+        svc.unlabel_parameter_version(&req).unwrap();
+    }
+
+    #[test]
+    fn get_parameter_by_version() {
+        let svc = make_service();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/ver-param", "Value": "v1", "Type": "String"}),
+        ))
+        .unwrap();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/ver-param", "Value": "v2", "Type": "String", "Overwrite": true}),
+        ))
+        .unwrap();
+
+        // Get version 1
+        let req = make_request("GetParameter", json!({"Name": "/ver-param:1"}));
+        let resp = svc.get_parameter(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameter"]["Value"], "v1");
+
+        // Get latest (version 2)
+        let req = make_request("GetParameter", json!({"Name": "/ver-param"}));
+        let resp = svc.get_parameter(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameter"]["Value"], "v2");
+    }
+
+    #[test]
+    fn get_parameter_history_with_versions() {
+        let svc = make_service();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/hist", "Value": "v1", "Type": "String"}),
+        ))
+        .unwrap();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/hist", "Value": "v2", "Type": "String", "Overwrite": true}),
+        ))
+        .unwrap();
+
+        let req = make_request("GetParameterHistory", json!({"Name": "/hist"}));
+        let resp = svc.get_parameter_history(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let history = body["Parameters"].as_array().unwrap();
+        assert_eq!(history.len(), 2);
+    }
+
+    #[test]
+    fn put_parameter_secure_string() {
+        let svc = make_service();
+        let req = make_request(
+            "PutParameter",
+            json!({"Name": "/secure", "Value": "secret", "Type": "SecureString"}),
+        );
+        svc.put_parameter(&req).unwrap();
+
+        let req = make_request(
+            "GetParameter",
+            json!({"Name": "/secure", "WithDecryption": true}),
+        );
+        let resp = svc.get_parameter(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameter"]["Type"], "SecureString");
+    }
+
+    #[test]
+    fn put_parameter_string_list() {
+        let svc = make_service();
+        let req = make_request(
+            "PutParameter",
+            json!({"Name": "/list", "Value": "a,b,c", "Type": "StringList"}),
+        );
+        svc.put_parameter(&req).unwrap();
+
+        let req = make_request("GetParameter", json!({"Name": "/list"}));
+        let resp = svc.get_parameter(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameter"]["Value"], "a,b,c");
+    }
+
+    #[test]
+    fn get_parameters_mixed_found_and_missing() {
+        let svc = make_service();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/exists", "Value": "v", "Type": "String"}),
+        ))
+        .unwrap();
+
+        let req = make_request("GetParameters", json!({"Names": ["/exists", "/missing"]}));
+        let resp = svc.get_parameters(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameters"].as_array().unwrap().len(), 1);
+        assert_eq!(body["InvalidParameters"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn delete_parameters_mixed() {
+        let svc = make_service();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/del-mix", "Value": "v", "Type": "String"}),
+        ))
+        .unwrap();
+
+        let req = make_request("DeleteParameters", json!({"Names": ["/del-mix", "/ghost"]}));
+        let resp = svc.delete_parameters(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["DeletedParameters"].as_array().unwrap().len(), 1);
+        assert_eq!(body["InvalidParameters"].as_array().unwrap().len(), 1);
+    }
 }


### PR DESCRIPTION
## Summary
- Cognito (+8 tests): device CRUD lifecycle via access tokens, revoke/refresh tokens, CSV header, import jobs, domain update, device error branches
- SSM (+10 tests): describe parameters with filters, get_parameters_by_path recursive, version selectors, labels, parameter history, SecureString/StringList types, mixed found/missing batch operations

## Test plan
- [x] `cargo test -p fakecloud-cognito` — 149 tests pass
- [x] `cargo test -p fakecloud-ssm` — 119 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 18 tests to `fakecloud-cognito` and `fakecloud-ssm` to deepen coverage of misc handlers and edge cases. Improves confidence in device flows, token paths, and SSM parameter operations without runtime changes.

- **Coverage**
  - `fakecloud-cognito` (+8): device confirm/list/get/update/forget via access tokens, invalid token branches, revoke token and invalid refresh flow, CSV header, start/stop import job, update user pool domain, admin update device status.
  - `fakecloud-ssm` (+10): DescribeParameters with filters, GetParametersByPath (recursive vs non-recursive), label/unlabel and get by label, get by version selector, parameter history, SecureString and StringList types, mixed found/missing for GetParameters and DeleteParameters.

<sup>Written for commit a6ff7fb485fe7bf89e7fca653c471fc29ad59b76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

