### PR TITLE
docs(website): add PHP and Java to homepage SDK references

### DIFF
--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -43,7 +43,7 @@
       <div class="feature">
         <div class="label">SDKs</div>
         <h3>First-party test clients</h3>
-        <p>TypeScript, Python, Go, and Rust SDKs wrap the <code>/_fakecloud/*</code> endpoints for resets, assertions, and manual control of async processors after your app has already used the normal AWS APIs.</p>
+        <p>TypeScript, Python, Go, PHP, Java, and Rust SDKs wrap the <code>/_fakecloud/*</code> endpoints for resets, assertions, and manual control of async processors after your app has already used the normal AWS APIs.</p>
       </div>
       <div class="feature">
         <div class="label">Coverage</div>
@@ -143,7 +143,7 @@
           <tr><td>Idle memory</td><td class="check">~10 MiB</td><td class="cross">~150 MiB</td></tr>
           <tr><td>Install size</td><td class="check">~19 MB binary</td><td class="cross">~1 GB Docker image</td></tr>
           <tr><td>AWS services</td><td>22</td><td>30+</td></tr>
-          <tr><td>Test assertion SDKs</td><td class="check">TypeScript, Python, Go, Rust</td><td>Python, Java</td></tr>
+          <tr><td>Test assertion SDKs</td><td class="check">TypeScript, Python, Go, PHP, Java, Rust</td><td>Python, Java</td></tr>
           <tr><td>Cognito User Pools</td><td class="check">80 operations</td><td class="cross">Paid only</td></tr>
           <tr><td>SES v2</td><td class="check">97 operations</td><td class="cross">Paid only</td></tr>
           <tr><td>SES inbound email</td><td class="check">Real receipt rule actions</td><td class="cross">Stored but never executed</td></tr>


### PR DESCRIPTION
## Summary

- Homepage feature card listed only 4 SDK languages, now lists all 6
- Comparison table same fix

## Test plan

- [ ] Visual check on homepage after deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the homepage to list all six SDKs. Adds PHP and Java to the SDKs feature card and the comparison table so both show TypeScript, Python, Go, PHP, Java, and Rust.

<sup>Written for commit 6932e14cd20113aa938ec99b086ef17005927daa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

