### PR TITLE
test(core,eventbridge,kinesis): registry + cross-service delivery impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2 0.10.9",
+ "tempfile",
  "tokio",
  "toml",
  "tracing",

--- a/crates/fakecloud-bedrock/src/faults.rs
+++ b/crates/fakecloud-bedrock/src/faults.rs
@@ -55,3 +55,106 @@ pub fn record_faulted_invocation(
         error: Some(format!("{}: {}", fault.error_type, fault.message)),
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+    }
+
+    fn rule(
+        error_type: &str,
+        message: &str,
+        http_status: u16,
+        remaining: u32,
+        model_id: Option<&str>,
+        operation: Option<&str>,
+    ) -> FaultRule {
+        FaultRule {
+            error_type: error_type.to_string(),
+            message: message.to_string(),
+            http_status,
+            remaining,
+            model_id: model_id.map(|s| s.to_string()),
+            operation: operation.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn take_matching_fault_none_when_empty() {
+        let s = shared();
+        assert!(take_matching_fault(&s, "model-x", "InvokeModel").is_none());
+    }
+
+    #[test]
+    fn take_matching_fault_matches_wildcard_rule() {
+        let s = shared();
+        s.write()
+            .fault_rules
+            .push(rule("Throttle", "slow down", 429, 3, None, None));
+        let hit = take_matching_fault(&s, "any-model", "InvokeModel").unwrap();
+        assert_eq!(hit.error_type, "Throttle");
+        assert_eq!(s.read().fault_rules[0].remaining, 2);
+    }
+
+    #[test]
+    fn take_matching_fault_removes_when_remaining_reaches_zero() {
+        let s = shared();
+        s.write()
+            .fault_rules
+            .push(rule("Err", "boom", 500, 1, None, None));
+        assert!(take_matching_fault(&s, "m", "o").is_some());
+        assert!(s.read().fault_rules.is_empty());
+    }
+
+    #[test]
+    fn take_matching_fault_scoped_by_model() {
+        let s = shared();
+        s.write()
+            .fault_rules
+            .push(rule("ModelErr", "fail", 500, 1, Some("target-model"), None));
+        assert!(take_matching_fault(&s, "other-model", "o").is_none());
+        assert!(take_matching_fault(&s, "target-model", "o").is_some());
+    }
+
+    #[test]
+    fn take_matching_fault_scoped_by_operation() {
+        let s = shared();
+        s.write()
+            .fault_rules
+            .push(rule("OpErr", "fail", 500, 1, None, Some("Converse")));
+        assert!(take_matching_fault(&s, "m", "InvokeModel").is_none());
+        assert!(take_matching_fault(&s, "m", "Converse").is_some());
+    }
+
+    #[test]
+    fn fault_to_error_preserves_status() {
+        let r = rule("Throttled", "slow", 429, 1, None, None);
+        let err = fault_to_error(&r);
+        assert_eq!(err.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[test]
+    fn fault_to_error_invalid_status_defaults_bad_request() {
+        let r = rule("Weird", "x", 9999, 1, None, None);
+        let err = fault_to_error(&r);
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn record_faulted_invocation_appends_error_entry() {
+        let s = shared();
+        let r = rule("Throttled", "slow", 429, 1, None, None);
+        record_faulted_invocation(&s, "m-1", b"input-body", &r);
+        let inv = &s.read().invocations[0];
+        assert_eq!(inv.model_id, "m-1");
+        assert_eq!(inv.input, "input-body");
+        assert_eq!(inv.output, "");
+        assert_eq!(inv.error.as_deref(), Some("Throttled: slow"));
+    }
+}

--- a/crates/fakecloud-bedrock/src/prompt.rs
+++ b/crates/fakecloud-bedrock/src/prompt.rs
@@ -87,3 +87,150 @@ pub fn resolve_override(state: &SharedBedrockState, model_id: &str, body: &[u8])
     }
     s.custom_responses.get(model_id).cloned()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+    }
+
+    #[test]
+    fn extract_prompt_from_converse_messages_and_system() {
+        let body = br#"{
+            "system": [{"text": "sys-prompt"}],
+            "messages": [
+                {"role": "user", "content": [{"text": "hello"}, {"text": "world"}]}
+            ]
+        }"#;
+        let text = extract_prompt_text("anthropic.claude-v2", body);
+        assert_eq!(text, "sys-prompt hello world");
+    }
+
+    #[test]
+    fn extract_prompt_from_anthropic_invoke_string_content() {
+        let body = br#"{"messages":[{"role":"user","content":"hi"}]}"#;
+        let text = extract_prompt_text("anthropic.claude-v2", body);
+        assert_eq!(text, "hi");
+    }
+
+    #[test]
+    fn extract_prompt_amazon_input_text() {
+        let body = br#"{"inputText":"amazon-prompt"}"#;
+        let text = extract_prompt_text("amazon.titan-text", body);
+        assert_eq!(text, "amazon-prompt");
+    }
+
+    #[test]
+    fn extract_prompt_generic_prompt_field() {
+        let body = br#"{"prompt":"raw-prompt"}"#;
+        let text = extract_prompt_text("anthropic.claude-v1", body);
+        assert_eq!(text, "raw-prompt");
+    }
+
+    #[test]
+    fn extract_prompt_input_text_fallback_for_non_amazon() {
+        let body = br#"{"inputText":"generic-input"}"#;
+        let text = extract_prompt_text("cohere.command", body);
+        assert_eq!(text, "generic-input");
+    }
+
+    #[test]
+    fn extract_prompt_invalid_json_returns_empty() {
+        let text = extract_prompt_text("any", b"{not-json");
+        assert_eq!(text, "");
+    }
+
+    #[test]
+    fn extract_prompt_empty_object_returns_empty() {
+        let text = extract_prompt_text("any", b"{}");
+        assert_eq!(text, "");
+    }
+
+    #[test]
+    fn match_rule_none_filter_matches_anything() {
+        let rules = vec![ResponseRule {
+            prompt_contains: None,
+            response: "r1".to_string(),
+        }];
+        assert!(match_rule(&rules, "x").is_some());
+    }
+
+    #[test]
+    fn match_rule_empty_filter_matches_anything() {
+        let rules = vec![ResponseRule {
+            prompt_contains: Some(String::new()),
+            response: "r".to_string(),
+        }];
+        assert!(match_rule(&rules, "").is_some());
+    }
+
+    #[test]
+    fn match_rule_substring_match() {
+        let rules = vec![
+            ResponseRule {
+                prompt_contains: Some("Bar".to_string()),
+                response: "B".to_string(),
+            },
+            ResponseRule {
+                prompt_contains: Some("Foo".to_string()),
+                response: "F".to_string(),
+            },
+        ];
+        assert_eq!(match_rule(&rules, "say Foo please").unwrap().response, "F");
+        assert_eq!(match_rule(&rules, "try Bar now").unwrap().response, "B");
+        assert!(match_rule(&rules, "neither").is_none());
+    }
+
+    #[test]
+    fn resolve_override_uses_response_rule_first() {
+        let state = shared();
+        state.write().response_rules.insert(
+            "m".to_string(),
+            vec![ResponseRule {
+                prompt_contains: Some("hello".to_string()),
+                response: "rule-wins".to_string(),
+            }],
+        );
+        state
+            .write()
+            .custom_responses
+            .insert("m".to_string(), "legacy-loses".to_string());
+        let body = br#"{"prompt":"hello world"}"#;
+        assert_eq!(
+            resolve_override(&state, "m", body).as_deref(),
+            Some("rule-wins")
+        );
+    }
+
+    #[test]
+    fn resolve_override_falls_back_to_custom_response() {
+        let state = shared();
+        state.write().response_rules.insert(
+            "m".to_string(),
+            vec![ResponseRule {
+                prompt_contains: Some("notfound".to_string()),
+                response: "rule".to_string(),
+            }],
+        );
+        state
+            .write()
+            .custom_responses
+            .insert("m".to_string(), "fallback".to_string());
+        let body = br#"{"prompt":"hi"}"#;
+        assert_eq!(
+            resolve_override(&state, "m", body).as_deref(),
+            Some("fallback")
+        );
+    }
+
+    #[test]
+    fn resolve_override_none_when_nothing_configured() {
+        let state = shared();
+        assert!(resolve_override(&state, "m", b"{}").is_none());
+    }
+}

