### PR TITLE
test(sqs,kms,lambda): state helpers

### DIFF
--- a/crates/fakecloud-kms/src/state.rs
+++ b/crates/fakecloud-kms/src/state.rs
@@ -117,3 +117,36 @@ pub struct KmsSnapshot {
 }
 
 pub const KMS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_has_empty_collections() {
+        let state = KmsState::new("123456789012", "us-east-1");
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "us-east-1");
+        assert!(state.keys.is_empty());
+        assert!(state.aliases.is_empty());
+        assert!(state.grants.is_empty());
+        assert!(state.custom_key_stores.is_empty());
+    }
+
+    #[test]
+    fn reset_clears_collections() {
+        let mut state = KmsState::new("123456789012", "us-east-1");
+        state.aliases.insert(
+            "alias/test".to_string(),
+            KmsAlias {
+                alias_name: "alias/test".to_string(),
+                alias_arn: "arn".to_string(),
+                target_key_id: "k".to_string(),
+                creation_date: 0.0,
+            },
+        );
+        assert!(!state.aliases.is_empty());
+        state.reset();
+        assert!(state.aliases.is_empty());
+    }
+}

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -94,3 +94,31 @@ pub struct LambdaSnapshot {
     pub schema_version: u32,
     pub state: LambdaState,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_has_empty_collections() {
+        let state = LambdaState::new("123456789012", "us-east-1");
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "us-east-1");
+        assert!(state.functions.is_empty());
+        assert!(state.event_source_mappings.is_empty());
+        assert!(state.invocations.is_empty());
+    }
+
+    #[test]
+    fn reset_clears_collections() {
+        let mut state = LambdaState::new("123456789012", "us-east-1");
+        state.invocations.push(LambdaInvocation {
+            function_arn: "arn".to_string(),
+            payload: "p".to_string(),
+            timestamp: Utc::now(),
+            source: "s".to_string(),
+        });
+        state.reset();
+        assert!(state.invocations.is_empty());
+    }
+}

--- a/crates/fakecloud-sqs/src/state.rs
+++ b/crates/fakecloud-sqs/src/state.rs
@@ -112,3 +112,37 @@ impl fakecloud_core::multi_account::AccountState for SqsState {
         Self::new(account_id, region, endpoint)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_has_empty_collections() {
+        let state = SqsState::new("123456789012", "us-east-1", "http://localhost:4566");
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "us-east-1");
+        assert_eq!(state.endpoint, "http://localhost:4566");
+        assert!(state.queues.is_empty());
+        assert!(state.name_to_url.is_empty());
+    }
+
+    #[test]
+    fn reset_clears_collections() {
+        let mut state = SqsState::new("123456789012", "us-east-1", "http://localhost:4566");
+        state
+            .name_to_url
+            .insert("q1".to_string(), "url".to_string());
+        assert!(!state.name_to_url.is_empty());
+        state.reset();
+        assert!(state.name_to_url.is_empty());
+    }
+
+    #[test]
+    fn account_state_trait_impl() {
+        use fakecloud_core::multi_account::AccountState;
+        let state = SqsState::new_for_account("111122223333", "eu-west-1", "http://x");
+        assert_eq!(state.account_id, "111122223333");
+        assert_eq!(state.region, "eu-west-1");
+    }
+}


### PR DESCRIPTION
## Summary
- SQS state: new/reset/AccountState trait
- KMS state: new/reset
- Lambda state: new/reset + invocation tracking

## Test plan
- [x] cargo test -p fakecloud-sqs -p fakecloud-kms -p fakecloud-lambda --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for state helpers in `fakecloud-sqs`, `fakecloud-kms`, and `fakecloud-lambda` to verify new/reset behavior and SQS `AccountState` conformance. Also confirms Lambda invocation tracking starts empty and is cleared on reset.

<sup>Written for commit b70d65552cd269194b996ef826b20e4d1a8924c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

