### PR TITLE
test(cognito,dynamodb): auth + tables CRUD error branches

### DIFF
--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -5799,4 +5799,194 @@ mod tests {
         let req = make_req("AdminUpdateDeviceStatus", &body.to_string());
         svc.admin_update_device_status(&req).unwrap();
     }
+
+    // ── auth.rs additional coverage ──
+
+    #[test]
+    fn admin_initiate_auth_missing_username_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+        let body = json!({
+            "UserPoolId": pool_id,
+            "ClientId": client_id,
+            "AuthFlow": "ADMIN_NO_SRP_AUTH",
+            "AuthParameters": {"PASSWORD": "Pass1!"}
+        });
+        let req = make_req("AdminInitiateAuth", &body.to_string());
+        assert!(block_on(svc.admin_initiate_auth(&req)).is_err());
+    }
+
+    #[test]
+    fn admin_initiate_auth_missing_password_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+        admin_create_user_helper(&svc, &pool_id, "nopass");
+        let body = json!({
+            "UserPoolId": pool_id,
+            "ClientId": client_id,
+            "AuthFlow": "ADMIN_NO_SRP_AUTH",
+            "AuthParameters": {"USERNAME": "nopass"}
+        });
+        let req = make_req("AdminInitiateAuth", &body.to_string());
+        assert!(block_on(svc.admin_initiate_auth(&req)).is_err());
+    }
+
+    #[test]
+    fn initiate_auth_refresh_token_errors_on_invalid() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+        let _ = pool_id;
+        let body = json!({
+            "ClientId": client_id,
+            "AuthFlow": "REFRESH_TOKEN_AUTH",
+            "AuthParameters": {"REFRESH_TOKEN": "bad-token"}
+        });
+        let req = make_req("InitiateAuth", &body.to_string());
+        assert!(block_on(svc.initiate_auth(&req)).is_err());
+    }
+
+    #[test]
+    fn initiate_auth_missing_client_id_errors() {
+        let (svc, _) = make_svc();
+        let body = json!({
+            "AuthFlow": "USER_PASSWORD_AUTH",
+            "AuthParameters": {"USERNAME": "u", "PASSWORD": "p"}
+        });
+        let req = make_req("InitiateAuth", &body.to_string());
+        assert!(block_on(svc.initiate_auth(&req)).is_err());
+    }
+
+    #[test]
+    fn initiate_auth_unknown_client_errors() {
+        let (svc, _) = make_svc();
+        let body = json!({
+            "ClientId": "ghost-client",
+            "AuthFlow": "USER_PASSWORD_AUTH",
+            "AuthParameters": {"USERNAME": "u", "PASSWORD": "p"}
+        });
+        let req = make_req("InitiateAuth", &body.to_string());
+        assert!(block_on(svc.initiate_auth(&req)).is_err());
+    }
+
+    #[test]
+    fn sign_up_missing_username_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+        let body = json!({
+            "ClientId": client_id,
+            "Password": "Password1!"
+        });
+        let req = make_req("SignUp", &body.to_string());
+        assert!(block_on(svc.sign_up(&req)).is_err());
+    }
+
+    #[test]
+    fn sign_up_missing_password_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+        let body = json!({
+            "ClientId": client_id,
+            "Username": "u"
+        });
+        let req = make_req("SignUp", &body.to_string());
+        assert!(block_on(svc.sign_up(&req)).is_err());
+    }
+
+    #[test]
+    fn sign_up_weak_password_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+        let body = json!({
+            "ClientId": client_id,
+            "Username": "weak",
+            "Password": "weak"
+        });
+        let req = make_req("SignUp", &body.to_string());
+        assert!(block_on(svc.sign_up(&req)).is_err());
+    }
+
+    #[test]
+    fn confirm_sign_up_unknown_user_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+        let _ = pool_id;
+        let body = json!({
+            "ClientId": client_id,
+            "Username": "ghost",
+            "ConfirmationCode": "123456"
+        });
+        let req = make_req("ConfirmSignUp", &body.to_string());
+        assert!(block_on(svc.confirm_sign_up(&req)).is_err());
+    }
+
+    #[test]
+    fn admin_confirm_sign_up_unknown_user_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let body = json!({
+            "UserPoolId": pool_id,
+            "Username": "ghost"
+        });
+        let req = make_req("AdminConfirmSignUp", &body.to_string());
+        assert!(block_on(svc.admin_confirm_sign_up(&req)).is_err());
+    }
+
+    #[test]
+    fn admin_reset_user_password_missing_user_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let body = json!({"UserPoolId": pool_id, "Username": "ghost"});
+        let req = make_req("AdminResetUserPassword", &body.to_string());
+        assert!(svc.admin_reset_user_password(&req).is_err());
+    }
+
+    #[test]
+    fn forgot_password_missing_client_errors() {
+        let (svc, _) = make_svc();
+        let body = json!({"Username": "u"});
+        let req = make_req("ForgotPassword", &body.to_string());
+        assert!(block_on(svc.forgot_password(&req)).is_err());
+    }
+
+    #[test]
+    fn confirm_forgot_password_unknown_user_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let client_id = create_client(&svc, &pool_id);
+        let _ = pool_id;
+        let body = json!({
+            "ClientId": client_id,
+            "Username": "ghost",
+            "ConfirmationCode": "123456",
+            "Password": "NewPass1!"
+        });
+        let req = make_req("ConfirmForgotPassword", &body.to_string());
+        assert!(svc.confirm_forgot_password(&req).is_err());
+    }
+
+    #[test]
+    fn change_password_missing_access_token_errors() {
+        let (svc, _) = make_svc();
+        let body = json!({
+            "PreviousPassword": "p1",
+            "ProposedPassword": "p2"
+        });
+        let req = make_req("ChangePassword", &body.to_string());
+        assert!(svc.change_password(&req).is_err());
+    }
+
+    #[test]
+    fn global_sign_out_missing_token_errors() {
+        let (svc, _) = make_svc();
+        let body = json!({});
+        let req = make_req("GlobalSignOut", &body.to_string());
+        assert!(svc.global_sign_out(&req).is_err());
+    }
 }

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -6234,4 +6234,257 @@ mod tests {
         );
         assert!(svc.describe_export(&req).is_err());
     }
