### PR TITLE
ci(tfacc): shard within-service tests to split long wall-clock poles

### DIFF
--- a/.github/workflows/tfacc.yml
+++ b/.github/workflows/tfacc.yml
@@ -41,17 +41,17 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     outputs:
-      services: ${{ steps.m.outputs.services }}
+      shards: ${{ steps.m.outputs.shards }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Emit service matrix
-        run: cargo run -q -p fakecloud-tfacc --bin tfacc_services > services.json
+      - name: Emit shard matrix
+        run: cargo run -q -p fakecloud-tfacc --bin tfacc_shards > shards.json
 
       - id: m
-        run: echo "services=$(cat services.json)" >> "$GITHUB_OUTPUT"
+        run: echo "shards=$(cat shards.json)" >> "$GITHUB_OUTPUT"
 
       # Build fakecloud once here so every matrix job can download the
       # binary as an artifact instead of rebuilding from scratch.
@@ -67,14 +67,14 @@ jobs:
           retention-days: 1
 
   tfacc:
-    name: tfacc ${{ matrix.service }}
+    name: tfacc ${{ matrix.name }}
     needs: [changes, tfacc-matrix]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        service: ${{ fromJson(needs.tfacc-matrix.outputs.services) }}
+        include: ${{ fromJson(needs.tfacc-matrix.outputs.shards) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -110,14 +110,14 @@ jobs:
       - name: Mark fakecloud binary executable
         run: chmod +x target/debug/fakecloud
 
-      - name: Run ${{ matrix.service }} acceptance tests
-        run: cargo test -p fakecloud-tfacc --test acc ${{ matrix.service }}_acceptance -- --nocapture
+      - name: Run ${{ matrix.name }} acceptance tests
+        run: cargo test -p fakecloud-tfacc --test acc ${{ matrix.test_fn }} -- --nocapture
 
       - name: Upload failing go test output
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: tfacc-${{ matrix.service }}-failure-log
+          name: tfacc-${{ matrix.name }}-failure-log
           path: target/tfacc/logs/${{ matrix.service }}-failure.log
           if-no-files-found: ignore
           retention-days: 7

--- a/crates/fakecloud-tfacc/Cargo.toml
+++ b/crates/fakecloud-tfacc/Cargo.toml
@@ -15,3 +15,7 @@ tokio = { workspace = true }
 [[bin]]
 name = "tfacc_services"
 path = "src/bin/tfacc_services.rs"
+
+[[bin]]
+name = "tfacc_shards"
+path = "src/bin/tfacc_shards.rs"

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -35,6 +35,40 @@ pub struct Service {
     pub deny: &'static [&'static str],
 }
 
+/// A CI matrix entry. Normally a shard is 1:1 with a `Service` (same
+/// regex and deny-list) and the shard name equals the service name. For
+/// the handful of services whose full test set exceeds a single runner's
+/// wall-clock budget, we define multiple shards over the same service
+/// with narrower run_regex + extended deny so the union of all shards
+/// equals the service's original selection.
+///
+/// The shards are what `tfacc.yml` fans out over — one GitHub Actions
+/// job per entry.
+pub struct Shard {
+    /// Matrix job name. For unsharded services this is just the service
+    /// name; for sharded services it is `<service>-<suffix>`.
+    pub name: &'static str,
+    /// Upstream directory — passed to `go test ./internal/service/<svc>/`.
+    pub service: &'static str,
+    /// Narrower `-run` regex than the owning `Service` uses.
+    pub run_regex: &'static str,
+    /// Extra tests to `-skip` on top of the owning `Service`'s deny-list.
+    /// Lets a sibling shard claim those tests without double-running them.
+    pub extra_deny: &'static [&'static str],
+}
+
+/// Combine a shard's `extra_deny` with its owning service's `deny` list
+/// and return the full set CI should skip.
+pub fn shard_deny_list(shard: &Shard) -> Vec<&'static str> {
+    let service = SERVICES
+        .iter()
+        .find(|s| s.name == shard.service)
+        .expect("shard references unknown service");
+    let mut out: Vec<&'static str> = service.deny.to_vec();
+    out.extend(shard.extra_deny.iter().copied());
+    out
+}
+
 pub const SERVICES: &[Service] = &[
     Service {
         name: "cognitoidp",
@@ -216,5 +250,130 @@ pub const SERVICES: &[Service] = &[
             "TestAccDynamoDBTable_gsiUpdateOtherAttributes",
             "TestAccDynamoDBTable_TTL_updateDisable",
         ],
+    },
+];
+
+/// CI matrix shards. One GitHub Actions job per entry.
+///
+/// Kept as a flat list (rather than generated from `SERVICES`) so a reader
+/// can see exactly which services are split and why. Services with one
+/// shard here use the default service regex + deny. Services with
+/// multiple shards partition the run_regex; `shard_deny_list` merges the
+/// service's deny with each shard's extra_deny to keep sibling shards
+/// from double-running the same tests.
+pub const SHARDS: &[Shard] = &[
+    // ─── unsharded services (1 shard each) ─────────────────────────
+    Shard {
+        name: "cognitoidp",
+        service: "cognitoidp",
+        run_regex: "^TestAccCognitoIDPUserPool_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "bedrock",
+        service: "bedrock",
+        run_regex: "^TestAccBedrockFoundationModelsDataSource_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "apigatewayv2",
+        service: "apigatewayv2",
+        run_regex: "^TestAccAPIGatewayV2API_basicHTTP$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kinesis",
+        service: "kinesis",
+        run_regex: "^TestAccKinesisStream_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "sns",
+        service: "sns",
+        run_regex: "^TestAccSNSTopic_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "events",
+        service: "events",
+        run_regex: "^TestAccEvents(Bus|Rule)_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kms",
+        service: "kms",
+        run_regex: "^TestAccKMSKey_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "logs",
+        service: "logs",
+        run_regex: "^TestAccLogsGroup_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "iam",
+        service: "iam",
+        run_regex: "^TestAccIAM(Role|User|Policy|Group)_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "ssm",
+        service: "ssm",
+        run_regex: "^TestAccSSMParameter_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "secretsmanager",
+        service: "secretsmanager",
+        run_regex: "^TestAccSecretsManagerSecret_basic$",
+        extra_deny: &[],
+    },
+    // ─── sqs split into core + encryption ──────────────────────────
+    // The full sqs regex is a union of ~12 TestAcc names; split so the
+    // core queue/policy/redrive suite runs in parallel with the
+    // encryption-attribute round-trip suite. Wall-clock for sqs drops
+    // from ~7m to ~the slower half of that.
+    Shard {
+        name: "sqs-core",
+        service: "sqs",
+        run_regex: concat!(
+            "^TestAccSQS(",
+            "Queue_(basic|redrivePolicy|redriveAllowPolicy|Policy_basic)",
+            "|QueuePolicy_basic",
+            "|QueueRedrivePolicy_basic",
+            "|QueueRedriveAllowPolicy_basic)$",
+        ),
+        extra_deny: &[],
+    },
+    Shard {
+        name: "sqs-encryption",
+        service: "sqs",
+        run_regex: concat!(
+            "^TestAccSQSQueue_(",
+            "encryption|managedEncryption",
+            "|defaultKMSDataKeyReusePeriodSeconds",
+            "|ManagedEncryption_kmsDataKeyReusePeriodSeconds",
+            "|noEncryptionKMSDataKeyReusePeriodSeconds)$",
+        ),
+        extra_deny: &[],
+    },
+    // ─── dynamodb split into a-g vs h-z ────────────────────────────
+    // dynamodb's `^TestAccDynamoDBTable_` regex selects ~50 tests after
+    // deny-listing. Splitting into two halves keyed on the first letter
+    // after the underscore roughly halves the wall-clock of the longest
+    // shard. Go test's -skip takes a regex, so we can cover the union
+    // without enumerating every upstream test name.
+    Shard {
+        name: "dynamodb-a-g",
+        service: "dynamodb",
+        run_regex: "^TestAccDynamoDBTable_[a-gA-G]",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "dynamodb-h-z",
+        service: "dynamodb",
+        run_regex: "^TestAccDynamoDBTable_[^a-gA-G]",
+        extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/src/bin/tfacc_shards.rs
+++ b/crates/fakecloud-tfacc/src/bin/tfacc_shards.rs
@@ -1,0 +1,27 @@
+//! Emits the `SHARDS` matrix as JSON for CI fan-out.
+//!
+//! Each element is `{"name":"...","service":"..."}` — the workflow uses
+//! `name` as the job display name and `service` is kept for context.
+//! The matching `#[tokio::test]` in `tests/acc.rs` picks up the shard
+//! metadata via `SHARDS` too, so this binary only needs to emit enough
+//! for the GHA matrix to fan out.
+
+use fakecloud_tfacc::SHARDS;
+
+fn main() {
+    let mut out = String::from("[");
+    for (i, shard) in SHARDS.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        // test_fn matches the `#[tokio::test]` in `tests/acc.rs` — shard
+        // names use dashes, Rust function names use underscores.
+        let test_fn = format!("{}_acceptance", shard.name.replace('-', "_"));
+        out.push_str(&format!(
+            r#"{{"name":"{}","service":"{}","test_fn":"{}"}}"#,
+            shard.name, shard.service, test_fn
+        ));
+    }
+    out.push(']');
+    println!("{out}");
+}

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -16,7 +16,7 @@ use std::process::{Command, Output, Stdio};
 
 pub mod allowlist;
 
-pub use allowlist::{Service, SERVICES};
+pub use allowlist::{shard_deny_list, Service, Shard, SERVICES, SHARDS};
 
 /// Pinned upstream provider tag. Bumping is a deliberate edit; newer tags
 /// may add acc tests that assume fields fakecloud does not yet return.
@@ -143,12 +143,23 @@ pub struct GoTestRunner<'a> {
 
 impl<'a> GoTestRunner<'a> {
     pub fn run_service(&self, service: &Service) -> GoTestResult {
-        let service_path = format!("./internal/service/{}/", service.name);
-        let run_re = service.run_regex;
-        let skip_re = if service.deny.is_empty() {
+        self.run_go_tests(service.name, service.run_regex, service.deny)
+    }
+
+    /// Run the `go test` slice for a single matrix shard. Merges the
+    /// shard's `extra_deny` with its owning service's deny-list so
+    /// sibling shards of the same service don't race on the same test.
+    pub fn run_shard(&self, shard: &Shard) -> GoTestResult {
+        let deny = shard_deny_list(shard);
+        self.run_go_tests(shard.service, shard.run_regex, &deny)
+    }
+
+    fn run_go_tests(&self, service: &str, run_regex: &str, deny: &[&str]) -> GoTestResult {
+        let service_path = format!("./internal/service/{service}/");
+        let skip_re = if deny.is_empty() {
             String::new()
         } else {
-            format!("^({})$", service.deny.join("|"))
+            format!("^({})$", deny.join("|"))
         };
 
         // `-parallel 4` lets Go's test runner execute up to 4 `t.Parallel()`
@@ -163,7 +174,7 @@ impl<'a> GoTestRunner<'a> {
             "test".into(),
             service_path,
             "-run".into(),
-            run_re.into(),
+            run_regex.to_string(),
             "-v".into(),
             "-timeout".into(),
             "90m".into(),

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -1,5 +1,6 @@
-//! One `#[tokio::test]` per allow-listed service. Each runs every
-//! `TestAcc*` test matching the service's `run_regex` minus its deny-list.
+//! One `#[tokio::test]` per CI matrix shard. Each runs the `TestAcc*`
+//! tests selected by its `Shard` (filtered by `run_regex` minus the
+//! merged deny-list).
 //!
 //! Hard-fails if the `go` or `terraform` binaries are missing. Running
 //! this crate is an opt-in signal that the caller wants the upstream
@@ -7,16 +8,15 @@
 //! run it would just hide regressions.
 
 use fakecloud_tfacc::{
-    allowlist::{Service, SERVICES},
-    require_toolchain, setup_provider_source, GoTestRunner, TestServer,
+    require_toolchain, setup_provider_source, GoTestRunner, Shard, TestServer, SHARDS,
 };
 
-async fn run_service(name: &str) {
+async fn run_shard(name: &str) {
     require_toolchain();
-    let service: &Service = SERVICES
+    let shard: &Shard = SHARDS
         .iter()
         .find(|s| s.name == name)
-        .unwrap_or_else(|| panic!("service `{name}` not in SERVICES allow-list"));
+        .unwrap_or_else(|| panic!("shard `{name}` not in SHARDS list"));
 
     let provider_root = setup_provider_source().expect("setup terraform-provider-aws");
     let server = TestServer::start().await;
@@ -24,70 +24,80 @@ async fn run_service(name: &str) {
         provider_root: &provider_root,
         endpoint: server.endpoint(),
     };
-    runner.run_service(service).assert_pass(name);
+    runner.run_shard(shard).assert_pass(name);
 }
 
 #[tokio::test]
 async fn cognitoidp_acceptance() {
-    run_service("cognitoidp").await;
+    run_shard("cognitoidp").await;
 }
 
 #[tokio::test]
 async fn bedrock_acceptance() {
-    run_service("bedrock").await;
+    run_shard("bedrock").await;
 }
 
 #[tokio::test]
 async fn apigatewayv2_acceptance() {
-    run_service("apigatewayv2").await;
+    run_shard("apigatewayv2").await;
 }
 
 #[tokio::test]
 async fn kinesis_acceptance() {
-    run_service("kinesis").await;
+    run_shard("kinesis").await;
 }
 
 #[tokio::test]
 async fn sns_acceptance() {
-    run_service("sns").await;
+    run_shard("sns").await;
 }
 
 #[tokio::test]
 async fn events_acceptance() {
-    run_service("events").await;
+    run_shard("events").await;
 }
 
 #[tokio::test]
 async fn kms_acceptance() {
-    run_service("kms").await;
+    run_shard("kms").await;
 }
 
 #[tokio::test]
 async fn logs_acceptance() {
-    run_service("logs").await;
+    run_shard("logs").await;
 }
 
 #[tokio::test]
 async fn iam_acceptance() {
-    run_service("iam").await;
+    run_shard("iam").await;
 }
 
 #[tokio::test]
 async fn ssm_acceptance() {
-    run_service("ssm").await;
+    run_shard("ssm").await;
 }
 
 #[tokio::test]
 async fn secretsmanager_acceptance() {
-    run_service("secretsmanager").await;
+    run_shard("secretsmanager").await;
 }
 
 #[tokio::test]
-async fn sqs_acceptance() {
-    run_service("sqs").await;
+async fn sqs_core_acceptance() {
+    run_shard("sqs-core").await;
 }
 
 #[tokio::test]
-async fn dynamodb_acceptance() {
-    run_service("dynamodb").await;
+async fn sqs_encryption_acceptance() {
+    run_shard("sqs-encryption").await;
+}
+
+#[tokio::test]
+async fn dynamodb_a_g_acceptance() {
+    run_shard("dynamodb-a-g").await;
+}
+
+#[tokio::test]
+async fn dynamodb_h_z_acceptance() {
+    run_shard("dynamodb-h-z").await;
 }


### PR DESCRIPTION
## Summary

- Terraform Acceptance runs one matrix job per service. The slowest arm (dynamodb, ~20m) caps the whole workflow.
- Split the two heaviest services: \`sqs\` -> \`sqs-core\` + \`sqs-encryption\`; \`dynamodb\` -> \`dynamodb-a-g\` + \`dynamodb-h-z\` (by first letter after \`TestAccDynamoDBTable_\`).
- New matrix has 15 shards instead of 13. Heaviest shard now runs ~half of what dynamodb previously did.
- Adds \`tfacc_shards\` bin that emits the matrix as JSON with \`name\`, \`service\`, \`test_fn\` fields. \`tests/acc.rs\` now has one \`#[tokio::test]\` per shard.
- Workflow consumes the shard JSON via \`matrix.include\`; job name + test function name come from the shard entry.

Part of the CI-speedup follow-up series after #600–#605.

## Test plan

- [ ] Workflow fans out to 15 \`tfacc <name>\` jobs (check the matrix in the Actions tab).
- [ ] \`dynamodb-a-g\` and \`dynamodb-h-z\` together cover every test \`tfacc dynamodb\` ran before (spot-check via \`go test -list\` on the provider).
- [ ] Critical path (slowest arm) drops from ~20m to ~12-14m.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shard Terraform acceptance tests within services to cut CI wall-clock. Splits the heaviest services and expands the matrix to 15 jobs, dropping the critical path from ~20m to ~12–14m.

- **New Features**
  - Split heavy services: `sqs` → `sqs-core` + `sqs-encryption`; `dynamodb` → `dynamodb-a-g` + `dynamodb-h-z` (by test name prefix).
  - Add `tfacc_shards` to emit shard JSON (`name`, `service`, `test_fn`); workflow now uses `matrix.include`, displays `matrix.name`, and runs `matrix.test_fn`.
  - Update `fakecloud-tfacc` tests and runner to shard-aware (`Shard`, `SHARDS`, `run_shard()`), merging deny-lists to avoid duplicate runs. Unsharded services remain 1:1.

<sup>Written for commit 448d64195aa2925c07aa5e7aec3e5115357e0c9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

