### PR TITLE
test(eventbridge): Scheduler tick target dispatch

### DIFF
--- a/crates/fakecloud-bedrock/src/guardrails.rs
+++ b/crates/fakecloud-bedrock/src/guardrails.rs
@@ -639,3 +639,309 @@ fn word_boundary_match(text: &str, word: &str) -> bool {
     }
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn empty_guardrail(id: &str) -> Guardrail {
+        Guardrail {
+            guardrail_id: id.to_string(),
+            guardrail_arn: format!("arn:aws:bedrock:us-east-1:123:guardrail/{id}"),
+            name: id.to_string(),
+            description: String::new(),
+            status: "READY".to_string(),
+            version: "DRAFT".to_string(),
+            next_version_number: 1,
+            blocked_input_messaging: "blocked input".to_string(),
+            blocked_outputs_messaging: "blocked output".to_string(),
+            content_policy: None,
+            word_policy: None,
+            sensitive_information_policy: None,
+            topic_policy: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn shared_state() -> SharedBedrockState {
+        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+    }
+
+    #[test]
+    fn word_boundary_matches_whole_word_only() {
+        assert!(word_boundary_match("the damn cat", "damn"));
+        assert!(word_boundary_match("damn!", "damn"));
+        assert!(!word_boundary_match("damnation is long", "damn"));
+        assert!(!word_boundary_match("subdamned", "damn"));
+    }
+
+    #[test]
+    fn evaluate_content_custom_word_match() {
+        let mut g = empty_guardrail("g1");
+        g.word_policy = Some(json!({
+            "wordsConfig": [{"text": "secret"}]
+        }));
+        let a = evaluate_content(&g, "this contains SECRET stuff");
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0]["wordPolicy"]["customWords"][0]["match"], "secret");
+    }
+
+    #[test]
+    fn evaluate_content_profanity_managed_list() {
+        let mut g = empty_guardrail("g1");
+        g.word_policy = Some(json!({
+            "managedWordListsConfig": [{"type": "PROFANITY"}]
+        }));
+        let a = evaluate_content(&g, "oh damn, that hurt");
+        assert!(!a.is_empty());
+        assert_eq!(
+            a[0]["wordPolicy"]["managedWordLists"][0]["type"],
+            "PROFANITY"
+        );
+    }
+
+    #[test]
+    fn evaluate_content_topic_match() {
+        let mut g = empty_guardrail("g1");
+        g.topic_policy = Some(json!({
+            "topicsConfig": [{
+                "name": "Politics",
+                "examples": ["election results"],
+            }]
+        }));
+        let a = evaluate_content(&g, "The election results were surprising");
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0]["topicPolicy"]["topics"][0]["name"], "Politics");
+    }
+
+    #[test]
+    fn evaluate_content_pii_email_detected() {
+        let mut g = empty_guardrail("g1");
+        g.sensitive_information_policy = Some(json!({
+            "piiEntitiesConfig": [{"type": "EMAIL", "action": "BLOCK"}]
+        }));
+        let a = evaluate_content(&g, "contact me at user@example.com please");
+        assert_eq!(a.len(), 1);
+        assert_eq!(
+            a[0]["sensitiveInformationPolicy"]["piiEntities"][0]["match"],
+            "user@example.com"
+        );
+    }
+
+    #[test]
+    fn evaluate_content_pii_phone_detected() {
+        let mut g = empty_guardrail("g1");
+        g.sensitive_information_policy = Some(json!({
+            "piiEntitiesConfig": [{"type": "PHONE", "action": "BLOCK"}]
+        }));
+        let a = evaluate_content(&g, "call 555-123-4567 now");
+        assert_eq!(a.len(), 1);
+    }
+
+    #[test]
+    fn evaluate_content_pii_unknown_type_ignored() {
+        let mut g = empty_guardrail("g1");
+        g.sensitive_information_policy = Some(json!({
+            "piiEntitiesConfig": [{"type": "BOGUS", "action": "BLOCK"}]
+        }));
+        let a = evaluate_content(&g, "test user@example.com");
+        assert!(a.is_empty());
+    }
+
+    #[test]
+    fn evaluate_content_regex_matches() {
+        let mut g = empty_guardrail("g1");
+        g.sensitive_information_policy = Some(json!({
+            "regexesConfig": [{
+                "name": "code",
+                "pattern": r"CODE-\d+",
+                "action": "ANONYMIZE"
+            }]
+        }));
+        let a = evaluate_content(&g, "ref CODE-12345 here");
+        assert_eq!(a.len(), 1);
+        assert_eq!(
+            a[0]["sensitiveInformationPolicy"]["regexes"][0]["match"],
+            "CODE-12345"
+        );
+    }
+
+    #[test]
+    fn evaluate_content_regex_invalid_pattern_skipped() {
+        let mut g = empty_guardrail("g1");
+        g.sensitive_information_policy = Some(json!({
+            "regexesConfig": [{
+                "name": "bad",
+                "pattern": "(unclosed",
+                "action": "BLOCK"
+            }]
+        }));
+        let a = evaluate_content(&g, "text");
+        assert!(a.is_empty());
+    }
+
+    #[test]
+    fn evaluate_content_empty_returns_no_assessments() {
+        let g = empty_guardrail("g1");
+        let a = evaluate_content(&g, "any text");
+        assert!(a.is_empty());
+    }
+
+    fn make_req() -> AwsRequest {
+        use bytes::Bytes;
+        use http::Method;
+        use std::collections::HashMap;
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "CreateGuardrail".to_string(),
+            method: Method::POST,
+            raw_path: "/guardrails".to_string(),
+            raw_query: String::new(),
+            path_segments: vec!["guardrails".to_string()],
+            query_params: HashMap::new(),
+            headers: http::HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "req-id".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn create_guardrail_requires_name() {
+        let state = shared_state();
+        let req = make_req();
+        let body = json!({});
+        let err = create_guardrail(&state, &req, &body).err().unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn create_guardrail_roundtrip() {
+        let state = shared_state();
+        let req = make_req();
+        let body = json!({
+            "name": "my-guard",
+            "blockedInputMessaging": "NOPE-IN",
+            "blockedOutputsMessaging": "NOPE-OUT",
+            "description": "some guard",
+            "wordPolicyConfig": {"wordsConfig": []},
+        });
+        let resp = create_guardrail(&state, &req, &body).unwrap();
+        assert_eq!(resp.status, StatusCode::CREATED);
+        let s = state.read();
+        assert_eq!(s.guardrails.len(), 1);
+        let g = s.guardrails.values().next().unwrap();
+        assert_eq!(g.name, "my-guard");
+        assert_eq!(g.blocked_input_messaging, "NOPE-IN");
+    }
+
+    #[test]
+    fn get_guardrail_not_found() {
+        let state = shared_state();
+        let req = make_req();
+        let err = get_guardrail(&state, &req, "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn delete_guardrail_removes_entry() {
+        let state = shared_state();
+        let gid = "gid-1";
+        state
+            .write()
+            .guardrails
+            .insert(gid.to_string(), empty_guardrail(gid));
+        delete_guardrail(&state, gid).unwrap();
+        assert!(state.read().guardrails.is_empty());
+    }
+
+    #[test]
+    fn delete_guardrail_not_found() {
+        let state = shared_state();
+        let err = delete_guardrail(&state, "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn list_guardrails_returns_all() {
+        let state = shared_state();
+        state
+            .write()
+            .guardrails
+            .insert("a".to_string(), empty_guardrail("a"));
+        state
+            .write()
+            .guardrails
+            .insert("b".to_string(), empty_guardrail("b"));
+        let req = make_req();
+        let resp = list_guardrails(&state, &req).unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[test]
+    fn apply_guardrail_noop_with_no_policies() {
+        let state = shared_state();
+        state
+            .write()
+            .guardrails
+            .insert("g".to_string(), empty_guardrail("g"));
+        let body = br#"{"content":[{"text":{"text":"hello"}}],"source":"INPUT"}"#;
+        let resp = apply_guardrail(&state, "g", "DRAFT", body).unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[test]
+    fn apply_guardrail_intervenes_on_blocked_word() {
+        let state = shared_state();
+        let mut g = empty_guardrail("g");
+        g.word_policy = Some(json!({"wordsConfig": [{"text": "forbidden"}]}));
+        state.write().guardrails.insert("g".to_string(), g);
+        let body = br#"{"content":[{"text":{"text":"this is forbidden"}}],"source":"INPUT"}"#;
+        let resp = apply_guardrail(&state, "g", "DRAFT", body).unwrap();
+        let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body_str.contains("GUARDRAIL_INTERVENED"));
+        assert!(body_str.contains("blocked input"));
+    }
+
+    #[test]
+    fn apply_guardrail_output_source_uses_output_message() {
+        let state = shared_state();
+        let mut g = empty_guardrail("g");
+        g.word_policy = Some(json!({"wordsConfig": [{"text": "x"}]}));
+        state.write().guardrails.insert("g".to_string(), g);
+        let body = br#"{"content":[{"text":{"text":"contains x value"}}],"source":"OUTPUT"}"#;
+        let resp = apply_guardrail(&state, "g", "DRAFT", body).unwrap();
+        let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body_str.contains("blocked output"));
+    }
+
+    #[test]
+    fn apply_guardrail_missing_returns_not_found() {
+        let state = shared_state();
+        let body = br#"{"content":[],"source":"INPUT"}"#;
+        let err = apply_guardrail(&state, "missing", "DRAFT", body)
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn apply_guardrail_missing_version_returns_not_found() {
+        let state = shared_state();
+        state
+            .write()
+            .guardrails
+            .insert("g".to_string(), empty_guardrail("g"));
+        let body = br#"{"content":[],"source":"INPUT"}"#;
+        let err = apply_guardrail(&state, "g", "99", body).err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -827,6 +827,183 @@ mod tests {
     }
 
     #[test]
+    fn extract_region_from_user_agent_finds_region_segment() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "user-agent",
+            "aws-sdk-rust/1.0 os/linux region/eu-central-1"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(
+            extract_region_from_user_agent(&headers),
+            Some("eu-central-1".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_region_from_user_agent_none_without_header() {
+        let headers = http::HeaderMap::new();
+        assert_eq!(extract_region_from_user_agent(&headers), None);
+    }
+
+    #[test]
+    fn extract_region_from_user_agent_ignores_empty_region() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("user-agent", "aws-sdk-java region/".parse().unwrap());
+        assert_eq!(extract_region_from_user_agent(&headers), None);
+    }
+
+    #[test]
+    fn extract_region_from_user_agent_none_when_no_region_marker() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("user-agent", "curl/7.79.1".parse().unwrap());
+        assert_eq!(extract_region_from_user_agent(&headers), None);
+    }
+
+    #[test]
+    fn aws_username_none_for_root() {
+        let p = Principal {
+            arn: "arn:aws:iam::123456789012:root".into(),
+            user_id: "123456789012".into(),
+            account_id: "123456789012".into(),
+            principal_type: PrincipalType::Root,
+            source_identity: None,
+            tags: None,
+        };
+        assert_eq!(aws_username_from_principal(&p), None);
+    }
+
+    #[test]
+    fn aws_username_bare_no_path() {
+        let p = Principal {
+            arn: "arn:aws:iam::123456789012:user/bob".into(),
+            user_id: "AIDABOB".into(),
+            account_id: "123456789012".into(),
+            principal_type: PrincipalType::User,
+            source_identity: None,
+            tags: None,
+        };
+        assert_eq!(aws_username_from_principal(&p), Some("bob".into()));
+    }
+
+    #[test]
+    fn principal_type_label_covers_federated_and_unknown() {
+        assert_eq!(
+            principal_type_label(PrincipalType::FederatedUser),
+            "FederatedUser"
+        );
+        assert_eq!(principal_type_label(PrincipalType::Unknown), "Unknown");
+    }
+
+    #[test]
+    fn build_condition_context_marks_secure_when_flag_set() {
+        let p = Principal {
+            arn: "arn:aws:iam::123456789012:user/alice".into(),
+            user_id: "AIDAALICE".into(),
+            account_id: "123456789012".into(),
+            principal_type: PrincipalType::User,
+            source_identity: None,
+            tags: None,
+        };
+        let ctx = build_condition_context(&p, None, "us-west-2", true);
+        assert_eq!(ctx.aws_secure_transport, Some(true));
+        assert!(ctx.aws_source_ip.is_none());
+        assert_eq!(ctx.aws_requested_region.as_deref(), Some("us-west-2"));
+    }
+
+    #[test]
+    fn is_secure_transport_case_insensitive() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-forwarded-proto", "HTTPS".parse().unwrap());
+        assert!(is_secure_transport(&headers));
+    }
+
+    #[test]
+    fn is_secure_transport_non_ascii_bytes_false() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "x-forwarded-proto",
+            http::HeaderValue::from_bytes(&[0xFF, 0xFE]).unwrap(),
+        );
+        assert!(!is_secure_transport(&headers));
+    }
+
+    #[test]
+    fn protocol_ext_error_status_is_bad_request() {
+        assert_eq!(AwsProtocol::Query.error_status(), StatusCode::BAD_REQUEST);
+        assert_eq!(AwsProtocol::Json.error_status(), StatusCode::BAD_REQUEST);
+        assert_eq!(AwsProtocol::Rest.error_status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            AwsProtocol::RestJson.error_status(),
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[test]
+    fn build_error_response_json_has_json_content_type() {
+        let resp = build_error_response(
+            StatusCode::BAD_REQUEST,
+            "TestCode",
+            "test msg",
+            "req-1",
+            AwsProtocol::Json,
+        );
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.contains("json"));
+        let rid = resp
+            .headers()
+            .get("x-amzn-requestid")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(rid, "req-1");
+    }
+
+    #[test]
+    fn build_error_response_rest_returns_xml_content_type() {
+        let resp = build_error_response(
+            StatusCode::NOT_FOUND,
+            "NoSuchBucket",
+            "bucket missing",
+            "req-2",
+            AwsProtocol::Rest,
+        );
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.contains("xml"));
+    }
+
+    #[test]
+    fn build_error_response_query_returns_xml() {
+        let resp = build_error_response(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            "bad param",
+            "req-3",
+            AwsProtocol::Query,
+        );
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.contains("xml"));
+    }
+
+    #[test]
     fn dispatch_config_carries_opt_in_flags() {
         let cfg = DispatchConfig {
             region: "eu-west-1".to_string(),

--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -350,4 +350,191 @@ mod tests {
         assert!(parse_amz_target("NoDotHere").is_none());
         assert!(parse_amz_target("").is_none());
     }
+
+    #[test]
+    fn parse_amz_target_various_prefixes() {
+        assert_eq!(
+            parse_amz_target("AmazonSQS.SendMessage").unwrap().service,
+            "sqs"
+        );
+        assert_eq!(
+            parse_amz_target("AmazonSNS.Publish").unwrap().service,
+            "sns"
+        );
+        assert_eq!(
+            parse_amz_target("DynamoDB_20120810.GetItem")
+                .unwrap()
+                .service,
+            "dynamodb"
+        );
+        assert_eq!(
+            parse_amz_target("Logs_20140328.PutLogEvents")
+                .unwrap()
+                .service,
+            "logs"
+        );
+        assert_eq!(
+            parse_amz_target("secretsmanager.GetSecretValue")
+                .unwrap()
+                .service,
+            "secretsmanager"
+        );
+        assert_eq!(
+            parse_amz_target("TrentService.Encrypt").unwrap().service,
+            "kms"
+        );
+        assert_eq!(
+            parse_amz_target("AWSCognitoIdentityProviderService.InitiateAuth")
+                .unwrap()
+                .service,
+            "cognito-idp"
+        );
+        assert_eq!(
+            parse_amz_target("AWSStepFunctions.StartExecution")
+                .unwrap()
+                .service,
+            "states"
+        );
+        assert!(parse_amz_target("UnknownServicePrefix.Action").is_none());
+    }
+
+    #[test]
+    fn infer_service_from_action_maps_sts() {
+        assert_eq!(
+            infer_service_from_action("AssumeRole").as_deref(),
+            Some("sts")
+        );
+        assert_eq!(
+            infer_service_from_action("GetCallerIdentity").as_deref(),
+            Some("sts")
+        );
+    }
+
+    #[test]
+    fn infer_service_from_action_maps_iam() {
+        assert_eq!(
+            infer_service_from_action("CreateUser").as_deref(),
+            Some("iam")
+        );
+        assert_eq!(
+            infer_service_from_action("ListRoles").as_deref(),
+            Some("iam")
+        );
+    }
+
+    #[test]
+    fn infer_service_from_action_maps_ses() {
+        assert_eq!(
+            infer_service_from_action("SendEmail").as_deref(),
+            Some("ses")
+        );
+        assert_eq!(
+            infer_service_from_action("ListIdentities").as_deref(),
+            Some("ses")
+        );
+    }
+
+    #[test]
+    fn infer_service_from_action_unknown_returns_none() {
+        assert!(infer_service_from_action("NotARealAction").is_none());
+    }
+
+    #[test]
+    fn rest_protocol_for_returns_none_for_non_rest_service() {
+        assert!(rest_protocol_for("sqs").is_none());
+    }
+
+    #[test]
+    fn url_decode_handles_percent_and_plus() {
+        assert_eq!(url_decode("hello+world"), "hello world");
+        assert_eq!(url_decode("hello%20world"), "hello world");
+        assert_eq!(url_decode("100%25"), "100%");
+    }
+
+    #[test]
+    fn url_decode_ignores_malformed_percent() {
+        assert_eq!(url_decode("%ZZ"), "");
+    }
+
+    #[test]
+    fn from_hex_valid_digits() {
+        assert_eq!(from_hex(b'0'), Some(0));
+        assert_eq!(from_hex(b'9'), Some(9));
+        assert_eq!(from_hex(b'a'), Some(10));
+        assert_eq!(from_hex(b'F'), Some(15));
+    }
+
+    #[test]
+    fn from_hex_invalid_returns_none() {
+        assert!(from_hex(b'g').is_none());
+        assert!(from_hex(b' ').is_none());
+    }
+
+    #[test]
+    fn detect_service_via_amz_target() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-amz-target", "AmazonSSM.GetParameter".parse().unwrap());
+        let query = HashMap::new();
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "ssm");
+        assert_eq!(detected.action, "GetParameter");
+    }
+
+    #[test]
+    fn detect_service_via_query_action_with_inferred_service() {
+        let headers = HeaderMap::new();
+        let mut query = HashMap::new();
+        query.insert("Action".to_string(), "AssumeRole".to_string());
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "sts");
+        assert_eq!(detected.action, "AssumeRole");
+        assert_eq!(detected.protocol, AwsProtocol::Query);
+    }
+
+    #[test]
+    fn detect_service_via_form_body() {
+        let headers = HeaderMap::new();
+        let query = HashMap::new();
+        let body = Bytes::from("Action=SendEmail&Source=x%40y.com");
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "ses");
+        assert_eq!(detected.action, "SendEmail");
+    }
+
+    #[test]
+    fn detect_service_via_sigv2_presigned() {
+        let headers = HeaderMap::new();
+        let mut query = HashMap::new();
+        query.insert("AWSAccessKeyId".to_string(), "AKID".to_string());
+        query.insert("Signature".to_string(), "sig".to_string());
+        query.insert("Expires".to_string(), "1234567890".to_string());
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "s3");
+        assert_eq!(detected.protocol, AwsProtocol::Rest);
+    }
+
+    #[test]
+    fn detect_service_via_sigv4_presigned_credential() {
+        let headers = HeaderMap::new();
+        let mut query = HashMap::new();
+        query.insert(
+            "X-Amz-Credential".to_string(),
+            "AKID/20240101/us-east-1/s3/aws4_request".to_string(),
+        );
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "s3");
+        assert_eq!(detected.protocol, AwsProtocol::Rest);
+    }
+
+    #[test]
+    fn detect_service_unknown_returns_none() {
+        let headers = HeaderMap::new();
+        let query = HashMap::new();
+        let body = Bytes::new();
+        assert!(detect_service(&headers, &query, &body).is_none());
+    }
 }

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -386,4 +386,334 @@ mod tests {
         assert!(parse_schedule("rate(abc minutes)").is_none());
         assert!(parse_schedule("cron(1 2 3)").is_none());
     }
