### PR TITLE
feat(scheduler): firing loop, SQS delivery, DLQ routing

### DIFF
--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -29,6 +29,29 @@ pub struct SqsMessageAttribute {
     pub binary_value: Option<String>,
 }
 
+/// Error returned by fallible SQS delivery. Used by Scheduler's DLQ
+/// routing, which must distinguish "target queue missing" from
+/// "delivered successfully" to decide whether to send to the
+/// `DeadLetterConfig.Arn`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SqsDeliveryError {
+    /// The target queue ARN did not resolve to any existing queue.
+    QueueNotFound(String),
+    /// The ARN could not be parsed into a valid SQS queue identifier.
+    InvalidArn(String),
+}
+
+impl std::fmt::Display for SqsDeliveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::QueueNotFound(arn) => write!(f, "queue not found: {arn}"),
+            Self::InvalidArn(arn) => write!(f, "invalid queue ARN: {arn}"),
+        }
+    }
+}
+
+impl std::error::Error for SqsDeliveryError {}
+
 /// Trait for delivering messages to SQS queues.
 pub trait SqsDelivery: Send + Sync {
     fn deliver_to_queue(
@@ -50,6 +73,29 @@ pub trait SqsDelivery: Send + Sync {
         // Default implementation: fall back to simple delivery
         let _ = (message_attributes, message_group_id, message_dedup_id);
         self.deliver_to_queue(queue_arn, message_body, &HashMap::new());
+    }
+
+    /// Fallible variant used by Scheduler's DLQ routing. Default
+    /// implementation assumes the queue exists (preserving the
+    /// fire-and-forget semantics of `deliver_to_queue`); the real SQS
+    /// impl overrides this to actually look up the queue and report
+    /// `QueueNotFound` so the caller can route to a DLQ.
+    fn try_deliver_to_queue_with_attrs(
+        &self,
+        queue_arn: &str,
+        message_body: &str,
+        message_attributes: &HashMap<String, SqsMessageAttribute>,
+        message_group_id: Option<&str>,
+        message_dedup_id: Option<&str>,
+    ) -> Result<(), SqsDeliveryError> {
+        self.deliver_to_queue_with_attrs(
+            queue_arn,
+            message_body,
+            message_attributes,
+            message_group_id,
+            message_dedup_id,
+        );
+        Ok(())
     }
 }
 
@@ -161,6 +207,30 @@ impl DeliveryBus {
                 message_group_id,
                 message_dedup_id,
             );
+        }
+    }
+
+    /// Fallible SQS send — returns `Err` when the target queue does not
+    /// exist, so callers (Scheduler) can route to a DLQ. Returns
+    /// `Err(QueueNotFound)` when no SQS sender is wired up at all,
+    /// matching the "target unreachable" semantics Scheduler relies on.
+    pub fn try_send_to_sqs_with_attrs(
+        &self,
+        queue_arn: &str,
+        message_body: &str,
+        message_attributes: &HashMap<String, SqsMessageAttribute>,
+        message_group_id: Option<&str>,
+        message_dedup_id: Option<&str>,
+    ) -> Result<(), SqsDeliveryError> {
+        match self.sqs_sender {
+            Some(ref sender) => sender.try_deliver_to_queue_with_attrs(
+                queue_arn,
+                message_body,
+                message_attributes,
+                message_group_id,
+                message_dedup_id,
+            ),
+            None => Err(SqsDeliveryError::QueueNotFound(queue_arn.to_string())),
         }
     }
 

--- a/crates/fakecloud-e2e/tests/scheduler.rs
+++ b/crates/fakecloud-e2e/tests/scheduler.rs
@@ -1,14 +1,65 @@
 //! End-to-end tests for EventBridge Scheduler (`scheduler.amazonaws.com`).
-//!
-//! Batch 1: CRUD round-trips against the AWS SDK. Firing / DLQ /
-//! self-delete tests land in Batch 2.
 
 mod helpers;
 
+use std::time::Duration;
+
 use aws_sdk_scheduler::types::{
-    ActionAfterCompletion, FlexibleTimeWindow, FlexibleTimeWindowMode, ScheduleState, Target,
+    ActionAfterCompletion, DeadLetterConfig, FlexibleTimeWindow, FlexibleTimeWindowMode,
+    ScheduleState, Target,
 };
+use aws_sdk_sqs::types::QueueAttributeName;
 use fakecloud_testkit::TestServer;
