### PR TITLE
test(core): protocol parse edges

### DIFF
--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -316,4 +316,38 @@ mod tests {
         assert_eq!(params.get("Action").unwrap(), "SendMessage");
         assert_eq!(params.get("MessageBody").unwrap(), "hello");
     }
+
+    #[test]
+    fn parse_query_body_empty_returns_empty_map() {
+        let body = Bytes::from("");
+        let params = parse_query_body(&body);
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn parse_query_body_duplicate_keys_last_wins() {
+        let body = Bytes::from("key=a&key=b");
+        let params = parse_query_body(&body);
+        assert_eq!(params.get("key").unwrap(), "b");
+    }
+
+    #[test]
+    fn parse_query_body_single_key() {
+        let body = Bytes::from("key=value");
+        let params = parse_query_body(&body);
+        assert_eq!(params.get("key").unwrap(), "value");
+    }
+
+    #[test]
+    fn parse_amz_target_rds() {
+        let result = parse_amz_target("AmazonEC2ContainerServiceV20141113.ListClusters");
+        // Not ECS — just verify doesn't panic on unknown prefixes
+        assert!(result.is_some() || result.is_none());
+    }
+
+    #[test]
+    fn parse_amz_target_invalid_returns_none() {
+        assert!(parse_amz_target("NoDotHere").is_none());
+        assert!(parse_amz_target("").is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- parse_query_body empty, duplicate keys, single key
- parse_amz_target invalid / empty strings

## Test plan
- [x] cargo test -p fakecloud-core --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for protocol parsing edge cases in `fakecloud-core` to lock down behavior and avoid regressions. Covers empty and duplicate-key query bodies, single-key parsing, and `parse_amz_target` handling of unknown prefixes and invalid/empty strings.

<sup>Written for commit c4209fed70ffe9e29ed72aa213f74014ea2f55ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

