### PR TITLE
feat(ssm,cloudformation): multi-account state isolation

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -268,11 +268,12 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .unwrap_or("String");
 
-        let mut state = self.ssm_state.write();
+        let mut accounts = self.ssm_state.write();
+        let state = accounts.get_or_create(&self.account_id);
         let arn = format!(
             "arn:aws:ssm:{}:{}:parameter{}",
-            state.region,
-            state.account_id,
+            self.region,
+            self.account_id,
             if name.starts_with('/') {
                 name.to_string()
             } else {
@@ -306,7 +307,8 @@ impl ResourceProvisioner {
     }
 
     fn delete_ssm_parameter(&self, physical_id: &str) -> Result<(), String> {
-        let mut state = self.ssm_state.write();
+        let mut accounts = self.ssm_state.write();
+        let state = accounts.get_or_create(&self.account_id);
         state.parameters.remove(physical_id);
         Ok(())
     }
@@ -936,10 +938,13 @@ mod tests {
                     "http://localhost:4566",
                 ),
             )),
-            ssm_state: Arc::new(RwLock::new(fakecloud_ssm::state::SsmState::new(
-                "123456789012",
-                "us-east-1",
-            ))),
+            ssm_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+            )),
             iam_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", "http://localhost:4566"),
             )),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -19,7 +19,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::resource_provisioner::ResourceProvisioner;
 use crate::state::{
-    CloudFormationSnapshot, SharedCloudFormationState, Stack, StackResource,
+    CloudFormationSnapshot, CloudFormationState, SharedCloudFormationState, Stack, StackResource,
     CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION,
 };
 use crate::template;
