### PR TITLE
test(rds,kinesis): CRUD error branches

### DIFF
--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -2778,4 +2778,170 @@ mod tests {
             "ExpiredIteratorException",
         );
     }
+
+    // ── missing params ──
+
+    #[test]
+    fn describe_stream_missing_name_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .describe_stream(&request("DescribeStream", json!({})))
+            .is_err());
+    }
+
+    #[test]
+    fn describe_stream_summary_missing_name_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .describe_stream_summary(&request("DescribeStreamSummary", json!({})))
+            .is_err());
+    }
+
+    #[test]
+    fn delete_stream_missing_name_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .delete_stream(&request("DeleteStream", json!({})))
+            .is_err());
+    }
+
+    #[test]
+    fn get_shard_iterator_missing_stream_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .get_shard_iterator(&request(
+                "GetShardIterator",
+                json!({"ShardId": "shardId-000000000000", "ShardIteratorType": "TRIM_HORIZON"})
+            ))
+            .is_err());
+    }
+
+    #[test]
+    fn put_record_missing_stream_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .put_record(&request(
+                "PutRecord",
+                json!({"Data": "aGVsbG8=", "PartitionKey": "k"})
+            ))
+            .is_err());
+    }
+
+    #[test]
+    fn start_stream_encryption_missing_stream_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .start_stream_encryption(&request(
+                "StartStreamEncryption",
+                json!({"EncryptionType": "KMS", "KeyId": "alias/aws/kinesis"})
+            ))
+            .is_err());
+    }
+
+    #[test]
+    fn stop_stream_encryption_missing_stream_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .stop_stream_encryption(&request(
+                "StopStreamEncryption",
+                json!({"EncryptionType": "KMS", "KeyId": "alias/aws/kinesis"})
+            ))
+            .is_err());
+    }
+
+    #[test]
+    fn start_stream_encryption_unknown_stream_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .start_stream_encryption(&request(
+                "StartStreamEncryption",
+                json!({
+                    "StreamName": "ghost",
+                    "EncryptionType": "KMS",
+                    "KeyId": "alias/aws/kinesis"
+                })
+            ))
+            .is_err());
+    }
+
+    #[test]
+    fn enable_enhanced_monitoring_unknown_stream_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .enable_enhanced_monitoring(&request(
+                "EnableEnhancedMonitoring",
+                json!({"StreamName": "ghost", "ShardLevelMetrics": ["IncomingBytes"]})
+            ))
+            .is_err());
+    }
+
+    #[test]
+    fn disable_enhanced_monitoring_unknown_stream_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .disable_enhanced_monitoring(&request(
+                "DisableEnhancedMonitoring",
+                json!({"StreamName": "ghost", "ShardLevelMetrics": ["IncomingBytes"]})
+            ))
+            .is_err());
+    }
+
+    #[test]
+    fn put_resource_policy_missing_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .put_resource_policy(&request("PutResourcePolicy", json!({})))
+            .is_err());
+    }
+
+    #[test]
+    fn delete_resource_policy_missing_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .delete_resource_policy(&request("DeleteResourcePolicy", json!({})))
+            .is_err());
+    }
+
+    #[test]
+    fn update_retention_below_minimum_errors() {
+        let (svc, _) = make_service();
+        create_stream_action(&svc, "retlow", 1);
+        assert!(svc
+            .increase_stream_retention_period(&request(
+                "IncreaseStreamRetentionPeriod",
+                json!({"StreamName": "retlow", "RetentionPeriodHours": 10})
+            ))
+            .is_err());
+    }
+
+    #[test]
+    fn list_streams_empty_returns_zero() {
+        let (svc, _) = make_service();
+        let resp = svc
+            .list_streams(&request("ListStreams", json!({})))
+            .unwrap();
+        let body = json_response(resp);
+        assert!(body["StreamNames"].as_array().unwrap().is_empty());
+        assert_eq!(body["HasMoreStreams"], false);
+    }
+
+    #[test]
+    fn create_stream_missing_name_errors() {
+        let (svc, _) = make_service();
+        assert!(svc
+            .create_stream(&request("CreateStream", json!({})))
+            .is_err());
+    }
+
+    #[test]
+    fn assert_code_kinesis_ok_panics_test() {
+        assert_code_kinesis::<()>(
+            Err(AwsServiceError::aws_error(
+                http::StatusCode::BAD_REQUEST,
+                "X",
+                "msg",
+            )),
+            "X",
+        );
+    }
 }

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -3708,4 +3708,195 @@ mod tests {
         );
         assert_code(svc.list_tags_for_resource(&req), "DBInstanceNotFound");
     }
