### PR TITLE
test(s3): object/bucket tagging lifecycle + errors

### DIFF
--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -5654,4 +5654,86 @@ mod tests {
             .put_bucket_website("123456789012", &req, "ghost")
             .is_err());
     }
+
+    #[test]
+    fn put_object_tagging_bucket_not_found() {
+        let svc = make_service();
+        let xml = b"<Tagging><TagSet></TagSet></Tagging>";
+        let req = make_request(Method::PUT, "/ghost/k", &[("tagging", "")], xml);
+        assert!(svc
+            .put_object_tagging("123456789012", &req, "ghost", "k")
+            .is_err());
+    }
+
+    #[test]
+    fn put_object_tagging_key_not_found() {
+        let svc = make_service();
+        seed_bucket(&svc, "pot");
+        let xml = b"<Tagging><TagSet></TagSet></Tagging>";
+        let req = make_request(Method::PUT, "/pot/ghost", &[("tagging", "")], xml);
+        assert!(svc
+            .put_object_tagging("123456789012", &req, "pot", "ghost")
+            .is_err());
+    }
+
+    #[test]
+    fn put_object_tagging_lifecycle() {
+        let svc = make_service();
+        seed_bucket(&svc, "pota");
+        let req = make_request(Method::PUT, "/pota/k", &[], b"x");
+        svc.put_object("123456789012", &req, "pota", "k").unwrap();
+
+        let xml =
+            b"<Tagging><TagSet><Tag><Key>env</Key><Value>prod</Value></Tag></TagSet></Tagging>";
+        let req = make_request(Method::PUT, "/pota/k", &[("tagging", "")], xml);
+        svc.put_object_tagging("123456789012", &req, "pota", "k")
+            .unwrap();
+
+        let req = make_request(Method::GET, "/pota/k", &[("tagging", "")], b"");
+        let resp = svc
+            .get_object_tagging("123456789012", &req, "pota", "k")
+            .unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body.contains("<Key>env</Key>"));
+
+        svc.delete_object_tagging("123456789012", "pota", "k")
+            .unwrap();
+    }
+
+    #[test]
+    fn delete_object_tagging_bucket_not_found() {
+        let svc = make_service();
+        assert!(svc
+            .delete_object_tagging("123456789012", "ghost", "k")
+            .is_err());
+    }
+
+    #[test]
+    fn put_bucket_tagging_bucket_not_found() {
+        let svc = make_service();
+        let xml = b"<Tagging><TagSet></TagSet></Tagging>";
+        let req = make_request(Method::PUT, "/ghost", &[("tagging", "")], xml);
+        assert!(svc
+            .put_bucket_tagging("123456789012", &req, "ghost")
+            .is_err());
+    }
+
+    #[test]
+    fn bucket_tagging_lifecycle() {
+        let svc = make_service();
+        seed_bucket(&svc, "bt");
+        let xml =
+            b"<Tagging><TagSet><Tag><Key>env</Key><Value>prod</Value></Tag></TagSet></Tagging>";
+        let req = make_request(Method::PUT, "/bt", &[("tagging", "")], xml);
+        svc.put_bucket_tagging("123456789012", &req, "bt").unwrap();
+
+        let req = make_request(Method::GET, "/bt", &[("tagging", "")], b"");
+        let resp = svc.get_bucket_tagging("123456789012", &req, "bt").unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body.contains("<Key>env</Key>"));
+
+        let req = make_request(Method::DELETE, "/bt", &[("tagging", "")], b"");
+        svc.delete_bucket_tagging("123456789012", &req, "bt")
+            .unwrap();
+    }
 }


### PR DESCRIPTION
## Summary
- Object tagging: put/get/delete lifecycle, bucket/key not found
- Bucket tagging: put/get/delete lifecycle, bucket not found

## Test plan
- [x] cargo test -p fakecloud-s3 --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for S3 object and bucket tagging in `fakecloud-s3`. Covers PUT/GET/DELETE lifecycles, validates expected XML in GET responses, and asserts proper errors for missing bucket or key across object and bucket tagging paths.

<sup>Written for commit 13a9df4caedbc73d53b56936db7f6222b4aac7b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

