### PR TITLE
test(ssm): state new

### DIFF
--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -746,3 +746,15 @@ pub struct SsmSnapshot {
 }
 
 pub const SSM_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_initializes() {
+        let state = SsmState::new("123456789012", "us-east-1");
+        assert_eq!(state.account_id, "123456789012");
+        assert_eq!(state.region, "us-east-1");
+    }
+}


### PR DESCRIPTION
## Summary
- new() initializes account/region

## Test plan
- [x] cargo test -p fakecloud-ssm --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test for SsmState::new to ensure it initializes account_id and region correctly. This guards against regressions in SSM state construction.

<sup>Written for commit 404b48e096f6ad185fa765639d8aacc6e7e023f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

