### PR TITLE
test(logs): delivery CRUD error paths

### DIFF
--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -1981,4 +1981,121 @@ mod tests {
         );
         assert!(svc.get_log_events(&req).is_err());
     }
+
+    // ── deliveries coverage ──
+
+    #[test]
+    fn put_delivery_destination_missing_name_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "PutDeliveryDestination",
+            json!({"deliveryDestinationType": "S3"}),
+        );
+        assert!(svc.put_delivery_destination(&req).is_err());
+    }
+
+    #[test]
+    fn put_delivery_destination_invalid_type_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "PutDeliveryDestination",
+            json!({"name": "d1", "deliveryDestinationType": "BOGUS"}),
+        );
+        assert!(svc.put_delivery_destination(&req).is_err());
+    }
+
+    #[test]
+    fn put_delivery_destination_invalid_output_format_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "PutDeliveryDestination",
+            json!({"name": "d1", "outputFormat": "xml"}),
+        );
+        assert!(svc.put_delivery_destination(&req).is_err());
+    }
+
+    #[test]
+    fn get_delivery_destination_unknown_errors() {
+        let svc = make_service();
+        let req = make_request("GetDeliveryDestination", json!({"name": "ghost"}));
+        assert!(svc.get_delivery_destination(&req).is_err());
+    }
+
+    #[test]
+    fn delete_delivery_destination_unknown_errors() {
+        let svc = make_service();
+        let req = make_request("DeleteDeliveryDestination", json!({"name": "ghost"}));
+        assert!(svc.delete_delivery_destination(&req).is_err());
+    }
+
+    #[test]
+    fn put_delivery_source_missing_name_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "PutDeliverySource",
+            json!({"resourceArn": "arn:aws:logs:us-east-1:123:log-group:g"}),
+        );
+        assert!(svc.put_delivery_source(&req).is_err());
+    }
+
+    #[test]
+    fn get_delivery_source_unknown_errors() {
+        let svc = make_service();
+        let req = make_request("GetDeliverySource", json!({"name": "ghost"}));
+        assert!(svc.get_delivery_source(&req).is_err());
+    }
+
+    #[test]
+    fn delete_delivery_source_unknown_errors() {
+        let svc = make_service();
+        let req = make_request("DeleteDeliverySource", json!({"name": "ghost"}));
+        assert!(svc.delete_delivery_source(&req).is_err());
+    }
+
+    #[test]
+    fn get_delivery_unknown_errors() {
+        let svc = make_service();
+        let req = make_request("GetDelivery", json!({"id": "ghost"}));
+        assert!(svc.get_delivery(&req).is_err());
+    }
+
+    #[test]
+    fn delete_delivery_unknown_errors() {
+        let svc = make_service();
+        let req = make_request("DeleteDelivery", json!({"id": "ghost"}));
+        assert!(svc.delete_delivery(&req).is_err());
+    }
+
+    #[test]
+    fn put_delivery_destination_policy_unknown_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "PutDeliveryDestinationPolicy",
+            json!({
+                "deliveryDestinationName": "ghost",
+                "deliveryDestinationPolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+            }),
+        );
+        assert!(svc.put_delivery_destination_policy(&req).is_err());
+    }
+
+    #[test]
+    fn get_delivery_destination_policy_unknown_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "GetDeliveryDestinationPolicy",
+            json!({"deliveryDestinationName": "ghost"}),
+        );
+        assert!(svc.get_delivery_destination_policy(&req).is_err());
+    }
+
+    #[test]
+    fn delete_delivery_destination_policy_unknown_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "DeleteDeliveryDestinationPolicy",
+            json!({"deliveryDestinationName": "ghost"}),
+        );
+        assert!(svc.delete_delivery_destination_policy(&req).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- PutDeliveryDestination: missing name, invalid type, invalid output format
- Get/Delete delivery destination unknown
- PutDeliverySource missing name; Get/Delete source unknown
- Get/Delete delivery unknown; destination policy unknown

## Test plan
- [x] cargo test -p fakecloud-logs --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for delivery destination, source, delivery, and destination policy error paths in `fakecloud-logs` streams service. Tests cover missing required fields, invalid type/output format, and unknown resource lookups across Put/Get/Delete operations.

<sup>Written for commit 6df806cb40848a3d6cf71d98b995b4e0251cb399. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

