### PR TITLE
feat(kms,secretsmanager,kinesis,bedrock): multi-account state isolation

### DIFF
--- a/crates/fakecloud-bedrock/src/async_invoke.rs
+++ b/crates/fakecloud-bedrock/src/async_invoke.rs
@@ -64,7 +64,8 @@ pub fn start_async_invoke(
         end_time: Some(now),
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.async_invocations
         .insert(invocation_arn.clone(), invocation);
 
@@ -76,9 +77,12 @@ pub fn start_async_invoke(
 
 pub fn get_async_invoke(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     invocation_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     // Look up by full ARN or by the UUID suffix
     let invocation = s
         .async_invocations
@@ -112,7 +116,9 @@ pub fn list_async_invokes(
     let next_token = req.query_params.get("nextToken");
     let status_filter = req.query_params.get("statusEquals");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&AsyncInvocation> = s
         .async_invocations
         .values()

--- a/crates/fakecloud-bedrock/src/automated_reasoning.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning.rs
@@ -550,7 +550,6 @@ fn test_case_to_json(tc: &AutomatedReasoningTestCase) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::BedrockState;
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
@@ -558,7 +557,13 @@ mod tests {
     use std::sync::Arc;
 
     fn shared() -> SharedBedrockState {
-        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
     }
 
     fn req() -> AwsRequest {
@@ -606,7 +611,7 @@ mod tests {
     fn create_policy_persists() {
         let s = shared();
         create_policy(&s, "pol-1");
-        assert_eq!(s.read().automated_reasoning_policies.len(), 1);
+        assert_eq!(s.read().default_ref().automated_reasoning_policies.len(), 1);
     }
 
     #[test]
@@ -614,15 +619,15 @@ mod tests {
         let s = shared();
         let arn = create_policy(&s, "pol-lookup");
         let id = arn.rsplit('/').next().unwrap().to_string();
-        assert!(get_automated_reasoning_policy(&s, &arn).is_ok());
-        assert!(get_automated_reasoning_policy(&s, &id).is_ok());
-        assert!(get_automated_reasoning_policy(&s, "pol-lookup").is_ok());
+        assert!(get_automated_reasoning_policy(&s, &req(), &arn).is_ok());
+        assert!(get_automated_reasoning_policy(&s, &req(), &id).is_ok());
+        assert!(get_automated_reasoning_policy(&s, &req(), "pol-lookup").is_ok());
     }
 
     #[test]
     fn get_policy_unknown_not_found() {
         let s = shared();
-        let err = get_automated_reasoning_policy(&s, "missing").err().unwrap();
+        let err = get_automated_reasoning_policy(&s, &req(), "missing").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -648,11 +653,13 @@ mod tests {
         let arn = create_policy(&s, "upd");
         update_automated_reasoning_policy(
             &s,
+            &req(),
             &arn,
             &json!({"policyName": "new-name", "description": "desc"}),
         )
         .unwrap();
-        let p = &s.read().automated_reasoning_policies[&arn];
+        let guard = s.read();
+        let p = &guard.default_ref().automated_reasoning_policies[&arn];
         assert_eq!(p.policy_name, "new-name");
         assert_eq!(p.description.as_deref(), Some("desc"));
     }
@@ -660,7 +667,7 @@ mod tests {
     #[test]
     fn update_policy_unknown_not_found() {
         let s = shared();
-        let err = update_automated_reasoning_policy(&s, "miss", &json!({}))
+        let err = update_automated_reasoning_policy(&s, &req(), "miss", &json!({}))
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -670,17 +677,17 @@ mod tests {
     fn delete_policy_removes_test_cases() {
         let s = shared();
         let arn = create_policy(&s, "del");
-        create_automated_reasoning_policy_test_case(&s, &arn, &json!({"testCaseName": "tc"}))
+        create_automated_reasoning_policy_test_case(&s, &req(), &arn, &json!({"testCaseName": "tc"}))
             .unwrap();
-        delete_automated_reasoning_policy(&s, &arn).unwrap();
-        assert!(s.read().automated_reasoning_policies.is_empty());
-        assert!(s.read().automated_reasoning_test_cases.is_empty());
+        delete_automated_reasoning_policy(&s, &req(), &arn).unwrap();
+        assert!(s.read().default_ref().automated_reasoning_policies.is_empty());
+        assert!(s.read().default_ref().automated_reasoning_test_cases.is_empty());
     }
 
     #[test]
     fn delete_policy_unknown_not_found() {
         let s = shared();
-        let err = delete_automated_reasoning_policy(&s, "miss").err().unwrap();
+        let err = delete_automated_reasoning_policy(&s, &req(), "miss").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -688,8 +695,9 @@ mod tests {
     fn create_version_bumps_and_appends() {
         let s = shared();
         let arn = create_policy(&s, "ver");
-        create_automated_reasoning_policy_version(&s, &arn, &json!({})).unwrap();
-        let p = &s.read().automated_reasoning_policies[&arn];
+        create_automated_reasoning_policy_version(&s, &req(), &arn, &json!({})).unwrap();
+        let guard = s.read();
+        let p = &guard.default_ref().automated_reasoning_policies[&arn];
         assert_eq!(p.version, "2");
         assert_eq!(p.versions, vec!["1".to_string(), "2".to_string()]);
     }
@@ -697,7 +705,7 @@ mod tests {
     #[test]
     fn create_version_unknown_not_found() {
         let s = shared();
-        let err = create_automated_reasoning_policy_version(&s, "miss", &json!({}))
+        let err = create_automated_reasoning_policy_version(&s, &req(), "miss", &json!({}))
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -733,6 +741,7 @@ mod tests {
         let arn = create_policy(&s, "tc-host");
         let resp = create_automated_reasoning_policy_test_case(
             &s,
+            &req(),
             &arn,
             &json!({"testCaseName": "tc1", "input": {"q": 1}, "expectedOutput": {"r": 2}}),
         )
@@ -741,32 +750,33 @@ mod tests {
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         let id = v["testCaseId"].as_str().unwrap().to_string();
 
-        let resp = get_automated_reasoning_policy_test_case(&s, &arn, &id).unwrap();
+        let resp = get_automated_reasoning_policy_test_case(&s, &req(), &arn, &id).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["testCaseName"], "tc1");
 
         update_automated_reasoning_policy_test_case(
             &s,
+            &req(),
             &arn,
             &id,
             &json!({"testCaseName": "tc1-new", "description": "d"}),
         )
         .unwrap();
-        let updated_name = s.read().automated_reasoning_test_cases[&(arn.clone(), id.clone())]
+        let updated_name = s.read().default_ref().automated_reasoning_test_cases[&(arn.clone(), id.clone())]
             .test_case_name
             .clone();
         assert_eq!(updated_name, "tc1-new");
 
-        delete_automated_reasoning_policy_test_case(&s, &arn, &id).unwrap();
-        assert!(s.read().automated_reasoning_test_cases.is_empty());
+        delete_automated_reasoning_policy_test_case(&s, &req(), &arn, &id).unwrap();
+        assert!(s.read().default_ref().automated_reasoning_test_cases.is_empty());
     }
 
     #[test]
     fn create_test_case_missing_name_errors() {
         let s = shared();
         let arn = create_policy(&s, "p");
-        let err = create_automated_reasoning_policy_test_case(&s, &arn, &json!({}))
+        let err = create_automated_reasoning_policy_test_case(&s, &req(), &arn, &json!({}))
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
@@ -777,6 +787,7 @@ mod tests {
         let s = shared();
         let err = create_automated_reasoning_policy_test_case(
             &s,
+            &req(),
             "missing-policy",
             &json!({"testCaseName": "tc"}),
         )
@@ -788,7 +799,7 @@ mod tests {
     #[test]
     fn get_test_case_unknown_policy_not_found() {
         let s = shared();
-        let err = get_automated_reasoning_policy_test_case(&s, "miss", "id")
+        let err = get_automated_reasoning_policy_test_case(&s, &req(), "miss", "id")
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -798,7 +809,7 @@ mod tests {
     fn get_test_case_unknown_id_not_found() {
         let s = shared();
         let arn = create_policy(&s, "p");
-        let err = get_automated_reasoning_policy_test_case(&s, &arn, "missing")
+        let err = get_automated_reasoning_policy_test_case(&s, &req(), &arn, "missing")
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -811,6 +822,7 @@ mod tests {
         for i in 0..3 {
             create_automated_reasoning_policy_test_case(
                 &s,
+                &req(),
                 &arn,
                 &json!({"testCaseName": format!("tc-{i}")}),
             )
@@ -838,7 +850,7 @@ mod tests {
     #[test]
     fn update_test_case_unknown_policy_not_found() {
         let s = shared();
-        let err = update_automated_reasoning_policy_test_case(&s, "miss", "id", &json!({}))
+        let err = update_automated_reasoning_policy_test_case(&s, &req(), "miss", "id", &json!({}))
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -848,7 +860,7 @@ mod tests {
     fn update_test_case_unknown_id_not_found() {
         let s = shared();
         let arn = create_policy(&s, "p2");
-        let err = update_automated_reasoning_policy_test_case(&s, &arn, "missing", &json!({}))
+        let err = update_automated_reasoning_policy_test_case(&s, &req(), &arn, "missing", &json!({}))
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -857,7 +869,7 @@ mod tests {
     #[test]
     fn delete_test_case_unknown_policy_not_found() {
         let s = shared();
-        let err = delete_automated_reasoning_policy_test_case(&s, "miss", "id")
+        let err = delete_automated_reasoning_policy_test_case(&s, &req(), "miss", "id")
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -867,7 +879,7 @@ mod tests {
     fn delete_test_case_unknown_id_not_found() {
         let s = shared();
         let arn = create_policy(&s, "p3");
-        let err = delete_automated_reasoning_policy_test_case(&s, &arn, "missing")
+        let err = delete_automated_reasoning_policy_test_case(&s, &req(), &arn, "missing")
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);

--- a/crates/fakecloud-bedrock/src/automated_reasoning.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning.rs
@@ -41,7 +41,8 @@ pub fn create_automated_reasoning_policy(
         updated_at: now,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.automated_reasoning_policies
         .insert(policy_arn.clone(), policy);
 
@@ -53,9 +54,12 @@ pub fn create_automated_reasoning_policy(
 
 pub fn get_automated_reasoning_policy(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy = find_policy(&s.automated_reasoning_policies, identifier).ok_or_else(|| {
         AwsServiceError::aws_error(
             StatusCode::NOT_FOUND,
@@ -79,7 +83,9 @@ pub fn list_automated_reasoning_policies(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&AutomatedReasoningPolicy> =
         s.automated_reasoning_policies.values().collect();
     items.sort_by(|a, b| a.policy_arn.cmp(&b.policy_arn));
@@ -123,10 +129,12 @@ pub fn list_automated_reasoning_policies(
 
 pub fn update_automated_reasoning_policy(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = find_policy_key(&s.automated_reasoning_policies, identifier).ok_or_else(|| {
         AwsServiceError::aws_error(
@@ -158,9 +166,11 @@ pub fn update_automated_reasoning_policy(
 
 pub fn delete_automated_reasoning_policy(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = find_policy_key(&s.automated_reasoning_policies, identifier).ok_or_else(|| {
         AwsServiceError::aws_error(
@@ -183,10 +193,12 @@ pub fn delete_automated_reasoning_policy(
 
 pub fn create_automated_reasoning_policy_version(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
     _body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = find_policy_key(&s.automated_reasoning_policies, identifier).ok_or_else(|| {
         AwsServiceError::aws_error(
@@ -223,7 +235,9 @@ pub fn export_automated_reasoning_policy_version(
     identifier: &str,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy = find_policy(&s.automated_reasoning_policies, identifier).ok_or_else(|| {
         AwsServiceError::aws_error(
             StatusCode::NOT_FOUND,
@@ -254,6 +268,7 @@ pub fn export_automated_reasoning_policy_version(
 
 pub fn create_automated_reasoning_policy_test_case(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -265,7 +280,8 @@ pub fn create_automated_reasoning_policy_test_case(
         )
     })?;
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let policy_arn = find_policy_key(&s.automated_reasoning_policies, policy_identifier)
         .ok_or_else(|| {
@@ -300,10 +316,13 @@ pub fn create_automated_reasoning_policy_test_case(
 
 pub fn get_automated_reasoning_policy_test_case(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     test_case_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
 
     let policy_arn = find_policy_key(&s.automated_reasoning_policies, policy_identifier)
         .ok_or_else(|| {
@@ -341,7 +360,9 @@ pub fn list_automated_reasoning_policy_test_cases(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
 
     let policy_arn = find_policy_key(&s.automated_reasoning_policies, policy_identifier)
         .ok_or_else(|| {
@@ -397,11 +418,13 @@ pub fn list_automated_reasoning_policy_test_cases(
 
 pub fn update_automated_reasoning_policy_test_case(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     test_case_id: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let policy_arn = find_policy_key(&s.automated_reasoning_policies, policy_identifier)
         .ok_or_else(|| {
@@ -442,10 +465,12 @@ pub fn update_automated_reasoning_policy_test_case(
 
 pub fn delete_automated_reasoning_policy_test_case(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     test_case_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let policy_arn = find_policy_key(&s.automated_reasoning_policies, policy_identifier)
         .ok_or_else(|| {

--- a/crates/fakecloud-bedrock/src/automated_reasoning.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning.rs
@@ -627,7 +627,9 @@ mod tests {
     #[test]
     fn get_policy_unknown_not_found() {
         let s = shared();
-        let err = get_automated_reasoning_policy(&s, &req(), "missing").err().unwrap();
+        let err = get_automated_reasoning_policy(&s, &req(), "missing")
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -677,17 +679,32 @@ mod tests {
     fn delete_policy_removes_test_cases() {
         let s = shared();
         let arn = create_policy(&s, "del");
-        create_automated_reasoning_policy_test_case(&s, &req(), &arn, &json!({"testCaseName": "tc"}))
-            .unwrap();
+        create_automated_reasoning_policy_test_case(
+            &s,
+            &req(),
+            &arn,
+            &json!({"testCaseName": "tc"}),
+        )
+        .unwrap();
         delete_automated_reasoning_policy(&s, &req(), &arn).unwrap();
-        assert!(s.read().default_ref().automated_reasoning_policies.is_empty());
-        assert!(s.read().default_ref().automated_reasoning_test_cases.is_empty());
+        assert!(s
+            .read()
+            .default_ref()
+            .automated_reasoning_policies
+            .is_empty());
+        assert!(s
+            .read()
+            .default_ref()
+            .automated_reasoning_test_cases
+            .is_empty());
     }
 
     #[test]
     fn delete_policy_unknown_not_found() {
         let s = shared();
-        let err = delete_automated_reasoning_policy(&s, &req(), "miss").err().unwrap();
+        let err = delete_automated_reasoning_policy(&s, &req(), "miss")
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -763,13 +780,18 @@ mod tests {
             &json!({"testCaseName": "tc1-new", "description": "d"}),
         )
         .unwrap();
-        let updated_name = s.read().default_ref().automated_reasoning_test_cases[&(arn.clone(), id.clone())]
+        let updated_name = s.read().default_ref().automated_reasoning_test_cases
+            [&(arn.clone(), id.clone())]
             .test_case_name
             .clone();
         assert_eq!(updated_name, "tc1-new");
 
         delete_automated_reasoning_policy_test_case(&s, &req(), &arn, &id).unwrap();
-        assert!(s.read().default_ref().automated_reasoning_test_cases.is_empty());
+        assert!(s
+            .read()
+            .default_ref()
+            .automated_reasoning_test_cases
+            .is_empty());
     }
 
     #[test]
@@ -860,9 +882,10 @@ mod tests {
     fn update_test_case_unknown_id_not_found() {
         let s = shared();
         let arn = create_policy(&s, "p2");
-        let err = update_automated_reasoning_policy_test_case(&s, &req(), &arn, "missing", &json!({}))
-            .err()
-            .unwrap();
+        let err =
+            update_automated_reasoning_policy_test_case(&s, &req(), &arn, "missing", &json!({}))
+                .err()
+                .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 

--- a/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
@@ -47,10 +47,12 @@ fn workflow_to_json(w: &AutomatedReasoningBuildWorkflow) -> Value {
 
 pub fn start_build_workflow(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     workflow_type: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     let workflow_id = Uuid::new_v4().to_string();
@@ -75,10 +77,13 @@ pub fn start_build_workflow(
 
 pub fn get_build_workflow(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     workflow_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     let workflow = s
@@ -108,7 +113,9 @@ pub fn list_build_workflows(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     let mut items: Vec<&AutomatedReasoningBuildWorkflow> = s
@@ -148,10 +155,12 @@ pub fn list_build_workflows(
 
 pub fn cancel_build_workflow(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     workflow_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     let workflow = s
@@ -173,10 +182,12 @@ pub fn cancel_build_workflow(
 
 pub fn delete_build_workflow(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     workflow_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     let key = (policy_arn.clone(), workflow_id.to_string());
@@ -199,10 +210,13 @@ pub fn delete_build_workflow(
 
 pub fn get_build_workflow_result_assets(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     workflow_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     if !s
@@ -221,10 +235,13 @@ pub fn get_build_workflow_result_assets(
 
 pub fn start_test_workflow(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     workflow_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     if !s
@@ -247,11 +264,14 @@ pub fn start_test_workflow(
 
 pub fn get_test_result(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     workflow_id: &str,
     test_case_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     if !s
@@ -297,7 +317,9 @@ pub fn list_test_results(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     if !s
@@ -348,10 +370,13 @@ pub fn list_test_results(
 
 pub fn get_annotations(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     workflow_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     if !s
@@ -376,11 +401,13 @@ pub fn get_annotations(
 
 pub fn update_annotations(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     workflow_id: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     if !s
@@ -402,10 +429,13 @@ pub fn update_annotations(
 
 pub fn get_next_scenario(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     policy_identifier: &str,
     workflow_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy_arn = require_policy_arn(&s.automated_reasoning_policies, policy_identifier)?;
 
     if !s

--- a/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
@@ -460,7 +460,7 @@ pub fn get_next_scenario(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{AutomatedReasoningPolicy, BedrockState};
+    use crate::state::AutomatedReasoningPolicy;
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
@@ -468,7 +468,13 @@ mod tests {
     use std::sync::Arc;
 
     fn shared() -> SharedBedrockState {
-        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
     }
 
     fn req() -> AwsRequest {
@@ -497,7 +503,7 @@ mod tests {
             Uuid::new_v4()
         );
         let now = Utc::now();
-        state.write().automated_reasoning_policies.insert(
+        state.write().default_mut().automated_reasoning_policies.insert(
             arn.clone(),
             AutomatedReasoningPolicy {
                 policy_arn: arn.clone(),
@@ -515,7 +521,7 @@ mod tests {
     }
 
     fn start_workflow(state: &SharedBedrockState, policy_id: &str) -> String {
-        let resp = start_build_workflow(state, policy_id, "BUILD").unwrap();
+        let resp = start_build_workflow(state, &req(), policy_id, "BUILD").unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         v["buildWorkflowId"].as_str().unwrap().to_string()
@@ -528,6 +534,7 @@ mod tests {
         let wid = start_workflow(&s, &arn);
         let w = s
             .read()
+            .default_ref()
             .ar_build_workflows
             .get(&(arn.clone(), wid))
             .unwrap()
@@ -539,7 +546,7 @@ mod tests {
     #[test]
     fn start_build_workflow_unknown_policy_not_found() {
         let s = shared();
-        let err = start_build_workflow(&s, "missing", "BUILD").err().unwrap();
+        let err = start_build_workflow(&s, &req(), "missing", "BUILD").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -548,7 +555,7 @@ mod tests {
         let s = shared();
         let arn = seed_policy(&s, "p");
         let wid = start_workflow(&s, &arn);
-        let resp = get_build_workflow(&s, &arn, &wid).unwrap();
+        let resp = get_build_workflow(&s, &req(), &arn, &wid).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["buildWorkflowId"], wid);
@@ -559,7 +566,7 @@ mod tests {
     fn get_build_workflow_unknown_returns_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = get_build_workflow(&s, &arn, "missing").err().unwrap();
+        let err = get_build_workflow(&s, &req(), &arn, "missing").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -592,8 +599,9 @@ mod tests {
         let s = shared();
         let arn = seed_policy(&s, "p");
         let wid = start_workflow(&s, &arn);
-        cancel_build_workflow(&s, &arn, &wid).unwrap();
-        let w = &s.read().ar_build_workflows[&(arn.clone(), wid.clone())];
+        cancel_build_workflow(&s, &req(), &arn, &wid).unwrap();
+        let guard = s.read();
+        let w = &guard.default_ref().ar_build_workflows[&(arn.clone(), wid.clone())];
         assert_eq!(w.status, "Cancelled");
     }
 
@@ -601,7 +609,7 @@ mod tests {
     fn cancel_build_workflow_unknown_returns_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = cancel_build_workflow(&s, &arn, "miss").err().unwrap();
+        let err = cancel_build_workflow(&s, &req(), &arn, "miss").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -610,23 +618,23 @@ mod tests {
         let s = shared();
         let arn = seed_policy(&s, "p");
         let wid = start_workflow(&s, &arn);
-        update_annotations(&s, &arn, &wid, &json!({"a": 1})).unwrap();
-        s.write().ar_test_results.insert(
+        update_annotations(&s, &req(), &arn, &wid, &json!({"a": 1})).unwrap();
+        s.write().default_mut().ar_test_results.insert(
             (arn.clone(), wid.clone(), "tc1".to_string()),
             json!({"t": 1}),
         );
-        delete_build_workflow(&s, &arn, &wid).unwrap();
+        delete_build_workflow(&s, &req(), &arn, &wid).unwrap();
         let g = s.read();
-        assert!(g.ar_build_workflows.is_empty());
-        assert!(g.ar_test_results.is_empty());
-        assert!(g.ar_annotations.is_empty());
+        assert!(g.default_ref().ar_build_workflows.is_empty());
+        assert!(g.default_ref().ar_test_results.is_empty());
+        assert!(g.default_ref().ar_annotations.is_empty());
     }
 
     #[test]
     fn delete_build_workflow_unknown_returns_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = delete_build_workflow(&s, &arn, "miss").err().unwrap();
+        let err = delete_build_workflow(&s, &req(), &arn, "miss").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -635,7 +643,7 @@ mod tests {
         let s = shared();
         let arn = seed_policy(&s, "p");
         let wid = start_workflow(&s, &arn);
-        let resp = get_build_workflow_result_assets(&s, &arn, &wid).unwrap();
+        let resp = get_build_workflow_result_assets(&s, &req(), &arn, &wid).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["assets"].as_array().unwrap().len(), 0);
@@ -645,7 +653,7 @@ mod tests {
     fn get_build_workflow_result_assets_unknown_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = get_build_workflow_result_assets(&s, &arn, "miss")
+        let err = get_build_workflow_result_assets(&s, &req(), &arn, "miss")
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -656,7 +664,7 @@ mod tests {
         let s = shared();
         let arn = seed_policy(&s, "p");
         let wid = start_workflow(&s, &arn);
-        let resp = start_test_workflow(&s, &arn, &wid).unwrap();
+        let resp = start_test_workflow(&s, &req(), &arn, &wid).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert!(v["testWorkflowId"].is_string());
@@ -666,7 +674,7 @@ mod tests {
     fn start_test_workflow_unknown_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = start_test_workflow(&s, &arn, "miss").err().unwrap();
+        let err = start_test_workflow(&s, &req(), &arn, "miss").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -675,7 +683,7 @@ mod tests {
         let s = shared();
         let arn = seed_policy(&s, "p");
         let wid = start_workflow(&s, &arn);
-        let resp = get_test_result(&s, &arn, &wid, "tc-x").unwrap();
+        let resp = get_test_result(&s, &req(), &arn, &wid, "tc-x").unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["status"], "NotRun");
@@ -687,11 +695,11 @@ mod tests {
         let s = shared();
         let arn = seed_policy(&s, "p");
         let wid = start_workflow(&s, &arn);
-        s.write().ar_test_results.insert(
+        s.write().default_mut().ar_test_results.insert(
             (arn.clone(), wid.clone(), "tc".to_string()),
             json!({"status": "Passed"}),
         );
-        let resp = get_test_result(&s, &arn, &wid, "tc").unwrap();
+        let resp = get_test_result(&s, &req(), &arn, &wid, "tc").unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["status"], "Passed");
@@ -701,7 +709,7 @@ mod tests {
     fn get_test_result_unknown_workflow_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = get_test_result(&s, &arn, "miss", "tc").err().unwrap();
+        let err = get_test_result(&s, &req(), &arn, "miss", "tc").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -711,7 +719,7 @@ mod tests {
         let arn = seed_policy(&s, "p");
         let wid = start_workflow(&s, &arn);
         for i in 0..3 {
-            s.write().ar_test_results.insert(
+            s.write().default_mut().ar_test_results.insert(
                 (arn.clone(), wid.clone(), format!("tc-{i}")),
                 json!({"testCaseId": format!("tc-{i}"), "status": "Passed"}),
             );
@@ -739,13 +747,13 @@ mod tests {
         let s = shared();
         let arn = seed_policy(&s, "p");
         let wid = start_workflow(&s, &arn);
-        let resp = get_annotations(&s, &arn, &wid).unwrap();
+        let resp = get_annotations(&s, &req(), &arn, &wid).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["annotations"].as_array().unwrap().len(), 0);
 
-        update_annotations(&s, &arn, &wid, &json!({"k": "v"})).unwrap();
-        let resp = get_annotations(&s, &arn, &wid).unwrap();
+        update_annotations(&s, &req(), &arn, &wid, &json!({"k": "v"})).unwrap();
+        let resp = get_annotations(&s, &req(), &arn, &wid).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["k"], "v");
@@ -755,7 +763,7 @@ mod tests {
     fn get_annotations_unknown_workflow_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = get_annotations(&s, &arn, "miss").err().unwrap();
+        let err = get_annotations(&s, &req(), &arn, "miss").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -763,7 +771,7 @@ mod tests {
     fn update_annotations_unknown_workflow_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = update_annotations(&s, &arn, "miss", &json!({}))
+        let err = update_annotations(&s, &req(), &arn, "miss", &json!({}))
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -774,7 +782,7 @@ mod tests {
         let s = shared();
         let arn = seed_policy(&s, "p");
         let wid = start_workflow(&s, &arn);
-        let resp = get_next_scenario(&s, &arn, &wid).unwrap();
+        let resp = get_next_scenario(&s, &req(), &arn, &wid).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["status"], "Ready");
@@ -785,7 +793,7 @@ mod tests {
     fn get_next_scenario_unknown_workflow_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = get_next_scenario(&s, &arn, "miss").err().unwrap();
+        let err = get_next_scenario(&s, &req(), &arn, "miss").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
@@ -503,20 +503,24 @@ mod tests {
             Uuid::new_v4()
         );
         let now = Utc::now();
-        state.write().default_mut().automated_reasoning_policies.insert(
-            arn.clone(),
-            AutomatedReasoningPolicy {
-                policy_arn: arn.clone(),
-                policy_name: name.to_string(),
-                description: None,
-                policy_document: json!({}),
-                status: "ACTIVE".to_string(),
-                version: "1".to_string(),
-                versions: vec!["1".to_string()],
-                created_at: now,
-                updated_at: now,
-            },
-        );
+        state
+            .write()
+            .default_mut()
+            .automated_reasoning_policies
+            .insert(
+                arn.clone(),
+                AutomatedReasoningPolicy {
+                    policy_arn: arn.clone(),
+                    policy_name: name.to_string(),
+                    description: None,
+                    policy_document: json!({}),
+                    status: "ACTIVE".to_string(),
+                    version: "1".to_string(),
+                    versions: vec!["1".to_string()],
+                    created_at: now,
+                    updated_at: now,
+                },
+            );
         arn
     }
 
@@ -546,7 +550,9 @@ mod tests {
     #[test]
     fn start_build_workflow_unknown_policy_not_found() {
         let s = shared();
-        let err = start_build_workflow(&s, &req(), "missing", "BUILD").err().unwrap();
+        let err = start_build_workflow(&s, &req(), "missing", "BUILD")
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -566,7 +572,9 @@ mod tests {
     fn get_build_workflow_unknown_returns_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = get_build_workflow(&s, &req(), &arn, "missing").err().unwrap();
+        let err = get_build_workflow(&s, &req(), &arn, "missing")
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -609,7 +617,9 @@ mod tests {
     fn cancel_build_workflow_unknown_returns_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = cancel_build_workflow(&s, &req(), &arn, "miss").err().unwrap();
+        let err = cancel_build_workflow(&s, &req(), &arn, "miss")
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -634,7 +644,9 @@ mod tests {
     fn delete_build_workflow_unknown_returns_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = delete_build_workflow(&s, &req(), &arn, "miss").err().unwrap();
+        let err = delete_build_workflow(&s, &req(), &arn, "miss")
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -709,7 +721,9 @@ mod tests {
     fn get_test_result_unknown_workflow_not_found() {
         let s = shared();
         let arn = seed_policy(&s, "p");
-        let err = get_test_result(&s, &req(), &arn, "miss", "tc").err().unwrap();
+        let err = get_test_result(&s, &req(), &arn, "miss", "tc")
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 

--- a/crates/fakecloud-bedrock/src/converse.rs
+++ b/crates/fakecloud-bedrock/src/converse.rs
@@ -2,18 +2,19 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsResponse, AwsServiceError};
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::SharedBedrockState;
 
 /// Handle the Converse API — unified conversation format across all models.
 pub fn converse(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     model_id: &str,
     body: &[u8],
 ) -> Result<AwsResponse, AwsServiceError> {
-    if let Some(fault) = crate::faults::take_matching_fault(state, model_id, "Converse") {
-        crate::faults::record_faulted_invocation(state, model_id, body, &fault);
+    if let Some(fault) = crate::faults::take_matching_fault(state, req, model_id, "Converse") {
+        crate::faults::record_faulted_invocation(state, req, model_id, body, &fault);
         return Err(crate::faults::fault_to_error(&fault));
     }
 
@@ -25,7 +26,7 @@ pub fn converse(
         .unwrap_or(u64::MAX);
     let tool_config = input.get("toolConfig");
 
-    let response_text = match crate::prompt::resolve_override(state, model_id, body) {
+    let response_text = match crate::prompt::resolve_override(state, req, model_id, body) {
         Some(custom) => {
             let parsed: Value = serde_json::from_str(&custom).unwrap_or_default();
             if let Some(text) = parsed["output"]["message"]["content"][0]["text"].as_str() {
@@ -107,7 +108,8 @@ pub fn converse(
 
     // Record invocation for introspection
     {
-        let mut s = state.write();
+        let mut accts = state.write();
+        let s = accts.get_or_create(&req.account_id);
         s.invocations.push(crate::state::ModelInvocation {
             model_id: model_id.to_string(),
             input: String::from_utf8_lossy(body).to_string(),

--- a/crates/fakecloud-bedrock/src/custom_model_deployments.rs
+++ b/crates/fakecloud-bedrock/src/custom_model_deployments.rs
@@ -35,7 +35,8 @@ pub fn create_custom_model_deployment(
         last_updated_at: now,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.custom_model_deployments
         .insert(deployment_arn.clone(), deployment);
 
@@ -47,9 +48,12 @@ pub fn create_custom_model_deployment(
 
 pub fn get_custom_model_deployment(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     deployment_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let deployment = find_deployment(&s.custom_model_deployments, deployment_identifier)?;
 
     Ok(AwsResponse::ok_json(deployment_to_json(deployment)))
@@ -67,7 +71,9 @@ pub fn list_custom_model_deployments(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&CustomModelDeployment> = s.custom_model_deployments.values().collect();
     items.sort_by(|a, b| a.deployment_arn.cmp(&b.deployment_arn));
 
@@ -100,10 +106,12 @@ pub fn list_custom_model_deployments(
 
 pub fn update_custom_model_deployment(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     deployment_identifier: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let key = find_deployment_key(&s.custom_model_deployments, deployment_identifier)?;
     let deployment = s
         .custom_model_deployments
@@ -123,9 +131,11 @@ pub fn update_custom_model_deployment(
 
 pub fn delete_custom_model_deployment(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     deployment_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let key = find_deployment_key(&s.custom_model_deployments, deployment_identifier)?;
     s.custom_model_deployments.remove(&key);
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))

--- a/crates/fakecloud-bedrock/src/custom_models.rs
+++ b/crates/fakecloud-bedrock/src/custom_models.rs
@@ -31,7 +31,8 @@ pub fn create_custom_model(
         creation_time: Utc::now(),
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.custom_models.insert(model_arn.clone(), model);
 
     Ok(AwsResponse::json(
@@ -42,9 +43,12 @@ pub fn create_custom_model(
 
 pub fn get_custom_model(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     model_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let model = s
         .custom_models
         .get(model_identifier)
@@ -82,7 +86,9 @@ pub fn list_custom_models(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&CustomModel> = s.custom_models.values().collect();
     items.sort_by(|a, b| a.model_arn.cmp(&b.model_arn));
 
@@ -122,9 +128,11 @@ pub fn list_custom_models(
 
 pub fn delete_custom_model(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     model_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = s
         .custom_models

--- a/crates/fakecloud-bedrock/src/customization.rs
+++ b/crates/fakecloud-bedrock/src/customization.rs
@@ -63,7 +63,8 @@ pub fn create_model_customization_job(
         last_modified_at: now,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.customization_jobs.insert(job_arn.clone(), job);
 
     Ok(AwsResponse::json(
@@ -77,7 +78,9 @@ pub fn get_model_customization_job(
     req: &AwsRequest,
     job_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
 
     // Job identifier can be an ARN or a job name
     let job = s
@@ -129,7 +132,9 @@ pub fn list_model_customization_jobs(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&crate::state::CustomizationJob> = s.customization_jobs.values().collect();
     items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
 
@@ -172,9 +177,11 @@ pub fn list_model_customization_jobs(
 
 pub fn stop_model_customization_job(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     job_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     // Find the key first to avoid double mutable borrow
     let key = s

--- a/crates/fakecloud-bedrock/src/enforced_guardrails.rs
+++ b/crates/fakecloud-bedrock/src/enforced_guardrails.rs
@@ -8,11 +8,13 @@ use crate::state::SharedBedrockState;
 
 pub fn put_enforced_guardrail_configuration(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
     let config_id = Uuid::new_v4().to_string();
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.enforced_guardrail_configs
         .insert(config_id.clone(), body.clone());
 
@@ -33,7 +35,9 @@ pub fn list_enforced_guardrails_configuration(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<(&String, &Value)> = s.enforced_guardrail_configs.iter().collect();
     items.sort_by(|a, b| a.0.cmp(b.0));
 
@@ -72,9 +76,11 @@ pub fn list_enforced_guardrails_configuration(
 
 pub fn delete_enforced_guardrail_configuration(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     config_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     match s.enforced_guardrail_configs.remove(config_id) {
         Some(_) => Ok(AwsResponse::json(StatusCode::OK, "{}".to_string())),

--- a/crates/fakecloud-bedrock/src/evaluation.rs
+++ b/crates/fakecloud-bedrock/src/evaluation.rs
@@ -40,7 +40,8 @@ pub fn create_evaluation_job(
         last_modified_time: now,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.evaluation_jobs.insert(job_arn.clone(), job);
 
     Ok(AwsResponse::json(
@@ -51,9 +52,12 @@ pub fn create_evaluation_job(
 
 pub fn get_evaluation_job(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     job_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let job = find_job(&s.evaluation_jobs, job_identifier)?;
 
     Ok(AwsResponse::ok_json(json!({
@@ -83,7 +87,9 @@ pub fn list_evaluation_jobs(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&EvaluationJob> = s.evaluation_jobs.values().collect();
     items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
 
@@ -124,9 +130,11 @@ pub fn list_evaluation_jobs(
 
 pub fn stop_evaluation_job(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     job_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let key = find_job_key(&s.evaluation_jobs, job_identifier)?;
     let job = s
         .evaluation_jobs
@@ -149,6 +157,7 @@ pub fn stop_evaluation_job(
 
 pub fn batch_delete_evaluation_job(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
     let job_identifiers = body["jobIdentifiers"].as_array().ok_or_else(|| {
@@ -159,7 +168,8 @@ pub fn batch_delete_evaluation_job(
         )
     })?;
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let mut errors: Vec<Value> = Vec::new();
 
     for identifier in job_identifiers {

--- a/crates/fakecloud-bedrock/src/evaluation.rs
+++ b/crates/fakecloud-bedrock/src/evaluation.rs
@@ -238,7 +238,6 @@ fn find_job_key(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::BedrockState;
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
@@ -246,7 +245,13 @@ mod tests {
     use std::sync::Arc;
 
     fn shared() -> SharedBedrockState {
-        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
     }
 
     fn req() -> AwsRequest {
@@ -280,8 +285,8 @@ mod tests {
         let resp = create_evaluation_job(&s, &req(), &body).unwrap();
         assert_eq!(resp.status, StatusCode::CREATED);
         let state = s.read();
-        assert_eq!(state.evaluation_jobs.len(), 1);
-        let job = state.evaluation_jobs.values().next().unwrap();
+        assert_eq!(state.default_ref().evaluation_jobs.len(), 1);
+        let job = state.default_ref().evaluation_jobs.values().next().unwrap();
         assert_eq!(job.job_type, "Automated");
         assert_eq!(job.job_name, "auto-eval");
         assert_eq!(job.status, "InProgress");
@@ -293,7 +298,7 @@ mod tests {
         let body = json!({"roleArn": "arn:aws:iam::123:role/b"});
         create_evaluation_job(&s, &req(), &body).unwrap();
         let state = s.read();
-        let job = state.evaluation_jobs.values().next().unwrap();
+        let job = state.default_ref().evaluation_jobs.values().next().unwrap();
         assert_eq!(job.job_type, "Human");
         assert_eq!(job.job_name, "eval-job");
     }
@@ -303,17 +308,17 @@ mod tests {
         let s = shared();
         let body = json!({"jobName": "my-eval"});
         create_evaluation_job(&s, &req(), &body).unwrap();
-        let arn = s.read().evaluation_jobs.keys().next().unwrap().clone();
+        let arn = s.read().default_ref().evaluation_jobs.keys().next().unwrap().clone();
         let id = arn.rsplit('/').next().unwrap().to_string();
-        assert!(get_evaluation_job(&s, &arn).is_ok());
-        assert!(get_evaluation_job(&s, &id).is_ok());
-        assert!(get_evaluation_job(&s, "my-eval").is_ok());
+        assert!(get_evaluation_job(&s, &req(), &arn).is_ok());
+        assert!(get_evaluation_job(&s, &req(), &id).is_ok());
+        assert!(get_evaluation_job(&s, &req(), "my-eval").is_ok());
     }
 
     #[test]
     fn get_evaluation_job_unknown_returns_not_found() {
         let s = shared();
-        let err = get_evaluation_job(&s, "missing").err().unwrap();
+        let err = get_evaluation_job(&s, &req(), "missing").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -337,25 +342,25 @@ mod tests {
     fn stop_evaluation_job_transitions_to_stopped() {
         let s = shared();
         create_evaluation_job(&s, &req(), &json!({})).unwrap();
-        let arn = s.read().evaluation_jobs.keys().next().unwrap().clone();
-        stop_evaluation_job(&s, &arn).unwrap();
-        assert_eq!(s.read().evaluation_jobs[&arn].status, "Stopped");
+        let arn = s.read().default_ref().evaluation_jobs.keys().next().unwrap().clone();
+        stop_evaluation_job(&s, &req(), &arn).unwrap();
+        assert_eq!(s.read().default_ref().evaluation_jobs[&arn].status, "Stopped");
     }
 
     #[test]
     fn stop_evaluation_job_conflict_when_not_in_progress() {
         let s = shared();
         create_evaluation_job(&s, &req(), &json!({})).unwrap();
-        let arn = s.read().evaluation_jobs.keys().next().unwrap().clone();
-        stop_evaluation_job(&s, &arn).unwrap();
-        let err = stop_evaluation_job(&s, &arn).err().unwrap();
+        let arn = s.read().default_ref().evaluation_jobs.keys().next().unwrap().clone();
+        stop_evaluation_job(&s, &req(), &arn).unwrap();
+        let err = stop_evaluation_job(&s, &req(), &arn).err().unwrap();
         assert_eq!(err.status(), StatusCode::CONFLICT);
     }
 
     #[test]
     fn stop_evaluation_job_unknown_returns_not_found() {
         let s = shared();
-        let err = stop_evaluation_job(&s, "missing").err().unwrap();
+        let err = stop_evaluation_job(&s, &req(), "missing").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -365,19 +370,19 @@ mod tests {
         create_evaluation_job(&s, &req(), &json!({"jobName": "a"})).unwrap();
         create_evaluation_job(&s, &req(), &json!({"jobName": "b"})).unwrap();
         let body = json!({"jobIdentifiers": ["a", "missing"]});
-        let resp = batch_delete_evaluation_job(&s, &body).unwrap();
+        let resp = batch_delete_evaluation_job(&s, &req(), &body).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         let errors = v["errors"].as_array().unwrap();
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0]["jobIdentifier"], "missing");
-        assert_eq!(s.read().evaluation_jobs.len(), 1);
+        assert_eq!(s.read().default_ref().evaluation_jobs.len(), 1);
     }
 
     #[test]
     fn batch_delete_missing_identifiers_returns_validation_error() {
         let s = shared();
-        let err = batch_delete_evaluation_job(&s, &json!({})).err().unwrap();
+        let err = batch_delete_evaluation_job(&s, &req(), &json!({})).err().unwrap();
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/fakecloud-bedrock/src/evaluation.rs
+++ b/crates/fakecloud-bedrock/src/evaluation.rs
@@ -308,7 +308,14 @@ mod tests {
         let s = shared();
         let body = json!({"jobName": "my-eval"});
         create_evaluation_job(&s, &req(), &body).unwrap();
-        let arn = s.read().default_ref().evaluation_jobs.keys().next().unwrap().clone();
+        let arn = s
+            .read()
+            .default_ref()
+            .evaluation_jobs
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
         let id = arn.rsplit('/').next().unwrap().to_string();
         assert!(get_evaluation_job(&s, &req(), &arn).is_ok());
         assert!(get_evaluation_job(&s, &req(), &id).is_ok());
@@ -342,16 +349,33 @@ mod tests {
     fn stop_evaluation_job_transitions_to_stopped() {
         let s = shared();
         create_evaluation_job(&s, &req(), &json!({})).unwrap();
-        let arn = s.read().default_ref().evaluation_jobs.keys().next().unwrap().clone();
+        let arn = s
+            .read()
+            .default_ref()
+            .evaluation_jobs
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
         stop_evaluation_job(&s, &req(), &arn).unwrap();
-        assert_eq!(s.read().default_ref().evaluation_jobs[&arn].status, "Stopped");
+        assert_eq!(
+            s.read().default_ref().evaluation_jobs[&arn].status,
+            "Stopped"
+        );
     }
 
     #[test]
     fn stop_evaluation_job_conflict_when_not_in_progress() {
         let s = shared();
         create_evaluation_job(&s, &req(), &json!({})).unwrap();
-        let arn = s.read().default_ref().evaluation_jobs.keys().next().unwrap().clone();
+        let arn = s
+            .read()
+            .default_ref()
+            .evaluation_jobs
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
         stop_evaluation_job(&s, &req(), &arn).unwrap();
         let err = stop_evaluation_job(&s, &req(), &arn).err().unwrap();
         assert_eq!(err.status(), StatusCode::CONFLICT);
@@ -382,7 +406,9 @@ mod tests {
     #[test]
     fn batch_delete_missing_identifiers_returns_validation_error() {
         let s = shared();
-        let err = batch_delete_evaluation_job(&s, &req(), &json!({})).err().unwrap();
+        let err = batch_delete_evaluation_job(&s, &req(), &json!({}))
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/fakecloud-bedrock/src/faults.rs
+++ b/crates/fakecloud-bedrock/src/faults.rs
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn take_matching_fault_none_when_empty() {
         let s = shared();
-        assert!(take_matching_fault(&s, &req(),"model-x", "InvokeModel").is_none());
+        assert!(take_matching_fault(&s, &req(), "model-x", "InvokeModel").is_none());
     }
 
     #[test]
@@ -130,7 +130,7 @@ mod tests {
             .default_mut()
             .fault_rules
             .push(rule("Throttle", "slow down", 429, 3, None, None));
-        let hit = take_matching_fault(&s, &req(),"any-model", "InvokeModel").unwrap();
+        let hit = take_matching_fault(&s, &req(), "any-model", "InvokeModel").unwrap();
         assert_eq!(hit.error_type, "Throttle");
         assert_eq!(s.read().default_ref().fault_rules[0].remaining, 2);
     }
@@ -142,30 +142,38 @@ mod tests {
             .default_mut()
             .fault_rules
             .push(rule("Err", "boom", 500, 1, None, None));
-        assert!(take_matching_fault(&s, &req(),"m", "o").is_some());
+        assert!(take_matching_fault(&s, &req(), "m", "o").is_some());
         assert!(s.read().default_ref().fault_rules.is_empty());
     }
 
     #[test]
     fn take_matching_fault_scoped_by_model() {
         let s = shared();
-        s.write()
-            .default_mut()
-            .fault_rules
-            .push(rule("ModelErr", "fail", 500, 1, Some("target-model"), None));
-        assert!(take_matching_fault(&s, &req(),"other-model", "o").is_none());
-        assert!(take_matching_fault(&s, &req(),"target-model", "o").is_some());
+        s.write().default_mut().fault_rules.push(rule(
+            "ModelErr",
+            "fail",
+            500,
+            1,
+            Some("target-model"),
+            None,
+        ));
+        assert!(take_matching_fault(&s, &req(), "other-model", "o").is_none());
+        assert!(take_matching_fault(&s, &req(), "target-model", "o").is_some());
     }
 
     #[test]
     fn take_matching_fault_scoped_by_operation() {
         let s = shared();
-        s.write()
-            .default_mut()
-            .fault_rules
-            .push(rule("OpErr", "fail", 500, 1, None, Some("Converse")));
-        assert!(take_matching_fault(&s, &req(),"m", "InvokeModel").is_none());
-        assert!(take_matching_fault(&s, &req(),"m", "Converse").is_some());
+        s.write().default_mut().fault_rules.push(rule(
+            "OpErr",
+            "fail",
+            500,
+            1,
+            None,
+            Some("Converse"),
+        ));
+        assert!(take_matching_fault(&s, &req(), "m", "InvokeModel").is_none());
+        assert!(take_matching_fault(&s, &req(), "m", "Converse").is_some());
     }
 
     #[test]

--- a/crates/fakecloud-bedrock/src/faults.rs
+++ b/crates/fakecloud-bedrock/src/faults.rs
@@ -63,12 +63,40 @@ pub fn record_faulted_invocation(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::BedrockState;
     use parking_lot::RwLock;
     use std::sync::Arc;
 
     fn shared() -> SharedBedrockState {
-        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
+    }
+
+    fn req() -> fakecloud_core::service::AwsRequest {
+        use bytes::Bytes;
+        use http::{HeaderMap, Method};
+        use std::collections::HashMap;
+        fakecloud_core::service::AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "req".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
     }
 
     fn rule(
@@ -92,48 +120,52 @@ mod tests {
     #[test]
     fn take_matching_fault_none_when_empty() {
         let s = shared();
-        assert!(take_matching_fault(&s, "model-x", "InvokeModel").is_none());
+        assert!(take_matching_fault(&s, &req(),"model-x", "InvokeModel").is_none());
     }
 
     #[test]
     fn take_matching_fault_matches_wildcard_rule() {
         let s = shared();
         s.write()
+            .default_mut()
             .fault_rules
             .push(rule("Throttle", "slow down", 429, 3, None, None));
-        let hit = take_matching_fault(&s, "any-model", "InvokeModel").unwrap();
+        let hit = take_matching_fault(&s, &req(),"any-model", "InvokeModel").unwrap();
         assert_eq!(hit.error_type, "Throttle");
-        assert_eq!(s.read().fault_rules[0].remaining, 2);
+        assert_eq!(s.read().default_ref().fault_rules[0].remaining, 2);
     }
 
     #[test]
     fn take_matching_fault_removes_when_remaining_reaches_zero() {
         let s = shared();
         s.write()
+            .default_mut()
             .fault_rules
             .push(rule("Err", "boom", 500, 1, None, None));
-        assert!(take_matching_fault(&s, "m", "o").is_some());
-        assert!(s.read().fault_rules.is_empty());
+        assert!(take_matching_fault(&s, &req(),"m", "o").is_some());
+        assert!(s.read().default_ref().fault_rules.is_empty());
     }
 
     #[test]
     fn take_matching_fault_scoped_by_model() {
         let s = shared();
         s.write()
+            .default_mut()
             .fault_rules
             .push(rule("ModelErr", "fail", 500, 1, Some("target-model"), None));
-        assert!(take_matching_fault(&s, "other-model", "o").is_none());
-        assert!(take_matching_fault(&s, "target-model", "o").is_some());
+        assert!(take_matching_fault(&s, &req(),"other-model", "o").is_none());
+        assert!(take_matching_fault(&s, &req(),"target-model", "o").is_some());
     }
 
     #[test]
     fn take_matching_fault_scoped_by_operation() {
         let s = shared();
         s.write()
+            .default_mut()
             .fault_rules
             .push(rule("OpErr", "fail", 500, 1, None, Some("Converse")));
-        assert!(take_matching_fault(&s, "m", "InvokeModel").is_none());
-        assert!(take_matching_fault(&s, "m", "Converse").is_some());
+        assert!(take_matching_fault(&s, &req(),"m", "InvokeModel").is_none());
+        assert!(take_matching_fault(&s, &req(),"m", "Converse").is_some());
     }
 
     #[test]
@@ -154,8 +186,9 @@ mod tests {
     fn record_faulted_invocation_appends_error_entry() {
         let s = shared();
         let r = rule("Throttled", "slow", 429, 1, None, None);
-        record_faulted_invocation(&s, "m-1", b"input-body", &r);
-        let inv = &s.read().invocations[0];
+        record_faulted_invocation(&s, &req(), "m-1", b"input-body", &r);
+        let guard = s.read();
+        let inv = &guard.default_ref().invocations[0];
         assert_eq!(inv.model_id, "m-1");
         assert_eq!(inv.input, "input-body");
         assert_eq!(inv.output, "");

--- a/crates/fakecloud-bedrock/src/faults.rs
+++ b/crates/fakecloud-bedrock/src/faults.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use http::StatusCode;
 
-use fakecloud_core::service::AwsServiceError;
+use fakecloud_core::service::{AwsRequest, AwsServiceError};
 
 use crate::state::{FaultRule, ModelInvocation, SharedBedrockState};
 
@@ -11,10 +11,12 @@ use crate::state::{FaultRule, ModelInvocation, SharedBedrockState};
 /// the intended error type/message/status.
 pub fn take_matching_fault(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     model_id: &str,
     operation: &str,
 ) -> Option<FaultRule> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let idx = s.fault_rules.iter().position(|rule| {
         rule.model_id
             .as_deref()
@@ -42,11 +44,13 @@ pub fn fault_to_error(fault: &FaultRule) -> AwsServiceError {
 /// Record an invocation that was rejected by an injected fault.
 pub fn record_faulted_invocation(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     model_id: &str,
     body: &[u8],
     fault: &FaultRule,
 ) {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.invocations.push(ModelInvocation {
         model_id: model_id.to_string(),
         input: String::from_utf8_lossy(body).to_string(),

--- a/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
+++ b/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
@@ -141,7 +141,6 @@ pub fn put_use_case_for_model_access(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::BedrockState;
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
@@ -149,7 +148,13 @@ mod tests {
     use std::sync::Arc;
 
     fn shared() -> SharedBedrockState {
-        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
     }
 
     fn req() -> AwsRequest {
@@ -186,13 +191,13 @@ mod tests {
         let s = shared();
         create_foundation_model_agreement(&s, &req(), &json!({"modelId": "anthropic.claude"}))
             .unwrap();
-        assert_eq!(s.read().foundation_model_agreements.len(), 1);
+        assert_eq!(s.read().default_ref().foundation_model_agreements.len(), 1);
     }
 
     #[test]
     fn delete_agreement_missing_model_id_errors() {
         let s = shared();
-        let err = delete_foundation_model_agreement(&s, &json!({}))
+        let err = delete_foundation_model_agreement(&s, &req(), &json!({}))
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
@@ -201,7 +206,7 @@ mod tests {
     #[test]
     fn delete_agreement_unknown_returns_not_found() {
         let s = shared();
-        let err = delete_foundation_model_agreement(&s, &json!({"modelId": "m"}))
+        let err = delete_foundation_model_agreement(&s, &req(), &json!({"modelId": "m"}))
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -211,14 +216,14 @@ mod tests {
     fn delete_agreement_removes_entry() {
         let s = shared();
         create_foundation_model_agreement(&s, &req(), &json!({"modelId": "m"})).unwrap();
-        delete_foundation_model_agreement(&s, &json!({"modelId": "m"})).unwrap();
-        assert!(s.read().foundation_model_agreements.is_empty());
+        delete_foundation_model_agreement(&s, &req(), &json!({"modelId": "m"})).unwrap();
+        assert!(s.read().default_ref().foundation_model_agreements.is_empty());
     }
 
     #[test]
     fn list_offers_returns_empty_list() {
         let s = shared();
-        let resp = list_foundation_model_agreement_offers(&s, "m").unwrap();
+        let resp = list_foundation_model_agreement_offers(&s, &req(), "m").unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["modelId"], "m");
@@ -228,13 +233,13 @@ mod tests {
     #[test]
     fn availability_reflects_agreement_state() {
         let s = shared();
-        let resp = get_foundation_model_availability(&s, "m").unwrap();
+        let resp = get_foundation_model_availability(&s, &req(), "m").unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["agreementAvailability"]["status"], "NOT_AVAILABLE");
 
         create_foundation_model_agreement(&s, &req(), &json!({"modelId": "m"})).unwrap();
-        let resp = get_foundation_model_availability(&s, "m").unwrap();
+        let resp = get_foundation_model_availability(&s, &req(), "m").unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["agreementAvailability"]["status"], "AVAILABLE");
@@ -243,13 +248,13 @@ mod tests {
     #[test]
     fn use_case_roundtrip() {
         let s = shared();
-        let resp = get_use_case_for_model_access(&s).unwrap();
+        let resp = get_use_case_for_model_access(&s, &req()).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert!(v["useCase"].is_null());
 
-        put_use_case_for_model_access(&s, &json!({"useCase": {"purpose": "research"}})).unwrap();
-        let resp = get_use_case_for_model_access(&s).unwrap();
+        put_use_case_for_model_access(&s, &req(), &json!({"useCase": {"purpose": "research"}})).unwrap();
+        let resp = get_use_case_for_model_access(&s, &req()).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["useCase"]["purpose"], "research");
@@ -258,7 +263,7 @@ mod tests {
     #[test]
     fn put_use_case_missing_field_errors() {
         let s = shared();
-        let err = put_use_case_for_model_access(&s, &json!({})).err().unwrap();
+        let err = put_use_case_for_model_access(&s, &req(), &json!({})).err().unwrap();
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
+++ b/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
@@ -9,7 +9,7 @@ use crate::state::{FoundationModelAgreement, SharedBedrockState};
 
 pub fn create_foundation_model_agreement(
     state: &SharedBedrockState,
-    _req: &AwsRequest,
+    req: &AwsRequest,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
     let model_id = body["modelId"].as_str().ok_or_else(|| {
@@ -28,7 +28,8 @@ pub fn create_foundation_model_agreement(
         created_at: Utc::now(),
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.foundation_model_agreements
         .insert(agreement_id, agreement);
 
@@ -39,6 +40,7 @@ pub fn create_foundation_model_agreement(
 
 pub fn delete_foundation_model_agreement(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
     let model_id = body["modelId"].as_str().ok_or_else(|| {
@@ -49,7 +51,8 @@ pub fn delete_foundation_model_agreement(
         )
     })?;
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let key = s
         .foundation_model_agreements
         .iter()
@@ -71,6 +74,7 @@ pub fn delete_foundation_model_agreement(
 
 pub fn list_foundation_model_agreement_offers(
     _state: &SharedBedrockState,
+    _req: &AwsRequest,
     model_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
     Ok(AwsResponse::ok_json(json!({
@@ -81,9 +85,12 @@ pub fn list_foundation_model_agreement_offers(
 
 pub fn get_foundation_model_availability(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     model_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let has_agreement = s
         .foundation_model_agreements
         .values()
@@ -99,8 +106,11 @@ pub fn get_foundation_model_availability(
 
 pub fn get_use_case_for_model_access(
     state: &SharedBedrockState,
+    req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let use_case = s.use_case_for_model_access.clone().unwrap_or(json!(null));
 
     Ok(AwsResponse::ok_json(json!({
@@ -110,6 +120,7 @@ pub fn get_use_case_for_model_access(
 
 pub fn put_use_case_for_model_access(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
     let use_case = body.get("useCase").cloned().ok_or_else(|| {
@@ -120,7 +131,8 @@ pub fn put_use_case_for_model_access(
         )
     })?;
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.use_case_for_model_access = Some(use_case);
 
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))

--- a/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
+++ b/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
@@ -217,7 +217,11 @@ mod tests {
         let s = shared();
         create_foundation_model_agreement(&s, &req(), &json!({"modelId": "m"})).unwrap();
         delete_foundation_model_agreement(&s, &req(), &json!({"modelId": "m"})).unwrap();
-        assert!(s.read().default_ref().foundation_model_agreements.is_empty());
+        assert!(s
+            .read()
+            .default_ref()
+            .foundation_model_agreements
+            .is_empty());
     }
 
     #[test]
@@ -253,7 +257,8 @@ mod tests {
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert!(v["useCase"].is_null());
 
-        put_use_case_for_model_access(&s, &req(), &json!({"useCase": {"purpose": "research"}})).unwrap();
+        put_use_case_for_model_access(&s, &req(), &json!({"useCase": {"purpose": "research"}}))
+            .unwrap();
         let resp = get_use_case_for_model_access(&s, &req()).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
@@ -263,7 +268,9 @@ mod tests {
     #[test]
     fn put_use_case_missing_field_errors() {
         let s = shared();
-        let err = put_use_case_for_model_access(&s, &req(), &json!({})).err().unwrap();
+        let err = put_use_case_for_model_access(&s, &req(), &json!({}))
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/fakecloud-bedrock/src/guardrails.rs
+++ b/crates/fakecloud-bedrock/src/guardrails.rs
@@ -54,7 +54,8 @@ pub fn create_guardrail(
         updated_at: now,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.guardrails.insert(guardrail_id.clone(), guardrail);
 
     Ok(AwsResponse::json(
@@ -77,7 +78,9 @@ pub fn get_guardrail(
     // Check if a specific version is requested
     let version = req.query_params.get("guardrailVersion");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
 
     // If a numbered version was requested, look it up in versions
     if let Some(ver) = version {
@@ -117,7 +120,9 @@ pub fn list_guardrails(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&Guardrail> = s.guardrails.values().collect();
     items.sort_by(|a, b| a.guardrail_id.cmp(&b.guardrail_id));
 
@@ -161,10 +166,12 @@ pub fn list_guardrails(
 
 pub fn update_guardrail(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     guardrail_id: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let guardrail = s.guardrails.get_mut(guardrail_id).ok_or_else(|| {
         AwsServiceError::aws_error(
             StatusCode::NOT_FOUND,
@@ -212,9 +219,11 @@ pub fn update_guardrail(
 
 pub fn delete_guardrail(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     guardrail_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.guardrails.remove(guardrail_id).ok_or_else(|| {
         AwsServiceError::aws_error(
             StatusCode::NOT_FOUND,
@@ -231,10 +240,12 @@ pub fn delete_guardrail(
 
 pub fn create_guardrail_version(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     guardrail_id: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let guardrail = s.guardrails.get_mut(guardrail_id).ok_or_else(|| {
         AwsServiceError::aws_error(
             StatusCode::NOT_FOUND,
@@ -285,13 +296,16 @@ pub fn create_guardrail_version(
 /// Handle the ApplyGuardrail API — evaluate content against a guardrail.
 pub fn apply_guardrail(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     guardrail_id: &str,
     guardrail_version: &str,
     body: &[u8],
 ) -> Result<AwsResponse, AwsServiceError> {
     let input: Value = serde_json::from_slice(body).unwrap_or_default();
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
 
     // Borrow a GuardrailView over DRAFT or a numbered version, avoiding
     // the 13-field clone needed to synthesize a temporary Guardrail.
@@ -643,7 +657,6 @@ fn word_boundary_match(text: &str, word: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::BedrockState;
     use parking_lot::RwLock;
     use std::sync::Arc;
 
@@ -668,7 +681,13 @@ mod tests {
     }
 
     fn shared_state() -> SharedBedrockState {
-        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
     }
 
     #[test]
@@ -836,7 +855,9 @@ mod tests {
         });
         let resp = create_guardrail(&state, &req, &body).unwrap();
         assert_eq!(resp.status, StatusCode::CREATED);
-        let s = state.read();
+        let accts = state.read();
+        let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+        let s = accts.get(&req.account_id).unwrap_or(&empty);
         assert_eq!(s.guardrails.len(), 1);
         let g = s.guardrails.values().next().unwrap();
         assert_eq!(g.name, "my-guard");
@@ -854,19 +875,22 @@ mod tests {
     #[test]
     fn delete_guardrail_removes_entry() {
         let state = shared_state();
+        let req = make_req();
         let gid = "gid-1";
         state
             .write()
+            .default_mut()
             .guardrails
             .insert(gid.to_string(), empty_guardrail(gid));
-        delete_guardrail(&state, gid).unwrap();
-        assert!(state.read().guardrails.is_empty());
+        delete_guardrail(&state, &req, gid).unwrap();
+        assert!(state.read().default_ref().guardrails.is_empty());
     }
 
     #[test]
     fn delete_guardrail_not_found() {
         let state = shared_state();
-        let err = delete_guardrail(&state, "missing").err().unwrap();
+        let req = make_req();
+        let err = delete_guardrail(&state, &req, "missing").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -875,10 +899,12 @@ mod tests {
         let state = shared_state();
         state
             .write()
+            .default_mut()
             .guardrails
             .insert("a".to_string(), empty_guardrail("a"));
         state
             .write()
+            .default_mut()
             .guardrails
             .insert("b".to_string(), empty_guardrail("b"));
         let req = make_req();
@@ -889,23 +915,30 @@ mod tests {
     #[test]
     fn apply_guardrail_noop_with_no_policies() {
         let state = shared_state();
+        let req = make_req();
         state
             .write()
+            .default_mut()
             .guardrails
             .insert("g".to_string(), empty_guardrail("g"));
         let body = br#"{"content":[{"text":{"text":"hello"}}],"source":"INPUT"}"#;
-        let resp = apply_guardrail(&state, "g", "DRAFT", body).unwrap();
+        let resp = apply_guardrail(&state, &req, "g", "DRAFT", body).unwrap();
         assert_eq!(resp.status, StatusCode::OK);
     }
 
     #[test]
     fn apply_guardrail_intervenes_on_blocked_word() {
         let state = shared_state();
+        let req = make_req();
         let mut g = empty_guardrail("g");
         g.word_policy = Some(json!({"wordsConfig": [{"text": "forbidden"}]}));
-        state.write().guardrails.insert("g".to_string(), g);
+        state
+            .write()
+            .default_mut()
+            .guardrails
+            .insert("g".to_string(), g);
         let body = br#"{"content":[{"text":{"text":"this is forbidden"}}],"source":"INPUT"}"#;
-        let resp = apply_guardrail(&state, "g", "DRAFT", body).unwrap();
+        let resp = apply_guardrail(&state, &req, "g", "DRAFT", body).unwrap();
         let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body_str.contains("GUARDRAIL_INTERVENED"));
         assert!(body_str.contains("blocked input"));
@@ -914,11 +947,16 @@ mod tests {
     #[test]
     fn apply_guardrail_output_source_uses_output_message() {
         let state = shared_state();
+        let req = make_req();
         let mut g = empty_guardrail("g");
         g.word_policy = Some(json!({"wordsConfig": [{"text": "x"}]}));
-        state.write().guardrails.insert("g".to_string(), g);
+        state
+            .write()
+            .default_mut()
+            .guardrails
+            .insert("g".to_string(), g);
         let body = br#"{"content":[{"text":{"text":"contains x value"}}],"source":"OUTPUT"}"#;
-        let resp = apply_guardrail(&state, "g", "DRAFT", body).unwrap();
+        let resp = apply_guardrail(&state, &req, "g", "DRAFT", body).unwrap();
         let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body_str.contains("blocked output"));
     }
@@ -926,8 +964,9 @@ mod tests {
     #[test]
     fn apply_guardrail_missing_returns_not_found() {
         let state = shared_state();
+        let req = make_req();
         let body = br#"{"content":[],"source":"INPUT"}"#;
-        let err = apply_guardrail(&state, "missing", "DRAFT", body)
+        let err = apply_guardrail(&state, &req, "missing", "DRAFT", body)
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -936,12 +975,16 @@ mod tests {
     #[test]
     fn apply_guardrail_missing_version_returns_not_found() {
         let state = shared_state();
+        let req = make_req();
         state
             .write()
+            .default_mut()
             .guardrails
             .insert("g".to_string(), empty_guardrail("g"));
         let body = br#"{"content":[],"source":"INPUT"}"#;
-        let err = apply_guardrail(&state, "g", "99", body).err().unwrap();
+        let err = apply_guardrail(&state, &req, "g", "99", body)
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/crates/fakecloud-bedrock/src/inference_profiles.rs
+++ b/crates/fakecloud-bedrock/src/inference_profiles.rs
@@ -35,7 +35,8 @@ pub fn create_inference_profile(
         updated_at: now,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     if let Some(tags) = body["tags"].as_array() {
         let tag_map: std::collections::HashMap<String, String> = tags
@@ -62,9 +63,12 @@ pub fn create_inference_profile(
 
 pub fn get_inference_profile(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let profile = s
         .inference_profiles
         .get(identifier)
@@ -106,7 +110,9 @@ pub fn list_inference_profiles(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&InferenceProfile> = s.inference_profiles.values().collect();
     items.sort_by(|a, b| a.inference_profile_arn.cmp(&b.inference_profile_arn));
 
@@ -149,9 +155,11 @@ pub fn list_inference_profiles(
 
 pub fn delete_inference_profile(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = s
         .inference_profiles

--- a/crates/fakecloud-bedrock/src/invocation_jobs.rs
+++ b/crates/fakecloud-bedrock/src/invocation_jobs.rs
@@ -36,7 +36,8 @@ pub fn create_model_invocation_job(
         end_time: None,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.model_invocation_jobs.insert(job_arn.clone(), job);
 
     Ok(AwsResponse::json(
@@ -47,9 +48,12 @@ pub fn create_model_invocation_job(
 
 pub fn get_model_invocation_job(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     job_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let job = find_job(&s.model_invocation_jobs, job_identifier)?;
 
     let mut resp = json!({
@@ -82,7 +86,9 @@ pub fn list_model_invocation_jobs(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&ModelInvocationJob> = s.model_invocation_jobs.values().collect();
     items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
 
@@ -124,9 +130,11 @@ pub fn list_model_invocation_jobs(
 
 pub fn stop_model_invocation_job(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     job_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let key = find_job_key(&s.model_invocation_jobs, job_identifier)?;
     let job = s
         .model_invocation_jobs

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsResponse, AwsServiceError};
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::SharedBedrockState;
 
@@ -10,6 +10,7 @@ use crate::state::SharedBedrockState;
 /// If a custom response has been configured via simulation endpoint, use that instead.
 pub fn invoke_model(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     model_id: &str,
     body: &[u8],
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -23,19 +24,20 @@ pub fn invoke_model(
     }
 
     // Fault injection: if a matching rule is queued, record the attempt and fail.
-    if let Some(fault) = crate::faults::take_matching_fault(state, model_id, "InvokeModel") {
-        crate::faults::record_faulted_invocation(state, model_id, body, &fault);
+    if let Some(fault) = crate::faults::take_matching_fault(state, req, model_id, "InvokeModel") {
+        crate::faults::record_faulted_invocation(state, req, model_id, body, &fault);
         return Err(crate::faults::fault_to_error(&fault));
     }
 
     let input: Value = serde_json::from_slice(body).unwrap_or_default();
 
-    let response_body = crate::prompt::resolve_override(state, model_id, body)
+    let response_body = crate::prompt::resolve_override(state, req, model_id, body)
         .unwrap_or_else(|| generate_canned_response(model_id, &input));
 
     // Record invocation for introspection
     {
-        let mut s = state.write();
+        let mut accts = state.write();
+        let s = accts.get_or_create(&req.account_id);
         s.invocations.push(crate::state::ModelInvocation {
             model_id: model_id.to_string(),
             input: String::from_utf8_lossy(body).to_string(),
@@ -64,6 +66,7 @@ pub fn invoke_model(
 /// Count tokens for the given input text (rough approximation).
 pub fn count_tokens(
     _state: &SharedBedrockState,
+    _req: &AwsRequest,
     model_id: &str,
     body: &[u8],
 ) -> Result<AwsResponse, AwsServiceError> {

--- a/crates/fakecloud-bedrock/src/logging.rs
+++ b/crates/fakecloud-bedrock/src/logging.rs
@@ -1,12 +1,13 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsResponse, AwsServiceError};
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::SharedBedrockState;
 
 pub fn put_model_invocation_logging_configuration(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
     let logging_config = body.get("loggingConfig").ok_or_else(|| {
@@ -31,7 +32,8 @@ pub fn put_model_invocation_logging_configuration(
             .unwrap_or(true),
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.logging_config = Some(config);
 
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
@@ -39,8 +41,11 @@ pub fn put_model_invocation_logging_configuration(
 
 pub fn get_model_invocation_logging_configuration(
     state: &SharedBedrockState,
+    req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     match &s.logging_config {
         Some(config) => {
             let mut logging_config = json!({
@@ -64,8 +69,10 @@ pub fn get_model_invocation_logging_configuration(
 
 pub fn delete_model_invocation_logging_configuration(
     state: &SharedBedrockState,
+    req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.logging_config = None;
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
 }

--- a/crates/fakecloud-bedrock/src/marketplace.rs
+++ b/crates/fakecloud-bedrock/src/marketplace.rs
@@ -408,7 +408,9 @@ mod tests {
     #[test]
     fn get_unknown_returns_not_found() {
         let s = shared();
-        let err = get_marketplace_model_endpoint(&s, &req(), "missing").err().unwrap();
+        let err = get_marketplace_model_endpoint(&s, &req(), "missing")
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -432,7 +434,8 @@ mod tests {
     fn update_sets_new_config() {
         let s = shared();
         let arn = create(&s, "up-ep");
-        update_marketplace_model_endpoint(&s, &req(), &arn, &json!({"endpointConfig": {"a": 1}})).unwrap();
+        update_marketplace_model_endpoint(&s, &req(), &arn, &json!({"endpointConfig": {"a": 1}}))
+            .unwrap();
         assert_eq!(
             s.read().default_ref().marketplace_endpoints[&arn].endpoint_config,
             json!({"a": 1})
@@ -459,7 +462,9 @@ mod tests {
     #[test]
     fn delete_unknown_returns_not_found() {
         let s = shared();
-        let err = delete_marketplace_model_endpoint(&s, &req(), "miss").err().unwrap();
+        let err = delete_marketplace_model_endpoint(&s, &req(), "miss")
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -468,7 +473,10 @@ mod tests {
         let s = shared();
         let arn = create(&s, "reg-ep");
         register_marketplace_model_endpoint(&s, &req(), &arn).unwrap();
-        assert_eq!(s.read().default_ref().marketplace_endpoints[&arn].status, "Registered");
+        assert_eq!(
+            s.read().default_ref().marketplace_endpoints[&arn].status,
+            "Registered"
+        );
     }
 
     #[test]
@@ -486,7 +494,10 @@ mod tests {
         let arn = create(&s, "dereg");
         register_marketplace_model_endpoint(&s, &req(), &arn).unwrap();
         deregister_marketplace_model_endpoint(&s, &req(), &arn).unwrap();
-        assert_eq!(s.read().default_ref().marketplace_endpoints[&arn].status, "Active");
+        assert_eq!(
+            s.read().default_ref().marketplace_endpoints[&arn].status,
+            "Active"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-bedrock/src/marketplace.rs
+++ b/crates/fakecloud-bedrock/src/marketplace.rs
@@ -45,7 +45,8 @@ pub fn create_marketplace_model_endpoint(
         updated_at: now,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.marketplace_endpoints
         .insert(endpoint_arn.clone(), endpoint);
 
@@ -57,9 +58,12 @@ pub fn create_marketplace_model_endpoint(
 
 pub fn get_marketplace_model_endpoint(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let endpoint = s
         .marketplace_endpoints
         .get(identifier)
@@ -101,7 +105,9 @@ pub fn list_marketplace_model_endpoints(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&MarketplaceModelEndpoint> = s.marketplace_endpoints.values().collect();
     items.sort_by(|a, b| a.endpoint_arn.cmp(&b.endpoint_arn));
 
@@ -143,10 +149,12 @@ pub fn list_marketplace_model_endpoints(
 
 pub fn update_marketplace_model_endpoint(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = s
         .marketplace_endpoints
@@ -190,9 +198,11 @@ pub fn update_marketplace_model_endpoint(
 
 pub fn delete_marketplace_model_endpoint(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = s
         .marketplace_endpoints
@@ -219,9 +229,11 @@ pub fn delete_marketplace_model_endpoint(
 
 pub fn register_marketplace_model_endpoint(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = s
         .marketplace_endpoints
@@ -262,9 +274,11 @@ pub fn register_marketplace_model_endpoint(
 
 pub fn deregister_marketplace_model_endpoint(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = s
         .marketplace_endpoints

--- a/crates/fakecloud-bedrock/src/marketplace.rs
+++ b/crates/fakecloud-bedrock/src/marketplace.rs
@@ -320,7 +320,6 @@ pub fn deregister_marketplace_model_endpoint(
 #[allow(clippy::too_many_lines)]
 mod tests {
     use super::*;
-    use crate::state::BedrockState;
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
@@ -328,7 +327,13 @@ mod tests {
     use std::sync::Arc;
 
     fn shared() -> SharedBedrockState {
-        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
     }
 
     fn req() -> AwsRequest {
@@ -385,7 +390,7 @@ mod tests {
     fn create_and_get_by_arn() {
         let s = shared();
         let arn = create(&s, "ep-1");
-        let resp = get_marketplace_model_endpoint(&s, &arn).unwrap();
+        let resp = get_marketplace_model_endpoint(&s, &req(), &arn).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["marketplaceModelEndpoint"]["endpointName"], "ep-1");
@@ -396,14 +401,14 @@ mod tests {
         let s = shared();
         let arn = create(&s, "my-ep");
         let id = arn.rsplit('/').next().unwrap().to_string();
-        assert!(get_marketplace_model_endpoint(&s, &id).is_ok());
-        assert!(get_marketplace_model_endpoint(&s, "my-ep").is_ok());
+        assert!(get_marketplace_model_endpoint(&s, &req(), &id).is_ok());
+        assert!(get_marketplace_model_endpoint(&s, &req(), "my-ep").is_ok());
     }
 
     #[test]
     fn get_unknown_returns_not_found() {
         let s = shared();
-        let err = get_marketplace_model_endpoint(&s, "missing").err().unwrap();
+        let err = get_marketplace_model_endpoint(&s, &req(), "missing").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -427,9 +432,9 @@ mod tests {
     fn update_sets_new_config() {
         let s = shared();
         let arn = create(&s, "up-ep");
-        update_marketplace_model_endpoint(&s, &arn, &json!({"endpointConfig": {"a": 1}})).unwrap();
+        update_marketplace_model_endpoint(&s, &req(), &arn, &json!({"endpointConfig": {"a": 1}})).unwrap();
         assert_eq!(
-            s.read().marketplace_endpoints[&arn].endpoint_config,
+            s.read().default_ref().marketplace_endpoints[&arn].endpoint_config,
             json!({"a": 1})
         );
     }
@@ -437,7 +442,7 @@ mod tests {
     #[test]
     fn update_unknown_returns_not_found() {
         let s = shared();
-        let err = update_marketplace_model_endpoint(&s, "miss", &json!({}))
+        let err = update_marketplace_model_endpoint(&s, &req(), "miss", &json!({}))
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -447,14 +452,14 @@ mod tests {
     fn delete_removes_endpoint() {
         let s = shared();
         let arn = create(&s, "del-ep");
-        delete_marketplace_model_endpoint(&s, &arn).unwrap();
-        assert!(s.read().marketplace_endpoints.is_empty());
+        delete_marketplace_model_endpoint(&s, &req(), &arn).unwrap();
+        assert!(s.read().default_ref().marketplace_endpoints.is_empty());
     }
 
     #[test]
     fn delete_unknown_returns_not_found() {
         let s = shared();
-        let err = delete_marketplace_model_endpoint(&s, "miss").err().unwrap();
+        let err = delete_marketplace_model_endpoint(&s, &req(), "miss").err().unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
@@ -462,14 +467,14 @@ mod tests {
     fn register_transitions_status() {
         let s = shared();
         let arn = create(&s, "reg-ep");
-        register_marketplace_model_endpoint(&s, &arn).unwrap();
-        assert_eq!(s.read().marketplace_endpoints[&arn].status, "Registered");
+        register_marketplace_model_endpoint(&s, &req(), &arn).unwrap();
+        assert_eq!(s.read().default_ref().marketplace_endpoints[&arn].status, "Registered");
     }
 
     #[test]
     fn register_unknown_returns_not_found() {
         let s = shared();
-        let err = register_marketplace_model_endpoint(&s, "miss")
+        let err = register_marketplace_model_endpoint(&s, &req(), "miss")
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -479,15 +484,15 @@ mod tests {
     fn deregister_resets_to_active() {
         let s = shared();
         let arn = create(&s, "dereg");
-        register_marketplace_model_endpoint(&s, &arn).unwrap();
-        deregister_marketplace_model_endpoint(&s, &arn).unwrap();
-        assert_eq!(s.read().marketplace_endpoints[&arn].status, "Active");
+        register_marketplace_model_endpoint(&s, &req(), &arn).unwrap();
+        deregister_marketplace_model_endpoint(&s, &req(), &arn).unwrap();
+        assert_eq!(s.read().default_ref().marketplace_endpoints[&arn].status, "Active");
     }
 
     #[test]
     fn deregister_unknown_returns_not_found() {
         let s = shared();
-        let err = deregister_marketplace_model_endpoint(&s, "miss")
+        let err = deregister_marketplace_model_endpoint(&s, &req(), "miss")
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);

--- a/crates/fakecloud-bedrock/src/model_copy.rs
+++ b/crates/fakecloud-bedrock/src/model_copy.rs
@@ -34,7 +34,8 @@ pub fn create_model_copy_job(
         creation_time: Utc::now(),
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.model_copy_jobs.insert(job_arn.clone(), job);
 
     Ok(AwsResponse::json(
@@ -45,9 +46,12 @@ pub fn create_model_copy_job(
 
 pub fn get_model_copy_job(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     job_arn: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let job = s
         .model_copy_jobs
         .get(job_arn)
@@ -86,7 +90,9 @@ pub fn list_model_copy_jobs(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&ModelCopyJob> = s.model_copy_jobs.values().collect();
     items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
 

--- a/crates/fakecloud-bedrock/src/model_import.rs
+++ b/crates/fakecloud-bedrock/src/model_import.rs
@@ -244,7 +244,13 @@ pub fn delete_imported_model(
     model_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
     let mut accts = state.write();
-    let s = accts.get_or_create(&req.account_id);
+    let Some(s) = accts.get_mut(&req.account_id) else {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::NOT_FOUND,
+            "ResourceNotFoundException",
+            format!("Imported model {model_identifier} not found"),
+        ));
+    };
     let key = s
         .imported_models
         .iter()

--- a/crates/fakecloud-bedrock/src/model_import.rs
+++ b/crates/fakecloud-bedrock/src/model_import.rs
@@ -49,7 +49,8 @@ pub fn create_model_import_job(
         creation_time: now,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.model_import_jobs.insert(job_arn.clone(), job);
     s.imported_models
         .insert(imported_model_arn.clone(), imported_model);
@@ -62,9 +63,12 @@ pub fn create_model_import_job(
 
 pub fn get_model_import_job(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     job_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let job = s
         .model_import_jobs
         .get(job_identifier)
@@ -106,7 +110,9 @@ pub fn list_model_import_jobs(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&ModelImportJob> = s.model_import_jobs.values().collect();
     items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
 
@@ -149,9 +155,12 @@ pub fn list_model_import_jobs(
 
 pub fn get_imported_model(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     model_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let model = s
         .imported_models
         .get(model_identifier)
@@ -190,7 +199,9 @@ pub fn list_imported_models(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&ImportedModel> = s.imported_models.values().collect();
     items.sort_by(|a, b| a.model_arn.cmp(&b.model_arn));
 
@@ -229,9 +240,11 @@ pub fn list_imported_models(
 
 pub fn delete_imported_model(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     model_identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let key = s
         .imported_models
         .iter()

--- a/crates/fakecloud-bedrock/src/prompt.rs
+++ b/crates/fakecloud-bedrock/src/prompt.rs
@@ -100,12 +100,40 @@ pub fn resolve_override(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::BedrockState;
     use parking_lot::RwLock;
     use std::sync::Arc;
 
     fn shared() -> SharedBedrockState {
-        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
+    }
+
+    fn req() -> AwsRequest {
+        use bytes::Bytes;
+        use http::{HeaderMap, Method};
+        use std::collections::HashMap;
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "req".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
     }
 
     #[test]
@@ -198,7 +226,7 @@ mod tests {
     #[test]
     fn resolve_override_uses_response_rule_first() {
         let state = shared();
-        state.write().response_rules.insert(
+        state.write().default_mut().response_rules.insert(
             "m".to_string(),
             vec![ResponseRule {
                 prompt_contains: Some("hello".to_string()),
@@ -207,11 +235,12 @@ mod tests {
         );
         state
             .write()
+            .default_mut()
             .custom_responses
             .insert("m".to_string(), "legacy-loses".to_string());
         let body = br#"{"prompt":"hello world"}"#;
         assert_eq!(
-            resolve_override(&state, "m", body).as_deref(),
+            resolve_override(&state, &req(), "m", body).as_deref(),
             Some("rule-wins")
         );
     }
@@ -219,7 +248,7 @@ mod tests {
     #[test]
     fn resolve_override_falls_back_to_custom_response() {
         let state = shared();
-        state.write().response_rules.insert(
+        state.write().default_mut().response_rules.insert(
             "m".to_string(),
             vec![ResponseRule {
                 prompt_contains: Some("notfound".to_string()),
@@ -228,11 +257,12 @@ mod tests {
         );
         state
             .write()
+            .default_mut()
             .custom_responses
             .insert("m".to_string(), "fallback".to_string());
         let body = br#"{"prompt":"hi"}"#;
         assert_eq!(
-            resolve_override(&state, "m", body).as_deref(),
+            resolve_override(&state, &req(), "m", body).as_deref(),
             Some("fallback")
         );
     }
@@ -240,6 +270,6 @@ mod tests {
     #[test]
     fn resolve_override_none_when_nothing_configured() {
         let state = shared();
-        assert!(resolve_override(&state, "m", b"{}").is_none());
+        assert!(resolve_override(&state, &req(), "m", b"{}").is_none());
     }
 }

--- a/crates/fakecloud-bedrock/src/prompt.rs
+++ b/crates/fakecloud-bedrock/src/prompt.rs
@@ -1,5 +1,7 @@
 use serde_json::Value;
 
+use fakecloud_core::service::AwsRequest;
+
 use crate::state::{ResponseRule, SharedBedrockState};
 
 /// Extract the user-visible prompt text from a runtime request body.
@@ -77,9 +79,16 @@ pub fn match_rule<'a>(rules: &'a [ResponseRule], prompt: &str) -> Option<&'a Res
 /// Resolve the response body a runtime call should use, applying
 /// rule-based overrides first, then the legacy single-response override.
 /// Returns `None` when neither is configured — caller falls back to canned.
-pub fn resolve_override(state: &SharedBedrockState, model_id: &str, body: &[u8]) -> Option<String> {
+pub fn resolve_override(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    model_id: &str,
+    body: &[u8],
+) -> Option<String> {
     let prompt = extract_prompt_text(model_id, body);
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     if let Some(rules) = s.response_rules.get(model_id) {
         if let Some(rule) = match_rule(rules, &prompt) {
             return Some(rule.response.clone());

--- a/crates/fakecloud-bedrock/src/prompt_routers.rs
+++ b/crates/fakecloud-bedrock/src/prompt_routers.rs
@@ -35,7 +35,8 @@ pub fn create_prompt_router(
         updated_at: now,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.prompt_routers.insert(router_arn.clone(), router);
 
     Ok(AwsResponse::json(
@@ -46,9 +47,12 @@ pub fn create_prompt_router(
 
 pub fn get_prompt_router(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let router = s
         .prompt_routers
         .get(identifier)
@@ -92,7 +96,9 @@ pub fn list_prompt_routers(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&PromptRouter> = s.prompt_routers.values().collect();
     items.sort_by(|a, b| a.prompt_router_arn.cmp(&b.prompt_router_arn));
 
@@ -135,9 +141,11 @@ pub fn list_prompt_routers(
 
 pub fn delete_prompt_router(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     identifier: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = s
         .prompt_routers

--- a/crates/fakecloud-bedrock/src/resource_policies.rs
+++ b/crates/fakecloud-bedrock/src/resource_policies.rs
@@ -2,12 +2,13 @@ use http::StatusCode;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use fakecloud_core::service::{AwsResponse, AwsServiceError};
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::SharedBedrockState;
 
 pub fn put_resource_policy(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
     let resource_arn = body["resourceArn"].as_str().ok_or_else(|| {
@@ -28,7 +29,8 @@ pub fn put_resource_policy(
 
     let revision_id = Uuid::new_v4().to_string();
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.resource_policies
         .insert(resource_arn.to_string(), policy.to_string());
 
@@ -40,9 +42,12 @@ pub fn put_resource_policy(
 
 pub fn get_resource_policy(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     resource_arn: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let policy = s
         .resource_policies
         .get(resource_arn)
@@ -70,9 +75,11 @@ pub fn get_resource_policy(
 
 pub fn delete_resource_policy(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     resource_arn: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     let key = if s.resource_policies.contains_key(resource_arn) {
         Some(resource_arn.to_string())

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -9,7 +9,9 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 use fakecloud_persistence::SnapshotStore;
 
 use crate::models;
-use crate::state::{BedrockSnapshot, SharedBedrockState, BEDROCK_SNAPSHOT_SCHEMA_VERSION};
+use crate::state::{
+    BedrockSnapshot, BedrockState, SharedBedrockState, BEDROCK_SNAPSHOT_SCHEMA_VERSION,
+};
 
 pub struct BedrockService {
     state: SharedBedrockState,
@@ -100,7 +102,8 @@ impl BedrockService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = BedrockSnapshot {
             schema_version: BEDROCK_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            state: None,
+            accounts: Some(self.state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -771,7 +774,7 @@ impl BedrockService {
 
     fn tag_resource(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         resource_arn: &str,
         body: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -783,7 +786,8 @@ impl BedrockService {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let resource_tags = state.tags.entry(resource_arn.to_string()).or_default();
         for tag in tags {
             let key = tag["key"].as_str().unwrap_or_default();
@@ -796,10 +800,12 @@ impl BedrockService {
 
     fn untag_resource_from_body(
         &self,
+        account_id: &str,
         resource_arn: &str,
         tag_keys: &[String],
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
         if let Some(resource_tags) = state.tags.get_mut(resource_arn) {
             for key in tag_keys {
                 resource_tags.remove(key);
@@ -811,10 +817,12 @@ impl BedrockService {
 
     fn list_tags_for_resource(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         resource_arn: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = BedrockState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let tags = state.tags.get(resource_arn);
         let tags_arr: Vec<Value> = match tags {
             Some(t) => {
@@ -881,7 +889,7 @@ impl AwsService for BedrockService {
                             .collect()
                     })
                     .unwrap_or_default();
-                self.untag_resource_from_body(arn, &tag_keys)
+                self.untag_resource_from_body(&req.account_id, arn, &tag_keys)
             }
             "ListTagsForResource" => {
                 let arn = body["resourceARN"].as_str().unwrap_or_default();
@@ -896,19 +904,24 @@ impl AwsService for BedrockService {
             "ListGuardrails" => crate::guardrails::list_guardrails(&self.state, &req),
             "UpdateGuardrail" => crate::guardrails::update_guardrail(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
                 &body,
             ),
-            "DeleteGuardrail" => {
-                crate::guardrails::delete_guardrail(&self.state, &resource_id.unwrap_or_default())
-            }
+            "DeleteGuardrail" => crate::guardrails::delete_guardrail(
+                &self.state,
+                &req,
+                &resource_id.unwrap_or_default(),
+            ),
             "CreateGuardrailVersion" => crate::guardrails::create_guardrail_version(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
                 &body,
             ),
             "ApplyGuardrail" => crate::guardrails::apply_guardrail(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
                 &extra_id.unwrap_or_default(),
                 &req.body,
@@ -919,11 +932,13 @@ impl AwsService for BedrockService {
             }
             "GetCustomModel" => crate::custom_models::get_custom_model(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             "ListCustomModels" => crate::custom_models::list_custom_models(&self.state, &req),
             "DeleteCustomModel" => crate::custom_models::delete_custom_model(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             // Custom model deployments
@@ -937,6 +952,7 @@ impl AwsService for BedrockService {
             "GetCustomModelDeployment" => {
                 crate::custom_model_deployments::get_custom_model_deployment(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
@@ -946,6 +962,7 @@ impl AwsService for BedrockService {
             "UpdateCustomModelDeployment" => {
                 crate::custom_model_deployments::update_custom_model_deployment(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     &body,
                 )
@@ -953,6 +970,7 @@ impl AwsService for BedrockService {
             "DeleteCustomModelDeployment" => {
                 crate::custom_model_deployments::delete_custom_model_deployment(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
@@ -962,25 +980,30 @@ impl AwsService for BedrockService {
             }
             "GetModelImportJob" => crate::model_import::get_model_import_job(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             "ListModelImportJobs" => crate::model_import::list_model_import_jobs(&self.state, &req),
             "GetImportedModel" => crate::model_import::get_imported_model(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             "ListImportedModels" => crate::model_import::list_imported_models(&self.state, &req),
             "DeleteImportedModel" => crate::model_import::delete_imported_model(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             // Model copy jobs
             "CreateModelCopyJob" => {
                 crate::model_copy::create_model_copy_job(&self.state, &req, &body)
             }
-            "GetModelCopyJob" => {
-                crate::model_copy::get_model_copy_job(&self.state, &resource_id.unwrap_or_default())
-            }
+            "GetModelCopyJob" => crate::model_copy::get_model_copy_job(
+                &self.state,
+                &req,
+                &resource_id.unwrap_or_default(),
+            ),
             "ListModelCopyJobs" => crate::model_copy::list_model_copy_jobs(&self.state, &req),
             // Model invocation jobs
             "CreateModelInvocationJob" => {
@@ -988,6 +1011,7 @@ impl AwsService for BedrockService {
             }
             "GetModelInvocationJob" => crate::invocation_jobs::get_model_invocation_job(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             "ListModelInvocationJobs" => {
@@ -995,22 +1019,26 @@ impl AwsService for BedrockService {
             }
             "StopModelInvocationJob" => crate::invocation_jobs::stop_model_invocation_job(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             // Evaluation jobs
             "CreateEvaluationJob" => {
                 crate::evaluation::create_evaluation_job(&self.state, &req, &body)
             }
-            "GetEvaluationJob" => {
-                crate::evaluation::get_evaluation_job(&self.state, &resource_id.unwrap_or_default())
-            }
+            "GetEvaluationJob" => crate::evaluation::get_evaluation_job(
+                &self.state,
+                &req,
+                &resource_id.unwrap_or_default(),
+            ),
             "ListEvaluationJobs" => crate::evaluation::list_evaluation_jobs(&self.state, &req),
             "StopEvaluationJob" => crate::evaluation::stop_evaluation_job(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             "BatchDeleteEvaluationJob" => {
-                crate::evaluation::batch_delete_evaluation_job(&self.state, &body)
+                crate::evaluation::batch_delete_evaluation_job(&self.state, &req, &body)
             }
             // Inference profiles
             "CreateInferenceProfile" => {
@@ -1018,6 +1046,7 @@ impl AwsService for BedrockService {
             }
             "GetInferenceProfile" => crate::inference_profiles::get_inference_profile(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             "ListInferenceProfiles" => {
@@ -1025,6 +1054,7 @@ impl AwsService for BedrockService {
             }
             "DeleteInferenceProfile" => crate::inference_profiles::delete_inference_profile(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             // Prompt routers
@@ -1033,23 +1063,27 @@ impl AwsService for BedrockService {
             }
             "GetPromptRouter" => crate::prompt_routers::get_prompt_router(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             "ListPromptRouters" => crate::prompt_routers::list_prompt_routers(&self.state, &req),
             "DeletePromptRouter" => crate::prompt_routers::delete_prompt_router(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             // Resource policies
             "PutResourcePolicy" => {
-                crate::resource_policies::put_resource_policy(&self.state, &body)
+                crate::resource_policies::put_resource_policy(&self.state, &req, &body)
             }
             "GetResourcePolicy" => crate::resource_policies::get_resource_policy(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             "DeleteResourcePolicy" => crate::resource_policies::delete_resource_policy(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             // Marketplace model endpoints
@@ -1058,6 +1092,7 @@ impl AwsService for BedrockService {
             }
             "GetMarketplaceModelEndpoint" => crate::marketplace::get_marketplace_model_endpoint(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             "ListMarketplaceModelEndpoints" => {
@@ -1066,6 +1101,7 @@ impl AwsService for BedrockService {
             "UpdateMarketplaceModelEndpoint" => {
                 crate::marketplace::update_marketplace_model_endpoint(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     &body,
                 )
@@ -1073,18 +1109,21 @@ impl AwsService for BedrockService {
             "DeleteMarketplaceModelEndpoint" => {
                 crate::marketplace::delete_marketplace_model_endpoint(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
             "RegisterMarketplaceModelEndpoint" => {
                 crate::marketplace::register_marketplace_model_endpoint(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
             "DeregisterMarketplaceModelEndpoint" => {
                 crate::marketplace::deregister_marketplace_model_endpoint(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
@@ -1099,33 +1138,41 @@ impl AwsService for BedrockService {
             "DeleteFoundationModelAgreement" => {
                 crate::foundation_model_agreements::delete_foundation_model_agreement(
                     &self.state,
+                    &req,
                     &body,
                 )
             }
             "ListFoundationModelAgreementOffers" => {
                 crate::foundation_model_agreements::list_foundation_model_agreement_offers(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
             "GetFoundationModelAvailability" => {
                 crate::foundation_model_agreements::get_foundation_model_availability(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
             "GetUseCaseForModelAccess" => {
-                crate::foundation_model_agreements::get_use_case_for_model_access(&self.state)
+                crate::foundation_model_agreements::get_use_case_for_model_access(&self.state, &req)
             }
             "PutUseCaseForModelAccess" => {
                 crate::foundation_model_agreements::put_use_case_for_model_access(
                     &self.state,
+                    &req,
                     &body,
                 )
             }
             // Enforced guardrails
             "PutEnforcedGuardrailConfiguration" => {
-                crate::enforced_guardrails::put_enforced_guardrail_configuration(&self.state, &body)
+                crate::enforced_guardrails::put_enforced_guardrail_configuration(
+                    &self.state,
+                    &req,
+                    &body,
+                )
             }
             "ListEnforcedGuardrailsConfiguration" => {
                 crate::enforced_guardrails::list_enforced_guardrails_configuration(
@@ -1136,6 +1183,7 @@ impl AwsService for BedrockService {
             "DeleteEnforcedGuardrailConfiguration" => {
                 crate::enforced_guardrails::delete_enforced_guardrail_configuration(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
@@ -1150,6 +1198,7 @@ impl AwsService for BedrockService {
             "GetAutomatedReasoningPolicy" => {
                 crate::automated_reasoning::get_automated_reasoning_policy(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
@@ -1159,6 +1208,7 @@ impl AwsService for BedrockService {
             "UpdateAutomatedReasoningPolicy" => {
                 crate::automated_reasoning::update_automated_reasoning_policy(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     &body,
                 )
@@ -1166,12 +1216,14 @@ impl AwsService for BedrockService {
             "DeleteAutomatedReasoningPolicy" => {
                 crate::automated_reasoning::delete_automated_reasoning_policy(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
             "CreateAutomatedReasoningPolicyVersion" => {
                 crate::automated_reasoning::create_automated_reasoning_policy_version(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     &body,
                 )
@@ -1186,6 +1238,7 @@ impl AwsService for BedrockService {
             "CreateAutomatedReasoningPolicyTestCase" => {
                 crate::automated_reasoning::create_automated_reasoning_policy_test_case(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     &body,
                 )
@@ -1193,6 +1246,7 @@ impl AwsService for BedrockService {
             "GetAutomatedReasoningPolicyTestCase" => {
                 crate::automated_reasoning::get_automated_reasoning_policy_test_case(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                 )
@@ -1207,6 +1261,7 @@ impl AwsService for BedrockService {
             "UpdateAutomatedReasoningPolicyTestCase" => {
                 crate::automated_reasoning::update_automated_reasoning_policy_test_case(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                     &body,
@@ -1215,6 +1270,7 @@ impl AwsService for BedrockService {
             "DeleteAutomatedReasoningPolicyTestCase" => {
                 crate::automated_reasoning::delete_automated_reasoning_policy_test_case(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                 )
@@ -1223,6 +1279,7 @@ impl AwsService for BedrockService {
             "StartAutomatedReasoningPolicyBuildWorkflow" => {
                 crate::automated_reasoning_workflows::start_build_workflow(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                 )
@@ -1230,6 +1287,7 @@ impl AwsService for BedrockService {
             "GetAutomatedReasoningPolicyBuildWorkflow" => {
                 crate::automated_reasoning_workflows::get_build_workflow(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                 )
@@ -1244,6 +1302,7 @@ impl AwsService for BedrockService {
             "CancelAutomatedReasoningPolicyBuildWorkflow" => {
                 crate::automated_reasoning_workflows::cancel_build_workflow(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                 )
@@ -1251,6 +1310,7 @@ impl AwsService for BedrockService {
             "DeleteAutomatedReasoningPolicyBuildWorkflow" => {
                 crate::automated_reasoning_workflows::delete_build_workflow(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                 )
@@ -1258,6 +1318,7 @@ impl AwsService for BedrockService {
             "GetAutomatedReasoningPolicyBuildWorkflowResultAssets" => {
                 crate::automated_reasoning_workflows::get_build_workflow_result_assets(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                 )
@@ -1265,6 +1326,7 @@ impl AwsService for BedrockService {
             "StartAutomatedReasoningPolicyTestWorkflow" => {
                 crate::automated_reasoning_workflows::start_test_workflow(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                 )
@@ -1276,6 +1338,7 @@ impl AwsService for BedrockService {
                 let test_case_id = parts.get(1).copied().unwrap_or_default();
                 crate::automated_reasoning_workflows::get_test_result(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     workflow_id,
                     test_case_id,
@@ -1292,6 +1355,7 @@ impl AwsService for BedrockService {
             "GetAutomatedReasoningPolicyAnnotations" => {
                 crate::automated_reasoning_workflows::get_annotations(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                 )
@@ -1299,6 +1363,7 @@ impl AwsService for BedrockService {
             "UpdateAutomatedReasoningPolicyAnnotations" => {
                 crate::automated_reasoning_workflows::update_annotations(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                     &body,
@@ -1307,6 +1372,7 @@ impl AwsService for BedrockService {
             "GetAutomatedReasoningPolicyNextScenario" => {
                 crate::automated_reasoning_workflows::get_next_scenario(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     extra_id.as_deref().unwrap_or_default(),
                 )
@@ -1325,6 +1391,7 @@ impl AwsService for BedrockService {
             }
             "StopModelCustomizationJob" => crate::customization::stop_model_customization_job(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             // Provisioned model throughput
@@ -1333,6 +1400,7 @@ impl AwsService for BedrockService {
             }
             "GetProvisionedModelThroughput" => crate::throughput::get_provisioned_model_throughput(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
             ),
             "ListProvisionedModelThroughputs" => {
@@ -1341,6 +1409,7 @@ impl AwsService for BedrockService {
             "UpdateProvisionedModelThroughput" => {
                 crate::throughput::update_provisioned_model_throughput(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                     &body,
                 )
@@ -1348,42 +1417,50 @@ impl AwsService for BedrockService {
             "DeleteProvisionedModelThroughput" => {
                 crate::throughput::delete_provisioned_model_throughput(
                     &self.state,
+                    &req,
                     &resource_id.unwrap_or_default(),
                 )
             }
             // Logging configuration
             "PutModelInvocationLoggingConfiguration" => {
-                crate::logging::put_model_invocation_logging_configuration(&self.state, &body)
+                crate::logging::put_model_invocation_logging_configuration(&self.state, &req, &body)
             }
             "GetModelInvocationLoggingConfiguration" => {
-                crate::logging::get_model_invocation_logging_configuration(&self.state)
+                crate::logging::get_model_invocation_logging_configuration(&self.state, &req)
             }
             "DeleteModelInvocationLoggingConfiguration" => {
-                crate::logging::delete_model_invocation_logging_configuration(&self.state)
+                crate::logging::delete_model_invocation_logging_configuration(&self.state, &req)
             }
             // Runtime operations
             "InvokeModel" => crate::invoke::invoke_model(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
                 &req.body,
             ),
             "CountTokens" => crate::invoke::count_tokens(
                 &self.state,
+                &req,
                 &resource_id.unwrap_or_default(),
                 &req.body,
             ),
-            "Converse" => {
-                crate::converse::converse(&self.state, &resource_id.unwrap_or_default(), &req.body)
-            }
+            "Converse" => crate::converse::converse(
+                &self.state,
+                &req,
+                &resource_id.unwrap_or_default(),
+                &req.body,
+            ),
             "InvokeModelWithResponseStream" | "InvokeModelWithBidirectionalStream" => {
                 let model_id = resource_id.unwrap_or_default();
                 if let Some(fault) = crate::faults::take_matching_fault(
                     &self.state,
+                    &req,
                     &model_id,
                     "InvokeModelWithResponseStream",
                 ) {
                     crate::faults::record_faulted_invocation(
                         &self.state,
+                        &req,
                         &model_id,
                         &req.body,
                         &fault,
@@ -1391,13 +1468,14 @@ impl AwsService for BedrockService {
                     return Err(crate::faults::fault_to_error(&fault));
                 }
                 let response_text =
-                    crate::streaming::get_response_text(&self.state, &model_id, &req.body);
+                    crate::streaming::get_response_text(&self.state, &req, &model_id, &req.body);
                 let body =
                     crate::streaming::build_invoke_stream_response(&model_id, &response_text);
 
                 // Record invocation
                 {
-                    let mut s = self.state.write();
+                    let mut accts = self.state.write();
+                    let s = accts.get_or_create(&req.account_id);
                     s.invocations.push(crate::state::ModelInvocation {
                         model_id: model_id.clone(),
                         input: String::from_utf8_lossy(&req.body).to_string(),
@@ -1416,11 +1494,15 @@ impl AwsService for BedrockService {
             }
             "ConverseStream" => {
                 let model_id = resource_id.unwrap_or_default();
-                if let Some(fault) =
-                    crate::faults::take_matching_fault(&self.state, &model_id, "ConverseStream")
-                {
+                if let Some(fault) = crate::faults::take_matching_fault(
+                    &self.state,
+                    &req,
+                    &model_id,
+                    "ConverseStream",
+                ) {
                     crate::faults::record_faulted_invocation(
                         &self.state,
+                        &req,
                         &model_id,
                         &req.body,
                         &fault,
@@ -1428,12 +1510,13 @@ impl AwsService for BedrockService {
                     return Err(crate::faults::fault_to_error(&fault));
                 }
                 let response_text =
-                    crate::streaming::get_response_text(&self.state, &model_id, &req.body);
+                    crate::streaming::get_response_text(&self.state, &req, &model_id, &req.body);
                 let body = crate::streaming::build_converse_stream_response(&response_text);
 
                 // Record invocation
                 {
-                    let mut s = self.state.write();
+                    let mut accts = self.state.write();
+                    let s = accts.get_or_create(&req.account_id);
                     s.invocations.push(crate::state::ModelInvocation {
                         model_id: model_id.clone(),
                         input: String::from_utf8_lossy(&req.body).to_string(),
@@ -1452,9 +1535,11 @@ impl AwsService for BedrockService {
             }
             // Async invoke
             "StartAsyncInvoke" => crate::async_invoke::start_async_invoke(&self.state, &req, &body),
-            "GetAsyncInvoke" => {
-                crate::async_invoke::get_async_invoke(&self.state, &resource_id.unwrap_or_default())
-            }
+            "GetAsyncInvoke" => crate::async_invoke::get_async_invoke(
+                &self.state,
+                &req,
+                &resource_id.unwrap_or_default(),
+            ),
             "ListAsyncInvokes" => crate::async_invoke::list_async_invokes(&self.state, &req),
 
             _ => Err(AwsServiceError::ActionNotImplemented {
@@ -1588,7 +1673,6 @@ impl AwsService for BedrockService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::BedrockState;
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
@@ -1597,7 +1681,13 @@ mod tests {
     use std::sync::Arc;
 
     fn make_state() -> SharedBedrockState {
-        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
     }
 
     fn make_request(method: Method, path: &str, body: &str) -> AwsRequest {
@@ -2236,7 +2326,8 @@ mod tests {
         );
         svc.handle(req).await.unwrap();
 
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         assert_eq!(s.invocations.len(), 1);
         assert_eq!(s.invocations[0].model_id, "anthropic.claude-v2");
     }
@@ -2473,7 +2564,7 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["modelArn"].as_str().unwrap();
 
-        let resp = crate::custom_models::get_custom_model(&state, arn).unwrap();
+        let resp = crate::custom_models::get_custom_model(&state, &req, arn).unwrap();
         let b = body_json(&resp);
         assert_eq!(b["modelName"], "my-model");
 
@@ -2481,8 +2572,8 @@ mod tests {
         let b = body_json(&resp);
         assert_eq!(b["modelSummaries"].as_array().unwrap().len(), 1);
 
-        crate::custom_models::delete_custom_model(&state, arn).unwrap();
-        assert!(crate::custom_models::get_custom_model(&state, arn).is_err());
+        crate::custom_models::delete_custom_model(&state, &req, arn).unwrap();
+        assert!(crate::custom_models::get_custom_model(&state, &req, arn).is_err());
     }
 
     #[test]
@@ -2500,7 +2591,7 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["customModelDeploymentArn"].as_str().unwrap();
 
-        crate::custom_model_deployments::get_custom_model_deployment(&state, arn).unwrap();
+        crate::custom_model_deployments::get_custom_model_deployment(&state, &req, arn).unwrap();
 
         let resp =
             crate::custom_model_deployments::list_custom_model_deployments(&state, &req).unwrap();
@@ -2508,8 +2599,9 @@ mod tests {
         assert!(!b["modelDeploymentSummaries"].as_array().unwrap().is_empty());
 
         let upd = serde_json::json!({"desiredModelUnits": 2});
-        crate::custom_model_deployments::update_custom_model_deployment(&state, arn, &upd).unwrap();
-        crate::custom_model_deployments::delete_custom_model_deployment(&state, arn).unwrap();
+        crate::custom_model_deployments::update_custom_model_deployment(&state, &req, arn, &upd)
+            .unwrap();
+        crate::custom_model_deployments::delete_custom_model_deployment(&state, &req, arn).unwrap();
     }
 
     #[test]
@@ -2525,7 +2617,7 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["jobArn"].as_str().unwrap();
 
-        crate::model_import::get_model_import_job(&state, arn).unwrap();
+        crate::model_import::get_model_import_job(&state, &req, arn).unwrap();
         let resp = crate::model_import::list_model_import_jobs(&state, &req).unwrap();
         let b = body_json(&resp);
         assert!(!b["modelImportJobSummaries"].as_array().unwrap().is_empty());
@@ -2548,7 +2640,7 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["jobArn"].as_str().unwrap();
 
-        crate::model_copy::get_model_copy_job(&state, arn).unwrap();
+        crate::model_copy::get_model_copy_job(&state, &req, arn).unwrap();
         let resp = crate::model_copy::list_model_copy_jobs(&state, &req).unwrap();
         let b = body_json(&resp);
         assert!(!b["modelCopyJobSummaries"].as_array().unwrap().is_empty());
@@ -2568,11 +2660,11 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["jobArn"].as_str().unwrap();
 
-        crate::invocation_jobs::get_model_invocation_job(&state, arn).unwrap();
+        crate::invocation_jobs::get_model_invocation_job(&state, &req, arn).unwrap();
         let resp = crate::invocation_jobs::list_model_invocation_jobs(&state, &req).unwrap();
         let b = body_json(&resp);
         assert!(!b["invocationJobSummaries"].as_array().unwrap().is_empty());
-        crate::invocation_jobs::stop_model_invocation_job(&state, arn).unwrap();
+        crate::invocation_jobs::stop_model_invocation_job(&state, &req, arn).unwrap();
     }
 
     #[test]
@@ -2588,7 +2680,7 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["jobArn"].as_str().unwrap();
 
-        crate::evaluation::get_evaluation_job(&state, arn).unwrap();
+        crate::evaluation::get_evaluation_job(&state, &req, arn).unwrap();
         let resp = crate::evaluation::list_evaluation_jobs(&state, &req).unwrap();
         let b = body_json(&resp);
         assert!(!b["jobSummaries"].as_array().unwrap().is_empty());
@@ -2608,14 +2700,14 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["inferenceProfileArn"].as_str().unwrap();
 
-        crate::inference_profiles::get_inference_profile(&state, arn).unwrap();
+        crate::inference_profiles::get_inference_profile(&state, &req, arn).unwrap();
         let resp = crate::inference_profiles::list_inference_profiles(&state, &req).unwrap();
         let b = body_json(&resp);
         assert!(!b["inferenceProfileSummaries"]
             .as_array()
             .unwrap()
             .is_empty());
-        crate::inference_profiles::delete_inference_profile(&state, arn).unwrap();
+        crate::inference_profiles::delete_inference_profile(&state, &req, arn).unwrap();
     }
 
     #[test]
@@ -2631,11 +2723,11 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["promptRouterArn"].as_str().unwrap();
 
-        crate::prompt_routers::get_prompt_router(&state, arn).unwrap();
+        crate::prompt_routers::get_prompt_router(&state, &req, arn).unwrap();
         let resp = crate::prompt_routers::list_prompt_routers(&state, &req).unwrap();
         let b = body_json(&resp);
         assert!(!b["promptRouterSummaries"].as_array().unwrap().is_empty());
-        crate::prompt_routers::delete_prompt_router(&state, arn).unwrap();
+        crate::prompt_routers::delete_prompt_router(&state, &req, arn).unwrap();
     }
 
     #[test]
@@ -2675,7 +2767,7 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["provisionedModelArn"].as_str().unwrap();
 
-        crate::throughput::get_provisioned_model_throughput(&state, arn).unwrap();
+        crate::throughput::get_provisioned_model_throughput(&state, &req, arn).unwrap();
         let resp = crate::throughput::list_provisioned_model_throughputs(&state, &req).unwrap();
         let b = body_json(&resp);
         assert!(!b["provisionedModelSummaries"]
@@ -2684,8 +2776,8 @@ mod tests {
             .is_empty());
 
         let upd = serde_json::json!({"desiredModelUnits": 2});
-        crate::throughput::update_provisioned_model_throughput(&state, arn, &upd).unwrap();
-        crate::throughput::delete_provisioned_model_throughput(&state, arn).unwrap();
+        crate::throughput::update_provisioned_model_throughput(&state, &req, arn, &upd).unwrap();
+        crate::throughput::delete_provisioned_model_throughput(&state, &req, arn).unwrap();
     }
 
     #[test]
@@ -2702,14 +2794,14 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["marketplaceModelEndpointArn"].as_str().unwrap();
 
-        crate::marketplace::get_marketplace_model_endpoint(&state, arn).unwrap();
+        crate::marketplace::get_marketplace_model_endpoint(&state, &req, arn).unwrap();
         let resp = crate::marketplace::list_marketplace_model_endpoints(&state, &req).unwrap();
         let b = body_json(&resp);
         assert!(!b["marketplaceModelEndpoints"]
             .as_array()
             .unwrap()
             .is_empty());
-        crate::marketplace::delete_marketplace_model_endpoint(&state, arn).unwrap();
+        crate::marketplace::delete_marketplace_model_endpoint(&state, &req, arn).unwrap();
     }
 
     #[test]
@@ -2725,7 +2817,7 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["invocationArn"].as_str().unwrap();
 
-        crate::async_invoke::get_async_invoke(&state, arn).unwrap();
+        crate::async_invoke::get_async_invoke(&state, &req, arn).unwrap();
         let resp = crate::async_invoke::list_async_invokes(&state, &req).unwrap();
         let b = body_json(&resp);
         assert!(!b["asyncInvokeSummaries"].as_array().unwrap().is_empty());
@@ -2746,15 +2838,16 @@ mod tests {
         let b = body_json(&resp);
         let arn = b["policyArn"].as_str().unwrap();
 
-        crate::automated_reasoning::get_automated_reasoning_policy(&state, arn).unwrap();
+        crate::automated_reasoning::get_automated_reasoning_policy(&state, &req, arn).unwrap();
         let resp =
             crate::automated_reasoning::list_automated_reasoning_policies(&state, &req).unwrap();
         let b = body_json(&resp);
         assert!(!b["policySummaries"].as_array().unwrap().is_empty());
 
         let upd = serde_json::json!({"description": "updated"});
-        crate::automated_reasoning::update_automated_reasoning_policy(&state, arn, &upd).unwrap();
-        crate::automated_reasoning::delete_automated_reasoning_policy(&state, arn).unwrap();
+        crate::automated_reasoning::update_automated_reasoning_policy(&state, &req, arn, &upd)
+            .unwrap();
+        crate::automated_reasoning::delete_automated_reasoning_policy(&state, &req, arn).unwrap();
     }
 
     #[test]
@@ -2765,14 +2858,16 @@ mod tests {
         crate::foundation_model_agreements::create_foundation_model_agreement(&state, &req, &body)
             .unwrap();
 
-        crate::foundation_model_agreements::get_use_case_for_model_access(&state).unwrap();
+        crate::foundation_model_agreements::get_use_case_for_model_access(&state, &req).unwrap();
     }
 
     #[test]
     fn enforced_guardrail_config() {
         let state = make_state();
         let body = serde_json::json!({"guardrailIdentifier":"g1","guardrailVersion":"1","modelArn":"arn:m"});
-        crate::enforced_guardrails::put_enforced_guardrail_configuration(&state, &body).unwrap();
+        let req = make_request(Method::POST, "/", "{}");
+        crate::enforced_guardrails::put_enforced_guardrail_configuration(&state, &req, &body)
+            .unwrap();
 
         let req = make_request(Method::GET, "/", "");
         crate::enforced_guardrails::list_enforced_guardrails_configuration(&state, &req).unwrap();
@@ -2789,8 +2884,10 @@ mod tests {
     #[test]
     fn automated_reasoning_policy_not_found_get() {
         let state = make_state();
+        let req = make_request(Method::GET, "/", "{}");
         let result = crate::automated_reasoning::get_automated_reasoning_policy(
             &state,
+            &req,
             "arn:aws:bedrock:us-east-1:123:automated-reasoning-policy/ghost",
         );
         assert!(result.is_err());
@@ -2799,8 +2896,10 @@ mod tests {
     #[test]
     fn automated_reasoning_policy_delete_not_found() {
         let state = make_state();
+        let req = make_request(Method::DELETE, "/", "{}");
         let result = crate::automated_reasoning::delete_automated_reasoning_policy(
             &state,
+            &req,
             "arn:aws:bedrock:us-east-1:123:automated-reasoning-policy/ghost",
         );
         assert!(result.is_err());

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -4,14 +4,24 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 
-pub type SharedBedrockState = Arc<RwLock<BedrockState>>;
+pub type SharedBedrockState =
+    Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<BedrockState>>>;
 
-pub const BEDROCK_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+impl fakecloud_core::multi_account::AccountState for BedrockState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
+
+pub const BEDROCK_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct BedrockSnapshot {
     pub schema_version: u32,
-    pub state: BedrockState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<BedrockState>>,
+    #[serde(default)]
+    pub state: Option<BedrockState>,
 }
 
 /// Serialize/deserialize `HashMap<(String, String), V>` as `Vec<(String, String, V)>`.

--- a/crates/fakecloud-bedrock/src/streaming.rs
+++ b/crates/fakecloud-bedrock/src/streaming.rs
@@ -195,10 +195,11 @@ pub fn default_stream_text() -> &'static str {
 /// legacy custom overrides for the given call.
 pub fn get_response_text(
     state: &crate::state::SharedBedrockState,
+    req: &fakecloud_core::service::AwsRequest,
     model_id: &str,
     body: &[u8],
 ) -> String {
-    let Some(custom) = crate::prompt::resolve_override(state, model_id, body) else {
+    let Some(custom) = crate::prompt::resolve_override(state, req, model_id, body) else {
         return default_stream_text().to_string();
     };
     // Try to extract text from a JSON response body.

--- a/crates/fakecloud-bedrock/src/throughput.rs
+++ b/crates/fakecloud-bedrock/src/throughput.rs
@@ -72,7 +72,8 @@ pub fn create_provisioned_model_throughput(
         last_modified_at: now,
     };
 
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     s.provisioned_throughputs
         .insert(provisioned_model_id, throughput);
 
@@ -87,9 +88,12 @@ pub fn create_provisioned_model_throughput(
 
 pub fn get_provisioned_model_throughput(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     provisioned_model_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let throughput = find_throughput(&s.provisioned_throughputs, provisioned_model_id)?;
 
     Ok(AwsResponse::ok_json(throughput_to_json(throughput)))
@@ -107,7 +111,9 @@ pub fn list_provisioned_model_throughputs(
         .max(1);
     let next_token = req.query_params.get("nextToken");
 
-    let s = state.read();
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&ProvisionedThroughput> = s.provisioned_throughputs.values().collect();
     items.sort_by(|a, b| a.provisioned_model_id.cmp(&b.provisioned_model_id));
 
@@ -153,10 +159,12 @@ pub fn list_provisioned_model_throughputs(
 
 pub fn update_provisioned_model_throughput(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     provisioned_model_id: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
     let throughput = find_throughput_mut(&mut s.provisioned_throughputs, provisioned_model_id)?;
 
     if let Some(units) = body["desiredModelUnits"].as_i64() {
@@ -173,9 +181,11 @@ pub fn update_provisioned_model_throughput(
 
 pub fn delete_provisioned_model_throughput(
     state: &SharedBedrockState,
+    req: &AwsRequest,
     provisioned_model_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let mut s = state.write();
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
 
     // Find by ID or ARN
     let key = s

--- a/crates/fakecloud-kinesis/src/delivery.rs
+++ b/crates/fakecloud-kinesis/src/delivery.rs
@@ -28,7 +28,11 @@ impl KinesisDelivery for KinesisDeliveryImpl {
         };
 
         let default_id = self.state.read().default_account_id().to_string();
-        let target_account = stream_arn.split(':').nth(4).unwrap_or(&default_id);
+        let target_account = stream_arn
+            .split(':')
+            .nth(4)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&default_id);
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(target_account);
         if let Some(stream) = state.streams.get_mut(stream_name) {

--- a/crates/fakecloud-kinesis/src/delivery.rs
+++ b/crates/fakecloud-kinesis/src/delivery.rs
@@ -27,10 +27,10 @@ impl KinesisDelivery for KinesisDeliveryImpl {
             stream_arn
         };
 
-        // Extract account_id from ARN: arn:aws:kinesis:region:ACCOUNT:stream/Name
-        let account_id = stream_arn.split(':').nth(4).unwrap_or("");
+        let default_id = self.state.read().default_account_id().to_string();
+        let target_account = stream_arn.split(':').nth(4).unwrap_or(&default_id);
         let mut accounts = self.state.write();
-        let state = accounts.get_or_create(account_id);
+        let state = accounts.get_or_create(target_account);
         if let Some(stream) = state.streams.get_mut(stream_name) {
             // Find the shard to write to based on partition key
             // For simplicity, hash the partition key and mod by shard count
@@ -74,5 +74,142 @@ impl KinesisDelivery for KinesisDeliveryImpl {
                 "Stream not found for Kinesis delivery"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{KinesisShard, KinesisState, KinesisStream, SharedKinesisState};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+
+    fn make_stream(name: &str, shard_count: usize) -> KinesisStream {
+        let shards = (0..shard_count)
+            .map(|i| KinesisShard {
+                shard_id: format!("shardId-{i:012}"),
+                starting_hash_key: "0".to_string(),
+                ending_hash_key: "340282366920938463463374607431768211455".to_string(),
+                parent_shard_id: None,
+                adjacent_parent_shard_id: None,
+                is_open: true,
+                next_sequence_number: 0,
+                records: Vec::new(),
+            })
+            .collect();
+        KinesisStream {
+            stream_name: name.to_string(),
+            stream_arn: format!("arn:aws:kinesis:us-east-1:123456789012:stream/{name}"),
+            stream_status: "ACTIVE".to_string(),
+            stream_creation_timestamp: Utc::now(),
+            retention_period_hours: 24,
+            stream_mode: "PROVISIONED".to_string(),
+            encryption_type: "NONE".to_string(),
+            key_id: None,
+            shard_count: shard_count as i32,
+            open_shard_count: shard_count as i32,
+            tags: HashMap::new(),
+            shards,
+            next_shard_index: shard_count as i32,
+            enhanced_metrics: Vec::new(),
+            warm_throughput_mibps: None,
+            max_record_size_kib: None,
+        }
+    }
+
+    fn make_state(stream: KinesisStream) -> SharedKinesisState {
+        let mut mas: fakecloud_core::multi_account::MultiAccountState<KinesisState> =
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", "");
+        mas.get_or_create("123456789012")
+            .streams
+            .insert(stream.stream_name.clone(), stream);
+        Arc::new(RwLock::new(mas))
+    }
+
+    #[test]
+    fn put_record_delivers_to_shard() {
+        let stream = make_stream("my-stream", 1);
+        let state = make_state(stream);
+        let delivery = KinesisDeliveryImpl::new(state.clone());
+        let encoded = base64::engine::general_purpose::STANDARD.encode(b"hello");
+        delivery.put_record(
+            "arn:aws:kinesis:us-east-1:123456789012:stream/my-stream",
+            &encoded,
+            "pk-1",
+        );
+        let mas = state.read();
+        let guard = mas.default_ref();
+        let stream = guard.streams.get("my-stream").unwrap();
+        assert_eq!(stream.shards[0].records.len(), 1);
+        let rec = &stream.shards[0].records[0];
+        assert_eq!(rec.data, b"hello");
+        assert_eq!(rec.partition_key, "pk-1");
+    }
+
+    #[test]
+    fn put_record_stores_raw_bytes_when_not_base64() {
+        let stream = make_stream("s", 1);
+        let state = make_state(stream);
+        let delivery = KinesisDeliveryImpl::new(state.clone());
+        delivery.put_record(
+            "arn:aws:kinesis:us-east-1:123456789012:stream/s",
+            "not-base64!",
+            "p",
+        );
+        let mas = state.read();
+        let guard = mas.default_ref();
+        let rec = &guard.streams.get("s").unwrap().shards[0].records[0];
+        assert_eq!(rec.data, b"not-base64!");
+    }
+
+    #[test]
+    fn put_record_distributes_across_shards_by_partition_key() {
+        let stream = make_stream("s", 4);
+        let state = make_state(stream);
+        let delivery = KinesisDeliveryImpl::new(state.clone());
+        delivery.put_record(
+            "arn:aws:kinesis:us-east-1:123456789012:stream/s",
+            &base64::engine::general_purpose::STANDARD.encode(b"a"),
+            "A",
+        );
+        delivery.put_record(
+            "arn:aws:kinesis:us-east-1:123456789012:stream/s",
+            &base64::engine::general_purpose::STANDARD.encode(b"b"),
+            "B",
+        );
+        let mas = state.read();
+        let guard = mas.default_ref();
+        let stream = guard.streams.get("s").unwrap();
+        let total: usize = stream.shards.iter().map(|s| s.records.len()).sum();
+        assert_eq!(total, 2);
+    }
+
+    #[test]
+    fn put_record_unknown_stream_is_noop() {
+        let stream = make_stream("s", 1);
+        let state = make_state(stream);
+        let delivery = KinesisDeliveryImpl::new(state.clone());
+        delivery.put_record(
+            "arn:aws:kinesis:us-east-1:123456789012:stream/other",
+            "AAA=",
+            "p",
+        );
+        let mas = state.read();
+        let guard = mas.default_ref();
+        assert!(guard.streams.get("s").unwrap().shards[0].records.is_empty());
+    }
+
+    #[test]
+    fn put_record_handles_plain_stream_name_arg() {
+        let stream = make_stream("plain", 1);
+        let state = make_state(stream);
+        let delivery = KinesisDeliveryImpl::new(state.clone());
+        delivery.put_record("plain", "AAA=", "p");
+        let mas = state.read();
+        let guard = mas.default_ref();
+        assert_eq!(
+            guard.streams.get("plain").unwrap().shards[0].records.len(),
+            1
+        );
     }
 }

--- a/crates/fakecloud-kinesis/src/delivery.rs
+++ b/crates/fakecloud-kinesis/src/delivery.rs
@@ -27,7 +27,10 @@ impl KinesisDelivery for KinesisDeliveryImpl {
             stream_arn
         };
 
-        let mut state = self.state.write();
+        // Extract account_id from ARN: arn:aws:kinesis:region:ACCOUNT:stream/Name
+        let account_id = stream_arn.split(':').nth(4).unwrap_or("");
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
         if let Some(stream) = state.streams.get_mut(stream_name) {
             // Find the shard to write to based on partition key
             // For simplicity, hash the partition key and mod by shard count

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -15,7 +15,7 @@ use fakecloud_core::validation::{
 use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    KinesisConsumer, KinesisRecord, KinesisShard, KinesisSnapshot, KinesisStream,
+    KinesisConsumer, KinesisRecord, KinesisShard, KinesisSnapshot, KinesisState, KinesisStream,
     SharedKinesisState, KINESIS_SNAPSHOT_SCHEMA_VERSION,
 };
 
@@ -154,7 +154,8 @@ impl KinesisService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = KinesisSnapshot {
             schema_version: KINESIS_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            state: None,
+            accounts: Some(self.state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -247,7 +248,8 @@ impl KinesisService {
         let shard_count = i32::try_from(shard_count)
             .map_err(|_| invalid_argument("ShardCount must be less than or equal to 2147483647"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         if state.streams.contains_key(stream_name) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -284,7 +286,9 @@ impl KinesisService {
 
     fn describe_stream(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let stream = state.lookup_stream(&body)?;
 
         Ok(AwsResponse::ok_json(json!({
@@ -306,7 +310,9 @@ impl KinesisService {
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let stream = state.lookup_stream(&body)?;
         let consumer_count = state
             .consumers
@@ -340,7 +346,9 @@ impl KinesisService {
         validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
         let limit = body["Limit"].as_i64().unwrap_or(100);
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let mut names: Vec<String> = state.streams.keys().cloned().collect();
         names.sort();
 
@@ -366,9 +374,10 @@ impl KinesisService {
 
     fn delete_stream(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
-        let stream_name = resolve_stream_name(&self.state.read(), &body)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let stream = state.streams.remove(&stream_name);
         if stream.is_none() {
             return Err(stream_not_found(&state.account_id, &stream_name));
@@ -381,8 +390,9 @@ impl KinesisService {
 
     fn add_tags_to_stream(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
             .streams
@@ -403,8 +413,9 @@ impl KinesisService {
 
     fn get_shard_iterator(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let shard_id = require_shard_id(&body)?;
         let iterator_type = body["ShardIteratorType"]
             .as_str()
@@ -430,7 +441,8 @@ impl KinesisService {
 
     fn get_records(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let iterator = body["ShardIterator"]
             .as_str()
             .filter(|value| !value.is_empty())
@@ -490,8 +502,9 @@ impl KinesisService {
 
     fn put_record(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
             .streams
@@ -514,8 +527,9 @@ impl KinesisService {
 
     fn put_records(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
             .streams
@@ -556,7 +570,9 @@ impl KinesisService {
 
     fn list_tags_for_stream(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let stream = state.lookup_stream(&body)?;
 
         let tags: Vec<Value> = stream
@@ -576,8 +592,9 @@ impl KinesisService {
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
             .streams
@@ -623,8 +640,9 @@ impl KinesisService {
             ));
         }
 
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
             .streams
@@ -664,7 +682,8 @@ impl KinesisService {
             .as_object()
             .ok_or_else(|| invalid_argument("Tags must be a map"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let stream_name = state
             .stream_name_from_arn(resource_arn)
             .ok_or_else(|| resource_not_found_arn(resource_arn))?;
@@ -685,7 +704,8 @@ impl KinesisService {
             .as_array()
             .ok_or_else(|| invalid_argument("TagKeys must be a list"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let stream_name = state
             .stream_name_from_arn(resource_arn)
             .ok_or_else(|| resource_not_found_arn(resource_arn))?;
@@ -701,7 +721,9 @@ impl KinesisService {
         validate_stream_id(&body)?;
         let resource_arn = require_resource_arn(&body)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let stream_name = state
             .stream_name_from_arn(resource_arn)
             .ok_or_else(|| resource_not_found_arn(resource_arn))?;
@@ -720,7 +742,9 @@ impl KinesisService {
         validate_stream_id(&body)?;
         let resource_arn = require_resource_arn(&body)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         state
             .stream_name_from_arn(resource_arn)
             .ok_or_else(|| resource_not_found_arn(resource_arn))?;
@@ -741,7 +765,8 @@ impl KinesisService {
             .as_str()
             .ok_or_else(|| invalid_argument("Policy is required"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         state
             .stream_name_from_arn(resource_arn)
             .ok_or_else(|| resource_not_found_arn(resource_arn))?;
@@ -757,7 +782,8 @@ impl KinesisService {
         validate_stream_id(&body)?;
         let resource_arn = require_resource_arn(&body)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         state
             .stream_name_from_arn(resource_arn)
             .ok_or_else(|| resource_not_found_arn(resource_arn))?;
@@ -788,8 +814,9 @@ impl KinesisService {
             .ok_or_else(|| invalid_argument("KeyId is required"))?;
         validate_optional_string_length("KeyId", Some(key_id), 1, 2048)?;
 
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
             .streams
@@ -813,8 +840,9 @@ impl KinesisService {
             .ok_or_else(|| invalid_argument("KeyId is required"))?;
         validate_optional_string_length("KeyId", body["KeyId"].as_str(), 1, 2048)?;
 
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
             .streams
@@ -836,8 +864,9 @@ impl KinesisService {
             .as_array()
             .ok_or_else(|| invalid_argument("ShardLevelMetrics is required"))?;
 
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream_arn = state.stream_arn(&stream_name);
         let stream = state
@@ -890,8 +919,9 @@ impl KinesisService {
             .as_array()
             .ok_or_else(|| invalid_argument("ShardLevelMetrics is required"))?;
 
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream_arn = state.stream_arn(&stream_name);
         let stream = state
@@ -930,9 +960,11 @@ impl KinesisService {
 
     fn describe_account_settings(
         &self,
-        _request: &AwsRequest,
+        request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         Ok(AwsResponse::ok_json(json!({
             "MinimumThroughputBillingCommitment": {
                 "Status": state.billing_commitment_status,
@@ -955,7 +987,8 @@ impl KinesisService {
             )));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         state.billing_commitment_status = status.to_string();
 
         Ok(AwsResponse::ok_json(json!({
@@ -965,8 +998,10 @@ impl KinesisService {
         })))
     }
 
-    fn describe_limits(&self, _request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    fn describe_limits(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let open_shard_count: i32 = state.streams.values().map(|s| s.open_shard_count).sum();
         let on_demand_count = state
             .streams
@@ -1000,7 +1035,8 @@ impl KinesisService {
             )));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let stream_name = state
             .stream_name_from_arn(stream_arn)
             .ok_or_else(|| resource_not_found_arn(stream_arn))?;
@@ -1023,8 +1059,9 @@ impl KinesisService {
             return Err(invalid_argument("WarmThroughputMiBps must be >= 0"));
         }
 
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream_arn = state.stream_arn(&stream_name);
         let stream = state
@@ -1056,7 +1093,8 @@ impl KinesisService {
             .as_i64()
             .ok_or_else(|| invalid_argument("MaxRecordSizeInKiB is required"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let stream_arn = body["StreamARN"]
             .as_str()
             .filter(|v| !v.is_empty())
@@ -1089,7 +1127,8 @@ impl KinesisService {
             .ok_or_else(|| invalid_argument("ConsumerName is required"))?;
         validate_string_length("ConsumerName", consumer_name, 1, 128)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let _stream_name = state
             .stream_name_from_arn(stream_arn)
             .ok_or_else(|| resource_not_found_arn(stream_arn))?;
@@ -1139,7 +1178,8 @@ impl KinesisService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
         validate_stream_id(&body)?;
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         let consumer_arn = if let Some(arn) = body["ConsumerARN"].as_str().filter(|v| !v.is_empty())
         {
@@ -1184,7 +1224,9 @@ impl KinesisService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
         validate_stream_id(&body)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         let consumer = if let Some(arn) = body["ConsumerARN"].as_str().filter(|v| !v.is_empty()) {
             validate_string_length("ConsumerARN", arn, 1, 2048)?;
@@ -1239,7 +1281,9 @@ impl KinesisService {
         validate_optional_json_range("MaxResults", &body["MaxResults"], 1, 10000)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(100) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let mut consumers: Vec<Value> = state
             .consumers
             .values()
@@ -1293,7 +1337,9 @@ impl KinesisService {
         validate_optional_json_range("MaxResults", &body["MaxResults"], 1, 10000)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(10000) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KinesisState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let stream = state.lookup_stream(&body)?;
 
         let exclusive_start = body["ExclusiveStartShardId"].as_str();
@@ -1336,8 +1382,9 @@ impl KinesisService {
             .filter(|v| !v.is_empty())
             .ok_or_else(|| invalid_argument("AdjacentShardToMerge is required"))?;
 
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
             .streams
@@ -1398,8 +1445,9 @@ impl KinesisService {
             .filter(|v| !v.is_empty())
             .ok_or_else(|| invalid_argument("NewStartingHashKey is required"))?;
 
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
             .streams
@@ -1466,8 +1514,9 @@ impl KinesisService {
             .as_str()
             .ok_or_else(|| invalid_argument("ScalingType is required"))?;
 
-        let mut state = self.state.write();
-        let stream_name = resolve_stream_name(&state, &body)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream_arn = state.stream_arn(&stream_name);
         let stream = state
@@ -1844,7 +1893,6 @@ mod tests {
     use parking_lot::RwLock;
 
     use super::*;
-    use crate::state::KinesisState;
 
     fn request(action: &str, body: Value) -> AwsRequest {
         AwsRequest {
@@ -1881,7 +1929,13 @@ mod tests {
 
     #[test]
     fn create_stream_stores_metadata() {
-        let state = Arc::new(RwLock::new(KinesisState::new("123456789012", "us-east-1")));
+        let state = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
         let service = KinesisService::new(state.clone());
 
         service
@@ -1891,8 +1945,9 @@ mod tests {
             ))
             .unwrap();
 
-        let state = state.read();
-        let stream = state.streams.get("orders").unwrap();
+        let _accts = state.read();
+        let st = _accts.default_ref();
+        let stream = st.streams.get("orders").unwrap();
         assert_eq!(stream.stream_status, "ACTIVE");
         assert_eq!(stream.shard_count, 2);
         assert_eq!(stream.retention_period_hours, 24);
@@ -1901,7 +1956,13 @@ mod tests {
 
     #[test]
     fn create_stream_rejects_duplicate_names() {
-        let state = Arc::new(RwLock::new(KinesisState::new("123456789012", "us-east-1")));
+        let state = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
         let service = KinesisService::new(state.clone());
 
         service
@@ -1923,7 +1984,13 @@ mod tests {
 
     #[test]
     fn update_retention_period_validates_direction() {
-        let state = Arc::new(RwLock::new(KinesisState::new("123456789012", "us-east-1")));
+        let state = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
         let service = KinesisService::new(state.clone());
 
         service
@@ -1987,7 +2054,13 @@ mod tests {
     // ── Helpers for the expanded test suite ─────────────────────────
 
     fn make_service() -> (KinesisService, SharedKinesisState) {
-        let state = Arc::new(RwLock::new(KinesisState::new("123456789012", "us-east-1")));
+        let state = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
         let svc = KinesisService::new(state.clone());
         (svc, state)
     }
@@ -2103,7 +2176,7 @@ mod tests {
         let (svc, state) = make_service();
         create_stream_action(&svc, "orders", 1);
         // Register a consumer on the stream.
-        let stream_arn = state.read().stream_arn("orders");
+        let stream_arn = state.read().default_ref().stream_arn("orders");
         svc.register_stream_consumer(&request(
             "RegisterStreamConsumer",
             json!({ "StreamARN": stream_arn, "ConsumerName": "c1" }),
@@ -2113,7 +2186,8 @@ mod tests {
         svc.delete_stream(&request("DeleteStream", json!({ "StreamName": "orders" })))
             .unwrap();
 
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         assert!(!s.streams.contains_key("orders"));
         assert!(s.consumers.is_empty());
     }
@@ -2156,7 +2230,8 @@ mod tests {
         assert_eq!(body["Records"].as_array().unwrap().len(), 2);
 
         // Verify records landed somewhere.
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         let stream = s.streams.get("orders").unwrap();
         let total: usize = stream.shards.iter().map(|sh| sh.records.len()).sum();
         assert_eq!(total, 2);
@@ -2176,7 +2251,13 @@ mod tests {
             }),
         ))
         .unwrap();
-        let shard_id = state.read().streams.get("orders").unwrap().shards[0]
+        let shard_id = state
+            .read()
+            .default_ref()
+            .streams
+            .get("orders")
+            .unwrap()
+            .shards[0]
             .shard_id
             .clone();
 
@@ -2280,6 +2361,7 @@ mod tests {
         assert_eq!(
             state
                 .read()
+                .default_ref()
                 .streams
                 .get("orders")
                 .unwrap()
@@ -2305,6 +2387,7 @@ mod tests {
         assert_eq!(
             state
                 .read()
+                .default_ref()
                 .streams
                 .get("orders")
                 .unwrap()
@@ -2342,7 +2425,13 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(
-            state.read().streams.get("orders").unwrap().encryption_type,
+            state
+                .read()
+                .default_ref()
+                .streams
+                .get("orders")
+                .unwrap()
+                .encryption_type,
             "KMS"
         );
         svc.stop_stream_encryption(&request(
@@ -2355,7 +2444,13 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(
-            state.read().streams.get("orders").unwrap().encryption_type,
+            state
+                .read()
+                .default_ref()
+                .streams
+                .get("orders")
+                .unwrap()
+                .encryption_type,
             "NONE"
         );
     }
@@ -2375,6 +2470,7 @@ mod tests {
         assert_eq!(
             state
                 .read()
+                .default_ref()
                 .streams
                 .get("orders")
                 .unwrap()
@@ -2390,7 +2486,8 @@ mod tests {
             }),
         ))
         .unwrap();
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         let metrics = &s.streams.get("orders").unwrap().enhanced_metrics;
         assert_eq!(metrics, &vec!["OutgoingBytes".to_string()]);
     }
@@ -2399,7 +2496,7 @@ mod tests {
     fn update_stream_mode_writes_new_mode() {
         let (svc, state) = make_service();
         create_stream_action(&svc, "orders", 1);
-        let stream_arn = state.read().stream_arn("orders");
+        let stream_arn = state.read().default_ref().stream_arn("orders");
         svc.update_stream_mode(&request(
             "UpdateStreamMode",
             json!({
@@ -2409,7 +2506,13 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(
-            state.read().streams.get("orders").unwrap().stream_mode,
+            state
+                .read()
+                .default_ref()
+                .streams
+                .get("orders")
+                .unwrap()
+                .stream_mode,
             "ON_DEMAND"
         );
     }
@@ -2420,7 +2523,7 @@ mod tests {
     fn register_describe_deregister_consumer() {
         let (svc, state) = make_service();
         create_stream_action(&svc, "orders", 1);
-        let stream_arn = state.read().stream_arn("orders");
+        let stream_arn = state.read().default_ref().stream_arn("orders");
         svc.register_stream_consumer(&request(
             "RegisterStreamConsumer",
             json!({ "StreamARN": stream_arn, "ConsumerName": "c1" }),
@@ -2441,14 +2544,14 @@ mod tests {
             json!({ "StreamARN": stream_arn, "ConsumerName": "c1" }),
         ))
         .unwrap();
-        assert!(state.read().consumers.is_empty());
+        assert!(state.read().default_ref().consumers.is_empty());
     }
 
     #[test]
     fn register_consumer_duplicate_errors() {
         let (svc, state) = make_service();
         create_stream_action(&svc, "orders", 1);
-        let stream_arn = state.read().stream_arn("orders");
+        let stream_arn = state.read().default_ref().stream_arn("orders");
         svc.register_stream_consumer(&request(
             "RegisterStreamConsumer",
             json!({ "StreamARN": stream_arn, "ConsumerName": "c1" }),
@@ -2467,7 +2570,7 @@ mod tests {
     fn list_stream_consumers_returns_registered_consumer() {
         let (svc, state) = make_service();
         create_stream_action(&svc, "orders", 1);
-        let stream_arn = state.read().stream_arn("orders");
+        let stream_arn = state.read().default_ref().stream_arn("orders");
         svc.register_stream_consumer(&request(
             "RegisterStreamConsumer",
             json!({ "StreamARN": stream_arn, "ConsumerName": "c1" }),
@@ -2491,7 +2594,7 @@ mod tests {
     fn put_get_delete_resource_policy() {
         let (svc, state) = make_service();
         create_stream_action(&svc, "orders", 1);
-        let stream_arn = state.read().stream_arn("orders");
+        let stream_arn = state.read().default_ref().stream_arn("orders");
         let policy_body = json!({"Version":"2012-10-17","Statement":[]}).to_string();
 
         svc.put_resource_policy(&request(
@@ -2548,14 +2651,20 @@ mod tests {
             json!({ "MinimumThroughputBillingCommitment": { "Status": "ENABLED" } }),
         ))
         .unwrap();
-        assert_eq!(state.read().billing_commitment_status, "ENABLED");
+        assert_eq!(
+            state.read().default_ref().billing_commitment_status,
+            "ENABLED"
+        );
 
         svc.update_account_settings(&request(
             "UpdateAccountSettings",
             json!({ "MinimumThroughputBillingCommitment": { "Status": "DISABLED" } }),
         ))
         .unwrap();
-        assert_eq!(state.read().billing_commitment_status, "DISABLED");
+        assert_eq!(
+            state.read().default_ref().billing_commitment_status,
+            "DISABLED"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-kinesis/src/state.rs
+++ b/crates/fakecloud-kinesis/src/state.rs
@@ -5,7 +5,14 @@ use chrono::{DateTime, Duration, Utc};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
-pub type SharedKinesisState = Arc<RwLock<KinesisState>>;
+pub type SharedKinesisState =
+    Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<KinesisState>>>;
+
+impl fakecloud_core::multi_account::AccountState for KinesisState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct KinesisState {
@@ -165,10 +172,13 @@ impl KinesisState {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct KinesisSnapshot {
     pub schema_version: u32,
-    pub state: KinesisState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<KinesisState>>,
+    #[serde(default)]
+    pub state: Option<KinesisState>,
 }
 
-pub const KINESIS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const KINESIS_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[cfg(test)]
 mod tests {

--- a/crates/fakecloud-kms/src/resource_policy.rs
+++ b/crates/fakecloud-kms/src/resource_policy.rs
@@ -33,7 +33,9 @@ impl ResourcePolicyProvider for KmsResourcePolicyProvider {
             return None;
         }
         let key_id = parse_key_id_from_arn(resource_arn)?;
-        let state = self.state.read();
+        let account_id = resource_arn.split(':').nth(4)?;
+        let accounts = self.state.read();
+        let state = accounts.get(account_id)?;
         let key = state.keys.get(&key_id)?;
         Some(key.policy.clone())
     }

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -263,7 +263,8 @@ impl KmsService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = KmsSnapshot {
             schema_version: KMS_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            state: None,
+            accounts: Some(self.state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -377,7 +378,9 @@ impl AwsService for KmsService {
             return Some(std::collections::HashMap::new());
         }
         let key_id = resource_arn.rsplit_once(":key/")?.1;
-        let state = self.state.read();
+        let account_id = resource_arn.split(':').nth(4).unwrap_or("").to_string();
+        let accounts = self.state.read();
+        let state = accounts.get(&account_id)?;
         let key = state.keys.get(key_id)?;
         Some(key.tags.clone())
     }
@@ -436,7 +439,9 @@ fn kms_resource_for(action: &str, state: &SharedKmsState, request: &AwsRequest) 
         let body = request.json_body();
         // Resolve alias -> key ARN when possible.
         if let Some(alias_name) = body["AliasName"].as_str() {
-            let s = state.read();
+            let accts = state.read();
+            let empty = KmsState::new(&request.account_id, &request.region);
+            let s = accts.get(&request.account_id).unwrap_or(&empty);
             if let Some(alias) = s.aliases.get(alias_name) {
                 if let Some(key) = s.keys.get(&alias.target_key_id) {
                     return key.arn.clone();
@@ -444,7 +449,7 @@ fn kms_resource_for(action: &str, state: &SharedKmsState, request: &AwsRequest) 
             }
             // For CreateAlias the target may be in TargetKeyId.
             if let Some(target) = body["TargetKeyId"].as_str() {
-                if let Some(key_id) = KmsService::resolve_key_id_with_state(&s, target) {
+                if let Some(key_id) = KmsService::resolve_key_id_with_state(s, target) {
                     if let Some(key) = s.keys.get(&key_id) {
                         return key.arn.clone();
                     }
@@ -457,8 +462,10 @@ fn kms_resource_for(action: &str, state: &SharedKmsState, request: &AwsRequest) 
     // All remaining operations carry a KeyId parameter.
     let body = request.json_body();
     if let Some(key_id_input) = body["KeyId"].as_str() {
-        let s = state.read();
-        if let Some(key_id) = KmsService::resolve_key_id_with_state(&s, key_id_input) {
+        let accts = state.read();
+        let empty = KmsState::new(&request.account_id, &request.region);
+        let s = accts.get(&request.account_id).unwrap_or(&empty);
+        if let Some(key_id) = KmsService::resolve_key_id_with_state(s, key_id_input) {
             if let Some(key) = s.keys.get(&key_id) {
                 return key.arn.clone();
             }
@@ -779,9 +786,16 @@ fn rand_bytes(n: usize) -> Vec<u8> {
 }
 
 impl KmsService {
-    fn resolve_key_id(&self, key_id_or_arn: &str) -> Option<String> {
-        let state = self.state.read();
-        Self::resolve_key_id_with_state(&state, key_id_or_arn)
+    fn resolve_key_id_for(
+        &self,
+        account_id: &str,
+        region: &str,
+        key_id_or_arn: &str,
+    ) -> Option<String> {
+        let accounts = self.state.read();
+        let empty = KmsState::new(account_id, region);
+        let state = accounts.get(account_id).unwrap_or(&empty);
+        Self::resolve_key_id_with_state(state, key_id_or_arn)
     }
 
     pub(crate) fn resolve_key_id_with_state(
@@ -836,21 +850,27 @@ impl KmsService {
             })
     }
 
-    fn resolve_required_key(&self, body: &Value) -> Result<String, AwsServiceError> {
+    fn resolve_required_key(
+        &self,
+        req: &AwsRequest,
+        body: &Value,
+    ) -> Result<String, AwsServiceError> {
         let key_id_input = Self::require_key_id(body)?;
-        self.resolve_key_id(&key_id_input).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id_input}' does not exist"),
-            )
-        })
+        self.resolve_key_id_for(&req.account_id, &req.region, &key_id_input)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id_input}' does not exist"),
+                )
+            })
     }
 
     fn create_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let input = CreateKeyInput::from_body(&req.json_body())?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let key_id = if input.multi_region {
             format!("mrk-{}", Uuid::new_v4().as_simple())
@@ -926,10 +946,12 @@ impl KmsService {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Check key policy for Deny rules
-        let resolved = Self::resolve_key_id_with_state(&state, key_id_input).ok_or_else(|| {
+        let resolved = Self::resolve_key_id_with_state(state, key_id_input).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotFoundException",
@@ -964,7 +986,9 @@ impl KmsService {
         let limit = body["Limit"].as_i64().unwrap_or(1000) as usize;
         let marker = body["Marker"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all_keys: Vec<Value> = state
             .keys
             .values()
@@ -1008,9 +1032,10 @@ impl KmsService {
 
     fn enable_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let resolved = self.resolve_required_key(&body)?;
+        let resolved = self.resolve_required_key(req, &body)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1026,9 +1051,10 @@ impl KmsService {
 
     fn disable_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let resolved = self.resolve_required_key(&body)?;
+        let resolved = self.resolve_required_key(req, &body)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1044,10 +1070,11 @@ impl KmsService {
 
     fn schedule_key_deletion(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let resolved = self.resolve_required_key(&body)?;
+        let resolved = self.resolve_required_key(req, &body)?;
         let pending_days = body["PendingWindowInDays"].as_i64().unwrap_or(30);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1075,9 +1102,10 @@ impl KmsService {
 
     fn cancel_key_deletion(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let resolved = self.resolve_required_key(&body)?;
+        let resolved = self.resolve_required_key(req, &body)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1109,15 +1137,19 @@ impl KmsService {
         })?;
         let plaintext_bytes = decode_plaintext(plaintext_b64)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1156,8 +1188,10 @@ impl KmsService {
             )
         })?;
 
-        let state = self.state.read();
-        let decoded = decode_ciphertext_envelope(&state, ciphertext_b64)?;
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let decoded = decode_ciphertext_envelope(state, ciphertext_b64)?;
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -1187,11 +1221,13 @@ impl KmsService {
             )
         })?;
 
-        let state = self.state.read();
-        let decoded = decode_ciphertext_envelope(&state, ciphertext_b64)?;
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let decoded = decode_ciphertext_envelope(state, ciphertext_b64)?;
 
         let dest_resolved =
-            Self::resolve_key_id_with_state(&state, dest_key_id).ok_or_else(|| {
+            Self::resolve_key_id_with_state(state, dest_key_id).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "NotFoundException",
@@ -1244,15 +1280,19 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1295,15 +1335,19 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1371,15 +1415,18 @@ impl KmsService {
         validate_alias_name(&alias_name)?;
         validate_alias_target(&target_key_id)?;
 
-        let resolved = self.resolve_key_id(&target_key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{target_key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &target_key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{target_key_id}' does not exist"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if state.aliases.contains_key(&alias_name) {
             let alias_arn = format!(
@@ -1429,7 +1476,8 @@ impl KmsService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.aliases.remove(alias_name).is_none() {
             let alias_arn = format!(
                 "arn:aws:kms:{}:{}:{}",
@@ -1462,15 +1510,18 @@ impl KmsService {
             )
         })?;
 
-        let resolved = self.resolve_key_id(target_key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{target_key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, target_key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{target_key_id}' does not exist"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let alias = state.aliases.get_mut(alias_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1501,11 +1552,13 @@ impl KmsService {
 
         let key_id_filter = body["KeyId"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Resolve key_id_filter to actual key ID if needed
         let resolved_filter =
-            key_id_filter.and_then(|kid| Self::resolve_key_id_with_state(&state, kid));
+            key_id_filter.and_then(|kid| Self::resolve_key_id_with_state(state, kid));
 
         let aliases: Vec<Value> = state
             .aliases
@@ -1538,15 +1591,18 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Invalid keyId {key_id}"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Invalid keyId {key_id}"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1571,15 +1627,18 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Invalid keyId {key_id}"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Invalid keyId {key_id}"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1603,15 +1662,19 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Invalid keyId {key_id}"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Invalid keyId {key_id}"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1633,10 +1696,11 @@ impl KmsService {
 
     fn update_key_description(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let resolved = self.resolve_required_key(&body)?;
+        let resolved = self.resolve_required_key(req, &body)?;
         let description = body["Description"].as_str().unwrap_or("").to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1662,15 +1726,19 @@ impl KmsService {
             ));
         }
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1701,17 +1769,20 @@ impl KmsService {
             ));
         }
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
         let policy = body["Policy"].as_str().unwrap_or("").to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1726,7 +1797,7 @@ impl KmsService {
 
     fn list_key_policies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let _resolved = self.resolve_required_key(&body)?;
+        let _resolved = self.resolve_required_key(req, &body)?;
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -1751,15 +1822,19 @@ impl KmsService {
             ));
         }
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1789,15 +1864,18 @@ impl KmsService {
             ));
         }
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1822,15 +1900,18 @@ impl KmsService {
             ));
         }
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1845,9 +1926,10 @@ impl KmsService {
 
     fn rotate_key_on_demand(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let resolved = self.resolve_required_key(&body)?;
+        let resolved = self.resolve_required_key(req, &body)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1874,12 +1956,14 @@ impl KmsService {
 
     fn list_key_rotations(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let resolved = self.resolve_required_key(&body)?;
+        let resolved = self.resolve_required_key(req, &body)?;
         validate_optional_json_range("limit", &body["Limit"], 1, 1000)?;
         let limit = body["Limit"].as_i64().unwrap_or(1000) as usize;
         let marker = body["Marker"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1945,15 +2029,19 @@ impl KmsService {
             ));
         }
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2023,15 +2111,19 @@ impl KmsService {
         require_non_empty_b64("Message", message_b64)?;
         require_non_empty_b64("Signature", signature_b64)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2068,15 +2160,19 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2114,13 +2210,15 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
         let grantee_principal = body["GranteePrincipal"].as_str().unwrap_or("").to_string();
         let retiring_principal = body["RetiringPrincipal"].as_str().map(|s| s.to_string());
@@ -2142,7 +2240,8 @@ impl KmsService {
         let grant_id = Uuid::new_v4().to_string();
         let grant_token = Uuid::new_v4().to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.grants.push(KmsGrant {
             grant_id: grant_id.clone(),
             grant_token: grant_token.clone(),
@@ -2169,17 +2268,21 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
         let grant_id_filter = body["GrantId"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let grants: Vec<Value> = state
             .grants
             .iter()
@@ -2222,7 +2325,9 @@ impl KmsService {
         let limit = body["Limit"].as_i64().unwrap_or(1000) as usize;
         let marker = body["Marker"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all_grants: Vec<Value> = state
             .grants
             .iter()
@@ -2269,15 +2374,18 @@ impl KmsService {
         let key_id = Self::require_key_id(&body)?;
         let grant_id = body["GrantId"].as_str().unwrap_or("");
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let idx = state
             .grants
             .iter()
@@ -2302,12 +2410,13 @@ impl KmsService {
         let grant_id = body["GrantId"].as_str();
         let key_id = body["KeyId"].as_str();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let idx = if let Some(token) = grant_token {
             state.grants.iter().position(|g| g.grant_token == token)
         } else if let (Some(kid), Some(gid)) = (key_id, grant_id) {
-            let resolved = Self::resolve_key_id_with_state(&state, kid);
+            let resolved = Self::resolve_key_id_with_state(state, kid);
             resolved.and_then(|r| {
                 state
                     .grants
@@ -2337,15 +2446,19 @@ impl KmsService {
         let mac_algorithm = body["MacAlgorithm"].as_str().unwrap_or("").to_string();
         let message_b64 = body["Message"].as_str().unwrap_or("");
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2397,15 +2510,19 @@ impl KmsService {
         let message_b64 = body["Message"].as_str().unwrap_or("");
         let mac_b64 = body["Mac"].as_str().unwrap_or("");
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2457,15 +2574,18 @@ impl KmsService {
         let key_id = Self::require_key_id(&body)?;
         let replica_region = body["ReplicaRegion"].as_str().unwrap_or("").to_string();
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Clone the source key once and drop the borrow — the replica reuses
         // every field except the region-dependent ones.
@@ -2548,15 +2668,19 @@ impl KmsService {
             .unwrap_or("RSA_2048")
             .to_string();
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2610,15 +2734,19 @@ impl KmsService {
             .unwrap_or("RSA_2048")
             .to_string();
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2674,15 +2802,19 @@ impl KmsService {
             )
         })?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2741,15 +2873,19 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let key = state.keys.get(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2807,15 +2943,18 @@ impl KmsService {
             )
         })?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2866,15 +3005,18 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2913,15 +3055,18 @@ impl KmsService {
             })?
             .to_string();
 
-        let resolved = self.resolve_key_id(&key_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Key '{key_id}' does not exist"),
-            )
-        })?;
+        let resolved = self
+            .resolve_key_id_for(&req.account_id, &req.region, &key_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotFoundException",
+                    format!("Key '{key_id}' does not exist"),
+                )
+            })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let account_id = state.account_id.clone();
         let key = state.keys.get_mut(&resolved).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -2975,7 +3120,8 @@ impl KmsService {
             &["AWS_CLOUDHSM", "EXTERNAL_KEY_STORE"],
         )?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Name must be unique
         if state
@@ -3033,7 +3179,8 @@ impl KmsService {
             })?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let store = state.custom_key_stores.get(&store_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -3072,7 +3219,9 @@ impl KmsService {
         let limit = body["Limit"].as_i64().unwrap_or(1000) as usize;
         let marker = body["Marker"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         let mut stores: Vec<&CustomKeyStore> = state
             .custom_key_stores
@@ -3142,7 +3291,8 @@ impl KmsService {
             })?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let store = state.custom_key_stores.get_mut(&store_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -3174,7 +3324,8 @@ impl KmsService {
             })?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let store = state.custom_key_stores.get_mut(&store_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -3203,7 +3354,8 @@ impl KmsService {
             })?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Check uniqueness of new name before borrowing store mutably
         if let Some(new_name) = body["NewCustomKeyStoreName"].as_str() {
@@ -3551,10 +3703,13 @@ mod tests {
     use std::sync::Arc;
 
     fn make_service() -> KmsService {
-        let state: SharedKmsState = Arc::new(RwLock::new(crate::state::KmsState::new(
-            "123456789012",
-            "us-east-1",
-        )));
+        let state: SharedKmsState = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
         KmsService::new(state)
     }
 
@@ -3848,7 +4003,8 @@ mod tests {
 
         // Key should be enabled
         {
-            let state = svc.state.read();
+            let _accts = svc.state.read();
+            let state = _accts.default_ref();
             let key = state.keys.get(&key_id).unwrap();
             assert!(key.imported_key_material);
             assert!(key.enabled);
@@ -3860,7 +4016,8 @@ mod tests {
 
         // Key should be disabled and pending import
         {
-            let state = svc.state.read();
+            let _accts = svc.state.read();
+            let state = _accts.default_ref();
             let key = state.keys.get(&key_id).unwrap();
             assert!(!key.imported_key_material);
             assert!(!key.enabled);
@@ -3907,7 +4064,8 @@ mod tests {
         );
         svc.update_primary_region(&req).unwrap();
 
-        let state = svc.state.read();
+        let _accts = svc.state.read();
+        let state = _accts.default_ref();
         let key = state.keys.get(&key_id).unwrap();
         assert_eq!(key.primary_region.as_deref(), Some("eu-west-1"));
         assert!(key.arn.contains("eu-west-1"));
@@ -4339,7 +4497,7 @@ mod tests {
         let key_id = create_key(&svc);
 
         // Delete the key from state directly to simulate inconsistency
-        svc.state.write().keys.remove(&key_id);
+        svc.state.write().default_mut().keys.remove(&key_id);
 
         let req = make_request("EnableKey", json!({ "KeyId": key_id }));
         let result = svc.enable_key(&req);
@@ -4350,7 +4508,7 @@ mod tests {
     fn disable_key_with_nonexistent_id_returns_error() {
         let svc = make_service();
         let key_id = create_key(&svc);
-        svc.state.write().keys.remove(&key_id);
+        svc.state.write().default_mut().keys.remove(&key_id);
 
         let req = make_request("DisableKey", json!({ "KeyId": key_id }));
         let result = svc.disable_key(&req);
@@ -4361,7 +4519,7 @@ mod tests {
     fn tag_resource_with_nonexistent_key_returns_error() {
         let svc = make_service();
         let key_id = create_key(&svc);
-        svc.state.write().keys.remove(&key_id);
+        svc.state.write().default_mut().keys.remove(&key_id);
 
         let req = make_request(
             "TagResource",
@@ -4387,7 +4545,8 @@ mod tests {
 
         // Verify key is pending deletion
         {
-            let state = svc.state.read();
+            let _accts = svc.state.read();
+            let state = _accts.default_ref();
             let key = state.keys.get(&key_id).unwrap();
             assert_eq!(key.key_state, "PendingDeletion");
             assert!(!key.enabled);
@@ -4402,7 +4561,8 @@ mod tests {
 
         // Key should be disabled (not enabled) with no deletion date
         {
-            let state = svc.state.read();
+            let _accts = svc.state.read();
+            let state = _accts.default_ref();
             let key = state.keys.get(&key_id).unwrap();
             assert_eq!(key.key_state, "Disabled");
             assert!(key.deletion_date.is_none());
@@ -4413,7 +4573,8 @@ mod tests {
         svc.enable_key(&req).unwrap();
 
         {
-            let state = svc.state.read();
+            let _accts = svc.state.read();
+            let state = _accts.default_ref();
             let key = state.keys.get(&key_id).unwrap();
             assert!(key.enabled);
             assert_eq!(key.key_state, "Enabled");
@@ -4896,7 +5057,8 @@ mod tests {
 
         // Verify alias points to key A
         {
-            let state = svc.state.read();
+            let _accts = svc.state.read();
+            let state = _accts.default_ref();
             let alias = state.aliases.get("alias/switchable").unwrap();
             assert_eq!(alias.target_key_id, key_a);
         }
@@ -4910,7 +5072,8 @@ mod tests {
 
         // Verify alias now points to key B
         {
-            let state = svc.state.read();
+            let _accts = svc.state.read();
+            let state = _accts.default_ref();
             let alias = state.aliases.get("alias/switchable").unwrap();
             assert_eq!(alias.target_key_id, key_b);
         }
@@ -4923,7 +5086,8 @@ mod tests {
 
         // Initially empty description
         {
-            let state = svc.state.read();
+            let _accts = svc.state.read();
+            let state = _accts.default_ref();
             let key = state.keys.get(&key_id).unwrap();
             assert_eq!(key.description, "");
         }
@@ -4936,7 +5100,8 @@ mod tests {
         svc.update_key_description(&req).unwrap();
 
         {
-            let state = svc.state.read();
+            let _accts = svc.state.read();
+            let state = _accts.default_ref();
             let key = state.keys.get(&key_id).unwrap();
             assert_eq!(key.description, "new description");
         }
@@ -4949,7 +5114,8 @@ mod tests {
         svc.update_key_description(&req).unwrap();
 
         {
-            let state = svc.state.read();
+            let _accts = svc.state.read();
+            let state = _accts.default_ref();
             let key = state.keys.get(&key_id).unwrap();
             assert_eq!(key.description, "updated again");
         }

--- a/crates/fakecloud-kms/src/state.rs
+++ b/crates/fakecloud-kms/src/state.rs
@@ -3,7 +3,13 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-pub type SharedKmsState = Arc<RwLock<KmsState>>;
+pub type SharedKmsState = Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<KmsState>>>;
+
+impl fakecloud_core::multi_account::AccountState for KmsState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct KmsState {
@@ -113,10 +119,13 @@ pub struct CustomKeyStore {
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct KmsSnapshot {
     pub schema_version: u32,
-    pub state: KmsState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<KmsState>>,
+    #[serde(default)]
+    pub state: Option<KmsState>,
 }
 
-pub const KMS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const KMS_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[cfg(test)]
 mod tests {

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -836,7 +836,10 @@ impl S3Service {
         if sse_algorithm.as_deref() == Some("aws:kms") {
             if let Some(ref kms) = self.kms_state {
                 if let Some(ref key_id) = sse_kms_key_id {
-                    let kms_state = kms.read();
+                    let kms_accounts = kms.read();
+                    let kms_state = kms_accounts
+                        .get(&req.account_id)
+                        .unwrap_or(kms_accounts.default_ref());
                     let key_exists = kms_state
                         .keys
                         .values()

--- a/crates/fakecloud-secretsmanager/src/rotation.rs
+++ b/crates/fakecloud-secretsmanager/src/rotation.rs
@@ -23,10 +23,10 @@ pub async fn check_and_rotate(
 
     // Collect secrets that need rotation while holding the lock briefly.
     let due_secrets: Vec<DueSecret> = {
-        let state = state.read();
-        state
-            .secrets
-            .values()
+        let accounts = state.read();
+        accounts
+            .iter()
+            .flat_map(|(_, acct)| acct.secrets.values())
             .filter_map(|secret| {
                 if secret.deleted {
                     return None;
@@ -56,8 +56,14 @@ pub async fn check_and_rotate(
 
         // Mutate state: create pending version, update timestamps
         let (invocation, version_created) = {
-            let mut state = state.write();
-            let secret = match state.secrets.get_mut(&due.name) {
+            let mut accounts = state.write();
+            // Find the account that owns this secret by ARN prefix
+            let account_id = due.arn.split(':').nth(4).unwrap_or("").to_string();
+            let acct = match accounts.get_mut(&account_id) {
+                Some(a) => a,
+                None => continue,
+            };
+            let secret = match acct.secrets.get_mut(&due.name) {
                 Some(s) => s,
                 None => continue,
             };
@@ -183,10 +189,13 @@ mod tests {
     use std::sync::Arc;
 
     fn make_state() -> SharedSecretsManagerState {
-        Arc::new(RwLock::new(SecretsManagerState::new(
-            "123456789012",
-            "us-east-1",
-        )))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
     }
 
     fn make_secret(
@@ -245,6 +254,7 @@ mod tests {
         let secret = make_secret("due-secret", true, Some(1), Some(2));
         state
             .write()
+            .default_mut()
             .secrets
             .insert("due-secret".to_string(), secret);
 
@@ -252,7 +262,8 @@ mod tests {
         assert_eq!(rotated, vec!["due-secret"]);
 
         // Verify a new version was created (simple rotation without Lambda)
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         let secret = &s.secrets["due-secret"];
         assert!(secret.versions.len() > 1, "new version should be created");
     }
@@ -262,7 +273,11 @@ mod tests {
         let state = make_state();
         // Rotation enabled, 30 day interval, last rotated 1 day ago → not due
         let secret = make_secret("not-due", true, Some(30), Some(1));
-        state.write().secrets.insert("not-due".to_string(), secret);
+        state
+            .write()
+            .default_mut()
+            .secrets
+            .insert("not-due".to_string(), secret);
 
         let rotated = check_and_rotate(&state, None).await;
         assert!(rotated.is_empty());
@@ -272,7 +287,11 @@ mod tests {
     async fn rotation_disabled_skipped() {
         let state = make_state();
         let secret = make_secret("disabled", false, Some(1), Some(2));
-        state.write().secrets.insert("disabled".to_string(), secret);
+        state
+            .write()
+            .default_mut()
+            .secrets
+            .insert("disabled".to_string(), secret);
 
         let rotated = check_and_rotate(&state, None).await;
         assert!(rotated.is_empty());
@@ -282,7 +301,11 @@ mod tests {
     async fn rotation_without_rules_skipped() {
         let state = make_state();
         let secret = make_secret("no-rules", true, None, Some(2));
-        state.write().secrets.insert("no-rules".to_string(), secret);
+        state
+            .write()
+            .default_mut()
+            .secrets
+            .insert("no-rules".to_string(), secret);
 
         let rotated = check_and_rotate(&state, None).await;
         assert!(rotated.is_empty());
@@ -292,7 +315,11 @@ mod tests {
     async fn rotation_without_last_rotated_skipped() {
         let state = make_state();
         let secret = make_secret("no-last", true, Some(1), None);
-        state.write().secrets.insert("no-last".to_string(), secret);
+        state
+            .write()
+            .default_mut()
+            .secrets
+            .insert("no-last".to_string(), secret);
 
         let rotated = check_and_rotate(&state, None).await;
         assert!(rotated.is_empty());
@@ -303,7 +330,11 @@ mod tests {
         let state = make_state();
         let mut secret = make_secret("deleted", true, Some(1), Some(2));
         secret.deleted = true;
-        state.write().secrets.insert("deleted".to_string(), secret);
+        state
+            .write()
+            .default_mut()
+            .secrets
+            .insert("deleted".to_string(), secret);
 
         let rotated = check_and_rotate(&state, None).await;
         assert!(rotated.is_empty());

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -14,8 +14,8 @@ use fakecloud_core::validation::*;
 use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    RotationRules, Secret, SecretVersion, SecretsManagerSnapshot, SharedSecretsManagerState,
-    SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
+    RotationRules, Secret, SecretVersion, SecretsManagerSnapshot, SecretsManagerState,
+    SharedSecretsManagerState, SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
 };
 
 /// Information needed to invoke the rotation Lambda after releasing state lock.
@@ -118,7 +118,8 @@ impl SecretsManagerService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = SecretsManagerSnapshot {
             schema_version: SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            state: None,
+            accounts: Some(self.state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -137,7 +138,8 @@ impl SecretsManagerService {
         let input = CreateSecretInput::from_body(&req.json_body())?;
         let has_value = input.secret_string.is_some() || input.secret_binary.is_some();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if let Some(existing) = state.secrets.get(&input.name) {
             if let Some(ref token) = input.client_request_token {
@@ -251,8 +253,9 @@ impl SecretsManagerService {
         validate_optional_string_length("versionId", body["VersionId"].as_str(), 32, 64)?;
         validate_optional_string_length("versionStage", body["VersionStage"].as_str(), 1, 256)?;
 
-        let mut state = self.state.write();
-        let secret = self.find_secret_mut(&mut state, &secret_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
 
         if secret.deleted {
             return Err(AwsServiceError::aws_error(
@@ -357,8 +360,9 @@ impl SecretsManagerService {
             ));
         }
 
-        let mut state = self.state.write();
-        let secret = match self.find_secret_mut(&mut state, &secret_id) {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = match self.find_secret_mut(state, &secret_id) {
             Ok(s) => s,
             Err(_) => {
                 return Err(AwsServiceError::aws_error(
@@ -495,8 +499,9 @@ impl SecretsManagerService {
         validate_optional_string_length("kmsKeyId", body["KmsKeyId"].as_str(), 0, 2048)?;
         validate_optional_string_length("secretString", body["SecretString"].as_str(), 1, 65536)?;
 
-        let mut state = self.state.write();
-        let secret = match self.find_secret_mut(&mut state, &secret_id) {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = match self.find_secret_mut(state, &secret_id) {
             Ok(s) => s,
             Err(_) => {
                 return Err(AwsServiceError::aws_error(
@@ -626,11 +631,12 @@ impl SecretsManagerService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if force_delete {
             // Force delete: if secret doesn't exist, create a fake response
-            match self.find_secret_mut(&mut state, &secret_id) {
+            match self.find_secret_mut(state, &secret_id) {
                 Ok(secret) => {
                     let arn = secret.arn.clone();
                     let name = secret.name.clone();
@@ -663,7 +669,7 @@ impl SecretsManagerService {
             }
         }
 
-        let secret = self.find_secret_mut(&mut state, &secret_id)?;
+        let secret = self.find_secret_mut(state, &secret_id)?;
 
         if secret.deleted {
             return Err(AwsServiceError::aws_error(
@@ -692,8 +698,9 @@ impl SecretsManagerService {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
-        let mut state = self.state.write();
-        let secret = self.find_secret_mut(&mut state, &secret_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
 
         // AWS allows restoring a secret that is not deleted (no-op)
         secret.deleted = false;
@@ -711,8 +718,10 @@ impl SecretsManagerService {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
-        let state = self.state.read();
-        let secret = self.find_secret_ref(&state, &secret_id)?;
+        let accounts = self.state.read();
+        let empty = SecretsManagerState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let secret = self.find_secret_ref(state, &secret_id)?;
 
         let mut response = json!({
             "ARN": secret.arn,
@@ -832,7 +841,9 @@ impl SecretsManagerService {
             }
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SecretsManagerState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         let mut secrets: Vec<&Secret> = state
             .secrets
@@ -941,8 +952,9 @@ impl SecretsManagerService {
 
         let new_tags = parse_tags(&body["Tags"]);
 
-        let mut state = self.state.write();
-        let secret = self.find_secret_mut(&mut state, &secret_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
 
         if !new_tags.is_empty() {
             secret.tags_ever_set = true;
@@ -972,8 +984,9 @@ impl SecretsManagerService {
             })
             .unwrap_or_default();
 
-        let mut state = self.state.write();
-        let secret = self.find_secret_mut(&mut state, &secret_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
 
         secret.tags.retain(|(k, _)| !tag_keys.contains(k));
 
@@ -985,8 +998,10 @@ impl SecretsManagerService {
         let secret_id = require_secret_id(&body)?;
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 4096)?;
 
-        let state = self.state.read();
-        let secret = self.find_secret_ref(&state, &secret_id)?;
+        let accounts = self.state.read();
+        let empty = SecretsManagerState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let secret = self.find_secret_ref(state, &secret_id)?;
 
         let versions: Vec<Value> = secret
             .versions
@@ -1181,8 +1196,9 @@ impl SecretsManagerService {
             }
         }
 
-        let mut state = self.state.write();
-        let secret = self.find_secret_mut(&mut state, &secret_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
 
         if secret.deleted {
             return Err(AwsServiceError::aws_error(
@@ -1273,8 +1289,9 @@ impl SecretsManagerService {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
-        let mut state = self.state.write();
-        let secret = self.find_secret_mut(&mut state, &secret_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
 
         if secret.deleted {
             return Err(AwsServiceError::aws_error(
@@ -1335,8 +1352,9 @@ impl SecretsManagerService {
         let move_to = body["MoveToVersionId"].as_str().map(|s| s.to_string());
         let remove_from = body["RemoveFromVersionId"].as_str().map(|s| s.to_string());
 
-        let mut state = self.state.write();
-        let secret = self.find_secret_mut(&mut state, &secret_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
 
         // Validate: if moving AWSCURRENT, must specify RemoveFromVersionId
         if version_stage == "AWSCURRENT" && move_to.is_some() && remove_from.is_none() {
@@ -1426,14 +1444,16 @@ impl SecretsManagerService {
             ));
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SecretsManagerState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let mut secret_values: Vec<Value> = Vec::new();
         let mut errors: Vec<Value> = Vec::new();
 
         if let Some(id_list) = secret_id_list {
             for id_val in id_list {
                 let sid = id_val.as_str().unwrap_or("");
-                match self.find_secret_ref(&state, sid) {
+                match self.find_secret_ref(state, sid) {
                     Ok(secret) => {
                         if secret.deleted {
                             errors.push(json!({
@@ -1568,8 +1588,10 @@ impl SecretsManagerService {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
-        let state = self.state.read();
-        let secret = self.find_secret_ref(&state, &secret_id)?;
+        let accounts = self.state.read();
+        let empty = SecretsManagerState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let secret = self.find_secret_ref(state, &secret_id)?;
 
         let mut response = json!({
             "ARN": secret.arn,
@@ -1598,8 +1620,10 @@ impl SecretsManagerService {
 
         // If SecretId is provided, verify the secret exists
         if let Some(secret_id) = body["SecretId"].as_str() {
-            let state = self.state.read();
-            self.find_secret_key(&state, secret_id)?;
+            let accounts = self.state.read();
+            let empty = SecretsManagerState::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+            self.find_secret_key(state, secret_id)?;
         }
 
         let response = json!({
@@ -1621,8 +1645,9 @@ impl SecretsManagerService {
         )?;
         let policy = body["ResourcePolicy"].as_str().map(|s| s.to_string());
 
-        let mut state = self.state.write();
-        let secret = self.find_secret_mut(&mut state, &secret_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
         secret.resource_policy = policy;
 
         let response = json!({
@@ -1637,8 +1662,9 @@ impl SecretsManagerService {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
-        let mut state = self.state.write();
-        let secret = self.find_secret_mut(&mut state, &secret_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
         secret.resource_policy = None;
 
         let response = json!({
@@ -1656,8 +1682,10 @@ impl SecretsManagerService {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
-        let state = self.state.read();
-        let secret = self.find_secret_ref(&state, &secret_id)?;
+        let accounts = self.state.read();
+        let empty = SecretsManagerState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let secret = self.find_secret_ref(state, &secret_id)?;
 
         let response = json!({
             "ARN": secret.arn,
@@ -1673,8 +1701,10 @@ impl SecretsManagerService {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
-        let state = self.state.read();
-        let secret = self.find_secret_ref(&state, &secret_id)?;
+        let accounts = self.state.read();
+        let empty = SecretsManagerState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let secret = self.find_secret_ref(state, &secret_id)?;
 
         let response = json!({
             "ARN": secret.arn,
@@ -1690,8 +1720,10 @@ impl SecretsManagerService {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
 
-        let state = self.state.read();
-        let secret = self.find_secret_ref(&state, &secret_id)?;
+        let accounts = self.state.read();
+        let empty = SecretsManagerState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let secret = self.find_secret_ref(state, &secret_id)?;
 
         let response = json!({
             "ARN": secret.arn,
@@ -2235,7 +2267,6 @@ fn base64_encode(input: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::SecretsManagerState;
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
@@ -2243,10 +2274,13 @@ mod tests {
     use std::sync::Arc;
 
     fn make_state() -> SharedSecretsManagerState {
-        Arc::new(RwLock::new(SecretsManagerState::new(
-            "123456789012",
-            "us-east-1",
-        )))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
     }
 
     fn expect_err(result: Result<AwsResponse, AwsServiceError>) -> AwsServiceError {
@@ -2557,7 +2591,8 @@ mod tests {
         // Real AWS leaves the AWSPENDING version creation to the rotation
         // Lambda's createSecret step, so we should NOT pre-create it. Verify
         // that no version with the rotation token exists yet.
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         let secret = s.secrets.get("rotate-me").unwrap();
         assert!(
             !secret.versions.contains_key(token),
@@ -2594,7 +2629,8 @@ mod tests {
         svc.handle(req).await.unwrap();
 
         // Verify the new version is AWSCURRENT (no pending)
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         let secret = s.secrets.get("rotate-no-lambda").unwrap();
         let new_ver = secret.versions.get(token).unwrap();
         assert!(new_ver.stages.contains(&"AWSCURRENT".to_string()));
@@ -2623,7 +2659,8 @@ mod tests {
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
 
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         let secret = s.secrets.get("rot-cfg").unwrap();
         assert_eq!(secret.rotation_enabled, Some(true));
         assert_eq!(
@@ -2653,7 +2690,8 @@ mod tests {
 
         // Get original version id
         let original_vid = {
-            let s = state.read();
+            let _accts = state.read();
+            let s = _accts.default_ref();
             let secret = s.secrets.get("rot-stages").unwrap();
             secret.current_version_id.clone().unwrap()
         };
@@ -2667,7 +2705,8 @@ mod tests {
         let req = make_request("RotateSecret", &body.to_string());
         svc.handle(req).await.unwrap();
 
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         let secret = s.secrets.get("rot-stages").unwrap();
 
         // New version should be AWSCURRENT
@@ -2702,7 +2741,8 @@ mod tests {
 
         // Verify rotation is enabled
         {
-            let s = state.read();
+            let _accts = state.read();
+            let s = _accts.default_ref();
             let secret = s.secrets.get("cancel-rot").unwrap();
             assert_eq!(secret.rotation_enabled, Some(true));
         }
@@ -2715,7 +2755,8 @@ mod tests {
         assert_eq!(body["Name"], "cancel-rot");
 
         // Verify rotation is disabled
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         let secret = s.secrets.get("cancel-rot").unwrap();
         assert_eq!(secret.rotation_enabled, Some(false));
     }
@@ -2952,7 +2993,8 @@ mod tests {
 
         // Get version IDs
         let (v1_id, v2_id) = {
-            let s = state.read();
+            let _accts = state.read();
+            let s = _accts.default_ref();
             let secret = s.secrets.get("stage-test").unwrap();
             let current = secret.current_version_id.clone().unwrap();
             let previous = secret
@@ -2976,7 +3018,8 @@ mod tests {
         assert_eq!(resp.status, StatusCode::OK);
 
         // Verify v1 is now AWSCURRENT
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         let secret = s.secrets.get("stage-test").unwrap();
         let v1 = secret.versions.get(&v1_id).unwrap();
         assert!(v1.stages.contains(&"AWSCURRENT".to_string()));
@@ -3001,7 +3044,8 @@ mod tests {
         svc.handle(req).await.unwrap();
 
         let vid = {
-            let s = state.read();
+            let _accts = state.read();
+            let s = _accts.default_ref();
             s.secrets
                 .get("custom-stage")
                 .unwrap()
@@ -3019,7 +3063,8 @@ mod tests {
         let req = make_request("UpdateSecretVersionStage", &body.to_string());
         svc.handle(req).await.unwrap();
 
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         let secret = s.secrets.get("custom-stage").unwrap();
         let ver = secret.versions.get(&vid).unwrap();
         assert!(ver.stages.contains(&"MYAPP_LIVE".to_string()));
@@ -3441,7 +3486,8 @@ mod tests {
         assert_eq!(b["Name"], "force-del");
 
         // Secret should be gone entirely
-        let s = state.read();
+        let _accts = state.read();
+        let s = _accts.default_ref();
         assert!(!s.secrets.contains_key("force-del"));
     }
 
@@ -3562,7 +3608,8 @@ mod tests {
         svc.handle(req).await.unwrap();
 
         let v1_id = {
-            let s = state.read();
+            let _accts = state.read();
+            let s = _accts.default_ref();
             s.secrets
                 .get("ver-get")
                 .unwrap()
@@ -3601,7 +3648,8 @@ mod tests {
         svc.handle(req).await.unwrap();
 
         let vid = {
-            let s = state.read();
+            let _accts = state.read();
+            let s = _accts.default_ref();
             s.secrets
                 .get("mismatch")
                 .unwrap()
@@ -4038,7 +4086,8 @@ mod tests {
         svc.handle(req).await.unwrap();
 
         let new_vid = {
-            let s = state.read();
+            let _accts = state.read();
+            let s = _accts.default_ref();
             let secret = s.secrets.get("stage-err").unwrap();
             secret
                 .versions

--- a/crates/fakecloud-secretsmanager/src/state.rs
+++ b/crates/fakecloud-secretsmanager/src/state.rs
@@ -60,17 +60,27 @@ impl SecretsManagerState {
     }
 }
 
-pub type SharedSecretsManagerState = Arc<RwLock<SecretsManagerState>>;
+pub type SharedSecretsManagerState =
+    Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<SecretsManagerState>>>;
+
+impl fakecloud_core::multi_account::AccountState for SecretsManagerState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
 
 /// On-disk snapshot envelope for Secrets Manager state. Versioned so
 /// format changes fail loudly on upgrade.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SecretsManagerSnapshot {
     pub schema_version: u32,
-    pub state: SecretsManagerState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<SecretsManagerState>>,
+    #[serde(default)]
+    pub state: Option<SecretsManagerState>,
 }
 
-pub const SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[cfg(test)]
 mod tests {

--- a/crates/fakecloud-server/src/kinesis_lambda_poller.rs
+++ b/crates/fakecloud-server/src/kinesis_lambda_poller.rs
@@ -61,7 +61,13 @@ impl KinesisLambdaPoller {
 
         for (mapping_uuid, stream_arn, function_arn, batch_size) in mappings {
             let deliveries = {
-                let kinesis = self.kinesis_state.read();
+                let kinesis_accounts = self.kinesis_state.read();
+                // Extract account_id from stream ARN: arn:aws:kinesis:region:ACCOUNT:stream/Name
+                let account_id = stream_arn.split(':').nth(4).unwrap_or("");
+                let kinesis = match kinesis_accounts.get(account_id) {
+                    Some(k) => k,
+                    None => continue,
+                };
                 let stream = match kinesis
                     .streams
                     .values()
@@ -137,7 +143,9 @@ impl KinesisLambdaPoller {
                 }
 
                 {
-                    let mut kinesis = self.kinesis_state.write();
+                    let account_id = stream_arn.split(':').nth(4).unwrap_or("");
+                    let mut kinesis_accounts = self.kinesis_state.write();
+                    let kinesis = kinesis_accounts.get_or_create(account_id);
                     kinesis.set_lambda_checkpoint(&mapping_uuid, &shard_id, end);
                 }
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -151,7 +151,11 @@ async fn main() {
     }
 
     let secretsmanager_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_secretsmanager::state::SecretsManagerState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
     let s3_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new(
@@ -164,7 +168,11 @@ async fn main() {
         fakecloud_logs::state::LogsState::new(&cli.account_id, &cli.region),
     ));
     let kms_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_kms::state::KmsState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
     let cloudformation_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_cloudformation::state::CloudFormationState::new(&cli.account_id, &cli.region),
@@ -176,7 +184,11 @@ async fn main() {
         fakecloud_cognito::state::CognitoState::new(&cli.account_id, &cli.region),
     ));
     let kinesis_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_kinesis::state::KinesisState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
     let rds_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_rds::state::RdsState::new(&cli.account_id, &cli.region),
@@ -194,7 +206,11 @@ async fn main() {
     ));
 
     let bedrock_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_bedrock::state::BedrockState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
 
     let rds_runtime = fakecloud_rds::runtime::RdsRuntime::new().map(Arc::new);
@@ -874,20 +890,31 @@ async fn main() {
                     {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_secretsmanager::state::SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_secretsmanager::state::SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "secretsmanager persistence schema mismatch: on-disk={}, expected={}",
+                                    "secretsmanager persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_secretsmanager::state::SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let secret_count = snapshot.state.secrets.len();
-                            *secretsmanager_state.write() = snapshot.state;
-                            tracing::info!(
-                                secrets = secret_count,
-                                "loaded secretsmanager persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *secretsmanager_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded secretsmanager persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let secret_count = single_state.secrets.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = secretsmanager_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    secrets = secret_count,
+                                    "loaded secretsmanager persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse secretsmanager persistence snapshot: {err}"
@@ -975,17 +1002,31 @@ async fn main() {
                     match serde_json::from_slice::<fakecloud_kms::state::KmsSnapshot>(&bytes) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_kms::state::KMS_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_kms::state::KMS_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "kms persistence schema mismatch: on-disk={}, expected={}",
+                                    "kms persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_kms::state::KMS_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let key_count = snapshot.state.keys.len();
-                            *kms_state.write() = snapshot.state;
-                            tracing::info!(keys = key_count, "loaded kms persistence snapshot",);
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *kms_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded kms persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let key_count = single_state.keys.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = kms_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    keys = key_count,
+                                    "loaded kms persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse kms persistence snapshot: {err}"
@@ -1295,20 +1336,31 @@ async fn main() {
                     ) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_kinesis::state::KINESIS_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_kinesis::state::KINESIS_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "kinesis persistence schema mismatch: on-disk={}, expected={}",
+                                    "kinesis persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_kinesis::state::KINESIS_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let stream_count = snapshot.state.streams.len();
-                            *kinesis_state.write() = snapshot.state;
-                            tracing::info!(
-                                streams = stream_count,
-                                "loaded kinesis persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *kinesis_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded kinesis persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let stream_count = single_state.streams.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = kinesis_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    streams = stream_count,
+                                    "loaded kinesis persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse kinesis persistence snapshot: {err}"
@@ -1605,20 +1657,31 @@ async fn main() {
                     ) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_bedrock::state::BEDROCK_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_bedrock::state::BEDROCK_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "bedrock persistence schema mismatch: on-disk={}, expected={}",
+                                    "bedrock persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_bedrock::state::BEDROCK_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let guardrail_count = snapshot.state.guardrails.len();
-                            *bedrock_state.write() = snapshot.state;
-                            tracing::info!(
-                                guardrails = guardrail_count,
-                                "loaded bedrock persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *bedrock_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded bedrock persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let guardrail_count = single_state.guardrails.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = bedrock_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    guardrails = guardrail_count,
+                                    "loaded bedrock persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse bedrock persistence snapshot: {err}"
@@ -2674,7 +2737,7 @@ async fn main() {
             axum::routing::get({
                 let bs = bedrock_state.clone();
                 move || async move {
-                    let state = bs.read();
+                    let accounts = bs.read(); let state = accounts.default_ref();
                     let invocations: Vec<serde_json::Value> = state
                         .invocations
                         .iter()
@@ -2699,7 +2762,7 @@ async fn main() {
                 let bs = bedrock_state.clone();
                 move |axum::extract::Path(model_id): axum::extract::Path<String>,
                       body: String| async move {
-                    let mut state = bs.write();
+                    let mut accounts = bs.write(); let state = accounts.default_mut();
                     state.custom_responses.insert(model_id.clone(), body);
                     axum::Json(
                         serde_json::json!({ "status": "ok", "modelId": model_id }),
@@ -2754,7 +2817,7 @@ async fn main() {
                             response,
                         });
                     }
-                    let mut state = bs.write();
+                    let mut accounts = bs.write(); let state = accounts.default_mut();
                     state.response_rules.insert(model_id.clone(), parsed);
                     (
                         axum::http::StatusCode::OK,
@@ -2768,7 +2831,7 @@ async fn main() {
             .delete({
                 let bs = bedrock_state.clone();
                 move |axum::extract::Path(model_id): axum::extract::Path<String>| async move {
-                    let mut state = bs.write();
+                    let mut accounts = bs.write(); let state = accounts.default_mut();
                     state.response_rules.remove(&model_id);
                     axum::Json(serde_json::json!({ "status": "ok", "modelId": model_id }))
                 }
@@ -2825,7 +2888,7 @@ async fn main() {
                             })),
                         );
                     }
-                    let mut state = bs.write();
+                    let mut accounts = bs.write(); let state = accounts.default_mut();
                     state
                         .fault_rules
                         .push(fakecloud_bedrock::state::FaultRule {
@@ -2845,7 +2908,7 @@ async fn main() {
             .get({
                 let bs = bedrock_state.clone();
                 move || async move {
-                    let state = bs.read();
+                    let accounts = bs.read(); let state = accounts.default_ref();
                     let faults: Vec<serde_json::Value> = state
                         .fault_rules
                         .iter()
@@ -2866,7 +2929,7 @@ async fn main() {
             .delete({
                 let bs = bedrock_state.clone();
                 move || async move {
-                    let mut state = bs.write();
+                    let mut accounts = bs.write(); let state = accounts.default_mut();
                     state.fault_rules.clear();
                     axum::Json(serde_json::json!({ "status": "ok" }))
                 }

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -340,9 +340,10 @@ mod tests {
                 fakecloud_lambda::state::LambdaState::new("123456789012", "us-east-1"),
             )),
             secretsmanager: Arc::new(parking_lot::RwLock::new(
-                fakecloud_secretsmanager::state::SecretsManagerState::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",
+                    "http://localhost:4566",
                 ),
             )),
             s3: Arc::new(parking_lot::RwLock::new(
@@ -356,7 +357,11 @@ mod tests {
                 fakecloud_logs::state::LogsState::new("123456789012", "us-east-1"),
             )),
             kms: Arc::new(parking_lot::RwLock::new(
-                fakecloud_kms::state::KmsState::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
             )),
             cloudformation: Arc::new(parking_lot::RwLock::new(
                 fakecloud_cloudformation::state::CloudFormationState::new(
@@ -371,7 +376,11 @@ mod tests {
                 fakecloud_cognito::state::CognitoState::new("123456789012", "us-east-1"),
             )),
             kinesis: Arc::new(parking_lot::RwLock::new(
-                fakecloud_kinesis::state::KinesisState::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
             )),
             rds: Arc::new(parking_lot::RwLock::new(rds)),
             elasticache: Arc::new(parking_lot::RwLock::new(
@@ -387,7 +396,11 @@ mod tests {
                 fakecloud_apigatewayv2::state::ApiGatewayV2State::new("123456789012", "us-east-1"),
             )),
             bedrock: Arc::new(parking_lot::RwLock::new(
-                fakecloud_bedrock::state::BedrockState::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
             )),
             container_runtime: None,
             rds_runtime: None,

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -311,7 +311,8 @@ impl SsmService {
             )
         })?;
 
-        let sm = sm_state.read();
+        let sm_accounts = sm_state.read();
+        let sm = sm_accounts.default_ref();
         let secret = sm.secrets.get(secret_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,


### PR DESCRIPTION
## Summary

Batch 5 of #381. Wraps KMS, SecretsManager, Kinesis, and Bedrock in `MultiAccountState<T>`.

- All 4 services: handlers use `get_or_create(&req.account_id)`, read-only handlers use read lock with fallback
- KMS resource policy provider extracts account from key ARN
- Kinesis delivery/poller extracts account from stream ARN
- SecretsManager rotation iterates all accounts
- Bedrock sub-modules receive `req` parameter for account routing
- Cross-service: S3 KMS key validation, SSM SecureString resolution updated
- Snapshot v2 with v1 backward compat for all 4

## Test plan

- [x] 2,961 workspace unit tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates state per account for KMS, Secrets Manager, Kinesis, and Bedrock by wrapping each service in `MultiAccountState<T>` and routing handlers via `get_or_create(&req.account_id)`. This prevents cross-account leakage and enables safe multi-account runs.

- **New Features**
  - `fakecloud-kms`: resource policies and tag reads resolve the account from key ARNs; all requests are account-scoped.
  - `fakecloud-kinesis`: delivery and Lambda poller extract account from stream ARNs; streams/shards are account-scoped. Restored full delivery module and tests with multi-account routing.
  - `fakecloud-secretsmanager`: rotation scans all accounts; handlers route per account.
  - `fakecloud-bedrock`: automated reasoning and workflows, faults, overrides, logging, async invoke, streaming, and runtime invoke accept `req` and use the account’s state.
  - Cross-service: S3 SSE-KMS key validation uses the request’s account; SSM SecureString resolution uses the default account.
  - Snapshots: schema v2 with v1 read compatibility for KMS, Secrets Manager, Kinesis, and Bedrock.

- **Bug Fixes**
  - `fakecloud-bedrock`: `delete_imported_model` uses `get_mut` to avoid creating empty account state on failed deletes.
  - `fakecloud-kinesis`: delivery filters empty account IDs when parsing ARNs and falls back to the default account.

<sup>Written for commit 42e07af6630265903ed5857660bba17ad012ef41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

