### PR TITLE
test(iam,bedrock): iam snapshot persistence + bedrock evaluation jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,6 +2279,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/fakecloud-bedrock/src/evaluation.rs
+++ b/crates/fakecloud-bedrock/src/evaluation.rs
@@ -224,3 +224,150 @@ fn find_job_key(
             )
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "Eval".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "req".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn create_evaluation_job_automated_detected_from_config() {
+        let s = shared();
+        let body = json!({
+            "jobName": "auto-eval",
+            "roleArn": "arn:aws:iam::123:role/bedrock",
+            "evaluationConfig": {"automated": {"datasetMetricConfigs": []}}
+        });
+        let resp = create_evaluation_job(&s, &req(), &body).unwrap();
+        assert_eq!(resp.status, StatusCode::CREATED);
+        let state = s.read();
+        assert_eq!(state.evaluation_jobs.len(), 1);
+        let job = state.evaluation_jobs.values().next().unwrap();
+        assert_eq!(job.job_type, "Automated");
+        assert_eq!(job.job_name, "auto-eval");
+        assert_eq!(job.status, "InProgress");
+    }
+
+    #[test]
+    fn create_evaluation_job_defaults_to_human_without_automated() {
+        let s = shared();
+        let body = json!({"roleArn": "arn:aws:iam::123:role/b"});
+        create_evaluation_job(&s, &req(), &body).unwrap();
+        let state = s.read();
+        let job = state.evaluation_jobs.values().next().unwrap();
+        assert_eq!(job.job_type, "Human");
+        assert_eq!(job.job_name, "eval-job");
+    }
+
+    #[test]
+    fn get_evaluation_job_by_arn_or_id_or_name() {
+        let s = shared();
+        let body = json!({"jobName": "my-eval"});
+        create_evaluation_job(&s, &req(), &body).unwrap();
+        let arn = s.read().evaluation_jobs.keys().next().unwrap().clone();
+        let id = arn.rsplit('/').next().unwrap().to_string();
+        assert!(get_evaluation_job(&s, &arn).is_ok());
+        assert!(get_evaluation_job(&s, &id).is_ok());
+        assert!(get_evaluation_job(&s, "my-eval").is_ok());
+    }
+
+    #[test]
+    fn get_evaluation_job_unknown_returns_not_found() {
+        let s = shared();
+        let err = get_evaluation_job(&s, "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn list_evaluation_jobs_paginates() {
+        let s = shared();
+        for i in 0..3 {
+            create_evaluation_job(&s, &req(), &json!({"jobName": format!("j{i}")})).unwrap();
+        }
+        let mut r = req();
+        r.query_params
+            .insert("maxResults".to_string(), "2".to_string());
+        let resp = list_evaluation_jobs(&s, &r).unwrap();
+        let text = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        let v: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(v["jobSummaries"].as_array().unwrap().len(), 2);
+        assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn stop_evaluation_job_transitions_to_stopped() {
+        let s = shared();
+        create_evaluation_job(&s, &req(), &json!({})).unwrap();
+        let arn = s.read().evaluation_jobs.keys().next().unwrap().clone();
+        stop_evaluation_job(&s, &arn).unwrap();
+        assert_eq!(s.read().evaluation_jobs[&arn].status, "Stopped");
+    }
+
+    #[test]
+    fn stop_evaluation_job_conflict_when_not_in_progress() {
+        let s = shared();
+        create_evaluation_job(&s, &req(), &json!({})).unwrap();
+        let arn = s.read().evaluation_jobs.keys().next().unwrap().clone();
+        stop_evaluation_job(&s, &arn).unwrap();
+        let err = stop_evaluation_job(&s, &arn).err().unwrap();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn stop_evaluation_job_unknown_returns_not_found() {
+        let s = shared();
+        let err = stop_evaluation_job(&s, "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn batch_delete_removes_matches_and_collects_errors() {
+        let s = shared();
+        create_evaluation_job(&s, &req(), &json!({"jobName": "a"})).unwrap();
+        create_evaluation_job(&s, &req(), &json!({"jobName": "b"})).unwrap();
+        let body = json!({"jobIdentifiers": ["a", "missing"]});
+        let resp = batch_delete_evaluation_job(&s, &body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        let errors = v["errors"].as_array().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0]["jobIdentifier"], "missing");
+        assert_eq!(s.read().evaluation_jobs.len(), 1);
+    }
+
+    #[test]
+    fn batch_delete_missing_identifiers_returns_validation_error() {
+        let s = shared();
+        let err = batch_delete_evaluation_job(&s, &json!({})).err().unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
+++ b/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
@@ -125,3 +125,128 @@ pub fn put_use_case_for_model_access(
 
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "Create".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "req".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn create_agreement_missing_model_id_errors() {
+        let s = shared();
+        let err = create_foundation_model_agreement(&s, &req(), &json!({}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn create_agreement_persists_entry() {
+        let s = shared();
+        create_foundation_model_agreement(&s, &req(), &json!({"modelId": "anthropic.claude"}))
+            .unwrap();
+        assert_eq!(s.read().foundation_model_agreements.len(), 1);
+    }
+
+    #[test]
+    fn delete_agreement_missing_model_id_errors() {
+        let s = shared();
+        let err = delete_foundation_model_agreement(&s, &json!({}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn delete_agreement_unknown_returns_not_found() {
+        let s = shared();
+        let err = delete_foundation_model_agreement(&s, &json!({"modelId": "m"}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn delete_agreement_removes_entry() {
+        let s = shared();
+        create_foundation_model_agreement(&s, &req(), &json!({"modelId": "m"})).unwrap();
+        delete_foundation_model_agreement(&s, &json!({"modelId": "m"})).unwrap();
+        assert!(s.read().foundation_model_agreements.is_empty());
+    }
+
+    #[test]
+    fn list_offers_returns_empty_list() {
+        let s = shared();
+        let resp = list_foundation_model_agreement_offers(&s, "m").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["modelId"], "m");
+        assert_eq!(v["offers"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn availability_reflects_agreement_state() {
+        let s = shared();
+        let resp = get_foundation_model_availability(&s, "m").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["agreementAvailability"]["status"], "NOT_AVAILABLE");
+
+        create_foundation_model_agreement(&s, &req(), &json!({"modelId": "m"})).unwrap();
+        let resp = get_foundation_model_availability(&s, "m").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["agreementAvailability"]["status"], "AVAILABLE");
+    }
+
+    #[test]
+    fn use_case_roundtrip() {
+        let s = shared();
+        let resp = get_use_case_for_model_access(&s).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["useCase"].is_null());
+
+        put_use_case_for_model_access(&s, &json!({"useCase": {"purpose": "research"}})).unwrap();
+        let resp = get_use_case_for_model_access(&s).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["useCase"]["purpose"], "research");
+    }
+
+    #[test]
+    fn put_use_case_missing_field_errors() {
+        let s = shared();
+        let err = put_use_case_for_model_access(&s, &json!({})).err().unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/fakecloud-iam/Cargo.toml
+++ b/crates/fakecloud-iam/Cargo.toml
@@ -23,3 +23,6 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/fakecloud-iam/src/persistence.rs
+++ b/crates/fakecloud-iam/src/persistence.rs
@@ -53,3 +53,46 @@ pub async fn save_iam_snapshot(
         Err(err) => tracing::error!(%err, "iam snapshot task panicked"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::IamState;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use fakecloud_persistence::DiskSnapshotStore;
+    use parking_lot::RwLock;
+
+    fn shared_state() -> SharedIamState {
+        let multi: MultiAccountState<IamState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://localhost:4566");
+        std::sync::Arc::new(RwLock::new(multi))
+    }
+
+    #[test]
+    fn new_snapshot_lock_returns_arc_mutex() {
+        let lock: IamSnapshotLock = new_snapshot_lock();
+        let _c = lock.clone();
+    }
+
+    #[tokio::test]
+    async fn save_snapshot_none_store_is_noop() {
+        let state = shared_state();
+        let lock = new_snapshot_lock();
+        save_iam_snapshot(&state, None, &lock).await;
+    }
+
+    #[tokio::test]
+    async fn save_snapshot_writes_bytes_to_disk_store() {
+        let state = shared_state();
+        let lock = new_snapshot_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("iam.json");
+        let store: std::sync::Arc<dyn SnapshotStore> =
+            std::sync::Arc::new(DiskSnapshotStore::new(path.clone()));
+        save_iam_snapshot(&state, Some(store), &lock).await;
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(!bytes.is_empty());
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["schema_version"], IAM_SNAPSHOT_SCHEMA_VERSION);
+    }
+}


### PR DESCRIPTION
Covers: iam persistence.rs save_iam_snapshot (memory noop + disk store roundtrip), bedrock evaluation.rs create/get/list/stop/batch_delete jobs + error paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `fakecloud-iam` snapshot persistence and `fakecloud-bedrock` evaluation jobs and foundation model agreements. Covers `save_iam_snapshot` no-op + disk write; evaluation create/get/list (pagination)/stop/batch_delete with status transitions and not-found/conflict/validation errors; and agreements create/delete, availability, list offers, and use case get/put with validation errors.

- **Dependencies**
  - Added dev dependency `tempfile` for disk snapshot tests.

<sup>Written for commit f47fd758169c6168046c80e46e6d85e846d15009. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

