### PR TITLE
test(bedrock): state new

### DIFF
--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -487,3 +487,17 @@ pub struct AutomatedReasoningTestCase {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_initializes_state() {
+        let state = BedrockState::new("123456789012", "us-east-1");
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "us-east-1");
+        assert!(state.guardrails.is_empty());
+        assert!(state.custom_models.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- new() initializes bedrock state with empty collections

## Test plan
- [x] cargo test -p fakecloud-bedrock --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test for `BedrockState::new` to verify it sets `account_id` and `region`, and initializes `guardrails` and `custom_models` as empty, preventing regressions in state initialization.

<sup>Written for commit 523ca00ee9f59e72e2b7bd7b45d4be85389e4b47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

