### PR TITLE
test(sns,sqs): publish paths, platform endpoints, queue validation

### DIFF
--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -5927,4 +5927,374 @@ mod tests {
         );
         svc.set_subscription_attributes(&req).unwrap();
     }
+
+    // ── publish error branches ──
+
+    #[test]
+    fn publish_missing_message_errors() {
+        let (svc, _) = make_sns();
+        svc.create_topic(&sns_request("CreateTopic", vec![("Name", "t")]))
+            .unwrap();
+        let req = sns_request(
+            "Publish",
+            vec![("TopicArn", "arn:aws:sns:us-east-1:123456789012:t")],
+        );
+        assert!(svc.publish(&req).is_err());
+    }
+
+    #[test]
+    fn publish_message_too_long_errors() {
+        let (svc, _) = make_sns();
+        svc.create_topic(&sns_request("CreateTopic", vec![("Name", "t")]))
+            .unwrap();
+        let big = "x".repeat(262145);
+        let req = sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:t"),
+                ("Message", &big),
+            ],
+        );
+        assert!(svc.publish(&req).is_err());
+    }
+
+    #[test]
+    fn publish_message_structure_invalid_json_errors() {
+        let (svc, _) = make_sns();
+        svc.create_topic(&sns_request("CreateTopic", vec![("Name", "t")]))
+            .unwrap();
+        let req = sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:t"),
+                ("Message", "not json"),
+                ("MessageStructure", "json"),
+            ],
+        );
+        assert!(svc.publish(&req).is_err());
+    }
+
+    #[test]
+    fn publish_message_structure_json_missing_default_errors() {
+        let (svc, _) = make_sns();
+        svc.create_topic(&sns_request("CreateTopic", vec![("Name", "t")]))
+            .unwrap();
+        let req = sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:t"),
+                ("Message", r#"{"email":"only"}"#),
+                ("MessageStructure", "json"),
+            ],
+        );
+        assert!(svc.publish(&req).is_err());
+    }
+
+    #[test]
+    fn publish_message_structure_json_uses_protocol_specific() {
+        let (svc, _) = make_sns();
+        let r = svc
+            .create_topic(&sns_request("CreateTopic", vec![("Name", "struc")]))
+            .unwrap();
+        let body = String::from_utf8(r.body.expect_bytes().to_vec()).unwrap();
+        let arn_start = body.find("<TopicArn>").unwrap() + 10;
+        let arn_end = body.find("</TopicArn>").unwrap();
+        let arn = body[arn_start..arn_end].to_string();
+
+        let req = sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", &arn),
+                ("Message", r#"{"default":"hi","sqs":"for sqs"}"#),
+                ("MessageStructure", "json"),
+            ],
+        );
+        svc.publish(&req).unwrap();
+    }
+
+    #[test]
+    fn publish_non_fifo_with_dedup_id_errors() {
+        let (svc, _) = make_sns();
+        svc.create_topic(&sns_request("CreateTopic", vec![("Name", "s")]))
+            .unwrap();
+        let req = sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:s"),
+                ("Message", "hi"),
+                ("MessageDeduplicationId", "d1"),
+            ],
+        );
+        assert!(svc.publish(&req).is_err());
+    }
+
+    #[test]
+    fn publish_fifo_without_dedup_errors() {
+        let (svc, _) = make_sns();
+        svc.create_topic(&sns_request(
+            "CreateTopic",
+            vec![
+                ("Name", "ff.fifo"),
+                ("Attributes.entry.1.key", "FifoTopic"),
+                ("Attributes.entry.1.value", "true"),
+            ],
+        ))
+        .unwrap();
+        let req = sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:ff.fifo"),
+                ("Message", "m"),
+                ("MessageGroupId", "g1"),
+            ],
+        );
+        assert!(svc.publish(&req).is_err());
+    }
+
+    #[test]
+    fn publish_fifo_with_content_based_dedup_works() {
+        let (svc, _) = make_sns();
+        svc.create_topic(&sns_request(
+            "CreateTopic",
+            vec![
+                ("Name", "cb.fifo"),
+                ("Attributes.entry.1.key", "FifoTopic"),
+                ("Attributes.entry.1.value", "true"),
+                ("Attributes.entry.2.key", "ContentBasedDeduplication"),
+                ("Attributes.entry.2.value", "true"),
+            ],
+        ))
+        .unwrap();
+        let req = sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", "arn:aws:sns:us-east-1:123456789012:cb.fifo"),
+                ("Message", "m"),
+                ("MessageGroupId", "g1"),
+            ],
+        );
+        svc.publish(&req).unwrap();
+    }
+
+    // ── platform endpoint publish/delete ──
+
+    #[test]
+    fn publish_to_unknown_platform_endpoint_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "Publish",
+            vec![
+                (
+                    "TargetArn",
+                    "arn:aws:sns:us-east-1:123456789012:endpoint/GCM/app/abc",
+                ),
+                ("Message", "hi"),
+            ],
+        );
+        assert!(svc.publish(&req).is_err());
+    }
+
+    #[test]
+    fn delete_endpoint_unknown_is_idempotent() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "DeleteEndpoint",
+            vec![(
+                "EndpointArn",
+                "arn:aws:sns:us-east-1:123456789012:endpoint/GCM/app/ghost",
+            )],
+        );
+        svc.delete_endpoint(&req).unwrap();
+    }
+
+    #[test]
+    fn delete_platform_application_unknown_is_ok() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "DeletePlatformApplication",
+            vec![(
+                "PlatformApplicationArn",
+                "arn:aws:sns:us-east-1:123456789012:app/GCM/ghost",
+            )],
+        );
+        svc.delete_platform_application(&req).unwrap();
+    }
+
+    #[test]
+    fn set_endpoint_attributes_unknown_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "SetEndpointAttributes",
+            vec![
+                (
+                    "EndpointArn",
+                    "arn:aws:sns:us-east-1:123456789012:endpoint/GCM/app/missing",
+                ),
+                ("Attributes.entry.1.key", "Enabled"),
+                ("Attributes.entry.1.value", "false"),
+            ],
+        );
+        assert!(svc.set_endpoint_attributes(&req).is_err());
+    }
+
+    // ── SMS attributes ──
+
+    #[test]
+    fn set_sms_attributes_stores_value() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "SetSMSAttributes",
+            vec![
+                ("attributes.entry.1.key", "DefaultSenderID"),
+                ("attributes.entry.1.value", "MyCorp"),
+            ],
+        );
+        svc.set_sms_attributes(&req).unwrap();
+        let req = sns_request("GetSMSAttributes", vec![]);
+        let resp = svc.get_sms_attributes(&req).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("MyCorp"));
+    }
+
+    #[test]
+    fn opt_in_phone_number_and_check() {
+        let (svc, _) = make_sns();
+        let _ = svc.check_if_phone_number_is_opted_out(&sns_request(
+            "CheckIfPhoneNumberIsOptedOut",
+            vec![("phoneNumber", "+15555555555")],
+        ));
+        let _ = svc.opt_in_phone_number(&sns_request(
+            "OptInPhoneNumber",
+            vec![("phoneNumber", "+15555555555")],
+        ));
+        svc.list_phone_numbers_opted_out(&sns_request("ListPhoneNumbersOptedOut", vec![]))
+            .unwrap();
+    }
+
+    // ── subscription attribute filter policy validation ──
+
+    #[test]
+    fn set_subscription_attributes_raw_message_delivery() {
+        let (svc, _) = make_sns();
+        let r = svc
+            .create_topic(&sns_request("CreateTopic", vec![("Name", "rmd")]))
+            .unwrap();
+        let body = String::from_utf8(r.body.expect_bytes().to_vec()).unwrap();
+        let arn_start = body.find("<TopicArn>").unwrap() + 10;
+        let arn_end = body.find("</TopicArn>").unwrap();
+        let arn = body[arn_start..arn_end].to_string();
+
+        let req = sns_request(
+            "Subscribe",
+            vec![
+                ("TopicArn", &arn),
+                ("Protocol", "sqs"),
+                ("Endpoint", "arn:aws:sqs:us-east-1:123456789012:q"),
+                ("ReturnSubscriptionArn", "true"),
+            ],
+        );
+        let r = svc.subscribe(&req).unwrap();
+        let body = String::from_utf8(r.body.expect_bytes().to_vec()).unwrap();
+        let sub_arn = body[body.find("<SubscriptionArn>").unwrap() + 17
+            ..body.find("</SubscriptionArn>").unwrap()]
+            .to_string();
+
+        let req = sns_request(
+            "SetSubscriptionAttributes",
+            vec![
+                ("SubscriptionArn", &sub_arn),
+                ("AttributeName", "RawMessageDelivery"),
+                ("AttributeValue", "true"),
+            ],
+        );
+        svc.set_subscription_attributes(&req).unwrap();
+    }
+
+    // ── list topics pagination ──
+
+    #[test]
+    fn list_topics_pagination_token() {
+        let (svc, _) = make_sns();
+        for i in 0..120 {
+            let name = format!("t{i}");
+            svc.create_topic(&sns_request("CreateTopic", vec![("Name", &name)]))
+                .unwrap();
+        }
+        let req = sns_request("ListTopics", vec![]);
+        let resp = svc.list_topics(&req).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("<NextToken>"));
+    }
+
+    // ── invalid topic name branches ──
+
+    #[test]
+    fn create_topic_empty_name_errors() {
+        let (svc, _) = make_sns();
+        assert!(svc
+            .create_topic(&sns_request("CreateTopic", vec![("Name", "")]))
+            .is_err());
+    }
+
+    #[test]
+    fn create_topic_too_long_name_errors() {
+        let (svc, _) = make_sns();
+        let name = "x".repeat(257);
+        assert!(svc
+            .create_topic(&sns_request("CreateTopic", vec![("Name", &name)]))
+            .is_err());
+    }
+
+    #[test]
+    fn create_topic_fifo_without_suffix_errors() {
+        let (svc, _) = make_sns();
+        assert!(svc
+            .create_topic(&sns_request(
+                "CreateTopic",
+                vec![
+                    ("Name", "plain"),
+                    ("Attributes.entry.1.key", "FifoTopic"),
+                    ("Attributes.entry.1.value", "true"),
+                ]
+            ))
+            .is_err());
+    }
+
+    #[test]
+    fn create_topic_non_fifo_with_fifo_suffix_errors() {
+        let (svc, _) = make_sns();
+        assert!(svc
+            .create_topic(&sns_request("CreateTopic", vec![("Name", "bad.fifo")]))
+            .is_err());
+    }
+
+    // ── subscribe protocol validation ──
+
+    #[test]
+    fn subscribe_missing_protocol_errors() {
+        let (svc, _) = make_sns();
+        svc.create_topic(&sns_request("CreateTopic", vec![("Name", "t")]))
+            .unwrap();
+        let req = sns_request(
+            "Subscribe",
+            vec![("TopicArn", "arn:aws:sns:us-east-1:123456789012:t")],
+        );
+        assert!(svc.subscribe(&req).is_err());
+    }
+
+    // ── get_topic_attributes wrong region ──
+
+    #[test]
+    fn get_topic_attributes_returns_policy() {
+        let (svc, _) = make_sns();
+        svc.create_topic(&sns_request("CreateTopic", vec![("Name", "pol")]))
+            .unwrap();
+        let req = sns_request(
+            "GetTopicAttributes",
+            vec![("TopicArn", "arn:aws:sns:us-east-1:123456789012:pol")],
+        );
+        let resp = svc.get_topic_attributes(&req).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("Policy"));
+    }
 }

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -4856,4 +4856,261 @@ mod tests {
         );
         svc.set_queue_attributes(&req).unwrap();
     }
