### PR TITLE
test(kms,stepfunctions): crypto error paths + choice/wait/map operators

### DIFF
--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -5343,4 +5343,222 @@ mod tests {
             .unwrap();
         assert_eq!(decoded.len(), 32);
     }
+
+    // ── missing params / unknown key error branches ──
+
+    #[test]
+    fn encrypt_missing_key_id_errors() {
+        let svc = make_service();
+        let req = make_request("Encrypt", json!({"Plaintext": "aGVsbG8="}));
+        assert!(svc.encrypt(&req).is_err());
+    }
+
+    #[test]
+    fn encrypt_unknown_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "Encrypt",
+            json!({"KeyId": "00000000-0000-0000-0000-000000000000", "Plaintext": "aGVsbG8="}),
+        );
+        assert!(svc.encrypt(&req).is_err());
+    }
+
+    #[test]
+    fn decrypt_invalid_ciphertext_errors() {
+        let svc = make_service();
+        let req = make_request("Decrypt", json!({"CiphertextBlob": "not-base64!!!"}));
+        assert!(svc.decrypt(&req).is_err());
+    }
+
+    #[test]
+    fn generate_data_key_missing_key_errors() {
+        let svc = make_service();
+        let req = make_request("GenerateDataKey", json!({"KeySpec": "AES_256"}));
+        assert!(svc.generate_data_key(&req).is_err());
+    }
+
+    #[test]
+    fn generate_data_key_without_plaintext_missing_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "GenerateDataKeyWithoutPlaintext",
+            json!({"KeySpec": "AES_256"}),
+        );
+        assert!(svc.generate_data_key_without_plaintext(&req).is_err());
+    }
+
+    #[test]
+    fn generate_random_too_many_bytes_errors() {
+        let svc = make_service();
+        let req = make_request("GenerateRandom", json!({"NumberOfBytes": 2048}));
+        assert!(svc.generate_random(&req).is_err());
+    }
+
+    #[test]
+    fn generate_random_zero_bytes_errors() {
+        let svc = make_service();
+        let req = make_request("GenerateRandom", json!({"NumberOfBytes": 0}));
+        assert!(svc.generate_random(&req).is_err());
+    }
+
+    #[test]
+    fn schedule_key_deletion_missing_key_errors() {
+        let svc = make_service();
+        let req = make_request("ScheduleKeyDeletion", json!({}));
+        assert!(svc.schedule_key_deletion(&req).is_err());
+    }
+
+    #[test]
+    fn cancel_key_deletion_unknown_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "CancelKeyDeletion",
+            json!({"KeyId": "00000000-0000-0000-0000-000000000000"}),
+        );
+        assert!(svc.cancel_key_deletion(&req).is_err());
+    }
+
+    #[test]
+    fn tag_resource_unknown_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "TagResource",
+            json!({
+                "KeyId": "00000000-0000-0000-0000-000000000000",
+                "Tags": [{"TagKey": "k", "TagValue": "v"}]
+            }),
+        );
+        assert!(svc.tag_resource(&req).is_err());
+    }
+
+    #[test]
+    fn untag_resource_unknown_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "UntagResource",
+            json!({
+                "KeyId": "00000000-0000-0000-0000-000000000000",
+                "TagKeys": ["k"]
+            }),
+        );
+        assert!(svc.untag_resource(&req).is_err());
+    }
+
+    #[test]
+    fn get_key_policy_unknown_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "GetKeyPolicy",
+            json!({"KeyId": "00000000-0000-0000-0000-000000000000"}),
+        );
+        assert!(svc.get_key_policy(&req).is_err());
+    }
+
+    #[test]
+    fn put_key_policy_unknown_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "PutKeyPolicy",
+            json!({
+                "KeyId": "00000000-0000-0000-0000-000000000000",
+                "Policy": "{}"
+            }),
+        );
+        assert!(svc.put_key_policy(&req).is_err());
+    }
+
+    #[test]
+    fn sign_missing_message_errors() {
+        let svc = make_service();
+        let req = make_request("Sign", json!({"KeyId": "00000000"}));
+        assert!(svc.sign(&req).is_err());
+    }
+
+    #[test]
+    fn verify_missing_signature_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "Verify",
+            json!({"KeyId": "00000000", "Message": "aGVsbG8="}),
+        );
+        assert!(svc.verify(&req).is_err());
+    }
+
+    #[test]
+    fn rotate_key_on_demand_missing_key_errors() {
+        let svc = make_service();
+        let req = make_request("RotateKeyOnDemand", json!({}));
+        assert!(svc.rotate_key_on_demand(&req).is_err());
+    }
+
+    #[test]
+    fn generate_mac_missing_message_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "GenerateMac",
+            json!({"KeyId": "x", "MacAlgorithm": "HMAC_SHA_256"}),
+        );
+        assert!(svc.generate_mac(&req).is_err());
+    }
+
+    #[test]
+    fn verify_mac_missing_message_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "VerifyMac",
+            json!({"KeyId": "x", "MacAlgorithm": "HMAC_SHA_256", "Mac": "abc"}),
+        );
+        assert!(svc.verify_mac(&req).is_err());
+    }
+
+    #[test]
+    fn replicate_key_missing_key_id_errors() {
+        let svc = make_service();
+        let req = make_request("ReplicateKey", json!({"ReplicaRegion": "eu-west-1"}));
+        assert!(svc.replicate_key(&req).is_err());
+    }
+
+    #[test]
+    fn replicate_key_unknown_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "ReplicateKey",
+            json!({
+                "KeyId": "00000000-0000-0000-0000-000000000000",
+                "ReplicaRegion": "eu-west-1"
+            }),
+        );
+        assert!(svc.replicate_key(&req).is_err());
+    }
+
+    #[test]
+    fn derive_shared_secret_missing_key_errors() {
+        let svc = make_service();
+        let req = make_request("DeriveSharedSecret", json!({}));
+        assert!(svc.derive_shared_secret(&req).is_err());
+    }
+
+    #[test]
+    fn generate_data_key_pair_missing_key_errors() {
+        let svc = make_service();
+        let req = make_request("GenerateDataKeyPair", json!({"KeyPairSpec": "RSA_2048"}));
+        assert!(svc.generate_data_key_pair(&req).is_err());
+    }
+
+    #[test]
+    fn generate_data_key_pair_without_plaintext_missing_key_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "GenerateDataKeyPairWithoutPlaintext",
+            json!({"KeyPairSpec": "RSA_2048"}),
+        );
+        assert!(svc.generate_data_key_pair_without_plaintext(&req).is_err());
+    }
+
+    #[test]
+    fn import_key_material_missing_key_errors() {
+        let svc = make_service();
+        let req = make_request("ImportKeyMaterial", json!({}));
+        assert!(svc.import_key_material(&req).is_err());
+    }
 }

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -2528,4 +2528,221 @@ mod tests {
         assert_eq!(exec.status, ExecutionStatus::Succeeded);
         assert!(exec.error.is_none());
     }