+
+    // ── tables.rs error branches ──
+
+    #[test]
+    fn create_table_missing_name_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateTable",
+            json!({
+                "AttributeDefinitions": [{"AttributeName": "k", "AttributeType": "S"}],
+                "KeySchema": [{"AttributeName": "k", "KeyType": "HASH"}],
+                "BillingMode": "PAY_PER_REQUEST"
+            }),
+        );
+        assert!(svc.create_table(&req).is_err());
+    }
+
+    #[test]
+    fn create_table_duplicate_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateTable",
+            json!({
+                "TableName": "dup",
+                "AttributeDefinitions": [{"AttributeName": "k", "AttributeType": "S"}],
+                "KeySchema": [{"AttributeName": "k", "KeyType": "HASH"}],
+                "BillingMode": "PAY_PER_REQUEST"
+            }),
+        );
+        svc.create_table(&req).unwrap();
+        assert!(svc.create_table(&req).is_err());
+    }
+
+    #[test]
+    fn delete_table_missing_name_errors() {
+        let svc = make_service();
+        let req = make_request("DeleteTable", json!({}));
+        assert!(svc.delete_table(&req).is_err());
+    }
+
+    #[test]
+    fn delete_table_not_found_errors() {
+        let svc = make_service();
+        let req = make_request("DeleteTable", json!({"TableName": "ghost"}));
+        assert!(svc.delete_table(&req).is_err());
+    }
+
+    #[test]
+    fn describe_table_missing_name_errors() {
+        let svc = make_service();
+        let req = make_request("DescribeTable", json!({}));
+        assert!(svc.describe_table(&req).is_err());
+    }
+
+    #[test]
+    fn describe_table_not_found_errors() {
+        let svc = make_service();
+        let req = make_request("DescribeTable", json!({"TableName": "ghost"}));
+        assert!(svc.describe_table(&req).is_err());
+    }
+
+    #[test]
+    fn update_table_missing_name_errors() {
+        let svc = make_service();
+        let req = make_request("UpdateTable", json!({}));
+        assert!(svc.update_table(&req).is_err());
+    }
+
+    #[test]
+    fn update_table_not_found_errors() {
+        let svc = make_service();
+        let req = make_request("UpdateTable", json!({"TableName": "ghost"}));
+        assert!(svc.update_table(&req).is_err());
+    }
+
+    #[test]
+    fn list_tables_pagination() {
+        let svc = make_service();
+        for i in 0..5 {
+            let req = make_request(
+                "CreateTable",
+                json!({
+                    "TableName": format!("pt{i}"),
+                    "AttributeDefinitions": [{"AttributeName": "k", "AttributeType": "S"}],
+                    "KeySchema": [{"AttributeName": "k", "KeyType": "HASH"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }),
+            );
+            svc.create_table(&req).unwrap();
+        }
+        let req = make_request("ListTables", json!({"Limit": 2}));
+        let resp = svc.list_tables(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["TableNames"].as_array().unwrap().len(), 2);
+        assert!(body["LastEvaluatedTableName"].is_string());
+    }
+
+    #[test]
+    fn list_tables_start_exclusive() {
+        let svc = make_service();
+        for i in 0..3 {
+            let req = make_request(
+                "CreateTable",
+                json!({
+                    "TableName": format!("pt{i}"),
+                    "AttributeDefinitions": [{"AttributeName": "k", "AttributeType": "S"}],
+                    "KeySchema": [{"AttributeName": "k", "KeyType": "HASH"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }),
+            );
+            svc.create_table(&req).unwrap();
+        }
+        let req = make_request("ListTables", json!({"ExclusiveStartTableName": "pt0"}));
+        let resp = svc.list_tables(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let names = body["TableNames"].as_array().unwrap();
+        assert!(!names.iter().any(|n| n == "pt0"));
+    }
+
+    #[test]
+    fn update_time_to_live_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "UpdateTimeToLive",
+            json!({
+                "TableName": "ghost",
+                "TimeToLiveSpecification": {"Enabled": true, "AttributeName": "ttl"}
+            }),
+        );
+        assert!(svc.update_time_to_live(&req).is_err());
+    }
+
+    #[test]
+    fn describe_time_to_live_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request("DescribeTimeToLive", json!({"TableName": "ghost"}));
+        assert!(svc.describe_time_to_live(&req).is_err());
+    }
+
+    // ── resource policy ──
+
+    #[test]
+    fn put_resource_policy_missing_policy_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateTable",
+            json!({
+                "TableName": "rp",
+                "AttributeDefinitions": [{"AttributeName": "k", "AttributeType": "S"}],
+                "KeySchema": [{"AttributeName": "k", "KeyType": "HASH"}],
+                "BillingMode": "PAY_PER_REQUEST"
+            }),
+        );
+        svc.create_table(&req).unwrap();
+        let req = make_request(
+            "PutResourcePolicy",
+            json!({"ResourceArn": "arn:aws:dynamodb:us-east-1:123456789012:table/rp"}),
+        );
+        assert!(svc.put_resource_policy(&req).is_err());
+    }
+
+    #[test]
+    fn get_resource_policy_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "GetResourcePolicy",
+            json!({"ResourceArn": "arn:aws:dynamodb:us-east-1:123456789012:table/ghost"}),
+        );
+        assert!(svc.get_resource_policy(&req).is_err());
+    }
+
+    // ── tags ──
+
+    #[test]
+    fn tag_resource_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "TagResource",
+            json!({
+                "ResourceArn": "arn:aws:dynamodb:us-east-1:123456789012:table/ghost",
+                "Tags": [{"Key": "k", "Value": "v"}]
+            }),
+        );
+        assert!(svc.tag_resource(&req).is_err());
+    }
+
+    #[test]
+    fn list_tags_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "ListTagsOfResource",
+            json!({"ResourceArn": "arn:aws:dynamodb:us-east-1:123456789012:table/ghost"}),
+        );
+        assert!(svc.list_tags_of_resource(&req).is_err());
+    }
+
+    // ── backups ──
+
+    #[test]
+    fn create_backup_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateBackup",
+            json!({"TableName": "ghost", "BackupName": "b1"}),
+        );
+        assert!(svc.create_backup(&req).is_err());
+    }
+
+    #[test]
+    fn delete_backup_not_found_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DeleteBackup",
+            json!({"BackupArn": "arn:aws:dynamodb:us-east-1:123:table/t/backup/ghost"}),
+        );
+        assert!(svc.delete_backup(&req).is_err());
+    }
+
+    #[test]
+    fn describe_backup_not_found_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribeBackup",
+            json!({"BackupArn": "arn:aws:dynamodb:us-east-1:123:table/t/backup/ghost"}),
+        );
+        assert!(svc.describe_backup(&req).is_err());
+    }
+
+    #[test]
+    fn restore_table_from_backup_not_found_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "RestoreTableFromBackup",
+            json!({
+                "TargetTableName": "restored",
+                "BackupArn": "arn:aws:dynamodb:us-east-1:123:table/t/backup/ghost"
+            }),
+        );
+        assert!(svc.restore_table_from_backup(&req).is_err());
+    }
+
+    #[test]
+    fn update_continuous_backups_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "UpdateContinuousBackups",
+            json!({
+                "TableName": "ghost",
+                "PointInTimeRecoverySpecification": {"PointInTimeRecoveryEnabled": true}
+            }),
+        );
+        assert!(svc.update_continuous_backups(&req).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- Cognito: AdminInitiateAuth missing params, InitiateAuth refresh-token + client validation, SignUp/ConfirmSignUp/AdminConfirmSignUp/AdminResetPassword/ForgotPassword/ConfirmForgotPassword/ChangePassword/GlobalSignOut error paths
- DynamoDB: CreateTable validation + duplicates, Delete/Describe/Update table not found, ListTables pagination/exclusive-start, UpdateTimeToLive/DescribeTimeToLive unknown, resource policy errors, tag resource unknown, backup CRUD not found, UpdateContinuousBackups unknown table

## Test plan
- [x] cargo test -p fakecloud-cognito --lib
- [x] cargo test -p fakecloud-dynamodb --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add negative-path tests for Cognito auth and DynamoDB tables/backups in `fakecloud-cognito` and `fakecloud-dynamodb` to tighten error handling. Covers missing/invalid auth params and tokens, unknown clients/users; and for DynamoDB: duplicate table create, not-found on delete/describe/update, ListTables pagination/exclusive-start, TTL, resource policy, tags, backups, and continuous backups on unknown tables.

<sup>Written for commit 74cee452ce25d39331ab48b43d94e839cdc51214. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

