### PR TITLE
test(ses): fanout classify coverage

### DIFF
--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -447,4 +447,24 @@ mod tests {
         assert_eq!(event["eventType"], "Complaint");
         assert_eq!(event["complaint"]["complaintFeedbackType"], "abuse");
     }
+
+    #[test]
+    fn classify_multiple_recipients_no_simulator() {
+        let recipients = vec![
+            "a@example.com".to_string(),
+            "b@example.com".to_string(),
+            "c@example.com".to_string(),
+        ];
+        let (events, suppress) = classify_recipients(&recipients);
+        assert!(events.contains(&SesEventType::Send));
+        assert!(events.contains(&SesEventType::Delivery));
+        assert!(!suppress);
+    }
+
+    #[test]
+    fn classify_empty_recipients() {
+        let (events, suppress) = classify_recipients(&[]);
+        assert!(!events.is_empty());
+        assert!(!suppress);
+    }
 }


### PR DESCRIPTION
## Summary
- classify_recipients with multiple non-simulator addresses
- classify_recipients with empty input

## Test plan
- [x] cargo test -p fakecloud-ses --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `classify_recipients` in `fakecloud-ses` covering multiple non-simulator recipients and empty input. Ensures Send and Delivery are emitted for multiple recipients and that events are non-empty with `suppress` remaining false.

<sup>Written for commit 1c0d16593171249e35cc82e81d4d04f8f435abbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

