### PR TITLE
test(bedrock): automated_reasoning build workflows

### DIFF
--- a/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
@@ -426,3 +426,336 @@ pub fn get_next_scenario(
         "inputs": [],
     })))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{AutomatedReasoningPolicy, BedrockState};
+    use bytes::Bytes;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        Arc::new(RwLock::new(BedrockState::new("123456789012", "us-east-1")))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "req".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn seed_policy(state: &SharedBedrockState, name: &str) -> String {
+        let arn = format!(
+            "arn:aws:bedrock:us-east-1:123456789012:automated-reasoning-policy/{}",
+            Uuid::new_v4()
+        );
+        let now = Utc::now();
+        state.write().automated_reasoning_policies.insert(
+            arn.clone(),
+            AutomatedReasoningPolicy {
+                policy_arn: arn.clone(),
+                policy_name: name.to_string(),
+                description: None,
+                policy_document: json!({}),
+                status: "ACTIVE".to_string(),
+                version: "1".to_string(),
+                versions: vec!["1".to_string()],
+                created_at: now,
+                updated_at: now,
+            },
+        );
+        arn
+    }
+
+    fn start_workflow(state: &SharedBedrockState, policy_id: &str) -> String {
+        let resp = start_build_workflow(state, policy_id, "BUILD").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        v["buildWorkflowId"].as_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn start_build_workflow_persists_entry() {
+        let s = shared();
+        let arn = seed_policy(&s, "p1");
+        let wid = start_workflow(&s, &arn);
+        let w = s
+            .read()
+            .ar_build_workflows
+            .get(&(arn.clone(), wid))
+            .unwrap()
+            .clone();
+        assert_eq!(w.workflow_type, "BUILD");
+        assert_eq!(w.status, "InProgress");
+    }
+
+    #[test]
+    fn start_build_workflow_unknown_policy_not_found() {
+        let s = shared();
+        let err = start_build_workflow(&s, "missing", "BUILD").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn get_build_workflow_roundtrip() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let wid = start_workflow(&s, &arn);
+        let resp = get_build_workflow(&s, &arn, &wid).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["buildWorkflowId"], wid);
+        assert_eq!(v["status"], "InProgress");
+    }
+
+    #[test]
+    fn get_build_workflow_unknown_returns_not_found() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let err = get_build_workflow(&s, &arn, "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn list_build_workflows_paginates() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        for _ in 0..3 {
+            start_workflow(&s, &arn);
+        }
+        let mut r = req();
+        r.query_params
+            .insert("maxResults".to_string(), "2".to_string());
+        let resp = list_build_workflows(&s, &arn, &r).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["buildWorkflowSummaries"].as_array().unwrap().len(), 2);
+        assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn list_build_workflows_unknown_policy_not_found() {
+        let s = shared();
+        let err = list_build_workflows(&s, "miss", &req()).err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn cancel_build_workflow_transitions_status() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let wid = start_workflow(&s, &arn);
+        cancel_build_workflow(&s, &arn, &wid).unwrap();
+        let w = &s.read().ar_build_workflows[&(arn.clone(), wid.clone())];
+        assert_eq!(w.status, "Cancelled");
+    }
+
+    #[test]
+    fn cancel_build_workflow_unknown_returns_not_found() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let err = cancel_build_workflow(&s, &arn, "miss").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn delete_build_workflow_cleans_annotations_and_results() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let wid = start_workflow(&s, &arn);
+        update_annotations(&s, &arn, &wid, &json!({"a": 1})).unwrap();
+        s.write().ar_test_results.insert(
+            (arn.clone(), wid.clone(), "tc1".to_string()),
+            json!({"t": 1}),
+        );
+        delete_build_workflow(&s, &arn, &wid).unwrap();
+        let g = s.read();
+        assert!(g.ar_build_workflows.is_empty());
+        assert!(g.ar_test_results.is_empty());
+        assert!(g.ar_annotations.is_empty());
+    }
+
+    #[test]
+    fn delete_build_workflow_unknown_returns_not_found() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let err = delete_build_workflow(&s, &arn, "miss").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn get_build_workflow_result_assets_returns_empty_list() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let wid = start_workflow(&s, &arn);
+        let resp = get_build_workflow_result_assets(&s, &arn, &wid).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["assets"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn get_build_workflow_result_assets_unknown_not_found() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let err = get_build_workflow_result_assets(&s, &arn, "miss")
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn start_test_workflow_returns_id() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let wid = start_workflow(&s, &arn);
+        let resp = start_test_workflow(&s, &arn, &wid).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["testWorkflowId"].is_string());
+    }
+
+    #[test]
+    fn start_test_workflow_unknown_not_found() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let err = start_test_workflow(&s, &arn, "miss").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn get_test_result_default_when_absent() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let wid = start_workflow(&s, &arn);
+        let resp = get_test_result(&s, &arn, &wid, "tc-x").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["status"], "NotRun");
+        assert_eq!(v["testCaseId"], "tc-x");
+    }
+
+    #[test]
+    fn get_test_result_returns_stored_value() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let wid = start_workflow(&s, &arn);
+        s.write().ar_test_results.insert(
+            (arn.clone(), wid.clone(), "tc".to_string()),
+            json!({"status": "Passed"}),
+        );
+        let resp = get_test_result(&s, &arn, &wid, "tc").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["status"], "Passed");
+    }
+
+    #[test]
+    fn get_test_result_unknown_workflow_not_found() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let err = get_test_result(&s, &arn, "miss", "tc").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn list_test_results_paginates() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let wid = start_workflow(&s, &arn);
+        for i in 0..3 {
+            s.write().ar_test_results.insert(
+                (arn.clone(), wid.clone(), format!("tc-{i}")),
+                json!({"testCaseId": format!("tc-{i}"), "status": "Passed"}),
+            );
+        }
+        let mut r = req();
+        r.query_params
+            .insert("maxResults".to_string(), "2".to_string());
+        let resp = list_test_results(&s, &arn, &wid, &r).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["testResultSummaries"].as_array().unwrap().len(), 2);
+        assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn list_test_results_unknown_workflow_not_found() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let err = list_test_results(&s, &arn, "miss", &req()).err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn annotations_roundtrip() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let wid = start_workflow(&s, &arn);
+        let resp = get_annotations(&s, &arn, &wid).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["annotations"].as_array().unwrap().len(), 0);
+
+        update_annotations(&s, &arn, &wid, &json!({"k": "v"})).unwrap();
+        let resp = get_annotations(&s, &arn, &wid).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["k"], "v");
+    }
+
+    #[test]
+    fn get_annotations_unknown_workflow_not_found() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let err = get_annotations(&s, &arn, "miss").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn update_annotations_unknown_workflow_not_found() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let err = update_annotations(&s, &arn, "miss", &json!({}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn get_next_scenario_returns_ready() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let wid = start_workflow(&s, &arn);
+        let resp = get_next_scenario(&s, &arn, &wid).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["status"], "Ready");
+        assert_eq!(v["workflowId"], wid);
+    }
+
+    #[test]
+    fn get_next_scenario_unknown_workflow_not_found() {
+        let s = shared();
+        let arn = seed_policy(&s, "p");
+        let err = get_next_scenario(&s, &arn, "miss").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Covers start/get/list/cancel/delete build workflows, start test workflow, get/list test results, annotations get/update, next scenario, cross-cleanup on delete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for Bedrock automated reasoning workflows: build start/get/list/cancel/delete, test start, test results get/list, annotations get/update, and next scenario. Verifies pagination, 404s for unknown resources, status transitions, default test result values, empty result assets, and cross-cleanup on delete.

<sup>Written for commit 97f60b727fed59e3f831337c46b0062b3078786d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

