### PR TITLE
docs: update Java SDK version from 0.1.0 to 0.9.2

### DIFF
--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.1.0")
+    testImplementation("dev.fakecloud:fakecloud:0.9.2")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.1.0</version>
+    <version>0.9.2</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/website/content/docs/getting-started/sdk-setup.md
+++ b/website/content/docs/getting-started/sdk-setup.md
@@ -81,7 +81,7 @@ $emails = $fc->ses()->getEmails()->emails;
 
 ```kotlin
 // build.gradle.kts
-testImplementation("dev.fakecloud:fakecloud:0.1.0")
+testImplementation("dev.fakecloud:fakecloud:0.9.2")
 ```
 
 ```java

--- a/website/content/docs/sdks/_index.md
+++ b/website/content/docs/sdks/_index.md
@@ -19,7 +19,7 @@ These SDKs are **not** the AWS SDK. Your application code still talks to fakeclo
 | Python     | `pip install fakecloud`                         | [Python SDK](/docs/sdks/python/) |
 | Go         | `go get github.com/faiscadev/fakecloud/sdks/go` | [Go SDK](/docs/sdks/go/) |
 | PHP        | `composer require fakecloud/fakecloud`          | [PHP SDK](/docs/sdks/php/) |
-| Java       | `dev.fakecloud:fakecloud:0.1.0`                 | [Java SDK](/docs/sdks/java/) |
+| Java       | `dev.fakecloud:fakecloud:0.9.2`                 | [Java SDK](/docs/sdks/java/) |
 | Rust       | `cargo add fakecloud-sdk`                       | [Rust SDK](/docs/sdks/rust/) |
 
 ## Common surface

--- a/website/content/docs/sdks/java.md
+++ b/website/content/docs/sdks/java.md
@@ -10,7 +10,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.1.0")
+    testImplementation("dev.fakecloud:fakecloud:0.9.2")
 }
 ```
 
@@ -20,7 +20,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.1.0</version>
+    <version>0.9.2</version>
     <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
## Summary

- Fix stale 0.1.0 version in 4 files (Java README, SDK setup, SDK index, Java SDK page)
- Actual version in build.gradle.kts is 0.9.2

## Test plan

- [x] `grep -r "0.1.0" sdks/java/ website/content/` returns no hits

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to reference Java SDK `dev.fakecloud:fakecloud:0.9.2` instead of `dev.fakecloud:fakecloud:0.1.0`, matching the current `build.gradle.kts`. Fixes stale version strings in the Java README, SDK setup guide, SDK index, and Java SDK page.

<sup>Written for commit 722b58f2a30da909498d0be9cf5bcb3d66e923ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

