### PR TITLE
test(kms): resource policy ARN parser + provider lookups

### DIFF
--- a/crates/fakecloud-kms/src/resource_policy.rs
+++ b/crates/fakecloud-kms/src/resource_policy.rs
@@ -95,4 +95,65 @@ mod tests {
             Some("mrk-abc123".to_string())
         );
     }
+
+    #[test]
+    fn parse_key_id_missing_key_segment() {
+        assert_eq!(
+            parse_key_id_from_arn("arn:aws:kms:us-east-1:123456789012:alias/my-alias"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_key_id_wrong_partition() {
+        assert_eq!(
+            parse_key_id_from_arn("arn:aws-cn:kms:cn-north-1:123:key/abc"),
+            None
+        );
+    }
+
+    fn make_state() -> SharedKmsState {
+        use crate::state::KmsState;
+        use fakecloud_core::multi_account::MultiAccountState;
+        use parking_lot::RwLock;
+        let multi: MultiAccountState<KmsState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://localhost");
+        Arc::new(RwLock::new(multi))
+    }
+
+    #[test]
+    fn resource_policy_non_kms_service_returns_none() {
+        let state = make_state();
+        let provider = KmsResourcePolicyProvider::new(state);
+        assert!(provider
+            .resource_policy("s3", "arn:aws:kms:us-east-1:123:key/abc")
+            .is_none());
+    }
+
+    #[test]
+    fn resource_policy_unknown_key_returns_none() {
+        let state = make_state();
+        let provider = KmsResourcePolicyProvider::new(state);
+        assert!(provider
+            .resource_policy("kms", "arn:aws:kms:us-east-1:123:key/missing")
+            .is_none());
+    }
+
+    #[test]
+    fn resource_policy_case_insensitive_service_name() {
+        let state = make_state();
+        let provider = KmsResourcePolicyProvider::new(state);
+        assert!(provider
+            .resource_policy("KMS", "arn:aws:kms:us-east-1:123:key/missing")
+            .is_none());
+    }
+
+    #[test]
+    fn shared_helper_returns_arc_provider() {
+        let state = make_state();
+        let arc: Arc<dyn ResourcePolicyProvider> = KmsResourcePolicyProvider::shared(state);
+        assert!(arc
+            .resource_policy("kms", "arn:aws:kms:us-east-1:123:key/missing")
+            .is_none());
+    }
 }


### PR DESCRIPTION
Covers parse_key_id edge cases (alias, wrong partition) + provider not-kms/unknown-key/case-insensitive/shared Arc helper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for KMS ARN key-id parsing and resource policy provider lookups to cover edge cases and prevent regressions.
Covers alias ARNs, missing key segment, wrong partition, non-KMS service names, unknown keys, case-insensitive service names, and the shared Arc provider helper.

<sup>Written for commit fe272a7bf07ba70832342a377e30e262d88c7fad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

