### PR TITLE
test(dynamodb): batch/transact/global-table error paths

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -6610,4 +6610,76 @@ mod tests {
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["Count"], 2);
     }
+
+    #[test]
+    fn batch_get_item_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "BatchGetItem",
+            json!({
+                "RequestItems": {
+                    "ghost": {"Keys": [{"k": {"S": "1"}}]}
+                }
+            }),
+        );
+        assert!(svc.batch_get_item(&req).is_err());
+    }
+
+    #[test]
+    fn batch_write_item_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "BatchWriteItem",
+            json!({
+                "RequestItems": {
+                    "ghost": [{"PutRequest": {"Item": {"k": {"S": "1"}}}}]
+                }
+            }),
+        );
+        assert!(svc.batch_write_item(&req).is_err());
+    }
+
+    #[test]
+    fn transact_write_items_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "TransactWriteItems",
+            json!({
+                "TransactItems": [{
+                    "Put": {"TableName": "ghost", "Item": {"k": {"S": "1"}}}
+                }]
+            }),
+        );
+        assert!(svc.transact_write_items(&req).is_err());
+    }
+
+    #[test]
+    fn transact_get_items_unknown_table_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "TransactGetItems",
+            json!({
+                "TransactItems": [{
+                    "Get": {"TableName": "ghost", "Key": {"k": {"S": "1"}}}
+                }]
+            }),
+        );
+        assert!(svc.transact_get_items(&req).is_err());
+    }
+
+    #[test]
+    fn describe_global_table_not_found_b() {
+        let svc = make_service();
+        let req = make_request("DescribeGlobalTable", json!({"GlobalTableName": "ghost"}));
+        assert!(svc.describe_global_table(&req).is_err());
+    }
+
+    #[test]
+    fn list_global_tables_empty_ok() {
+        let svc = make_service();
+        let req = make_request("ListGlobalTables", json!({}));
+        let resp = svc.list_global_tables(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["GlobalTables"].is_array());
+    }
 }


### PR DESCRIPTION
## Summary
- BatchGetItem/BatchWriteItem unknown table
- TransactGet/WriteItems unknown table
- DescribeGlobalTable not found, ListGlobalTables empty

## Test plan
- [x] cargo test -p fakecloud-dynamodb --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for DynamoDB error paths in `fakecloud-dynamodb`. Verify unknown tables fail for BatchGet/BatchWrite and TransactGet/TransactWrite, DescribeGlobalTable errors, and ListGlobalTables returns an empty array.

<sup>Written for commit 7a7ec4f4d91d93cdaa77d8dd99b8ff5b8c2a0390. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