+
+    // ── Pass state with ResultPath ──
+
+    #[test]
+    fn pass_state_result_path_merges_into_input() {
+        let state = make_state();
+        let arn = arn_for("result-path");
+        let def = json!({
+            "StartAt": "P",
+            "States": {
+                "P": {"Type": "Pass", "Result": {"x": 2}, "ResultPath": "$.data", "End": true}
+            }
+        });
+        drive(&state, &arn, def, Some(r#"{"a":1}"#));
+        let output = read_exec(&state, &arn, |e| e.output.clone().unwrap_or_default());
+        let v: Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(v["a"], 1);
+        assert_eq!(v["data"]["x"], 2);
+    }
+
+    // ── Choice with many operators ──
+
+    #[test]
+    fn choice_string_greater_than_equals() {
+        let state = make_state();
+        let arn = arn_for("choice-sgte");
+        let def = json!({
+            "StartAt": "C",
+            "States": {
+                "C": {
+                    "Type": "Choice",
+                    "Choices": [
+                        {"Variable": "$.val", "StringGreaterThanEquals": "apple", "Next": "End"}
+                    ],
+                    "Default": "Fail"
+                },
+                "End": {"Type": "Pass", "End": true},
+                "Fail": {"Type": "Fail"}
+            }
+        });
+        drive(&state, &arn, def, Some(r#"{"val":"banana"}"#));
+        let status = read_exec(&state, &arn, |e| e.status);
+        assert_eq!(status, ExecutionStatus::Succeeded);
+    }
+
+    #[test]
+    fn choice_is_present_and_is_null() {
+        let state = make_state();
+        let arn = arn_for("choice-ispres");
+        let def = json!({
+            "StartAt": "C",
+            "States": {
+                "C": {
+                    "Type": "Choice",
+                    "Choices": [
+                        {"Variable": "$.foo", "IsPresent": true, "Next": "End"}
+                    ],
+                    "Default": "Fail"
+                },
+                "End": {"Type": "Pass", "End": true},
+                "Fail": {"Type": "Fail"}
+            }
+        });
+        drive(&state, &arn, def, Some(r#"{"foo":null}"#));
+        assert_eq!(
+            read_exec(&state, &arn, |e| e.status),
+            ExecutionStatus::Succeeded
+        );
+    }
+
+    #[test]
+    fn choice_or_short_circuits() {
+        let state = make_state();
+        let arn = arn_for("choice-or");
+        let def = json!({
+            "StartAt": "C",
+            "States": {
+                "C": {
+                    "Type": "Choice",
+                    "Choices": [{
+                        "Or": [
+                            {"Variable": "$.x", "NumericEquals": 99},
+                            {"Variable": "$.y", "StringEquals": "b"}
+                        ],
+                        "Next": "End"
+                    }],
+                    "Default": "Fail"
+                },
+                "End": {"Type": "Pass", "End": true},
+                "Fail": {"Type": "Fail"}
+            }
+        });
+        drive(&state, &arn, def, Some(r#"{"x":1,"y":"b"}"#));
+        assert_eq!(
+            read_exec(&state, &arn, |e| e.status),
+            ExecutionStatus::Succeeded
+        );
+    }
+
+    #[test]
+    fn choice_not_negates() {
+        let state = make_state();
+        let arn = arn_for("choice-not");
+        let def = json!({
+            "StartAt": "C",
+            "States": {
+                "C": {
+                    "Type": "Choice",
+                    "Choices": [{
+                        "Not": {"Variable": "$.x", "NumericEquals": 99},
+                        "Next": "End"
+                    }],
+                    "Default": "Fail"
+                },
+                "End": {"Type": "Pass", "End": true},
+                "Fail": {"Type": "Fail"}
+            }
+        });
+        drive(&state, &arn, def, Some(r#"{"x":1}"#));
+        assert_eq!(
+            read_exec(&state, &arn, |e| e.status),
+            ExecutionStatus::Succeeded
+        );
+    }
+
+    #[test]
+    fn choice_boolean_equals() {
+        let state = make_state();
+        let arn = arn_for("choice-bool");
+        let def = json!({
+            "StartAt": "C",
+            "States": {
+                "C": {
+                    "Type": "Choice",
+                    "Choices": [
+                        {"Variable": "$.ok", "BooleanEquals": true, "Next": "End"}
+                    ],
+                    "Default": "Fail"
+                },
+                "End": {"Type": "Pass", "End": true},
+                "Fail": {"Type": "Fail"}
+            }
+        });
+        drive(&state, &arn, def, Some(r#"{"ok":true}"#));
+        assert_eq!(
+            read_exec(&state, &arn, |e| e.status),
+            ExecutionStatus::Succeeded
+        );
+    }
+
+    // ── Wait with SecondsPath ──
+
+    #[test]
+    fn wait_seconds_path_uses_input_value() {
+        let state = make_state();
+        let arn = arn_for("wait-sp");
+        let def = json!({
+            "StartAt": "W",
+            "States": {
+                "W": {"Type": "Wait", "SecondsPath": "$.wait", "End": true}
+            }
+        });
+        drive(&state, &arn, def, Some(r#"{"wait":0}"#));
+        assert_eq!(
+            read_exec(&state, &arn, |e| e.status),
+            ExecutionStatus::Succeeded
+        );
+    }
+
+    // ── Map state with empty input array ──
+
+    #[test]
+    fn map_state_empty_array_succeeds() {
+        let state = make_state();
+        let arn = arn_for("map-empty");
+        let def = json!({
+            "StartAt": "M",
+            "States": {
+                "M": {
+                    "Type": "Map",
+                    "ItemsPath": "$.items",
+                    "ItemProcessor": {
+                        "StartAt": "P",
+                        "States": {
+                            "P": {"Type": "Pass", "End": true}
+                        }
+                    },
+                    "End": true
+                }
+            }
+        });
+        drive(&state, &arn, def, Some(r#"{"items":[]}"#));
+        assert_eq!(
+            read_exec(&state, &arn, |e| e.status),
+            ExecutionStatus::Succeeded
+        );
+    }
+
+    // ── Fail state with Error + Cause ──
+
+    #[test]
+    fn fail_state_with_explicit_error_and_cause() {
+        let state = make_state();
+        let arn = arn_for("fail-fields");
+        create_execution(&state, &arn, None);
+        let def = json!({
+            "StartAt": "F",
+            "States": {
+                "F": {"Type": "Fail", "Error": "MyError", "Cause": "my cause"}
+            }
+        });
+        drive(&state, &arn, def, None);
+        let status = read_exec(&state, &arn, |e| e.status);
+        assert_eq!(status, ExecutionStatus::Failed);
+        let err = read_exec(&state, &arn, |e| e.error.clone().unwrap_or_default());
+        assert_eq!(err, "MyError");
+    }
 }


### PR DESCRIPTION
## Summary
- KMS: Encrypt/Decrypt/GenerateDataKey missing + unknown key, ScheduleKeyDeletion missing, CancelKeyDeletion unknown, GenerateRandom bounds, tag/untag/GetKeyPolicy/PutKeyPolicy unknown, Sign/Verify/MAC missing params, ReplicateKey validation, DeriveSharedSecret/ImportKeyMaterial missing
- StepFunctions interpreter: Pass ResultPath merging, Choice operators (StringGreaterThanEquals, IsPresent, Or, Not, BooleanEquals), Wait SecondsPath, Map with empty array, Fail with explicit Error+Cause

## Test plan
- [x] cargo test -p fakecloud-kms --lib
- [x] cargo test -p fakecloud-stepfunctions --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand test coverage in `fakecloud-kms` for error paths and missing parameters across crypto APIs, including Encrypt/Decrypt/GenerateDataKey/GenerateRandom, tag/untag, key policy, signing/MAC, ReplicateKey, DeriveSharedSecret, ImportKeyMaterial, and RotateKeyOnDemand.
Add `fakecloud-stepfunctions` tests for Pass ResultPath merge, Choice operators (StringGreaterThanEquals, IsPresent, Or, Not, BooleanEquals), Wait SecondsPath, Map on empty arrays, and Fail with explicit Error/Cause.

<sup>Written for commit 80f175033dfd9feac65aee11e42a3dc425939f1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

