### PR TITLE
feat(scheduler): IAM enforcement, persistence, introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "percent-encoding",

--- a/crates/fakecloud-e2e/tests/iam_enforcement_scheduler.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement_scheduler.rs
@@ -1,0 +1,190 @@
+//! IAM enforcement tests for the Scheduler service.
+
+mod helpers;
+
+use aws_credential_types::Credentials;
+use aws_sdk_iam::Client as IamClient;
+use aws_sdk_scheduler::types::{FlexibleTimeWindow, FlexibleTimeWindowMode, Target};
+use aws_sdk_scheduler::Client as SchedulerClient;
+use helpers::TestServer;
+
+async fn start_strict() -> TestServer {
+    TestServer::start_with_env(&[
+        ("FAKECLOUD_IAM", "strict"),
+        ("FAKECLOUD_VERIFY_SIGV4", "true"),
+    ])
+    .await
+}
+
+async fn sdk_config_with(server: &TestServer, akid: &str, secret: &str) -> aws_config::SdkConfig {
+    aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(
+            akid,
+            secret,
+            None,
+            None,
+            "fakecloud-scheduler-iam",
+        ))
+        .load()
+        .await
+}
+
+async fn bootstrap_user(server: &TestServer, name: &str) -> (String, String) {
+    let boot = sdk_config_with(server, "test", "test").await;
+    let iam_boot = IamClient::new(&boot);
+    iam_boot.create_user().user_name(name).send().await.unwrap();
+    let ak = iam_boot
+        .create_access_key()
+        .user_name(name)
+        .send()
+        .await
+        .unwrap();
+    let key = ak.access_key().unwrap();
+    (
+        key.access_key_id().to_string(),
+        key.secret_access_key().to_string(),
+    )
+}
+
+async fn attach_inline_policy(server: &TestServer, user: &str, name: &str, document: &str) {
+    let boot = sdk_config_with(server, "test", "test").await;
+    IamClient::new(&boot)
+        .put_user_policy()
+        .user_name(user)
+        .policy_name(name)
+        .policy_document(document)
+        .send()
+        .await
+        .unwrap();
+}
+
+fn off_window() -> FlexibleTimeWindow {
+    FlexibleTimeWindow::builder()
+        .mode(FlexibleTimeWindowMode::Off)
+        .build()
+        .unwrap()
+}
+
+fn sqs_target() -> Target {
+    Target::builder()
+        .arn("arn:aws:sqs:us-east-1:000000000000:dest")
+        .role_arn("arn:aws:iam::000000000000:role/s")
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn deny_blocks_create_schedule() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "alice").await;
+    attach_inline_policy(
+        &server,
+        "alice",
+        "deny-sched",
+        r#"{
+            "Version":"2012-10-17",
+            "Statement":[{"Effect":"Deny","Action":"scheduler:*","Resource":"*"}]
+        }"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let client = SchedulerClient::new(&cfg);
+    let err = client
+        .create_schedule()
+        .name("denied")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(off_window())
+        .target(sqs_target())
+        .send()
+        .await
+        .expect_err("Deny should block CreateSchedule");
+    assert!(format!("{err:?}").contains("AccessDenied"));
+}
+
+#[tokio::test]
+async fn allow_permits_create_schedule() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "bob").await;
+    attach_inline_policy(
+        &server,
+        "bob",
+        "allow-sched",
+        r#"{
+            "Version":"2012-10-17",
+            "Statement":[{"Effect":"Allow","Action":"scheduler:*","Resource":"*"}]
+        }"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let client = SchedulerClient::new(&cfg);
+    client
+        .create_schedule()
+        .name("allowed")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(off_window())
+        .target(sqs_target())
+        .send()
+        .await
+        .expect("Allow should permit CreateSchedule");
+}
+
+#[tokio::test]
+async fn schedule_group_condition_key_gates_access() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "carol").await;
+    // Only allow CreateSchedule when ScheduleGroup == "prod".
+    attach_inline_policy(
+        &server,
+        "carol",
+        "gate-group",
+        r#"{
+            "Version":"2012-10-17",
+            "Statement":[{
+                "Effect":"Allow",
+                "Action":"scheduler:*",
+                "Resource":"*",
+                "Condition":{"StringEquals":{"scheduler:ScheduleGroup":"prod"}}
+            }]
+        }"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let client = SchedulerClient::new(&cfg);
+    // Create the prod group using root-bypass so the condition can resolve.
+    let root_cfg = sdk_config_with(&server, "test", "test").await;
+    SchedulerClient::new(&root_cfg)
+        .create_schedule_group()
+        .name("prod")
+        .send()
+        .await
+        .unwrap();
+
+    // Wrong group → Deny.
+    let err = client
+        .create_schedule()
+        .name("in-default")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(off_window())
+        .target(sqs_target())
+        .send()
+        .await
+        .expect_err("group 'default' should be blocked by condition");
+    assert!(format!("{err:?}").contains("AccessDenied"));
+
+    // Right group → allow.
+    client
+        .create_schedule()
+        .name("in-prod")
+        .group_name("prod")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(off_window())
+        .target(sqs_target())
+        .send()
+        .await
+        .expect("group 'prod' should satisfy the condition");
+}

