### PR TITLE
test(apigatewayv2): lambda_proxy edges

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -299,4 +299,77 @@ mod tests {
         assert_eq!(result.status, StatusCode::OK);
         assert_eq!(result.body.expect_bytes(), b"binary data".as_slice());
     }
+
+    #[test]
+    fn test_parse_lambda_response_no_body_defaults_empty() {
+        let response = json!({"statusCode": 204});
+        let result = parse_lambda_response(response).unwrap();
+        assert_eq!(result.status, StatusCode::NO_CONTENT);
+        assert!(result.body.expect_bytes().is_empty());
+    }
+
+    #[test]
+    fn test_parse_lambda_response_invalid_status_errors() {
+        let response = json!({"statusCode": 9999, "body": ""});
+        assert!(parse_lambda_response(response).is_err());
+    }
+
+    #[test]
+    fn test_parse_lambda_response_invalid_base64_errors() {
+        let response = json!({
+            "statusCode": 200,
+            "body": "not-base64!!!",
+            "isBase64Encoded": true
+        });
+        assert!(parse_lambda_response(response).is_err());
+    }
+
+    #[test]
+    fn test_construct_event_with_binary_body() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/octet-stream".parse().unwrap());
+        let req = AwsRequest {
+            service: "apigateway".to_string(),
+            action: "Execute".to_string(),
+            method: Method::POST,
+            raw_path: "/prod/img".to_string(),
+            raw_query: String::new(),
+            path_segments: vec!["prod".to_string(), "img".to_string()],
+            query_params: HashMap::new(),
+            headers,
+            body: Bytes::from(vec![0xFF, 0xFE, 0xFD]),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "request-id".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        };
+        let event = construct_event(&req, "POST /img", "prod", HashMap::new());
+        assert_eq!(event["isBase64Encoded"], true);
+    }
+
+    #[test]
+    fn test_construct_event_empty_body() {
+        let req = AwsRequest {
+            service: "apigateway".to_string(),
+            action: "Execute".to_string(),
+            method: Method::GET,
+            raw_path: "/prod/noop".to_string(),
+            raw_query: String::new(),
+            path_segments: vec!["prod".to_string(), "noop".to_string()],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "request-id".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        };
+        let event = construct_event(&req, "GET /noop", "prod", HashMap::new());
+        assert_eq!(event["isBase64Encoded"], false);
+        assert!(event["body"].is_null());
+    }
 }


### PR DESCRIPTION
## Summary
- parse_lambda_response empty body + invalid status + invalid base64
- construct_event binary body + empty body

## Test plan
- [x] cargo test -p fakecloud-apigatewayv2 --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add edge-case tests in `fakecloud-apigatewayv2` Lambda proxy to validate `parse_lambda_response` and `construct_event` behavior. Covers empty body defaults, invalid status/base64 errors, binary body setting `isBase64Encoded`, and empty body yielding null body with `isBase64Encoded=false`.

<sup>Written for commit 76634cd9d9a2760d40ca211e29cfe0351ded35a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

