### PR TITLE
ci: run conformance tests with cargo-nextest

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -18,13 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build server
         run: cargo build --bin fakecloud
 
       - name: Run conformance integration tests
-        run: cargo test -p fakecloud-conformance --tests
+        run: cargo nextest run -P ci -p fakecloud-conformance --tests
 
       - name: Build conformance tool
         run: cargo build -p fakecloud-conformance


### PR DESCRIPTION
## Summary

- Conformance uses \`cargo test\` (serial). E2E already uses \`cargo nextest run\`.
- Switch conformance to \`cargo nextest run -P ci\` and install nextest via \`taiki-e/install-action\` (same pin as e2e).
- The \`ci\` profile is already defined in \`.config/nextest.toml\`.

Batch 4 of CI-speedup series. ~663 conformance tests currently run sequentially per service file; parallelising drops wall-clock noticeably.

## Test plan

- [ ] Conformance workflow total wall-clock drops from ~5-6m to ~3-4m.
- [ ] No tests regress (same pass/fail set as before).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch conformance CI from `cargo test` to `cargo nextest run -P ci` to run tests in parallel and cut runtime from ~5–6m to ~3–4m. Matches the e2e setup; uses the `ci` profile in `.config/nextest.toml`.

- **Dependencies**
  - Add `taiki-e/install-action` to install `cargo nextest` (same pin as e2e).

<sup>Written for commit 0ecc451cda95a5cdd63bfb68b92e55ff4f8613fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

