### PR TITLE
test(cognito): state helpers

### DIFF
--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -582,3 +582,32 @@ pub fn default_schema_attributes() -> Vec<SchemaAttribute> {
 
     attrs
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_initializes_empty() {
+        let state = CognitoState::new("123456789012", "us-east-1");
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "us-east-1");
+        assert!(state.user_pools.is_empty());
+        assert!(state.users.is_empty());
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut state = CognitoState::new("123456789012", "us-east-1");
+        state.tags.insert("arn".to_string(), HashMap::new());
+        state.reset();
+        assert!(state.tags.is_empty());
+    }
+
+    #[test]
+    fn default_schema_attributes_returns_standard() {
+        let attrs = default_schema_attributes();
+        assert!(attrs.iter().any(|a| a.name == "sub"));
+        assert!(attrs.iter().any(|a| a.name == "email"));
+    }
+}


### PR DESCRIPTION
## Summary
- new() empty collections
- reset clears tags
- default_schema_attributes returns standard attrs

## Test plan
- [x] cargo test -p fakecloud-cognito --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for Cognito state helpers to ensure new() initializes empty collections, reset clears tags, and default_schema_attributes returns standard attributes like sub and email.

<sup>Written for commit b5c39aea71634f99f53b98208b6b9369d45806b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

