### PR TITLE
test(rds): modify + describe filter errors

### DIFF
--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -3994,4 +3994,43 @@ mod tests {
         );
         assert!(svc.create_db_instance(&req).await.is_err());
     }
+
+    #[test]
+    fn modify_db_instance_missing_id_errors() {
+        let svc = make_service();
+        let req = request("ModifyDBInstance", &[]);
+        assert!(svc.modify_db_instance(&req).is_err());
+    }
+
+    #[test]
+    fn modify_db_parameter_group_unknown_pg_errors() {
+        let svc = make_service();
+        let req = request(
+            "ModifyDBParameterGroup",
+            &[
+                ("DBParameterGroupName", "ghost"),
+                ("Parameters.member.1.ParameterName", "p"),
+                ("Parameters.member.1.ParameterValue", "v"),
+                ("Parameters.member.1.ApplyMethod", "immediate"),
+            ],
+        );
+        assert!(svc.modify_db_parameter_group(&req).is_err());
+    }
+
+    #[test]
+    fn describe_db_parameter_groups_unknown_errors() {
+        let svc = make_service();
+        let req = request(
+            "DescribeDBParameterGroups",
+            &[("DBParameterGroupName", "ghost")],
+        );
+        assert!(svc.describe_db_parameter_groups(&req).is_err());
+    }
+
+    #[test]
+    fn describe_db_subnet_groups_unknown_errors() {
+        let svc = make_service();
+        let req = request("DescribeDBSubnetGroups", &[("DBSubnetGroupName", "ghost")]);
+        assert!(svc.describe_db_subnet_groups(&req).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- ModifyDBInstance missing id
- ModifyDBParameterGroup unknown pg
- DescribeDBParameterGroups/SubnetGroups unknown

## Test plan
- [x] cargo test -p fakecloud-rds --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests in `fakecloud-rds` to verify correct error responses for invalid RDS requests. Covers missing DBInstanceIdentifier in ModifyDBInstance, unknown DBParameterGroup in ModifyDBParameterGroup, and unknown names in DescribeDBParameterGroups and DescribeDBSubnetGroups.

<sup>Written for commit 059593a3607a4989685a3260c6dc04f55b7e2caa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

