### PR TITLE
test(lambda,cognito): function/ESM + device + import-job error paths

### DIFF
--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -6211,4 +6211,85 @@ mod tests {
         let req = make_req("UpdateUserPoolClient", &body.to_string());
         assert!(svc.update_user_pool_client(&req).is_err());
     }
+
+    #[test]
+    fn admin_get_device_not_found() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let body = json!({
+            "UserPoolId": pool_id,
+            "Username": "ghost",
+            "DeviceKey": "dk-ghost"
+        });
+        let req = make_req("AdminGetDevice", &body.to_string());
+        assert!(svc.admin_get_device(&req).is_err());
+    }
+
+    #[test]
+    fn admin_list_devices_unknown_user_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let body = json!({"UserPoolId": pool_id, "Username": "ghost"});
+        let req = make_req("AdminListDevices", &body.to_string());
+        assert!(svc.admin_list_devices(&req).is_err());
+    }
+
+    #[test]
+    fn admin_forget_device_unknown_user_errors() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let body = json!({
+            "UserPoolId": pool_id,
+            "Username": "ghost",
+            "DeviceKey": "dk"
+        });
+        let req = make_req("AdminForgetDevice", &body.to_string());
+        assert!(svc.admin_forget_device(&req).is_err());
+    }
+
+    #[test]
+    fn revoke_token_invalid_errors() {
+        let (svc, _) = make_svc();
+        let body = json!({"ClientId": "c", "Token": "bogus"});
+        let req = make_req("RevokeToken", &body.to_string());
+        assert!(svc.revoke_token(&req).is_err());
+    }
+
+    #[test]
+    fn describe_user_import_job_not_found() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let body = json!({"UserPoolId": pool_id, "JobId": "ghost"});
+        let req = make_req("DescribeUserImportJob", &body.to_string());
+        assert!(svc.describe_user_import_job(&req).is_err());
+    }
+
+    #[test]
+    fn start_user_import_job_not_found() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let body = json!({"UserPoolId": pool_id, "JobId": "ghost"});
+        let req = make_req("StartUserImportJob", &body.to_string());
+        assert!(svc.start_user_import_job(&req).is_err());
+    }
+
+    #[test]
+    fn stop_user_import_job_not_found() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let body = json!({"UserPoolId": pool_id, "JobId": "ghost"});
+        let req = make_req("StopUserImportJob", &body.to_string());
+        assert!(svc.stop_user_import_job(&req).is_err());
+    }
+
+    #[test]
+    fn get_csv_header_basic() {
+        let (svc, _) = make_svc();
+        let pool_id = create_pool(&svc);
+        let body = json!({"UserPoolId": pool_id});
+        let req = make_req("GetCSVHeader", &body.to_string());
+        let resp = svc.get_csv_header(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["CSVHeader"].is_array());
+    }
 }

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1632,4 +1632,48 @@ mod tests {
         let req = make_request(Method::POST, "/unknown/route", "{}");
         assert!(svc.handle(req).await.is_err());
     }
+
+    #[tokio::test]
+    async fn publish_version_unknown_function_errors() {
+        let svc = LambdaService::new(make_state());
+        assert!(svc.publish_version("ghost").is_err());
+    }
+
+    #[tokio::test]
+    async fn get_function_unknown_errors() {
+        let svc = LambdaService::new(make_state());
+        assert!(svc.get_function("ghost").is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_function_unknown_errors() {
+        let svc = LambdaService::new(make_state());
+        assert!(svc.delete_function("ghost").is_err());
+    }
+
+    #[tokio::test]
+    async fn get_event_source_mapping_unknown_errors() {
+        let svc = LambdaService::new(make_state());
+        assert!(svc.get_event_source_mapping("ghost").is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_event_source_mapping_unknown_errors() {
+        let svc = LambdaService::new(make_state());
+        assert!(svc.delete_event_source_mapping("ghost").is_err());
+    }
+
+    #[tokio::test]
+    async fn list_functions_empty_ok() {
+        let svc = LambdaService::new(make_state());
+        let resp = svc.list_functions().unwrap();
+        assert_eq!(resp.status, http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn list_event_source_mappings_empty_ok() {
+        let svc = LambdaService::new(make_state());
+        let resp = svc.list_event_source_mappings().unwrap();
+        assert_eq!(resp.status, http::StatusCode::OK);
+    }
 }


### PR DESCRIPTION
## Summary
- Lambda: publish-version/get/delete function unknown, get/delete ESM unknown, list empty
- Cognito misc: admin device get/list/forget unknown user, revoke token invalid, user import job describe/start/stop not found, get_csv_header

## Test plan
- [x] cargo test -p fakecloud-lambda --lib
- [x] cargo test -p fakecloud-cognito --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for error paths in `fakecloud-lambda` and `fakecloud-cognito` to improve coverage and verify expected responses. Tests cover Lambda publish/get/delete and event source mapping get/delete returning errors for unknown IDs, list functions/mappings empty OK; Cognito admin device operations error on unknown users, invalid token revocation, user import job describe/start/stop not found, and GetCSVHeader returns an array.

<sup>Written for commit 11e2f287f4d88f11a5ef78bcb7945d01b663d4fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

