### PR TITLE
test(sns): SnsDeliveryImpl publish_to_topic unit tests

### DIFF
--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -200,3 +200,212 @@ impl SnsDelivery for SnsDeliveryImpl {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{SharedSnsState, SnsState, SnsSubscription, SnsTopic};
+    use chrono::Utc;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::collections::{BTreeMap, HashMap};
+
+    const ACCOUNT: &str = "123456789012";
+    const REGION: &str = "us-east-1";
+    const ENDPOINT: &str = "http://localhost:4566";
+
+    fn make_topic(name: &str) -> (SnsTopic, String) {
+        let arn = format!("arn:aws:sns:{REGION}:{ACCOUNT}:{name}");
+        let topic = SnsTopic {
+            topic_arn: arn.clone(),
+            name: name.to_string(),
+            attributes: HashMap::new(),
+            tags: Vec::new(),
+            is_fifo: false,
+            created_at: Utc::now(),
+        };
+        (topic, arn)
+    }
+
+    fn make_subscription(
+        topic_arn: &str,
+        protocol: &str,
+        endpoint: &str,
+        confirmed: bool,
+    ) -> SnsSubscription {
+        let sub_arn = format!("{topic_arn}:{}", uuid::Uuid::new_v4());
+        SnsSubscription {
+            subscription_arn: sub_arn,
+            topic_arn: topic_arn.to_string(),
+            protocol: protocol.to_string(),
+            endpoint: endpoint.to_string(),
+            owner: ACCOUNT.to_string(),
+            attributes: HashMap::new(),
+            confirmed,
+            confirmation_token: None,
+        }
+    }
+
+    fn make_state(topics: Vec<SnsTopic>, subs: Vec<SnsSubscription>) -> SharedSnsState {
+        let mut multi: MultiAccountState<SnsState> =
+            MultiAccountState::new(ACCOUNT, REGION, ENDPOINT);
+        let state = multi.default_mut();
+        for t in topics {
+            state.topics.insert(t.topic_arn.clone(), t);
+        }
+        let mut sub_map: BTreeMap<String, SnsSubscription> = BTreeMap::new();
+        for s in subs {
+            sub_map.insert(s.subscription_arn.clone(), s);
+        }
+        state.subscriptions = sub_map;
+        Arc::new(RwLock::new(multi))
+    }
+
+    #[test]
+    fn publish_records_message_in_topic() {
+        let (topic, arn) = make_topic("t1");
+        let state = make_state(vec![topic], vec![]);
+        let bus = Arc::new(DeliveryBus::new());
+        let delivery = SnsDeliveryImpl::new(state.clone(), bus);
+        delivery.publish_to_topic(&arn, "hello", Some("hi"));
+        let guard = state.read();
+        let s = guard.default_ref();
+        assert_eq!(s.published.len(), 1);
+        let msg = &s.published[0];
+        assert_eq!(msg.message, "hello");
+        assert_eq!(msg.subject.as_deref(), Some("hi"));
+        assert_eq!(msg.topic_arn, arn);
+    }
+
+    #[test]
+    fn publish_unknown_topic_noop() {
+        let (topic, _arn) = make_topic("t1");
+        let state = make_state(vec![topic], vec![]);
+        let bus = Arc::new(DeliveryBus::new());
+        let delivery = SnsDeliveryImpl::new(state.clone(), bus);
+        delivery.publish_to_topic(
+            &format!("arn:aws:sns:{REGION}:{ACCOUNT}:unknown"),
+            "body",
+            None,
+        );
+        let guard = state.read();
+        assert!(guard.default_ref().published.is_empty());
+    }
+
+    #[test]
+    fn publish_records_email_delivery() {
+        let (topic, arn) = make_topic("t1");
+        let sub = make_subscription(&arn, "email", "user@example.com", true);
+        let state = make_state(vec![topic], vec![sub]);
+        let bus = Arc::new(DeliveryBus::new());
+        let delivery = SnsDeliveryImpl::new(state.clone(), bus);
+        delivery.publish_to_topic(&arn, "greetings", Some("subj"));
+        let guard = state.read();
+        let s = guard.default_ref();
+        assert_eq!(s.sent_emails.len(), 1);
+        assert_eq!(s.sent_emails[0].email_address, "user@example.com");
+        assert_eq!(s.sent_emails[0].message, "greetings");
+        assert_eq!(s.sent_emails[0].subject.as_deref(), Some("subj"));
+    }
+
+    #[test]
+    fn publish_records_sms_delivery() {
+        let (topic, arn) = make_topic("t1");
+        let sub = make_subscription(&arn, "sms", "+14155550199", true);
+        let state = make_state(vec![topic], vec![sub]);
+        let bus = Arc::new(DeliveryBus::new());
+        let delivery = SnsDeliveryImpl::new(state.clone(), bus);
+        delivery.publish_to_topic(&arn, "text-body", None);
+        let guard = state.read();
+        let s = guard.default_ref();
+        assert_eq!(s.sms_messages.len(), 1);
+        assert_eq!(s.sms_messages[0].0, "+14155550199");
+        assert_eq!(s.sms_messages[0].1, "text-body");
+    }
+
+    #[test]
+    fn publish_unconfirmed_subscription_skipped() {
+        let (topic, arn) = make_topic("t1");
+        let sub = make_subscription(&arn, "email", "user@example.com", false);
+        let state = make_state(vec![topic], vec![sub]);
+        let bus = Arc::new(DeliveryBus::new());
+        let delivery = SnsDeliveryImpl::new(state.clone(), bus);
+        delivery.publish_to_topic(&arn, "msg", None);
+        let guard = state.read();
+        let s = guard.default_ref();
+        assert!(s.sent_emails.is_empty());
+        assert_eq!(s.published.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn publish_records_lambda_invocation() {
+        let (topic, arn) = make_topic("t1");
+        let fn_arn = format!("arn:aws:lambda:{REGION}:{ACCOUNT}:function:myFn");
+        let sub = make_subscription(&arn, "lambda", &fn_arn, true);
+        let state = make_state(vec![topic], vec![sub]);
+        let bus = Arc::new(DeliveryBus::new());
+        let delivery = SnsDeliveryImpl::new(state.clone(), bus);
+        delivery.publish_to_topic(&arn, "payload", Some("s"));
+        let guard = state.read();
+        let s = guard.default_ref();
+        assert_eq!(s.lambda_invocations.len(), 1);
+        assert_eq!(s.lambda_invocations[0].function_arn, fn_arn);
+        assert_eq!(s.lambda_invocations[0].message, "payload");
+    }
+
+    #[tokio::test]
+    async fn publish_with_sqs_subscriber_calls_delivery_bus() {
+        use fakecloud_core::delivery::SqsDelivery;
+        use std::sync::Mutex;
+
+        #[derive(Default)]
+        struct Recorder {
+            calls: Mutex<Vec<(String, String)>>,
+        }
+
+        impl SqsDelivery for Recorder {
+            fn deliver_to_queue(
+                &self,
+                queue_arn: &str,
+                message_body: &str,
+                _attrs: &HashMap<String, String>,
+            ) {
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push((queue_arn.to_string(), message_body.to_string()));
+            }
+
+            fn deliver_to_queue_with_attrs(
+                &self,
+                queue_arn: &str,
+                message_body: &str,
+                _attrs: &HashMap<String, fakecloud_core::delivery::SqsMessageAttribute>,
+                _group: Option<&str>,
+                _dedup: Option<&str>,
+            ) {
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push((queue_arn.to_string(), message_body.to_string()));
+            }
+        }
+
+        let recorder = Arc::new(Recorder::default());
+        let (topic, arn) = make_topic("t1");
+        let q_arn = format!("arn:aws:sqs:{REGION}:{ACCOUNT}:q1");
+        let sub = make_subscription(&arn, "sqs", &q_arn, true);
+        let state = make_state(vec![topic], vec![sub]);
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let delivery = SnsDeliveryImpl::new(state.clone(), bus);
+        delivery.publish_to_topic(&arn, "hello-sqs", Some("s"));
+        let calls = recorder.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, q_arn);
+        let envelope: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+        assert_eq!(envelope["Type"], "Notification");
+        assert_eq!(envelope["Message"], "hello-sqs");
+        assert_eq!(envelope["Subject"], "s");
+        assert_eq!(envelope["TopicArn"], arn);
+    }
+}

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -114,3 +114,187 @@ impl SqsDelivery for SqsDeliveryImpl {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{SharedSqsState, SqsQueue, SqsState};
+    use chrono::Utc;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    const ACCOUNT: &str = "123456789012";
+    const REGION: &str = "us-east-1";
+    const ENDPOINT: &str = "http://localhost:4566";
+
+    fn make_queue(name: &str, is_fifo: bool, content_based_dedup: bool) -> SqsQueue {
+        let mut attributes = HashMap::new();
+        if content_based_dedup {
+            attributes.insert(
+                "ContentBasedDeduplication".to_string(),
+                "true".to_string(),
+            );
+        }
+        SqsQueue {
+            queue_name: name.to_string(),
+            queue_url: format!("{ENDPOINT}/{ACCOUNT}/{name}"),
+            arn: format!("arn:aws:sqs:{REGION}:{ACCOUNT}:{name}"),
+            created_at: Utc::now(),
+            messages: VecDeque::new(),
+            inflight: Vec::new(),
+            attributes,
+            is_fifo,
+            dedup_cache: HashMap::new(),
+            redrive_policy: None,
+            tags: HashMap::new(),
+            next_sequence_number: 0,
+            permission_labels: Vec::new(),
+            receipt_handle_map: HashMap::new(),
+        }
+    }
+
+    fn make_state_with_queue(queue: SqsQueue) -> SharedSqsState {
+        let mut multi: MultiAccountState<SqsState> =
+            MultiAccountState::new(ACCOUNT, REGION, ENDPOINT);
+        let state = multi.default_mut();
+        state
+            .name_to_url
+            .insert(queue.queue_name.clone(), queue.queue_url.clone());
+        state.queues.insert(queue.queue_url.clone(), queue);
+        Arc::new(RwLock::new(multi))
+    }
+
+    #[test]
+    fn deliver_to_queue_pushes_message() {
+        let queue = make_queue("standard", false, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        delivery.deliver_to_queue(&arn, "hello", &HashMap::new());
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        assert_eq!(q.messages.len(), 1);
+        let msg = q.messages.front().unwrap();
+        assert_eq!(msg.body, "hello");
+        assert!(msg.message_group_id.is_none());
+        assert!(msg.message_dedup_id.is_none());
+    }
+
+    #[test]
+    fn deliver_fifo_without_dedup_id_is_dropped() {
+        let queue = make_queue("fifo.fifo", true, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        delivery.deliver_to_queue_with_attrs(&arn, "body", &HashMap::new(), Some("g1"), None);
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        assert!(q.messages.is_empty());
+    }
+
+    #[test]
+    fn deliver_fifo_content_based_dedup_generates_id() {
+        let queue = make_queue("fifo.fifo", true, true);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        delivery.deliver_to_queue_with_attrs(&arn, "body", &HashMap::new(), Some("g1"), None);
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        assert_eq!(q.messages.len(), 1);
+        assert!(q.messages.front().unwrap().message_dedup_id.is_some());
+    }
+
+    #[test]
+    fn deliver_fifo_with_explicit_dedup_id_preserved() {
+        let queue = make_queue("fifo.fifo", true, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        delivery.deliver_to_queue_with_attrs(
+            &arn,
+            "body",
+            &HashMap::new(),
+            Some("g1"),
+            Some("dedup-123"),
+        );
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        assert_eq!(q.messages.len(), 1);
+        let msg = q.messages.front().unwrap();
+        assert_eq!(msg.message_dedup_id.as_deref(), Some("dedup-123"));
+        assert_eq!(msg.message_group_id.as_deref(), Some("g1"));
+    }
+
+    #[test]
+    fn deliver_includes_string_message_attribute() {
+        let queue = make_queue("standard", false, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "TraceId".to_string(),
+            SqsMessageAttribute {
+                data_type: "String".to_string(),
+                string_value: Some("abc".to_string()),
+                binary_value: None,
+            },
+        );
+        delivery.deliver_to_queue_with_attrs(&arn, "body", &attrs, None, None);
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        let msg = q.messages.front().unwrap();
+        let trace = msg.message_attributes.get("TraceId").unwrap();
+        assert_eq!(trace.data_type, "String");
+        assert_eq!(trace.string_value.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn deliver_decodes_binary_message_attribute() {
+        let queue = make_queue("standard", false, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        let encoded = base64::engine::general_purpose::STANDARD.encode([0x01, 0x02, 0x03]);
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "Blob".to_string(),
+            SqsMessageAttribute {
+                data_type: "Binary".to_string(),
+                string_value: None,
+                binary_value: Some(encoded),
+            },
+        );
+        delivery.deliver_to_queue_with_attrs(&arn, "body", &attrs, None, None);
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        let msg = q.messages.front().unwrap();
+        let blob = msg.message_attributes.get("Blob").unwrap();
+        assert_eq!(blob.binary_value.as_deref(), Some(&[0x01u8, 0x02, 0x03][..]));
+    }
+
+    #[test]
+    fn deliver_unknown_queue_is_noop() {
+        let queue = make_queue("standard", false, false);
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+        let delivery = SqsDeliveryImpl::new(state.clone());
+        delivery.deliver_to_queue(
+            &format!("arn:aws:sqs:{REGION}:{ACCOUNT}:missing"),
+            "body",
+            &HashMap::new(),
+        );
+        let guard = state.read();
+        let q = guard.default_ref().queues.get(&url).unwrap();
+        assert!(q.messages.is_empty());
+    }
+}

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -132,10 +132,7 @@ mod tests {
     fn make_queue(name: &str, is_fifo: bool, content_based_dedup: bool) -> SqsQueue {
         let mut attributes = HashMap::new();
         if content_based_dedup {
-            attributes.insert(
-                "ContentBasedDeduplication".to_string(),
-                "true".to_string(),
-            );
+            attributes.insert("ContentBasedDeduplication".to_string(), "true".to_string());
         }
         SqsQueue {
             queue_name: name.to_string(),
@@ -279,7 +276,10 @@ mod tests {
         let q = guard.default_ref().queues.get(&url).unwrap();
         let msg = q.messages.front().unwrap();
         let blob = msg.message_attributes.get("Blob").unwrap();
-        assert_eq!(blob.binary_value.as_deref(), Some(&[0x01u8, 0x02, 0x03][..]));
+        assert_eq!(
+            blob.binary_value.as_deref(),
+            Some(&[0x01u8, 0x02, 0x03][..])
+        );
     }
 
     #[test]


### PR DESCRIPTION
Covers delivery.rs: topic lookup, published record, email/sms/lambda fan-out, SQS envelope via DeliveryBus, unconfirmed skip, unknown topic noop. ~206 missed lines from 0% -> near full.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `fakecloud-sns` publish_to_topic and `fakecloud-sqs` deliver_to_queue to verify delivery paths and raise coverage. Covers topic lookup and publish recording, fan-out to email/SMS/Lambda/SQS with DeliveryBus SNS envelope, FIFO dedup (explicit and content-based), string/binary message attributes, and no-ops for unknown topics/queues and unconfirmed subscriptions; plus minor formatting.

<sup>Written for commit 4ce4c9a306e098723d24ead5017e4162ae0ef486. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

