### PR TITLE
test(aws): xml wrap_xml + xml_escape

### DIFF
--- a/crates/fakecloud-aws/src/xml.rs
+++ b/crates/fakecloud-aws/src/xml.rs
@@ -26,3 +26,40 @@ pub fn xml_escape(s: &str) -> String {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_xml_prepends_declaration() {
+        let out = wrap_xml("<foo/>");
+        assert!(out.starts_with("<?xml"));
+        assert!(out.contains("<foo/>"));
+    }
+
+    #[test]
+    fn xml_escape_standard_entities() {
+        assert_eq!(
+            xml_escape("a&b<c>d\"e'f"),
+            "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+        );
+    }
+
+    #[test]
+    fn xml_escape_preserves_whitespace() {
+        assert_eq!(xml_escape("a\tb\nc\rd"), "a\tb\nc\rd");
+    }
+
+    #[test]
+    fn xml_escape_control_chars() {
+        let input = "a\x01b";
+        let out = xml_escape(input);
+        assert_eq!(out, "a&#x1;b");
+    }
+
+    #[test]
+    fn xml_escape_plain_chars() {
+        assert_eq!(xml_escape("hello"), "hello");
+    }
+}


### PR DESCRIPTION
## Summary
- wrap_xml prepends declaration
- xml_escape standard entities
- xml_escape preserves whitespace
- xml_escape control chars
- xml_escape plain chars

## Test plan
- [x] cargo test -p fakecloud-aws --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `fakecloud-aws` XML helpers to strengthen coverage. Verifies `wrap_xml` prepends the XML declaration and `xml_escape` correctly escapes standard entities, preserves whitespace, encodes control characters, and leaves plain text unchanged.

<sup>Written for commit 6c4d4fabecb3050fee5cb6068b69dc1c9e0a0bfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

