### PR TITLE
test(logs): query + query_definition error paths + describe_queries filters

### DIFF
--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -503,4 +503,191 @@ mod tests {
             assert!(!body["success"].as_bool().unwrap_or(true));
         }
     }
+
+    // ---- start_query error paths ----
+
+    #[test]
+    fn start_query_missing_log_group_name_errors() {
+        let svc = make_service();
+        let req = make_request("StartQuery", json!({ "queryString": "fields @timestamp" }));
+        assert!(svc.start_query(&req).is_err());
+    }
+
+    #[test]
+    fn start_query_unknown_log_group_errors() {
+        let svc = make_service();
+        let req = make_request(
+            "StartQuery",
+            json!({
+                "logGroupName": "missing",
+                "startTime": 0,
+                "endTime": 0,
+                "queryString": "fields @timestamp"
+            }),
+        );
+        assert!(svc.start_query(&req).is_err());
+    }
+
+    #[test]
+    fn start_query_ok_path() {
+        let svc = make_service();
+        create_group(&svc, "app");
+        let req = make_request(
+            "StartQuery",
+            json!({
+                "logGroupName": "app",
+                "startTime": 0,
+                "endTime": 0,
+                "queryString": "fields @timestamp"
+            }),
+        );
+        let resp = svc.start_query(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["queryId"].is_string());
+    }
+
+    // ---- get_query_results error paths ----
+
+    #[test]
+    fn get_query_results_missing_query_id_errors() {
+        let svc = make_service();
+        let req = make_request("GetQueryResults", json!({}));
+        assert!(svc.get_query_results(&req).is_err());
+    }
+
+    #[test]
+    fn get_query_results_unknown_id_errors() {
+        let svc = make_service();
+        let req = make_request("GetQueryResults", json!({"queryId": "missing"}));
+        assert!(svc.get_query_results(&req).is_err());
+    }
+
+    #[test]
+    fn get_query_results_returns_complete_status() {
+        let svc = make_service();
+        create_group(&svc, "app");
+        let start = make_request(
+            "StartQuery",
+            json!({
+                "logGroupName": "app",
+                "startTime": 0,
+                "endTime": 0,
+                "queryString": "fields @timestamp"
+            }),
+        );
+        let resp = svc.start_query(&start).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let qid = body["queryId"].as_str().unwrap().to_string();
+        let get = make_request("GetQueryResults", json!({"queryId": qid}));
+        let resp = svc.get_query_results(&get).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["status"], "Complete");
+        assert!(body["results"].is_array());
+    }
+
+    // ---- put_query_definition error paths ----
+
+    #[test]
+    fn put_query_definition_update_existing() {
+        let svc = make_service();
+        let put = make_request(
+            "PutQueryDefinition",
+            json!({"name": "qd-1", "queryString": "fields @timestamp"}),
+        );
+        let resp = svc.put_query_definition(&put).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let qid = body["queryDefinitionId"].as_str().unwrap().to_string();
+
+        // Update using queryDefinitionId
+        let update = make_request(
+            "PutQueryDefinition",
+            json!({
+                "queryDefinitionId": qid,
+                "name": "qd-1-updated",
+                "queryString": "fields @timestamp | limit 10"
+            }),
+        );
+        svc.put_query_definition(&update).unwrap();
+
+        let list = make_request("DescribeQueryDefinitions", json!({}));
+        let resp = svc.describe_query_definitions(&list).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let defs = body["queryDefinitions"].as_array().unwrap();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0]["name"], "qd-1-updated");
+    }
+
+    #[test]
+    fn describe_queries_filters_by_log_group() {
+        let svc = make_service();
+        create_group(&svc, "app-a");
+        create_group(&svc, "app-b");
+        for g in &["app-a", "app-b"] {
+            let req = make_request(
+                "StartQuery",
+                json!({
+                    "logGroupName": g,
+                    "startTime": 0,
+                    "endTime": 0,
+                    "queryString": "fields @timestamp"
+                }),
+            );
+            svc.start_query(&req).unwrap();
+        }
+        let req = make_request("DescribeQueries", json!({"logGroupName": "app-a"}));
+        let resp = svc.describe_queries(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let queries = body["queries"].as_array().unwrap();
+        assert_eq!(queries.len(), 1);
+        assert_eq!(queries[0]["logGroupName"], "app-a");
+    }
+
+    #[test]
+    fn describe_queries_returns_all_when_no_filter() {
+        let svc = make_service();
+        create_group(&svc, "g1");
+        let req = make_request(
+            "StartQuery",
+            json!({
+                "logGroupName": "g1",
+                "startTime": 0,
+                "endTime": 0,
+                "queryString": "fields @timestamp"
+            }),
+        );
+        svc.start_query(&req).unwrap();
+        let req = make_request("DescribeQueries", json!({}));
+        let resp = svc.describe_queries(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["queries"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn list_log_groups_for_query_returns_stub_list() {
+        let svc = make_service();
+        create_group(&svc, "app");
+        let start = make_request(
+            "StartQuery",
+            json!({
+                "logGroupName": "app",
+                "startTime": 0,
+                "endTime": 0,
+                "queryString": "fields @timestamp"
+            }),
+        );
+        let resp = svc.start_query(&start).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let qid = body["queryId"].as_str().unwrap().to_string();
+        let req = make_request("ListLogGroupsForQuery", json!({"queryId": qid}));
+        let resp = svc.list_log_groups_for_query(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["logGroupIdentifiers"].is_array());
+    }
+
+    #[test]
+    fn list_log_groups_for_query_missing_id_errors() {
+        let svc = make_service();
+        let req = make_request("ListLogGroupsForQuery", json!({}));
+        assert!(svc.list_log_groups_for_query(&req).is_err());
+    }
 }


### PR DESCRIPTION
Covers start_query missing/unknown log group + ok path, get_query_results missing/unknown queryId + complete status, put_query_definition update flow, describe_queries logGroupName filter + all, list_log_groups_for_query stub + missing id.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for the Logs query APIs in `fakecloud-logs`, covering StartQuery, GetQueryResults, PutQueryDefinition updates, DescribeQueries filters, and ListLogGroupsForQuery. Validates error handling for missing/unknown inputs, confirms successful paths (including Complete status), and ensures DescribeQueries returns all results when no filter is provided.

<sup>Written for commit b67f81d97d89d876ec1c6ab2a95117950ad7b61b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

