### PR TITLE
test(ses): state helpers

### DIFF
--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -416,3 +416,28 @@ impl SesState {
 }
 
 pub type SharedSesState = Arc<RwLock<SesState>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_initializes_defaults() {
+        let state = SesState::new("123456789012", "us-east-1");
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "us-east-1");
+        assert!(state.identities.is_empty());
+        assert!(state.configuration_sets.is_empty());
+        assert!(state.account_settings.sending_enabled);
+    }
+
+    #[test]
+    fn reset_preserves_account_region() {
+        let mut state = SesState::new("123456789012", "eu-west-1");
+        state.account_settings.sending_enabled = false;
+        state.reset();
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "eu-west-1");
+        assert!(state.account_settings.sending_enabled);
+    }
+}


### PR DESCRIPTION
## Summary
- new() initializes defaults (sending_enabled true)
- reset preserves account/region, resets settings

## Test plan
- [x] cargo test -p fakecloud-ses --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests in `fakecloud-ses` for `SesState::new` and `SesState::reset` to lock down default initialization and state preservation.
Tests confirm `new` sets empty collections and `sending_enabled = true`, and `reset` keeps `account_id`/`region` while restoring defaults.

<sup>Written for commit c6d8c8afb218b52219464999002c9a06e0eabfe8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

