### PR TITLE
test(persistence): config validation

### DIFF
--- a/crates/fakecloud-persistence/src/config.rs
+++ b/crates/fakecloud-persistence/src/config.rs
@@ -54,3 +54,59 @@ impl PersistenceConfig {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_config_has_defaults() {
+        let cfg = PersistenceConfig::memory();
+        assert_eq!(cfg.mode, StorageMode::Memory);
+        assert!(cfg.data_path.is_none());
+        assert_eq!(cfg.s3_cache_bytes, 0);
+    }
+
+    #[test]
+    fn persistent_config_stores_path() {
+        let cfg = PersistenceConfig::persistent(PathBuf::from("/tmp/x"), 1024);
+        assert_eq!(cfg.mode, StorageMode::Persistent);
+        assert_eq!(
+            cfg.data_path.as_deref(),
+            Some(std::path::Path::new("/tmp/x"))
+        );
+        assert_eq!(cfg.s3_cache_bytes, 1024);
+    }
+
+    #[test]
+    fn validate_memory_ok() {
+        assert!(PersistenceConfig::memory().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_persistent_requires_path() {
+        let cfg = PersistenceConfig {
+            mode: StorageMode::Persistent,
+            data_path: None,
+            s3_cache_bytes: 0,
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_memory_with_data_path_errors() {
+        let cfg = PersistenceConfig {
+            mode: StorageMode::Memory,
+            data_path: Some(PathBuf::from("/tmp")),
+            s3_cache_bytes: 0,
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_persistent_with_path_ok() {
+        assert!(PersistenceConfig::persistent(PathBuf::from("/tmp"), 0)
+            .validate()
+            .is_ok());
+    }
+}


### PR DESCRIPTION
## Summary
- memory/persistent config constructors
- validate: memory ok, persistent requires path, memory+path errors

## Test plan
- [x] cargo test -p fakecloud-persistence --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `PersistenceConfig` in `fakecloud-persistence` to verify constructors and validation rules. Memory has defaults (no path, 0 cache); persistent stores and requires a path; memory with a path errors; persistent with a path passes.

<sup>Written for commit 130b5bf4975b2e8ee6851131dfbc21d4ccf41cb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

