### PR TITLE
test(sdk,bedrock): SDK error display + bedrock state lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,6 +2467,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -500,4 +500,68 @@ mod tests {
         assert!(state.guardrails.is_empty());
         assert!(state.custom_models.is_empty());
     }
+
+    #[test]
+    fn new_initializes_all_collections_empty() {
+        let s = BedrockState::new("123", "us-east-1");
+        assert!(s.tags.is_empty());
+        assert!(s.guardrail_versions.is_empty());
+        assert!(s.customization_jobs.is_empty());
+        assert!(s.provisioned_throughputs.is_empty());
+        assert!(s.logging_config.is_none());
+        assert!(s.invocations.is_empty());
+        assert!(s.custom_responses.is_empty());
+        assert!(s.response_rules.is_empty());
+        assert!(s.fault_rules.is_empty());
+        assert!(s.async_invocations.is_empty());
+        assert!(s.custom_model_deployments.is_empty());
+        assert!(s.model_import_jobs.is_empty());
+        assert!(s.imported_models.is_empty());
+        assert!(s.model_copy_jobs.is_empty());
+        assert!(s.model_invocation_jobs.is_empty());
+        assert!(s.evaluation_jobs.is_empty());
+        assert!(s.inference_profiles.is_empty());
+        assert!(s.prompt_routers.is_empty());
+        assert!(s.resource_policies.is_empty());
+        assert!(s.marketplace_endpoints.is_empty());
+        assert!(s.foundation_model_agreements.is_empty());
+        assert!(s.use_case_for_model_access.is_none());
+        assert!(s.enforced_guardrail_configs.is_empty());
+        assert!(s.automated_reasoning_policies.is_empty());
+        assert!(s.automated_reasoning_test_cases.is_empty());
+        assert!(s.ar_build_workflows.is_empty());
+        assert!(s.ar_test_results.is_empty());
+        assert!(s.ar_annotations.is_empty());
+    }
+
+    #[test]
+    fn reset_clears_all_collections() {
+        let mut s = BedrockState::new("123", "us-east-1");
+        s.tags.insert("arn".to_string(), HashMap::new());
+        s.custom_responses.insert("m".to_string(), "r".to_string());
+        s.fault_rules.push(FaultRule {
+            error_type: "T".to_string(),
+            message: "m".to_string(),
+            http_status: 500,
+            remaining: 1,
+            model_id: None,
+            operation: None,
+        });
+        s.use_case_for_model_access = Some(serde_json::json!({"a": 1}));
+        s.logging_config = Some(LoggingConfig {
+            cloud_watch_config: None,
+            s3_config: None,
+            text_data_delivery_enabled: false,
+            image_data_delivery_enabled: false,
+            embedding_data_delivery_enabled: false,
+        });
+
+        s.reset();
+
+        assert!(s.tags.is_empty());
+        assert!(s.custom_responses.is_empty());
+        assert!(s.fault_rules.is_empty());
+        assert!(s.use_case_for_model_access.is_none());
+        assert!(s.logging_config.is_none());
+    }
 }

--- a/crates/fakecloud-sdk/Cargo.toml
+++ b/crates/fakecloud-sdk/Cargo.toml
@@ -12,3 +12,6 @@ homepage.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/fakecloud-sdk/src/error.rs
+++ b/crates/fakecloud-sdk/src/error.rs
@@ -32,3 +32,49 @@ impl From<reqwest::Error> for Error {
         Error::Http(e)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error as _;
+
+    #[test]
+    fn api_error_display_contains_status_and_body() {
+        let err = Error::Api {
+            status: 404,
+            body: "not found".to_string(),
+        };
+        let text = format!("{err}");
+        assert!(text.contains("404"));
+        assert!(text.contains("not found"));
+    }
+
+    #[test]
+    fn api_error_has_no_source() {
+        let err = Error::Api {
+            status: 500,
+            body: "oops".to_string(),
+        };
+        assert!(err.source().is_none());
+    }
+
+    #[test]
+    fn debug_impl_works() {
+        let err = Error::Api {
+            status: 400,
+            body: "bad".to_string(),
+        };
+        let d = format!("{err:?}");
+        assert!(d.contains("Api"));
+    }
+
+    #[tokio::test]
+    async fn http_error_display_includes_prefix() {
+        let resp = reqwest::get("http://127.0.0.1:1/nope").await;
+        let reqwest_err = resp.err().unwrap();
+        let err: Error = reqwest_err.into();
+        let text = format!("{err}");
+        assert!(text.starts_with("HTTP error:"));
+        assert!(err.source().is_some());
+    }
+}


### PR DESCRIPTION
Covers: fakecloud-sdk Error Display/source/From, bedrock state new + reset for all collections and logging_config.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `fakecloud-sdk` error Display/source and for `fakecloud-bedrock` state lifecycle (new/reset). Ensures errors include status/body and state starts empty and fully resets, including `logging_config` and all collections.

- **Dependencies**
  - Add `tokio` to `fakecloud-sdk` dev-dependencies with `rt-multi-thread` and `macros` for async HTTP error tests.

<sup>Written for commit 2ea2a67090b5b0aa50ae579b83459e1b68f8c172. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

