### PR TITLE
test(logs): state helpers

### DIFF
--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -365,3 +365,25 @@ pub struct LogsSnapshot {
 }
 
 pub const LOGS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_initializes_empty() {
+        let state = LogsState::new("123456789012", "us-east-1");
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "us-east-1");
+        assert!(state.log_groups.is_empty());
+        assert!(state.queries.is_empty());
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut state = LogsState::new("123456789012", "us-east-1");
+        state.bearer_token_auth.insert("g".to_string(), true);
+        state.reset();
+        assert!(state.bearer_token_auth.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- new() initializes empty collections
- reset clears state

## Test plan
- [x] cargo test -p fakecloud-logs --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `LogsState::new` and `reset` in `fakecloud-logs` to verify account/region initialization and proper clearing of collections. Confirms `log_groups`, `queries`, and `bearer_token_auth` are empty after reset.

<sup>Written for commit d0e9cb5bff908228ad6d7a19c5f305c77bf389b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

