### PR TITLE
test(ssm): state default seeding + reset counter reset

### DIFF
--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -757,4 +757,49 @@ mod tests {
         assert_eq!(state.account_id, "123456789012");
         assert_eq!(state.region, "us-east-1");
     }
+
+    #[test]
+    fn new_seeds_default_region_parameters() {
+        let state = SsmState::new("123456789012", "us-east-1");
+        let region_key = "/aws/service/global-infrastructure/regions/us-east-1";
+        assert!(state.parameters.contains_key(region_key));
+        let long_key = format!("{region_key}/longName");
+        assert!(state.parameters.contains_key(&long_key));
+    }
+
+    #[test]
+    fn new_seeds_default_service_parameters() {
+        let state = SsmState::new("123456789012", "us-east-1");
+        let key = "/aws/service/global-infrastructure/services/lambda";
+        assert!(state.parameters.contains_key(key));
+    }
+
+    #[test]
+    fn reset_reseeds_defaults() {
+        let mut state = SsmState::new("123456789012", "us-east-1");
+        state.parameters.clear();
+        state.documents.clear();
+        state.ops_item_counter = 42;
+        state.reset();
+        // Defaults re-seeded
+        let key = "/aws/service/global-infrastructure/services/s3";
+        assert!(state.parameters.contains_key(key));
+        assert_eq!(state.ops_item_counter, 0);
+    }
+
+    #[test]
+    fn reset_clears_ephemeral_counters() {
+        let mut state = SsmState::new("123456789012", "us-east-1");
+        state.mw_execution_counter = 7;
+        state.automation_execution_counter = 3;
+        state.session_counter = 9;
+        state.activation_counter = 2;
+        state.execution_preview_counter = 5;
+        state.reset();
+        assert_eq!(state.mw_execution_counter, 0);
+        assert_eq!(state.automation_execution_counter, 0);
+        assert_eq!(state.session_counter, 0);
+        assert_eq!(state.activation_counter, 0);
+        assert_eq!(state.execution_preview_counter, 0);
+    }
 }


### PR DESCRIPTION
Covers seeded region/service parameters on new(), reset re-seeds defaults and zeros all ephemeral counters.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to verify SSM state default seeding and reset behavior. Confirms `SsmState::new` seeds AWS region/service parameters and `reset()` re-seeds defaults and clears all ephemeral counters.

<sup>Written for commit ae27f641ac1b5d1778ffe9c13256f0fd62350982. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