+
+    #[test]
+    fn parse_rate_zero_is_valid() {
+        let s = parse_schedule("rate(0 seconds)");
+        assert!(matches!(s, Some(Schedule::Rate(d)) if d == Duration::ZERO));
+    }
+
+    #[test]
+    fn parse_rate_unknown_unit_rejected() {
+        assert!(parse_schedule("rate(1 fortnight)").is_none());
+    }
+
+    #[test]
+    fn parse_cron_question_mark_is_any() {
+        let s = parse_schedule("cron(? ? ? ? ? ?)");
+        assert!(matches!(s, Some(Schedule::Cron(_))));
+    }
+
+    #[test]
+    fn parse_cron_non_numeric_field_is_any() {
+        let s = parse_schedule("cron(xyz 12 * * ? *)");
+        match s {
+            Some(Schedule::Cron(c)) => assert!(matches!(c.minute, CronField::Any)),
+            _ => panic!("expected cron"),
+        }
+    }
+
+    #[test]
+    fn cron_wildcard_always_matches() {
+        let cron = CronExpr {
+            minute: CronField::Any,
+            hour: CronField::Any,
+            day_of_month: CronField::Any,
+            month: CronField::Any,
+            day_of_week: CronField::Any,
+        };
+        assert!(cron_matches_now(&cron));
+    }
+
+    #[test]
+    fn cron_impossible_minute_never_matches() {
+        let cron = CronExpr {
+            minute: CronField::Value(99),
+            hour: CronField::Any,
+            day_of_month: CronField::Any,
+            month: CronField::Any,
+            day_of_week: CronField::Any,
+        };
+        assert!(!cron_matches_now(&cron));
+    }
+
+    mod tick_tests {
+        use super::*;
+        use crate::state::{
+            EventBridgeState, EventRule, EventTarget as EbTarget, RuleKey, SharedEventBridgeState,
+        };
+        use fakecloud_core::delivery::{
+            EventBridgeDelivery, KinesisDelivery, SnsDelivery, SqsDelivery, StepFunctionsDelivery,
+        };
+        use parking_lot::RwLock;
+        use std::sync::Mutex;
+
+        #[derive(Default)]
+        struct Recorder {
+            sqs: Mutex<Vec<(String, String)>>,
+            sns: Mutex<Vec<(String, String)>>,
+            stepfunctions: Mutex<Vec<(String, String)>>,
+        }
+
+        impl SqsDelivery for Recorder {
+            fn deliver_to_queue(&self, arn: &str, body: &str, _attrs: &HashMap<String, String>) {
+                self.sqs
+                    .lock()
+                    .unwrap()
+                    .push((arn.to_string(), body.to_string()));
+            }
+
+            fn deliver_to_queue_with_attrs(
+                &self,
+                arn: &str,
+                body: &str,
+                _attrs: &HashMap<String, fakecloud_core::delivery::SqsMessageAttribute>,
+                _group: Option<&str>,
+                _dedup: Option<&str>,
+            ) {
+                self.sqs
+                    .lock()
+                    .unwrap()
+                    .push((arn.to_string(), body.to_string()));
+            }
+        }
+
+        impl SnsDelivery for Recorder {
+            fn publish_to_topic(&self, arn: &str, msg: &str, _subject: Option<&str>) {
+                self.sns
+                    .lock()
+                    .unwrap()
+                    .push((arn.to_string(), msg.to_string()));
+            }
+        }
+
+        impl StepFunctionsDelivery for Recorder {
+            fn start_execution(&self, arn: &str, input: &str) {
+                self.stepfunctions
+                    .lock()
+                    .unwrap()
+                    .push((arn.to_string(), input.to_string()));
+            }
+        }
+
+        impl EventBridgeDelivery for Recorder {
+            fn put_event(&self, _source: &str, _detail_type: &str, _detail: &str, _bus: &str) {}
+        }
+
+        impl KinesisDelivery for Recorder {
+            fn put_record(&self, _stream_arn: &str, _data: &str, _partition_key: &str) {}
+        }
+
+        fn make_state() -> (SharedEventBridgeState, EventBridgeState) {
+            let state = EventBridgeState::new("123456789012", "us-east-1");
+            let shared = Arc::new(RwLock::new(state.clone()));
+            (shared, state)
+        }
+
+        fn make_rule(name: &str, schedule: &str, target_arn: &str) -> EventRule {
+            EventRule {
+                name: name.to_string(),
+                arn: format!("arn:aws:events:us-east-1:123456789012:rule/{name}"),
+                event_bus_name: "default".to_string(),
+                event_pattern: None,
+                schedule_expression: Some(schedule.to_string()),
+                state: "ENABLED".to_string(),
+                description: None,
+                role_arn: None,
+                managed_by: None,
+                created_by: None,
+                targets: vec![EbTarget {
+                    id: "t1".to_string(),
+                    arn: target_arn.to_string(),
+                    input: None,
+                    input_path: None,
+                    input_transformer: None,
+                    sqs_parameters: None,
+                }],
+                tags: HashMap::new(),
+                last_fired: None,
+            }
+        }
+
+        fn build_scheduler(state: SharedEventBridgeState, recorder: Arc<Recorder>) -> Scheduler {
+            let bus = Arc::new(
+                DeliveryBus::new()
+                    .with_sqs(recorder.clone())
+                    .with_sns(recorder.clone())
+                    .with_stepfunctions(recorder.clone()),
+            );
+            Scheduler::new(state, bus)
+        }
+
+        #[test]
+        fn tick_disabled_rule_is_skipped() {
+            let (shared, _) = make_state();
+            {
+                let mut s = shared.write();
+                let mut rule = make_rule("r", "rate(1 second)", "arn:aws:sqs:us-east-1:123:q");
+                rule.state = "DISABLED".to_string();
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let scheduler = build_scheduler(shared.clone(), recorder.clone());
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            scheduler.tick(&mut last);
+            assert!(recorder.sqs.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn tick_rule_without_targets_is_skipped() {
+            let (shared, _) = make_state();
+            {
+                let mut s = shared.write();
+                let mut rule = make_rule("r", "rate(1 second)", "arn:aws:sqs:us-east-1:123:q");
+                rule.targets.clear();
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let scheduler = build_scheduler(shared.clone(), recorder.clone());
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            scheduler.tick(&mut last);
+            assert!(recorder.sqs.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn tick_invalid_schedule_is_skipped() {
+            let (shared, _) = make_state();
+            {
+                let mut s = shared.write();
+                let rule = make_rule("r", "bogus", "arn:aws:sqs:us-east-1:123:q");
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let scheduler = build_scheduler(shared.clone(), recorder.clone());
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            scheduler.tick(&mut last);
+            assert!(recorder.sqs.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn tick_fires_rate_rule_to_sqs_target() {
+            let (shared, _) = make_state();
+            let q_arn = "arn:aws:sqs:us-east-1:123456789012:q1".to_string();
+            {
+                let mut s = shared.write();
+                let rule = make_rule("r", "rate(1 second)", &q_arn);
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let scheduler = build_scheduler(shared.clone(), recorder.clone());
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            scheduler.tick(&mut last);
+            let calls = recorder.sqs.lock().unwrap();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0].0, q_arn);
+            let payload: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+            assert_eq!(payload["detail-type"], "Scheduled Event");
+            assert_eq!(payload["source"], "aws.events");
+        }
+
+        #[test]
+        fn tick_fires_to_sns_target() {
+            let (shared, _) = make_state();
+            let topic_arn = "arn:aws:sns:us-east-1:123456789012:t1".to_string();
+            {
+                let mut s = shared.write();
+                let rule = make_rule("r", "rate(1 second)", &topic_arn);
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let scheduler = build_scheduler(shared.clone(), recorder.clone());
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            scheduler.tick(&mut last);
+            let calls = recorder.sns.lock().unwrap();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0].0, topic_arn);
+        }
+
+        #[test]
+        fn tick_fires_to_stepfunctions_target() {
+            let (shared, _) = make_state();
+            let sm_arn = "arn:aws:states:us-east-1:123456789012:stateMachine:m1".to_string();
+            {
+                let mut s = shared.write();
+                let rule = make_rule("r", "rate(1 second)", &sm_arn);
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let scheduler = build_scheduler(shared.clone(), recorder.clone());
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            scheduler.tick(&mut last);
+            let calls = recorder.stepfunctions.lock().unwrap();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0].0, sm_arn);
+            let guard = shared.read();
+            assert_eq!(guard.step_function_executions.len(), 1);
+        }
+
+        #[test]
+        fn tick_lambda_target_records_invocation() {
+            let (shared, _) = make_state();
+            let fn_arn = "arn:aws:lambda:us-east-1:123456789012:function:F".to_string();
+            {
+                let mut s = shared.write();
+                let rule = make_rule("r", "rate(1 second)", &fn_arn);
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let scheduler = build_scheduler(shared.clone(), recorder.clone());
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            scheduler.tick(&mut last);
+            let guard = shared.read();
+            assert_eq!(guard.lambda_invocations.len(), 1);
+            assert_eq!(guard.lambda_invocations[0].function_arn, fn_arn);
+        }
+
+        #[test]
+        fn tick_logs_target_records_delivery() {
+            let (shared, _) = make_state();
+            let lg_arn = "arn:aws:logs:us-east-1:123456789012:log-group:lg".to_string();
+            {
+                let mut s = shared.write();
+                let rule = make_rule("r", "rate(1 second)", &lg_arn);
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let scheduler = build_scheduler(shared.clone(), recorder.clone());
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            scheduler.tick(&mut last);
+            let guard = shared.read();
+            assert_eq!(guard.log_deliveries.len(), 1);
+            assert_eq!(guard.log_deliveries[0].log_group_arn, lg_arn);
+        }
+
+        #[test]
+        fn tick_updates_last_fired() {
+            let (shared, _) = make_state();
+            {
+                let mut s = shared.write();
+                let rule = make_rule("r", "rate(1 second)", "arn:aws:sqs:us-east-1:123:q");
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let scheduler = build_scheduler(shared.clone(), recorder.clone());
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            scheduler.tick(&mut last);
+            let guard = shared.read();
+            let rule = guard
+                .rules
+                .get(&("default".to_string(), "r".to_string()))
+                .unwrap();
+            assert!(rule.last_fired.is_some());
+        }
+    }
 }


### PR DESCRIPTION
Adds Scheduler tick() tests covering SQS/SNS/Lambda/Logs/StepFunctions target delivery, disabled/targetless/invalid-schedule skipping, last_fired update, and extra parse_schedule/cron edge cases. ~280 missed lines -> substantial coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for the `fakecloud-eventbridge` scheduler `tick()`: dispatch to SQS, SNS, Lambda, CloudWatch Logs, and Step Functions; skip disabled/targetless/invalid rules; update `last_fired`; plus extra `rate`/`cron` parsing (zero-rate, wildcards, invalid units). Expand `fakecloud-core` protocol/dispatch tests (user-agent region, secure transport, IAM principal helpers, error response content types, `detect_service`/`infer_service`, `rest_protocol_for`, `url_decode`) and add `fakecloud-bedrock` guardrails tests for CRUD, content evaluation (custom words, managed profanity/topics/PII/regex), and `apply_guardrail` for input/output and not-found.

<sup>Written for commit c1f18474a12122f04152f8b2970b90389bf72ffb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