+
+    // ── snapshot operations ──
+
+    #[tokio::test]
+    async fn create_db_snapshot_missing_id_errors() {
+        let svc = make_service();
+        let req = request(
+            "CreateDBSnapshot",
+            &[("DBInstanceIdentifier", "nonexistent")],
+        );
+        assert_code(svc.create_db_snapshot(&req).await, "MissingParameter");
+    }
+
+    #[tokio::test]
+    async fn create_db_snapshot_unknown_instance_errors() {
+        let svc = make_service();
+        let req = request(
+            "CreateDBSnapshot",
+            &[
+                ("DBSnapshotIdentifier", "snap1"),
+                ("DBInstanceIdentifier", "ghost"),
+            ],
+        );
+        assert!(svc.create_db_snapshot(&req).await.is_err());
+    }
+
+    // ── delete_db_instance ──
+
+    #[tokio::test]
+    async fn delete_db_instance_missing_id_errors() {
+        let svc = make_service();
+        let req = request("DeleteDBInstance", &[]);
+        assert_code(svc.delete_db_instance(&req).await, "MissingParameter");
+    }
+
+    // ── reboot_db_instance ──
+
+    #[tokio::test]
+    async fn reboot_db_instance_missing_id_errors() {
+        let svc = make_service();
+        let req = request("RebootDBInstance", &[]);
+        assert_code(svc.reboot_db_instance(&req).await, "MissingParameter");
+    }
+
+    // ── create_db_instance validation ──
+
+    #[tokio::test]
+    async fn create_db_instance_missing_id_errors() {
+        let svc = make_service();
+        let req = request(
+            "CreateDBInstance",
+            &[
+                ("Engine", "postgres"),
+                ("DBInstanceClass", "db.t3.micro"),
+                ("AllocatedStorage", "20"),
+                ("MasterUsername", "admin"),
+                ("MasterUserPassword", "secretpass"),
+            ],
+        );
+        assert!(svc.create_db_instance(&req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_db_instance_unsupported_engine_errors() {
+        let svc = make_service();
+        let req = request(
+            "CreateDBInstance",
+            &[
+                ("DBInstanceIdentifier", "db1"),
+                ("Engine", "mongodb"),
+                ("DBInstanceClass", "db.t3.micro"),
+                ("AllocatedStorage", "20"),
+                ("MasterUsername", "admin"),
+                ("MasterUserPassword", "secretpass"),
+            ],
+        );
+        assert!(svc.create_db_instance(&req).await.is_err());
+    }
+
+    // ── restore_db_instance_from_db_snapshot ──
+
+    #[tokio::test]
+    async fn restore_db_instance_missing_ids_errors() {
+        let svc = make_service();
+        let req = request("RestoreDBInstanceFromDBSnapshot", &[]);
+        assert!(svc
+            .restore_db_instance_from_db_snapshot(&req)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn restore_db_instance_unknown_snapshot_errors() {
+        let svc = make_service();
+        let req = request(
+            "RestoreDBInstanceFromDBSnapshot",
+            &[
+                ("DBInstanceIdentifier", "restored"),
+                ("DBSnapshotIdentifier", "missing"),
+            ],
+        );
+        assert!(svc
+            .restore_db_instance_from_db_snapshot(&req)
+            .await
+            .is_err());
+    }
+
+    // ── create_db_instance_read_replica ──
+
+    #[tokio::test]
+    async fn create_read_replica_missing_source_errors() {
+        let svc = make_service();
+        let req = request(
+            "CreateDBInstanceReadReplica",
+            &[("DBInstanceIdentifier", "replica1")],
+        );
+        assert!(svc.create_db_instance_read_replica(&req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_read_replica_unknown_source_errors() {
+        let svc = make_service();
+        let req = request(
+            "CreateDBInstanceReadReplica",
+            &[
+                ("DBInstanceIdentifier", "replica1"),
+                ("SourceDBInstanceIdentifier", "ghost"),
+            ],
+        );
+        assert!(svc.create_db_instance_read_replica(&req).await.is_err());
+    }
+
+    // ── describe_db_snapshots with filters ──
+
+    #[test]
+    fn describe_db_snapshots_by_snapshot_id_only() {
+        let svc = make_service();
+        seed_snapshot(&svc, "s1", "inst1");
+        let req = request("DescribeDBSnapshots", &[("DBSnapshotIdentifier", "s1")]);
+        let resp = svc.describe_db_snapshots(&req).unwrap();
+        let b = body_of(resp);
+        assert!(b.contains("<DBSnapshotIdentifier>s1</DBSnapshotIdentifier>"));
+    }
+
+    #[test]
+    fn describe_db_snapshots_by_instance_id_returns_matching() {
+        let svc = make_service();
+        seed_snapshot(&svc, "s1", "inst1");
+        seed_snapshot(&svc, "s2", "inst2");
+        let req = request("DescribeDBSnapshots", &[("DBInstanceIdentifier", "inst1")]);
+        let resp = svc.describe_db_snapshots(&req).unwrap();
+        let b = body_of(resp);
+        assert!(b.contains("s1"));
+        assert!(!b.contains("<DBSnapshotIdentifier>s2</DBSnapshotIdentifier>"));
+    }
+
+    // ── modify_db_parameter_group ──
+
+    #[test]
+    fn modify_db_parameter_group_missing_name() {
+        let svc = make_service();
+        let req = request("ModifyDBParameterGroup", &[]);
+        assert!(svc.modify_db_parameter_group(&req).is_err());
+    }
+
+    // ── modify_db_subnet_group ──
+
+    #[test]
+    fn modify_db_subnet_group_unknown_errors() {
+        let svc = make_service();
+        let req = request(
+            "ModifyDBSubnetGroup",
+            &[
+                ("DBSubnetGroupName", "ghost"),
+                ("SubnetIds.SubnetIdentifier.1", "subnet-a"),
+                ("SubnetIds.SubnetIdentifier.2", "subnet-b"),
+            ],
+        );
+        assert!(svc.modify_db_subnet_group(&req).is_err());
+    }
+
+    // ── describe_db_instances ──
+
+    #[test]
+    fn describe_db_instances_empty_returns_xml() {
+        let svc = make_service();
+        let req = request("DescribeDBInstances", &[]);
+        let resp = svc.describe_db_instances(&req).unwrap();
+        let b = body_of(resp);
+        assert!(b.contains("DescribeDBInstancesResult"));
+    }
 }


### PR DESCRIPTION
## Summary
- RDS: CreateDBSnapshot/DeleteDBInstance/RebootDBInstance missing params, RestoreDBInstanceFromDBSnapshot + CreateDBInstanceReadReplica validation, create-db-instance unsupported engine + missing id, modify parameter/subnet group, describe-db-snapshots filters
- Kinesis: Describe/Delete/GetShardIterator/PutRecord missing stream, StartStreamEncryption/StopStreamEncryption validation, EnhancedMonitoring unknown stream, ResourcePolicy missing, retention-below-minimum error

## Test plan
- [x] cargo test -p fakecloud-rds --lib
- [x] cargo test -p fakecloud-kinesis --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests in `fakecloud-rds` and `fakecloud-kinesis` to cover error branches and ensure AWS‑compatible validation and error codes. Focuses on missing required params, unknown resources, unsupported engines, and boundary cases like retention limits and empty listings.

<sup>Written for commit 9b0895a57dbd21f76353c1a2a50c79542a47ae92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

