### PR TITLE
test(s3): lifecycle parser + helpers

### DIFF
--- a/crates/fakecloud-s3/src/lifecycle.rs
+++ b/crates/fakecloud-s3/src/lifecycle.rs
@@ -435,4 +435,64 @@ mod tests {
         assert_eq!(rules[1].prefix.as_deref(), Some("b/"));
         assert_eq!(rules[1].expiration_days, Some(20));
     }
+
+    #[test]
+    fn parse_empty_lifecycle_xml_returns_empty() {
+        let xml = "<LifecycleConfiguration></LifecycleConfiguration>";
+        let rules = parse_lifecycle_rules(xml);
+        assert!(rules.is_some());
+        assert!(rules.unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_rule_with_noncurrent_version_expiration() {
+        let xml = r#"<LifecycleConfiguration>
+            <Rule>
+                <ID>nc-rule</ID>
+                <Status>Enabled</Status>
+                <Prefix>x/</Prefix>
+                <NoncurrentVersionExpiration><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration>
+            </Rule>
+        </LifecycleConfiguration>"#;
+        let rules = parse_lifecycle_rules(xml).unwrap();
+        assert_eq!(rules.len(), 1);
+    }
+
+    #[test]
+    fn parse_rule_with_abort_incomplete_multipart() {
+        let xml = r#"<LifecycleConfiguration>
+            <Rule>
+                <ID>mp-rule</ID>
+                <Status>Enabled</Status>
+                <Prefix></Prefix>
+                <AbortIncompleteMultipartUpload><DaysAfterInitiation>7</DaysAfterInitiation></AbortIncompleteMultipartUpload>
+            </Rule>
+        </LifecycleConfiguration>"#;
+        let rules = parse_lifecycle_rules(xml).unwrap();
+        assert_eq!(rules.len(), 1);
+    }
+
+    #[test]
+    fn parse_date_valid() {
+        let d = parse_date("2025-01-15T00:00:00Z");
+        assert!(d.is_some());
+    }
+
+    #[test]
+    fn parse_date_invalid_returns_none() {
+        assert!(parse_date("bogus").is_none());
+    }
+
+    #[test]
+    fn extract_block_finds_tag() {
+        let body = "<a><b>content</b></a>";
+        let block = extract_block(body, "b");
+        assert_eq!(block, Some("content"));
+    }
+
+    #[test]
+    fn extract_block_missing_tag_returns_none() {
+        let body = "<a></a>";
+        assert!(extract_block(body, "missing").is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- Empty lifecycle xml returns empty
- Rule with NoncurrentVersionExpiration
- Rule with AbortIncompleteMultipartUpload
- parse_date valid/invalid
- extract_block found/missing

## Test plan
- [x] cargo test -p fakecloud-s3 --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests in `fakecloud-s3` for S3 lifecycle XML parsing and helper functions to improve coverage and catch edge cases. Cases include empty config, NoncurrentVersionExpiration, AbortIncompleteMultipartUpload, valid/invalid date parsing, and block extraction found/missing.

<sup>Written for commit a4206cf29c1efc88edc7967ae79e80f04549f5e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

