### PR TITLE
test(apigatewayv2): http_proxy edges

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/http_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/http_proxy.rs
@@ -126,4 +126,19 @@ mod tests {
         let result = forward_request("not-a-valid-url", &req, Some(5000)).await;
         assert!(result.is_err());
     }
+
+    #[tokio::test]
+    async fn test_forward_request_unreachable_host_errors() {
+        let req = create_test_request();
+        // Non-existent port on localhost should fail quickly
+        let result = forward_request("http://127.0.0.1:1/unreachable", &req, Some(200)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_forward_request_default_timeout() {
+        let req = create_test_request();
+        let result = forward_request("http://127.0.0.1:1/x", &req, None).await;
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- forward_request unreachable host
- forward_request default timeout

## Test plan
- [x] cargo test -p fakecloud-apigatewayv2 --lib
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add edge-case tests for `forward_request` in `fakecloud-apigatewayv2` to verify behavior with unreachable targets and the default timeout path. Ensures requests to `127.0.0.1:1` fail quickly and that passing `None` triggers the default timeout and returns an error.

<sup>Written for commit 7829c02684638358c7085b62887580a66245aa25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

