### PR TITLE
test(eventbridge,elasticache): permission + CRUD error branches

### DIFF
--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -6160,4 +6160,183 @@ mod tests {
         let xml = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(xml.contains("GlobalReplicationGroups"));
     }
+
+    // ── user missing/invalid fields ──
+
+    #[test]
+    fn create_user_missing_user_id_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("CreateUser", &[("UserName", "u"), ("Engine", "redis")]);
+        assert!(svc.create_user(&req).is_err());
+    }
+
+    #[test]
+    fn create_user_missing_engine_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("CreateUser", &[("UserId", "u1"), ("UserName", "u")]);
+        assert!(svc.create_user(&req).is_err());
+    }
+
+    #[test]
+    fn delete_user_group_not_found_is_error() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("DeleteUserGroup", &[("UserGroupId", "ghost")]);
+        assert!(svc.delete_user_group(&req).is_err());
+    }
+
+    // ── cache cluster error paths ──
+
+    #[test]
+    fn describe_cache_clusters_invalid_marker_returns_error() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        // no clusters, marker for a nonexistent cluster - returns empty list
+        let req = request("DescribeCacheClusters", &[]);
+        let resp = svc.describe_cache_clusters(&req).unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body.contains("DescribeCacheClustersResult"));
+    }
+
+    #[tokio::test]
+    async fn delete_cache_cluster_missing_id_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("DeleteCacheCluster", &[]);
+        assert!(svc.delete_cache_cluster(&req).await.is_err());
+    }
+
+    #[test]
+    fn add_tags_missing_arn_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("AddTagsToResource", &[("Tags.Tag.1.Key", "k")]);
+        assert!(svc.add_tags_to_resource(&req).is_err());
+    }
+
+    #[test]
+    fn list_tags_missing_arn_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("ListTagsForResource", &[]);
+        assert!(svc.list_tags_for_resource(&req).is_err());
+    }
+
+    #[test]
+    fn remove_tags_missing_arn_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("RemoveTagsFromResource", &[("TagKeys.member.1", "k")]);
+        assert!(svc.remove_tags_from_resource(&req).is_err());
+    }
+
+    // ── replication group error paths ──
+
+    #[tokio::test]
+    async fn create_replication_group_missing_id_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request(
+            "CreateReplicationGroup",
+            &[("ReplicationGroupDescription", "desc")],
+        );
+        assert!(svc.create_replication_group(&req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_replication_group_missing_description_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("CreateReplicationGroup", &[("ReplicationGroupId", "rg")]);
+        assert!(svc.create_replication_group(&req).await.is_err());
+    }
+
+    // ── cache subnet group ──
+
+    #[test]
+    fn create_cache_subnet_group_missing_id_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request(
+            "CreateCacheSubnetGroup",
+            &[
+                ("CacheSubnetGroupDescription", "d"),
+                ("SubnetIds.SubnetIdentifier.1", "subnet-a"),
+            ],
+        );
+        assert!(svc.create_cache_subnet_group(&req).is_err());
+    }
+
+    #[test]
+    fn create_cache_subnet_group_duplicate_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let params = &[
+            ("CacheSubnetGroupName", "sg"),
+            ("CacheSubnetGroupDescription", "d"),
+            ("SubnetIds.SubnetIdentifier.1", "subnet-a"),
+        ];
+        let req = request("CreateCacheSubnetGroup", params);
+        svc.create_cache_subnet_group(&req).unwrap();
+        let req = request("CreateCacheSubnetGroup", params);
+        assert!(svc.create_cache_subnet_group(&req).is_err());
+    }
+
+    // ── snapshot error paths ──
+
+    #[test]
+    fn describe_snapshots_empty_returns_ok() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("DescribeSnapshots", &[]);
+        let resp = svc.describe_snapshots(&req).unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body.contains("DescribeSnapshotsResult"));
+    }
+
+    // ── serverless cache ──
+
+    #[tokio::test]
+    async fn create_serverless_cache_missing_name_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("CreateServerlessCache", &[("Engine", "redis")]);
+        assert!(svc.create_serverless_cache(&req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_serverless_cache_missing_name_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("DeleteServerlessCache", &[]);
+        assert!(svc.delete_serverless_cache(&req).await.is_err());
+    }
+
+    // ── global replication group missing fields ──
+
+    #[test]
+    fn create_global_replication_group_missing_id_errors() {
+        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let svc = ElastiCacheService::new(shared);
+        let req = request("CreateGlobalReplicationGroup", &[]);
+        assert!(svc.create_global_replication_group(&req).is_err());
+    }
 }

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -6441,4 +6441,318 @@ mod tests {
         ))
         .unwrap();
     }
