### PR TITLE
feat(lambda,eventbridge,logs): multi-account state isolation

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -490,7 +490,7 @@ impl ResourceProvisioner {
             .unwrap_or("default");
 
         let mut eb_accounts = self.eventbridge_state.write();
-        let state = eb_accounts.default_mut();
+        let state = eb_accounts.get_or_create(&self.account_id);
 
         // Validate that the event bus exists
         if !state.buses.contains_key(event_bus_name) {
@@ -764,7 +764,7 @@ impl ResourceProvisioner {
             .map(|v| v as i32);
 
         let mut logs_accounts = self.logs_state.write();
-        let state = logs_accounts.default_mut();
+        let state = logs_accounts.get_or_create(&self.account_id);
         let arn = format!(
             "arn:aws:logs:{}:{}:log-group:{}:*",
             state.region, state.account_id, log_group_name

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -489,7 +489,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .unwrap_or("default");
 
-        let mut state = self.eventbridge_state.write();
+        let mut eb_accounts = self.eventbridge_state.write();
+        let state = eb_accounts.default_mut();
 
         // Validate that the event bus exists
         if !state.buses.contains_key(event_bus_name) {
@@ -550,7 +551,8 @@ impl ResourceProvisioner {
     }
 
     fn delete_eventbridge_rule(&self, physical_id: &str) -> Result<(), String> {
-        let mut state = self.eventbridge_state.write();
+        let mut eb_accounts = self.eventbridge_state.write();
+        let state = eb_accounts.default_mut();
         // physical_id is the ARN; find the rule key
         let key = state
             .rules
@@ -761,7 +763,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_i64())
             .map(|v| v as i32);
 
-        let mut state = self.logs_state.write();
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.default_mut();
         let arn = format!(
             "arn:aws:logs:{}:{}:log-group:{}:*",
             state.region, state.account_id, log_group_name
@@ -791,7 +794,8 @@ impl ResourceProvisioner {
     }
 
     fn delete_log_group(&self, physical_id: &str) -> Result<(), String> {
-        let mut state = self.logs_state.write();
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.default_mut();
         // physical_id is the ARN; find the log group name
         let name = state
             .log_groups
@@ -944,16 +948,15 @@ mod tests {
                 "us-east-1", "",
             ))),
             eventbridge_state: Arc::new(RwLock::new(
-                fakecloud_eventbridge::state::EventBridgeState::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             dynamodb_state: Arc::new(RwLock::new(fakecloud_core::multi_account::MultiAccountState::new(
                 "123456789012",
                 "us-east-1", "",
             ))),
-            logs_state: Arc::new(RwLock::new(fakecloud_logs::state::LogsState::new(
-                "123456789012",
-                "us-east-1",
-            ))),
+            logs_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),
@@ -1042,7 +1045,8 @@ mod tests {
         let prov = make_provisioner();
         // Create a custom bus first
         {
-            let mut state = prov.eventbridge_state.write();
+            let mut eb_accounts = prov.eventbridge_state.write();
+            let state = eb_accounts.default_mut();
             state.buses.insert(
                 "custom-bus".to_string(),
                 fakecloud_eventbridge::state::EventBus {

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -868,7 +868,11 @@ mod tests {
                 ),
             )),
             eventbridge: Arc::new(RwLock::new(
-                fakecloud_eventbridge::state::EventBridgeState::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
             )),
             dynamodb: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
@@ -877,10 +881,13 @@ mod tests {
                     "",
                 ),
             )),
-            logs: Arc::new(RwLock::new(fakecloud_logs::state::LogsState::new(
-                "123456789012",
-                "us-east-1",
-            ))),
+            logs: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-eventbridge/src/delivery.rs
+++ b/crates/fakecloud-eventbridge/src/delivery.rs
@@ -36,7 +36,8 @@ impl EventBridgeDelivery for EventBridgeDeliveryImpl {
             resources: Vec::new(),
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.default_mut();
         state.events.push(event);
 
         // Find matching rules and their targets
@@ -62,7 +63,7 @@ impl EventBridgeDelivery for EventBridgeDeliveryImpl {
             .collect();
 
         // Drop the lock before delivering
-        drop(state);
+        drop(accounts);
 
         if matching_targets.is_empty() {
             return;
@@ -100,9 +101,7 @@ impl EventBridgeDelivery for EventBridgeDeliveryImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{
-        EventBridgeState, EventRule, EventTarget as EbTarget, SharedEventBridgeState,
-    };
+    use crate::state::{EventRule, EventTarget as EbTarget, SharedEventBridgeState};
     use fakecloud_core::delivery::{SnsDelivery, SqsDelivery};
     use parking_lot::RwLock;
     use std::sync::Mutex;
@@ -146,10 +145,9 @@ mod tests {
     }
 
     fn make_shared() -> SharedEventBridgeState {
-        Arc::new(RwLock::new(EventBridgeState::new(
-            "123456789012",
-            "us-east-1",
-        )))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ))
     }
 
     fn make_rule(name: &str, pattern: Option<&str>, target_arn: &str) -> EventRule {
@@ -184,9 +182,10 @@ mod tests {
         let delivery = EventBridgeDeliveryImpl::new(state.clone(), bus);
         delivery.put_event("my.source", "MyType", r#"{"k":"v"}"#, "default");
         let guard = state.read();
-        assert_eq!(guard.events.len(), 1);
-        assert_eq!(guard.events[0].source, "my.source");
-        assert_eq!(guard.events[0].detail_type, "MyType");
+        let default = guard.default_ref();
+        assert_eq!(default.events.len(), 1);
+        assert_eq!(default.events[0].source, "my.source");
+        assert_eq!(default.events[0].detail_type, "MyType");
     }
 
     #[test]
@@ -194,7 +193,8 @@ mod tests {
         let state = make_shared();
         let q_arn = "arn:aws:sqs:us-east-1:123456789012:q".to_string();
         {
-            let mut s = state.write();
+            let mut s_accounts = state.write();
+            let s = s_accounts.default_mut();
             let rule = make_rule("r", None, &q_arn);
             s.rules
                 .insert(("default".to_string(), "r".to_string()), rule);
@@ -216,7 +216,8 @@ mod tests {
         let state = make_shared();
         let topic_arn = "arn:aws:sns:us-east-1:123456789012:t".to_string();
         {
-            let mut s = state.write();
+            let mut s_accounts = state.write();
+            let s = s_accounts.default_mut();
             let rule = make_rule("r", None, &topic_arn);
             s.rules
                 .insert(("default".to_string(), "r".to_string()), rule);
@@ -236,7 +237,8 @@ mod tests {
         let state = make_shared();
         let q_arn = "arn:aws:sqs:us-east-1:123456789012:q".to_string();
         {
-            let mut s = state.write();
+            let mut s_accounts = state.write();
+            let s = s_accounts.default_mut();
             let mut rule = make_rule("r", None, &q_arn);
             rule.state = "DISABLED".to_string();
             s.rules
@@ -254,7 +256,8 @@ mod tests {
         let state = make_shared();
         let q_arn = "arn:aws:sqs:us-east-1:123456789012:q".to_string();
         {
-            let mut s = state.write();
+            let mut s_accounts = state.write();
+            let s = s_accounts.default_mut();
             let mut rule = make_rule("r", None, &q_arn);
             rule.event_bus_name = "custom-bus".to_string();
             s.rules
@@ -272,7 +275,8 @@ mod tests {
         let state = make_shared();
         let q_arn = "arn:aws:sqs:us-east-1:123456789012:q".to_string();
         {
-            let mut s = state.write();
+            let mut s_accounts = state.write();
+            let s = s_accounts.default_mut();
             let rule = make_rule("r", None, &q_arn);
             s.rules
                 .insert(("default".to_string(), "r".to_string()), rule);

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -155,77 +155,81 @@ impl Scheduler {
         let now = Utc::now();
 
         // Collect rules that need to fire (to avoid holding lock during delivery)
-        let mut to_fire: Vec<(String, Vec<crate::state::EventTarget>)> = Vec::new();
+        // Each entry includes the account_id that owns the rule
+        let mut to_fire: Vec<(String, String, String, Vec<crate::state::EventTarget>)> = Vec::new();
 
         {
             let mut accounts = self.state.write();
-            let state = accounts.default_mut();
-            let rule_keys: Vec<crate::state::RuleKey> = state.rules.keys().cloned().collect();
+            for (account_id, state) in accounts.iter_mut() {
+                let account_id = account_id.to_string();
+                let region = state.region.clone();
+                let rule_keys: Vec<crate::state::RuleKey> = state.rules.keys().cloned().collect();
 
-            for key in rule_keys {
-                let rule = match state.rules.get(&key) {
-                    Some(r) => r,
-                    None => continue,
-                };
-                let name = rule.name.clone();
+                for key in rule_keys {
+                    let rule = match state.rules.get(&key) {
+                        Some(r) => r,
+                        None => continue,
+                    };
+                    let name = rule.name.clone();
 
-                if rule.state != "ENABLED" {
-                    continue;
-                }
+                    if rule.state != "ENABLED" {
+                        continue;
+                    }
 
-                let schedule_expr = match &rule.schedule_expression {
-                    Some(s) => s.clone(),
-                    None => continue,
-                };
+                    let schedule_expr = match &rule.schedule_expression {
+                        Some(s) => s.clone(),
+                        None => continue,
+                    };
 
-                if rule.targets.is_empty() {
-                    continue;
-                }
+                    if rule.targets.is_empty() {
+                        continue;
+                    }
 
-                let schedule = match parse_schedule(&schedule_expr) {
-                    Some(s) => s,
-                    None => continue,
-                };
+                    let schedule = match parse_schedule(&schedule_expr) {
+                        Some(s) => s,
+                        None => continue,
+                    };
 
-                let should_fire = match &schedule {
-                    Schedule::Rate(duration) => match rule.last_fired {
-                        Some(last) => {
-                            let elapsed = now.signed_duration_since(last);
-                            elapsed.to_std().unwrap_or(Duration::ZERO) >= *duration
-                        }
-                        None => true, // Never fired, fire immediately
-                    },
-                    Schedule::Cron(cron) => {
-                        if !cron_matches_now(cron) {
-                            false
-                        } else {
-                            // Avoid firing multiple times in the same minute
-                            let current = (now.hour(), now.minute());
-                            let last = cron_last_minute.get(&key);
-                            if last == Some(&current) {
+                    let should_fire = match &schedule {
+                        Schedule::Rate(duration) => match rule.last_fired {
+                            Some(last) => {
+                                let elapsed = now.signed_duration_since(last);
+                                elapsed.to_std().unwrap_or(Duration::ZERO) >= *duration
+                            }
+                            None => true, // Never fired, fire immediately
+                        },
+                        Schedule::Cron(cron) => {
+                            if !cron_matches_now(cron) {
                                 false
                             } else {
-                                cron_last_minute.insert(key.clone(), current);
-                                true
+                                // Avoid firing multiple times in the same minute
+                                let current = (now.hour(), now.minute());
+                                let last = cron_last_minute.get(&key);
+                                if last == Some(&current) {
+                                    false
+                                } else {
+                                    cron_last_minute.insert(key.clone(), current);
+                                    true
+                                }
                             }
                         }
-                    }
-                };
+                    };
 
-                if should_fire {
-                    let targets = rule.targets.clone();
-                    // Update last_fired while we hold the write lock
-                    if let Some(r) = state.rules.get_mut(&key) {
-                        r.last_fired = Some(now);
+                    if should_fire {
+                        let targets = rule.targets.clone();
+                        // Update last_fired while we hold the write lock
+                        if let Some(r) = state.rules.get_mut(&key) {
+                            r.last_fired = Some(now);
+                        }
+                        to_fire.push((account_id.clone(), region.clone(), name, targets));
                     }
-                    to_fire.push((name, targets));
                 }
             }
         }
         // Lock is dropped here
 
         // Deliver events
-        for (rule_name, targets) in to_fire {
+        for (account_id, region, rule_name, targets) in to_fire {
             let event_id = uuid::Uuid::new_v4().to_string();
             let event_json = json!({
                 "version": "0",
@@ -234,7 +238,7 @@ impl Scheduler {
                 "detail-type": "Scheduled Event",
                 "detail": {},
                 "time": now.to_rfc3339(),
-                "region": "us-east-1",
+                "region": region,
             });
             let event_str = event_json.to_string();
 
@@ -254,7 +258,7 @@ impl Scheduler {
                         "Scheduler delivering to Lambda function"
                     );
                     let mut eb_accounts = self.state.write();
-                    let eb_state = eb_accounts.default_mut();
+                    let eb_state = eb_accounts.get_or_create(&account_id);
                     eb_state
                         .lambda_invocations
                         .push(crate::state::LambdaInvocation {
@@ -264,12 +268,15 @@ impl Scheduler {
                         });
                     drop(eb_accounts);
                     if let Some(ref ls) = self.lambda_state {
-                        ls.write().default_mut().invocations.push(LambdaInvocation {
-                            function_arn: arn.clone(),
-                            payload: event_str.clone(),
-                            timestamp: now,
-                            source: "aws:events".to_string(),
-                        });
+                        ls.write()
+                            .get_or_create(&account_id)
+                            .invocations
+                            .push(LambdaInvocation {
+                                function_arn: arn.clone(),
+                                payload: event_str.clone(),
+                                timestamp: now,
+                                source: "aws:events".to_string(),
+                            });
                     }
                     crate::service::invoke_lambda_async(
                         &self.container_runtime,
@@ -284,7 +291,7 @@ impl Scheduler {
                         "Scheduler delivering to CloudWatch Logs"
                     );
                     let mut eb_accounts = self.state.write();
-                    let eb_state = eb_accounts.default_mut();
+                    let eb_state = eb_accounts.get_or_create(&account_id);
                     eb_state.log_deliveries.push(crate::state::LogDelivery {
                         log_group_arn: arn.clone(),
                         payload: event_str.clone(),
@@ -301,7 +308,7 @@ impl Scheduler {
                     );
                     self.delivery.start_stepfunctions_execution(arn, &event_str);
                     let mut eb_accounts = self.state.write();
-                    let eb_state = eb_accounts.default_mut();
+                    let eb_state = eb_accounts.get_or_create(&account_id);
                     eb_state
                         .step_function_executions
                         .push(crate::state::StepFunctionExecution {

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -158,7 +158,8 @@ impl Scheduler {
         let mut to_fire: Vec<(String, Vec<crate::state::EventTarget>)> = Vec::new();
 
         {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.default_mut();
             let rule_keys: Vec<crate::state::RuleKey> = state.rules.keys().cloned().collect();
 
             for key in rule_keys {
@@ -252,17 +253,18 @@ impl Scheduler {
                         payload = %event_str,
                         "Scheduler delivering to Lambda function"
                     );
-                    let mut state = self.state.write();
-                    state
+                    let mut eb_accounts = self.state.write();
+                    let eb_state = eb_accounts.default_mut();
+                    eb_state
                         .lambda_invocations
                         .push(crate::state::LambdaInvocation {
                             function_arn: arn.clone(),
                             payload: event_str.clone(),
                             timestamp: now,
                         });
-                    drop(state);
+                    drop(eb_accounts);
                     if let Some(ref ls) = self.lambda_state {
-                        ls.write().invocations.push(LambdaInvocation {
+                        ls.write().default_mut().invocations.push(LambdaInvocation {
                             function_arn: arn.clone(),
                             payload: event_str.clone(),
                             timestamp: now,
@@ -281,13 +283,14 @@ impl Scheduler {
                         payload = %event_str,
                         "Scheduler delivering to CloudWatch Logs"
                     );
-                    let mut state = self.state.write();
-                    state.log_deliveries.push(crate::state::LogDelivery {
+                    let mut eb_accounts = self.state.write();
+                    let eb_state = eb_accounts.default_mut();
+                    eb_state.log_deliveries.push(crate::state::LogDelivery {
                         log_group_arn: arn.clone(),
                         payload: event_str.clone(),
                         timestamp: now,
                     });
-                    drop(state);
+                    drop(eb_accounts);
                     if let Some(ref log_state) = self.logs_state {
                         crate::service::deliver_to_logs(log_state, arn, &event_str, now);
                     }
@@ -297,8 +300,9 @@ impl Scheduler {
                         "Scheduler delivering to Step Functions"
                     );
                     self.delivery.start_stepfunctions_execution(arn, &event_str);
-                    let mut state = self.state.write();
-                    state
+                    let mut eb_accounts = self.state.write();
+                    let eb_state = eb_accounts.default_mut();
+                    eb_state
                         .step_function_executions
                         .push(crate::state::StepFunctionExecution {
                             state_machine_arn: arn.clone(),
@@ -506,7 +510,13 @@ mod tests {
 
         fn make_state() -> (SharedEventBridgeState, EventBridgeState) {
             let state = EventBridgeState::new("123456789012", "us-east-1");
-            let shared = Arc::new(RwLock::new(state.clone()));
+            let shared = Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            ));
             (shared, state)
         }
 
@@ -549,7 +559,8 @@ mod tests {
         fn tick_disabled_rule_is_skipped() {
             let (shared, _) = make_state();
             {
-                let mut s = shared.write();
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
                 let mut rule = make_rule("r", "rate(1 second)", "arn:aws:sqs:us-east-1:123:q");
                 rule.state = "DISABLED".to_string();
                 s.rules
@@ -566,7 +577,8 @@ mod tests {
         fn tick_rule_without_targets_is_skipped() {
             let (shared, _) = make_state();
             {
-                let mut s = shared.write();
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
                 let mut rule = make_rule("r", "rate(1 second)", "arn:aws:sqs:us-east-1:123:q");
                 rule.targets.clear();
                 s.rules
@@ -583,7 +595,8 @@ mod tests {
         fn tick_invalid_schedule_is_skipped() {
             let (shared, _) = make_state();
             {
-                let mut s = shared.write();
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
                 let rule = make_rule("r", "bogus", "arn:aws:sqs:us-east-1:123:q");
                 s.rules
                     .insert(("default".to_string(), "r".to_string()), rule);
@@ -600,7 +613,8 @@ mod tests {
             let (shared, _) = make_state();
             let q_arn = "arn:aws:sqs:us-east-1:123456789012:q1".to_string();
             {
-                let mut s = shared.write();
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
                 let rule = make_rule("r", "rate(1 second)", &q_arn);
                 s.rules
                     .insert(("default".to_string(), "r".to_string()), rule);
@@ -622,7 +636,8 @@ mod tests {
             let (shared, _) = make_state();
             let topic_arn = "arn:aws:sns:us-east-1:123456789012:t1".to_string();
             {
-                let mut s = shared.write();
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
                 let rule = make_rule("r", "rate(1 second)", &topic_arn);
                 s.rules
                     .insert(("default".to_string(), "r".to_string()), rule);
@@ -641,7 +656,8 @@ mod tests {
             let (shared, _) = make_state();
             let sm_arn = "arn:aws:states:us-east-1:123456789012:stateMachine:m1".to_string();
             {
-                let mut s = shared.write();
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
                 let rule = make_rule("r", "rate(1 second)", &sm_arn);
                 s.rules
                     .insert(("default".to_string(), "r".to_string()), rule);
@@ -653,7 +669,9 @@ mod tests {
             let calls = recorder.stepfunctions.lock().unwrap();
             assert_eq!(calls.len(), 1);
             assert_eq!(calls[0].0, sm_arn);
-            let guard = shared.read();
+            let _mas = shared.read();
+            let guard = _mas.default_ref();
+
             assert_eq!(guard.step_function_executions.len(), 1);
         }
 
@@ -662,7 +680,8 @@ mod tests {
             let (shared, _) = make_state();
             let fn_arn = "arn:aws:lambda:us-east-1:123456789012:function:F".to_string();
             {
-                let mut s = shared.write();
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
                 let rule = make_rule("r", "rate(1 second)", &fn_arn);
                 s.rules
                     .insert(("default".to_string(), "r".to_string()), rule);
@@ -671,7 +690,9 @@ mod tests {
             let scheduler = build_scheduler(shared.clone(), recorder.clone());
             let mut last = HashMap::<RuleKey, (u32, u32)>::new();
             scheduler.tick(&mut last);
-            let guard = shared.read();
+            let _mas = shared.read();
+            let guard = _mas.default_ref();
+
             assert_eq!(guard.lambda_invocations.len(), 1);
             assert_eq!(guard.lambda_invocations[0].function_arn, fn_arn);
         }
@@ -681,7 +702,8 @@ mod tests {
             let (shared, _) = make_state();
             let lg_arn = "arn:aws:logs:us-east-1:123456789012:log-group:lg".to_string();
             {
-                let mut s = shared.write();
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
                 let rule = make_rule("r", "rate(1 second)", &lg_arn);
                 s.rules
                     .insert(("default".to_string(), "r".to_string()), rule);
@@ -690,7 +712,9 @@ mod tests {
             let scheduler = build_scheduler(shared.clone(), recorder.clone());
             let mut last = HashMap::<RuleKey, (u32, u32)>::new();
             scheduler.tick(&mut last);
-            let guard = shared.read();
+            let _mas = shared.read();
+            let guard = _mas.default_ref();
+
             assert_eq!(guard.log_deliveries.len(), 1);
             assert_eq!(guard.log_deliveries[0].log_group_arn, lg_arn);
         }
@@ -699,7 +723,8 @@ mod tests {
         fn tick_updates_last_fired() {
             let (shared, _) = make_state();
             {
-                let mut s = shared.write();
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
                 let rule = make_rule("r", "rate(1 second)", "arn:aws:sqs:us-east-1:123:q");
                 s.rules
                     .insert(("default".to_string(), "r".to_string()), rule);
@@ -708,7 +733,9 @@ mod tests {
             let scheduler = build_scheduler(shared.clone(), recorder.clone());
             let mut last = HashMap::<RuleKey, (u32, u32)>::new();
             scheduler.tick(&mut last);
-            let guard = shared.read();
+            let _mas = shared.read();
+            let guard = _mas.default_ref();
+
             let rule = guard
                 .rules
                 .get(&("default".to_string(), "r".to_string()))

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -20,8 +20,8 @@ use fakecloud_lambda::state::{LambdaInvocation, SharedLambdaState};
 use fakecloud_logs::state::SharedLogsState;
 
 use crate::state::{
-    ApiDestination, Archive, Connection, Endpoint, EventBridgeSnapshot, EventBus, EventRule,
-    EventTarget, PartnerEventSource, PutEvent, Replay, SharedEventBridgeState,
+    ApiDestination, Archive, Connection, Endpoint, EventBridgeSnapshot, EventBridgeState, EventBus,
+    EventRule, EventTarget, PartnerEventSource, PutEvent, Replay, SharedEventBridgeState,
     EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
 };
 
@@ -171,7 +171,8 @@ impl EventBridgeService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = EventBridgeSnapshot {
             schema_version: EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            accounts: Some(self.state.read().clone()),
+            state: None,
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -403,9 +404,11 @@ impl EventBridgeService {
         // Partner event bus validation
         if name.starts_with("aws.partner/") {
             let event_source = body["EventSourceName"].as_str().unwrap_or("");
-            let state_r = self.state.read();
+            let accounts_r = self.state.read();
+            let empty_r = EventBridgeState::new(&req.account_id, &req.region);
+            let state_r = accounts_r.get(&req.account_id).unwrap_or(&empty_r);
             let has_source = state_r.partner_event_sources.contains_key(event_source);
-            drop(state_r);
+            drop(accounts_r);
             if !has_source {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -415,7 +418,8 @@ impl EventBridgeService {
             }
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if state.buses.contains_key(&name) {
             return Err(AwsServiceError::aws_error(
@@ -466,7 +470,8 @@ impl EventBridgeService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.buses.remove(name);
         state.rules.retain(|k, _| k.0 != name);
 
@@ -490,7 +495,9 @@ impl EventBridgeService {
             })?;
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let filtered: Vec<&_> = state
             .buses
             .values()
@@ -518,7 +525,9 @@ impl EventBridgeService {
         validate_optional_string_length("name", body["Name"].as_str(), 1, 1600)?;
         let name = body["Name"].as_str().unwrap_or("default");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let bus = state.buses.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -560,7 +569,8 @@ impl EventBridgeService {
         validate_optional_string_length("statementId", body["StatementId"].as_str(), 1, 64)?;
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let bus = state.buses.get_mut(event_bus_name).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -622,7 +632,8 @@ impl EventBridgeService {
         let statement_id = body["StatementId"].as_str().unwrap_or("");
         let remove_all = body["RemoveAllPermissions"].as_bool().unwrap_or(false);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let bus = state.buses.get_mut(event_bus_name).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -698,7 +709,8 @@ impl EventBridgeService {
             .unwrap_or("default")
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let event_bus_name = state.resolve_bus_name(&raw_bus);
 
         let event_pattern = body["EventPattern"].as_str().and_then(|s| {
@@ -785,7 +797,8 @@ impl EventBridgeService {
         validate_optional_string_length("eventBusName", body["EventBusName"].as_str(), 1, 1600)?;
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let bus_name = state.resolve_bus_name(event_bus_name);
         let key = (bus_name, name.to_string());
 
@@ -815,7 +828,9 @@ impl EventBridgeService {
         let limit = body["Limit"].as_u64().map(|n| n as usize);
         let next_token = body["NextToken"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let bus_name = state.resolve_bus_name(event_bus_name);
 
         let mut rules: Vec<&EventRule> = state
@@ -887,7 +902,9 @@ impl EventBridgeService {
         validate_optional_string_length("eventBusName", body["EventBusName"].as_str(), 1, 1600)?;
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let bus_name = state.resolve_bus_name(event_bus_name);
         let key = (bus_name.clone(), name.to_string());
 
@@ -940,7 +957,8 @@ impl EventBridgeService {
         validate_optional_string_length("eventBusName", body["EventBusName"].as_str(), 1, 1600)?;
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let bus_name = state.resolve_bus_name(event_bus_name);
         let key = (bus_name, name.to_string());
 
@@ -964,7 +982,8 @@ impl EventBridgeService {
         validate_optional_string_length("eventBusName", body["EventBusName"].as_str(), 1, 1600)?;
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let bus_name = state.resolve_bus_name(event_bus_name);
         let key = (bus_name, name.to_string());
 
@@ -1021,7 +1040,8 @@ impl EventBridgeService {
             }
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let bus_name = state.resolve_bus_name(event_bus_name);
         let key = (bus_name.clone(), rule_name.to_string());
 
@@ -1061,7 +1081,8 @@ impl EventBridgeService {
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
             .collect();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let bus_name = state.resolve_bus_name(event_bus_name);
         let key = (bus_name.clone(), rule_name.to_string());
 
@@ -1093,7 +1114,9 @@ impl EventBridgeService {
         let limit = body["Limit"].as_u64().map(|n| n as usize);
         let next_token = body["NextToken"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let bus_name = state.resolve_bus_name(event_bus_name);
         let key = (bus_name, rule_name.to_string());
 
@@ -1146,7 +1169,9 @@ impl EventBridgeService {
         let limit = body["Limit"].as_u64().map(|n| n as usize);
         let next_token = body["NextToken"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let bus_name = state.resolve_bus_name(event_bus_name);
 
         // Deduplicate rule names
@@ -1205,7 +1230,8 @@ impl EventBridgeService {
             .to_string();
         validate_string_length("account", &account, 12, 12)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.partner_event_sources.contains_key(&name) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::CONFLICT,
@@ -1247,7 +1273,8 @@ impl EventBridgeService {
             .ok_or_else(|| missing("Account"))?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         match state.partner_event_sources.get(&name) {
             Some(ps) if ps.account == account => {
                 state.partner_event_sources.remove(&name);
@@ -1283,7 +1310,9 @@ impl EventBridgeService {
             .to_string();
         validate_string_length("name", &name, 1, 256)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let ps = state.partner_event_sources.get(&name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -1309,7 +1338,9 @@ impl EventBridgeService {
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all: Vec<Value> = state
             .partner_event_sources
             .values()
@@ -1344,7 +1375,9 @@ impl EventBridgeService {
         validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 2048)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let accounts: Vec<Value> = state
             .partner_event_sources
             .values()
@@ -1365,7 +1398,8 @@ impl EventBridgeService {
             .ok_or_else(|| missing("Name"))?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let ps = state.partner_event_sources.get_mut(&name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -1386,7 +1420,8 @@ impl EventBridgeService {
             .ok_or_else(|| missing("Name"))?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let ps = state.partner_event_sources.get_mut(&name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -1407,7 +1442,9 @@ impl EventBridgeService {
             .ok_or_else(|| missing("Name"))?
             .to_string();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let ps = state.partner_event_sources.get(&name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -1433,7 +1470,9 @@ impl EventBridgeService {
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all: Vec<Value> = state
             .partner_event_sources
             .values()
@@ -1552,7 +1591,8 @@ impl EventBridgeService {
         )?;
         let name = body["Name"].as_str().unwrap_or("default");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let bus = state.buses.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1600,7 +1640,8 @@ impl EventBridgeService {
         let event_buses = body["EventBuses"].as_array().cloned().unwrap_or_default();
         let role_arn = body["RoleArn"].as_str().map(|s| s.to_string());
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.endpoints.contains_key(&name) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::CONFLICT,
@@ -1658,7 +1699,8 @@ impl EventBridgeService {
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.endpoints.remove(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1675,7 +1717,9 @@ impl EventBridgeService {
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let ep = state.endpoints.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1719,7 +1763,9 @@ impl EventBridgeService {
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["MaxResults"].as_i64().unwrap_or(100) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all: Vec<Value> = state
             .endpoints
             .values()
@@ -1759,7 +1805,8 @@ impl EventBridgeService {
         validate_required("Name", &body["Name"])?;
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let ep = state.endpoints.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1805,7 +1852,8 @@ impl EventBridgeService {
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let conn = state.connections.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1854,7 +1902,8 @@ impl EventBridgeService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mut result_entries = Vec::new();
         let mut events_to_deliver = Vec::new();
         let mut failed_count = 0;
@@ -1897,7 +1946,7 @@ impl EventBridgeService {
             };
 
             archive_matching_event(
-                &mut state,
+                state,
                 &event,
                 &event_bus_name,
                 &source,
@@ -1946,7 +1995,7 @@ impl EventBridgeService {
         }
 
         // Drop the lock before delivering
-        drop(state);
+        drop(accounts);
 
         // Deliver to targets
         for (event_id, source, detail_type, detail, time, resources, targets) in events_to_deliver {
@@ -2010,7 +2059,8 @@ impl EventBridgeService {
                         "EventBridge delivering to Lambda function"
                     );
                     let now = Utc::now();
-                    let mut state = self.state.write();
+                    let mut accounts = self.state.write();
+                    let state = accounts.get_or_create(&req.account_id);
                     state
                         .lambda_invocations
                         .push(crate::state::LambdaInvocation {
@@ -2018,10 +2068,10 @@ impl EventBridgeService {
                             payload: body_str.clone(),
                             timestamp: now,
                         });
-                    drop(state);
+                    drop(accounts);
                     // Record in Lambda state for cross-service visibility
                     if let Some(ref ls) = self.lambda_state {
-                        ls.write().invocations.push(LambdaInvocation {
+                        ls.write().default_mut().invocations.push(LambdaInvocation {
                             function_arn: arn.clone(),
                             payload: body_str.clone(),
                             timestamp: now,
@@ -2042,13 +2092,14 @@ impl EventBridgeService {
                         "EventBridge delivering to CloudWatch Logs"
                     );
                     let now = Utc::now();
-                    let mut state = self.state.write();
+                    let mut accounts = self.state.write();
+                    let state = accounts.get_or_create(&req.account_id);
                     state.log_deliveries.push(crate::state::LogDelivery {
                         log_group_arn: arn.clone(),
                         payload: body_str.clone(),
                         timestamp: now,
                     });
-                    drop(state);
+                    drop(accounts);
                     // Write event to CloudWatch Logs state
                     if let Some(ref log_state) = self.logs_state {
                         deliver_to_logs(log_state, arn, &body_str, now);
@@ -2066,7 +2117,8 @@ impl EventBridgeService {
                         "EventBridge delivering to Step Functions"
                     );
                     self.delivery.start_stepfunctions_execution(arn, &body_str);
-                    let mut state = self.state.write();
+                    let mut accounts = self.state.write();
+                    let state = accounts.get_or_create(&req.account_id);
                     state
                         .step_function_executions
                         .push(crate::state::StepFunctionExecution {
@@ -2076,7 +2128,9 @@ impl EventBridgeService {
                         });
                 } else if arn.contains(":api-destination/") {
                     // ApiDestination target: look up destination + connection, then POST
-                    let state = self.state.read();
+                    let accounts = self.state.read();
+                    let empty = EventBridgeState::new(&req.account_id, &req.region);
+                    let state = accounts.get(&req.account_id).unwrap_or(&empty);
                     let dest = state.api_destinations.values().find(|d| d.arn == *arn);
                     if let Some(dest) = dest {
                         let url = dest.invocation_endpoint.clone();
@@ -2086,7 +2140,7 @@ impl EventBridgeService {
                             .values()
                             .find(|c| c.arn == dest.connection_arn)
                             .cloned();
-                        drop(state);
+                        drop(accounts);
 
                         let payload = body_str.clone();
                         tokio::spawn(async move {
@@ -2159,8 +2213,9 @@ impl EventBridgeService {
         validate_string_length("resourceARN", arn, 1, 1600)?;
         validate_required("Tags", &body["Tags"])?;
 
-        let mut state = self.state.write();
-        let tag_map = find_tags_mut(&mut state, arn)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let tag_map = find_tags_mut(state, arn)?;
 
         fakecloud_core::tags::apply_tags(tag_map, &body, "Tags", "Key", "Value").map_err(|f| {
             AwsServiceError::aws_error(
@@ -2182,8 +2237,9 @@ impl EventBridgeService {
         validate_string_length("resourceARN", arn, 1, 1600)?;
         validate_required("TagKeys", &body["TagKeys"])?;
 
-        let mut state = self.state.write();
-        let tag_map = find_tags_mut(&mut state, arn)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let tag_map = find_tags_mut(state, arn)?;
 
         fakecloud_core::tags::remove_tags(tag_map, &body, "TagKeys").map_err(|f| {
             AwsServiceError::aws_error(
@@ -2204,8 +2260,10 @@ impl EventBridgeService {
             .ok_or_else(|| missing("ResourceARN"))?;
         validate_string_length("resourceARN", arn, 1, 1600)?;
 
-        let state = self.state.read();
-        let tag_map = find_tags(&state, arn)?;
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let tag_map = find_tags(state, arn)?;
 
         let tags = fakecloud_core::tags::tags_to_json(tag_map, "Key", "Value");
 
@@ -2242,7 +2300,8 @@ impl EventBridgeService {
             validate_event_pattern(pattern)?;
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Validate event bus exists
         let bus_name = state.resolve_bus_name(&event_source_arn);
@@ -2352,7 +2411,9 @@ impl EventBridgeService {
             .ok_or_else(|| missing("ArchiveName"))?;
         validate_string_length("archiveName", name, 1, 48)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let archive = state.archives.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2437,7 +2498,9 @@ impl EventBridgeService {
 
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all: Vec<Value> = state
             .archives
             .values()
@@ -2492,7 +2555,8 @@ impl EventBridgeService {
             validate_event_pattern(pattern)?;
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let archive = state.archives.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2526,7 +2590,8 @@ impl EventBridgeService {
             .ok_or_else(|| missing("ArchiveName"))?;
         validate_string_length("archiveName", name, 1, 48)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if !state.archives.contains_key(name) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2575,7 +2640,8 @@ impl EventBridgeService {
         validate_required("AuthParameters", &body["AuthParameters"])?;
         let auth_params = body["AuthParameters"].clone();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let now = Utc::now();
         let conn_uuid = uuid::Uuid::new_v4();
         let arn = format!(
@@ -2615,7 +2681,9 @@ impl EventBridgeService {
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let conn = state.connections.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2671,7 +2739,9 @@ impl EventBridgeService {
         let connection_state = body["ConnectionState"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all: Vec<Value> = state
             .connections
             .values()
@@ -2722,7 +2792,8 @@ impl EventBridgeService {
             &["BASIC", "OAUTH_CLIENT_CREDENTIALS", "API_KEY"],
         )?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let conn = state.connections.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2757,7 +2828,8 @@ impl EventBridgeService {
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let conn = state.connections.remove(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2814,7 +2886,8 @@ impl EventBridgeService {
             validate_range_i64("invocationRateLimitPerSecond", r, 1, i64::MAX)?;
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let now = Utc::now();
         let dest_uuid = uuid::Uuid::new_v4();
         let arn = format!(
@@ -2850,7 +2923,9 @@ impl EventBridgeService {
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let dest = state.api_destinations.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2890,7 +2965,9 @@ impl EventBridgeService {
         let connection_arn = body["ConnectionArn"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all: Vec<Value> = state
             .api_destinations
             .values()
@@ -2956,7 +3033,8 @@ impl EventBridgeService {
             validate_range_i64("invocationRateLimitPerSecond", r, 1, i64::MAX)?;
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let dest = state.api_destinations.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2996,7 +3074,8 @@ impl EventBridgeService {
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_string_length("name", name, 1, 64)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if !state.api_destinations.contains_key(name) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -3014,7 +3093,8 @@ impl EventBridgeService {
     fn start_replay(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let input = StartReplayInput::from_body(&req.json_body())?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Validate event bus + archive, in the order the real service validates them.
         let bus_name = state.resolve_bus_name(&input.destination_arn);
@@ -3072,7 +3152,7 @@ impl EventBridgeService {
         );
 
         let events_to_deliver = collect_replay_events_with_targets(
-            &state,
+            state,
             &archive_name,
             &bus_name,
             input.event_start_time,
@@ -3095,7 +3175,7 @@ impl EventBridgeService {
         };
         state.replays.insert(input.name, replay);
 
-        drop(state);
+        drop(accounts);
 
         for (event, targets) in events_to_deliver {
             let detail_value: Value = serde_json::from_str(&event.detail).unwrap_or(json!({}));
@@ -3167,7 +3247,8 @@ impl EventBridgeService {
             self.delivery
                 .publish_to_sns(target_arn, &body_str, Some(&event.detail_type));
         } else if target_arn.contains(":lambda:") {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.default_mut();
             state
                 .lambda_invocations
                 .push(crate::state::LambdaInvocation {
@@ -3175,9 +3256,9 @@ impl EventBridgeService {
                     payload: body_str.clone(),
                     timestamp: Utc::now(),
                 });
-            drop(state);
+            drop(accounts);
             if let Some(ref ls) = self.lambda_state {
-                ls.write().invocations.push(LambdaInvocation {
+                ls.write().default_mut().invocations.push(LambdaInvocation {
                     function_arn: target_arn.clone(),
                     payload: body_str.clone(),
                     timestamp: Utc::now(),
@@ -3191,20 +3272,22 @@ impl EventBridgeService {
                 &body_str,
             );
         } else if target_arn.contains(":logs:") {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.default_mut();
             state.log_deliveries.push(crate::state::LogDelivery {
                 log_group_arn: target_arn.clone(),
                 payload: body_str.clone(),
                 timestamp: Utc::now(),
             });
-            drop(state);
+            drop(accounts);
             if let Some(ref log_state) = self.logs_state {
                 deliver_to_logs(log_state, target_arn, &body_str, Utc::now());
             }
         } else if target_arn.contains(":states:") {
             self.delivery
                 .start_stepfunctions_execution(target_arn, &body_str);
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.default_mut();
             state
                 .step_function_executions
                 .push(crate::state::StepFunctionExecution {
@@ -3235,7 +3318,9 @@ impl EventBridgeService {
             .ok_or_else(|| missing("ReplayName"))?;
         validate_string_length("replayName", name, 1, 64)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let replay = state.replays.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -3320,7 +3405,9 @@ impl EventBridgeService {
 
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = EventBridgeState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all: Vec<Value> = state
             .replays
             .values()
@@ -3368,7 +3455,8 @@ impl EventBridgeService {
             .ok_or_else(|| missing("ReplayName"))?;
         validate_string_length("replayName", name, 1, 64)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let replay = state.replays.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -3948,7 +4036,8 @@ pub fn invoke_lambda_async(
 
     tokio::spawn(async move {
         let func = {
-            let state = lambda_state.read();
+            let accounts = lambda_state.read();
+            let state = accounts.default_ref();
             state.functions.get(&func_name).cloned()
         };
         let func = match func {
@@ -3999,7 +4088,8 @@ pub fn deliver_to_logs(
     let stream_name = "events".to_string();
     let ts_millis = timestamp.timestamp_millis();
 
-    let mut state = logs_state.write();
+    let mut accounts = logs_state.write();
+    let state = accounts.default_mut();
     let region = state.region.clone();
     let account_id = state.account_id.clone();
 
@@ -4411,15 +4501,13 @@ mod tests {
 
     // ---- list_connections / list_api_destinations filtering & pagination ----
 
-    use crate::state::EventBridgeState;
     use fakecloud_core::delivery::DeliveryBus;
     use parking_lot::RwLock;
 
     fn make_service() -> EventBridgeService {
-        let state = Arc::new(RwLock::new(EventBridgeState::new(
-            "123456789012",
-            "us-east-1",
-        )));
+        let state = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let delivery = Arc::new(DeliveryBus::new());
         EventBridgeService::new(state, delivery)
     }
@@ -4463,7 +4551,8 @@ mod tests {
 
     fn create_api_destination(svc: &EventBridgeService, name: &str, conn_name: &str) {
         let conn_arn_field = {
-            let state = svc.state.read();
+            let _mas = svc.state.read();
+            let state = _mas.default_ref();
             state.connections.get(conn_name).unwrap().arn.clone()
         };
         let req = make_request(
@@ -4522,7 +4611,8 @@ mod tests {
 
         // All connections start as AUTHORIZED; change one
         {
-            let mut state = svc.state.write();
+            let mut _mas = svc.state.write();
+            let state = _mas.default_mut();
             state
                 .connections
                 .get_mut("conn-b")
@@ -4637,7 +4727,8 @@ mod tests {
         create_api_destination(&svc, "dest-3", "conn-a");
 
         let conn_a_arn = {
-            let state = svc.state.read();
+            let _mas = svc.state.read();
+            let state = _mas.default_ref();
             state.connections.get("conn-a").unwrap().arn.clone()
         };
 
@@ -4825,13 +4916,16 @@ mod tests {
     fn create_replay(svc: &EventBridgeService, name: &str) {
         // Need an archive first for the replay's event source
         let archive_arn = {
-            let state = svc.state.read();
-            if state.archives.contains_key("replay-archive") {
-                state.archives["replay-archive"].arn.clone()
+            let guard = svc.state.read();
+            let st = guard.default_ref();
+            if st.archives.contains_key("replay-archive") {
+                st.archives["replay-archive"].arn.clone()
             } else {
-                drop(state);
+                drop(guard);
                 create_archive(svc, "replay-archive");
-                svc.state.read().archives["replay-archive"].arn.clone()
+                svc.state.read().default_ref().archives["replay-archive"]
+                    .arn
+                    .clone()
             }
         };
         let req = make_request(
@@ -5173,7 +5267,8 @@ mod tests {
         );
         svc.deactivate_event_source(&req).unwrap();
         {
-            let state = svc.state.read();
+            let _mas = svc.state.read();
+            let state = _mas.default_ref();
             assert_eq!(
                 state.partner_event_sources["aws.partner/test"].state,
                 "INACTIVE"
@@ -5184,7 +5279,8 @@ mod tests {
         let req = make_request("ActivateEventSource", json!({ "Name": "aws.partner/test" }));
         svc.activate_event_source(&req).unwrap();
         {
-            let state = svc.state.read();
+            let _mas = svc.state.read();
+            let state = _mas.default_ref();
             assert_eq!(
                 state.partner_event_sources["aws.partner/test"].state,
                 "ACTIVE"
@@ -5220,6 +5316,7 @@ mod tests {
         assert!(svc
             .state
             .read()
+            .default_ref()
             .partner_event_sources
             .contains_key("aws.partner/test"));
 
@@ -5232,6 +5329,7 @@ mod tests {
         assert!(!svc
             .state
             .read()
+            .default_ref()
             .partner_event_sources
             .contains_key("aws.partner/test"));
 
@@ -5290,10 +5388,9 @@ mod tests {
 
         let messages: Arc<parking_lot::Mutex<Vec<(String, String)>>> =
             Arc::new(parking_lot::Mutex::new(Vec::new()));
-        let state = Arc::new(RwLock::new(EventBridgeState::new(
-            "123456789012",
-            "us-east-1",
-        )));
+        let state = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let delivery = Arc::new(DeliveryBus::new().with_sqs(Arc::new(RecordingSqsDelivery {
             messages: messages.clone(),
         })));
@@ -5365,7 +5462,8 @@ mod tests {
 
         // Verify archive has 2 events
         {
-            let state = svc.state.read();
+            let _mas = svc.state.read();
+            let state = _mas.default_ref();
             let archive = state.archives.get("test-archive").unwrap();
             assert_eq!(archive.events.len(), 2);
             assert_eq!(archive.event_count, 2);
@@ -5376,7 +5474,8 @@ mod tests {
 
         // StartReplay: should re-deliver the archived events
         let archive_arn = {
-            let state = svc.state.read();
+            let _mas = svc.state.read();
+            let state = _mas.default_ref();
             state.archives.get("test-archive").unwrap().arn.clone()
         };
 
@@ -5416,7 +5515,8 @@ mod tests {
         }
 
         // Verify replay is marked as COMPLETED
-        let state = svc.state.read();
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
         let replay = state.replays.get("my-replay").unwrap();
         assert_eq!(replay.state, "COMPLETED");
     }
@@ -5502,17 +5602,17 @@ mod tests {
         // This test verifies that the PutEvents code path correctly identifies
         // api-destination ARN targets and resolves the destination metadata.
         // The actual HTTP call goes to a non-existent host (fire-and-forget).
-        let state = Arc::new(RwLock::new(EventBridgeState::new(
-            "123456789012",
-            "us-east-1",
-        )));
+        let state = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let delivery = Arc::new(DeliveryBus::new());
         let svc = EventBridgeService::new(state, delivery);
 
         // Create connection and api destination
         create_connection(&svc, "my-conn");
         let conn_arn = {
-            let state = svc.state.read();
+            let _mas = svc.state.read();
+            let state = _mas.default_ref();
             state.connections.get("my-conn").unwrap().arn.clone()
         };
         let req = make_request(
@@ -5527,7 +5627,8 @@ mod tests {
         svc.create_api_destination(&req).unwrap();
 
         let dest_arn = {
-            let state = svc.state.read();
+            let _mas = svc.state.read();
+            let state = _mas.default_ref();
             state.api_destinations.get("my-dest").unwrap().arn.clone()
         };
 
@@ -5608,7 +5709,8 @@ mod tests {
     fn put_rule_persists_event_pattern_and_state() {
         let svc = make_service();
         put_rule_simple(&svc, "r1");
-        let state = svc.state.read();
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
         let rule = state
             .rules
             .get(&("default".to_string(), "r1".to_string()))
@@ -5654,7 +5756,8 @@ mod tests {
         put_rule_simple(&svc, "r1");
         // Inject a target directly.
         {
-            let mut state = svc.state.write();
+            let mut _mas = svc.state.write();
+            let state = _mas.default_mut();
             let rule = state
                 .rules
                 .get_mut(&("default".to_string(), "r1".to_string()))
@@ -5675,7 +5778,8 @@ mod tests {
             json!({ "Name": "r1", "Description": "updated", "EventPattern": r#"{"source":["a"]}"# }),
         );
         svc.put_rule(&req).unwrap();
-        let state = svc.state.read();
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
         let rule = state
             .rules
             .get(&("default".to_string(), "r1".to_string()))
@@ -5721,6 +5825,7 @@ mod tests {
         assert!(!svc
             .state
             .read()
+            .default_ref()
             .rules
             .contains_key(&("default".to_string(), "r1".to_string())));
     }
@@ -5734,6 +5839,7 @@ mod tests {
         assert_eq!(
             svc.state
                 .read()
+                .default_ref()
                 .rules
                 .get(&("default".to_string(), "r1".to_string()))
                 .unwrap()
@@ -5745,6 +5851,7 @@ mod tests {
         assert_eq!(
             svc.state
                 .read()
+                .default_ref()
                 .rules
                 .get(&("default".to_string(), "r1".to_string()))
                 .unwrap()
@@ -5888,7 +5995,8 @@ mod tests {
         );
         svc.put_targets(&second).unwrap();
 
-        let state = svc.state.read();
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
         let rule = state
             .rules
             .get(&("default".to_string(), "r1".to_string()))
@@ -5963,6 +6071,7 @@ mod tests {
         let arn = svc
             .state
             .read()
+            .default_ref()
             .rules
             .get(&("default".to_string(), "r1".to_string()))
             .unwrap()
@@ -5994,6 +6103,7 @@ mod tests {
         let arn = svc
             .state
             .read()
+            .default_ref()
             .rules
             .get(&("default".to_string(), "r1".to_string()))
             .unwrap()
@@ -6014,7 +6124,8 @@ mod tests {
         );
         svc.untag_resource(&untag).unwrap();
 
-        let state = svc.state.read();
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
         let rule = state
             .rules
             .get(&("default".to_string(), "r1".to_string()))
@@ -6654,13 +6765,14 @@ mod tests {
     fn create_api_destination_invalid_method_errors() {
         let svc = make_service();
         create_connection(&svc, "conn-m");
-        let state = svc.state.read();
-        let conn_arn = state
+        let guard = svc.state.read();
+        let st = guard.default_ref();
+        let conn_arn = st
             .connections
             .get("conn-m")
             .map(|c| c.arn.clone())
             .unwrap_or_default();
-        drop(state);
+        drop(guard);
 
         let req = make_request(
             "CreateApiDestination",

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -3194,7 +3194,13 @@ impl EventBridgeService {
             let event_str = event_json.to_string();
 
             for target in targets {
-                self.deliver_replay_event_to_target(&target, &event, &event_json, &event_str);
+                self.deliver_replay_event_to_target(
+                    &target,
+                    &event,
+                    &event_json,
+                    &event_str,
+                    &req.account_id,
+                );
             }
         }
 
@@ -3211,6 +3217,7 @@ impl EventBridgeService {
         event: &PutEvent,
         event_json: &Value,
         event_str: &str,
+        account_id: &str,
     ) {
         let target_arn = &target.arn;
         let body_str = if let Some(ref transformer) = target.input_transformer {
@@ -3248,7 +3255,7 @@ impl EventBridgeService {
                 .publish_to_sns(target_arn, &body_str, Some(&event.detail_type));
         } else if target_arn.contains(":lambda:") {
             let mut accounts = self.state.write();
-            let state = accounts.default_mut();
+            let state = accounts.get_or_create(account_id);
             state
                 .lambda_invocations
                 .push(crate::state::LambdaInvocation {
@@ -3258,12 +3265,15 @@ impl EventBridgeService {
                 });
             drop(accounts);
             if let Some(ref ls) = self.lambda_state {
-                ls.write().default_mut().invocations.push(LambdaInvocation {
-                    function_arn: target_arn.clone(),
-                    payload: body_str.clone(),
-                    timestamp: Utc::now(),
-                    source: "aws:events".to_string(),
-                });
+                ls.write()
+                    .get_or_create(account_id)
+                    .invocations
+                    .push(LambdaInvocation {
+                        function_arn: target_arn.clone(),
+                        payload: body_str.clone(),
+                        timestamp: Utc::now(),
+                        source: "aws:events".to_string(),
+                    });
             }
             invoke_lambda_async(
                 &self.container_runtime,
@@ -3273,7 +3283,7 @@ impl EventBridgeService {
             );
         } else if target_arn.contains(":logs:") {
             let mut accounts = self.state.write();
-            let state = accounts.default_mut();
+            let state = accounts.get_or_create(account_id);
             state.log_deliveries.push(crate::state::LogDelivery {
                 log_group_arn: target_arn.clone(),
                 payload: body_str.clone(),
@@ -3287,7 +3297,7 @@ impl EventBridgeService {
             self.delivery
                 .start_stepfunctions_execution(target_arn, &body_str);
             let mut accounts = self.state.write();
-            let state = accounts.default_mut();
+            let state = accounts.get_or_create(account_id);
             state
                 .step_function_executions
                 .push(crate::state::StepFunctionExecution {

--- a/crates/fakecloud-eventbridge/src/simulation.rs
+++ b/crates/fakecloud-eventbridge/src/simulation.rs
@@ -47,23 +47,24 @@ pub fn fire_rule(
     let container_runtime = ctx.container_runtime;
 
     let (targets, account_id, region) = {
-        let state = state.read();
+        let eb_accounts = state.read();
+        let eb_state = eb_accounts.default_ref();
 
         // Verify bus exists
-        if !state.buses.contains_key(bus_name) {
+        if !eb_state.buses.contains_key(bus_name) {
             return Err(format!("Event bus '{bus_name}' not found"));
         }
 
         let key = (bus_name.to_string(), rule_name.to_string());
-        let rule = match state.rules.get(&key) {
+        let rule = match eb_state.rules.get(&key) {
             Some(r) => r,
             None => return Err(format!("Rule '{rule_name}' not found on bus '{bus_name}'")),
         };
 
         (
             rule.targets.clone(),
-            state.account_id.clone(),
-            state.region.clone(),
+            eb_state.account_id.clone(),
+            eb_state.region.clone(),
         )
     };
 
@@ -90,7 +91,8 @@ pub fn fire_rule(
 
     // Record the event in state
     {
-        let mut s = state.write();
+        let mut s_accounts = state.write();
+        let s = s_accounts.default_mut();
         s.events.push(crate::state::PutEvent {
             event_id: event_id.clone(),
             source: "aws.events".to_string(),
@@ -138,15 +140,16 @@ pub fn fire_rule(
                 arn: arn.clone(),
             });
         } else if arn.contains(":lambda:") {
-            let mut s = state.write();
+            let mut s_accounts = state.write();
+            let s = s_accounts.default_mut();
             s.lambda_invocations.push(crate::state::LambdaInvocation {
                 function_arn: arn.clone(),
                 payload: body_str.clone(),
                 timestamp: now,
             });
-            drop(s);
+            drop(s_accounts);
             if let Some(ref ls) = lambda_state {
-                ls.write().invocations.push(LambdaInvocation {
+                ls.write().default_mut().invocations.push(LambdaInvocation {
                     function_arn: arn.clone(),
                     payload: body_str.clone(),
                     timestamp: now,
@@ -159,13 +162,14 @@ pub fn fire_rule(
                 arn: arn.clone(),
             });
         } else if arn.contains(":logs:") {
-            let mut s = state.write();
+            let mut s_accounts = state.write();
+            let s = s_accounts.default_mut();
             s.log_deliveries.push(crate::state::LogDelivery {
                 log_group_arn: arn.clone(),
                 payload: body_str.clone(),
                 timestamp: now,
             });
-            drop(s);
+            drop(s_accounts);
             if let Some(ref log_state) = logs_state {
                 crate::service::deliver_to_logs(log_state, arn, &body_str, now);
             }
@@ -216,14 +220,13 @@ fn resolve_target_body(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{EventBridgeState, EventRule};
+    use crate::state::EventRule;
     use parking_lot::RwLock;
 
     fn make_state() -> SharedEventBridgeState {
-        Arc::new(RwLock::new(EventBridgeState::new(
-            "123456789012",
-            "us-east-1",
-        )))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ))
     }
 
     fn add_rule(
@@ -233,7 +236,8 @@ mod tests {
         enabled: bool,
         targets: Vec<EventTarget>,
     ) {
-        let mut s = state.write();
+        let mut s_accounts = state.write();
+        let s = s_accounts.default_mut();
         let key = (bus.to_string(), name.to_string());
         s.rules.insert(
             key,
@@ -292,7 +296,8 @@ mod tests {
         );
 
         // Verify event was recorded
-        let s = state.read();
+        let s_accounts = state.read();
+        let s = s_accounts.default_ref();
         assert!(s.events.iter().any(|e| e.source == "aws.events"));
     }
 

--- a/crates/fakecloud-eventbridge/src/state.rs
+++ b/crates/fakecloud-eventbridge/src/state.rs
@@ -303,7 +303,14 @@ impl EventBridgeState {
     }
 }
 
-pub type SharedEventBridgeState = Arc<RwLock<EventBridgeState>>;
+pub type SharedEventBridgeState =
+    Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<EventBridgeState>>>;
+
+impl fakecloud_core::multi_account::AccountState for EventBridgeState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -357,7 +364,10 @@ mod tests {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventBridgeSnapshot {
     pub schema_version: u32,
-    pub state: EventBridgeState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<EventBridgeState>>,
+    #[serde(default)]
+    pub state: Option<EventBridgeState>,
 }
 
-pub const EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION: u32 = 2;

--- a/crates/fakecloud-lambda/src/resource_policy.rs
+++ b/crates/fakecloud-lambda/src/resource_policy.rs
@@ -46,7 +46,10 @@ impl ResourcePolicyProvider for LambdaResourcePolicyProvider {
             return None;
         }
         let function_name = parse_function_name(resource_arn)?;
-        let state = self.state.read();
+        // Extract account ID from ARN: arn:aws:lambda:REGION:ACCOUNT:function:NAME
+        let account_id = resource_arn.split(':').nth(4).unwrap_or("").to_string();
+        let accounts = self.state.read();
+        let state = accounts.get(&account_id)?;
         state
             .functions
             .get(function_name)
@@ -120,9 +123,12 @@ mod tests {
     }
 
     fn state_with(func: LambdaFunction) -> SharedLambdaState {
-        let mut s = LambdaState::new("123456789012", "us-east-1");
-        s.functions.insert(func.function_name.clone(), func);
-        Arc::new(RwLock::new(s))
+        let mut mas: fakecloud_core::multi_account::MultiAccountState<LambdaState> =
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", "");
+        mas.get_or_create("123456789012")
+            .functions
+            .insert(func.function_name.clone(), func);
+        Arc::new(RwLock::new(mas))
     }
 
     #[test]

--- a/crates/fakecloud-lambda/src/runtime.rs
+++ b/crates/fakecloud-lambda/src/runtime.rs
@@ -392,11 +392,12 @@ impl ContainerRuntime {
         lambda_state: &crate::state::SharedLambdaState,
     ) -> Vec<serde_json::Value> {
         let containers = self.containers.read();
-        let state = lambda_state.read();
+        let accounts = lambda_state.read();
+        let default_state = accounts.default_ref();
         containers
             .iter()
             .map(|(name, container)| {
-                let runtime = state
+                let runtime = default_state
                     .functions
                     .get(name)
                     .map(|f| f.runtime.clone())

--- a/crates/fakecloud-lambda/src/runtime.rs
+++ b/crates/fakecloud-lambda/src/runtime.rs
@@ -393,14 +393,12 @@ impl ContainerRuntime {
     ) -> Vec<serde_json::Value> {
         let containers = self.containers.read();
         let accounts = lambda_state.read();
-        let default_state = accounts.default_ref();
         containers
             .iter()
             .map(|(name, container)| {
-                let runtime = default_state
-                    .functions
-                    .get(name)
-                    .map(|f| f.runtime.clone())
+                let runtime = accounts
+                    .iter()
+                    .find_map(|(_, state)| state.functions.get(name).map(|f| f.runtime.clone()))
                     .unwrap_or_default();
                 let last_used = container.last_used.read();
                 let idle_secs = last_used.elapsed().as_secs();

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -284,9 +284,10 @@ impl LambdaService {
         &self,
         function_name: &str,
         account_id: &str,
+        region: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let accounts = self.state.read();
-        let empty = LambdaState::new(account_id, "");
+        let empty = LambdaState::new(account_id, region);
         let state = accounts.get(account_id).unwrap_or(&empty);
         let func = state.functions.get(function_name).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -889,7 +890,11 @@ impl AwsService for LambdaService {
         let result = match action {
             "CreateFunction" => self.create_function(&req),
             "ListFunctions" => self.list_functions(aid),
-            "GetFunction" => self.get_function(resource_name.as_deref().unwrap_or(""), aid),
+            "GetFunction" => self.get_function(
+                resource_name.as_deref().unwrap_or(""),
+                aid,
+                req.region.as_str(),
+            ),
             "DeleteFunction" => self.delete_function(resource_name.as_deref().unwrap_or(""), aid),
             "Invoke" => {
                 self.invoke(resource_name.as_deref().unwrap_or(""), &req.body, aid)
@@ -1693,7 +1698,9 @@ mod tests {
     #[tokio::test]
     async fn get_function_unknown_errors() {
         let svc = LambdaService::new(make_state());
-        assert!(svc.get_function("ghost", "123456789012").is_err());
+        assert!(svc
+            .get_function("ghost", "123456789012", "us-east-1")
+            .is_err());
     }
 
     #[tokio::test]

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -13,7 +13,7 @@ use fakecloud_persistence::SnapshotStore;
 
 use crate::runtime::ContainerRuntime;
 use crate::state::{
-    EventSourceMapping, LambdaFunction, LambdaSnapshot, SharedLambdaState,
+    EventSourceMapping, LambdaFunction, LambdaSnapshot, LambdaState, SharedLambdaState,
     LAMBDA_SNAPSHOT_SCHEMA_VERSION,
 };
 
@@ -148,7 +148,8 @@ impl LambdaService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = LambdaSnapshot {
             schema_version: LAMBDA_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            accounts: Some(self.state.read().clone()),
+            state: None,
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -225,7 +226,8 @@ impl LambdaService {
         let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
         let input = CreateFunctionInput::from_body(&body)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if state.functions.contains_key(&input.function_name) {
             return Err(AwsServiceError::aws_error(
@@ -278,8 +280,14 @@ impl LambdaService {
         Ok(AwsResponse::json(StatusCode::CREATED, response.to_string()))
     }
 
-    fn get_function(&self, function_name: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    fn get_function(
+        &self,
+        function_name: &str,
+        account_id: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = LambdaState::new(account_id, "");
+        let state = accounts.get(account_id).unwrap_or(&empty);
         let func = state.functions.get(function_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -306,8 +314,13 @@ impl LambdaService {
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
     }
 
-    fn delete_function(&self, function_name: &str) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+    fn delete_function(
+        &self,
+        function_name: &str,
+        account_id: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
         let region = state.region.clone();
         let account_id = state.account_id.clone();
         if state.functions.remove(function_name).is_none() {
@@ -331,8 +344,10 @@ impl LambdaService {
         Ok(AwsResponse::json(StatusCode::NO_CONTENT, ""))
     }
 
-    fn list_functions(&self) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    fn list_functions(&self, account_id: &str) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = LambdaState::new(account_id, "");
+        let state = accounts.get(account_id).unwrap_or(&empty);
         let functions: Vec<Value> = state
             .functions
             .values()
@@ -350,9 +365,12 @@ impl LambdaService {
         &self,
         function_name: &str,
         payload: &[u8],
+        account_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let func = {
-            let state = self.state.read();
+            let accounts = self.state.read();
+            let empty = LambdaState::new(account_id, "");
+            let state = accounts.get(account_id).unwrap_or(&empty);
             state.functions.get(function_name).cloned().ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::NOT_FOUND,
@@ -401,8 +419,14 @@ impl LambdaService {
         }
     }
 
-    fn publish_version(&self, function_name: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    fn publish_version(
+        &self,
+        function_name: &str,
+        account_id: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = LambdaState::new(account_id, "");
+        let state = accounts.get(account_id).unwrap_or(&empty);
         let func = state.functions.get(function_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -449,7 +473,8 @@ impl LambdaService {
             })?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Resolve function name to ARN
         let function_arn = if function_name.starts_with("arn:") {
@@ -496,8 +521,10 @@ impl LambdaService {
         ))
     }
 
-    fn list_event_source_mappings(&self) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    fn list_event_source_mappings(&self, account_id: &str) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = LambdaState::new(account_id, "");
+        let state = accounts.get(account_id).unwrap_or(&empty);
         let mappings: Vec<Value> = state
             .event_source_mappings
             .values()
@@ -511,8 +538,14 @@ impl LambdaService {
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
     }
 
-    fn get_event_source_mapping(&self, uuid: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    fn get_event_source_mapping(
+        &self,
+        uuid: &str,
+        account_id: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = LambdaState::new(account_id, "");
+        let state = accounts.get(account_id).unwrap_or(&empty);
         let mapping = state.event_source_mappings.get(uuid).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -525,8 +558,13 @@ impl LambdaService {
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
     }
 
-    fn delete_event_source_mapping(&self, uuid: &str) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+    fn delete_event_source_mapping(
+        &self,
+        uuid: &str,
+        account_id: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
         let mapping = state.event_source_mappings.remove(uuid).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -643,7 +681,8 @@ impl LambdaService {
             .and_then(|v| v.as_str())
             .map(str::to_string);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let func = state.functions.get_mut(function_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -736,8 +775,10 @@ impl LambdaService {
         &self,
         function_name: &str,
         statement_id: &str,
+        account_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
         let func = state.functions.get_mut(function_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -785,8 +826,14 @@ impl LambdaService {
         Ok(AwsResponse::json(StatusCode::NO_CONTENT, String::new()))
     }
 
-    fn get_policy(&self, function_name: &str) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    fn get_policy(
+        &self,
+        function_name: &str,
+        account_id: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = LambdaState::new(account_id, "");
+        let state = accounts.get(account_id).unwrap_or(&empty);
         let func = state.functions.get(function_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -838,30 +885,31 @@ impl AwsService for LambdaService {
                 | "DeleteEventSourceMapping"
         );
 
+        let aid = &req.account_id;
         let result = match action {
             "CreateFunction" => self.create_function(&req),
-            "ListFunctions" => self.list_functions(),
-            "GetFunction" => self.get_function(resource_name.as_deref().unwrap_or("")),
-            "DeleteFunction" => self.delete_function(resource_name.as_deref().unwrap_or("")),
+            "ListFunctions" => self.list_functions(aid),
+            "GetFunction" => self.get_function(resource_name.as_deref().unwrap_or(""), aid),
+            "DeleteFunction" => self.delete_function(resource_name.as_deref().unwrap_or(""), aid),
             "Invoke" => {
-                self.invoke(resource_name.as_deref().unwrap_or(""), &req.body)
+                self.invoke(resource_name.as_deref().unwrap_or(""), &req.body, aid)
                     .await
             }
-            "PublishVersion" => self.publish_version(resource_name.as_deref().unwrap_or("")),
+            "PublishVersion" => self.publish_version(resource_name.as_deref().unwrap_or(""), aid),
             "AddPermission" => self.add_permission(resource_name.as_deref().unwrap_or(""), &req),
-            "GetPolicy" => self.get_policy(resource_name.as_deref().unwrap_or("")),
+            "GetPolicy" => self.get_policy(resource_name.as_deref().unwrap_or(""), aid),
             "RemovePermission" => {
                 // Path: /2015-03-31/functions/{name}/policy/{sid}
                 let sid = req.path_segments.get(4).cloned().unwrap_or_default();
-                self.remove_permission(resource_name.as_deref().unwrap_or(""), &sid)
+                self.remove_permission(resource_name.as_deref().unwrap_or(""), &sid, aid)
             }
             "CreateEventSourceMapping" => self.create_event_source_mapping(&req),
-            "ListEventSourceMappings" => self.list_event_source_mappings(),
+            "ListEventSourceMappings" => self.list_event_source_mappings(aid),
             "GetEventSourceMapping" => {
-                self.get_event_source_mapping(resource_name.as_deref().unwrap_or(""))
+                self.get_event_source_mapping(resource_name.as_deref().unwrap_or(""), aid)
             }
             "DeleteEventSourceMapping" => {
-                self.delete_event_source_mapping(resource_name.as_deref().unwrap_or(""))
+                self.delete_event_source_mapping(resource_name.as_deref().unwrap_or(""), aid)
             }
             _ => Err(AwsServiceError::action_not_implemented("lambda", action)),
         };
@@ -918,7 +966,9 @@ impl AwsService for LambdaService {
             "DeleteEventSourceMapping" => "DeleteEventSourceMapping",
             _ => return None,
         };
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = LambdaState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let resource = match action {
             "GetFunction" | "DeleteFunction" | "InvokeFunction" | "PublishVersion"
             | "AddPermission" | "RemovePermission" | "GetPolicy" => {
@@ -984,7 +1034,6 @@ impl AwsService for LambdaService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::LambdaState;
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
@@ -992,7 +1041,9 @@ mod tests {
     use std::sync::Arc;
 
     fn make_state() -> SharedLambdaState {
-        Arc::new(RwLock::new(LambdaState::new("123456789012", "us-east-1")))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ))
     }
 
     fn make_request(method: Method, path: &str, body: &str) -> AwsRequest {
@@ -1636,44 +1687,48 @@ mod tests {
     #[tokio::test]
     async fn publish_version_unknown_function_errors() {
         let svc = LambdaService::new(make_state());
-        assert!(svc.publish_version("ghost").is_err());
+        assert!(svc.publish_version("ghost", "123456789012").is_err());
     }
 
     #[tokio::test]
     async fn get_function_unknown_errors() {
         let svc = LambdaService::new(make_state());
-        assert!(svc.get_function("ghost").is_err());
+        assert!(svc.get_function("ghost", "123456789012").is_err());
     }
 
     #[tokio::test]
     async fn delete_function_unknown_errors() {
         let svc = LambdaService::new(make_state());
-        assert!(svc.delete_function("ghost").is_err());
+        assert!(svc.delete_function("ghost", "123456789012").is_err());
     }
 
     #[tokio::test]
     async fn get_event_source_mapping_unknown_errors() {
         let svc = LambdaService::new(make_state());
-        assert!(svc.get_event_source_mapping("ghost").is_err());
+        assert!(svc
+            .get_event_source_mapping("ghost", "123456789012")
+            .is_err());
     }
 
     #[tokio::test]
     async fn delete_event_source_mapping_unknown_errors() {
         let svc = LambdaService::new(make_state());
-        assert!(svc.delete_event_source_mapping("ghost").is_err());
+        assert!(svc
+            .delete_event_source_mapping("ghost", "123456789012")
+            .is_err());
     }
 
     #[tokio::test]
     async fn list_functions_empty_ok() {
         let svc = LambdaService::new(make_state());
-        let resp = svc.list_functions().unwrap();
+        let resp = svc.list_functions("123456789012").unwrap();
         assert_eq!(resp.status, http::StatusCode::OK);
     }
 
     #[tokio::test]
     async fn list_event_source_mappings_empty_ok() {
         let svc = LambdaService::new(make_state());
-        let resp = svc.list_event_source_mappings().unwrap();
+        let resp = svc.list_event_source_mappings("123456789012").unwrap();
         assert_eq!(resp.status, http::StatusCode::OK);
     }
 }

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -85,14 +85,24 @@ impl LambdaState {
     }
 }
 
-pub type SharedLambdaState = Arc<RwLock<LambdaState>>;
+pub type SharedLambdaState =
+    Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<LambdaState>>>;
 
-pub const LAMBDA_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+impl fakecloud_core::multi_account::AccountState for LambdaState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
+
+pub const LAMBDA_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LambdaSnapshot {
     pub schema_version: u32,
-    pub state: LambdaState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<LambdaState>>,
+    #[serde(default)]
+    pub state: Option<LambdaState>,
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-logs/src/service/anomaly.rs
+++ b/crates/fakecloud-logs/src/service/anomaly.rs
@@ -66,7 +66,8 @@ impl LogsService {
         let anomaly_visibility_time = body["anomalyVisibilityTime"].as_i64();
 
         let now = Utc::now().timestamp_millis();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let detector_id = uuid::Uuid::new_v4().to_string();
         let arn = format!(
             "arn:aws:logs:{}:{}:anomaly-detector:{}",
@@ -106,7 +107,9 @@ impl LogsService {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let detector = state.anomaly_detectors.get(arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -152,7 +155,8 @@ impl LogsService {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.anomaly_detectors.remove(arn).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -180,7 +184,9 @@ impl LogsService {
         let filter_log_group_arn = body["filterLogGroupArn"].as_str();
         let _limit = body["limit"].as_i64().unwrap_or(50);
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let detectors: Vec<Value> = state
             .anomaly_detectors
             .values()
@@ -241,7 +247,8 @@ impl LogsService {
         )?;
         let enabled = body["enabled"].as_bool().unwrap_or(true);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let detector = state.anomaly_detectors.get_mut(arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -68,7 +68,8 @@ impl LogsService {
             })
             .unwrap_or_default();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Check if updating - cannot change output format
         if let Some(existing) = state.delivery_destinations.get(&name) {
@@ -151,7 +152,9 @@ impl LogsService {
 
         validate_string_length("name", name, 1, 60)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let dd = state.delivery_destinations.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -183,7 +186,9 @@ impl LogsService {
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let dds: Vec<Value> = state
             .delivery_destinations
             .values()
@@ -221,7 +226,8 @@ impl LogsService {
 
         validate_string_length("name", name, 1, 60)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.delivery_destinations.remove(name).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -259,7 +265,8 @@ impl LogsService {
         validate_string_length("deliveryDestinationName", name, 1, 60)?;
         validate_string_length("deliveryDestinationPolicy", &policy, 1, 51200)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let dd = state.delivery_destinations.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -296,7 +303,9 @@ impl LogsService {
 
         validate_string_length("deliveryDestinationName", name, 1, 60)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let dd = state.delivery_destinations.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -337,7 +346,8 @@ impl LogsService {
 
         validate_string_length("deliveryDestinationName", name, 1, 60)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let dd = state.delivery_destinations.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -439,7 +449,8 @@ impl LogsService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Cannot update with different resourceArn
         if let Some(existing) = state.delivery_sources.get(&name) {
@@ -501,7 +512,9 @@ impl LogsService {
 
         validate_string_length("name", name, 1, 60)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let ds = state.delivery_sources.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -534,7 +547,9 @@ impl LogsService {
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let sources: Vec<Value> = state
             .delivery_sources
             .values()
@@ -571,7 +586,8 @@ impl LogsService {
 
         validate_string_length("name", name, 1, 60)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.delivery_sources.remove(name).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -631,7 +647,8 @@ impl LogsService {
         let field_delimiter = body["fieldDelimiter"].as_str().map(|s| s.to_string());
         let s3_delivery_config = body["s3DeliveryConfiguration"].clone();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify source exists
         if !state.delivery_sources.contains_key(&delivery_source_name) {
@@ -747,7 +764,9 @@ impl LogsService {
 
         validate_string_length("id", delivery_id, 1, 64)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let d = state.deliveries.get(delivery_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -780,7 +799,9 @@ impl LogsService {
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let deliveries: Vec<Value> = state
             .deliveries
             .values()
@@ -814,7 +835,8 @@ impl LogsService {
 
         validate_string_length("id", delivery_id, 1, 64)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.deliveries.remove(delivery_id).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -833,7 +855,9 @@ impl LogsService {
         let body = req.json_body();
         let id = require_str(&body, "id")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         if !state.deliveries.contains_key(id) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -841,7 +865,7 @@ impl LogsService {
                 format!("Delivery not found: {id}"),
             ));
         }
-        drop(state);
+        drop(accounts);
 
         // No-op: delivery configuration update is accepted but not stored
         Ok(AwsResponse::json(StatusCode::OK, "{}"))

--- a/crates/fakecloud-logs/src/service/destinations.rs
+++ b/crates/fakecloud-logs/src/service/destinations.rs
@@ -58,7 +58,8 @@ impl LogsService {
             })
             .unwrap_or_default();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let arn = format!(
             "arn:aws:logs:{}:{}:destination:{}",
             state.region, state.account_id, destination_name
@@ -113,7 +114,9 @@ impl LogsService {
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let destinations: Vec<Value> = state
             .destinations
             .values()
@@ -154,7 +157,8 @@ impl LogsService {
 
         validate_string_length("destinationName", name, 1, 512)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.destinations.remove(name).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -191,7 +195,8 @@ impl LogsService {
 
         validate_string_length("accessPolicy", policy, 1, 5120)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let dest = state.destinations.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-logs/src/service/exports.rs
+++ b/crates/fakecloud-logs/src/service/exports.rs
@@ -52,7 +52,9 @@ impl LogsService {
         )?;
         validate_string_length("destination", &destination, 1, 512)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         if !state.log_groups.contains_key(&log_group_name) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -60,7 +62,7 @@ impl LogsService {
                 "The specified log group does not exist.",
             ));
         }
-        drop(state);
+        drop(accounts);
 
         let task_name = body["taskName"].as_str().map(|s| s.to_string());
         let log_stream_name_prefix = body["logStreamNamePrefix"].as_str().map(|s| s.to_string());
@@ -76,7 +78,8 @@ impl LogsService {
         };
 
         // Collect matching events and write to export storage
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if from_time < to_time {
             if let Some(group) = state.log_groups.get(&log_group_name) {
                 let mut exported_lines: Vec<String> = Vec::new();
@@ -146,7 +149,9 @@ impl LogsService {
             ],
         )?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         if let Some(task_id) = task_id_filter {
             let task = state.export_tasks.iter().find(|t| t.task_id == task_id);
@@ -213,7 +218,8 @@ impl LogsService {
 
         validate_string_length("taskId", task_id, 1, 512)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let task = state
             .export_tasks
             .iter_mut()
@@ -241,7 +247,9 @@ impl LogsService {
         let body = req.json_body();
         let key_prefix = body["keyPrefix"].as_str().unwrap_or("");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let entries: Vec<Value> = state
             .export_storage
             .iter()

--- a/crates/fakecloud-logs/src/service/filters.rs
+++ b/crates/fakecloud-logs/src/service/filters.rs
@@ -55,7 +55,8 @@ impl LogsService {
         validate_string_length("filterName", &filter_name, 1, 512)?;
         validate_optional_string_length("filterPattern", Some(&filter_pattern), 0, 1024)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(log_group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -121,7 +122,9 @@ impl LogsService {
             512,
         )?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let group = state.log_groups.get(log_group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -180,7 +183,8 @@ impl LogsService {
         validate_string_length("logGroupName", log_group_name, 1, 512)?;
         validate_string_length("filterName", filter_name, 1, 512)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(log_group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -282,7 +286,8 @@ impl LogsService {
 
         let now = Utc::now().timestamp_millis();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Update existing or add new
         if let Some(existing) = state
@@ -322,7 +327,9 @@ impl LogsService {
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 2048)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let filters: Vec<Value> = state
             .metric_filters
             .iter()
@@ -409,7 +416,8 @@ impl LogsService {
         validate_string_length("filterName", filter_name, 1, 512)?;
         validate_string_length("logGroupName", log_group_name, 1, 512)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let idx = state
             .metric_filters
             .iter()

--- a/crates/fakecloud-logs/src/service/groups.rs
+++ b/crates/fakecloud-logs/src/service/groups.rs
@@ -33,7 +33,8 @@ impl LogsService {
         validate_string_length("logGroupName", &name, 1, 512)?;
         validate_optional_string_length("kmsKeyId", body["kmsKeyId"].as_str(), 1, 256)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.log_groups.contains_key(&name) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -101,7 +102,8 @@ impl LogsService {
 
         validate_string_length("logGroupName", name, 1, 512)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         // Check deletion protection
         if let Some(group) = state.log_groups.get(name) {
             if group.deletion_protection {
@@ -153,7 +155,9 @@ impl LogsService {
             &["STANDARD", "INFREQUENT_ACCESS", "DELIVERY"],
         )?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let mut groups: Vec<&LogGroup> = state
             .log_groups
             .values()
@@ -247,7 +251,8 @@ impl LogsService {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -276,7 +281,8 @@ impl LogsService {
 
         validate_string_length("logGroupName", name, 1, 512)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -318,7 +324,8 @@ impl LogsService {
 
         let resolved_name = resolve_log_group_name(log_group_name, resource_identifier)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state
             .log_groups
             .get_mut(resolved_name.as_str())
@@ -350,7 +357,8 @@ impl LogsService {
 
         let resolved_name = resolve_log_group_name(log_group_name, resource_identifier)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state
             .log_groups
             .get_mut(resolved_name.as_str())
@@ -395,7 +403,9 @@ impl LogsService {
             log_group_id.to_string()
         };
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         if !state.log_groups.contains_key(&group_name) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -445,7 +455,8 @@ impl LogsService {
             log_group_id
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -519,7 +530,9 @@ impl LogsService {
             &["STANDARD", "INFREQUENT_ACCESS", "DELIVERY"],
         )?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let mut groups: Vec<&LogGroup> = state
             .log_groups
             .values()
@@ -626,7 +639,8 @@ mod tests {
         );
         svc.associate_kms_key(&req).unwrap();
 
-        let state = svc.state.read();
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
         assert_eq!(
             state.log_groups["grp"].kms_key_id.as_deref(),
             Some("arn:aws:kms:us-east-1:123456789012:key/abc-123")
@@ -649,7 +663,8 @@ mod tests {
         let req = make_request("DisassociateKmsKey", json!({ "resourceIdentifier": "grp" }));
         svc.disassociate_kms_key(&req).unwrap();
 
-        let state = svc.state.read();
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
         assert!(state.log_groups["grp"].kms_key_id.is_none());
     }
 }

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -33,7 +33,8 @@ impl LogsService {
             creation_time: now,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.import_tasks.insert(import_id.clone(), task);
 
         Ok(AwsResponse::json(
@@ -56,7 +57,9 @@ impl LogsService {
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let tasks: Vec<Value> = state
             .import_tasks
             .values()
@@ -98,7 +101,8 @@ impl LogsService {
         let body = req.json_body();
         let import_id = require_str(&body, "importId")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         match state.import_tasks.get_mut(import_id) {
             Some(task) => {
                 task.status = "CANCELLED".to_string();
@@ -132,7 +136,8 @@ impl LogsService {
             creation_time: now,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state
             .integrations
             .insert(integration_name.to_string(), integration);
@@ -151,7 +156,9 @@ impl LogsService {
         let body = req.json_body();
         let integration_name = require_str(&body, "integrationName")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         match state.integrations.get(integration_name) {
             Some(i) => Ok(AwsResponse::json(
                 StatusCode::OK,
@@ -178,7 +185,8 @@ impl LogsService {
         let integration_name = require_str(&body, "integrationName")?;
         validate_string_length("integrationName", integration_name, 1, 50)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.integrations.remove(integration_name);
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
@@ -201,7 +209,9 @@ impl LogsService {
             &["PROVISIONING", "ACTIVE", "FAILED"],
         )?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let integrations: Vec<Value> = state
             .integrations
             .values()
@@ -233,10 +243,8 @@ impl LogsService {
         validate_optional_string_length("description", body["description"].as_str(), 0, 1024)?;
         validate_optional_string_length("kmsKeyId", body["kmsKeyId"].as_str(), 0, 256)?;
 
-        let state_r = self.state.read();
-        let account_id = state_r.account_id.clone();
-        let region = state_r.region.clone();
-        drop(state_r);
+        let account_id = req.account_id.clone();
+        let region = req.region.clone();
 
         let arn = Arn::new(
             "logs",
@@ -255,7 +263,8 @@ impl LogsService {
             last_modified_time: now,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.lookup_tables.insert(arn.clone(), table);
 
         Ok(AwsResponse::json(
@@ -271,7 +280,9 @@ impl LogsService {
         let body = req.json_body();
         let lookup_table_arn = require_str(&body, "lookupTableArn")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         match state.lookup_tables.get(lookup_table_arn) {
             Some(t) => Ok(AwsResponse::json(
                 StatusCode::OK,
@@ -306,7 +317,9 @@ impl LogsService {
         validate_optional_range_i64("maxResults", body["maxResults"].as_i64(), 1, 100)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let tables: Vec<Value> = state
             .lookup_tables
             .values()
@@ -330,7 +343,8 @@ impl LogsService {
         let body = req.json_body();
         let lookup_table_arn = require_str(&body, "lookupTableArn")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.lookup_tables.remove(lookup_table_arn);
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
@@ -343,7 +357,8 @@ impl LogsService {
         let lookup_table_arn = require_str(&body, "lookupTableArn")?;
         let table_body = require_str(&body, "tableBody")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         match state.lookup_tables.get_mut(lookup_table_arn) {
             Some(t) => {
                 t.table_body = table_body.to_string();
@@ -391,10 +406,8 @@ impl LogsService {
         )?;
         validate_optional_enum_value("state", &body["state"], &["ENABLED", "DISABLED"])?;
 
-        let state_r = self.state.read();
-        let account_id = state_r.account_id.clone();
-        let region = state_r.region.clone();
-        drop(state_r);
+        let account_id = req.account_id.clone();
+        let region = req.region.clone();
 
         let arn = Arn::new(
             "logs",
@@ -417,7 +430,8 @@ impl LogsService {
             last_modified_time: now,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.scheduled_queries.insert(arn.clone(), sq);
 
         Ok(AwsResponse::json(
@@ -433,7 +447,9 @@ impl LogsService {
         let body = req.json_body();
         let identifier = require_str(&body, "identifier")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         match state.scheduled_queries.get(identifier) {
             Some(sq) => Ok(AwsResponse::json(
                 StatusCode::OK,
@@ -483,7 +499,9 @@ impl LogsService {
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
         validate_optional_enum_value("state", &body["state"], &["ENABLED", "DISABLED"])?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let queries: Vec<Value> = state
             .scheduled_queries
             .values()
@@ -507,7 +525,8 @@ impl LogsService {
         let body = req.json_body();
         let identifier = require_str(&body, "identifier")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.scheduled_queries.remove(identifier);
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
@@ -523,7 +542,8 @@ impl LogsService {
         let schedule_expression = require_str(&body, "scheduleExpression")?;
         let execution_role_arn = require_str(&body, "executionRoleArn")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         match state.scheduled_queries.get_mut(identifier) {
             Some(sq) => {
                 sq.query_string = query_string.to_string();
@@ -582,7 +602,8 @@ impl LogsService {
             .as_bool()
             .unwrap_or(false);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state
             .bearer_token_auth
             .insert(log_group_identifier.to_string(), enabled);
@@ -628,7 +649,8 @@ impl LogsService {
             .unwrap_or("unknown")
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state
             .s3_table_sources
             .entry(integration_arn.to_string())
@@ -646,7 +668,9 @@ impl LogsService {
         validate_optional_range_i64("maxResults", body["maxResults"].as_i64(), 1, 100)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let sources: Vec<Value> = state
             .s3_table_sources
             .get(integration_arn)
@@ -737,7 +761,8 @@ mod tests {
 
         // Manually set query status to Running so we can test cancellation
         {
-            let mut state = svc.state.write();
+            let mut _mas = svc.state.write();
+            let state = _mas.default_mut();
             state.queries.get_mut(&qid).unwrap().status = "Running".to_string();
         }
 
@@ -746,7 +771,8 @@ mod tests {
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["success"], true);
 
-        let state = svc.state.read();
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
         assert_eq!(state.queries[&qid].status, "Cancelled");
     }
 
@@ -764,7 +790,8 @@ mod tests {
         );
         svc.put_log_group_deletion_protection(&req).unwrap();
 
-        let state = svc.state.read();
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
         assert!(state.log_groups["prot-group"].deletion_protection);
     }
 
@@ -1185,9 +1212,11 @@ mod tests {
         );
         svc.put_log_group_deletion_protection(&req).unwrap();
 
-        let state = svc.state.read();
-        assert!(state.log_groups["dp-toggle"].deletion_protection);
-        drop(state);
+        {
+            let _mas = svc.state.read();
+            let state = _mas.default_ref();
+            assert!(state.log_groups["dp-toggle"].deletion_protection);
+        }
 
         // Disable
         let req = make_request(
@@ -1199,7 +1228,8 @@ mod tests {
         );
         svc.put_log_group_deletion_protection(&req).unwrap();
 
-        let state = svc.state.read();
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
         assert!(!state.log_groups["dp-toggle"].deletion_protection);
     }
 

--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -115,7 +115,8 @@ impl LogsService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = LogsSnapshot {
             schema_version: LOGS_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            accounts: Some(self.state.read().clone()),
+            state: None,
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -693,7 +694,6 @@ fn resolve_json_path_simple<'a>(
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use super::*;
-    use crate::state::LogsState;
     use bytes::Bytes;
     use fakecloud_core::delivery::DeliveryBus;
     use http::{HeaderMap, Method};
@@ -701,10 +701,9 @@ pub(crate) mod test_helpers {
     use std::sync::Arc;
 
     pub fn make_service() -> LogsService {
-        let state = Arc::new(parking_lot::RwLock::new(LogsState::new(
-            "123456789012",
-            "us-east-1",
-        )));
+        let state = Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let delivery_bus = Arc::new(DeliveryBus::new());
         LogsService::new(state, delivery_bus)
     }

--- a/crates/fakecloud-logs/src/service/policies.rs
+++ b/crates/fakecloud-logs/src/service/policies.rs
@@ -42,7 +42,8 @@ impl LogsService {
 
         let now = Utc::now().timestamp_millis();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Check limit (10 per region) only if adding new
         if !state.resource_policies.contains_key(&policy_name)
@@ -88,7 +89,9 @@ impl LogsService {
             &body["policyScope"],
             &["ACCOUNT", "RESOURCE"],
         )?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         let mut policies: Vec<Value> = state
             .resource_policies
@@ -127,7 +130,8 @@ impl LogsService {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.resource_policies.remove(policy_name).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -181,7 +185,8 @@ impl LogsService {
         })?;
 
         let now = Utc::now().timestamp_millis();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let account_id = state.account_id.clone();
         let scope = body["scope"].as_str().map(|s| s.to_string());
         let selection_criteria = body["selectionCriteria"].as_str().map(|s| s.to_string());
@@ -247,7 +252,9 @@ impl LogsService {
         })?;
         let policy_name = body["policyName"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let policies: Vec<Value> = state
             .account_policies
             .values()
@@ -299,7 +306,8 @@ impl LogsService {
         })?;
 
         let key = (policy_name.to_string(), policy_type.to_string());
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.account_policies.remove(&key).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -352,7 +360,8 @@ impl LogsService {
         };
 
         let now = Utc::now().timestamp_millis();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -406,7 +415,9 @@ impl LogsService {
             log_group_id.clone()
         };
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let group = state.log_groups.get(&group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -457,7 +468,8 @@ impl LogsService {
             log_group_id
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -521,7 +533,8 @@ impl LogsService {
         let policy_name = body["policyName"].as_str().unwrap_or("default").to_string();
 
         let now = Utc::now().timestamp_millis();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -575,7 +588,9 @@ impl LogsService {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let mut policies = Vec::new();
 
         for id_val in log_group_ids {
@@ -631,7 +646,8 @@ impl LogsService {
             log_group_id
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -709,7 +725,8 @@ impl LogsService {
         };
 
         let now = Utc::now().timestamp_millis();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -752,7 +769,9 @@ impl LogsService {
             log_group_id.clone()
         };
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let group = state.log_groups.get(&group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -804,7 +823,8 @@ impl LogsService {
             log_group_id
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(&group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -29,7 +29,8 @@ impl LogsService {
         validate_string_length("logGroupName", log_group_name, 1, 512)?;
         validate_optional_string_length("queryString", Some(&query_string), 0, 10000)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify log group exists
         if !state.log_groups.contains_key(log_group_name) {
@@ -77,7 +78,9 @@ impl LogsService {
 
         validate_string_length("queryId", query_id, 1, 256)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let query_info = state.queries.get(query_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -152,7 +155,9 @@ impl LogsService {
             &["CWLI", "SQL", "PPL"],
         )?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let queries: Vec<Value> = state
             .queries
             .values()
@@ -244,7 +249,8 @@ impl LogsService {
 
         let now = Utc::now().timestamp_millis();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.query_definitions.insert(
             query_definition_id.clone(),
             QueryDefinition {
@@ -285,7 +291,9 @@ impl LogsService {
             &["CWLI", "SQL", "PPL"],
         )?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let defs: Vec<Value> = state
             .query_definitions
             .values()
@@ -322,7 +330,8 @@ impl LogsService {
 
         validate_string_length("queryDefinitionId", qd_id, 1, 256)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let success = state.query_definitions.remove(qd_id).is_some();
 
         Ok(AwsResponse::json(
@@ -341,7 +350,8 @@ impl LogsService {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let query = state.queries.get_mut(query_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -45,7 +45,8 @@ impl LogsService {
         validate_string_length("logGroupName", group_name, 1, 512)?;
         validate_string_length("logStreamName", &stream_name, 1, 512)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let region = state.region.clone();
         let account_id = state.account_id.clone();
 
@@ -110,7 +111,8 @@ impl LogsService {
         validate_string_length("logGroupName", group_name, 1, 512)?;
         validate_string_length("logStreamName", stream_name, 1, 512)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -211,7 +213,9 @@ impl LogsService {
             ));
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let group = state.log_groups.get(group_name.as_str()).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -371,7 +375,8 @@ impl LogsService {
             has_rejected = true;
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(group_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -489,7 +494,7 @@ impl LogsService {
             }
         }
 
-        drop(state);
+        drop(accounts);
 
         if !filters_to_deliver.is_empty() && !accepted_events.is_empty() {
             for (filter_name, filter_pattern, destination_arn) in &filters_to_deliver {
@@ -688,7 +693,9 @@ impl LogsService {
             }
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let group = state.log_groups.get(group_name.as_str()).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -870,7 +877,9 @@ impl LogsService {
             ));
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let group = state
             .log_groups
             .get(resolved_group_name.as_str())

--- a/crates/fakecloud-logs/src/service/tags.rs
+++ b/crates/fakecloud-logs/src/service/tags.rs
@@ -29,7 +29,8 @@ impl LogsService {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -67,7 +68,8 @@ impl LogsService {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let group = state.log_groups.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -100,7 +102,9 @@ impl LogsService {
 
         validate_string_length("logGroupName", name, 1, 512)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let group = state.log_groups.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -142,7 +146,8 @@ impl LogsService {
             .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
             .collect();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Try log group
         if let Some(group) = state
@@ -196,7 +201,8 @@ impl LogsService {
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
             .collect();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Try log group
         if let Some(group) = state
@@ -240,7 +246,9 @@ impl LogsService {
 
         validate_string_length("resourceArn", arn, 1, 1011)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Try log group
         if let Some(group) = state

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -3,7 +3,13 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-pub type SharedLogsState = Arc<RwLock<LogsState>>;
+pub type SharedLogsState = Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<LogsState>>>;
+
+impl fakecloud_core::multi_account::AccountState for LogsState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
 
 /// JSON object keys must be strings, so serialize
 /// `HashMap<(String,String), AccountPolicy>` as a list of
@@ -361,10 +367,13 @@ pub struct ScheduledQuery {
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct LogsSnapshot {
     pub schema_version: u32,
-    pub state: LogsState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<LogsState>>,
+    #[serde(default)]
+    pub state: Option<LogsState>,
 }
 
-pub const LOGS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const LOGS_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[cfg(test)]
 mod tests {

--- a/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
+++ b/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
@@ -50,7 +50,8 @@ impl DynamoDbStreamsLambdaPoller {
     async fn poll(&self) {
         // Collect enabled mappings that point to DynamoDB streams
         let mappings: Vec<(String, String, String, i64)> = {
-            let lambda = self.lambda_state.read();
+            let lambda_accounts = self.lambda_state.read();
+            let lambda = lambda_accounts.default_ref();
             lambda
                 .event_source_mappings
                 .values()
@@ -185,7 +186,8 @@ impl DynamoDbStreamsLambdaPoller {
                 }
             } else {
                 // No delivery mechanism, just record
-                let mut lambda = self.lambda_state.write();
+                let mut lambda_accounts = self.lambda_state.write();
+                let lambda = lambda_accounts.default_mut();
                 lambda.invocations.push(LambdaInvocation {
                     function_arn: function_arn.clone(),
                     payload: payload.clone(),

--- a/crates/fakecloud-server/src/kinesis_lambda_poller.rs
+++ b/crates/fakecloud-server/src/kinesis_lambda_poller.rs
@@ -39,7 +39,8 @@ impl KinesisLambdaPoller {
 
     async fn poll(&self) {
         let mappings: Vec<(String, String, String, i64)> = {
-            let lambda = self.lambda_state.read();
+            let lambda_accounts = self.lambda_state.read();
+            let lambda = lambda_accounts.default_ref();
             lambda
                 .event_source_mappings
                 .values()
@@ -150,7 +151,8 @@ impl KinesisLambdaPoller {
                 }
 
                 if !used_real_delivery {
-                    let mut lambda = self.lambda_state.write();
+                    let mut lambda_accounts = self.lambda_state.write();
+                    let lambda = lambda_accounts.default_mut();
                     lambda.invocations.push(LambdaInvocation {
                         function_arn: function_arn.clone(),
                         payload,

--- a/crates/fakecloud-server/src/kinesis_lambda_poller.rs
+++ b/crates/fakecloud-server/src/kinesis_lambda_poller.rs
@@ -40,18 +40,22 @@ impl KinesisLambdaPoller {
     async fn poll(&self) {
         let mappings: Vec<(String, String, String, i64)> = {
             let lambda_accounts = self.lambda_state.read();
-            let lambda = lambda_accounts.default_ref();
-            lambda
-                .event_source_mappings
-                .values()
-                .filter(|m| m.enabled && m.event_source_arn.contains(":kinesis:"))
-                .map(|m| {
-                    (
-                        m.uuid.clone(),
-                        m.event_source_arn.clone(),
-                        m.function_arn.clone(),
-                        m.batch_size,
-                    )
+            lambda_accounts
+                .iter()
+                .flat_map(|(_, lambda)| {
+                    lambda
+                        .event_source_mappings
+                        .values()
+                        .filter(|m| m.enabled && m.event_source_arn.contains(":kinesis:"))
+                        .map(|m| {
+                            (
+                                m.uuid.clone(),
+                                m.event_source_arn.clone(),
+                                m.function_arn.clone(),
+                                m.batch_size,
+                            )
+                        })
+                        .collect::<Vec<_>>()
                 })
                 .collect()
         };
@@ -151,8 +155,9 @@ impl KinesisLambdaPoller {
                 }
 
                 if !used_real_delivery {
+                    let fn_account = function_arn.split(':').nth(4).unwrap_or("");
                     let mut lambda_accounts = self.lambda_state.write();
-                    let lambda = lambda_accounts.default_mut();
+                    let lambda = lambda_accounts.get_or_create(fn_account);
                     lambda.invocations.push(LambdaInvocation {
                         function_arn: function_arn.clone(),
                         payload,

--- a/crates/fakecloud-server/src/lambda_delivery.rs
+++ b/crates/fakecloud-server/src/lambda_delivery.rs
@@ -38,9 +38,21 @@ impl LambdaDelivery for LambdaDeliveryImpl {
             }
         };
 
+        // Extract account ID from ARN
+        let account_id = {
+            let parts: Vec<&str> = function_arn.split(':').collect();
+            if parts.len() >= 5 {
+                parts[4].to_string()
+            } else {
+                String::new()
+            }
+        };
+
         let func = {
-            let state = self.lambda_state.read();
-            state.functions.get(&function_name).cloned()
+            let accounts = self.lambda_state.read();
+            accounts
+                .get(&account_id)
+                .and_then(|state| state.functions.get(&function_name).cloned())
         };
 
         let runtime = self.runtime.clone();
@@ -53,7 +65,8 @@ impl LambdaDelivery for LambdaDeliveryImpl {
 
             // Record invocation regardless of whether code exists
             {
-                let mut state = lambda_state.write();
+                let mut accounts = lambda_state.write();
+                let state = accounts.get_or_create(&account_id);
                 state
                     .invocations
                     .push(fakecloud_lambda::state::LambdaInvocation {

--- a/crates/fakecloud-server/src/lambda_delivery.rs
+++ b/crates/fakecloud-server/src/lambda_delivery.rs
@@ -38,13 +38,14 @@ impl LambdaDelivery for LambdaDeliveryImpl {
             }
         };
 
-        // Extract account ID from ARN
+        // Extract account ID from ARN, falling back to the default account
         let account_id = {
             let parts: Vec<&str> = function_arn.split(':').collect();
-            if parts.len() >= 5 {
-                parts[4].to_string()
+            let parsed = if parts.len() >= 5 { parts[4] } else { "" };
+            if parsed.is_empty() {
+                self.lambda_state.read().default_account_id().to_string()
             } else {
-                String::new()
+                parsed.to_string()
             }
         };
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -119,7 +119,11 @@ async fn main() {
         mas
     }));
     let eb_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_eventbridge::state::EventBridgeState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
     let ssm_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_ssm::state::SsmState::new(&cli.account_id, &cli.region),
@@ -132,7 +136,11 @@ async fn main() {
         ),
     ));
     let lambda_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_lambda::state::LambdaState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
 
     // Reap any backing containers left behind by a previous fakecloud process
@@ -165,7 +173,11 @@ async fn main() {
         ),
     ));
     let logs_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_logs::state::LogsState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
     let kms_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new(
@@ -624,22 +636,31 @@ async fn main() {
                     ) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_eventbridge::state::EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_eventbridge::state::EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "eventbridge persistence schema mismatch: on-disk={}, expected={}",
+                                    "eventbridge persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_eventbridge::state::EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let bus_count = snapshot.state.buses.len();
-                            let rule_count = snapshot.state.rules.len();
-                            *eb_state.write() = snapshot.state;
-                            tracing::info!(
-                                buses = bus_count,
-                                rules = rule_count,
-                                "loaded eventbridge persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *eb_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded eventbridge persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let bus_count = single_state.buses.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = eb_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    buses = bus_count,
+                                    "loaded eventbridge persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse eventbridge persistence snapshot: {err}"
@@ -829,20 +850,31 @@ async fn main() {
                     {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_lambda::state::LAMBDA_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_lambda::state::LAMBDA_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "lambda persistence schema mismatch: on-disk={}, expected={}",
+                                    "lambda persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_lambda::state::LAMBDA_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let fn_count = snapshot.state.functions.len();
-                            *lambda_state.write() = snapshot.state;
-                            tracing::info!(
-                                functions = fn_count,
-                                "loaded lambda persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *lambda_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded lambda persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let fn_count = single_state.functions.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = lambda_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    functions = fn_count,
+                                    "loaded lambda persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse lambda persistence snapshot: {err}"
@@ -952,20 +984,31 @@ async fn main() {
                     match serde_json::from_slice::<fakecloud_logs::state::LogsSnapshot>(&bytes) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_logs::state::LOGS_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_logs::state::LOGS_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "logs persistence schema mismatch: on-disk={}, expected={}",
+                                    "logs persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_logs::state::LOGS_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let group_count = snapshot.state.log_groups.len();
-                            *logs_state.write() = snapshot.state;
-                            tracing::info!(
-                                log_groups = group_count,
-                                "loaded logs persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *logs_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded logs persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let group_count = single_state.log_groups.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = logs_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    log_groups = group_count,
+                                    "loaded logs persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse logs persistence snapshot: {err}"
@@ -1820,7 +1863,8 @@ async fn main() {
             axum::routing::get({
                 let ls = lambda_invocations_state.clone();
                 move || async move {
-                    let state = ls.read();
+                    let accounts = ls.read();
+                    let state = accounts.default_ref();
                     let invocations = state
                         .invocations
                         .iter()
@@ -2146,7 +2190,8 @@ async fn main() {
             axum::routing::get({
                 let es = eb_introspection_state;
                 move || async move {
-                    let state = es.read();
+                    let accounts = es.read();
+                    let state = accounts.default_ref();
                     let events = state
                         .events
                         .iter()

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -874,6 +874,8 @@ async fn main() {
                                     functions = fn_count,
                                     "loaded lambda persistence snapshot (migrated from v1)"
                                 );
+                            } else {
+                                tracing::warn!("lambda persistence snapshot has neither accounts nor state; starting empty");
                             }
                         }
                         Err(err) => fatal_exit(format_args!(
@@ -1008,6 +1010,8 @@ async fn main() {
                                     log_groups = group_count,
                                     "loaded logs persistence snapshot (migrated from v1)"
                                 );
+                            } else {
+                                tracing::warn!("logs persistence snapshot has neither accounts nor state; starting empty");
                             }
                         }
                         Err(err) => fatal_exit(format_args!(

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -45,7 +45,8 @@ impl ResetState {
                 s.default_mut().seed_default_opted_out();
             }
             "events" | "eventbridge" => {
-                let mut eb = self.eb.write();
+                let mut eb_accounts = self.eb.write();
+                let eb = eb_accounts.default_mut();
                 eb.rules.clear();
                 eb.events.clear();
                 eb.archives.clear();
@@ -64,7 +65,7 @@ impl ResetState {
                 self.dynamodb.write().reset();
             }
             "lambda" => {
-                self.lambda.write().reset();
+                self.lambda.write().default_mut().reset();
                 if let Some(ref rt) = self.container_runtime {
                     let rt = rt.clone();
                     tokio::spawn(async move { rt.stop_all().await });
@@ -77,7 +78,7 @@ impl ResetState {
                 self.s3.write().reset();
             }
             "logs" => {
-                self.logs.write().reset();
+                self.logs.write().default_mut().reset();
             }
             "kms" => {
                 self.kms.write().reset();
@@ -134,7 +135,8 @@ impl ResetState {
             sns.default_mut().seed_default_opted_out();
         }
         {
-            let mut eb = self.eb.write();
+            let mut eb_accounts = self.eb.write();
+            let eb = eb_accounts.default_mut();
             eb.rules.clear();
             eb.events.clear();
             eb.archives.clear();
@@ -148,7 +150,7 @@ impl ResetState {
         }
         self.ssm.write().reset();
         self.dynamodb.write().reset();
-        self.lambda.write().reset();
+        self.lambda.write().default_mut().reset();
         // Stop all Lambda containers on reset
         if let Some(ref rt) = self.container_runtime {
             let rt = rt.clone();
@@ -156,7 +158,7 @@ impl ResetState {
         }
         self.secretsmanager.write().reset();
         self.s3.write().reset();
-        self.logs.write().reset();
+        self.logs.write().default_mut().reset();
         self.kms.write().reset();
         self.cloudformation.write().reset();
         self.ses.write().reset();
@@ -324,7 +326,11 @@ mod tests {
                 ),
             )),
             eb: Arc::new(parking_lot::RwLock::new(
-                fakecloud_eventbridge::state::EventBridgeState::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
             )),
             ssm: Arc::new(parking_lot::RwLock::new(
                 fakecloud_ssm::state::SsmState::new("123456789012", "us-east-1"),
@@ -337,7 +343,11 @@ mod tests {
                 ),
             )),
             lambda: Arc::new(parking_lot::RwLock::new(
-                fakecloud_lambda::state::LambdaState::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
             )),
             secretsmanager: Arc::new(parking_lot::RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
@@ -354,7 +364,11 @@ mod tests {
                 ),
             )),
             logs: Arc::new(parking_lot::RwLock::new(
-                fakecloud_logs::state::LogsState::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
             )),
             kms: Arc::new(parking_lot::RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -65,7 +65,7 @@ impl ResetState {
                 self.dynamodb.write().reset();
             }
             "lambda" => {
-                self.lambda.write().default_mut().reset();
+                self.lambda.write().reset();
                 if let Some(ref rt) = self.container_runtime {
                     let rt = rt.clone();
                     tokio::spawn(async move { rt.stop_all().await });
@@ -78,7 +78,7 @@ impl ResetState {
                 self.s3.write().reset();
             }
             "logs" => {
-                self.logs.write().default_mut().reset();
+                self.logs.write().reset();
             }
             "kms" => {
                 self.kms.write().reset();

--- a/crates/fakecloud-server/src/sqs_lambda_poller.rs
+++ b/crates/fakecloud-server/src/sqs_lambda_poller.rs
@@ -47,7 +47,8 @@ impl SqsLambdaPoller {
     async fn poll(&self) {
         // Collect enabled mappings that point to SQS sources
         let mappings: Vec<(String, String, i64)> = {
-            let lambda = self.lambda_state.read();
+            let lambda_accounts = self.lambda_state.read();
+            let lambda = lambda_accounts.default_ref();
             lambda
                 .event_source_mappings
                 .values()
@@ -159,7 +160,8 @@ impl SqsLambdaPoller {
             }
 
             // Record the invocation in Lambda state (for observability / testing)
-            let mut lambda = self.lambda_state.write();
+            let mut lambda_accounts = self.lambda_state.write();
+            let lambda = lambda_accounts.default_mut();
             lambda.invocations.push(LambdaInvocation {
                 function_arn,
                 payload,

--- a/crates/fakecloud-server/src/sqs_lambda_poller.rs
+++ b/crates/fakecloud-server/src/sqs_lambda_poller.rs
@@ -48,17 +48,21 @@ impl SqsLambdaPoller {
         // Collect enabled mappings that point to SQS sources
         let mappings: Vec<(String, String, i64)> = {
             let lambda_accounts = self.lambda_state.read();
-            let lambda = lambda_accounts.default_ref();
-            lambda
-                .event_source_mappings
-                .values()
-                .filter(|m| m.enabled && m.event_source_arn.contains(":sqs:"))
-                .map(|m| {
-                    (
-                        m.event_source_arn.clone(),
-                        m.function_arn.clone(),
-                        m.batch_size,
-                    )
+            lambda_accounts
+                .iter()
+                .flat_map(|(_, lambda)| {
+                    lambda
+                        .event_source_mappings
+                        .values()
+                        .filter(|m| m.enabled && m.event_source_arn.contains(":sqs:"))
+                        .map(|m| {
+                            (
+                                m.event_source_arn.clone(),
+                                m.function_arn.clone(),
+                                m.batch_size,
+                            )
+                        })
+                        .collect::<Vec<_>>()
                 })
                 .collect()
         };
@@ -160,8 +164,9 @@ impl SqsLambdaPoller {
             }
 
             // Record the invocation in Lambda state (for observability / testing)
+            let fn_account = function_arn.split(':').nth(4).unwrap_or("");
             let mut lambda_accounts = self.lambda_state.write();
-            let lambda = lambda_accounts.default_mut();
+            let lambda = lambda_accounts.get_or_create(fn_account);
             lambda.invocations.push(LambdaInvocation {
                 function_arn,
                 payload,


### PR DESCRIPTION
## Summary

Batch 6 of #381. Wraps Lambda, EventBridge, and Logs in `MultiAccountState<T>`.

- Lambda: 15 handlers, resource policy provider, runtime listing
- EventBridge: 62+ accesses, cross-service Lambda/Logs delivery, simulation/scheduler
- Logs: 12 service files, all mechanical
- Cross-service: lambda_delivery, pollers, CloudFormation provisioner all updated
- Snapshot v2 with v1 backward compat

## Test plan

- [x] All workspace unit tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-account state isolation to `fakecloud-lambda`, `fakecloud-eventbridge`, and `fakecloud-logs` using `MultiAccountState`, enabling true multi-account behavior. Cross-service deliveries, pollers, CloudFormation, and snapshots are account-aware with a backward-compatible v2 schema, and scheduler/pollers now iterate all accounts and route invocations to the owning account.

- **Bug Fixes**
  - EventBridge: scheduler ticks across all accounts; replay delivery accepts an account_id; CloudFormation rules/log groups use the caller’s account.
  - Lambda: SQS/Kinesis pollers scan all accounts and write invocations to the function’s account; warm container listing searches all accounts; get_function fallback uses the real region.
  - Delivery: function account extracted from ARN with default-account fallback when missing.
  - Snapshots: v2 writer handles legacy shape; warn when both legacy/new fields are None.

- **Migration**
  - No manual steps. Existing v1 snapshots load into v2 automatically.
  - Ensure Lambda ARNs include the account ID for correct policy lookup and delivery routing (falls back to the default account if omitted).

<sup>Written for commit 3d11ed8ebdaad4985c6e75a2302497e5319bea9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

