### PR TITLE
test(sqs): unit tests for SqsDeliveryImpl

### DIFF
--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -114,3 +114,187 @@ impl SqsDelivery for SqsDeliveryImpl {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{SharedSqsState, SqsQueue, SqsState};
+    use chrono::Utc;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    const ACCOUNT: &str = "123456789012";
+    const REGION: &str = "us-east-1";
+    const ENDPOINT: &str = "http://localhost:4566";
+
+    fn make_queue(name: &str, is_fifo: bool, content_based_dedup: bool) -> SqsQueue {
+        let mut attributes = HashMap::new();
+        if content_based_dedup {
+            attributes.insert(
+                "ContentBasedDeduplication".to_string(),
+                "true".to_string(),
+            );
+        }
+        SqsQueue {
+            queue_name: name.to_string(),
+            queue_url: format!("{ENDPOINT}/{ACCOUNT}/{name}"),
+            arn: format!("arn:aws:sqs:{REGION}:{ACCOUNT}:{name}"),
+            created_at: Utc::now(),
+            messages: VecDeque::new(),
+            inflight: Vec::new(),
+            attributes,
+            is_fifo,
+            dedup_cache: HashMap::new(),
+            redrive_policy: None,
+            tags: HashMap::new(),
+            next_sequence_number: 0,
+            permission_labels: Vec::new(),
+            receipt_handle_map: HashMap::new(),
+        }
+    }
+
+    fn make_state_with_queue(queue: SqsQueue) -> SharedSqsState {
+        let mut multi: MultiAccountState<SqsState> =
+            MultiAccountState::new(ACCOUNT, REGION, ENDPOINT);
+        let state = multi.default_mut();
+        state
+            .name_to_url
+            .insert(queue.queue_name.clone(), queue.queue_url.clone());
+        state.queues.insert(queue.queue_url.clone(), queue);
+        Arc::new(RwLock::new(multi))
+    }
+
+    #[test]
+    fn deliver_to_queue_pushes_message() {
+        let queue = make_queue("standard", false, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        delivery.deliver_to_queue(&arn, "hello", &HashMap::new());
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        assert_eq!(q.messages.len(), 1);
+        let msg = q.messages.front().unwrap();
+        assert_eq!(msg.body, "hello");
+        assert!(msg.message_group_id.is_none());
+        assert!(msg.message_dedup_id.is_none());
+    }
+
+    #[test]
+    fn deliver_fifo_without_dedup_id_is_dropped() {
+        let queue = make_queue("fifo.fifo", true, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        delivery.deliver_to_queue_with_attrs(&arn, "body", &HashMap::new(), Some("g1"), None);
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        assert!(q.messages.is_empty());
+    }
+
+    #[test]
+    fn deliver_fifo_content_based_dedup_generates_id() {
+        let queue = make_queue("fifo.fifo", true, true);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        delivery.deliver_to_queue_with_attrs(&arn, "body", &HashMap::new(), Some("g1"), None);
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        assert_eq!(q.messages.len(), 1);
+        assert!(q.messages.front().unwrap().message_dedup_id.is_some());
+    }
+
+    #[test]
+    fn deliver_fifo_with_explicit_dedup_id_preserved() {
+        let queue = make_queue("fifo.fifo", true, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        delivery.deliver_to_queue_with_attrs(
+            &arn,
+            "body",
+            &HashMap::new(),
+            Some("g1"),
+            Some("dedup-123"),
+        );
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        assert_eq!(q.messages.len(), 1);
+        let msg = q.messages.front().unwrap();
+        assert_eq!(msg.message_dedup_id.as_deref(), Some("dedup-123"));
+        assert_eq!(msg.message_group_id.as_deref(), Some("g1"));
+    }
+
+    #[test]
+    fn deliver_includes_string_message_attribute() {
+        let queue = make_queue("standard", false, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "TraceId".to_string(),
+            SqsMessageAttribute {
+                data_type: "String".to_string(),
+                string_value: Some("abc".to_string()),
+                binary_value: None,
+            },
+        );
+        delivery.deliver_to_queue_with_attrs(&arn, "body", &attrs, None, None);
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        let msg = q.messages.front().unwrap();
+        let trace = msg.message_attributes.get("TraceId").unwrap();
+        assert_eq!(trace.data_type, "String");
+        assert_eq!(trace.string_value.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn deliver_decodes_binary_message_attribute() {
+        let queue = make_queue("standard", false, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        let encoded = base64::engine::general_purpose::STANDARD.encode([0x01, 0x02, 0x03]);
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "Blob".to_string(),
+            SqsMessageAttribute {
+                data_type: "Binary".to_string(),
+                string_value: None,
+                binary_value: Some(encoded),
+            },
+        );
+        delivery.deliver_to_queue_with_attrs(&arn, "body", &attrs, None, None);
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        let msg = q.messages.front().unwrap();
+        let blob = msg.message_attributes.get("Blob").unwrap();
+        assert_eq!(blob.binary_value.as_deref(), Some(&[0x01u8, 0x02, 0x03][..]));
+    }
+
+    #[test]
+    fn deliver_unknown_queue_is_noop() {
+        let queue = make_queue("standard", false, false);
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        delivery.deliver_to_queue(
+            &format!("arn:aws:sqs:{REGION}:{ACCOUNT}:missing"),
+            "body",
+            &HashMap::new(),
+        );
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        assert!(q.messages.is_empty());
+    }
+}

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -132,10 +132,7 @@ mod tests {
     fn make_queue(name: &str, is_fifo: bool, content_based_dedup: bool) -> SqsQueue {
         let mut attributes = HashMap::new();
         if content_based_dedup {
-            attributes.insert(
-                "ContentBasedDeduplication".to_string(),
-                "true".to_string(),
-            );
+            attributes.insert("ContentBasedDeduplication".to_string(), "true".to_string());
         }
         SqsQueue {
             queue_name: name.to_string(),
@@ -279,7 +276,10 @@ mod tests {
         let q = guard.default_ref().queues.get(&url).unwrap();
         let msg = q.messages.front().unwrap();
         let blob = msg.message_attributes.get("Blob").unwrap();
-        assert_eq!(blob.binary_value.as_deref(), Some(&[0x01u8, 0x02, 0x03][..]));
+        assert_eq!(
+            blob.binary_value.as_deref(),
+            Some(&[0x01u8, 0x02, 0x03][..])
+        );
     }
 
     #[test]


### PR DESCRIPTION
Cover delivery.rs paths: standard + FIFO queues, content-based dedup, explicit dedup, string/binary attributes, unknown queue noop. ~110 missed lines -> ~0% coverage to ~full.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `fakecloud-sqs` delivery (`SqsDeliveryImpl`) covering standard and FIFO paths, including content-based and explicit dedup (drop on missing FIFO dedup), message group IDs, and string/binary attributes with base64 decode. Also checks unknown-queue no-op and raises `delivery.rs` coverage from ~0% to near full.

<sup>Written for commit e4bc519dcf75deb09052cc73bcad17cbe24953a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