+
+async fn wait_for_message(
+    sqs: &aws_sdk_sqs::Client,
+    queue_url: &str,
+    timeout: Duration,
+) -> Option<aws_sdk_sqs::types::Message> {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        let resp = sqs
+            .receive_message()
+            .queue_url(queue_url)
+            .wait_time_seconds(1)
+            .max_number_of_messages(1)
+            .message_attribute_names("All")
+            .send()
+            .await
+            .unwrap();
+        if let Some(msgs) = resp.messages {
+            if let Some(m) = msgs.into_iter().next() {
+                return Some(m);
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    None
+}
+
+async fn queue_url(sqs: &aws_sdk_sqs::Client, name: &str) -> String {
+    sqs.create_queue()
+        .queue_name(name)
+        .send()
+        .await
+        .unwrap()
+        .queue_url
+        .unwrap()
+}
+
+async fn queue_arn(sqs: &aws_sdk_sqs::Client, url: &str) -> String {
+    sqs.get_queue_attributes()
+        .queue_url(url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .clone()
+}
 
 fn sqs_target() -> Target {
     Target::builder()
@@ -215,4 +266,124 @@ async fn scheduler_group_lifecycle() {
         .await
         .expect_err("group should be gone");
     assert!(format!("{err:?}").contains("ResourceNotFound"));
+}
+
+// ---------------------------------------------------------------------------
+// Firing semantics (Batch 2)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scheduler_rate_expression_delivers_input_to_sqs() {
+    let server = TestServer::start().await;
+    let sched = server.scheduler_client().await;
+    let sqs = server.sqs_client().await;
+
+    let q_url = queue_url(&sqs, "fire-dest").await;
+    let q_arn = queue_arn(&sqs, &q_url).await;
+
+    let target = Target::builder()
+        .arn(q_arn.clone())
+        .role_arn("arn:aws:iam::000000000000:role/scheduler")
+        .input("{\"msg\":\"hello\"}")
+        .build()
+        .unwrap();
+
+    sched
+        .create_schedule()
+        .name("fire-rate")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(off_window())
+        .target(target)
+        .send()
+        .await
+        .expect("create_schedule");
+
+    let msg = wait_for_message(&sqs, &q_url, Duration::from_secs(10))
+        .await
+        .expect("scheduler should deliver within 10s");
+    assert_eq!(msg.body.unwrap(), "{\"msg\":\"hello\"}");
+}
+
+#[tokio::test]
+async fn scheduler_at_one_shot_delete_removes_schedule_after_fire() {
+    let server = TestServer::start().await;
+    let sched = server.scheduler_client().await;
+    let sqs = server.sqs_client().await;
+
+    let q_url = queue_url(&sqs, "once-dest").await;
+    let q_arn = queue_arn(&sqs, &q_url).await;
+
+    let target = Target::builder()
+        .arn(q_arn)
+        .role_arn("arn:aws:iam::000000000000:role/scheduler")
+        .input("{\"one\":\"shot\"}")
+        .build()
+        .unwrap();
+
+    // Past-dated so it fires on the next tick.
+    sched
+        .create_schedule()
+        .name("once-delete")
+        .schedule_expression("at(2020-01-01T00:00:00)")
+        .flexible_time_window(off_window())
+        .target(target)
+        .action_after_completion(ActionAfterCompletion::Delete)
+        .send()
+        .await
+        .unwrap();
+
+    let msg = wait_for_message(&sqs, &q_url, Duration::from_secs(10))
+        .await
+        .expect("one-shot should fire within 10s");
+    assert_eq!(msg.body.unwrap(), "{\"one\":\"shot\"}");
+
+    // Give the ticker a beat to apply the DELETE post-fire action.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let err = sched
+        .get_schedule()
+        .name("once-delete")
+        .send()
+        .await
+        .expect_err("schedule should be deleted after firing");
+    assert!(format!("{err:?}").contains("ResourceNotFound"));
+}
+
+#[tokio::test]
+async fn scheduler_dlq_routing_on_missing_target_queue() {
+    let server = TestServer::start().await;
+    let sched = server.scheduler_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create ONLY the DLQ — the target queue ARN is bogus on purpose.
+    let dlq_url = queue_url(&sqs, "dlq-dest").await;
+    let dlq_arn = queue_arn(&sqs, &dlq_url).await;
+
+    let target = Target::builder()
+        .arn("arn:aws:sqs:us-east-1:000000000000:no-such-queue")
+        .role_arn("arn:aws:iam::000000000000:role/scheduler")
+        .input("{\"original\":true}")
+        .dead_letter_config(DeadLetterConfig::builder().arn(dlq_arn.clone()).build())
+        .build()
+        .unwrap();
+
+    sched
+        .create_schedule()
+        .name("dlq-test")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(off_window())
+        .target(target)
+        .send()
+        .await
+        .unwrap();
+
+    let msg = wait_for_message(&sqs, &dlq_url, Duration::from_secs(10))
+        .await
+        .expect("DLQ should receive failed delivery");
+    assert_eq!(msg.body.unwrap(), "{\"original\":true}");
+    let attrs = msg
+        .message_attributes
+        .expect("DLQ message should have attrs");
+    assert!(attrs.contains_key("X-Amz-Scheduler-Attempt"));
+    assert!(attrs.contains_key("X-Amz-Scheduler-Schedule-Arn"));
+    assert!(attrs.contains_key("X-Amz-Scheduler-Error-Code"));
 }

--- a/crates/fakecloud-scheduler/src/delivery.rs
+++ b/crates/fakecloud-scheduler/src/delivery.rs
@@ -1,0 +1,306 @@
+//! Target delivery + DLQ routing for fired schedules.
+//!
+//! Scheduler's firing contract: every enabled schedule whose expression
+//! matches the current tick has its `Target.Input` body delivered to
+//! `Target.Arn`. If delivery fails (target queue missing, etc.) and
+//! `Target.DeadLetterConfig.Arn` is set, we route the original input +
+//! failure metadata headers to the DLQ so tests can observe the
+//! failure. No retry policy is modeled in Batch 2 — every fire is a
+//! single attempt.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use fakecloud_core::delivery::{DeliveryBus, SqsDeliveryError, SqsMessageAttribute};
+
+use crate::state::Schedule;
+
+/// Attempt to deliver a fired schedule's target. Returns `Ok(())` when
+/// the target accepted the message (or the target type is a fire-and-
+/// forget SNS/Lambda/SFN that we don't currently validate). Returns
+/// `Err` only for SQS-shaped targets where the queue doesn't exist —
+/// that's the specific signal Scheduler's DLQ routing needs.
+pub fn deliver_target(bus: &Arc<DeliveryBus>, schedule: &Schedule) -> Result<(), SqsDeliveryError> {
+    let arn = &schedule.target.arn;
+    let body = schedule.target.input.as_deref().unwrap_or("{}");
+
+    if arn.contains(":sqs:") {
+        let attrs = HashMap::new();
+        let group_id = schedule
+            .target
+            .sqs_parameters
+            .as_ref()
+            .and_then(|s| s.message_group_id.as_deref());
+        return bus.try_send_to_sqs_with_attrs(arn, body, &attrs, group_id, None);
+    }
+
+    if arn.contains(":sns:") {
+        bus.publish_to_sns(arn, body, None);
+        return Ok(());
+    }
+
+    if arn.contains(":lambda:") {
+        // Fire-and-forget async invocation. A proper implementation
+        // would await the future, but DeliveryBus::invoke_lambda is
+        // async and we're called from the synchronous tick loop.
+        let bus = bus.clone();
+        let arn = arn.clone();
+        let body = body.to_string();
+        tokio::spawn(async move {
+            let _ = bus.invoke_lambda(&arn, &body).await;
+        });
+        return Ok(());
+    }
+
+    if arn.contains(":states:") {
+        bus.start_stepfunctions_execution(arn, body);
+        return Ok(());
+    }
+
+    if arn.contains(":events:") {
+        bus.put_event_to_eventbridge("aws.scheduler", "Scheduled Event", body, "default");
+        return Ok(());
+    }
+
+    // Unsupported target type — log and succeed so we don't push it to
+    // DLQ (DLQ is for deliverable-target failures, not unknown targets).
+    tracing::warn!(target_arn = %arn, schedule = %schedule.name, "scheduler: unsupported target type, skipping");
+    Ok(())
+}
+
+/// Route a failed delivery to the schedule's DLQ, if one is
+/// configured. Metadata headers mirror AWS's format so tests can
+/// assert on `X-Amz-Scheduler-Attempt` etc.
+pub fn route_to_dlq(
+    bus: &Arc<DeliveryBus>,
+    schedule: &Schedule,
+    error_code: &str,
+    error_message: &str,
+) {
+    let dlq_arn = match schedule
+        .target
+        .dead_letter_config
+        .as_ref()
+        .and_then(|d| d.arn.as_ref())
+    {
+        Some(arn) => arn.clone(),
+        None => return,
+    };
+
+    let mut attrs: HashMap<String, SqsMessageAttribute> = HashMap::new();
+    attrs.insert("X-Amz-Scheduler-Attempt".to_string(), string_attr("1"));
+    attrs.insert(
+        "X-Amz-Scheduler-Schedule-Arn".to_string(),
+        string_attr(&schedule.arn),
+    );
+    attrs.insert(
+        "X-Amz-Scheduler-Target-Arn".to_string(),
+        string_attr(&schedule.target.arn),
+    );
+    attrs.insert(
+        "X-Amz-Scheduler-Error-Code".to_string(),
+        string_attr(error_code),
+    );
+    attrs.insert(
+        "X-Amz-Scheduler-Error-Message".to_string(),
+        string_attr(error_message),
+    );
+    attrs.insert(
+        "X-Amz-Scheduler-Group".to_string(),
+        string_attr(&schedule.group_name),
+    );
+
+    let body = schedule.target.input.as_deref().unwrap_or("{}");
+    if let Err(err) = bus.try_send_to_sqs_with_attrs(&dlq_arn, body, &attrs, None, None) {
+        tracing::error!(
+            schedule = %schedule.name,
+            dlq = %dlq_arn,
+            %err,
+            "scheduler: DLQ delivery failed — message dropped"
+        );
+    } else {
+        tracing::info!(
+            schedule = %schedule.name,
+            dlq = %dlq_arn,
+            %error_code,
+            "scheduler: delivery failed, routed to DLQ"
+        );
+    }
+}
+
+fn string_attr(v: &str) -> SqsMessageAttribute {
+    SqsMessageAttribute {
+        data_type: "String".to_string(),
+        string_value: Some(v.to_string()),
+        binary_value: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{DeadLetterConfig, FlexibleTimeWindow, Schedule, Target};
+    use chrono::Utc;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    type RecordedCall = (String, String, HashMap<String, SqsMessageAttribute>);
+
+    struct Recorder {
+        calls: Mutex<Vec<RecordedCall>>,
+        fail_arn: Option<String>,
+    }
+
+    impl fakecloud_core::delivery::SqsDelivery for Recorder {
+        fn deliver_to_queue(&self, _arn: &str, _body: &str, _attrs: &HashMap<String, String>) {}
+
+        fn try_deliver_to_queue_with_attrs(
+            &self,
+            queue_arn: &str,
+            message_body: &str,
+            message_attributes: &HashMap<String, SqsMessageAttribute>,
+            _group: Option<&str>,
+            _dedup: Option<&str>,
+        ) -> Result<(), SqsDeliveryError> {
+            if Some(queue_arn.to_string()) == self.fail_arn {
+                return Err(SqsDeliveryError::QueueNotFound(queue_arn.to_string()));
+            }
+            self.calls.lock().unwrap().push((
+                queue_arn.to_string(),
+                message_body.to_string(),
+                message_attributes.clone(),
+            ));
+            Ok(())
+        }
+    }
+
+    fn make_schedule(target_arn: &str, dlq: Option<&str>, input: Option<&str>) -> Schedule {
+        Schedule {
+            arn: "arn:aws:scheduler:us-east-1:1:schedule/default/t".to_string(),
+            name: "t".to_string(),
+            group_name: "default".to_string(),
+            schedule_expression: "rate(1 minute)".to_string(),
+            schedule_expression_timezone: None,
+            start_date: None,
+            end_date: None,
+            description: None,
+            state: "ENABLED".to_string(),
+            kms_key_arn: None,
+            action_after_completion: "NONE".to_string(),
+            flexible_time_window: FlexibleTimeWindow::default(),
+            target: Target {
+                arn: target_arn.to_string(),
+                role_arn: "arn:aws:iam::1:role/s".to_string(),
+                input: input.map(String::from),
+                dead_letter_config: dlq.map(|arn| DeadLetterConfig {
+                    arn: Some(arn.to_string()),
+                }),
+                retry_policy: None,
+                sqs_parameters: None,
+                ecs_parameters: None,
+                eventbridge_parameters: None,
+                kinesis_parameters: None,
+                sagemaker_pipeline_parameters: None,
+            },
+            creation_date: Utc::now(),
+            last_modification_date: Utc::now(),
+            last_fired: None,
+        }
+    }
+
+    #[test]
+    fn deliver_target_sqs_success() {
+        let recorder = Arc::new(Recorder {
+            calls: Mutex::new(Vec::new()),
+            fail_arn: None,
+        });
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let sched = make_schedule("arn:aws:sqs:us-east-1:1:dest", None, Some(r#"{"v":1}"#));
+        let result = deliver_target(&bus, &sched);
+        assert!(result.is_ok());
+        let calls = recorder.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, r#"{"v":1}"#);
+    }
+
+    #[test]
+    fn deliver_target_sqs_missing_queue_returns_err() {
+        let recorder = Arc::new(Recorder {
+            calls: Mutex::new(Vec::new()),
+            fail_arn: Some("arn:aws:sqs:us-east-1:1:missing".to_string()),
+        });
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let sched = make_schedule("arn:aws:sqs:us-east-1:1:missing", None, None);
+        let result = deliver_target(&bus, &sched);
+        assert!(matches!(result, Err(SqsDeliveryError::QueueNotFound(_))));
+    }
+
+    #[test]
+    fn route_to_dlq_includes_metadata_headers() {
+        let recorder = Arc::new(Recorder {
+            calls: Mutex::new(Vec::new()),
+            fail_arn: None,
+        });
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let sched = make_schedule(
+            "arn:aws:sqs:us-east-1:1:main",
+            Some("arn:aws:sqs:us-east-1:1:dlq"),
+            Some(r#"{"original":true}"#),
+        );
+        route_to_dlq(&bus, &sched, "QueueNotFound", "queue missing");
+        let calls = recorder.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        let (arn, body, attrs) = &calls[0];
+        assert_eq!(arn, "arn:aws:sqs:us-east-1:1:dlq");
+        assert_eq!(body, r#"{"original":true}"#);
+        assert_eq!(
+            attrs
+                .get("X-Amz-Scheduler-Attempt")
+                .and_then(|a| a.string_value.as_deref()),
+            Some("1")
+        );
+        assert_eq!(
+            attrs
+                .get("X-Amz-Scheduler-Error-Code")
+                .and_then(|a| a.string_value.as_deref()),
+            Some("QueueNotFound")
+        );
+        assert_eq!(
+            attrs
+                .get("X-Amz-Scheduler-Schedule-Arn")
+                .and_then(|a| a.string_value.as_deref()),
+            Some("arn:aws:scheduler:us-east-1:1:schedule/default/t")
+        );
+    }
+
+    #[test]
+    fn route_to_dlq_without_config_is_noop() {
+        let recorder = Arc::new(Recorder {
+            calls: Mutex::new(Vec::new()),
+            fail_arn: None,
+        });
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let sched = make_schedule("arn:aws:sqs:us-east-1:1:main", None, None);
+        route_to_dlq(&bus, &sched, "X", "y");
+        assert!(recorder.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn deliver_target_unknown_arn_is_ok() {
+        let recorder = Arc::new(Recorder {
+            calls: Mutex::new(Vec::new()),
+            fail_arn: None,
+        });
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let sched = make_schedule("arn:aws:ec2:us-east-1:1:instance/foo", None, None);
+        assert!(deliver_target(&bus, &sched).is_ok());
+        assert!(recorder.calls.lock().unwrap().is_empty());
+    }
+
+    // Silence unused warning on AtomicUsize import when we expand later.
+    #[allow(dead_code)]
+    fn _placeholder(_: AtomicUsize) {
+        let _ = Ordering::SeqCst;
+    }
+}

--- a/crates/fakecloud-scheduler/src/delivery.rs
+++ b/crates/fakecloud-scheduler/src/delivery.rs
@@ -31,7 +31,13 @@ pub fn deliver_target(bus: &Arc<DeliveryBus>, schedule: &Schedule) -> Result<(),
             .sqs_parameters
             .as_ref()
             .and_then(|s| s.message_group_id.as_deref());
-        return bus.try_send_to_sqs_with_attrs(arn, body, &attrs, group_id, None);
+        // FIFO queues without content-based dedup reject messages
+        // lacking a dedup ID; AWS Scheduler synthesizes one per fire
+        // so the message survives regardless of the queue's dedup
+        // policy. Use the schedule ARN + fire timestamp so the same
+        // schedule can fire repeatedly without being deduplicated.
+        let dedup_id = fifo_dedup_id(arn, &schedule.arn);
+        return bus.try_send_to_sqs_with_attrs(arn, body, &attrs, group_id, dedup_id.as_deref());
     }
 
     if arn.contains(":sns:") {
@@ -58,7 +64,8 @@ pub fn deliver_target(bus: &Arc<DeliveryBus>, schedule: &Schedule) -> Result<(),
     }
 
     if arn.contains(":events:") {
-        bus.put_event_to_eventbridge("aws.scheduler", "Scheduled Event", body, "default");
+        let bus_name = event_bus_name_from_arn(arn);
+        bus.put_event_to_eventbridge("aws.scheduler", "Scheduled Event", body, &bus_name);
         return Ok(());
     }
 
@@ -111,7 +118,17 @@ pub fn route_to_dlq(
     );
 
     let body = schedule.target.input.as_deref().unwrap_or("{}");
-    if let Err(err) = bus.try_send_to_sqs_with_attrs(&dlq_arn, body, &attrs, None, None) {
+    let dedup_id = fifo_dedup_id(&dlq_arn, &schedule.arn);
+    // FIFO DLQs need a MessageGroupId; use the schedule name so each
+    // schedule's DLQ messages fall in its own ordered stream.
+    let group_id = dedup_id.as_ref().map(|_| schedule.name.clone());
+    if let Err(err) = bus.try_send_to_sqs_with_attrs(
+        &dlq_arn,
+        body,
+        &attrs,
+        group_id.as_deref(),
+        dedup_id.as_deref(),
+    ) {
         tracing::error!(
             schedule = %schedule.name,
             dlq = %dlq_arn,
@@ -125,6 +142,41 @@ pub fn route_to_dlq(
             %error_code,
             "scheduler: delivery failed, routed to DLQ"
         );
+    }
+}
+
+/// Build a dedup ID for FIFO queues. Returns `Some(...)` only when
+/// the target queue name ends in `.fifo`; standard queues ignore
+/// dedup IDs so we skip the allocation. The ID combines the schedule
+/// ARN with a unique per-fire UUID so repeated fires of the same
+/// schedule aren't deduplicated.
+fn fifo_dedup_id(queue_arn: &str, schedule_arn: &str) -> Option<String> {
+    if !queue_arn.ends_with(".fifo") {
+        return None;
+    }
+    Some(format!("{}-{}", schedule_arn, uuid::Uuid::new_v4()))
+}
+
+/// Extract the EventBridge bus name from a `:events:` target ARN.
+/// Two shapes are accepted:
+/// - `arn:aws:events:<region>:<account>:event-bus/<name>`
+/// - `arn:aws:events:<region>:<account>:bus/<name>` (legacy / alias)
+///
+/// Returns `"default"` only when the ARN names the default bus or is
+/// malformed; never as a silent fallback for a custom bus name.
+fn event_bus_name_from_arn(arn: &str) -> String {
+    let resource = match arn.split(':').nth(5) {
+        Some(r) => r,
+        None => return "default".to_string(),
+    };
+    let name = resource
+        .strip_prefix("event-bus/")
+        .or_else(|| resource.strip_prefix("bus/"))
+        .unwrap_or("default");
+    if name.is_empty() {
+        "default".to_string()
+    } else {
+        name.to_string()
     }
 }
 
@@ -284,6 +336,37 @@ mod tests {
         let sched = make_schedule("arn:aws:sqs:us-east-1:1:main", None, None);
         route_to_dlq(&bus, &sched, "X", "y");
         assert!(recorder.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn fifo_dedup_id_generated_for_fifo_queue() {
+        let id = fifo_dedup_id("arn:aws:sqs:us-east-1:1:q.fifo", "arn:sched/a");
+        assert!(id.is_some());
+        let s = id.unwrap();
+        assert!(s.starts_with("arn:sched/a-"));
+    }
+
+    #[test]
+    fn fifo_dedup_id_skipped_for_standard_queue() {
+        let id = fifo_dedup_id("arn:aws:sqs:us-east-1:1:standard", "arn:sched/a");
+        assert!(id.is_none());
+    }
+
+    #[test]
+    fn event_bus_name_from_arn_custom() {
+        assert_eq!(
+            event_bus_name_from_arn("arn:aws:events:us-east-1:1:event-bus/my-bus"),
+            "my-bus"
+        );
+    }
+
+    #[test]
+    fn event_bus_name_from_arn_default_fallback() {
+        assert_eq!(
+            event_bus_name_from_arn("arn:aws:events:us-east-1:1:event-bus/default"),
+            "default"
+        );
+        assert_eq!(event_bus_name_from_arn("arn:malformed"), "default");
     }
 
     #[test]

--- a/crates/fakecloud-scheduler/src/delivery.rs
+++ b/crates/fakecloud-scheduler/src/delivery.rs
@@ -147,14 +147,15 @@ pub fn route_to_dlq(
 
 /// Build a dedup ID for FIFO queues. Returns `Some(...)` only when
 /// the target queue name ends in `.fifo`; standard queues ignore
-/// dedup IDs so we skip the allocation. The ID combines the schedule
-/// ARN with a unique per-fire UUID so repeated fires of the same
-/// schedule aren't deduplicated.
-fn fifo_dedup_id(queue_arn: &str, schedule_arn: &str) -> Option<String> {
+/// dedup IDs so we skip the allocation. SQS caps MessageDeduplicationId
+/// at 128 chars, so we use a bare UUID (36 chars) rather than
+/// concatenating the schedule ARN — schedule ARNs can themselves reach
+/// ~150 chars and would push combined IDs over the limit.
+fn fifo_dedup_id(queue_arn: &str, _schedule_arn: &str) -> Option<String> {
     if !queue_arn.ends_with(".fifo") {
         return None;
     }
-    Some(format!("{}-{}", schedule_arn, uuid::Uuid::new_v4()))
+    Some(uuid::Uuid::new_v4().to_string())
 }
 
 /// Extract the EventBridge bus name from a `:events:` target ARN.
@@ -343,7 +344,22 @@ mod tests {
         let id = fifo_dedup_id("arn:aws:sqs:us-east-1:1:q.fifo", "arn:sched/a");
         assert!(id.is_some());
         let s = id.unwrap();
-        assert!(s.starts_with("arn:sched/a-"));
+        // SQS caps MessageDeduplicationId at 128 chars.
+        assert!(s.len() <= 128);
+        // Two fires must not collide.
+        let id2 = fifo_dedup_id("arn:aws:sqs:us-east-1:1:q.fifo", "arn:sched/a").unwrap();
+        assert_ne!(s, id2);
+    }
+
+    #[test]
+    fn fifo_dedup_id_stays_under_128_char_limit_for_long_arns() {
+        let long_arn = format!(
+            "arn:aws:scheduler:us-east-1:123456789012:schedule/{}/{}",
+            "g".repeat(64),
+            "s".repeat(64)
+        );
+        let id = fifo_dedup_id("arn:aws:sqs:us-east-1:1:q.fifo", &long_arn).unwrap();
+        assert!(id.len() <= 128, "got {} chars", id.len());
     }
 
     #[test]

--- a/crates/fakecloud-scheduler/src/expr.rs
+++ b/crates/fakecloud-scheduler/src/expr.rs
@@ -85,25 +85,25 @@ fn parse_cron(inner: &str) -> Option<Expr> {
     if parts.len() != 6 {
         return None;
     }
+    // Reject tokens we don't understand (ranges, lists, step values,
+    // month/weekday name shorthands). Falling back to wildcard would
+    // cause unsupported schedules to fire every minute instead of
+    // being silently disabled. `year` (parts[5]) is accepted but not
+    // enforced at fire time — matches existing eventbridge behavior.
     Some(Expr::Cron(CronExpr {
-        minute: parse_cron_field(parts[0]),
-        hour: parse_cron_field(parts[1]),
-        day_of_month: parse_cron_field(parts[2]),
-        month: parse_cron_field(parts[3]),
-        day_of_week: parse_cron_field(parts[4]),
-        // year (parts[5]) is parsed but not enforced — matches existing
-        // eventbridge behavior.
+        minute: parse_cron_field(parts[0])?,
+        hour: parse_cron_field(parts[1])?,
+        day_of_month: parse_cron_field(parts[2])?,
+        month: parse_cron_field(parts[3])?,
+        day_of_week: parse_cron_field(parts[4])?,
     }))
 }
 
-fn parse_cron_field(s: &str) -> CronField {
+fn parse_cron_field(s: &str) -> Option<CronField> {
     if s == "*" || s == "?" {
-        return CronField::Any;
+        return Some(CronField::Any);
     }
-    match s.parse::<u32>() {
-        Ok(v) => CronField::Value(v),
-        Err(_) => CronField::Any,
-    }
+    s.parse::<u32>().ok().map(CronField::Value)
 }
 
 /// Decide whether `expr` is due to fire, given its `last_fired` time
@@ -189,6 +189,17 @@ mod tests {
         assert!(matches!(parse("cron(* * * * ? *)"), Some(Expr::Cron(_))));
         assert!(matches!(parse("cron(0 12 * * ? *)"), Some(Expr::Cron(_))));
         assert!(parse("cron(1 2 3)").is_none());
+    }
+
+    #[test]
+    fn parse_cron_rejects_unsupported_tokens() {
+        // Non-numeric, non-wildcard tokens are now rejected instead
+        // of being silently converted to wildcards (which would make
+        // every unsupported schedule fire every minute).
+        assert!(parse("cron(*/5 * * * ? *)").is_none());
+        assert!(parse("cron(1,3,5 * * * ? *)").is_none());
+        assert!(parse("cron(1-3 * * * ? *)").is_none());
+        assert!(parse("cron(xyz 12 * * ? *)").is_none());
     }
 
     #[test]

--- a/crates/fakecloud-scheduler/src/expr.rs
+++ b/crates/fakecloud-scheduler/src/expr.rs
@@ -1,0 +1,258 @@
+//! Schedule expression parsing and matching.
+//!
+//! EventBridge Scheduler supports three expression forms:
+//! - `at(yyyy-mm-ddThh:mm:ss)` — one-shot execution at a specific instant
+//! - `rate(N unit)` — recurring every N minutes|hours|days (SECONDS NOT
+//!   allowed by AWS, but fakecloud accepts them for fast-iteration tests)
+//! - `cron(min hour dom month dow year)` — six-field recurring expression
+//!
+//! The matching logic mirrors the simplified cron implementation in
+//! `fakecloud-eventbridge::scheduler`: each field is either a wildcard
+//! (`*` / `?`) or a single numeric value. Full cron syntax (ranges,
+//! lists, step values) is not currently supported — the firing loop
+//! simply skips schedules whose expressions don't match this grammar.
+
+use chrono::{DateTime, Datelike, NaiveDateTime, TimeZone, Timelike, Utc};
+use std::time::Duration;
+
+/// Parsed schedule expression.
+#[derive(Debug, Clone)]
+pub enum Expr {
+    /// One-shot `at(...)` expression, resolved to a wall-clock instant.
+    At(DateTime<Utc>),
+    /// Recurring `rate(...)` expression.
+    Rate(Duration),
+    /// Recurring `cron(...)` expression.
+    Cron(CronExpr),
+}
+
+#[derive(Debug, Clone)]
+pub struct CronExpr {
+    pub minute: CronField,
+    pub hour: CronField,
+    pub day_of_month: CronField,
+    pub month: CronField,
+    pub day_of_week: CronField,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CronField {
+    Any,
+    Value(u32),
+}
+
+/// Parse a schedule expression. Returns `None` on any shape we don't
+/// recognize — the firing loop treats unparseable schedules as
+/// permanently disabled (they never fire, they never error).
+pub fn parse(expr: &str) -> Option<Expr> {
+    let expr = expr.trim();
+    if let Some(inner) = expr.strip_prefix("at(").and_then(|s| s.strip_suffix(')')) {
+        return parse_at(inner.trim());
+    }
+    if let Some(inner) = expr.strip_prefix("rate(").and_then(|s| s.strip_suffix(')')) {
+        return parse_rate(inner.trim());
+    }
+    if let Some(inner) = expr.strip_prefix("cron(").and_then(|s| s.strip_suffix(')')) {
+        return parse_cron(inner.trim());
+    }
+    None
+}
+
+fn parse_at(inner: &str) -> Option<Expr> {
+    // AWS docs: at(yyyy-mm-ddThh:mm:ss) — no timezone, no fractional seconds
+    let dt = NaiveDateTime::parse_from_str(inner, "%Y-%m-%dT%H:%M:%S").ok()?;
+    Some(Expr::At(Utc.from_utc_datetime(&dt)))
+}
+
+fn parse_rate(inner: &str) -> Option<Expr> {
+    let parts: Vec<&str> = inner.split_whitespace().collect();
+    if parts.len() != 2 {
+        return None;
+    }
+    let value: u64 = parts[0].parse().ok()?;
+    let secs = match parts[1] {
+        "second" | "seconds" => value,
+        "minute" | "minutes" => value * 60,
+        "hour" | "hours" => value * 3600,
+        "day" | "days" => value * 86400,
+        _ => return None,
+    };
+    Some(Expr::Rate(Duration::from_secs(secs)))
+}
+
+fn parse_cron(inner: &str) -> Option<Expr> {
+    let parts: Vec<&str> = inner.split_whitespace().collect();
+    if parts.len() != 6 {
+        return None;
+    }
+    Some(Expr::Cron(CronExpr {
+        minute: parse_cron_field(parts[0]),
+        hour: parse_cron_field(parts[1]),
+        day_of_month: parse_cron_field(parts[2]),
+        month: parse_cron_field(parts[3]),
+        day_of_week: parse_cron_field(parts[4]),
+        // year (parts[5]) is parsed but not enforced — matches existing
+        // eventbridge behavior.
+    }))
+}
+
+fn parse_cron_field(s: &str) -> CronField {
+    if s == "*" || s == "?" {
+        return CronField::Any;
+    }
+    match s.parse::<u32>() {
+        Ok(v) => CronField::Value(v),
+        Err(_) => CronField::Any,
+    }
+}
+
+/// Decide whether `expr` is due to fire, given its `last_fired` time
+/// (if any) and the current wall clock `now`.
+///
+/// Contract per expression kind:
+/// - `At(t)`: fires once when `now >= t` AND `last_fired` is `None`.
+///   The ticker consumes this by deleting/disabling the schedule after
+///   the first fire so subsequent ticks don't re-fire it.
+/// - `Rate(d)`: fires if never fired (bootstraps on first tick), or if
+///   `now - last_fired >= d`.
+/// - `Cron(c)`: fires when every field matches the current minute AND
+///   we haven't already fired within this same minute (ticker
+///   dedupe lives outside this function — see `CronFireTracker`).
+pub fn is_due(expr: &Expr, last_fired: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    match expr {
+        Expr::At(t) => last_fired.is_none() && now >= *t,
+        Expr::Rate(d) => match last_fired {
+            Some(last) => {
+                now.signed_duration_since(last)
+                    .to_std()
+                    .unwrap_or(Duration::ZERO)
+                    >= *d
+            }
+            None => true,
+        },
+        Expr::Cron(c) => matches_cron(c, now),
+    }
+}
+
+/// Check whether each cron field matches the fields of `now`. The
+/// per-minute dedupe has to live in the ticker because we need to
+/// track fires across multiple calls without mutating the cron state.
+pub fn matches_cron(c: &CronExpr, now: DateTime<Utc>) -> bool {
+    let match_field = |f: &CronField, actual: u32| -> bool {
+        matches!(f, CronField::Any) || matches!(f, CronField::Value(v) if *v == actual)
+    };
+    match_field(&c.minute, now.minute())
+        && match_field(&c.hour, now.hour())
+        && match_field(&c.day_of_month, now.day())
+        && match_field(&c.month, now.month())
+        && match_field(&c.day_of_week, now.weekday().num_days_from_sunday())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rate_forms() {
+        assert!(matches!(parse("rate(1 minute)"), Some(Expr::Rate(_))));
+        assert!(matches!(parse("rate(5 minutes)"), Some(Expr::Rate(_))));
+        assert!(matches!(parse("rate(1 hour)"), Some(Expr::Rate(_))));
+        assert!(matches!(parse("rate(2 days)"), Some(Expr::Rate(_))));
+        assert!(matches!(parse("rate(1 second)"), Some(Expr::Rate(_))));
+    }
+
+    #[test]
+    fn parse_rate_rejects_bad_unit_and_shape() {
+        assert!(parse("rate(1 fortnight)").is_none());
+        assert!(parse("rate(abc minutes)").is_none());
+        assert!(parse("rate(5)").is_none());
+    }
+
+    #[test]
+    fn parse_at_utc() {
+        let e = parse("at(2030-01-01T12:00:00)").unwrap();
+        match e {
+            Expr::At(t) => assert_eq!(t.timestamp(), 1893499200),
+            _ => panic!("expected At"),
+        }
+    }
+
+    #[test]
+    fn parse_at_rejects_garbage() {
+        assert!(parse("at(2030-01-01)").is_none());
+        assert!(parse("at(nope)").is_none());
+        assert!(parse("at()").is_none());
+    }
+
+    #[test]
+    fn parse_cron_shape() {
+        assert!(matches!(parse("cron(* * * * ? *)"), Some(Expr::Cron(_))));
+        assert!(matches!(parse("cron(0 12 * * ? *)"), Some(Expr::Cron(_))));
+        assert!(parse("cron(1 2 3)").is_none());
+    }
+
+    #[test]
+    fn parse_unknown_returns_none() {
+        assert!(parse("every day at noon").is_none());
+        assert!(parse("").is_none());
+        assert!(parse("at").is_none());
+    }
+
+    #[test]
+    fn is_due_at_fires_once_after_target() {
+        let t = Utc.with_ymd_and_hms(2030, 1, 1, 12, 0, 0).unwrap();
+        let expr = Expr::At(t);
+        assert!(!is_due(&expr, None, t - chrono::Duration::seconds(1)));
+        assert!(is_due(&expr, None, t));
+        assert!(is_due(&expr, None, t + chrono::Duration::seconds(10)));
+        assert!(!is_due(&expr, Some(t), t + chrono::Duration::seconds(10)));
+    }
+
+    #[test]
+    fn is_due_rate_fires_on_bootstrap_and_after_interval() {
+        let expr = Expr::Rate(Duration::from_secs(60));
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        assert!(is_due(&expr, None, now));
+        assert!(!is_due(
+            &expr,
+            Some(now),
+            now + chrono::Duration::seconds(30)
+        ));
+        assert!(is_due(
+            &expr,
+            Some(now),
+            now + chrono::Duration::seconds(60)
+        ));
+        assert!(is_due(
+            &expr,
+            Some(now),
+            now + chrono::Duration::seconds(61)
+        ));
+    }
+
+    #[test]
+    fn is_due_cron_wildcards_always_match() {
+        let c = CronExpr {
+            minute: CronField::Any,
+            hour: CronField::Any,
+            day_of_month: CronField::Any,
+            month: CronField::Any,
+            day_of_week: CronField::Any,
+        };
+        let now = Utc.with_ymd_and_hms(2026, 5, 15, 10, 30, 0).unwrap();
+        assert!(is_due(&Expr::Cron(c), None, now));
+    }
+
+    #[test]
+    fn is_due_cron_specific_minute_mismatch() {
+        let c = CronExpr {
+            minute: CronField::Value(45),
+            hour: CronField::Any,
+            day_of_month: CronField::Any,
+            month: CronField::Any,
+            day_of_week: CronField::Any,
+        };
+        let now = Utc.with_ymd_and_hms(2026, 5, 15, 10, 30, 0).unwrap();
+        assert!(!is_due(&Expr::Cron(c), None, now));
+    }
+}

--- a/crates/fakecloud-scheduler/src/lib.rs
+++ b/crates/fakecloud-scheduler/src/lib.rs
@@ -5,5 +5,8 @@
 //! ScheduleGroup, FlexibleTimeWindow, DeadLetterConfig,
 //! ActionAfterCompletion), and REST-JSON protocol.
 
+pub mod delivery;
+pub mod expr;
 pub mod service;
 pub mod state;
+pub mod ticker;

--- a/crates/fakecloud-scheduler/src/ticker.rs
+++ b/crates/fakecloud-scheduler/src/ticker.rs
@@ -1,0 +1,427 @@
+//! Background firing loop for EventBridge Scheduler.
+//!
+//! A single tokio task scans every enabled schedule once per second,
+//! fires the ones whose expressions are due, updates `last_fired`, and
+//! handles `ActionAfterCompletion=DELETE` for one-shot `at(...)` runs.
+//! Delivery itself lives in `delivery.rs`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Timelike, Utc};
+
+use fakecloud_core::delivery::DeliveryBus;
+
+use crate::delivery::{deliver_target, route_to_dlq};
+use crate::expr::{self, Expr};
+use crate::state::{ScheduleKey, SharedSchedulerState};
+
+pub struct Ticker {
+    state: SharedSchedulerState,
+    delivery: Arc<DeliveryBus>,
+}
+
+impl Ticker {
+    pub fn new(state: SharedSchedulerState, delivery: Arc<DeliveryBus>) -> Self {
+        Self { state, delivery }
+    }
+
+    pub async fn run(self) {
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // (hour, minute) pair of the last cron fire, keyed by schedule
+        // identity — keeps cron schedules from firing multiple times
+        // inside the same minute when the 1s tick runs 60+ times.
+        let mut cron_last_minute: HashMap<(String, ScheduleKey), (u32, u32)> = HashMap::new();
+        loop {
+            interval.tick().await;
+            self.tick(&mut cron_last_minute);
+        }
+    }
+
+    fn tick(&self, cron_last_minute: &mut HashMap<(String, ScheduleKey), (u32, u32)>) {
+        let now = Utc::now();
+        // Phase 1: collect due schedules while holding a short write lock.
+        let mut due: Vec<(String, ScheduleKey)> = Vec::new();
+        let mut post_fire_actions: Vec<(String, ScheduleKey, PostFire)> = Vec::new();
+        {
+            let mut accounts = self.state.write();
+            let account_ids: Vec<String> = accounts.iter().map(|(id, _)| id.to_string()).collect();
+            for account_id in account_ids {
+                let Some(state) = accounts.get_mut(&account_id) else {
+                    continue;
+                };
+                let keys: Vec<ScheduleKey> = state.schedules.keys().cloned().collect();
+                for key in keys {
+                    let Some(sched) = state.schedules.get(&key) else {
+                        continue;
+                    };
+                    if sched.state != "ENABLED" {
+                        continue;
+                    }
+                    if let Some(end) = sched.end_date {
+                        if now > end {
+                            continue;
+                        }
+                    }
+                    if let Some(start) = sched.start_date {
+                        if now < start {
+                            continue;
+                        }
+                    }
+                    let Some(expr) = expr::parse(&sched.schedule_expression) else {
+                        continue;
+                    };
+                    if !is_due_with_dedup(
+                        &expr,
+                        sched.last_fired,
+                        now,
+                        &(account_id.clone(), key.clone()),
+                        cron_last_minute,
+                    ) {
+                        continue;
+                    }
+                    if let Some(sched_mut) = state.schedules.get_mut(&key) {
+                        sched_mut.last_fired = Some(now);
+                        let post = post_fire_action(&expr, sched_mut);
+                        post_fire_actions.push((account_id.clone(), key.clone(), post));
+                    }
+                    due.push((account_id.clone(), key));
+                }
+            }
+        }
+
+        // Phase 2: deliver without holding the state lock.
+        let mut fired: Vec<(String, ScheduleKey)> = Vec::with_capacity(due.len());
+        for (account_id, key) in &due {
+            let snapshot = {
+                let accounts = self.state.read();
+                accounts
+                    .get(account_id)
+                    .and_then(|s| s.schedules.get(key).cloned())
+            };
+            let Some(sched) = snapshot else {
+                continue;
+            };
+            match deliver_target(&self.delivery, &sched) {
+                Ok(()) => {
+                    tracing::debug!(
+                        schedule = %sched.name,
+                        group = %sched.group_name,
+                        target = %sched.target.arn,
+                        "scheduler: fired"
+                    );
+                }
+                Err(err) => {
+                    route_to_dlq(
+                        &self.delivery,
+                        &sched,
+                        "TargetDeliveryFailed",
+                        &err.to_string(),
+                    );
+                }
+            }
+            fired.push((account_id.clone(), key.clone()));
+        }
+
+        // Phase 3: apply post-fire actions (DELETE on completion for at()).
+        if !post_fire_actions.is_empty() {
+            let mut accounts = self.state.write();
+            for (account_id, key, post) in post_fire_actions {
+                let Some(state) = accounts.get_mut(&account_id) else {
+                    continue;
+                };
+                match post {
+                    PostFire::Delete => {
+                        state.schedules.remove(&key);
+                    }
+                    PostFire::None => {}
+                }
+            }
+        }
+    }
+}
+
+enum PostFire {
+    None,
+    Delete,
+}
+
+fn post_fire_action(expr: &Expr, schedule: &crate::state::Schedule) -> PostFire {
+    if matches!(expr, Expr::At(_)) && schedule.action_after_completion == "DELETE" {
+        PostFire::Delete
+    } else {
+        PostFire::None
+    }
+}
+
+fn is_due_with_dedup(
+    expr: &Expr,
+    last_fired: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+    key: &(String, ScheduleKey),
+    cron_last_minute: &mut HashMap<(String, ScheduleKey), (u32, u32)>,
+) -> bool {
+    match expr {
+        Expr::Cron(c) => {
+            if !expr::matches_cron(c, now) {
+                return false;
+            }
+            let current = (now.hour(), now.minute());
+            if cron_last_minute.get(key) == Some(&current) {
+                return false;
+            }
+            cron_last_minute.insert(key.clone(), current);
+            true
+        }
+        _ => expr::is_due(expr, last_fired, now),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{
+        FlexibleTimeWindow, Schedule, SchedulerState, SharedSchedulerState, Target,
+    };
+    use chrono::Utc;
+    use fakecloud_core::delivery::{SqsDelivery, SqsDeliveryError, SqsMessageAttribute};
+    use parking_lot::RwLock;
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    const ACCOUNT: &str = "111122223333";
+
+    fn make_state() -> SharedSchedulerState {
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(ACCOUNT, "us-east-1", ""),
+        ))
+    }
+
+    fn seed_schedule(state: &SharedSchedulerState, name: &str, expr: &str, target_arn: &str) {
+        let now = Utc::now();
+        let mut accounts = state.write();
+        let s = accounts.get_or_create(ACCOUNT);
+        s.schedules.insert(
+            ("default".to_string(), name.to_string()),
+            Schedule {
+                arn: format!("arn:aws:scheduler:us-east-1:{ACCOUNT}:schedule/default/{name}"),
+                name: name.to_string(),
+                group_name: "default".to_string(),
+                schedule_expression: expr.to_string(),
+                schedule_expression_timezone: None,
+                start_date: None,
+                end_date: None,
+                description: None,
+                state: "ENABLED".to_string(),
+                kms_key_arn: None,
+                action_after_completion: "NONE".to_string(),
+                flexible_time_window: FlexibleTimeWindow::default(),
+                target: Target {
+                    arn: target_arn.to_string(),
+                    role_arn: "arn:aws:iam::1:role/s".to_string(),
+                    input: Some(r#"{"msg":"hello"}"#.to_string()),
+                    dead_letter_config: None,
+                    retry_policy: None,
+                    sqs_parameters: None,
+                    ecs_parameters: None,
+                    eventbridge_parameters: None,
+                    kinesis_parameters: None,
+                    sagemaker_pipeline_parameters: None,
+                },
+                creation_date: now,
+                last_modification_date: now,
+                last_fired: None,
+            },
+        );
+    }
+
+    #[derive(Default)]
+    struct Recorder {
+        calls: Mutex<Vec<(String, String)>>,
+    }
+    impl SqsDelivery for Recorder {
+        fn deliver_to_queue(&self, _arn: &str, _body: &str, _a: &HashMap<String, String>) {}
+
+        fn try_deliver_to_queue_with_attrs(
+            &self,
+            queue_arn: &str,
+            message_body: &str,
+            _attrs: &HashMap<String, SqsMessageAttribute>,
+            _g: Option<&str>,
+            _d: Option<&str>,
+        ) -> Result<(), SqsDeliveryError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((queue_arn.to_string(), message_body.to_string()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn rate_schedule_fires_on_first_tick_and_delivers_input() {
+        let state = make_state();
+        seed_schedule(
+            &state,
+            "r",
+            "rate(1 minute)",
+            "arn:aws:sqs:us-east-1:111122223333:q",
+        );
+        let rec = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(rec.clone()));
+        let ticker = Ticker::new(state.clone(), bus);
+        let mut cron = HashMap::new();
+        ticker.tick(&mut cron);
+        let calls = rec.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "arn:aws:sqs:us-east-1:111122223333:q");
+        assert_eq!(calls[0].1, r#"{"msg":"hello"}"#);
+    }
+
+    #[test]
+    fn disabled_schedule_does_not_fire() {
+        let state = make_state();
+        seed_schedule(
+            &state,
+            "r",
+            "rate(1 minute)",
+            "arn:aws:sqs:us-east-1:111122223333:q",
+        );
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_or_create(ACCOUNT);
+            s.schedules
+                .get_mut(&("default".to_string(), "r".to_string()))
+                .unwrap()
+                .state = "DISABLED".to_string();
+        }
+        let rec = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(rec.clone()));
+        let ticker = Ticker::new(state.clone(), bus);
+        let mut cron = HashMap::new();
+        ticker.tick(&mut cron);
+        assert!(rec.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn at_one_shot_with_delete_after_fire_removes_schedule() {
+        let state = make_state();
+        // `at(2000-01-01T00:00:00)` is always in the past so it fires on first tick.
+        seed_schedule(
+            &state,
+            "once",
+            "at(2000-01-01T00:00:00)",
+            "arn:aws:sqs:us-east-1:111122223333:dest",
+        );
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_or_create(ACCOUNT);
+            s.schedules
+                .get_mut(&("default".to_string(), "once".to_string()))
+                .unwrap()
+                .action_after_completion = "DELETE".to_string();
+        }
+        let rec = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(rec.clone()));
+        let ticker = Ticker::new(state.clone(), bus);
+        let mut cron = HashMap::new();
+        ticker.tick(&mut cron);
+        assert_eq!(rec.calls.lock().unwrap().len(), 1);
+        let accounts = state.read();
+        let s = accounts.get(ACCOUNT).unwrap();
+        assert!(!s
+            .schedules
+            .contains_key(&("default".to_string(), "once".to_string())));
+    }
+
+    #[test]
+    fn dlq_receives_failed_delivery_with_headers() {
+        let state = make_state();
+        seed_schedule(
+            &state,
+            "dlqtest",
+            "rate(1 minute)",
+            "arn:aws:sqs:us-east-1:111122223333:missing",
+        );
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_or_create(ACCOUNT);
+            s.schedules
+                .get_mut(&("default".to_string(), "dlqtest".to_string()))
+                .unwrap()
+                .target
+                .dead_letter_config = Some(crate::state::DeadLetterConfig {
+                arn: Some("arn:aws:sqs:us-east-1:111122223333:dlq".to_string()),
+            });
+        }
+
+        // Recorder that fails on missing queue and records everything else.
+        struct FailingRecorder {
+            calls: Mutex<Vec<(String, HashMap<String, SqsMessageAttribute>)>>,
+        }
+        impl SqsDelivery for FailingRecorder {
+            fn deliver_to_queue(&self, _a: &str, _b: &str, _c: &HashMap<String, String>) {}
+            fn try_deliver_to_queue_with_attrs(
+                &self,
+                queue_arn: &str,
+                _body: &str,
+                attrs: &HashMap<String, SqsMessageAttribute>,
+                _g: Option<&str>,
+                _d: Option<&str>,
+            ) -> Result<(), SqsDeliveryError> {
+                if queue_arn.ends_with(":missing") {
+                    return Err(SqsDeliveryError::QueueNotFound(queue_arn.to_string()));
+                }
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push((queue_arn.to_string(), attrs.clone()));
+                Ok(())
+            }
+        }
+
+        let rec = Arc::new(FailingRecorder {
+            calls: Mutex::new(Vec::new()),
+        });
+        let bus = Arc::new(DeliveryBus::new().with_sqs(rec.clone()));
+        let ticker = Ticker::new(state.clone(), bus);
+        let mut cron = HashMap::new();
+        ticker.tick(&mut cron);
+        let calls = rec.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].0.ends_with(":dlq"));
+        assert!(calls[0].1.contains_key("X-Amz-Scheduler-Attempt"));
+    }
+
+    #[test]
+    fn end_date_past_prevents_firing() {
+        let state = make_state();
+        seed_schedule(
+            &state,
+            "ended",
+            "rate(1 minute)",
+            "arn:aws:sqs:us-east-1:111122223333:q",
+        );
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_or_create(ACCOUNT);
+            s.schedules
+                .get_mut(&("default".to_string(), "ended".to_string()))
+                .unwrap()
+                .end_date = Some(Utc::now() - chrono::Duration::hours(1));
+        }
+        let rec = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(rec.clone()));
+        let ticker = Ticker::new(state.clone(), bus);
+        let mut cron = HashMap::new();
+        ticker.tick(&mut cron);
+        assert!(rec.calls.lock().unwrap().is_empty());
+    }
+
+    // Silence unused-import warning.
+    #[allow(dead_code)]
+    fn _unused(_: VecDeque<()>, _: SchedulerState) {}
+}

--- a/crates/fakecloud-scheduler/src/ticker.rs
+++ b/crates/fakecloud-scheduler/src/ticker.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::{DateTime, Timelike, Utc};
+use chrono::{DateTime, Datelike, Timelike, Utc};
 
 use fakecloud_core::delivery::DeliveryBus;
 
@@ -33,14 +33,14 @@ impl Ticker {
         // (hour, minute) pair of the last cron fire, keyed by schedule
         // identity — keeps cron schedules from firing multiple times
         // inside the same minute when the 1s tick runs 60+ times.
-        let mut cron_last_minute: HashMap<(String, ScheduleKey), (u32, u32)> = HashMap::new();
+        let mut cron_last_minute: HashMap<(String, ScheduleKey), CronFireStamp> = HashMap::new();
         loop {
             interval.tick().await;
             self.tick(&mut cron_last_minute);
         }
     }
 
-    fn tick(&self, cron_last_minute: &mut HashMap<(String, ScheduleKey), (u32, u32)>) {
+    fn tick(&self, cron_last_minute: &mut HashMap<(String, ScheduleKey), CronFireStamp>) {
         let now = Utc::now();
         // Phase 1: collect due schedules while holding a short write lock.
         let mut due: Vec<(String, ScheduleKey)> = Vec::new();
@@ -156,19 +156,41 @@ fn post_fire_action(expr: &Expr, schedule: &crate::state::Schedule) -> PostFire 
     }
 }
 
+/// Identity of the last minute-slot a cron schedule fired in. Keyed
+/// by full (year, ordinal, hour, minute) so subsequent days of the
+/// same (hour, minute) are treated as fresh fires.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct CronFireStamp {
+    year: i32,
+    ordinal: u32,
+    hour: u32,
+    minute: u32,
+}
+
+impl CronFireStamp {
+    fn from(now: DateTime<Utc>) -> Self {
+        Self {
+            year: now.year(),
+            ordinal: now.ordinal(),
+            hour: now.hour(),
+            minute: now.minute(),
+        }
+    }
+}
+
 fn is_due_with_dedup(
     expr: &Expr,
     last_fired: Option<DateTime<Utc>>,
     now: DateTime<Utc>,
     key: &(String, ScheduleKey),
-    cron_last_minute: &mut HashMap<(String, ScheduleKey), (u32, u32)>,
+    cron_last_minute: &mut HashMap<(String, ScheduleKey), CronFireStamp>,
 ) -> bool {
     match expr {
         Expr::Cron(c) => {
             if !expr::matches_cron(c, now) {
                 return false;
             }
-            let current = (now.hour(), now.minute());
+            let current = CronFireStamp::from(now);
             if cron_last_minute.get(key) == Some(&current) {
                 return false;
             }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -703,6 +703,7 @@ async fn main() {
     // Spawn the EventBridge scheduler as a background task
     let eb_state_for_ses = eb_state.clone();
     let eb_state_for_sfn = eb_state.clone();
+    let eb_state_for_scheduler = eb_state.clone();
     let mut scheduler = fakecloud_eventbridge::scheduler::Scheduler::new(eb_state, delivery_for_eb)
         .with_lambda(lambda_state.clone())
         .with_logs(logs_state.clone());
@@ -1766,15 +1767,54 @@ async fn main() {
     let scheduler_service = SchedulerService::new(scheduler_state.clone());
     registry.register(Arc::new(scheduler_service));
 
-    // Spawn the Scheduler firing loop as a background task. Shares the
-    // SQS delivery bus used by EventBridge Rules so the same cross-
-    // service delivery plumbing (DLQ routing included) applies.
+    // Spawn the Scheduler firing loop as a background task. Mirrors
+    // EventBridge's delivery bus so every target type Scheduler
+    // routes (`:sqs:`, `:sns:`, `:lambda:`, `:states:`, `:events:`)
+    // resolves to a live sender.
+    let sfn_delivery_for_scheduler: Arc<dyn fakecloud_core::delivery::StepFunctionsDelivery> = {
+        let mut sns_fanout_for_sfn = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+        if let Some(ref ld) = lambda_delivery {
+            sns_fanout_for_sfn = sns_fanout_for_sfn.with_lambda(ld.clone());
+        }
+        let sns_for_sfn = Arc::new(fakecloud_sns::delivery::SnsDeliveryImpl::new(
+            sns_state.clone(),
+            Arc::new(sns_fanout_for_sfn),
+        ));
+        let eb_for_sfn = Arc::new(
+            fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
+                eb_state_for_scheduler.clone(),
+                Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+            ),
+        );
+        let mut sfn_interpreter_bus = DeliveryBus::new()
+            .with_sqs(sqs_delivery.clone())
+            .with_sns(sns_for_sfn)
+            .with_eventbridge(eb_for_sfn);
+        if let Some(ref ld) = lambda_delivery {
+            sfn_interpreter_bus = sfn_interpreter_bus.with_lambda(ld.clone());
+        }
+        Arc::new(stepfunctions_delivery::StepFunctionsDeliveryImpl::new(
+            stepfunctions_state.clone(),
+            Some(Arc::new(sfn_interpreter_bus)),
+            Some(dynamodb_state.clone()),
+        ))
+    };
+    let eb_delivery_for_scheduler = Arc::new(
+        fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
+            eb_state_for_scheduler,
+            Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+        ),
+    );
     let delivery_for_scheduler = {
-        let mut bus = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+        let mut bus = DeliveryBus::new()
+            .with_sqs(sqs_delivery.clone())
+            .with_sns(sns_delivery_for_scheduler)
+            .with_eventbridge(eb_delivery_for_scheduler)
+            .with_stepfunctions(sfn_delivery_for_scheduler);
         if let Some(ref ld) = lambda_delivery {
             bus = bus.with_lambda(ld.clone());
         }
-        Arc::new(bus.with_sns(sns_delivery_for_scheduler))
+        Arc::new(bus)
     };
     let scheduler_ticker =
         fakecloud_scheduler::ticker::Ticker::new(scheduler_state.clone(), delivery_for_scheduler);

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -331,6 +331,7 @@ async fn main() {
     // Step 3: S3 delivery (S3 notifications can push to SQS, SNS, Lambda, and EventBridge)
     let sns_delivery_for_ses = sns_delivery.clone();
     let sns_delivery_for_cf = sns_delivery.clone();
+    let sns_delivery_for_scheduler = sns_delivery.clone();
     let eb_delivery_for_s3 = Arc::new(
         fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
             eb_state.clone(),
@@ -1764,6 +1765,20 @@ async fn main() {
 
     let scheduler_service = SchedulerService::new(scheduler_state.clone());
     registry.register(Arc::new(scheduler_service));
+
+    // Spawn the Scheduler firing loop as a background task. Shares the
+    // SQS delivery bus used by EventBridge Rules so the same cross-
+    // service delivery plumbing (DLQ routing included) applies.
+    let delivery_for_scheduler = {
+        let mut bus = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+        if let Some(ref ld) = lambda_delivery {
+            bus = bus.with_lambda(ld.clone());
+        }
+        Arc::new(bus.with_sns(sns_delivery_for_scheduler))
+    };
+    let scheduler_ticker =
+        fakecloud_scheduler::ticker::Ticker::new(scheduler_state.clone(), delivery_for_scheduler);
+    tokio::spawn(scheduler_ticker.run());
 
     // Spawn background tasks
     let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state.clone());

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -332,6 +332,8 @@ async fn main() {
     let sns_delivery_for_ses = sns_delivery.clone();
     let sns_delivery_for_cf = sns_delivery.clone();
     let sns_delivery_for_scheduler = sns_delivery.clone();
+    let sns_delivery_for_scheduler_eb = sns_delivery.clone();
+    let sns_delivery_for_scheduler_sfn_eb = sns_delivery.clone();
     let eb_delivery_for_s3 = Arc::new(
         fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
             eb_state.clone(),
@@ -1780,10 +1782,20 @@ async fn main() {
             sns_state.clone(),
             Arc::new(sns_fanout_for_sfn),
         ));
+        // Inner bus for EB rule delivery: matches other call-sites'
+        // surface (SQS + SNS + Lambda) so Scheduler-triggered SFN
+        // executions that hit EB rules fanning to SNS don't get
+        // silently dropped.
+        let mut inner_eb_bus = DeliveryBus::new()
+            .with_sqs(sqs_delivery.clone())
+            .with_sns(sns_delivery_for_scheduler_sfn_eb);
+        if let Some(ref ld) = lambda_delivery {
+            inner_eb_bus = inner_eb_bus.with_lambda(ld.clone());
+        }
         let eb_for_sfn = Arc::new(
             fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
                 eb_state_for_scheduler.clone(),
-                Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+                Arc::new(inner_eb_bus),
             ),
         );
         let mut sfn_interpreter_bus = DeliveryBus::new()
@@ -1799,12 +1811,20 @@ async fn main() {
             Some(dynamodb_state.clone()),
         ))
     };
-    let eb_delivery_for_scheduler = Arc::new(
-        fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
-            eb_state_for_scheduler,
-            Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
-        ),
-    );
+    let eb_delivery_for_scheduler = {
+        let mut inner = DeliveryBus::new()
+            .with_sqs(sqs_delivery.clone())
+            .with_sns(sns_delivery_for_scheduler_eb);
+        if let Some(ref ld) = lambda_delivery {
+            inner = inner.with_lambda(ld.clone());
+        }
+        Arc::new(
+            fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
+                eb_state_for_scheduler,
+                Arc::new(inner),
+            ),
+        )
+    };
     let delivery_for_scheduler = {
         let mut bus = DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use base64::Engine;
 use chrono::Utc;
 
-use fakecloud_core::delivery::{SqsDelivery, SqsMessageAttribute};
+use fakecloud_core::delivery::{SqsDelivery, SqsDeliveryError, SqsMessageAttribute};
 
 use crate::state::{MessageAttribute, SharedSqsState, SqsMessage};
 
@@ -36,82 +36,110 @@ impl SqsDelivery for SqsDeliveryImpl {
         message_group_id: Option<&str>,
         message_dedup_id: Option<&str>,
     ) {
+        if let Err(err) = self.try_deliver_to_queue_with_attrs(
+            queue_arn,
+            message_body,
+            message_attributes,
+            message_group_id,
+            message_dedup_id,
+        ) {
+            tracing::warn!(%err, queue_arn, "SQS delivery failed");
+        }
+    }
+
+    fn try_deliver_to_queue_with_attrs(
+        &self,
+        queue_arn: &str,
+        message_body: &str,
+        message_attributes: &HashMap<String, SqsMessageAttribute>,
+        message_group_id: Option<&str>,
+        message_dedup_id: Option<&str>,
+    ) -> Result<(), SqsDeliveryError> {
         let mut accounts = self.state.write();
 
         // Parse account from queue ARN (arn:aws:sqs:region:ACCOUNT:name)
         let default_id = accounts.default_account_id().to_string();
-        let target_account = queue_arn.split(':').nth(4).unwrap_or(&default_id);
-        let state = accounts.get_or_create(target_account);
+        let target_account = queue_arn
+            .split(':')
+            .nth(4)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| SqsDeliveryError::InvalidArn(queue_arn.to_string()))?
+            .to_string();
+        let target_account = if target_account.is_empty() {
+            default_id
+        } else {
+            target_account
+        };
+        let state = accounts.get_or_create(&target_account);
 
         // Find queue by ARN
-        let queue = state.queues.values_mut().find(|q| q.arn == queue_arn);
+        let queue = state
+            .queues
+            .values_mut()
+            .find(|q| q.arn == queue_arn)
+            .ok_or_else(|| SqsDeliveryError::QueueNotFound(queue_arn.to_string()))?;
 
-        if let Some(queue) = queue {
-            // For FIFO queues without content-based dedup, require explicit dedup ID
-            if queue.is_fifo && message_dedup_id.is_none() {
-                let content_based = queue
-                    .attributes
-                    .get("ContentBasedDeduplication")
-                    .map(|v| v.as_str())
-                    == Some("true");
-                if !content_based {
-                    tracing::debug!(
-                        queue_arn,
-                        "skipping delivery: FIFO queue requires dedup ID or content-based dedup"
-                    );
-                    return;
-                }
+        // For FIFO queues without content-based dedup, require explicit dedup ID
+        if queue.is_fifo && message_dedup_id.is_none() {
+            let content_based = queue
+                .attributes
+                .get("ContentBasedDeduplication")
+                .map(|v| v.as_str())
+                == Some("true");
+            if !content_based {
+                tracing::debug!(
+                    queue_arn,
+                    "skipping delivery: FIFO queue requires dedup ID or content-based dedup"
+                );
+                return Ok(());
             }
-
-            let now = Utc::now();
-
-            // For FIFO queues with content-based dedup, generate dedup ID if not provided
-            let effective_dedup_id = if message_dedup_id.is_some() {
-                message_dedup_id.map(|s| s.to_string())
-            } else if queue.is_fifo {
-                // Content-based dedup: use SHA-256 of body (matches real SQS behavior)
-                Some(crate::service::sha256_hex(message_body))
-            } else {
-                None
-            };
-
-            // Convert SqsMessageAttribute to the SQS state MessageAttribute
-            let sqs_attrs: HashMap<String, MessageAttribute> = message_attributes
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        k.clone(),
-                        MessageAttribute {
-                            data_type: v.data_type.clone(),
-                            string_value: v.string_value.clone(),
-                            binary_value: v.binary_value.as_ref().and_then(|s| {
-                                base64::engine::general_purpose::STANDARD.decode(s).ok()
-                            }),
-                        },
-                    )
-                })
-                .collect();
-
-            let msg = SqsMessage {
-                message_id: uuid::Uuid::new_v4().to_string(),
-                receipt_handle: None,
-                md5_of_body: crate::service::md5_hex(message_body),
-                body: message_body.to_string(),
-                sent_timestamp: now.timestamp_millis(),
-                attributes: HashMap::new(),
-                message_attributes: sqs_attrs,
-                visible_at: None,
-                receive_count: 0,
-                message_group_id: message_group_id.map(|s| s.to_string()),
-                message_dedup_id: effective_dedup_id,
-                created_at: now,
-                sequence_number: None,
-            };
-            queue.messages.push_back(msg);
-            tracing::debug!(queue_arn, "delivered message to SQS queue");
-        } else {
-            tracing::warn!(queue_arn, "SQS delivery target queue not found");
         }
+
+        let now = Utc::now();
+
+        let effective_dedup_id = if message_dedup_id.is_some() {
+            message_dedup_id.map(|s| s.to_string())
+        } else if queue.is_fifo {
+            Some(crate::service::sha256_hex(message_body))
+        } else {
+            None
+        };
+
+        let sqs_attrs: HashMap<String, MessageAttribute> = message_attributes
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    MessageAttribute {
+                        data_type: v.data_type.clone(),
+                        string_value: v.string_value.clone(),
+                        binary_value: v
+                            .binary_value
+                            .as_ref()
+                            .and_then(|s| base64::engine::general_purpose::STANDARD.decode(s).ok()),
+                    },
+                )
+            })
+            .collect();
+
+        let msg = SqsMessage {
+            message_id: uuid::Uuid::new_v4().to_string(),
+            receipt_handle: None,
+            md5_of_body: crate::service::md5_hex(message_body),
+            body: message_body.to_string(),
+            sent_timestamp: now.timestamp_millis(),
+            attributes: HashMap::new(),
+            message_attributes: sqs_attrs,
+            visible_at: None,
+            receive_count: 0,
+            message_group_id: message_group_id.map(|s| s.to_string()),
+            message_dedup_id: effective_dedup_id,
+            created_at: now,
+            sequence_number: None,
+        };
+        queue.messages.push_back(msg);
+        tracing::debug!(queue_arn, "delivered message to SQS queue");
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Second of four PRs closing the EventBridge Scheduler migration gap. Scheduler now actually fires schedules and delivers `Target.Input` to SQS, with DLQ routing on failure and one-shot self-delete.

- `expr.rs` — parse `at()`, `rate()`, `cron()`, `is_due` + `matches_cron` matchers
- `ticker.rs` — 1s `tokio::time::interval` scans every ENABLED schedule, fires due ones, honors `start_date`/`end_date`, cleans up one-shot `at()` schedules with `ActionAfterCompletion=DELETE`
- `delivery.rs` — route `:sqs:`/`:sns:`/`:lambda:`/`:states:`/`:events:` target types; on SQS `QueueNotFound`, push original `Input` to `DeadLetterConfig.Arn` with `X-Amz-Scheduler-*` metadata attributes
- Core: adds `SqsDeliveryError` + fallible `SqsDelivery::try_deliver_to_queue_with_attrs` (default impl succeeds; SQS impl reports `QueueNotFound`) — needed because Scheduler's DLQ routing must distinguish "delivered" from "target missing"
- Server wires a dedicated `DeliveryBus` and spawns the ticker at startup

## Test plan

- [x] 37 unit tests pass (expr parsing, ticker: disabled schedule skipped, end-date past skipped, at+DELETE self-deletes, DLQ receives failed delivery with metadata, rate delivers Input)
- [x] 3 new E2E tests asserting against a running fakecloud + real AWS SDK:
  - rate expression delivers `Input` JSON to target SQS queue
  - at expression + `ActionAfterCompletion=DELETE` → message delivered, schedule gone
  - DLQ routing: target queue missing → DLQ receives original input + `X-Amz-Scheduler-Attempt`/`Schedule-Arn`/`Error-Code` attributes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [ ] CI green
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the EventBridge Scheduler firing loop to deliver schedule targets and route failures to DLQs. Adds real delivery for `:sqs:`, `:sns:`, `:lambda:`, `:states:`, and `:events:` targets and runs at server startup.

- **New Features**
  - Parse `at(...)`, `rate(...)`, `cron(...)` with `is_due`; cron parser rejects ranges/lists/steps and uses per-minute dedupe keyed by year+ordinal/hour/minute.
  - 1s ticker scans enabled schedules, honors start/end windows, updates `last_fired`, and deletes one‑shot `at` schedules when `ActionAfterCompletion=DELETE`.
  - `:sqs:` delivery synthesizes per‑fire UUID dedup IDs for `*.fifo` (kept under SQS’s 128‑char limit); on missing target queue, sends original `Input` to `DeadLetterConfig.Arn` with `X-Amz-Scheduler-*` metadata; FIFO DLQs include group/dedup.
  - Other targets: publish to `:sns:`, async invoke `:lambda:`, start `:states:` executions, and put to EventBridge `:events:` with bus name parsed from the ARN.

- **Refactors**
  - In `fakecloud-core`, add `SqsDeliveryError` and `SqsDelivery::try_deliver_to_queue_with_attrs`; `DeliveryBus::try_send_to_sqs_with_attrs` returns `QueueNotFound` when unwired.
  - In `fakecloud-sqs`, validate ARNs and report `QueueNotFound`/`InvalidArn`; enforce FIFO dedup semantics.
  - In `fakecloud-server`, spawn the scheduler ticker at boot with a `DeliveryBus` wired for SQS, SNS, Lambda, Step Functions, and EventBridge; EventBridge delivery used by Scheduler (including via Step Functions) now carries SNS and Lambda on inner buses so EB rules that fan out to SNS deliver correctly.

<sup>Written for commit d57e24b29ee11da60b9a5f2918dfd6ed6b2daff9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

