### PR TITLE
ci: share fakecloud binary across tfacc and e2e matrix jobs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,13 +10,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  e2e-matrix:
+  e2e-build:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build E2E partition tool
         run: cargo build -q -p fakecloud-e2e --bin e2e_nextest_partitions
@@ -24,6 +25,19 @@ jobs:
       - id: matrix
         name: Generate E2E matrix
         run: echo "matrix=$(./target/debug/e2e_nextest_partitions matrix)" >> "$GITHUB_OUTPUT"
+
+      # Build fakecloud once here so every partition job can download the
+      # binary as an artifact instead of rebuilding from scratch.
+      - name: Build fakecloud
+        run: cargo build --bin fakecloud
+
+      - name: Upload fakecloud binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fakecloud-binary-e2e
+          path: target/debug/fakecloud
+          if-no-files-found: error
+          retention-days: 1
 
   e2e-partition-check:
     runs-on: ubuntu-latest
@@ -48,11 +62,11 @@ jobs:
 
   e2e:
     name: E2E ${{ matrix.name }}
-    needs: [e2e-matrix, e2e-partition-check]
+    needs: [e2e-build, e2e-partition-check]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.e2e-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.e2e-build.outputs.matrix) }}
     env:
       NEXTEST_FILTER: ${{ matrix.filter }}
       NEXTEST_PARTITION: ${{ matrix.partition }}
@@ -86,8 +100,14 @@ jobs:
             podman system prune -af || true
           fi
 
-      - name: Build server
-        run: cargo build --bin fakecloud
+      - name: Download fakecloud binary
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: fakecloud-binary-e2e
+          path: target/debug
+
+      - name: Mark fakecloud binary executable
+        run: chmod +x target/debug/fakecloud
 
       - name: Run nextest partition
         run: |

--- a/.github/workflows/tfacc.yml
+++ b/.github/workflows/tfacc.yml
@@ -25,6 +25,19 @@ jobs:
       - id: m
         run: echo "services=$(cat services.json)" >> "$GITHUB_OUTPUT"
 
+      # Build fakecloud once here so every matrix job can download the
+      # binary as an artifact instead of rebuilding from scratch.
+      - name: Build fakecloud
+        run: cargo build --bin fakecloud
+
+      - name: Upload fakecloud binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fakecloud-binary-tfacc
+          path: target/debug/fakecloud
+          if-no-files-found: error
+          retention-days: 1
+
   tfacc:
     name: tfacc ${{ matrix.service }}
     needs: tfacc-matrix
@@ -59,8 +72,14 @@ jobs:
           restore-keys: |
             tfacc-${{ runner.os }}-
 
-      - name: Build fakecloud
-        run: cargo build --bin fakecloud
+      - name: Download fakecloud binary
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: fakecloud-binary-tfacc
+          path: target/debug
+
+      - name: Mark fakecloud binary executable
+        run: chmod +x target/debug/fakecloud
 
       - name: Run ${{ matrix.service }} acceptance tests
         run: cargo test -p fakecloud-tfacc --test acc ${{ matrix.service }}_acceptance -- --nocapture


### PR DESCRIPTION
## Summary

- tfacc ran 13 parallel matrix jobs per PR; every one rebuilt \`fakecloud\` from scratch (~2-3m each).
- e2e ran 10 nextest partitions; every one rebuilt \`fakecloud\` too.
- Build it once in each workflow's matrix-generator job, upload as a 1-day-retention artifact, and download it from every fan-out job.
- Also adds \`Swatinem/rust-cache\` to \`e2e-build\` which had none.

Batch 2 of the CI-speedup series. Stacks on Batch 1 (PR #600) but independent: branches are separate, main merge order doesn't matter.

## Test plan

- [ ] tfacc: confirm each \`tfacc <service>\` job now has \"Download fakecloud binary\" step and no \"Build fakecloud\" step.
- [ ] e2e: confirm \`e2e-build\` uploads artifact, partition jobs download it.
- [ ] End-to-end: confirm tfacc matrix and e2e partition jobs both still pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the `fakecloud` binary once per workflow and shares it across `tfacc` and E2E matrix jobs via short-lived artifacts to remove redundant builds and speed up CI. Also adds `Swatinem/rust-cache` to the E2E build stage.

- **Refactors**
  - E2E: new `e2e-build` job generates the matrix, builds `fakecloud`, and uploads `fakecloud-binary-e2e` (1-day retention); partition jobs download it and `chmod +x`; `e2e` now depends on `e2e-build`.
  - TFACC: `tfacc-matrix` builds `fakecloud` and uploads `fakecloud-binary-tfacc` (1-day retention); fan-out jobs download it and `chmod +x`.
  - Removed per-job `cargo build --bin fakecloud` from all matrix partitions.

- **Dependencies**
  - Added `Swatinem/rust-cache@v2` to `e2e-build` for faster cold builds.

<sup>Written for commit 55e0c097e00413b4c503e427bc89fca5bd9adf76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

