### PR TITLE
test(apigatewayv2): CORS resolve_origin paths

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/cors.rs
+++ b/crates/fakecloud-apigatewayv2/src/cors.rs
@@ -242,4 +242,54 @@ mod tests {
             "true"
         );
     }
+
+    #[test]
+    fn test_resolve_origin_wildcard_short_circuits() {
+        let req = create_test_request(Method::OPTIONS, false);
+        let origins = vec!["*".to_string(), "https://b.com".to_string()];
+        assert_eq!(resolve_origin(&origins, &req), "*");
+    }
+
+    #[test]
+    fn test_resolve_origin_matching_request_origin_reflected() {
+        let mut req = create_test_request(Method::OPTIONS, false);
+        req.headers
+            .insert("origin", "https://a.com".parse().unwrap());
+        let origins = vec!["https://a.com".to_string(), "https://b.com".to_string()];
+        assert_eq!(resolve_origin(&origins, &req), "https://a.com");
+    }
+
+    #[test]
+    fn test_resolve_origin_no_match_returns_first() {
+        let req = create_test_request(Method::OPTIONS, false);
+        let origins = vec!["https://a.com".to_string()];
+        assert_eq!(resolve_origin(&origins, &req), "https://a.com");
+    }
+
+    #[test]
+    fn test_resolve_origin_empty_origins_returns_star() {
+        let req = create_test_request(Method::OPTIONS, false);
+        let origins: Vec<String> = vec![];
+        assert_eq!(resolve_origin(&origins, &req), "*");
+    }
+
+    #[test]
+    fn add_cors_headers_wildcard_origin() {
+        let cors_config = CorsConfiguration {
+            allow_credentials: None,
+            allow_headers: None,
+            allow_methods: None,
+            allow_origins: Some(vec!["*".to_string()]),
+            expose_headers: None,
+            max_age: None,
+        };
+        let response = AwsResponse {
+            status: StatusCode::OK,
+            content_type: "application/json".to_string(),
+            headers: HeaderMap::new(),
+            body: Bytes::from(b"x".to_vec()).into(),
+        };
+        let out = add_cors_headers(response, &cors_config);
+        assert_eq!(out.headers.get("access-control-allow-origin").unwrap(), "*");
+    }
 }


### PR DESCRIPTION
## Summary
- resolve_origin wildcard / matching / no-match / empty
- add_cors_headers wildcard

## Test plan
- [x] cargo test -p fakecloud-apigatewayv2 --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added unit tests for CORS origin resolution and wildcard behavior in `fakecloud-apigatewayv2`. Cases cover wildcard short-circuit, reflecting a matching request origin, defaulting to the first origin on no match, empty origins returning "*", and verifying wildcard `allow_origins` sets Access-Control-Allow-Origin to "*".

<sup>Written for commit e904033021df72a1c82ba7520a7088f895d1e01f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