--- a/crates/fakecloud-core/src/registry.rs
+++ b/crates/fakecloud-core/src/registry.rs
@@ -44,3 +44,94 @@ impl ServiceRegistry {
         (enforced, skipped)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+    use async_trait::async_trait;
+
+    struct EnforcedService {
+        name: &'static str,
+    }
+
+    #[async_trait]
+    impl AwsService for EnforcedService {
+        fn service_name(&self) -> &str {
+            self.name
+        }
+        async fn handle(&self, _: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+            unreachable!()
+        }
+        fn supported_actions(&self) -> &[&str] {
+            &[]
+        }
+        fn iam_enforceable(&self) -> bool {
+            true
+        }
+    }
+
+    struct UnenforcedService {
+        name: &'static str,
+    }
+
+    #[async_trait]
+    impl AwsService for UnenforcedService {
+        fn service_name(&self) -> &str {
+            self.name
+        }
+        async fn handle(&self, _: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+            unreachable!()
+        }
+        fn supported_actions(&self) -> &[&str] {
+            &[]
+        }
+    }
+
+    #[test]
+    fn new_is_empty() {
+        let r = ServiceRegistry::new();
+        assert!(r.service_names().is_empty());
+        assert!(r.get("anything").is_none());
+    }
+
+    #[test]
+    fn register_then_get_roundtrip() {
+        let mut r = ServiceRegistry::new();
+        r.register(Arc::new(EnforcedService { name: "s3" }));
+        assert!(r.get("s3").is_some());
+        assert!(r.get("missing").is_none());
+    }
+
+    #[test]
+    fn service_names_collects_registered() {
+        let mut r = ServiceRegistry::new();
+        r.register(Arc::new(EnforcedService { name: "s3" }));
+        r.register(Arc::new(UnenforcedService { name: "sts" }));
+        let mut names = r.service_names();
+        names.sort();
+        assert_eq!(names, vec!["s3", "sts"]);
+    }
+
+    #[test]
+    fn iam_split_sorts_and_separates_groups() {
+        let mut r = ServiceRegistry::new();
+        r.register(Arc::new(EnforcedService { name: "s3" }));
+        r.register(Arc::new(EnforcedService { name: "iam" }));
+        r.register(Arc::new(UnenforcedService { name: "sts" }));
+        r.register(Arc::new(UnenforcedService { name: "bedrock" }));
+        let (enforced, skipped) = r.iam_enforcement_split();
+        assert_eq!(enforced, vec!["iam", "s3"]);
+        assert_eq!(skipped, vec!["bedrock", "sts"]);
+    }
+
+    #[test]
+    fn register_overwrites_same_name() {
+        let mut r = ServiceRegistry::new();
+        r.register(Arc::new(EnforcedService { name: "s3" }));
+        r.register(Arc::new(UnenforcedService { name: "s3" }));
+        let (enforced, skipped) = r.iam_enforcement_split();
+        assert!(enforced.is_empty());
+        assert_eq!(skipped, vec!["s3"]);
+    }
+}

