### PR TITLE
test(cloudformation): state helpers

### DIFF
--- a/crates/fakecloud-cloudformation/src/state.rs
+++ b/crates/fakecloud-cloudformation/src/state.rs
@@ -60,3 +60,39 @@ pub struct CloudFormationSnapshot {
     pub schema_version: u32,
     pub state: CloudFormationState,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_initializes_empty() {
+        let state = CloudFormationState::new("123456789012", "us-east-1");
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "us-east-1");
+        assert!(state.stacks.is_empty());
+    }
+
+    #[test]
+    fn reset_clears_stacks() {
+        let mut state = CloudFormationState::new("123456789012", "us-east-1");
+        state.stacks.insert(
+            "s1".to_string(),
+            Stack {
+                name: "s1".to_string(),
+                stack_id: "id".to_string(),
+                template: "{}".to_string(),
+                status: "CREATE_COMPLETE".to_string(),
+                resources: vec![],
+                parameters: HashMap::new(),
+                tags: HashMap::new(),
+                created_at: Utc::now(),
+                updated_at: None,
+                description: None,
+                notification_arns: vec![],
+            },
+        );
+        state.reset();
+        assert!(state.stacks.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- new() empty state
- reset clears stacks

## Test plan
- [x] cargo test -p fakecloud-cloudformation --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `fakecloud-cloudformation` state helpers to verify `CloudFormationState::new` initializes an empty state and `reset` clears all stacks. Improves coverage and guards against regressions in state lifecycle behavior.

<sup>Written for commit 5f614ee94f94a4350883f2d91bb060474ca5ba93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

