### PR TITLE
test(s3,ssm,logs): bucket lifecycle, param filters, log stream edges

### DIFF
--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -1503,4 +1503,482 @@ mod tests {
         let results = body["results"].as_array().unwrap();
         assert_eq!(results.len(), 2, "Should only match ERROR JSON events");
     }
+
+    // ── create_log_stream validation ──
+
+    #[test]
+    fn create_log_stream_missing_group_errors() {
+        let svc = make_service();
+        let req = make_request("CreateLogStream", json!({"logStreamName": "s"}));
+        assert!(svc.create_log_stream(&req).is_err());
+    }
+
+    #[test]
+    fn create_log_stream_missing_stream_errors() {
+        let svc = make_service();
+        create_group(&svc, "g1");
+        let req = make_request("CreateLogStream", json!({"logGroupName": "g1"}));
+        assert!(svc.create_log_stream(&req).is_err());
+    }
+
+    #[test]
+    fn create_log_stream_nonexistent_group_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateLogStream",
+            json!({"logGroupName": "missing", "logStreamName": "s"}),
+        );
+        assert!(svc.create_log_stream(&req).is_err());
+    }
+
+    #[test]
+    fn create_log_stream_duplicate_errors() {
+        let svc = make_service();
+        create_group(&svc, "dup");
+        create_stream(&svc, "dup", "s");
+        let req = make_request(
+            "CreateLogStream",
+            json!({"logGroupName": "dup", "logStreamName": "s"}),
+        );
+        assert!(svc.create_log_stream(&req).is_err());
+    }
+
+    // ── delete_log_stream validation ──
+
+    #[test]
+    fn delete_log_stream_missing_group_errors() {
+        let svc = make_service();
+        let req = make_request("DeleteLogStream", json!({"logStreamName": "s"}));
+        assert!(svc.delete_log_stream(&req).is_err());
+    }
+
+    #[test]
+    fn delete_log_stream_missing_stream_errors() {
+        let svc = make_service();
+        let req = make_request("DeleteLogStream", json!({"logGroupName": "g"}));
+        assert!(svc.delete_log_stream(&req).is_err());
+    }
+
+    #[test]
+    fn delete_log_stream_nonexistent_group() {
+        let svc = make_service();
+        let req = make_request(
+            "DeleteLogStream",
+            json!({"logGroupName": "missing", "logStreamName": "s"}),
+        );
+        assert!(svc.delete_log_stream(&req).is_err());
+    }
+
+    #[test]
+    fn delete_log_stream_nonexistent_stream() {
+        let svc = make_service();
+        create_group(&svc, "g2");
+        let req = make_request(
+            "DeleteLogStream",
+            json!({"logGroupName": "g2", "logStreamName": "missing"}),
+        );
+        assert!(svc.delete_log_stream(&req).is_err());
+    }
+
+    #[test]
+    fn delete_log_stream_succeeds() {
+        let svc = make_service();
+        create_group(&svc, "gd");
+        create_stream(&svc, "gd", "s");
+        let req = make_request(
+            "DeleteLogStream",
+            json!({"logGroupName": "gd", "logStreamName": "s"}),
+        );
+        svc.delete_log_stream(&req).unwrap();
+    }
+
+    // ── describe_log_streams ──
+
+    #[test]
+    fn describe_log_streams_missing_group_errors() {
+        let svc = make_service();
+        let req = make_request("DescribeLogStreams", json!({}));
+        assert!(svc.describe_log_streams(&req).is_err());
+    }
+
+    #[test]
+    fn describe_log_streams_identifier_ending_in_colon_star_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeLogStreams",
+            json!({"logGroupIdentifier": "arn:aws:logs:us-east-1:123456789012:log-group:x:*"}),
+        );
+        assert!(svc.describe_log_streams(&req).is_err());
+    }
+
+    #[test]
+    fn describe_log_streams_identifier_as_arn() {
+        let svc = make_service();
+        create_group(&svc, "ident");
+        create_stream(&svc, "ident", "s1");
+        let req = make_request(
+            "DescribeLogStreams",
+            json!({"logGroupIdentifier": "arn:aws:logs:us-east-1:123456789012:log-group:ident"}),
+        );
+        let resp = svc.describe_log_streams(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["logStreams"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn describe_log_streams_limit_over_50_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeLogStreams",
+            json!({"logGroupName": "g", "limit": 100}),
+        );
+        assert!(svc.describe_log_streams(&req).is_err());
+    }
+
+    #[test]
+    fn describe_log_streams_invalid_order_by_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeLogStreams",
+            json!({"logGroupName": "g", "orderBy": "Bogus"}),
+        );
+        assert!(svc.describe_log_streams(&req).is_err());
+    }
+
+    #[test]
+    fn describe_log_streams_last_event_time_with_prefix_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeLogStreams",
+            json!({
+                "logGroupName": "g",
+                "orderBy": "LastEventTime",
+                "logStreamNamePrefix": "abc"
+            }),
+        );
+        assert!(svc.describe_log_streams(&req).is_err());
+    }
+
+    #[test]
+    fn describe_log_streams_missing_group_resource_error() {
+        let svc = make_service();
+        let req = make_request("DescribeLogStreams", json!({"logGroupName": "missing"}));
+        assert!(svc.describe_log_streams(&req).is_err());
+    }
+
+    #[test]
+    fn describe_log_streams_with_prefix_filter() {
+        let svc = make_service();
+        create_group(&svc, "pref");
+        create_stream(&svc, "pref", "web-1");
+        create_stream(&svc, "pref", "api-1");
+        let req = make_request(
+            "DescribeLogStreams",
+            json!({"logGroupName": "pref", "logStreamNamePrefix": "web"}),
+        );
+        let resp = svc.describe_log_streams(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["logStreams"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn describe_log_streams_pagination() {
+        let svc = make_service();
+        create_group(&svc, "pg");
+        for i in 0..5 {
+            create_stream(&svc, "pg", &format!("s{i}"));
+        }
+        let req = make_request(
+            "DescribeLogStreams",
+            json!({"logGroupName": "pg", "limit": 2}),
+        );
+        let resp = svc.describe_log_streams(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["logStreams"].as_array().unwrap().len(), 2);
+        assert!(body["nextToken"].is_string());
+
+        let token = body["nextToken"].as_str().unwrap().to_string();
+        let req = make_request(
+            "DescribeLogStreams",
+            json!({"logGroupName": "pg", "limit": 2, "nextToken": token}),
+        );
+        let resp = svc.describe_log_streams(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["logStreams"].as_array().unwrap().len(), 2);
+    }
+
+    // ── put_log_events ──
+
+    #[test]
+    fn put_log_events_missing_group() {
+        let svc = make_service();
+        let req = make_request("PutLogEvents", json!({"logStreamName": "s"}));
+        assert!(svc.put_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn put_log_events_missing_stream() {
+        let svc = make_service();
+        let req = make_request("PutLogEvents", json!({"logGroupName": "g"}));
+        assert!(svc.put_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn put_log_events_missing_events() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        create_stream(&svc, "g", "s");
+        let req = make_request(
+            "PutLogEvents",
+            json!({"logGroupName": "g", "logStreamName": "s"}),
+        );
+        assert!(svc.put_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn put_log_events_non_chronological_errors() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        create_stream(&svc, "g", "s");
+        let now = chrono::Utc::now().timestamp_millis();
+        let req = make_request(
+            "PutLogEvents",
+            json!({
+                "logGroupName": "g",
+                "logStreamName": "s",
+                "logEvents": [
+                    {"timestamp": now, "message": "b"},
+                    {"timestamp": now - 1000, "message": "a"}
+                ]
+            }),
+        );
+        assert!(svc.put_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn put_log_events_too_old_rejected() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        create_stream(&svc, "g", "s");
+        let now = chrono::Utc::now().timestamp_millis();
+        let old = now - 20 * 24 * 60 * 60 * 1000;
+        let req = make_request(
+            "PutLogEvents",
+            json!({
+                "logGroupName": "g",
+                "logStreamName": "s",
+                "logEvents": [
+                    {"timestamp": old, "message": "old"},
+                    {"timestamp": now, "message": "new"}
+                ]
+            }),
+        );
+        let resp = svc.put_log_events(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["rejectedLogEventsInfo"].is_object());
+    }
+
+    #[test]
+    fn put_log_events_too_new_rejected() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        create_stream(&svc, "g", "s");
+        let now = chrono::Utc::now().timestamp_millis();
+        let future = now + 10 * 60 * 60 * 1000;
+        let req = make_request(
+            "PutLogEvents",
+            json!({
+                "logGroupName": "g",
+                "logStreamName": "s",
+                "logEvents": [
+                    {"timestamp": now, "message": "now"},
+                    {"timestamp": future, "message": "future"}
+                ]
+            }),
+        );
+        let resp = svc.put_log_events(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["rejectedLogEventsInfo"].is_object());
+    }
+
+    #[test]
+    fn put_log_events_nonexistent_group_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "PutLogEvents",
+            json!({
+                "logGroupName": "missing",
+                "logStreamName": "s",
+                "logEvents": [{"timestamp": 1000, "message": "x"}]
+            }),
+        );
+        assert!(svc.put_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn put_log_events_nonexistent_stream_errors() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        let req = make_request(
+            "PutLogEvents",
+            json!({
+                "logGroupName": "g",
+                "logStreamName": "missing",
+                "logEvents": [{"timestamp": 1000, "message": "x"}]
+            }),
+        );
+        assert!(svc.put_log_events(&req).is_err());
+    }
+
+    // ── get_log_events ──
+
+    #[test]
+    fn get_log_events_basic_returns_events() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        create_stream(&svc, "g", "s");
+        put_events(&svc, "g", "s", &["a", "b", "c"]);
+
+        let req = make_request(
+            "GetLogEvents",
+            json!({"logGroupName": "g", "logStreamName": "s"}),
+        );
+        let resp = svc.get_log_events(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["events"].as_array().unwrap().len(), 3);
+        assert!(body["nextForwardToken"].is_string());
+        assert!(body["nextBackwardToken"].is_string());
+    }
+
+    #[test]
+    fn get_log_events_start_from_head() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        create_stream(&svc, "g", "s");
+        put_events(&svc, "g", "s", &["a", "b", "c"]);
+
+        let req = make_request(
+            "GetLogEvents",
+            json!({
+                "logGroupName": "g",
+                "logStreamName": "s",
+                "startFromHead": true,
+                "limit": 2
+            }),
+        );
+        let resp = svc.get_log_events(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["events"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn get_log_events_missing_group_errors() {
+        let svc = make_service();
+        let req = make_request("GetLogEvents", json!({"logStreamName": "s"}));
+        assert!(svc.get_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn get_log_events_missing_stream_errors() {
+        let svc = make_service();
+        let req = make_request("GetLogEvents", json!({"logGroupName": "g"}));
+        assert!(svc.get_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn get_log_events_limit_over_10000() {
+        let svc = make_service();
+        let req = make_request(
+            "GetLogEvents",
+            json!({"logGroupName": "g", "logStreamName": "s", "limit": 20000}),
+        );
+        assert!(svc.get_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn get_log_events_invalid_next_token_format() {
+        let svc = make_service();
+        let req = make_request(
+            "GetLogEvents",
+            json!({
+                "logGroupName": "g",
+                "logStreamName": "s",
+                "nextToken": "bogus"
+            }),
+        );
+        assert!(svc.get_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn get_log_events_identifier_colon_star_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "GetLogEvents",
+            json!({
+                "logGroupIdentifier": "arn:aws:logs:us-east-1:123456789012:log-group:g:*",
+                "logStreamName": "s"
+            }),
+        );
+        assert!(svc.get_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn get_log_events_identifier_as_arn_resolves() {
+        let svc = make_service();
+        create_group(&svc, "ga");
+        create_stream(&svc, "ga", "s");
+        put_events(&svc, "ga", "s", &["x"]);
+        let req = make_request(
+            "GetLogEvents",
+            json!({
+                "logGroupIdentifier": "arn:aws:logs:us-east-1:123456789012:log-group:ga",
+                "logStreamName": "s"
+            }),
+        );
+        let resp = svc.get_log_events(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["events"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn get_log_events_time_range_filters() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        create_stream(&svc, "g", "s");
+        put_events(&svc, "g", "s", &["a", "b", "c"]);
+
+        let req = make_request(
+            "GetLogEvents",
+            json!({
+                "logGroupName": "g",
+                "logStreamName": "s",
+                "startTime": 0,
+                "endTime": i64::MAX
+            }),
+        );
+        let resp = svc.get_log_events(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["events"].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn get_log_events_missing_group_resource_error() {
+        let svc = make_service();
+        let req = make_request(
+            "GetLogEvents",
+            json!({"logGroupName": "missing", "logStreamName": "s"}),
+        );
+        assert!(svc.get_log_events(&req).is_err());
+    }
+
+    #[test]
+    fn get_log_events_missing_stream_resource_error() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        let req = make_request(
+            "GetLogEvents",
+            json!({"logGroupName": "g", "logStreamName": "missing"}),
+        );
+        assert!(svc.get_log_events(&req).is_err());
+    }
 }

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -4843,4 +4843,290 @@ mod tests {
         assert!(body.contains("<IsTruncated>true</IsTruncated>"));
         assert!(body.contains("<MaxKeys>2</MaxKeys>"));
     }
+
+    // ── buckets.rs coverage (list/create/delete/head/location) ──
+
+    #[test]
+    fn list_buckets_empty_account() {
+        let svc = make_service();
+        let req = make_request(Method::GET, "/", &[], b"");
+        let resp = svc.list_buckets("123456789012", &req).unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body.contains("<ListAllMyBucketsResult"));
+        assert!(body.contains("<Owner><ID>123456789012</ID>"));
+        assert!(body.contains("<Buckets></Buckets>"));
+    }
+
+    #[test]
+    fn list_buckets_sorted_by_name() {
+        let svc = make_service();
+        seed_bucket(&svc, "zeta");
+        seed_bucket(&svc, "alpha");
+        seed_bucket(&svc, "middle");
+
+        let req = make_request(Method::GET, "/", &[], b"");
+        let resp = svc.list_buckets("123456789012", &req).unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        let a = body.find("alpha").unwrap();
+        let m = body.find("middle").unwrap();
+        let z = body.find("zeta").unwrap();
+        assert!(a < m && m < z, "buckets must be sorted");
+    }
+
+    #[test]
+    fn create_bucket_invalid_name_errors() {
+        let svc = make_service();
+        let req = make_request(Method::PUT, "/AB", &[], b"");
+        assert_aws_err(
+            svc.create_bucket("123456789012", &req, "AB"),
+            "InvalidBucketName",
+        );
+    }
+
+    #[test]
+    fn create_bucket_idempotent_same_region_us_east_1() {
+        let svc = make_service();
+        let req = make_request(Method::PUT, "/idem", &[], b"");
+        svc.create_bucket("123456789012", &req, "idem").unwrap();
+        let resp = svc.create_bucket("123456789012", &req, "idem").unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[test]
+    fn create_bucket_already_owned_other_region() {
+        let svc = make_service();
+        let mut req = make_request(
+            Method::PUT,
+            "/bk1",
+            &[],
+            b"<CreateBucketConfiguration><LocationConstraint>eu-west-1</LocationConstraint></CreateBucketConfiguration>",
+        );
+        req.region = "eu-west-1".to_string();
+        svc.create_bucket("123456789012", &req, "bk1").unwrap();
+        assert_aws_err(
+            svc.create_bucket("123456789012", &req, "bk1"),
+            "BucketAlreadyOwnedByYou",
+        );
+    }
+
+    #[test]
+    fn create_bucket_us_east_1_with_explicit_constraint_invalid() {
+        let svc = make_service();
+        let req = make_request(
+            Method::PUT,
+            "/bk2",
+            &[],
+            b"<CreateBucketConfiguration><LocationConstraint>us-east-1</LocationConstraint></CreateBucketConfiguration>",
+        );
+        assert_aws_err(
+            svc.create_bucket("123456789012", &req, "bk2"),
+            "InvalidLocationConstraint",
+        );
+    }
+
+    #[test]
+    fn create_bucket_constraint_mismatch_region_errors() {
+        let svc = make_service();
+        let mut req = make_request(
+            Method::PUT,
+            "/bk3",
+            &[],
+            b"<CreateBucketConfiguration><LocationConstraint>us-west-2</LocationConstraint></CreateBucketConfiguration>",
+        );
+        req.region = "eu-west-1".to_string();
+        assert_aws_err(
+            svc.create_bucket("123456789012", &req, "bk3"),
+            "IllegalLocationConstraintException",
+        );
+    }
+
+    #[test]
+    fn create_bucket_missing_constraint_in_non_default_region_errors() {
+        let svc = make_service();
+        let mut req = make_request(Method::PUT, "/bk4", &[], b"");
+        req.region = "eu-west-1".to_string();
+        assert_aws_err(
+            svc.create_bucket("123456789012", &req, "bk4"),
+            "IllegalLocationConstraintException",
+        );
+    }
+
+    #[test]
+    fn create_bucket_invalid_region_constraint() {
+        let svc = make_service();
+        let req = make_request(
+            Method::PUT,
+            "/bk5",
+            &[],
+            b"<CreateBucketConfiguration><LocationConstraint>not-a-region</LocationConstraint></CreateBucketConfiguration>",
+        );
+        assert_aws_err(
+            svc.create_bucket("123456789012", &req, "bk5"),
+            "InvalidLocationConstraint",
+        );
+    }
+
+    #[test]
+    fn create_bucket_with_us_east_1_constraint_when_region_not_matching() {
+        let svc = make_service();
+        let mut req = make_request(
+            Method::PUT,
+            "/bk6",
+            &[],
+            b"<CreateBucketConfiguration><LocationConstraint>us-east-1</LocationConstraint></CreateBucketConfiguration>",
+        );
+        req.region = "eu-west-1".to_string();
+        assert_aws_err(
+            svc.create_bucket("123456789012", &req, "bk6"),
+            "IllegalLocationConstraintException",
+        );
+    }
+
+    #[test]
+    fn create_bucket_with_object_lock_enables_versioning() {
+        let svc = make_service();
+        let mut req = make_request(Method::PUT, "/olb", &[], b"");
+        req.headers
+            .insert("x-amz-bucket-object-lock-enabled", "true".parse().unwrap());
+        svc.create_bucket("123456789012", &req, "olb").unwrap();
+        let accts = svc.state.read();
+        let state = accts.get("123456789012").unwrap();
+        let b = state.buckets.get("olb").unwrap();
+        assert_eq!(b.versioning.as_deref(), Some("Enabled"));
+        assert!(b
+            .object_lock_config
+            .as_deref()
+            .unwrap_or("")
+            .contains("ObjectLockEnabled"));
+    }
+
+    #[test]
+    fn create_bucket_with_object_ownership_header() {
+        let svc = make_service();
+        let mut req = make_request(Method::PUT, "/own", &[], b"");
+        req.headers.insert(
+            "x-amz-object-ownership",
+            "BucketOwnerEnforced".parse().unwrap(),
+        );
+        svc.create_bucket("123456789012", &req, "own").unwrap();
+        let accts = svc.state.read();
+        let state = accts.get("123456789012").unwrap();
+        let b = state.buckets.get("own").unwrap();
+        assert!(b
+            .ownership_controls
+            .as_deref()
+            .unwrap_or("")
+            .contains("BucketOwnerEnforced"));
+    }
+
+    #[test]
+    fn create_bucket_with_canned_acl_public_read() {
+        let svc = make_service();
+        let mut req = make_request(Method::PUT, "/prb", &[], b"");
+        req.headers
+            .insert("x-amz-acl", "public-read".parse().unwrap());
+        svc.create_bucket("123456789012", &req, "prb").unwrap();
+        let accts = svc.state.read();
+        let state = accts.get("123456789012").unwrap();
+        let b = state.buckets.get("prb").unwrap();
+        assert!(!b.acl_grants.is_empty());
+    }
+
+    #[test]
+    fn delete_bucket_nonexistent_errors() {
+        let svc = make_service();
+        let req = make_request(Method::DELETE, "/nope", &[], b"");
+        assert_aws_err(
+            svc.delete_bucket("123456789012", &req, "nope"),
+            "NoSuchBucket",
+        );
+    }
+
+    #[test]
+    fn delete_bucket_not_empty_errors() {
+        let svc = make_service();
+        seed_bucket(&svc, "full");
+        seed_object(&svc, "full", "k", b"x");
+        let req = make_request(Method::DELETE, "/full", &[], b"");
+        assert_aws_err(
+            svc.delete_bucket("123456789012", &req, "full"),
+            "BucketNotEmpty",
+        );
+    }
+
+    #[test]
+    fn delete_bucket_with_versions_not_empty_errors() {
+        let svc = make_service();
+        seed_bucket(&svc, "ver");
+        {
+            let mut mas = svc.state.write();
+            let state = mas.default_mut();
+            let b = state.buckets.get_mut("ver").unwrap();
+            b.object_versions.insert(
+                "k".to_string(),
+                vec![S3Object {
+                    key: "k".to_string(),
+                    body: fakecloud_persistence::BodyRef::Memory(Bytes::from_static(b"v")),
+                    content_type: "text/plain".to_string(),
+                    etag: "\"abc\"".to_string(),
+                    size: 1,
+                    last_modified: chrono::Utc::now(),
+                    ..Default::default()
+                }],
+            );
+        }
+        let req = make_request(Method::DELETE, "/ver", &[], b"");
+        assert_aws_err(
+            svc.delete_bucket("123456789012", &req, "ver"),
+            "BucketNotEmpty",
+        );
+    }
+
+    #[test]
+    fn delete_bucket_empty_succeeds() {
+        let svc = make_service();
+        seed_bucket(&svc, "empty");
+        let req = make_request(Method::DELETE, "/empty", &[], b"");
+        let resp = svc.delete_bucket("123456789012", &req, "empty").unwrap();
+        assert_eq!(resp.status, StatusCode::NO_CONTENT);
+    }
+
+    #[test]
+    fn head_bucket_missing_errors() {
+        let svc = make_service();
+        assert_aws_err(svc.head_bucket("123456789012", "nope"), "NoSuchBucket");
+    }
+
+    #[test]
+    fn head_bucket_exists_returns_ok() {
+        let svc = make_service();
+        seed_bucket(&svc, "hb");
+        let resp = svc.head_bucket("123456789012", "hb").unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[test]
+    fn get_bucket_location_us_east_1_returns_empty() {
+        let svc = make_service();
+        seed_bucket(&svc, "loc");
+        let resp = svc.get_bucket_location("123456789012", "loc").unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body.contains("<LocationConstraint"));
+        assert!(body.contains("></LocationConstraint>"));
+    }
+
+    #[test]
+    fn get_bucket_location_other_region_returns_region() {
+        let svc = make_service();
+        {
+            let mut mas = svc.state.write();
+            let state = mas.default_mut();
+            state
+                .buckets
+                .insert("eu".to_string(), S3Bucket::new("eu", "eu-west-1", "owner"));
+        }
+        let resp = svc.get_bucket_location("123456789012", "eu").unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body.contains(">eu-west-1<"));
+    }
 }

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -3444,4 +3444,264 @@ mod tests {
         assert_eq!(body["DeletedParameters"].as_array().unwrap().len(), 1);
         assert_eq!(body["InvalidParameters"].as_array().unwrap().len(), 1);
     }
+
+    // ── parameters.rs filter validation coverage ──
+
+    #[test]
+    fn describe_parameters_invalid_filter_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeParameters",
+            json!({
+                "ParameterFilters": [{"Key": "Bogus", "Values": ["x"]}]
+            }),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_label_filter_rejected() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeParameters",
+            json!({
+                "ParameterFilters": [{"Key": "Label", "Values": ["v1"]}]
+            }),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_missing_values_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeParameters",
+            json!({"ParameterFilters": [{"Key": "Name"}]}),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_duplicate_filter_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeParameters",
+            json!({
+                "ParameterFilters": [
+                    {"Key": "Name", "Values": ["a"]},
+                    {"Key": "Name", "Values": ["b"]}
+                ]
+            }),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_path_invalid_option_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeParameters",
+            json!({
+                "ParameterFilters": [
+                    {"Key": "Path", "Option": "Equals", "Values": ["/foo"]}
+                ]
+            }),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_path_aws_prefix_rejected() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeParameters",
+            json!({
+                "ParameterFilters": [
+                    {"Key": "Path", "Values": ["/aws/secret"]}
+                ]
+            }),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_tier_invalid_value_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeParameters",
+            json!({"ParameterFilters": [{"Key": "Tier", "Values": ["Bogus"]}]}),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_type_invalid_value_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeParameters",
+            json!({"ParameterFilters": [{"Key": "Type", "Values": ["Bogus"]}]}),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_name_invalid_option_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeParameters",
+            json!({
+                "ParameterFilters": [
+                    {"Key": "Name", "Option": "EndsWith", "Values": ["x"]}
+                ]
+            }),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_key_length_exceeds() {
+        let svc = make_service();
+        let long_key = "k".repeat(140);
+        let req = make_request(
+            "DescribeParameters",
+            json!({
+                "ParameterFilters": [
+                    {"Key": long_key, "Values": ["v"]}
+                ]
+            }),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_option_length_exceeds() {
+        let svc = make_service();
+        let long_opt = "x".repeat(20);
+        let req = make_request(
+            "DescribeParameters",
+            json!({
+                "ParameterFilters": [
+                    {"Key": "Name", "Option": long_opt, "Values": ["v"]}
+                ]
+            }),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn describe_parameters_value_length_exceeds() {
+        let svc = make_service();
+        let long_val = "v".repeat(1100);
+        let req = make_request(
+            "DescribeParameters",
+            json!({
+                "ParameterFilters": [
+                    {"Key": "Name", "Values": [long_val]}
+                ]
+            }),
+        );
+        expect_err_code(svc.describe_parameters(&req), "ValidationException");
+    }
+
+    #[test]
+    fn get_parameters_by_path_filters_disallow_name() {
+        let svc = make_service();
+        let req = make_request(
+            "GetParametersByPath",
+            json!({
+                "Path": "/",
+                "ParameterFilters": [
+                    {"Key": "Name", "Values": ["x"]}
+                ]
+            }),
+        );
+        expect_err_code(svc.get_parameters_by_path(&req), "ValidationException");
+    }
+
+    #[test]
+    fn get_parameters_by_path_missing_path_errors() {
+        let svc = make_service();
+        let req = make_request("GetParametersByPath", json!({}));
+        expect_err_code(svc.get_parameters_by_path(&req), "ValidationException");
+    }
+
+    #[test]
+    fn put_parameter_securestring_encrypted_roundtrip() {
+        let svc = make_service();
+        let req = make_request(
+            "PutParameter",
+            json!({
+                "Name": "/sec",
+                "Value": "secret-value",
+                "Type": "SecureString"
+            }),
+        );
+        svc.put_parameter(&req).unwrap();
+
+        let req = make_request(
+            "GetParameter",
+            json!({"Name": "/sec", "WithDecryption": true}),
+        );
+        let resp = svc.get_parameter(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameter"]["Value"], "secret-value");
+    }
+
+    #[test]
+    fn put_parameter_stringlist_with_commas() {
+        let svc = make_service();
+        let req = make_request(
+            "PutParameter",
+            json!({"Name": "/list", "Value": "a,b,c", "Type": "StringList"}),
+        );
+        svc.put_parameter(&req).unwrap();
+    }
+
+    #[test]
+    fn get_parameter_by_arn_resolves() {
+        let svc = make_service();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/byarn", "Value": "v", "Type": "String"}),
+        ))
+        .unwrap();
+
+        let arn = "arn:aws:ssm:us-east-1:123456789012:parameter/byarn";
+        let req = make_request("GetParameter", json!({"Name": arn}));
+        let resp = svc.get_parameter(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameter"]["Name"], "/byarn");
+    }
+
+    #[test]
+    fn get_parameter_with_version_selector() {
+        let svc = make_service();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/verp", "Value": "v1", "Type": "String"}),
+        ))
+        .unwrap();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/verp", "Value": "v2", "Type": "String", "Overwrite": true}),
+        ))
+        .unwrap();
+
+        let req = make_request("GetParameter", json!({"Name": "/verp:1"}));
+        let resp = svc.get_parameter(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Parameter"]["Value"], "v1");
+    }
+
+    #[test]
+    fn get_parameter_nonexistent_version_errors() {
+        let svc = make_service();
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/gpnv", "Value": "v", "Type": "String"}),
+        ))
+        .unwrap();
+        let req = make_request("GetParameter", json!({"Name": "/gpnv:99"}));
+        expect_err_code(svc.get_parameter(&req), "ParameterVersionNotFound");
+    }
 }


### PR DESCRIPTION
## Summary
- S3 buckets.rs: list/create/delete/head/get-location covered incl. region constraint validation, object-lock, ownership, ACL, idempotent recreate, BucketNotEmpty (versions + objects)
- SSM parameter filter validation: invalid keys, Label rejection, duplicates, Path/Tier/Type/Name options, key/option/value length limits, ARN resolution, version selector, SecureString roundtrip
- Logs streams: create/delete/describe/put/get-log-events edge cases incl. identifier-as-ARN, `:*` validation, chronological ordering, too-old/too-new rejection, pagination, invalid nextToken

## Test plan
- [x] cargo test -p fakecloud-s3 --lib
- [x] cargo test -p fakecloud-ssm --lib
- [x] cargo test -p fakecloud-logs --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand tests in `fakecloud-s3`, `fakecloud-ssm`, and `fakecloud-logs` to harden bucket lifecycle, parameter filtering, and log stream behaviors. Covers S3 region constraints, object lock, ownership, ACLs, idempotent create, and BucketNotEmpty; SSM filter keys/options/lengths, ARN and version selectors, and SecureString decryption; and Logs stream create/delete/describe and put/get events with ARN identifiers, :* validation, ordering, time-window rejects, pagination, and nextToken checks.

<sup>Written for commit 0b40f6168dba30c62a3b6e0def8871b1664755fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