@@ -147,7 +147,8 @@ impl CloudFormationService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = CloudFormationSnapshot {
             schema_version: CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            state: None,
+            accounts: Some(self.state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -162,8 +163,7 @@ impl CloudFormationService {
         }
     }
 
-    fn provisioner(&self, stack_id: &str) -> ResourceProvisioner {
-        let cf_state = self.state.read();
+    fn provisioner(&self, stack_id: &str, account_id: &str, region: &str) -> ResourceProvisioner {
         ResourceProvisioner {
             sqs_state: self.deps.sqs.clone(),
             sns_state: self.deps.sns.clone(),
@@ -174,8 +174,8 @@ impl CloudFormationService {
             dynamodb_state: self.deps.dynamodb.clone(),
             logs_state: self.deps.logs.clone(),
             delivery: self.deps.delivery.clone(),
-            account_id: cf_state.account_id.clone(),
-            region: cf_state.region.clone(),
+            account_id: account_id.to_string(),
+            region: region.to_string(),
             stack_id: stack_id.to_string(),
         }
     }
@@ -286,7 +286,9 @@ impl CloudFormationService {
 
         // Check if stack already exists and is not deleted
         {
-            let state = self.state.read();
+            let accounts = self.state.read();
+            let empty = CloudFormationState::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
             if let Some(existing) = state.stacks.get(stack_name.as_str()) {
                 if existing.status != "DELETE_COMPLETE" {
                     return Err(AwsServiceError::aws_error(
@@ -307,18 +309,15 @@ impl CloudFormationService {
             AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
         })?;
 
-        let stack_id = {
-            let state = self.state.read();
-            format!(
-                "arn:aws:cloudformation:{}:{}:stack/{}/{}",
-                state.region,
-                state.account_id,
-                stack_name,
-                uuid::Uuid::new_v4()
-            )
-        };
+        let stack_id = format!(
+            "arn:aws:cloudformation:{}:{}:stack/{}/{}",
+            req.region,
+            req.account_id,
+            stack_name,
+            uuid::Uuid::new_v4()
+        );
 
-        let provisioner = self.provisioner(&stack_id);
+        let provisioner = self.provisioner(&stack_id, &req.account_id, &req.region);
         let resources =
             provision_stack_resources(&provisioner, &parsed.resources, template_body, &parameters)?;
 
@@ -337,7 +336,8 @@ impl CloudFormationService {
         };
 
         {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
             state.stacks.insert(stack_name.clone(), stack);
         }
 
@@ -364,7 +364,8 @@ impl CloudFormationService {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Find stack by name or stack ID
         let stack = state.stacks.values_mut().find(|s| {
@@ -379,8 +380,8 @@ impl CloudFormationService {
 
             // Build the provisioner while we still have the stack_id
             // Drop the write lock temporarily so the provisioner can read state
-            drop(state);
-            let provisioner = self.provisioner(&stack_id);
+            drop(accounts);
+            let provisioner = self.provisioner(&stack_id, &req.account_id, &req.region);
 
             // Delete resources in reverse order
             for resource in resources.iter().rev() {
@@ -388,12 +389,13 @@ impl CloudFormationService {
             }
 
             // Re-acquire the write lock to update stack status
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
             if let Some(stack) = state.stacks.values_mut().find(|s| s.stack_id == stack_id) {
                 stack.status = "DELETE_COMPLETE".to_string();
                 stack.resources.clear();
             }
-            drop(state);
+            drop(accounts);
 
             Self::send_stack_notification(
                 &self.deps.delivery,
@@ -413,7 +415,9 @@ impl CloudFormationService {
     fn describe_stacks(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let stack_name = Self::get_param(req, "StackName");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = CloudFormationState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let stacks: Vec<Stack> = if let Some(ref name) = stack_name {
             state
                 .stacks
@@ -449,7 +453,9 @@ impl CloudFormationService {
     }
 
     fn list_stacks(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = CloudFormationState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let stacks: Vec<Stack> = state.stacks.values().cloned().collect();
 
         Ok(AwsResponse::xml(
@@ -467,7 +473,9 @@ impl CloudFormationService {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = CloudFormationState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let stack = state
             .stacks
             .values()
@@ -497,7 +505,9 @@ impl CloudFormationService {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = CloudFormationState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let stack = state
             .stacks
             .values()
@@ -531,7 +541,9 @@ impl CloudFormationService {
 
         // Get stack_id before write lock for the provisioner
         let found_stack_id = {
-            let state = self.state.read();
+            let accounts = self.state.read();
+            let empty = CloudFormationState::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
             state
                 .stacks
                 .values()
@@ -543,9 +555,10 @@ impl CloudFormationService {
                 .unwrap_or_default()
         };
 
-        let provisioner = self.provisioner(&found_stack_id);
+        let provisioner = self.provisioner(&found_stack_id, &req.account_id, &req.region);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let stack = state
             .stacks
             .values_mut()
@@ -589,7 +602,7 @@ impl CloudFormationService {
         let stack_name_for_notif = stack.name.clone();
 
         if let Err(error_msg) = update_result {
-            drop(state);
+            drop(accounts);
             Self::send_stack_notification(
                 &self.deps.delivery,
                 &notification_arns,
@@ -604,7 +617,7 @@ impl CloudFormationService {
             ));
         }
 
-        drop(state);
+        drop(accounts);
         Self::send_stack_notification(
             &self.deps.delivery,
             &notification_arns,
@@ -628,7 +641,9 @@ impl CloudFormationService {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = CloudFormationState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let stack = state
             .stacks
             .values()
@@ -824,16 +839,18 @@ fn apply_resource_updates(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::CloudFormationState;
     use http::HeaderMap;
     use parking_lot::RwLock;
     use std::sync::Arc;
 
     fn make_service() -> CloudFormationService {
-        let cf_state = Arc::new(RwLock::new(CloudFormationState::new(
-            "123456789012",
-            "us-east-1",
-        )));
+        let cf_state = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
         let deps = CloudFormationDeps {
             sqs: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
@@ -849,10 +866,13 @@ mod tests {
                     "http://localhost:4566",
                 ),
             )),
-            ssm: Arc::new(RwLock::new(fakecloud_ssm::state::SsmState::new(
-                "123456789012",
-                "us-east-1",
-            ))),
+            ssm: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+            )),
             iam: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
@@ -942,7 +962,8 @@ mod tests {
         assert!(result.is_err());
 
         // Stack status should be UPDATE_FAILED
-        let state = svc.state.read();
+        let accounts = svc.state.read();
+        let state = accounts.get("123456789012").unwrap();
         let stack = state.stacks.get("test-stack").unwrap();
         assert_eq!(stack.status, "UPDATE_FAILED");
     }
@@ -977,7 +998,8 @@ mod tests {
         assert!(result.is_ok(), "CreateStack failed: {:?}", result.err());
 
         // Verify both resources were created
-        let state = svc.state.read();
+        let accounts = svc.state.read();
+        let state = accounts.get("123456789012").unwrap();
         let stack = state.stacks.get("ref-stack").unwrap();
         assert_eq!(stack.resources.len(), 2);
         assert_eq!(stack.status, "CREATE_COMPLETE");

--- a/crates/fakecloud-cloudformation/src/state.rs
+++ b/crates/fakecloud-cloudformation/src/state.rs
@@ -51,14 +51,24 @@ impl CloudFormationState {
     }
 }
 
-pub type SharedCloudFormationState = Arc<RwLock<CloudFormationState>>;
+pub type SharedCloudFormationState =
+    Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<CloudFormationState>>>;
 
-pub const CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+impl fakecloud_core::multi_account::AccountState for CloudFormationState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
+
+pub const CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CloudFormationSnapshot {
     pub schema_version: u32,
-    pub state: CloudFormationState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<CloudFormationState>>,
+    #[serde(default)]
+    pub state: Option<CloudFormationState>,
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -126,7 +126,11 @@ async fn main() {
         ),
     ));
     let ssm_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_ssm::state::SsmState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
     let dynamodb_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new(
@@ -187,7 +191,11 @@ async fn main() {
         ),
     ));
     let cloudformation_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_cloudformation::state::CloudFormationState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
     let ses_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_ses::state::SesState::new(&cli.account_id, &cli.region),
@@ -447,7 +455,7 @@ async fn main() {
                     {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_cloudformation::state::CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_cloudformation::state::CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
                                     "cloudformation persistence schema mismatch: on-disk={}, expected={}",
@@ -455,12 +463,23 @@ async fn main() {
                                     fakecloud_cloudformation::state::CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let stack_count = snapshot.state.stacks.len();
-                            *cloudformation_state.write() = snapshot.state;
-                            tracing::info!(
-                                stacks = stack_count,
-                                "loaded cloudformation persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *cloudformation_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded cloudformation persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let stack_count = single_state.stacks.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = cloudformation_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    stacks = stack_count,
+                                    "loaded cloudformation persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse cloudformation persistence snapshot: {err}"
@@ -790,7 +809,7 @@ async fn main() {
                     match serde_json::from_slice::<fakecloud_ssm::state::SsmSnapshot>(&bytes) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_ssm::state::SSM_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_ssm::state::SSM_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
                                     "ssm persistence schema mismatch: on-disk={}, expected={}",
@@ -798,12 +817,23 @@ async fn main() {
                                     fakecloud_ssm::state::SSM_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let param_count = snapshot.state.parameters.len();
-                            *ssm_state.write() = snapshot.state;
-                            tracing::info!(
-                                parameters = param_count,
-                                "loaded ssm persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *ssm_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded ssm persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let param_count = single_state.parameters.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = ssm_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    parameters = param_count,
+                                    "loaded ssm persistence snapshot (migrated from v1)"
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse ssm persistence snapshot: {err}"

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -333,7 +333,11 @@ mod tests {
                 ),
             )),
             ssm: Arc::new(parking_lot::RwLock::new(
-                fakecloud_ssm::state::SsmState::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
             )),
             dynamodb: Arc::new(parking_lot::RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
@@ -378,9 +382,10 @@ mod tests {
                 ),
             )),
             cloudformation: Arc::new(parking_lot::RwLock::new(
-                fakecloud_cloudformation::state::CloudFormationState::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",
+                    "http://localhost:4566",
                 ),
             )),
             ses: Arc::new(parking_lot::RwLock::new(

--- a/crates/fakecloud-ssm/src/service/associations.rs
+++ b/crates/fakecloud-ssm/src/service/associations.rs
@@ -8,12 +8,16 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{SsmAssociation, SsmAssociationVersion};
+use crate::state::{SsmAssociation, SsmAssociationVersion, SsmState};
 
 use super::{missing, SsmService};
 
 impl SsmService {
-    pub(super) fn create_association_inner(&self, body: &Value) -> Result<Value, AwsServiceError> {
+    pub(super) fn create_association_inner(
+        &self,
+        body: &Value,
+        account_id: &str,
+    ) -> Result<Value, AwsServiceError> {
         let input = CreateAssociationInput::from_body(body)?;
 
         let now = Utc::now();
@@ -65,7 +69,8 @@ impl SsmService {
 
         let resp = association_to_json(&assoc);
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
         state.associations.insert(association_id, assoc);
 
         Ok(resp)
@@ -76,7 +81,7 @@ impl SsmService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let resp = self.create_association_inner(&body)?;
+        let resp = self.create_association_inner(&body, &req.account_id)?;
         Ok(AwsResponse::ok_json(
             json!({ "AssociationDescription": resp }),
         ))
@@ -91,7 +96,9 @@ impl SsmService {
         let name = body["Name"].as_str();
         let instance_id = body["InstanceId"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         let assoc = if let Some(id) = association_id {
             state.associations.get(id)
@@ -124,7 +131,8 @@ impl SsmService {
         let name = body["Name"].as_str();
         let instance_id = body["InstanceId"].as_str();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let key = if let Some(id) = association_id {
             if state.associations.contains_key(id) {
@@ -166,7 +174,9 @@ impl SsmService {
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all: Vec<Value> = state
             .associations
             .values()
@@ -212,7 +222,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("AssociationId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let assoc = state.associations.get_mut(association_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -297,7 +308,9 @@ impl SsmService {
             .ok_or_else(|| missing("AssociationId"))?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let assoc = state.associations.get(association_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -365,7 +378,8 @@ impl SsmService {
             .unwrap_or("Pending")
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let assoc = state
             .associations
             .values_mut()
@@ -418,7 +432,7 @@ impl SsmService {
         let mut failed = Vec::new();
 
         for entry in entries {
-            match self.create_association_inner(entry) {
+            match self.create_association_inner(entry, &req.account_id) {
                 Ok(desc) => successful.push(desc),
                 Err(e) => {
                     let entry_name = entry["Name"].as_str().unwrap_or("");
@@ -478,7 +492,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("InstanceId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let associations: Vec<Value> = state
             .associations
             .values()
@@ -517,7 +533,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("InstanceId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let statuses: Vec<Value> = state
             .associations
             .values()

--- a/crates/fakecloud-ssm/src/service/automation.rs
+++ b/crates/fakecloud-ssm/src/service/automation.rs
@@ -8,7 +8,7 @@ use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{AutomationExecution, ExecutionPreview};
+use crate::state::{AutomationExecution, ExecutionPreview, SsmState};
 
 use super::{missing, SsmService};
 
@@ -59,7 +59,8 @@ impl SsmService {
         let max_errors = body["MaxErrors"].as_str().map(|s| s.to_string());
 
         let now = Utc::now();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.automation_execution_counter += 1;
         let exec_id = format!(
             "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
@@ -107,7 +108,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("AutomationExecutionId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let exec = state
             .automation_executions
             .get_mut(exec_id)
@@ -134,7 +136,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("AutomationExecutionId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let exec = state.automation_executions.get(exec_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -154,7 +158,9 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let items: Vec<Value> = state
             .automation_executions
             .values()
@@ -185,7 +191,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("AutomationExecutionId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let exec = state.automation_executions.get(exec_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -224,7 +232,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("SignalType"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         if !state.automation_executions.contains_key(exec_id) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -261,7 +271,8 @@ impl SsmService {
             body["Runbooks"].as_array().cloned().unwrap_or_default();
 
         let now = Utc::now();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.automation_execution_counter += 1;
         let exec_id = format!(
             "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
@@ -311,7 +322,8 @@ impl SsmService {
             .to_string();
 
         let now = Utc::now();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.execution_preview_counter += 1;
         let preview_id = format!(
             "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
@@ -340,7 +352,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("ExecutionPreviewId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let preview = state.execution_previews.get(preview_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-ssm/src/service/commands.rs
+++ b/crates/fakecloud-ssm/src/service/commands.rs
@@ -8,7 +8,7 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::SsmCommand;
+use crate::state::{SsmCommand, SsmState};
 
 use super::{missing, SsmService};
 
@@ -150,7 +150,8 @@ impl SsmService {
             document_hash_type: input.document_hash_type.clone(),
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.commands.push(cmd);
 
         let expires = now + chrono::Duration::seconds(input.timeout.unwrap_or(3600));
@@ -195,7 +196,9 @@ impl SsmService {
         let command_id = body["CommandId"].as_str();
         let instance_id = body["InstanceId"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all_commands: Vec<Value> = state
             .commands
             .iter()
@@ -271,7 +274,9 @@ impl SsmService {
         let plugin_name = body["PluginName"].as_str();
         validate_optional_string_length("PluginName", plugin_name, 4, 500)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let cmd = state
             .commands
             .iter()
@@ -329,7 +334,9 @@ impl SsmService {
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let command_id = body["CommandId"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all_invocations: Vec<Value> = state
             .commands
             .iter()
@@ -372,7 +379,8 @@ impl SsmService {
             .ok_or_else(|| missing("CommandId"))?;
         validate_string_length("CommandId", command_id, 36, 36)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if let Some(cmd) = state
             .commands
             .iter_mut()

--- a/crates/fakecloud-ssm/src/service/compliance.rs
+++ b/crates/fakecloud-ssm/src/service/compliance.rs
@@ -6,7 +6,7 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::ComplianceItem;
+use crate::state::{ComplianceItem, SsmState};
 
 use super::{missing, SsmService};
 
@@ -48,7 +48,8 @@ impl SsmService {
             .ok_or_else(|| missing("ExecutionSummary"))?;
         let items = body["Items"].as_array().ok_or_else(|| missing("Items"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Remove existing compliance items for this resource/type
         state
@@ -105,7 +106,9 @@ impl SsmService {
             .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
             .unwrap_or_default();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all_items: Vec<Value> = state
             .compliance_items
             .iter()
@@ -155,7 +158,9 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Group by compliance_type
         let mut type_counts: HashMap<String, (i64, i64)> = HashMap::new(); // (compliant, non_compliant)
@@ -198,7 +203,9 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Group by resource_id
         let mut resource_status: HashMap<String, (String, String, i64, i64)> = HashMap::new();

--- a/crates/fakecloud-ssm/src/service/documents.rs
+++ b/crates/fakecloud-ssm/src/service/documents.rs
@@ -8,7 +8,7 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{SsmDocument, SsmDocumentVersion, SsmResourcePolicy};
+use crate::state::{SsmDocument, SsmDocumentVersion, SsmResourcePolicy, SsmState};
 use sha2::{Digest, Sha256};
 
 use super::{missing, SsmService};
@@ -200,7 +200,8 @@ impl SsmService {
             })
             .unwrap_or_default();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if state.documents.contains_key(&name) {
             return Err(AwsServiceError::aws_error(
@@ -309,7 +310,9 @@ impl SsmService {
         let version_name = body["VersionName"].as_str();
         let requested_format = body["DocumentFormat"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let doc = state
             .documents
             .get(name)
@@ -346,7 +349,8 @@ impl SsmService {
         let doc_version = body["DocumentVersion"].as_str();
         let version_name = body["VersionName"].as_str();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         if doc_version.is_some() || version_name.is_some() {
             // Deleting a specific version
@@ -408,7 +412,8 @@ impl SsmService {
         let doc_format = body["DocumentFormat"].as_str();
         let target_version = body["DocumentVersion"].as_str();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let doc = state
             .documents
             .get_mut(name)
@@ -475,7 +480,9 @@ impl SsmService {
         let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let doc = state
             .documents
             .get(name)
@@ -547,7 +554,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("DocumentVersion"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let doc = state
             .documents
             .get_mut(name)
@@ -589,7 +597,9 @@ impl SsmService {
         let max_results = body["MaxResults"].as_i64().unwrap_or(10) as usize;
         let filters = body["Filters"].as_array();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all_docs: Vec<Value> = state
             .documents
             .values()
@@ -611,7 +621,9 @@ impl SsmService {
         let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let doc = state.documents.get(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -705,7 +717,8 @@ impl SsmService {
             Ok(result)
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let doc = state.documents.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -744,7 +757,9 @@ impl SsmService {
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let doc = state
             .documents
             .get(name)
@@ -804,7 +819,9 @@ impl SsmService {
         let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         if !state.documents.contains_key(name) {
             return Err(doc_not_found(name));
         }
@@ -833,7 +850,8 @@ impl SsmService {
         let policy_id = body["PolicyId"].as_str().map(|s| s.to_string());
         let policy_hash = body["PolicyHash"].as_str().map(|s| s.to_string());
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // If PolicyId is provided, update existing
         if let Some(ref pid) = policy_id {
@@ -889,7 +907,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("ResourceArn"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let policies: Vec<Value> = state
             .resource_policies
             .iter()
@@ -921,7 +941,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("PolicyHash"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let idx = state
             .resource_policies
             .iter()

--- a/crates/fakecloud-ssm/src/service/instances.rs
+++ b/crates/fakecloud-ssm/src/service/instances.rs
@@ -7,7 +7,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::SsmActivation;
+use crate::state::{SsmActivation, SsmState};
 
 use super::{missing, SsmService};
 
@@ -52,7 +52,8 @@ impl SsmService {
             .unwrap_or_default();
 
         let now = Utc::now();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.activation_counter += 1;
         let activation_id = format!(
             "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
@@ -89,7 +90,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("ActivationId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.activations.remove(activation_id).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -107,7 +109,9 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let activations: Vec<Value> = state
             .activations
             .values()
@@ -155,7 +159,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("InstanceId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.managed_instances.remove(instance_id);
         // AWS doesn't error on non-existent instances
 
@@ -168,7 +173,9 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 5, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let instances: Vec<Value> = state
             .managed_instances
             .values()
@@ -202,7 +209,9 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 5, 1000)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let instances: Vec<Value> = state
             .managed_instances
             .values()
@@ -240,7 +249,8 @@ impl SsmService {
             .ok_or_else(|| missing("IamRole"))?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let instance = state
             .managed_instances
             .get_mut(instance_id)

--- a/crates/fakecloud-ssm/src/service/inventory.rs
+++ b/crates/fakecloud-ssm/src/service/inventory.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{InventoryDeletion, InventoryEntry, InventoryItem};
+use crate::state::{InventoryDeletion, InventoryEntry, InventoryItem, SsmState};
 
 use super::{missing, SsmService};
 
@@ -66,7 +66,8 @@ impl SsmService {
             });
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let entry = state
             .inventory_entries
             .entry(instance_id.clone())
@@ -96,7 +97,9 @@ impl SsmService {
     pub(super) fn get_inventory(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let entities: Vec<Value> = state
             .inventory_entries
             .values()
@@ -194,7 +197,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("TypeName"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let entries: Vec<&HashMap<String, String>> = state
             .inventory_entries
             .get(instance_id)
@@ -246,7 +251,8 @@ impl SsmService {
             .ok_or_else(|| missing("TypeName"))?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Remove matching inventory items
         for entry in state.inventory_entries.values_mut() {
@@ -288,7 +294,9 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let deletions: Vec<Value> = state
             .inventory_deletions
             .iter()

--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -7,7 +7,7 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{MaintenanceWindow, MaintenanceWindowTarget, MaintenanceWindowTask};
+use crate::state::{MaintenanceWindow, MaintenanceWindowTarget, MaintenanceWindowTask, SsmState};
 
 use super::{missing, SsmService};
 
@@ -98,7 +98,8 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let input = CreateMaintenanceWindowInput::from_body(&req.json_body())?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Idempotency: if a window with the same ClientToken already exists,
         // hand back its id without creating a new window.
@@ -147,7 +148,9 @@ impl SsmService {
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let filters = body["Filters"].as_array();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all_windows: Vec<Value> = state
             .maintenance_windows
             .values()
@@ -221,7 +224,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let mw = state
             .maintenance_windows
             .get(window_id)
@@ -265,7 +270,8 @@ impl SsmService {
             .ok_or_else(|| missing("WindowId"))?;
         validate_string_length("WindowId", window_id, 20, 20)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.maintenance_windows.remove(window_id).is_none() {
             return Err(mw_not_found(window_id));
         }
@@ -289,7 +295,8 @@ impl SsmService {
         validate_optional_range_i64("Duration", body["Duration"].as_i64(), 1, 24)?;
         validate_optional_range_i64("Cutoff", body["Cutoff"].as_i64(), 0, 23)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mw = state
             .maintenance_windows
             .get_mut(window_id)
@@ -359,7 +366,8 @@ impl SsmService {
             &uuid::Uuid::new_v4().to_string().replace('-', "")
         );
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mw = state
             .maintenance_windows
             .get_mut(window_id)
@@ -391,7 +399,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowTargetId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mw = state
             .maintenance_windows
             .get_mut(window_id)
@@ -414,7 +423,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let mw = state
             .maintenance_windows
             .get(window_id)
@@ -476,7 +487,8 @@ impl SsmService {
             &uuid::Uuid::new_v4().to_string().replace('-', "")
         );
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mw = state
             .maintenance_windows
             .get_mut(window_id)
@@ -512,7 +524,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowTaskId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mw = state
             .maintenance_windows
             .get_mut(window_id)
@@ -535,7 +548,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let mw = state
             .maintenance_windows
             .get(window_id)
@@ -589,7 +604,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowTargetId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mw = state
             .maintenance_windows
             .get_mut(window_id)
@@ -650,7 +666,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowTaskId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mw = state
             .maintenance_windows
             .get_mut(window_id)
@@ -726,7 +743,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowTaskId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let mw = state
             .maintenance_windows
             .get(window_id)
@@ -780,7 +799,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowExecutionId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let exec = state
             .maintenance_window_executions
             .iter()
@@ -817,7 +838,9 @@ impl SsmService {
             .ok_or_else(|| missing("WindowExecutionId"))?;
         let task_id = body["TaskId"].as_str().ok_or_else(|| missing("TaskId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let exec = state
             .maintenance_window_executions
             .iter()
@@ -870,7 +893,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("InvocationId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let exec = state
             .maintenance_window_executions
             .iter()
@@ -948,7 +973,9 @@ impl SsmService {
             .ok_or_else(|| missing("WindowId"))?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all: Vec<Value> = state
             .maintenance_window_executions
             .iter()
@@ -991,7 +1018,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowExecutionId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let tasks: Vec<Value> = state
             .maintenance_window_executions
             .iter()
@@ -1040,7 +1069,9 @@ impl SsmService {
             .ok_or_else(|| missing("WindowExecutionId"))?;
         let task_id = body["TaskId"].as_str().ok_or_else(|| missing("TaskId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let invocations: Vec<Value> = state
             .maintenance_window_executions
             .iter()
@@ -1121,7 +1152,9 @@ impl SsmService {
             })
             .collect();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let windows: Vec<Value> = state
             .maintenance_windows
             .values()
@@ -1163,7 +1196,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("WindowExecutionId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let exec = state
             .maintenance_window_executions
             .iter_mut()

--- a/crates/fakecloud-ssm/src/service/misc.rs
+++ b/crates/fakecloud-ssm/src/service/misc.rs
@@ -5,7 +5,7 @@ use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::SsmServiceSetting;
+use crate::state::{SsmServiceSetting, SsmState};
 
 use super::{missing, SsmService};
 
@@ -47,7 +47,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("SettingId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         if let Some(setting) = state.service_settings.get(setting_id) {
             Ok(AwsResponse::ok_json(json!({
                 "ServiceSetting": {
@@ -84,7 +86,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("SettingId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.service_settings.remove(setting_id);
 
         let default_value = get_default_service_setting(setting_id);
@@ -116,7 +119,8 @@ impl SsmService {
             .ok_or_else(|| missing("SettingValue"))?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let now = Utc::now();
         let account_id = state.account_id.clone();
         state.service_settings.insert(

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -154,7 +154,8 @@ impl SsmService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = SsmSnapshot {
             schema_version: SSM_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            state: None,
+            accounts: Some(self.state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -568,10 +569,13 @@ mod tests {
     use std::sync::Arc;
 
     fn make_service() -> SsmService {
-        let state: SharedSsmState = Arc::new(RwLock::new(crate::state::SsmState::new(
-            "123456789012",
-            "us-east-1",
-        )));
+        let state: SharedSsmState = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
         SsmService::new(state)
     }
 
@@ -1351,7 +1355,8 @@ mod tests {
         // Manually insert an execution for testing
         {
             let now = chrono::Utc::now();
-            let mut state = svc.state.write();
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("123456789012");
             let exec = crate::state::MaintenanceWindowExecution {
                 window_execution_id: exec_id.to_string(),
                 window_id: window_id.clone(),

--- a/crates/fakecloud-ssm/src/service/ops.rs
+++ b/crates/fakecloud-ssm/src/service/ops.rs
@@ -9,7 +9,7 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{OpsItemRelatedItem, OpsMetadataEntry, SsmOpsItem};
+use crate::state::{OpsItemRelatedItem, OpsMetadataEntry, SsmOpsItem, SsmState};
 
 use super::{missing, SsmService};
 
@@ -62,7 +62,8 @@ impl SsmService {
             .unwrap_or_default();
 
         let now = Utc::now();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.ops_item_counter += 1;
         let ops_item_id = format!("oi-{:012x}", state.ops_item_counter);
 
@@ -101,7 +102,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("OpsItemId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let item = state.ops_items.get(ops_item_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -121,7 +124,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("OpsItemId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let account_id = state.account_id.clone();
         let item = state.ops_items.get_mut(ops_item_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -173,7 +177,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("OpsItemId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.ops_items.remove(ops_item_id);
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -186,7 +191,9 @@ impl SsmService {
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all: Vec<Value> = state
             .ops_items
             .values()
@@ -254,7 +261,8 @@ impl SsmService {
             .to_string();
 
         let now = Utc::now();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify ops item exists
         if !state.ops_items.contains_key(&ops_item_id) {
@@ -298,7 +306,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("AssociationId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let before = state.ops_item_related_items.len();
         state
             .ops_item_related_items
@@ -320,7 +329,9 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let ops_item_id = body["OpsItemId"].as_str();
 
         let items: Vec<Value> = state
@@ -351,7 +362,9 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Filter by OpsItemId if provided in Filters
         let filter_id = body["Filters"].as_array().and_then(|filters| {
@@ -404,7 +417,8 @@ impl SsmService {
             .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
             .unwrap_or_default();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let arn = format!(
             "arn:aws:ssm:{}:{}:opsmetadata/{}",
             state.region, state.account_id, resource_id
@@ -438,7 +452,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("OpsMetadataArn"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let entry = state.ops_metadata.get(arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -462,7 +478,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("OpsMetadataArn"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let entry = state.ops_metadata.get_mut(arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -496,7 +513,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("OpsMetadataArn"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.ops_metadata.remove(arn).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -514,7 +532,9 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let items: Vec<Value> = state
             .ops_metadata
             .values()

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -9,7 +9,7 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{SsmParameter, SsmParameterVersion};
+use crate::state::{SsmParameter, SsmParameterVersion, SsmState};
 
 use super::{missing, SsmService, PARAMETER_VERSION_LIMIT};
 
@@ -277,7 +277,8 @@ impl SsmService {
     pub(super) fn put_parameter(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let input = PutParameterInput::from_body(&req.json_body())?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if let Some(existing) = lookup_param_mut(&mut state.parameters, &input.name) {
             return apply_overwrite(existing, input);
         }
@@ -299,6 +300,7 @@ impl SsmService {
         raw_name: &str,
         secret_name: &str,
         region: &str,
+        account_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let sm_state = self.secretsmanager_state.as_ref().ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -359,11 +361,7 @@ impl SsmService {
 
         let value = version.secret_string.as_deref().unwrap_or("").to_string();
 
-        let ssm_state = self.state.read();
-        let arn = format!(
-            "arn:aws:ssm:{region}:{}:parameter{}",
-            ssm_state.account_id, raw_name
-        );
+        let arn = format!("arn:aws:ssm:{region}:{}:parameter{}", account_id, raw_name);
 
         Ok(AwsResponse::ok_json(json!({
             "Parameter": {
@@ -395,14 +393,21 @@ impl SsmService {
 
         // Resolve Secrets Manager references via cross-service lookup
         if let Some(secret_name) = raw_name.strip_prefix("/aws/reference/secretsmanager/") {
-            return self.resolve_secretsmanager_param(raw_name, secret_name, &req.region);
+            return self.resolve_secretsmanager_param(
+                raw_name,
+                secret_name,
+                &req.region,
+                &req.account_id,
+            );
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Handle ARN-style names directly (they contain many colons)
         if raw_name.starts_with("arn:aws:ssm:") {
-            let param = resolve_param_by_name_or_arn(&state, raw_name)?;
+            let param = resolve_param_by_name_or_arn(state, raw_name)?;
             return Ok(AwsResponse::ok_json(json!({
                 "Parameter": param_to_json(param, true, with_decryption, &req.region),
             })));
@@ -416,7 +421,7 @@ impl SsmService {
         }
 
         // Try looking up by name or by ARN - use raw_name in error for full context
-        let param = resolve_param_by_name_or_arn(&state, base_name)
+        let param = resolve_param_by_name_or_arn(state, base_name)
             .map_err(|_| param_not_found(raw_name))?;
 
         match selector {
@@ -496,7 +501,9 @@ impl SsmService {
             ));
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let mut parameters = Vec::new();
         let mut invalid = Vec::new();
         let mut seen_names = std::collections::HashSet::new();
@@ -629,7 +636,9 @@ impl SsmService {
             validate_parameter_filters_by_path(f)?;
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all_params: Vec<&SsmParameter> = state
             .parameters
             .values()
@@ -659,7 +668,8 @@ impl SsmService {
         let body = req.json_body();
         let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if remove_param(&mut state.parameters, name).is_none() {
             return Err(param_not_found(name));
         }
@@ -674,7 +684,8 @@ impl SsmService {
         let body = req.json_body();
         let names = body["Names"].as_array().ok_or_else(|| missing("Names"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mut deleted = Vec::new();
         let mut invalid = Vec::new();
 
@@ -718,7 +729,9 @@ impl SsmService {
             validate_parameter_filters(filters)?;
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Check if any filter explicitly targets /aws/ prefix paths
         let targets_aws_prefix = param_filters.as_ref().is_some_and(|filters| {
@@ -797,7 +810,9 @@ impl SsmService {
         }
         let max_results = max_results.unwrap_or(50) as usize;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let param = state
             .parameters
             .get(name)
@@ -868,7 +883,8 @@ impl SsmService {
 
         validate_label_lengths(&label_strings)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let param =
             lookup_param_mut(&mut state.parameters, name).ok_or_else(|| param_not_found(name))?;
 
@@ -953,7 +969,8 @@ impl SsmService {
             .as_i64()
             .ok_or_else(|| missing("ParameterVersion"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let param =
             lookup_param_mut(&mut state.parameters, name).ok_or_else(|| param_not_found(name))?;
 

--- a/crates/fakecloud-ssm/src/service/patches.rs
+++ b/crates/fakecloud-ssm/src/service/patches.rs
@@ -7,7 +7,7 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{PatchBaseline, PatchGroup};
+use crate::state::{PatchBaseline, PatchGroup, SsmState};
 
 use super::{missing, SsmService};
 
@@ -18,7 +18,8 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let input = CreatePatchBaselineInput::from_body(&req.json_body())?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Idempotency: if a baseline with the same ClientToken already exists, return it
         if let Some(ref token) = input.client_token {
@@ -70,7 +71,8 @@ impl SsmService {
             .ok_or_else(|| missing("BaselineId"))?;
         validate_string_length("BaselineId", baseline_id, 20, 128)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.patch_baselines.remove(baseline_id);
         // Also remove any patch group associations
         state
@@ -89,7 +91,9 @@ impl SsmService {
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let filters = body["Filters"].as_array();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all_baselines: Vec<Value> = state
             .patch_baselines
             .values()
@@ -155,7 +159,9 @@ impl SsmService {
             .ok_or_else(|| missing("BaselineId"))?;
         validate_string_length("BaselineId", baseline_id, 20, 128)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let pb = state.patch_baselines.get(baseline_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -211,7 +217,8 @@ impl SsmService {
             .to_string();
         validate_string_length("PatchGroup", &patch_group, 1, 256)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Check baseline exists (AWS returns "Maintenance window" in this error, not "Patch baseline")
         if !state.patch_baselines.contains_key(&baseline_id) {
@@ -267,7 +274,8 @@ impl SsmService {
             .ok_or_else(|| missing("PatchGroup"))?;
         validate_string_length("PatchGroup", patch_group, 1, 256)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Check if the association exists
         let exists = state
@@ -328,7 +336,9 @@ impl SsmService {
         )?;
         let operating_system = body["OperatingSystem"].as_str().unwrap_or("WINDOWS");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Find a patch group association matching both patch group and OS
         let found = state.patch_groups.iter().find(|pg| {
@@ -367,7 +377,9 @@ impl SsmService {
         let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
         let filters = body["Filters"].as_array();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let all_mappings: Vec<Value> = state
             .patch_groups
             .iter()
@@ -436,7 +448,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("BaselineId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let pb = state.patch_baselines.get_mut(baseline_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -682,7 +695,9 @@ impl SsmService {
         )?;
         let operating_system = body["OperatingSystem"].as_str().unwrap_or("WINDOWS");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Check if a custom default has been registered
         if let Some(ref baseline_id) = state.default_patch_baseline_id {
@@ -711,7 +726,8 @@ impl SsmService {
             .ok_or_else(|| missing("BaselineId"))?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify baseline exists (custom or default)
         if !state.patch_baselines.contains_key(&baseline_id)

--- a/crates/fakecloud-ssm/src/service/resource_sync.rs
+++ b/crates/fakecloud-ssm/src/service/resource_sync.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::ResourceDataSync;
+use crate::state::{ResourceDataSync, SsmState};
 
 use super::{missing, SsmService};
 
@@ -21,7 +21,8 @@ impl SsmService {
             .ok_or_else(|| missing("SyncName"))?
             .to_string();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.resource_data_syncs.contains_key(&sync_name) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -57,7 +58,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("SyncName"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if state.resource_data_syncs.remove(sync_name).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -76,7 +78,9 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_string_length("SyncType", body["SyncType"].as_str(), 1, 64)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let syncs: Vec<Value> = state
             .resource_data_syncs
             .values()
@@ -128,7 +132,8 @@ impl SsmService {
             .cloned()
             .ok_or_else(|| missing("SyncSource"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let sync = state
             .resource_data_syncs
             .get_mut(sync_name)

--- a/crates/fakecloud-ssm/src/service/sessions.rs
+++ b/crates/fakecloud-ssm/src/service/sessions.rs
@@ -6,7 +6,7 @@ use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::SsmSession;
+use crate::state::{SsmSession, SsmState};
 
 use super::{missing, SsmService};
 
@@ -22,7 +22,8 @@ impl SsmService {
         let reason = body["Reason"].as_str().map(|s| s.to_string());
 
         let now = Utc::now();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.session_counter += 1;
         let session_id = format!("session-{:012x}", state.session_counter);
         let account_id = state.account_id.clone();
@@ -51,7 +52,9 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("SessionId"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let session = state.sessions.get(session_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -77,7 +80,8 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("SessionId"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         if let Some(session) = state.sessions.get_mut(session_id) {
             session.status = "Terminated".to_string();
             session.end_date = Some(Utc::now());
@@ -96,7 +100,9 @@ impl SsmService {
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 200)?;
         let state_filter = body["State"].as_str().ok_or_else(|| missing("State"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let sessions: Vec<Value> = state
             .sessions
             .values()
@@ -137,7 +143,8 @@ impl SsmService {
             .as_array()
             .ok_or_else(|| missing("Targets"))?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.session_counter += 1;
         let access_request_id = format!("ar-{:012x}", state.session_counter);
 

--- a/crates/fakecloud-ssm/src/service/tags.rs
+++ b/crates/fakecloud-ssm/src/service/tags.rs
@@ -9,6 +9,7 @@ use fakecloud_core::validation::*;
 
 use super::parameters::{lookup_param, lookup_param_mut};
 use super::{missing, SsmService};
+use crate::state::SsmState;
 
 const INVALID_RESOURCE_TYPE_MSG: &str = " is not a valid resource type. \
     Valid resource types are: ManagedInstance, MaintenanceWindow, \
@@ -108,8 +109,9 @@ impl SsmService {
             .ok_or_else(|| missing("ResourceId"))?;
         validate_required("Tags", &body["Tags"])?;
 
-        let mut state = self.state.write();
-        let tag_map = Self::resolve_tags_mut(&mut state, resource_type, resource_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let tag_map = Self::resolve_tags_mut(state, resource_type, resource_id)?;
         tags::apply_tags(tag_map, &body, "Tags", "Key", "Value").map_err(|f| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -133,8 +135,9 @@ impl SsmService {
             .ok_or_else(|| missing("ResourceId"))?;
         validate_required("TagKeys", &body["TagKeys"])?;
 
-        let mut state = self.state.write();
-        let tag_map = Self::resolve_tags_mut(&mut state, resource_type, resource_id)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let tag_map = Self::resolve_tags_mut(state, resource_type, resource_id)?;
         tags::remove_tags(tag_map, &body, "TagKeys").map_err(|f| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -156,8 +159,10 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("ResourceId"))?;
 
-        let state = self.state.read();
-        let tag_map = Self::resolve_tags(&state, resource_type, resource_id)?;
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let tag_map = Self::resolve_tags(state, resource_type, resource_id)?;
         let result = tags::tags_to_json(tag_map, "Key", "Value");
 
         Ok(AwsResponse::ok_json(json!({ "TagList": result })))

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -735,17 +735,26 @@ pub struct ResourceDataSync {
     pub sync_last_modified_time: DateTime<Utc>,
 }
 
-pub type SharedSsmState = Arc<RwLock<SsmState>>;
+pub type SharedSsmState = Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<SsmState>>>;
+
+impl fakecloud_core::multi_account::AccountState for SsmState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
 
 /// On-disk snapshot envelope for SSM state. Versioned so format
 /// changes fail loudly on upgrade.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmSnapshot {
     pub schema_version: u32,
-    pub state: SsmState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<SsmState>>,
+    #[serde(default)]
+    pub state: Option<SsmState>,
 }
 
-pub const SSM_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const SSM_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Batch 7 of #381. SSM (128 accesses across 16 files) and CloudFormation multi-account.

- SSM: all handler files, default params seeded per-account
- CloudFormation: service + resource provisioner use account_id
- Snapshot v2 with v1 backward compat

## Test plan

- [x] All workspace unit tests pass
- [x] Clippy clean
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate SSM and CloudFormation state per account/region using `fakecloud_core::multi_account::MultiAccountState`, and route all reads/writes by request `account_id`. Adds v2 persistence with automatic migration from v1.

- **New Features**
  - `fakecloud-ssm`: All handlers use per-account state; defaults seeded via `AccountState::new_for_account`.
  - `fakecloud-cloudformation`: Service and provisioner take `account_id`/`region`; SSM ARNs built with request account/region; stack ops isolated per account.
  - `fakecloud-server`: Wiring updated to multi-account for SSM and CloudFormation.

- **Migration**
  - Snapshot schema bumped to v2 for `ssm` and `cloudformation`; v1 files auto-migrate on startup.
  - No manual steps required. New accounts are created lazily and seeded with defaults.

<sup>Written for commit b070d10ebe1186471687f57b5e6aaf2f7a3e64cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

