### PR TITLE
test(iam): xml_responses helpers

### DIFF
--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -868,3 +868,28 @@ fn generate_alphanum_id(len: usize) -> String {
         .take(len)
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_encode_policy_escapes_special_chars() {
+        let encoded = url_encode_policy("a b");
+        assert!(encoded.contains("%20") || encoded.contains("+"));
+    }
+
+    #[test]
+    fn generate_alphanum_id_length() {
+        let id = generate_alphanum_id(20);
+        assert_eq!(id.len(), 20);
+        assert!(id.chars().all(|c| c.is_alphanumeric()));
+    }
+
+    #[test]
+    fn generate_alphanum_id_uniqueness() {
+        let a = generate_alphanum_id(16);
+        let b = generate_alphanum_id(16);
+        assert_ne!(a, b);
+    }
+}


### PR DESCRIPTION
## Summary
- url_encode_policy escapes spaces
- generate_alphanum_id length + uniqueness

## Test plan
- [x] cargo test -p fakecloud-iam --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests in `fakecloud-iam` for `url_encode_policy` and `generate_alphanum_id`. Tests verify space escaping in URL-encoded policies, fixed-length alphanumeric IDs, and basic uniqueness to prevent regressions.

<sup>Written for commit 51bae3657a2071389014ab0951a95164caab1152. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

