### PR TITLE
test(sns): missing-ARN error paths across operations

### DIFF
--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -6297,4 +6297,139 @@ mod tests {
         let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("Policy"));
     }
+
+    // ── PublishBatch error paths ──
+
+    #[test]
+    fn publish_batch_missing_topic_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "PublishBatch",
+            vec![
+                ("PublishBatchRequestEntries.member.1.Id", "e1"),
+                ("PublishBatchRequestEntries.member.1.Message", "hi"),
+            ],
+        );
+        assert!(svc.publish_batch(&req).is_err());
+    }
+
+    #[test]
+    fn subscribe_missing_topic_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request("Subscribe", vec![("Protocol", "sqs")]);
+        assert!(svc.subscribe(&req).is_err());
+    }
+
+    #[test]
+    fn unsubscribe_missing_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request("Unsubscribe", vec![]);
+        assert!(svc.unsubscribe(&req).is_err());
+    }
+
+    #[test]
+    fn get_subscription_attributes_missing_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request("GetSubscriptionAttributes", vec![]);
+        assert!(svc.get_subscription_attributes(&req).is_err());
+    }
+
+    #[test]
+    fn set_subscription_attributes_missing_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "SetSubscriptionAttributes",
+            vec![("AttributeName", "x"), ("AttributeValue", "y")],
+        );
+        assert!(svc.set_subscription_attributes(&req).is_err());
+    }
+
+    #[test]
+    fn set_topic_attributes_missing_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "SetTopicAttributes",
+            vec![("AttributeName", "DisplayName"), ("AttributeValue", "x")],
+        );
+        assert!(svc.set_topic_attributes(&req).is_err());
+    }
+
+    #[test]
+    fn list_tags_missing_resource_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request("ListTagsForResource", vec![]);
+        assert!(svc.list_tags_for_resource(&req).is_err());
+    }
+
+    #[test]
+    fn tag_resource_missing_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "TagResource",
+            vec![("Tags.member.1.Key", "k"), ("Tags.member.1.Value", "v")],
+        );
+        assert!(svc.tag_resource(&req).is_err());
+    }
+
+    #[test]
+    fn untag_resource_missing_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request("UntagResource", vec![("TagKeys.member.1", "k")]);
+        assert!(svc.untag_resource(&req).is_err());
+    }
+
+    #[test]
+    fn add_permission_missing_topic_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "AddPermission",
+            vec![("Label", "l"), ("AWSAccountId.member.1", "123")],
+        );
+        assert!(svc.add_permission(&req).is_err());
+    }
+
+    #[test]
+    fn remove_permission_missing_topic_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request("RemovePermission", vec![("Label", "l")]);
+        assert!(svc.remove_permission(&req).is_err());
+    }
+
+    #[test]
+    fn create_platform_endpoint_missing_app_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request("CreatePlatformEndpoint", vec![("Token", "t")]);
+        assert!(svc.create_platform_endpoint(&req).is_err());
+    }
+
+    #[test]
+    fn set_platform_application_attributes_unknown_app_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request(
+            "SetPlatformApplicationAttributes",
+            vec![
+                (
+                    "PlatformApplicationArn",
+                    "arn:aws:sns:us-east-1:123456789012:app/GCM/ghost",
+                ),
+                ("Attributes.entry.1.key", "PlatformCredential"),
+                ("Attributes.entry.1.value", "x"),
+            ],
+        );
+        assert!(svc.set_platform_application_attributes(&req).is_err());
+    }
+
+    #[test]
+    fn delete_topic_missing_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request("DeleteTopic", vec![]);
+        assert!(svc.delete_topic(&req).is_err());
+    }
+
+    #[test]
+    fn get_topic_attributes_missing_arn_errors() {
+        let (svc, _) = make_sns();
+        let req = sns_request("GetTopicAttributes", vec![]);
+        assert!(svc.get_topic_attributes(&req).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- PublishBatch missing topic
- Subscribe/unsubscribe/get+set subscription/topic attributes missing ARN
- Tag/untag/list-tags missing resource ARN
- add/remove permission missing topic/label
- create_platform_endpoint missing app ARN, set app attrs unknown
- delete_topic/get_topic_attributes missing ARN

## Test plan
- [x] cargo test -p fakecloud-sns --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests that validate missing-ARN and missing-parameter error paths across SNS operations in `fakecloud-sns`. This strengthens negative-path coverage for topics, subscriptions, tagging, permissions, platform applications, and batch publish to prevent validation regressions.

<sup>Written for commit e917b2fa7ee80fca670d11d5500be669dc99078b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