--- a/crates/fakecloud-e2e/tests/scheduler_introspection.rs
+++ b/crates/fakecloud-e2e/tests/scheduler_introspection.rs
@@ -1,0 +1,149 @@
+//! Introspection endpoints for EventBridge Scheduler.
+
+mod helpers;
+
+use aws_sdk_scheduler::types::{FlexibleTimeWindow, FlexibleTimeWindowMode, Target};
+use aws_sdk_sqs::types::QueueAttributeName;
+use helpers::TestServer;
+
+fn off_window() -> FlexibleTimeWindow {
+    FlexibleTimeWindow::builder()
+        .mode(FlexibleTimeWindowMode::Off)
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn list_schedules_endpoint_returns_created_schedules() {
+    let server = TestServer::start().await;
+    let sched = server.scheduler_client().await;
+
+    sched
+        .create_schedule()
+        .name("intro-1")
+        .schedule_expression("rate(1 hour)")
+        .flexible_time_window(off_window())
+        .target(
+            Target::builder()
+                .arn("arn:aws:sqs:us-east-1:000000000000:q")
+                .role_arn("arn:aws:iam::000000000000:role/s")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp: serde_json::Value = reqwest::get(format!(
+        "{}/_fakecloud/scheduler/schedules",
+        server.endpoint()
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+    let arr = resp["schedules"].as_array().expect("schedules array");
+    assert!(arr
+        .iter()
+        .any(|s| s["name"] == "intro-1" && s["groupName"] == "default"));
+}
+
+#[tokio::test]
+async fn fire_schedule_endpoint_triggers_sqs_delivery() {
+    let server = TestServer::start().await;
+    let sched = server.scheduler_client().await;
+    let sqs = server.sqs_client().await;
+
+    let q_url = sqs
+        .create_queue()
+        .queue_name("fire-intro")
+        .send()
+        .await
+        .unwrap()
+        .queue_url
+        .unwrap();
+    let q_arn = sqs
+        .get_queue_attributes()
+        .queue_url(&q_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .clone();
+
+    // Use a schedule that will NOT naturally fire within the test (20-year rate)
+    // so we can isolate the introspection fire.
+    sched
+        .create_schedule()
+        .name("manual-fire")
+        .schedule_expression("rate(365 days)")
+        .flexible_time_window(off_window())
+        .target(
+            Target::builder()
+                .arn(q_arn)
+                .role_arn("arn:aws:iam::000000000000:role/s")
+                .input("{\"forced\":true}")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Wait a tick so the first-bootstrap auto-fire goes to the queue,
+    // then drain it.
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    sqs.receive_message()
+        .queue_url(&q_url)
+        .max_number_of_messages(10)
+        .wait_time_seconds(1)
+        .send()
+        .await
+        .unwrap();
+
+    // Now drive the introspection endpoint.
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{}/_fakecloud/scheduler/fire/default/manual-fire",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["scheduleArn"]
+        .as_str()
+        .unwrap()
+        .contains("schedule/default/manual-fire"));
+
+    let msgs = sqs
+        .receive_message()
+        .queue_url(&q_url)
+        .wait_time_seconds(3)
+        .send()
+        .await
+        .unwrap();
+    let ms = msgs.messages.unwrap_or_default();
+    assert!(!ms.is_empty(), "fire endpoint should have delivered");
+    assert_eq!(ms[0].body.as_deref(), Some("{\"forced\":true}"));
+}
+
+#[tokio::test]
+async fn fire_schedule_endpoint_returns_404_for_missing() {
+    let server = TestServer::start().await;
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{}/_fakecloud/scheduler/fire/default/does-not-exist",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}

--- a/crates/fakecloud-e2e/tests/scheduler_persistence.rs
+++ b/crates/fakecloud-e2e/tests/scheduler_persistence.rs
@@ -1,0 +1,105 @@
+//! Persistence round-trips for EventBridge Scheduler.
+
+mod helpers;
+
+use aws_sdk_scheduler::types::{
+    ActionAfterCompletion, FlexibleTimeWindow, FlexibleTimeWindowMode, ScheduleState, Target,
+};
+use helpers::TestServer;
+
+fn off_window() -> FlexibleTimeWindow {
+    FlexibleTimeWindow::builder()
+        .mode(FlexibleTimeWindowMode::Off)
+        .build()
+        .unwrap()
+}
+
+fn sqs_target() -> Target {
+    Target::builder()
+        .arn("arn:aws:sqs:us-east-1:000000000000:dest")
+        .role_arn("arn:aws:iam::000000000000:role/s")
+        .input("{\"v\":1}")
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn schedule_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.scheduler_client().await;
+
+    client
+        .create_schedule_group()
+        .name("customgrp")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_schedule()
+        .name("nightly")
+        .group_name("customgrp")
+        .schedule_expression("rate(1 day)")
+        .flexible_time_window(off_window())
+        .target(sqs_target())
+        .state(ScheduleState::Disabled)
+        .action_after_completion(ActionAfterCompletion::None)
+        .description("backup job")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let client = server.scheduler_client().await;
+
+    let got = client
+        .get_schedule()
+        .name("nightly")
+        .group_name("customgrp")
+        .send()
+        .await
+        .expect("schedule should survive restart");
+    assert_eq!(got.schedule_expression().unwrap(), "rate(1 day)");
+    assert_eq!(got.state().unwrap(), &ScheduleState::Disabled);
+    assert_eq!(got.description().unwrap(), "backup job");
+    assert_eq!(
+        got.target().unwrap().arn(),
+        "arn:aws:sqs:us-east-1:000000000000:dest"
+    );
+
+    let group = client
+        .get_schedule_group()
+        .name("customgrp")
+        .send()
+        .await
+        .expect("group should survive restart");
+    assert_eq!(group.name().unwrap(), "customgrp");
+}
+
+#[tokio::test]
+async fn deleted_schedule_stays_deleted_after_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.scheduler_client().await;
+
+    client
+        .create_schedule()
+        .name("temp")
+        .schedule_expression("rate(1 hour)")
+        .flexible_time_window(off_window())
+        .target(sqs_target())
+        .send()
+        .await
+        .unwrap();
+    client.delete_schedule().name("temp").send().await.unwrap();
+
+    server.restart().await;
+    let client = server.scheduler_client().await;
+    let err = client
+        .get_schedule()
+        .name("temp")
+        .send()
+        .await
+        .expect_err("deleted schedule must not resurrect");
+    assert!(format!("{err:?}").contains("ResourceNotFound"));
+}

--- a/crates/fakecloud-scheduler/Cargo.toml
+++ b/crates/fakecloud-scheduler/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-scheduler/src/lib.rs
+++ b/crates/fakecloud-scheduler/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod delivery;
 pub mod expr;
+pub mod persistence;
 pub mod service;
 pub mod simulation;
 pub mod state;

--- a/crates/fakecloud-scheduler/src/lib.rs
+++ b/crates/fakecloud-scheduler/src/lib.rs
@@ -8,5 +8,6 @@
 pub mod delivery;
 pub mod expr;
 pub mod service;
+pub mod simulation;
 pub mod state;
 pub mod ticker;

--- a/crates/fakecloud-scheduler/src/persistence.rs
+++ b/crates/fakecloud-scheduler/src/persistence.rs
@@ -1,0 +1,137 @@
+//! Snapshot load helper for the scheduler state.
+//!
+//! Keeps the server's `main.rs` wiring block thin (single fn call)
+//! while the interesting branches — schema-version gate, migration-
+//! point, empty-startup — get unit-tested here.
+
+use fakecloud_persistence::SnapshotStore;
+
+use crate::state::{SchedulerSnapshot, SharedSchedulerState, SCHEDULER_SNAPSHOT_SCHEMA_VERSION};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum LoadOutcome {
+    /// No snapshot file on disk; start with fresh state.
+    Empty,
+    /// Snapshot loaded successfully; returns the restored account count.
+    Loaded(usize),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoadError {
+    #[error("failed to read scheduler persistence snapshot: {0}")]
+    Io(String),
+    #[error("failed to parse scheduler persistence snapshot: {0}")]
+    Parse(String),
+    #[error("scheduler persistence schema too new: on-disk={on_disk}, max supported={supported}")]
+    SchemaTooNew { on_disk: u32, supported: u32 },
+}
+
+/// Load a snapshot into `state`. Returns `Empty` when the store has
+/// nothing saved, `Loaded(n)` after a successful restore, or a
+/// descriptive error the server turns into a fatal startup message.
+pub fn load_into(
+    store: &dyn SnapshotStore,
+    state: &SharedSchedulerState,
+) -> Result<LoadOutcome, LoadError> {
+    let Some(bytes) = store.load().map_err(|e| LoadError::Io(e.to_string()))? else {
+        return Ok(LoadOutcome::Empty);
+    };
+    let snapshot: SchedulerSnapshot =
+        serde_json::from_slice(&bytes).map_err(|e| LoadError::Parse(e.to_string()))?;
+    if snapshot.schema_version > SCHEDULER_SNAPSHOT_SCHEMA_VERSION {
+        return Err(LoadError::SchemaTooNew {
+            on_disk: snapshot.schema_version,
+            supported: SCHEDULER_SNAPSHOT_SCHEMA_VERSION,
+        });
+    }
+    let accounts = snapshot.accounts.account_count();
+    *state.write() = snapshot.accounts;
+    Ok(LoadOutcome::Loaded(accounts))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{SchedulerSnapshot, SchedulerState};
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    fn make_state() -> SharedSchedulerState {
+        Arc::new(RwLock::new(MultiAccountState::new(
+            "000000000000",
+            "us-east-1",
+            "",
+        )))
+    }
+
+    struct MemStore {
+        data: Mutex<Option<Vec<u8>>>,
+    }
+    impl MemStore {
+        fn new(data: Option<Vec<u8>>) -> Self {
+            Self {
+                data: Mutex::new(data),
+            }
+        }
+    }
+    impl SnapshotStore for MemStore {
+        fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+            Ok(self.data.lock().unwrap().clone())
+        }
+        fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+            *self.data.lock().unwrap() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn load_into_empty_returns_empty() {
+        let state = make_state();
+        let store = MemStore::new(None);
+        let outcome = load_into(&store, &state).unwrap();
+        assert_eq!(outcome, LoadOutcome::Empty);
+    }
+
+    #[test]
+    fn load_into_valid_snapshot_restores_accounts() {
+        let state = make_state();
+        let mut mas: MultiAccountState<SchedulerState> =
+            MultiAccountState::new("999999999999", "us-east-1", "");
+        mas.get_or_create("999999999999");
+        let snap = SchedulerSnapshot {
+            schema_version: SCHEDULER_SNAPSHOT_SCHEMA_VERSION,
+            accounts: mas,
+        };
+        let bytes = serde_json::to_vec(&snap).unwrap();
+        let store = MemStore::new(Some(bytes));
+        let outcome = load_into(&store, &state).unwrap();
+        assert_eq!(outcome, LoadOutcome::Loaded(1));
+        let accounts = state.read();
+        assert!(accounts.get("999999999999").is_some());
+    }
+
+    #[test]
+    fn load_into_rejects_future_schema() {
+        let state = make_state();
+        let mas: MultiAccountState<SchedulerState> =
+            MultiAccountState::new("000000000000", "us-east-1", "");
+        let snap = SchedulerSnapshot {
+            schema_version: SCHEDULER_SNAPSHOT_SCHEMA_VERSION + 1,
+            accounts: mas,
+        };
+        let bytes = serde_json::to_vec(&snap).unwrap();
+        let store = MemStore::new(Some(bytes));
+        let err = load_into(&store, &state).err().unwrap();
+        assert!(matches!(err, LoadError::SchemaTooNew { .. }));
+    }
+
+    #[test]
+    fn load_into_reports_parse_errors() {
+        let state = make_state();
+        let store = MemStore::new(Some(b"not json".to_vec()));
+        let err = load_into(&store, &state).err().unwrap();
+        assert!(matches!(err, LoadError::Parse(_)));
+    }
+}

--- a/crates/fakecloud-scheduler/src/service.rs
+++ b/crates/fakecloud-scheduler/src/service.rs
@@ -9,15 +9,18 @@ use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
 use http::{Method, StatusCode};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
     group_arn, schedule_arn, DeadLetterConfig, FlexibleTimeWindow, RetryPolicy, Schedule,
-    ScheduleGroup, SharedSchedulerState, SqsParameters, Target, DEFAULT_GROUP,
+    ScheduleGroup, SchedulerSnapshot, SharedSchedulerState, SqsParameters, Target, DEFAULT_GROUP,
+    SCHEDULER_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const NAME_MAX: usize = 64;
@@ -25,11 +28,44 @@ const NAME_PATTERN_DESC: &str = r"^[0-9a-zA-Z-_.]+$";
 
 pub struct SchedulerService {
     state: SharedSchedulerState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl SchedulerService {
     pub fn new(state: SharedSchedulerState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = SchedulerSnapshot {
+            schema_version: SCHEDULER_SNAPSHOT_SCHEMA_VERSION,
+            accounts: self.state.read().clone(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write scheduler snapshot"),
+            Err(err) => tracing::error!(%err, "scheduler snapshot task panicked"),
+        }
     }
 
     fn resolve_action(req: &AwsRequest) -> Option<(&'static str, PathArgs)> {
@@ -544,7 +580,18 @@ impl AwsService for SchedulerService {
             )
         })?;
 
-        match (action, &args) {
+        let mutates = matches!(
+            action,
+            "CreateSchedule"
+                | "UpdateSchedule"
+                | "DeleteSchedule"
+                | "CreateScheduleGroup"
+                | "DeleteScheduleGroup"
+                | "TagResource"
+                | "UntagResource"
+        );
+
+        let result = match (action, &args) {
             ("CreateSchedule", PathArgs::Name(n)) => self.create_schedule(&req, n),
             ("GetSchedule", PathArgs::Name(n)) => self.get_schedule(&req, n),
             ("UpdateSchedule", PathArgs::Name(n)) => self.update_schedule(&req, n),
@@ -558,7 +605,12 @@ impl AwsService for SchedulerService {
             ("UntagResource", PathArgs::Arn(a)) => self.untag_resource(&req, a),
             ("ListTagsForResource", PathArgs::Arn(a)) => self.list_tags_for_resource(&req, a),
             _ => Err(AwsServiceError::action_not_implemented("scheduler", action)),
+        };
+
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {
@@ -577,6 +629,142 @@ impl AwsService for SchedulerService {
             "ListTagsForResource",
         ]
     }
+
+    fn iam_enforceable(&self) -> bool {
+        true
+    }
+
+    fn iam_action_for(&self, request: &AwsRequest) -> Option<fakecloud_core::auth::IamAction> {
+        let (raw_action, args) = Self::resolve_action(request)?;
+        let action: &'static str = match raw_action {
+            "CreateSchedule" => "CreateSchedule",
+            "GetSchedule" => "GetSchedule",
+            "UpdateSchedule" => "UpdateSchedule",
+            "DeleteSchedule" => "DeleteSchedule",
+            "ListSchedules" => "ListSchedules",
+            "CreateScheduleGroup" => "CreateScheduleGroup",
+            "GetScheduleGroup" => "GetScheduleGroup",
+            "DeleteScheduleGroup" => "DeleteScheduleGroup",
+            "ListScheduleGroups" => "ListScheduleGroups",
+            "TagResource" => "TagResource",
+            "UntagResource" => "UntagResource",
+            "ListTagsForResource" => "ListTagsForResource",
+            _ => return None,
+        };
+        let region = request.region.as_str();
+        let account = request
+            .principal
+            .as_ref()
+            .map(|p| p.account_id.as_str())
+            .unwrap_or(request.account_id.as_str());
+        let resource = match (action, &args) {
+            ("CreateSchedule", PathArgs::Name(n))
+            | ("GetSchedule", PathArgs::Name(n))
+            | ("UpdateSchedule", PathArgs::Name(n))
+            | ("DeleteSchedule", PathArgs::Name(n)) => {
+                let group = schedule_group_from_request(request);
+                schedule_arn(region, account, &group, n)
+            }
+            ("CreateScheduleGroup", PathArgs::Name(n))
+            | ("GetScheduleGroup", PathArgs::Name(n))
+            | ("DeleteScheduleGroup", PathArgs::Name(n)) => group_arn(region, account, n),
+            ("TagResource", PathArgs::Arn(a))
+            | ("UntagResource", PathArgs::Arn(a))
+            | ("ListTagsForResource", PathArgs::Arn(a)) => a.clone(),
+            ("ListSchedules", _) | ("ListScheduleGroups", _) => "*".to_string(),
+            _ => "*".to_string(),
+        };
+        Some(fakecloud_core::auth::IamAction {
+            service: "scheduler",
+            action,
+            resource,
+        })
+    }
+
+    fn iam_condition_keys_for(
+        &self,
+        request: &AwsRequest,
+        action: &fakecloud_core::auth::IamAction,
+    ) -> BTreeMap<String, Vec<String>> {
+        let mut out = BTreeMap::new();
+        // `scheduler:ScheduleGroup` is the only documented service-
+        // specific condition key on Scheduler operations. Emit it
+        // whenever the request targets a specific group.
+        let group = match action.action {
+            "CreateSchedule" | "UpdateSchedule" => Self::body_field(&request.body, "GroupName")
+                .unwrap_or_else(|| DEFAULT_GROUP.to_string()),
+            "GetSchedule" | "DeleteSchedule" => schedule_group_from_request(request),
+            "CreateScheduleGroup" | "GetScheduleGroup" | "DeleteScheduleGroup" => {
+                // The resource ARN already contains the group name.
+                arn_group_name(&action.resource).unwrap_or_default()
+            }
+            _ => return out,
+        };
+        if !group.is_empty() {
+            out.insert("scheduler:schedulegroup".to_string(), vec![group]);
+        }
+        out
+    }
+
+    fn resource_tags_for(&self, resource_arn: &str) -> Option<HashMap<String, String>> {
+        let group_name = group_name_from_tag_arn(resource_arn).ok()?;
+        let accounts = self.state.read();
+        let account_id = arn_account_id(resource_arn)?;
+        let state = accounts.get(&account_id)?;
+        state.groups.get(&group_name).map(|g| g.tags.clone())
+    }
+
+    fn request_tags_from(
+        &self,
+        request: &AwsRequest,
+        action: &str,
+    ) -> Option<HashMap<String, String>> {
+        match action {
+            "CreateScheduleGroup" | "TagResource" => {
+                let body: Value = serde_json::from_slice(&request.body).ok()?;
+                let arr = body.get("Tags").and_then(|v| v.as_array())?;
+                let mut out = HashMap::new();
+                for tag in arr {
+                    if let (Some(k), Some(v)) = (
+                        tag.get("Key").and_then(|v| v.as_str()),
+                        tag.get("Value").and_then(|v| v.as_str()),
+                    ) {
+                        out.insert(k.to_string(), v.to_string());
+                    }
+                }
+                Some(out)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl SchedulerService {
+    fn body_field(body: &[u8], key: &str) -> Option<String> {
+        serde_json::from_slice::<Value>(body)
+            .ok()
+            .and_then(|v| v.get(key).and_then(|f| f.as_str()).map(String::from))
+    }
+}
+
+/// Resolve the schedule group a request targets: explicit `groupName`
+/// query param (Get/Delete) takes priority, otherwise default.
+fn schedule_group_from_request(request: &AwsRequest) -> String {
+    request
+        .query_params
+        .get("groupName")
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_GROUP.to_string())
+}
+
+fn arn_group_name(arn: &str) -> Option<String> {
+    arn.split(':')
+        .nth(5)
+        .and_then(|r| r.strip_prefix("schedule-group/").map(str::to_string))
+}
+
+fn arn_account_id(arn: &str) -> Option<String> {
+    arn.split(':').nth(4).map(str::to_string)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/fakecloud-scheduler/src/service.rs
+++ b/crates/fakecloud-scheduler/src/service.rs
@@ -658,10 +658,14 @@ impl AwsService for SchedulerService {
             .map(|p| p.account_id.as_str())
             .unwrap_or(request.account_id.as_str());
         let resource = match (action, &args) {
-            ("CreateSchedule", PathArgs::Name(n))
-            | ("GetSchedule", PathArgs::Name(n))
-            | ("UpdateSchedule", PathArgs::Name(n))
-            | ("DeleteSchedule", PathArgs::Name(n)) => {
+            ("CreateSchedule", PathArgs::Name(n)) | ("UpdateSchedule", PathArgs::Name(n)) => {
+                // Create/Update pass GroupName in the request body.
+                let group = Self::body_field(&request.body, "GroupName")
+                    .unwrap_or_else(|| DEFAULT_GROUP.to_string());
+                schedule_arn(region, account, &group, n)
+            }
+            ("GetSchedule", PathArgs::Name(n)) | ("DeleteSchedule", PathArgs::Name(n)) => {
+                // Get/Delete pass GroupName as a query string parameter.
                 let group = schedule_group_from_request(request);
                 schedule_arn(region, account, &group, n)
             }
@@ -1491,6 +1495,161 @@ mod tests {
             .err()
             .unwrap();
         assert_eq!(err.code(), "ValidationException");
+    }
+
+    #[tokio::test]
+    async fn iam_action_for_maps_create_schedule_to_schedule_arn() {
+        let svc = SchedulerService::new(make_state());
+        let body = json!({
+            "GroupName": "prod",
+            "ScheduleExpression": "rate(1 minute)",
+            "FlexibleTimeWindow": { "Mode": "OFF" },
+            "Target": {
+                "Arn": "arn:aws:sqs:us-east-1:111122223333:q",
+                "RoleArn": "arn:aws:iam::111122223333:role/s"
+            }
+        })
+        .to_string();
+        let req = make_request(Method::POST, "/schedules/s1", &body);
+        let action = svc.iam_action_for(&req).unwrap();
+        assert_eq!(action.service, "scheduler");
+        assert_eq!(action.action, "CreateSchedule");
+        assert_eq!(
+            action.resource,
+            "arn:aws:scheduler:us-east-1:111122223333:schedule/prod/s1"
+        );
+    }
+
+    #[tokio::test]
+    async fn iam_action_for_get_schedule_uses_group_name_query_param() {
+        let svc = SchedulerService::new(make_state());
+        let req = make_request(Method::GET, "/schedules/s1?groupName=mygrp", "");
+        let action = svc.iam_action_for(&req).unwrap();
+        assert_eq!(action.action, "GetSchedule");
+        assert!(action.resource.contains("schedule/mygrp/s1"));
+    }
+
+    #[tokio::test]
+    async fn iam_action_for_schedule_group_ops() {
+        let svc = SchedulerService::new(make_state());
+        let action = svc
+            .iam_action_for(&make_request(Method::POST, "/schedule-groups/g1", "{}"))
+            .unwrap();
+        assert_eq!(action.action, "CreateScheduleGroup");
+        assert_eq!(
+            action.resource,
+            "arn:aws:scheduler:us-east-1:111122223333:schedule-group/g1"
+        );
+    }
+
+    #[tokio::test]
+    async fn iam_action_for_list_ops_return_wildcard() {
+        let svc = SchedulerService::new(make_state());
+        assert_eq!(
+            svc.iam_action_for(&make_request(Method::GET, "/schedules", ""))
+                .unwrap()
+                .resource,
+            "*"
+        );
+        assert_eq!(
+            svc.iam_action_for(&make_request(Method::GET, "/schedule-groups", ""))
+                .unwrap()
+                .resource,
+            "*"
+        );
+    }
+
+    #[tokio::test]
+    async fn iam_condition_keys_for_emits_schedule_group() {
+        let svc = SchedulerService::new(make_state());
+        let body = json!({
+            "GroupName": "prod",
+            "ScheduleExpression": "rate(1 minute)",
+            "FlexibleTimeWindow": { "Mode": "OFF" },
+            "Target": {
+                "Arn": "arn:aws:sqs:us-east-1:1:q",
+                "RoleArn": "arn:aws:iam::1:role/s"
+            }
+        })
+        .to_string();
+        let req = make_request(Method::POST, "/schedules/s", &body);
+        let action = svc.iam_action_for(&req).unwrap();
+        let keys = svc.iam_condition_keys_for(&req, &action);
+        assert_eq!(
+            keys.get("scheduler:schedulegroup"),
+            Some(&vec!["prod".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn iam_condition_keys_for_get_uses_query_group() {
+        let svc = SchedulerService::new(make_state());
+        let req = make_request(Method::GET, "/schedules/s?groupName=alt", "");
+        let action = svc.iam_action_for(&req).unwrap();
+        let keys = svc.iam_condition_keys_for(&req, &action);
+        assert_eq!(
+            keys.get("scheduler:schedulegroup"),
+            Some(&vec!["alt".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn iam_condition_keys_for_list_is_empty() {
+        let svc = SchedulerService::new(make_state());
+        let req = make_request(Method::GET, "/schedules", "");
+        let action = svc.iam_action_for(&req).unwrap();
+        assert!(svc.iam_condition_keys_for(&req, &action).is_empty());
+    }
+
+    #[tokio::test]
+    async fn resource_tags_for_returns_group_tags() {
+        let svc = SchedulerService::new(make_state());
+        svc.handle(make_request(
+            Method::POST,
+            "/schedule-groups/tagged",
+            r#"{"Tags":[{"Key":"env","Value":"prod"}]}"#,
+        ))
+        .await
+        .unwrap();
+        let tags = svc
+            .resource_tags_for("arn:aws:scheduler:us-east-1:111122223333:schedule-group/tagged")
+            .unwrap();
+        assert_eq!(tags.get("env"), Some(&"prod".to_string()));
+    }
+
+    #[tokio::test]
+    async fn resource_tags_for_unknown_group_returns_none() {
+        let svc = SchedulerService::new(make_state());
+        let tags = svc
+            .resource_tags_for("arn:aws:scheduler:us-east-1:111122223333:schedule-group/missing");
+        // Group missing -> None; distinguishable from "group exists, no tags" (Some(empty))
+        assert!(tags.is_none());
+    }
+
+    #[tokio::test]
+    async fn request_tags_from_extracts_create_group_tags() {
+        let svc = SchedulerService::new(make_state());
+        let req = make_request(
+            Method::POST,
+            "/schedule-groups/g",
+            r#"{"Tags":[{"Key":"a","Value":"1"},{"Key":"b","Value":"2"}]}"#,
+        );
+        let tags = svc.request_tags_from(&req, "CreateScheduleGroup").unwrap();
+        assert_eq!(tags.get("a"), Some(&"1".to_string()));
+        assert_eq!(tags.get("b"), Some(&"2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn request_tags_from_returns_none_for_non_tag_actions() {
+        let svc = SchedulerService::new(make_state());
+        let req = make_request(Method::GET, "/schedules", "");
+        assert!(svc.request_tags_from(&req, "ListSchedules").is_none());
+    }
+
+    #[tokio::test]
+    async fn iam_enforceable_is_true() {
+        let svc = SchedulerService::new(make_state());
+        assert!(svc.iam_enforceable());
     }
 
     #[tokio::test]

--- a/crates/fakecloud-scheduler/src/simulation.rs
+++ b/crates/fakecloud-scheduler/src/simulation.rs
@@ -1,0 +1,243 @@
+//! Test-only helpers that drive the Scheduler firing pipeline from
+//! introspection endpoints. Lets integration tests bypass the wall
+//! clock by poking a specific schedule and observing delivery.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use fakecloud_core::delivery::DeliveryBus;
+
+use crate::delivery::{deliver_target, route_to_dlq};
+use crate::state::SharedSchedulerState;
+
+/// Fire a specific schedule right now, regardless of its expression.
+/// Applies the same post-fire handling as the ticker — `last_fired`
+/// is bumped and `ActionAfterCompletion=DELETE` removes the schedule.
+/// Returns the target ARN on success (so the endpoint can echo it
+/// back to the caller).
+pub fn fire_once(
+    state: &SharedSchedulerState,
+    delivery: &Arc<DeliveryBus>,
+    account_id: &str,
+    group_name: &str,
+    schedule_name: &str,
+) -> Result<String, String> {
+    let (sched_snapshot, should_delete) = {
+        let mut accounts = state.write();
+        let account_state = accounts
+            .get_mut(account_id)
+            .ok_or_else(|| format!("account not found: {account_id}"))?;
+        let key = (group_name.to_string(), schedule_name.to_string());
+        let sched = account_state
+            .schedules
+            .get_mut(&key)
+            .ok_or_else(|| format!("schedule not found: {group_name}/{schedule_name}"))?;
+        sched.last_fired = Some(Utc::now());
+        let snap = sched.clone();
+        let should_delete = sched.schedule_expression.starts_with("at(")
+            && sched.action_after_completion == "DELETE";
+        (snap, should_delete)
+    };
+
+    match deliver_target(delivery, &sched_snapshot) {
+        Ok(()) => {}
+        Err(err) => {
+            route_to_dlq(
+                delivery,
+                &sched_snapshot,
+                "TargetDeliveryFailed",
+                &err.to_string(),
+            );
+        }
+    }
+
+    if should_delete {
+        let mut accounts = state.write();
+        if let Some(account_state) = accounts.get_mut(account_id) {
+            account_state
+                .schedules
+                .remove(&(group_name.to_string(), schedule_name.to_string()));
+        }
+    }
+
+    Ok(sched_snapshot.target.arn)
+}
+
+/// Snapshot of every schedule across every account, for the
+/// `GET /_fakecloud/scheduler/schedules` introspection endpoint.
+#[derive(Debug, Clone)]
+pub struct ScheduleRow {
+    pub account_id: String,
+    pub group_name: String,
+    pub name: String,
+    pub arn: String,
+    pub state: String,
+    pub schedule_expression: String,
+    pub target_arn: String,
+    pub last_fired: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+pub fn list_all_schedules(state: &SharedSchedulerState) -> Vec<ScheduleRow> {
+    let accounts = state.read();
+    let mut rows: Vec<ScheduleRow> = accounts
+        .iter()
+        .flat_map(|(account_id, s)| {
+            let account_id = account_id.to_string();
+            s.schedules.values().map(move |sched| ScheduleRow {
+                account_id: account_id.clone(),
+                group_name: sched.group_name.clone(),
+                name: sched.name.clone(),
+                arn: sched.arn.clone(),
+                state: sched.state.clone(),
+                schedule_expression: sched.schedule_expression.clone(),
+                target_arn: sched.target.arn.clone(),
+                last_fired: sched.last_fired,
+            })
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        a.account_id
+            .cmp(&b.account_id)
+            .then_with(|| a.group_name.cmp(&b.group_name))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{
+        FlexibleTimeWindow, Schedule, SchedulerState, SharedSchedulerState, Target,
+    };
+    use fakecloud_core::delivery::{SqsDelivery, SqsDeliveryError, SqsMessageAttribute};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    fn make_state() -> SharedSchedulerState {
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("000000000000", "us-east-1", ""),
+        ))
+    }
+
+    fn seed(state: &SharedSchedulerState, name: &str, expr: &str, action: &str) {
+        let now = Utc::now();
+        let mut accounts = state.write();
+        let s = accounts.get_or_create("000000000000");
+        s.schedules.insert(
+            ("default".to_string(), name.to_string()),
+            Schedule {
+                arn: format!("arn:aws:scheduler:us-east-1:000000000000:schedule/default/{name}"),
+                name: name.to_string(),
+                group_name: "default".to_string(),
+                schedule_expression: expr.to_string(),
+                schedule_expression_timezone: None,
+                start_date: None,
+                end_date: None,
+                description: None,
+                state: "ENABLED".to_string(),
+                kms_key_arn: None,
+                action_after_completion: action.to_string(),
+                flexible_time_window: FlexibleTimeWindow::default(),
+                target: Target {
+                    arn: "arn:aws:sqs:us-east-1:000000000000:q".to_string(),
+                    role_arn: "arn:aws:iam::000000000000:role/s".to_string(),
+                    input: Some("{\"x\":1}".to_string()),
+                    dead_letter_config: None,
+                    retry_policy: None,
+                    sqs_parameters: None,
+                    ecs_parameters: None,
+                    eventbridge_parameters: None,
+                    kinesis_parameters: None,
+                    sagemaker_pipeline_parameters: None,
+                },
+                creation_date: now,
+                last_modification_date: now,
+                last_fired: None,
+            },
+        );
+    }
+
+    #[derive(Default)]
+    struct Recorder {
+        calls: Mutex<Vec<(String, String)>>,
+    }
+    impl SqsDelivery for Recorder {
+        fn deliver_to_queue(&self, _a: &str, _b: &str, _c: &HashMap<String, String>) {}
+
+        fn try_deliver_to_queue_with_attrs(
+            &self,
+            arn: &str,
+            body: &str,
+            _a: &HashMap<String, SqsMessageAttribute>,
+            _g: Option<&str>,
+            _d: Option<&str>,
+        ) -> Result<(), SqsDeliveryError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((arn.to_string(), body.to_string()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn fire_once_delivers_and_updates_last_fired() {
+        let state = make_state();
+        seed(&state, "s", "rate(1 day)", "NONE");
+        let rec = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(rec.clone()));
+        fire_once(&state, &bus, "000000000000", "default", "s").unwrap();
+        assert_eq!(rec.calls.lock().unwrap().len(), 1);
+        let accounts = state.read();
+        let sched = accounts
+            .get("000000000000")
+            .unwrap()
+            .schedules
+            .get(&("default".to_string(), "s".to_string()))
+            .unwrap();
+        assert!(sched.last_fired.is_some());
+    }
+
+    #[test]
+    fn fire_once_deletes_at_schedule_with_delete_action() {
+        let state = make_state();
+        seed(&state, "once", "at(2020-01-01T00:00:00)", "DELETE");
+        let rec = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(rec.clone()));
+        fire_once(&state, &bus, "000000000000", "default", "once").unwrap();
+        let accounts = state.read();
+        assert!(!accounts
+            .get("000000000000")
+            .unwrap()
+            .schedules
+            .contains_key(&("default".to_string(), "once".to_string())));
+    }
+
+    #[test]
+    fn fire_once_reports_missing_schedule() {
+        let state = make_state();
+        let bus = Arc::new(DeliveryBus::new());
+        let err = fire_once(&state, &bus, "000000000000", "default", "nope")
+            .err()
+            .unwrap();
+        assert!(err.contains("not found"));
+    }
+
+    #[test]
+    fn list_all_schedules_returns_sorted_rows() {
+        let state = make_state();
+        seed(&state, "b", "rate(1 day)", "NONE");
+        seed(&state, "a", "rate(1 day)", "NONE");
+        let rows = list_all_schedules(&state);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].name, "a");
+        assert_eq!(rows[1].name, "b");
+    }
+
+    // Silence unused-import warning.
+    #[allow(dead_code)]
+    fn _type_check(_: SchedulerState) {}
+}

--- a/crates/fakecloud-scheduler/src/simulation.rs
+++ b/crates/fakecloud-scheduler/src/simulation.rs
@@ -78,6 +78,33 @@ pub struct ScheduleRow {
     pub last_fired: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Ready-to-serialize response for the fire-once introspection endpoint.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FireScheduleResponse {
+    #[serde(rename = "scheduleArn")]
+    pub schedule_arn: String,
+    #[serde(rename = "targetArn")]
+    pub target_arn: String,
+}
+
+/// Fire a schedule and assemble the response body the introspection
+/// endpoint echoes back. Extracted so the HTTP route closure is a
+/// one-liner and the interesting logic has unit coverage.
+pub fn fire_schedule_response(
+    state: &SharedSchedulerState,
+    delivery: &Arc<DeliveryBus>,
+    region: &str,
+    account_id: &str,
+    group: &str,
+    name: &str,
+) -> Result<FireScheduleResponse, String> {
+    let target_arn = fire_once(state, delivery, account_id, group, name)?;
+    Ok(FireScheduleResponse {
+        schedule_arn: format!("arn:aws:scheduler:{region}:{account_id}:schedule/{group}/{name}"),
+        target_arn,
+    })
+}
+
 pub fn list_all_schedules(state: &SharedSchedulerState) -> Vec<ScheduleRow> {
     let accounts = state.read();
     let mut rows: Vec<ScheduleRow> = accounts
@@ -221,6 +248,32 @@ mod tests {
         let state = make_state();
         let bus = Arc::new(DeliveryBus::new());
         let err = fire_once(&state, &bus, "000000000000", "default", "nope")
+            .err()
+            .unwrap();
+        assert!(err.contains("not found"));
+    }
+
+    #[test]
+    fn fire_schedule_response_builds_arn_and_target() {
+        let state = make_state();
+        seed(&state, "s", "rate(1 day)", "NONE");
+        let rec = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(rec.clone()));
+        let resp =
+            fire_schedule_response(&state, &bus, "us-east-1", "000000000000", "default", "s")
+                .unwrap();
+        assert_eq!(
+            resp.schedule_arn,
+            "arn:aws:scheduler:us-east-1:000000000000:schedule/default/s"
+        );
+        assert_eq!(resp.target_arn, "arn:aws:sqs:us-east-1:000000000000:q");
+    }
+
+    #[test]
+    fn fire_schedule_response_propagates_missing_error() {
+        let state = make_state();
+        let bus = Arc::new(DeliveryBus::new());
+        let err = fire_schedule_response(&state, &bus, "us-east-1", "000000000000", "g", "none")
             .err()
             .unwrap();
         assert!(err.contains("not found"));

--- a/crates/fakecloud-scheduler/src/state.rs
+++ b/crates/fakecloud-scheduler/src/state.rs
@@ -157,6 +157,16 @@ impl AccountState for SchedulerState {
 
 pub type SharedSchedulerState = Arc<RwLock<MultiAccountState<SchedulerState>>>;
 
+/// Bumped whenever the on-disk shape of `SchedulerSnapshot` changes.
+/// Schema version 1 is the initial format introduced by Batch 3.
+pub const SCHEDULER_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SchedulerSnapshot {
+    pub schema_version: u32,
+    pub accounts: MultiAccountState<SchedulerState>,
+}
+
 /// Build an EventBridge Scheduler schedule ARN.
 /// Format: `arn:aws:scheduler:<region>:<account>:schedule/<group>/<name>`.
 pub fn schedule_arn(region: &str, account_id: &str, group: &str, name: &str) -> String {

--- a/crates/fakecloud-scheduler/src/state.rs
+++ b/crates/fakecloud-scheduler/src/state.rs
@@ -104,8 +104,41 @@ pub struct SchedulerState {
     pub region: String,
     #[serde(default)]
     pub groups: HashMap<String, ScheduleGroup>,
-    #[serde(default)]
+    // JSON can't represent a tuple-keyed map, so we (de)serialize
+    // schedules as a flat Vec<Schedule> and rebuild the in-memory
+    // `(group, name)` index on read. Pre-refactor versions silently
+    // dropped the entire map during save — the regression that broke
+    // schedule-survives-restart.
+    #[serde(default, with = "schedules_vec_serde")]
     pub schedules: HashMap<ScheduleKey, Schedule>,
+}
+
+mod schedules_vec_serde {
+    use super::{Schedule, ScheduleKey};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::collections::HashMap;
+
+    pub fn serialize<S: Serializer>(
+        schedules: &HashMap<ScheduleKey, Schedule>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut sorted: Vec<&Schedule> = schedules.values().collect();
+        sorted.sort_by(|a, b| {
+            a.group_name
+                .cmp(&b.group_name)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        sorted.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<ScheduleKey, Schedule>, D::Error> {
+        let v: Vec<Schedule> = Vec::deserialize(deserializer)?;
+        Ok(v.into_iter()
+            .map(|s| ((s.group_name.clone(), s.name.clone()), s))
+            .collect())
+    }
 }
 
 impl SchedulerState {

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -299,6 +299,34 @@ pub struct FireRuleResponse {
     pub targets: Vec<FireRuleTarget>,
 }
 
+// ── Scheduler (EventBridge Scheduler) ───────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchedulerSchedule {
+    pub account_id: String,
+    pub group_name: String,
+    pub name: String,
+    pub arn: String,
+    pub state: String,
+    pub schedule_expression: String,
+    pub target_arn: String,
+    pub last_fired: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchedulerSchedulesResponse {
+    pub schedules: Vec<SchedulerSchedule>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FireScheduleResponse {
+    pub schedule_arn: String,
+    pub target_arn: String,
+}
+
 // ── S3 ──────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1805,39 +1805,14 @@ async fn main() {
                 .clone();
             let path = data_path.join("scheduler").join("snapshot.json");
             let store = fakecloud_persistence::DiskSnapshotStore::new(path);
-            match fakecloud_persistence::SnapshotStore::load(&store) {
-                Ok(Some(bytes)) => {
-                    match serde_json::from_slice::<fakecloud_scheduler::state::SchedulerSnapshot>(
-                        &bytes,
-                    ) {
-                        Ok(snapshot) => {
-                            if snapshot.schema_version
-                                > fakecloud_scheduler::state::SCHEDULER_SNAPSHOT_SCHEMA_VERSION
-                            {
-                                fatal_exit(format_args!(
-                                    "scheduler persistence schema too new: on-disk={}, max supported={}",
-                                    snapshot.schema_version,
-                                    fakecloud_scheduler::state::SCHEDULER_SNAPSHOT_SCHEMA_VERSION,
-                                ));
-                            }
-                            let account_count = snapshot.accounts.account_count();
-                            *scheduler_state.write() = snapshot.accounts;
-                            tracing::info!(
-                                accounts = account_count,
-                                "loaded scheduler persistence snapshot"
-                            );
-                        }
-                        Err(err) => fatal_exit(format_args!(
-                            "failed to parse scheduler persistence snapshot: {err}"
-                        )),
-                    }
+            match fakecloud_scheduler::persistence::load_into(&store, &scheduler_state) {
+                Ok(fakecloud_scheduler::persistence::LoadOutcome::Loaded(accounts)) => {
+                    tracing::info!(accounts, "loaded scheduler persistence snapshot");
                 }
-                Ok(None) => {
+                Ok(fakecloud_scheduler::persistence::LoadOutcome::Empty) => {
                     tracing::info!("no scheduler persistence snapshot found; starting empty");
                 }
-                Err(err) => fatal_exit(format_args!(
-                    "failed to read scheduler persistence snapshot: {err}"
-                )),
+                Err(err) => fatal_exit(format_args!("{err}")),
             }
             Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
         } else {
@@ -2533,22 +2508,17 @@ async fn main() {
                     let default_account = default_account.clone();
                     let default_region = default_region.clone();
                     async move {
-                        match fakecloud_scheduler::simulation::fire_once(
+                        match fakecloud_scheduler::simulation::fire_schedule_response(
                             &state,
                             &delivery,
+                            &default_region,
                             &default_account,
                             &group,
                             &name,
                         ) {
-                            Ok(target_arn) => (
+                            Ok(body) => (
                                 axum::http::StatusCode::OK,
-                                axum::Json(serde_json::json!(types::FireScheduleResponse {
-                                    schedule_arn: format!(
-                                        "arn:aws:scheduler:{}:{}:schedule/{}/{}",
-                                        default_region, default_account, group, name
-                                    ),
-                                    target_arn,
-                                })),
+                                axum::Json(serde_json::json!(body)),
                             ),
                             Err(msg) => (
                                 axum::http::StatusCode::NOT_FOUND,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1796,7 +1796,57 @@ async fn main() {
     }
     registry.register(Arc::new(bedrock_service));
 
-    let scheduler_service = SchedulerService::new(scheduler_state.clone());
+    let scheduler_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("scheduler").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_scheduler::state::SchedulerSnapshot>(
+                        &bytes,
+                    ) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_scheduler::state::SCHEDULER_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "scheduler persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_scheduler::state::SCHEDULER_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let account_count = snapshot.accounts.account_count();
+                            *scheduler_state.write() = snapshot.accounts;
+                            tracing::info!(
+                                accounts = account_count,
+                                "loaded scheduler persistence snapshot"
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse scheduler persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no scheduler persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read scheduler persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut scheduler_service = SchedulerService::new(scheduler_state.clone());
+    if let Some(store) = scheduler_snapshot_store {
+        scheduler_service = scheduler_service.with_snapshot_store(store);
+    }
     registry.register(Arc::new(scheduler_service));
 
     // Spawn the Scheduler firing loop as a background task. Mirrors
@@ -1866,6 +1916,11 @@ async fn main() {
         }
         Arc::new(bus)
     };
+    let scheduler_state_for_list = scheduler_state.clone();
+    let scheduler_state_for_fire = scheduler_state.clone();
+    let delivery_for_scheduler_fire = delivery_for_scheduler.clone();
+    let default_account_for_scheduler_fire = cli.account_id.clone();
+    let default_region_for_scheduler_fire = cli.region.clone();
     let scheduler_ticker =
         fakecloud_scheduler::ticker::Ticker::new(scheduler_state.clone(), delivery_for_scheduler);
     tokio::spawn(scheduler_ticker.run());
@@ -2439,6 +2494,68 @@ async fn main() {
                         })
                         .collect();
                     axum::Json(types::S3NotificationsResponse { notifications })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/scheduler/schedules",
+            axum::routing::get({
+                let state = scheduler_state_for_list;
+                move || async move {
+                    let rows = fakecloud_scheduler::simulation::list_all_schedules(&state);
+                    let schedules = rows
+                        .into_iter()
+                        .map(|r| types::SchedulerSchedule {
+                            account_id: r.account_id,
+                            group_name: r.group_name,
+                            name: r.name,
+                            arn: r.arn,
+                            state: r.state,
+                            schedule_expression: r.schedule_expression,
+                            target_arn: r.target_arn,
+                            last_fired: r.last_fired.map(|t| t.to_rfc3339()),
+                        })
+                        .collect();
+                    axum::Json(types::SchedulerSchedulesResponse { schedules })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/scheduler/fire/{group}/{name}",
+            axum::routing::post({
+                let state = scheduler_state_for_fire;
+                let delivery = delivery_for_scheduler_fire;
+                let default_account = default_account_for_scheduler_fire;
+                let default_region = default_region_for_scheduler_fire;
+                move |axum::extract::Path((group, name)): axum::extract::Path<(String, String)>| {
+                    let state = state.clone();
+                    let delivery = delivery.clone();
+                    let default_account = default_account.clone();
+                    let default_region = default_region.clone();
+                    async move {
+                        match fakecloud_scheduler::simulation::fire_once(
+                            &state,
+                            &delivery,
+                            &default_account,
+                            &group,
+                            &name,
+                        ) {
+                            Ok(target_arn) => (
+                                axum::http::StatusCode::OK,
+                                axum::Json(serde_json::json!(types::FireScheduleResponse {
+                                    schedule_arn: format!(
+                                        "arn:aws:scheduler:{}:{}:schedule/{}/{}",
+                                        default_region, default_account, group, name
+                                    ),
+                                    target_arn,
+                                })),
+                            ),
+                            Err(msg) => (
+                                axum::http::StatusCode::NOT_FOUND,
+                                axum::Json(serde_json::json!({ "error": msg })),
+                            ),
+                        }
+                    }
                 }
             }),
         )


### PR DESCRIPTION
## Summary

Third PR in the EventBridge Scheduler migration. Brings Scheduler in line with every other recently-shipped service.

- **IAM enforcement** — `iam_enforceable=true`, action mapping across all 12 ops, `scheduler:ScheduleGroup` condition key, `aws:ResourceTag/*` + `aws:RequestTag/*` ABAC support
- **Persistence** — `SchedulerSnapshot` (schema v1), load on startup, save on every mutation
- **Introspection** — `GET /_fakecloud/scheduler/schedules`, `POST /_fakecloud/scheduler/fire/{group}/{name}`; new `simulation::fire_once` applies the ticker's full post-fire handling

## Test plan

- [x] 47 unit tests pass (10 new: `fire_once`, `list_all_schedules`, tag-extractor, etc.)
- [x] 3 new E2E IAM tests — Deny blocks CreateSchedule, Allow permits, `scheduler:ScheduleGroup` gates access
- [x] 2 new E2E persistence tests — schedule + group survive restart, deleted schedule stays deleted
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [ ] CI green
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IAM enforcement, persistence, and introspection to EventBridge Scheduler so policies are honored, state survives restarts, and schedules can be listed/fired via `/_fakecloud` endpoints. Also fixes snapshot serialization so schedules reliably persist across restarts.

- **New Features**
  - IAM: `iam_enforceable=true` with action mapping for all scheduler ops; correct resource ARNs; `scheduler:ScheduleGroup` condition key; ABAC via `aws:ResourceTag/*` and `aws:RequestTag/*`.
  - Persistence: `SchedulerSnapshot` (schema v1); server loads snapshot on startup in persistent mode; `SchedulerService` saves after successful mutations.
  - Introspection: `GET /_fakecloud/scheduler/schedules` (sorted list) and `POST /_fakecloud/scheduler/fire/{group}/{name}` (fires now, updates `last_fired`, deletes one-shots; 404 if missing).
  - SDK types: `SchedulerSchedule`, `SchedulerSchedulesResponse`, and `FireScheduleResponse` in `fakecloud-sdk`.
  - Refactor: extracted `persistence::load_into` and `simulation::fire_schedule_response`; `fakecloud-server` calls these helpers to reduce boilerplate and improve unit coverage.

- **Bug Fixes**
  - Persistence: serialize `schedules` via a flat Vec to ensure JSON round-trips; previously tuple-keyed map serialized empty and dropped schedules on save.
  - IAM: action mapping now reads `GroupName` from the request body for Create/UpdateSchedule and from the `groupName` query for Get/DeleteSchedule to build correct schedule ARNs.

<sup>Written for commit 21bf4b8548312f900364e1b59d82d9b3e7a2f936. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