--- a/crates/fakecloud-eventbridge/src/delivery.rs
+++ b/crates/fakecloud-eventbridge/src/delivery.rs
@@ -96,3 +96,194 @@ impl EventBridgeDelivery for EventBridgeDeliveryImpl {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{
+        EventBridgeState, EventRule, EventTarget as EbTarget, SharedEventBridgeState,
+    };
+    use fakecloud_core::delivery::{SnsDelivery, SqsDelivery};
+    use parking_lot::RwLock;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct Recorder {
+        sqs: Mutex<Vec<(String, String)>>,
+        sns: Mutex<Vec<(String, String, Option<String>)>>,
+    }
+
+    impl SqsDelivery for Recorder {
+        fn deliver_to_queue(&self, arn: &str, body: &str, _: &HashMap<String, String>) {
+            self.sqs
+                .lock()
+                .unwrap()
+                .push((arn.to_string(), body.to_string()));
+        }
+        fn deliver_to_queue_with_attrs(
+            &self,
+            arn: &str,
+            body: &str,
+            _: &HashMap<String, fakecloud_core::delivery::SqsMessageAttribute>,
+            _: Option<&str>,
+            _: Option<&str>,
+        ) {
+            self.sqs
+                .lock()
+                .unwrap()
+                .push((arn.to_string(), body.to_string()));
+        }
+    }
+
+    impl SnsDelivery for Recorder {
+        fn publish_to_topic(&self, arn: &str, msg: &str, subject: Option<&str>) {
+            self.sns.lock().unwrap().push((
+                arn.to_string(),
+                msg.to_string(),
+                subject.map(|s| s.to_string()),
+            ));
+        }
+    }
+
+    fn make_shared() -> SharedEventBridgeState {
+        Arc::new(RwLock::new(EventBridgeState::new(
+            "123456789012",
+            "us-east-1",
+        )))
+    }
+
+    fn make_rule(name: &str, pattern: Option<&str>, target_arn: &str) -> EventRule {
+        EventRule {
+            name: name.to_string(),
+            arn: format!("arn:aws:events:us-east-1:123456789012:rule/{name}"),
+            event_bus_name: "default".to_string(),
+            event_pattern: pattern.map(|s| s.to_string()),
+            schedule_expression: None,
+            state: "ENABLED".to_string(),
+            description: None,
+            role_arn: None,
+            managed_by: None,
+            created_by: None,
+            targets: vec![EbTarget {
+                id: "t1".to_string(),
+                arn: target_arn.to_string(),
+                input: None,
+                input_path: None,
+                input_transformer: None,
+                sqs_parameters: None,
+            }],
+            tags: HashMap::new(),
+            last_fired: None,
+        }
+    }
+
+    #[test]
+    fn put_event_appends_to_events_log() {
+        let state = make_shared();
+        let bus = Arc::new(DeliveryBus::new());
+        let delivery = EventBridgeDeliveryImpl::new(state.clone(), bus);
+        delivery.put_event("my.source", "MyType", r#"{"k":"v"}"#, "default");
+        let guard = state.read();
+        assert_eq!(guard.events.len(), 1);
+        assert_eq!(guard.events[0].source, "my.source");
+        assert_eq!(guard.events[0].detail_type, "MyType");
+    }
+
+    #[test]
+    fn put_event_dispatches_matching_sqs_target() {
+        let state = make_shared();
+        let q_arn = "arn:aws:sqs:us-east-1:123456789012:q".to_string();
+        {
+            let mut s = state.write();
+            let rule = make_rule("r", None, &q_arn);
+            s.rules
+                .insert(("default".to_string(), "r".to_string()), rule);
+        }
+        let recorder = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let delivery = EventBridgeDeliveryImpl::new(state, bus);
+        delivery.put_event("app", "Changed", r#"{"x":1}"#, "default");
+        let calls = recorder.sqs.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, q_arn);
+        let env: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+        assert_eq!(env["detail-type"], "Changed");
+        assert_eq!(env["source"], "app");
+    }
+
+    #[test]
+    fn put_event_dispatches_to_sns_target() {
+        let state = make_shared();
+        let topic_arn = "arn:aws:sns:us-east-1:123456789012:t".to_string();
+        {
+            let mut s = state.write();
+            let rule = make_rule("r", None, &topic_arn);
+            s.rules
+                .insert(("default".to_string(), "r".to_string()), rule);
+        }
+        let recorder = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sns(recorder.clone()));
+        let delivery = EventBridgeDeliveryImpl::new(state, bus);
+        delivery.put_event("app", "Changed", r#"{}"#, "default");
+        let calls = recorder.sns.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, topic_arn);
+        assert_eq!(calls[0].2.as_deref(), Some("Changed"));
+    }
+
+    #[test]
+    fn put_event_skips_disabled_rule() {
+        let state = make_shared();
+        let q_arn = "arn:aws:sqs:us-east-1:123456789012:q".to_string();
+        {
+            let mut s = state.write();
+            let mut rule = make_rule("r", None, &q_arn);
+            rule.state = "DISABLED".to_string();
+            s.rules
+                .insert(("default".to_string(), "r".to_string()), rule);
+        }
+        let recorder = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let delivery = EventBridgeDeliveryImpl::new(state, bus);
+        delivery.put_event("app", "Changed", r#"{}"#, "default");
+        assert!(recorder.sqs.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn put_event_skips_other_bus_rule() {
+        let state = make_shared();
+        let q_arn = "arn:aws:sqs:us-east-1:123456789012:q".to_string();
+        {
+            let mut s = state.write();
+            let mut rule = make_rule("r", None, &q_arn);
+            rule.event_bus_name = "custom-bus".to_string();
+            s.rules
+                .insert(("custom-bus".to_string(), "r".to_string()), rule);
+        }
+        let recorder = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let delivery = EventBridgeDeliveryImpl::new(state, bus);
+        delivery.put_event("app", "Changed", r#"{}"#, "default");
+        assert!(recorder.sqs.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn put_event_handles_invalid_detail_json_gracefully() {
+        let state = make_shared();
+        let q_arn = "arn:aws:sqs:us-east-1:123456789012:q".to_string();
+        {
+            let mut s = state.write();
+            let rule = make_rule("r", None, &q_arn);
+            s.rules
+                .insert(("default".to_string(), "r".to_string()), rule);
+        }
+        let recorder = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let delivery = EventBridgeDeliveryImpl::new(state, bus);
+        delivery.put_event("app", "Type", "not-json", "default");
+        let calls = recorder.sqs.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        let env: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+        assert_eq!(env["detail"], serde_json::json!({}));
+    }
+}

--- a/crates/fakecloud-kinesis/src/delivery.rs
+++ b/crates/fakecloud-kinesis/src/delivery.rs
@@ -73,3 +73,132 @@ impl KinesisDelivery for KinesisDeliveryImpl {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{KinesisShard, KinesisState, KinesisStream, SharedKinesisState};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+
+    fn make_stream(name: &str, shard_count: usize) -> KinesisStream {
+        let shards = (0..shard_count)
+            .map(|i| KinesisShard {
+                shard_id: format!("shardId-{i:012}"),
+                starting_hash_key: "0".to_string(),
+                ending_hash_key: "340282366920938463463374607431768211455".to_string(),
+                parent_shard_id: None,
+                adjacent_parent_shard_id: None,
+                is_open: true,
+                next_sequence_number: 0,
+                records: Vec::new(),
+            })
+            .collect();
+        KinesisStream {
+            stream_name: name.to_string(),
+            stream_arn: format!("arn:aws:kinesis:us-east-1:123456789012:stream/{name}"),
+            stream_status: "ACTIVE".to_string(),
+            stream_creation_timestamp: Utc::now(),
+            retention_period_hours: 24,
+            stream_mode: "PROVISIONED".to_string(),
+            encryption_type: "NONE".to_string(),
+            key_id: None,
+            shard_count: shard_count as i32,
+            open_shard_count: shard_count as i32,
+            tags: HashMap::new(),
+            shards,
+            next_shard_index: shard_count as i32,
+            enhanced_metrics: Vec::new(),
+            warm_throughput_mibps: None,
+            max_record_size_kib: None,
+        }
+    }
+
+    fn make_state(stream: KinesisStream) -> SharedKinesisState {
+        let mut s = KinesisState::new("123456789012", "us-east-1");
+        s.streams.insert(stream.stream_name.clone(), stream);
+        Arc::new(RwLock::new(s))
+    }
+
+    #[test]
+    fn put_record_delivers_to_shard() {
+        let stream = make_stream("my-stream", 1);
+        let state = make_state(stream);
+        let delivery = KinesisDeliveryImpl::new(state.clone());
+        let encoded = base64::engine::general_purpose::STANDARD.encode(b"hello");
+        delivery.put_record(
+            "arn:aws:kinesis:us-east-1:123456789012:stream/my-stream",
+            &encoded,
+            "pk-1",
+        );
+        let guard = state.read();
+        let stream = guard.streams.get("my-stream").unwrap();
+        assert_eq!(stream.shards[0].records.len(), 1);
+        let rec = &stream.shards[0].records[0];
+        assert_eq!(rec.data, b"hello");
+        assert_eq!(rec.partition_key, "pk-1");
+    }
+
+    #[test]
+    fn put_record_stores_raw_bytes_when_not_base64() {
+        let stream = make_stream("s", 1);
+        let state = make_state(stream);
+        let delivery = KinesisDeliveryImpl::new(state.clone());
+        delivery.put_record(
+            "arn:aws:kinesis:us-east-1:123456789012:stream/s",
+            "not-base64!",
+            "p",
+        );
+        let guard = state.read();
+        let rec = &guard.streams.get("s").unwrap().shards[0].records[0];
+        assert_eq!(rec.data, b"not-base64!");
+    }
+
+    #[test]
+    fn put_record_distributes_across_shards_by_partition_key() {
+        let stream = make_stream("s", 4);
+        let state = make_state(stream);
+        let delivery = KinesisDeliveryImpl::new(state.clone());
+        delivery.put_record(
+            "arn:aws:kinesis:us-east-1:123456789012:stream/s",
+            &base64::engine::general_purpose::STANDARD.encode(b"a"),
+            "A",
+        );
+        delivery.put_record(
+            "arn:aws:kinesis:us-east-1:123456789012:stream/s",
+            &base64::engine::general_purpose::STANDARD.encode(b"b"),
+            "B",
+        );
+        let guard = state.read();
+        let stream = guard.streams.get("s").unwrap();
+        let total: usize = stream.shards.iter().map(|s| s.records.len()).sum();
+        assert_eq!(total, 2);
+    }
+
+    #[test]
+    fn put_record_unknown_stream_is_noop() {
+        let stream = make_stream("s", 1);
+        let state = make_state(stream);
+        let delivery = KinesisDeliveryImpl::new(state.clone());
+        delivery.put_record(
+            "arn:aws:kinesis:us-east-1:123456789012:stream/other",
+            "AAA=",
+            "p",
+        );
+        let guard = state.read();
+        assert!(guard.streams.get("s").unwrap().shards[0].records.is_empty());
+    }
+
+    #[test]
+    fn put_record_handles_plain_stream_name_arg() {
+        let stream = make_stream("plain", 1);
+        let state = make_state(stream);
+        let delivery = KinesisDeliveryImpl::new(state.clone());
+        delivery.put_record("plain", "AAA=", "p");
+        let guard = state.read();
+        assert_eq!(
+            guard.streams.get("plain").unwrap().shards[0].records.len(),
+            1
+        );
+    }
+}

--- a/crates/fakecloud-s3/Cargo.toml
+++ b/crates/fakecloud-s3/Cargo.toml
@@ -29,3 +29,6 @@ sha1 = { workspace = true }
 sha2 = { workspace = true }
 crc32fast = { workspace = true }
 toml = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/fakecloud-s3/src/inventory.rs
+++ b/crates/fakecloud-s3/src/inventory.rs
@@ -195,4 +195,112 @@ mod tests {
     fn csv_escape_value_with_comma_and_quotes() {
         assert_eq!(csv_escape("a,\"b\""), "\"a,\"\"b\"\"\"");
     }
+
+    #[test]
+    fn parse_inventory_missing_destination_block_is_none() {
+        let xml = "<InventoryConfiguration></InventoryConfiguration>";
+        assert!(parse_inventory_destination(xml).is_none());
+    }
+
+    #[test]
+    fn parse_inventory_missing_bucket_returns_none() {
+        let xml = "<InventoryConfiguration>
+            <Destination>
+                <S3BucketDestination>
+                    <Format>CSV</Format>
+                </S3BucketDestination>
+            </Destination>
+        </InventoryConfiguration>";
+        assert!(parse_inventory_destination(xml).is_none());
+    }
+
+    #[test]
+    fn parse_inventory_without_prefix_field_is_ok() {
+        let xml = "<InventoryConfiguration>
+            <Destination>
+                <S3BucketDestination>
+                    <Bucket>arn:aws:s3:::dest</Bucket>
+                </S3BucketDestination>
+            </Destination>
+        </InventoryConfiguration>";
+        let dest = parse_inventory_destination(xml).unwrap();
+        assert_eq!(dest.bucket_arn, "arn:aws:s3:::dest");
+        assert!(dest.prefix.is_none());
+    }
+
+    #[test]
+    fn generate_inventory_writes_csv_report() {
+        use crate::state::{memory_body, S3Bucket, S3Object, S3State};
+        use fakecloud_core::multi_account::MultiAccountState;
+        use parking_lot::RwLock;
+        use std::sync::Arc;
+
+        let mut s = S3State::new("123456789012", "us-east-1");
+        let mut src = S3Bucket::new("src", "us-east-1", "owner");
+        src.objects.insert(
+            "file.txt".to_string(),
+            S3Object {
+                key: "file.txt".to_string(),
+                body: memory_body(Bytes::from_static(b"abc")),
+                content_type: "text/plain".to_string(),
+                etag: "abc".to_string(),
+                size: 3,
+                last_modified: Utc::now(),
+                storage_class: "STANDARD".to_string(),
+                ..Default::default()
+            },
+        );
+        src.inventory_configs.insert(
+            "cfg".to_string(),
+            r#"<InventoryConfiguration>
+                <Destination>
+                    <S3BucketDestination>
+                        <Bucket>arn:aws:s3:::dest</Bucket>
+                        <Prefix>inv/</Prefix>
+                    </S3BucketDestination>
+                </Destination>
+            </InventoryConfiguration>"#
+                .to_string(),
+        );
+        s.buckets.insert("src".to_string(), src);
+        s.buckets.insert(
+            "dest".to_string(),
+            S3Bucket::new("dest", "us-east-1", "owner"),
+        );
+
+        let mut multi: MultiAccountState<S3State> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        *multi.default_mut() = s;
+        let shared: SharedS3State = Arc::new(RwLock::new(multi));
+
+        generate_inventory_report(&shared, "src", "cfg");
+
+        let guard = shared.read();
+        let dest = guard.default_ref().buckets.get("dest").unwrap();
+        assert_eq!(dest.objects.len(), 1);
+        let (key, obj) = dest.objects.iter().next().unwrap();
+        assert!(key.starts_with("inv/src/cfg/data/"));
+        assert_eq!(obj.content_type, "text/csv");
+    }
+
+    #[test]
+    fn generate_inventory_missing_config_is_noop() {
+        use crate::state::{S3Bucket, S3State};
+        use fakecloud_core::multi_account::MultiAccountState;
+        use parking_lot::RwLock;
+        use std::sync::Arc;
+
+        let mut s = S3State::new("123456789012", "us-east-1");
+        s.buckets.insert(
+            "src".to_string(),
+            S3Bucket::new("src", "us-east-1", "owner"),
+        );
+        let mut multi: MultiAccountState<S3State> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        *multi.default_mut() = s;
+        let shared: SharedS3State = Arc::new(RwLock::new(multi));
+
+        // Should not panic even though cfg doesn't exist
+        generate_inventory_report(&shared, "src", "missing");
+    }
 }

--- a/crates/fakecloud-s3/src/logging.rs
+++ b/crates/fakecloud-s3/src/logging.rs
@@ -231,4 +231,52 @@ mod tests {
         assert!(entry.contains("req-abc"));
         assert!(entry.contains("\"GET /my-bucket/my-key.txt HTTP/1.1\""));
     }
+
+    #[test]
+    fn parse_logging_config_missing_target_bucket_returns_none() {
+        let xml = r#"<BucketLoggingStatus>
+            <LoggingEnabled><TargetPrefix>logs/</TargetPrefix></LoggingEnabled>
+        </BucketLoggingStatus>"#;
+        assert!(parse_logging_config(xml).is_none());
+    }
+
+    #[test]
+    fn parse_logging_config_empty_prefix_defaults_to_empty_string() {
+        let xml = r#"<BucketLoggingStatus>
+            <LoggingEnabled><TargetBucket>log</TargetBucket></LoggingEnabled>
+        </BucketLoggingStatus>"#;
+        let cfg = parse_logging_config(xml).unwrap();
+        assert_eq!(cfg.target_bucket, "log");
+        assert_eq!(cfg.target_prefix, "");
+    }
+
+    #[test]
+    fn format_log_entry_replaces_missing_key_with_dash() {
+        let request = AccessLogRequest {
+            operation: "GET.BUCKET",
+            key: None,
+            status: 200,
+            request_id: "req-x",
+            method: "GET",
+            path: "/my-bucket",
+        };
+        let entry = format_access_log_entry("owner", "my-bucket", &request);
+        assert!(entry.contains("REST.GET.BUCKET - "));
+    }
+
+    #[test]
+    fn operation_name_maps_all_common_methods() {
+        use http::Method;
+        assert_eq!(operation_name(&Method::GET, None), "GET.BUCKET");
+        assert_eq!(operation_name(&Method::GET, Some("k")), "GET.OBJECT");
+        assert_eq!(operation_name(&Method::PUT, None), "PUT.BUCKET");
+        assert_eq!(operation_name(&Method::PUT, Some("k")), "PUT.OBJECT");
+        assert_eq!(operation_name(&Method::DELETE, None), "DELETE.BUCKET");
+        assert_eq!(operation_name(&Method::DELETE, Some("k")), "DELETE.OBJECT");
+        assert_eq!(operation_name(&Method::HEAD, None), "HEAD.BUCKET");
+        assert_eq!(operation_name(&Method::HEAD, Some("k")), "HEAD.OBJECT");
+        assert_eq!(operation_name(&Method::POST, None), "POST");
+        assert_eq!(operation_name(&Method::POST, Some("k")), "POST");
+        assert_eq!(operation_name(&Method::OPTIONS, None), "UNKNOWN");
+    }
 }

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -269,3 +269,106 @@ pub type SharedS3State = Arc<RwLock<fakecloud_core::multi_account::MultiAccountS
 pub fn memory_body(bytes: Bytes) -> BodyRef {
     BodyRef::Memory(bytes)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn new_bucket_seeds_full_control_acl() {
+        let b = S3Bucket::new("my-bucket", "us-east-1", "owner-id");
+        assert_eq!(b.name, "my-bucket");
+        assert_eq!(b.region, "us-east-1");
+        assert_eq!(b.acl_owner_id, "owner-id");
+        assert_eq!(b.acl_grants.len(), 1);
+        assert_eq!(b.acl_grants[0].permission, "FULL_CONTROL");
+        assert_eq!(b.acl_grants[0].grantee_type, "CanonicalUser");
+        assert!(!b.eventbridge_enabled);
+        assert!(b.versioning.is_none());
+    }
+
+    #[test]
+    fn s3state_new_and_reset_clears_buckets() {
+        let mut state = S3State::new("123456789012", "us-east-1");
+        assert!(state.buckets.is_empty());
+        state
+            .buckets
+            .insert("b".to_string(), S3Bucket::new("b", "us-east-1", "owner"));
+        state.notification_events.push(S3NotificationEvent {
+            bucket: "b".to_string(),
+            key: "k".to_string(),
+            event_type: "s3:ObjectCreated:Put".to_string(),
+            timestamp: Utc::now(),
+        });
+        state.reset();
+        assert!(state.buckets.is_empty());
+        assert!(state.notification_events.is_empty());
+    }
+
+    #[test]
+    fn read_body_from_memory_returns_bytes() {
+        let state = S3State::new("123", "us-east-1");
+        let body = memory_body(Bytes::from_static(b"hello"));
+        assert_eq!(state.read_body(&body).unwrap(), &b"hello"[..]);
+    }
+
+    #[test]
+    fn read_body_from_disk_reads_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.as_file().write_all(b"file-body").unwrap();
+        let body = BodyRef::Disk {
+            bucket: "b".to_string(),
+            key: "k".to_string(),
+            version: None,
+            path: tmp.path().to_path_buf(),
+            size: 9,
+        };
+        let state = S3State::new("123", "us-east-1");
+        assert_eq!(state.read_body(&body).unwrap(), &b"file-body"[..]);
+    }
+
+    #[test]
+    fn read_body_range_slices_memory() {
+        let state = S3State::new("123", "us-east-1");
+        let body = memory_body(Bytes::from_static(b"abcdefghij"));
+        assert_eq!(state.read_body_range(&body, 2, 4).unwrap(), &b"cdef"[..]);
+    }
+
+    #[test]
+    fn read_body_range_memory_beyond_length_returns_empty() {
+        let state = S3State::new("123", "us-east-1");
+        let body = memory_body(Bytes::from_static(b"abc"));
+        assert!(state.read_body_range(&body, 100, 4).unwrap().is_empty());
+    }
+
+    #[test]
+    fn read_body_range_memory_clamps_to_length() {
+        let state = S3State::new("123", "us-east-1");
+        let body = memory_body(Bytes::from_static(b"abcdef"));
+        assert_eq!(state.read_body_range(&body, 4, 100).unwrap(), &b"ef"[..]);
+    }
+
+    #[test]
+    fn read_body_range_from_disk() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.as_file().write_all(b"0123456789").unwrap();
+        let body = BodyRef::Disk {
+            bucket: "b".to_string(),
+            key: "k".to_string(),
+            version: None,
+            path: tmp.path().to_path_buf(),
+            size: 10,
+        };
+        let state = S3State::new("123", "us-east-1");
+        assert_eq!(state.read_body_range(&body, 3, 4).unwrap(), &b"3456"[..]);
+    }
+
+    #[test]
+    fn account_state_impl_new_for_account() {
+        use fakecloud_core::multi_account::AccountState;
+        let s = S3State::new_for_account("111122223333", "eu-west-1", "http://x");
+        assert_eq!(s.account_id, "111122223333");
+        assert_eq!(s.region, "eu-west-1");
+    }
+}


### PR DESCRIPTION
Covers: ServiceRegistry register/get/service_names/iam_enforcement_split, EventBridgeDeliveryImpl.put_event dispatch to SQS/SNS + disabled/other-bus/invalid-json paths, KinesisDeliveryImpl.put_record shard routing + raw/base64 + unknown stream. All three files were 0% coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests to `fakecloud-core`, `fakecloud-eventbridge`, `fakecloud-kinesis`, `fakecloud-bedrock`, and `fakecloud-s3` covering registry lookups, cross-service delivery, Bedrock faults/prompts, and S3 state I/O, logging, and inventory.

Includes: registry register/get/service_names + IAM split; EventBridge SQS/SNS dispatch, disabled/other-bus, and invalid detail; Kinesis shard routing, base64 vs raw, and unknown/plain stream names; Bedrock fault match/status mapping/invocation recording + prompt overrides; and S3 bucket/state lifecycle + read_body/read_range for memory/disk, logging config parse/format + operation mapping, and inventory destination parse + CSV report generation.

<sup>Written for commit ba0096e4ca02102c8cc3ab048a2bcc0559662246. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