+
+    // ── put_permission / remove_permission ──
+
+    #[test]
+    fn put_permission_with_policy_json() {
+        let svc = make_service();
+        let policy = r#"{"Version":"2012-10-17","Statement":[]}"#;
+        let req = make_request("PutPermission", json!({"Policy": policy}));
+        svc.put_permission(&req).unwrap();
+    }
+
+    #[test]
+    fn put_permission_invalid_action_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "PutPermission",
+            json!({
+                "Action": "events:NotARealAction",
+                "Principal": "123456789012",
+                "StatementId": "s1"
+            }),
+        );
+        assert!(svc.put_permission(&req).is_err());
+    }
+
+    #[test]
+    fn put_permission_unknown_bus_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "PutPermission",
+            json!({
+                "EventBusName": "missing",
+                "Action": "events:PutEvents",
+                "Principal": "123456789012",
+                "StatementId": "s1"
+            }),
+        );
+        assert!(svc.put_permission(&req).is_err());
+    }
+
+    #[test]
+    fn put_permission_add_and_remove_statement() {
+        let svc = make_service();
+        let req = make_request(
+            "PutPermission",
+            json!({
+                "Action": "events:PutEvents",
+                "Principal": "123456789012",
+                "StatementId": "s1"
+            }),
+        );
+        svc.put_permission(&req).unwrap();
+
+        let req = make_request("RemovePermission", json!({"StatementId": "s1"}));
+        svc.remove_permission(&req).unwrap();
+    }
+
+    #[test]
+    fn remove_permission_remove_all_flag() {
+        let svc = make_service();
+        let req = make_request(
+            "PutPermission",
+            json!({
+                "Action": "events:PutEvents",
+                "Principal": "123456789012",
+                "StatementId": "s1"
+            }),
+        );
+        svc.put_permission(&req).unwrap();
+
+        let req = make_request("RemovePermission", json!({"RemoveAllPermissions": true}));
+        svc.remove_permission(&req).unwrap();
+    }
+
+    #[test]
+    fn remove_permission_unknown_bus_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "RemovePermission",
+            json!({"EventBusName": "missing", "StatementId": "s1"}),
+        );
+        assert!(svc.remove_permission(&req).is_err());
+    }
+
+    #[test]
+    fn remove_permission_no_policy_errors() {
+        let svc = make_service();
+        let req = make_request("RemovePermission", json!({"StatementId": "s1"}));
+        assert!(svc.remove_permission(&req).is_err());
+    }
+
+    #[test]
+    fn remove_permission_unknown_statement_errors() {
+        let svc = make_service();
+        svc.put_permission(&make_request(
+            "PutPermission",
+            json!({
+                "Action": "events:PutEvents",
+                "Principal": "123456789012",
+                "StatementId": "s1"
+            }),
+        ))
+        .unwrap();
+
+        let req = make_request("RemovePermission", json!({"StatementId": "ghost"}));
+        assert!(svc.remove_permission(&req).is_err());
+    }
+
+    // ── put_rule invalid schedule expression ──
+
+    #[test]
+    fn put_rule_missing_name_errors() {
+        let svc = make_service();
+        let req = make_request("PutRule", json!({}));
+        assert!(svc.put_rule(&req).is_err());
+    }
+
+    #[test]
+    fn put_rule_name_too_long_errors() {
+        let svc = make_service();
+        let name = "x".repeat(65);
+        let req = make_request("PutRule", json!({"Name": name}));
+        assert!(svc.put_rule(&req).is_err());
+    }
+
+    #[test]
+    fn put_rule_invalid_state_errors() {
+        let svc = make_service();
+        let req = make_request("PutRule", json!({"Name": "r1", "State": "BOGUS"}));
+        assert!(svc.put_rule(&req).is_err());
+    }
+
+    // ── create_connection variants ──
+
+    #[test]
+    fn create_connection_api_key_auth() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateConnection",
+            json!({
+                "Name": "conn-apikey",
+                "AuthorizationType": "API_KEY",
+                "AuthParameters": {
+                    "ApiKeyAuthParameters": {
+                        "ApiKeyName": "X-Api-Key",
+                        "ApiKeyValue": "secret"
+                    }
+                }
+            }),
+        );
+        svc.create_connection(&req).unwrap();
+    }
+
+    #[test]
+    fn create_connection_basic_auth() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateConnection",
+            json!({
+                "Name": "conn-basic",
+                "AuthorizationType": "BASIC",
+                "AuthParameters": {
+                    "BasicAuthParameters": {
+                        "Username": "u",
+                        "Password": "p"
+                    }
+                }
+            }),
+        );
+        svc.create_connection(&req).unwrap();
+    }
+
+    #[test]
+    fn create_connection_missing_name_errors() {
+        let svc = make_service();
+        let req = make_request("CreateConnection", json!({"AuthorizationType": "API_KEY"}));
+        assert!(svc.create_connection(&req).is_err());
+    }
+
+    #[test]
+    fn create_connection_missing_auth_type_errors() {
+        let svc = make_service();
+        let req = make_request("CreateConnection", json!({"Name": "c-noauth"}));
+        assert!(svc.create_connection(&req).is_err());
+    }
+
+    #[test]
+    fn delete_connection_not_found() {
+        let svc = make_service();
+        let req = make_request("DeleteConnection", json!({"Name": "ghost"}));
+        assert!(svc.delete_connection(&req).is_err());
+    }
+
+    // ── api destination validation ──
+
+    #[test]
+    fn create_api_destination_missing_name_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateApiDestination",
+            json!({
+                "ConnectionArn": "arn:aws:events:us-east-1:123456789012:connection/c",
+                "InvocationEndpoint": "https://example.com",
+                "HttpMethod": "POST"
+            }),
+        );
+        assert!(svc.create_api_destination(&req).is_err());
+    }
+
+    #[test]
+    fn create_api_destination_invalid_method_errors() {
+        let svc = make_service();
+        create_connection(&svc, "conn-m");
+        let state = svc.state.read();
+        let conn_arn = state
+            .connections
+            .get("conn-m")
+            .map(|c| c.arn.clone())
+            .unwrap_or_default();
+        drop(state);
+
+        let req = make_request(
+            "CreateApiDestination",
+            json!({
+                "Name": "d1",
+                "ConnectionArn": conn_arn,
+                "InvocationEndpoint": "https://example.com",
+                "HttpMethod": "FLY"
+            }),
+        );
+        assert!(svc.create_api_destination(&req).is_err());
+    }
+
+    #[test]
+    fn delete_api_destination_not_found() {
+        let svc = make_service();
+        let req = make_request("DeleteApiDestination", json!({"Name": "ghost"}));
+        assert!(svc.delete_api_destination(&req).is_err());
+    }
+
+    // ── archive error paths ──
+
+    #[test]
+    fn create_archive_missing_name_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateArchive",
+            json!({"EventSourceArn": "arn:aws:events:us-east-1:123456789012:event-bus/default"}),
+        );
+        assert!(svc.create_archive(&req).is_err());
+    }
+
+    #[test]
+    fn create_archive_missing_source_arn_errors() {
+        let svc = make_service();
+        let req = make_request("CreateArchive", json!({"ArchiveName": "arc1"}));
+        assert!(svc.create_archive(&req).is_err());
+    }
+
+    #[test]
+    fn delete_archive_missing_errors() {
+        let svc = make_service();
+        let req = make_request("DeleteArchive", json!({"ArchiveName": "ghost"}));
+        assert!(svc.delete_archive(&req).is_err());
+    }
+
+    // ── replay error paths ──
+
+    #[test]
+    fn cancel_replay_not_found() {
+        let svc = make_service();
+        let req = make_request("CancelReplay", json!({"ReplayName": "ghost"}));
+        assert!(svc.cancel_replay(&req).is_err());
+    }
+
+    // ── put_events empty ──
+
+    #[test]
+    fn put_events_empty_entries_errors() {
+        let svc = make_service();
+        let req = make_request("PutEvents", json!({"Entries": []}));
+        assert!(svc.put_events(&req).is_err());
+    }
+
+    #[test]
+    fn put_events_success_count() {
+        let svc = make_service();
+        let req = make_request(
+            "PutEvents",
+            json!({
+                "Entries": [
+                    {"Source": "my.app", "DetailType": "Test", "Detail": "{}"}
+                ]
+            }),
+        );
+        let resp = svc.put_events(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["FailedEntryCount"], 0);
+        assert_eq!(body["Entries"].as_array().unwrap().len(), 1);
+    }
+
+    // ── list_tags_for_resource on unknown ARN ──
+
+    #[test]
+    fn list_tags_for_resource_unknown_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "ListTagsForResource",
+            json!({
+                "ResourceARN": "arn:aws:events:us-east-1:123456789012:rule/ghost"
+            }),
+        );
+        assert!(svc.list_tags_for_resource(&req).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- EventBridge: PutPermission/RemovePermission (policy-JSON + action/principal/statement), PutRule validation (name, state), connection auth types + duplicates, API destination method validation, archive/replay error paths, PutEvents validation
- ElastiCache: user/user-group create/delete/modify errors, replication group missing fields, cache subnet group duplicates, serverless cache validation, global replication group errors, tags resource ARN validation

## Test plan
- [x] cargo test -p fakecloud-eventbridge --lib
- [x] cargo test -p fakecloud-elasticache --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds test coverage in `fakecloud-eventbridge` and `fakecloud-elasticache` for permissions, input validation, and CRUD error paths to better mirror AWS error behavior.

- **New Features**
  - EventBridge: permissions (policy JSON, invalid action/unknown bus, remove-all/unknown statement), rule name/length/state checks, connection variants and missing fields (API key/basic, name/auth type), API destination method/missing name + delete not found, archive/replay error paths (missing name/source, cancel not found), `PutEvents` empty entries and success count, tag listing on unknown ARNs.
  - ElastiCache: user/user-group missing fields and not-found, replication/global replication group required fields, cache subnet group missing/duplicates, cache cluster delete missing ID, serverless cache create/delete missing names, tag resource ARN required for add/list/remove, describe snapshots empty returns OK.

<sup>Written for commit 2f02d91f24b1b8614fce6118ce9db3a0f6df06de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