+
+    // ── create queue validation branches ──
+
+    #[test]
+    fn create_queue_name_too_long() {
+        let svc = make_service();
+        let name = "x".repeat(81);
+        let req = make_request("CreateQueue", json!({"QueueName": name}));
+        expect_err(svc.create_queue(&req));
+    }
+
+    #[test]
+    fn create_queue_name_empty() {
+        let svc = make_service();
+        let req = make_request("CreateQueue", json!({"QueueName": ""}));
+        expect_err(svc.create_queue(&req));
+    }
+
+    #[test]
+    fn create_queue_invalid_chars() {
+        let svc = make_service();
+        let req = make_request("CreateQueue", json!({"QueueName": "bad name"}));
+        expect_err(svc.create_queue(&req));
+    }
+
+    #[test]
+    fn create_queue_fifo_without_suffix() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateQueue",
+            json!({
+                "QueueName": "plain",
+                "Attributes": {"FifoQueue": "true"}
+            }),
+        );
+        expect_err(svc.create_queue(&req));
+    }
+
+    #[test]
+    fn create_queue_invalid_max_message_size() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateQueue",
+            json!({
+                "QueueName": "mms",
+                "Attributes": {"MaximumMessageSize": "100"}
+            }),
+        );
+        expect_err(svc.create_queue(&req));
+    }
+
+    #[test]
+    fn create_queue_invalid_delay_seconds() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateQueue",
+            json!({
+                "QueueName": "ds",
+                "Attributes": {"DelaySeconds": "10000"}
+            }),
+        );
+        expect_err(svc.create_queue(&req));
+    }
+
+    // ── send_message error branches ──
+
+    #[test]
+    fn send_message_missing_queue_url() {
+        let svc = make_service();
+        let req = make_request("SendMessage", json!({"MessageBody": "hi"}));
+        expect_err(svc.send_message(&req));
+    }
+
+    #[test]
+    fn send_message_queue_not_found_detailed() {
+        let svc = make_service();
+        let req = make_request(
+            "SendMessage",
+            json!({
+                "QueueUrl": "http://localhost:4566/123456789012/ghost",
+                "MessageBody": "hi"
+            }),
+        );
+        expect_err(svc.send_message(&req));
+    }
+
+    #[test]
+    fn send_message_invalid_delay_seconds() {
+        let svc = make_service();
+        let req = make_request("CreateQueue", json!({"QueueName": "d"}));
+        let resp = svc.create_queue(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let url = body["QueueUrl"].as_str().unwrap().to_string();
+        let req = make_request(
+            "SendMessage",
+            json!({
+                "QueueUrl": url,
+                "MessageBody": "hi",
+                "DelaySeconds": 9999
+            }),
+        );
+        expect_err(svc.send_message(&req));
+    }
+
+    // ── change_message_visibility error branches ──
+
+    #[test]
+    fn change_message_visibility_over_max_errors() {
+        let svc = make_service();
+        let req = make_request("CreateQueue", json!({"QueueName": "cmv"}));
+        let resp = svc.create_queue(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let url = body["QueueUrl"].as_str().unwrap().to_string();
+        let req = make_request(
+            "ChangeMessageVisibility",
+            json!({
+                "QueueUrl": url,
+                "ReceiptHandle": "bogus",
+                "VisibilityTimeout": 99999
+            }),
+        );
+        expect_err(svc.change_message_visibility(&req));
+    }
+
+    // ── delete_message ──
+
+    #[test]
+    fn delete_message_missing_receipt_errors() {
+        let svc = make_service();
+        let req = make_request("CreateQueue", json!({"QueueName": "dm"}));
+        let resp = svc.create_queue(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let url = body["QueueUrl"].as_str().unwrap().to_string();
+        let req = make_request("DeleteMessage", json!({"QueueUrl": url}));
+        expect_err(svc.delete_message(&req));
+    }
+
+    // ── get_queue_attributes ──
+
+    #[test]
+    fn get_queue_attributes_filtered_by_names() {
+        let svc = make_service();
+        svc.create_queue(&make_request("CreateQueue", json!({"QueueName": "filt"})))
+            .unwrap();
+        let req = make_request(
+            "GetQueueAttributes",
+            json!({
+                "QueueUrl": "http://localhost:4566/123456789012/filt",
+                "AttributeNames": ["VisibilityTimeout"]
+            }),
+        );
+        let resp = svc.get_queue_attributes(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["Attributes"]["VisibilityTimeout"].is_string());
+        assert!(body["Attributes"]["MessageRetentionPeriod"].is_null());
+    }
+
+    // ── set_queue_attributes error branches ──
+
+    // ── list_queues pagination/prefix ──
+
+    #[test]
+    fn list_queues_by_prefix_pagination() {
+        let svc = make_service();
+        for i in 0..10 {
+            svc.create_queue(&make_request(
+                "CreateQueue",
+                json!({"QueueName": format!("pfx-{i}")}),
+            ))
+            .unwrap();
+        }
+        svc.create_queue(&make_request("CreateQueue", json!({"QueueName": "other"})))
+            .unwrap();
+        let req = make_request(
+            "ListQueues",
+            json!({"QueueNamePrefix": "pfx-", "MaxResults": 3}),
+        );
+        let resp = svc.list_queues(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["QueueUrls"].as_array().unwrap().len(), 3);
+        assert!(body["NextToken"].is_string());
+    }
+
+    // ── tag_queue errors ──
+
+    #[test]
+    fn tag_queue_missing_url_errors() {
+        let svc = make_service();
+        let req = make_request("TagQueue", json!({"Tags": {"env": "prod"}}));
+        expect_err(svc.tag_queue(&req));
+    }
+
+    // ── fifo queue specific errors ──
+
+    #[test]
+    fn send_to_fifo_without_dedup_id_and_no_content_dedup_errors() {
+        let svc = make_service();
+        svc.create_queue(&make_request(
+            "CreateQueue",
+            json!({
+                "QueueName": "nd.fifo",
+                "Attributes": {"FifoQueue": "true"}
+            }),
+        ))
+        .unwrap();
+        let req = make_request(
+            "SendMessage",
+            json!({
+                "QueueUrl": "http://localhost:4566/123456789012/nd.fifo",
+                "MessageBody": "m",
+                "MessageGroupId": "g1"
+            }),
+        );
+        expect_err(svc.send_message(&req));
+    }
+
+    // ── purge queue ──
+
+    #[test]
+    fn purge_queue_missing_url_errors() {
+        let svc = make_service();
+        let req = make_request("PurgeQueue", json!({}));
+        expect_err(svc.purge_queue(&req));
+    }
+
+    // ── delete_message_batch ──
+
+    #[test]
+    fn delete_message_batch_empty_errors() {
+        let svc = make_service();
+        svc.create_queue(&make_request("CreateQueue", json!({"QueueName": "dmb"})))
+            .unwrap();
+        let req = make_request(
+            "DeleteMessageBatch",
+            json!({
+                "QueueUrl": "http://localhost:4566/123456789012/dmb",
+                "Entries": []
+            }),
+        );
+        expect_err(svc.delete_message_batch(&req));
+    }
+
+    // ── list_dead_letter_source_queues nonexistent ──
+
+    #[test]
+    fn list_dead_letter_source_queues_nonexistent_ok() {
+        let svc = make_service();
+        svc.create_queue(&make_request("CreateQueue", json!({"QueueName": "dlq"})))
+            .unwrap();
+        let req = make_request(
+            "ListDeadLetterSourceQueues",
+            json!({"QueueUrl": "http://localhost:4566/123456789012/dlq"}),
+        );
+        let resp = svc.list_dead_letter_source_queues(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["queueUrls"].as_array().unwrap().is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- SNS: publish error branches (missing message, too long, MessageStructure=json, FIFO dedup logic, platform endpoint paths), topic name validation, SMS attributes, subscription raw-message delivery, list-topics pagination
- SQS: CreateQueue validation (name length/chars, FIFO suffix, DelaySeconds, MaximumMessageSize), SendMessage error branches, DeleteMessage missing receipt, GetQueueAttributes filtered, ListQueues prefix pagination, FIFO dedup requirement, ListDeadLetterSourceQueues empty

## Test plan
- [x] cargo test -p fakecloud-sns --lib
- [x] cargo test -p fakecloud-sqs --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add broad test coverage in `fakecloud-sns` and `fakecloud-sqs` to lock down AWS‑compatible validation, error paths, and pagination behavior. SNS tests cover Publish errors (missing/oversized message, MessageStructure=json, FIFO dedup rules), platform endpoints, SMS attributes, subscription RawMessageDelivery, topic name rules, and ListTopics pagination; SQS tests cover CreateQueue validation (name/chars/attrs), Send/Delete/ChangeVisibility errors, GetQueueAttributes filtering, ListQueues prefix pagination, FIFO dedup rules, Tag/Purge/DeleteMessageBatch errors, and empty ListDeadLetterSourceQueues.

<sup>Written for commit 613018a91a01d5596f2dae7244f9d43a7746f4ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

