### PR TITLE
ci: small e2e workflow cleanups

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,15 +50,8 @@ jobs:
       - name: Build E2E partition tool
         run: cargo build -q -p fakecloud-e2e --bin e2e_nextest_partitions
 
-      - name: Prune Docker state before tests
-        run: docker system prune -af --volumes || true
-
       - name: Verify E2E partition coverage
         run: ./target/debug/e2e_nextest_partitions check
-
-      - name: Prune Docker state after tests
-        if: always()
-        run: docker system prune -af --volumes || true
 
   e2e:
     name: E2E ${{ matrix.name }}


### PR DESCRIPTION
## Summary

Two cleanups in \`e2e.yml\`:

- Add \`Swatinem/rust-cache\` to the \`e2e-matrix\` job. It had no cache, so its \`cargo build\` rebuild was fully cold every run.
- Drop the \`docker system prune\` steps from \`e2e-partition-check\`. That job only runs a Rust binary that validates partition coverage; it never touches Docker, so the prunes are dead weight.

Batch 5 of the CI-speedup series.

## Test plan

- [ ] \`e2e-matrix\` runtime drops on 2nd run (cache hit).
- [ ] \`e2e-partition-check\` no longer spends time on docker prunes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up the E2E workflow by caching the partition tool build and removing unnecessary Docker prune steps. Saves ~1 minute on the critical path once the cache warms.

- **Refactors**
  - Added `Swatinem/rust-cache` to `e2e-matrix` to reuse `cargo build` outputs for the `e2e_nextest_partitions` tool.
  - Removed `docker system prune -af --volumes` before/after in `e2e-partition-check`, which only runs the Rust partition coverage check.

<sup>Written for commit 885987be6517fb5a75309bff2ae902e1efc1359d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

