### PR TITLE
test(bedrock): automated reasoning + unknown route

### DIFF
--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -2777,4 +2777,32 @@ mod tests {
         let req = make_request(Method::GET, "/", "");
         crate::enforced_guardrails::list_enforced_guardrails_configuration(&state, &req).unwrap();
     }
+
+    #[tokio::test]
+    async fn unknown_route_returns_error_b() {
+        let state = make_state();
+        let svc = BedrockService::new(state);
+        let req = make_request(Method::POST, "/unknown/route", "");
+        assert!(svc.handle(req).await.is_err());
+    }
+
+    #[test]
+    fn automated_reasoning_policy_not_found_get() {
+        let state = make_state();
+        let result = crate::automated_reasoning::get_automated_reasoning_policy(
+            &state,
+            "arn:aws:bedrock:us-east-1:123:automated-reasoning-policy/ghost",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn automated_reasoning_policy_delete_not_found() {
+        let state = make_state();
+        let result = crate::automated_reasoning::delete_automated_reasoning_policy(
+            &state,
+            "arn:aws:bedrock:us-east-1:123:automated-reasoning-policy/ghost",
+        );
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- Unknown route returns error
- Automated reasoning policy get/delete unknown arn

## Test plan
- [x] cargo test -p fakecloud-bedrock --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests in `fakecloud-bedrock` to ensure unknown routes return errors and automated reasoning policy GET/DELETE return errors for unknown ARNs. This locks in expected error handling and prevents regressions.

<sup>Written for commit 72873df274f4457a54face90245fb294ccc2c69e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

