### PR TITLE
feat(rds,elasticache,apigatewayv2,stepfunctions): multi-account state isolation

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -10,8 +10,8 @@ use fakecloud_core::validation::*;
 use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    ApiGatewayV2Snapshot, ApiRequest, Authorizer, Deployment, HttpApi, Integration, Route,
-    SharedApiGatewayV2State, Stage, APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
+    ApiGatewayV2Snapshot, ApiGatewayV2State, ApiRequest, Authorizer, Deployment, HttpApi,
+    Integration, Route, SharedApiGatewayV2State, Stage, APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
 };
 use crate::{cors, http_proxy, lambda_proxy, mock, router::Router};
 
@@ -80,7 +80,8 @@ impl ApiGatewayV2Service {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = ApiGatewayV2Snapshot {
             schema_version: APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            state: None,
+            accounts: Some(self.state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -352,7 +353,8 @@ impl ApiGatewayV2Service {
         let mut api = HttpApi::new(api_id, name, description, tags, region);
         api.cors_configuration = cors_configuration;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let api_clone = api.clone();
         state.apis.insert(api.api_id.clone(), api);
 
@@ -361,7 +363,7 @@ impl ApiGatewayV2Service {
 
     fn get_api(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let api_id = api_id.ok_or_else(|| {
@@ -372,7 +374,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let api = state.apis.get(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -384,8 +388,10 @@ impl ApiGatewayV2Service {
         Ok(AwsResponse::ok_json(json!(api)))
     }
 
-    fn get_apis(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let state = self.state.read();
+    fn get_apis(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let apis: Vec<&HttpApi> = state.apis.values().collect();
 
         Ok(AwsResponse::ok_json(json!({
@@ -407,7 +413,8 @@ impl ApiGatewayV2Service {
         })?;
 
         let body = req.json_body();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let api = state.apis.get_mut(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -440,7 +447,7 @@ impl ApiGatewayV2Service {
 
     fn delete_api(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let api_id = api_id.ok_or_else(|| {
@@ -451,7 +458,8 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         state.apis.remove(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -507,7 +515,8 @@ impl ApiGatewayV2Service {
             authorizer_id,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -529,7 +538,7 @@ impl ApiGatewayV2Service {
 
     fn get_route(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
         route_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -549,7 +558,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         let routes = state.routes.get(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -572,7 +583,7 @@ impl ApiGatewayV2Service {
 
     fn get_routes(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let api_id = api_id.ok_or_else(|| {
@@ -583,7 +594,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -628,7 +641,8 @@ impl ApiGatewayV2Service {
         })?;
 
         let body = req.json_body();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let routes = state.routes.get_mut(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -667,7 +681,7 @@ impl ApiGatewayV2Service {
 
     fn delete_route(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
         route_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -687,7 +701,8 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let routes = state.routes.get_mut(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -751,7 +766,8 @@ impl ApiGatewayV2Service {
             timeout_in_millis,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -773,7 +789,7 @@ impl ApiGatewayV2Service {
 
     fn get_integration(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
         integration_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -793,7 +809,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         let integrations = state.integrations.get(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -816,7 +834,7 @@ impl ApiGatewayV2Service {
 
     fn get_integrations(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let api_id = api_id.ok_or_else(|| {
@@ -827,7 +845,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -872,7 +892,8 @@ impl ApiGatewayV2Service {
         })?;
 
         let body = req.json_body();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let integrations = state.integrations.get_mut(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -911,7 +932,7 @@ impl ApiGatewayV2Service {
 
     fn delete_integration(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
         integration_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -931,7 +952,8 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let integrations = state.integrations.get_mut(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -996,7 +1018,8 @@ impl ApiGatewayV2Service {
             last_updated_date: None,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -1031,7 +1054,7 @@ impl ApiGatewayV2Service {
 
     fn get_stage(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
         stage_name: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -1051,7 +1074,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         let stages = state.stages.get(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -1074,7 +1099,7 @@ impl ApiGatewayV2Service {
 
     fn get_stages(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let api_id = api_id.ok_or_else(|| {
@@ -1085,7 +1110,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -1130,7 +1157,8 @@ impl ApiGatewayV2Service {
         })?;
 
         let body = req.json_body();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let stages = state.stages.get_mut(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -1167,7 +1195,7 @@ impl ApiGatewayV2Service {
 
     fn delete_stage(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
         stage_name: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -1187,7 +1215,8 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         let stages = state.stages.get_mut(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -1237,7 +1266,8 @@ impl ApiGatewayV2Service {
             auto_deployed: false,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -1269,7 +1299,7 @@ impl ApiGatewayV2Service {
 
     fn get_deployment(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
         deployment_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -1289,7 +1319,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         let deployments = state.deployments.get(api_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -1312,7 +1344,7 @@ impl ApiGatewayV2Service {
 
     fn get_deployments(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let api_id = api_id.ok_or_else(|| {
@@ -1323,7 +1355,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -1416,7 +1450,8 @@ impl ApiGatewayV2Service {
             jwt_configuration,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -1438,7 +1473,7 @@ impl ApiGatewayV2Service {
 
     fn get_authorizer(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
         authorizer_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -1458,7 +1493,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -1486,7 +1523,7 @@ impl ApiGatewayV2Service {
 
     fn get_authorizers(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let api_id = api_id.ok_or_else(|| {
@@ -1497,7 +1534,9 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -1542,7 +1581,8 @@ impl ApiGatewayV2Service {
         })?;
 
         let body = req.json_body();
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -1598,7 +1638,7 @@ impl ApiGatewayV2Service {
 
     fn delete_authorizer(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         api_id: Option<&str>,
         authorizer_id: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -1618,7 +1658,8 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Verify API exists
         if !state.apis.contains_key(api_id) {
@@ -1661,7 +1702,9 @@ impl ApiGatewayV2Service {
 
         // Find the API for this stage and get CORS configuration
         let (api_id, routes, cors_config) = {
-            let state = self.state.read();
+            let accounts = self.state.read();
+            let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
             // Find which API has this stage (sort by API ID for deterministic resolution)
             let mut stage_entries: Vec<_> = state
@@ -1732,7 +1775,9 @@ impl ApiGatewayV2Service {
             })?;
 
         let integration = {
-            let state = self.state.read();
+            let accounts = self.state.read();
+            let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
             state
                 .integrations
                 .get(&api_id)
@@ -1858,7 +1903,8 @@ impl ApiGatewayV2Service {
             status_code,
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.request_history.push(request_record);
     }
 }
@@ -1871,7 +1917,6 @@ fn generate_id(prefix: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::ApiGatewayV2State;
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
@@ -1880,10 +1925,9 @@ mod tests {
     use std::sync::Arc;
 
     fn make_state() -> SharedApiGatewayV2State {
-        Arc::new(RwLock::new(ApiGatewayV2State::new(
-            "123456789012",
-            "us-east-1",
-        )))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ))
     }
 
     fn make_request(method: Method, path: &str, body: &str) -> AwsRequest {

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -3,7 +3,14 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-pub type SharedApiGatewayV2State = Arc<parking_lot::RwLock<ApiGatewayV2State>>;
+pub type SharedApiGatewayV2State =
+    Arc<parking_lot::RwLock<fakecloud_core::multi_account::MultiAccountState<ApiGatewayV2State>>>;
+
+impl fakecloud_core::multi_account::AccountState for ApiGatewayV2State {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiGatewayV2State {
@@ -27,12 +34,15 @@ pub struct ApiGatewayV2State {
     pub request_history: Vec<ApiRequest>,
 }
 
-pub const APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiGatewayV2Snapshot {
     pub schema_version: u32,
-    pub state: ApiGatewayV2State,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<ApiGatewayV2State>>,
+    #[serde(default)]
+    pub state: Option<ApiGatewayV2State>,
 }
 
 impl ApiGatewayV2State {

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -119,7 +119,8 @@ impl ElastiCacheService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = ElastiCacheSnapshot {
             schema_version: ELASTICACHE_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            state: None,
+            accounts: Some(self.state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -281,7 +282,9 @@ impl ElastiCacheService {
         let max_records = optional_usize_param(request, "MaxRecords")?;
         let marker = optional_param(request, "Marker");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         let groups: Vec<&CacheParameterGroup> = state
             .parameter_groups
@@ -334,7 +337,9 @@ impl ElastiCacheService {
         let max_records = optional_usize_param(request, "MaxRecords")?;
         let marker = optional_param(request, "Marker");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let mut nodes: Vec<&ReservedCacheNode> = state.reserved_cache_nodes.values().collect();
         nodes.retain(|node| {
             reserved_cache_node_id
@@ -401,7 +406,9 @@ impl ElastiCacheService {
         let max_records = optional_usize_param(request, "MaxRecords")?;
         let marker = optional_param(request, "Marker");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let mut offerings: Vec<&ReservedCacheNodesOffering> =
             state.reserved_cache_nodes_offerings.iter().collect();
         offerings.retain(|offering| {
@@ -504,7 +511,8 @@ impl ElastiCacheService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if state.subnet_groups.contains_key(&name) {
             return Err(AwsServiceError::aws_error(
@@ -555,7 +563,9 @@ impl ElastiCacheService {
         let max_records = optional_usize_param(request, "MaxRecords")?;
         let marker = optional_param(request, "Marker");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         let groups: Vec<&CacheSubnetGroup> = if let Some(ref name) = group_name {
             match state.subnet_groups.get(name) {
@@ -605,7 +615,8 @@ impl ElastiCacheService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let name = required_param(request, "CacheSubnetGroupName")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if name == "default" {
             return Err(AwsServiceError::aws_error(
@@ -639,7 +650,8 @@ impl ElastiCacheService {
         let description = optional_param(request, "CacheSubnetGroupDescription");
         let subnet_ids = parse_member_list(&request.query_params, "SubnetIds", "SubnetIdentifier");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let region = state.region.clone();
 
         let group = state.subnet_groups.get_mut(&name).ok_or_else(|| {
@@ -714,7 +726,8 @@ impl ElastiCacheService {
                 .unwrap_or(true);
 
         let (preferred_availability_zone, arn) = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             if !state.begin_cache_cluster_creation(&cache_cluster_id) {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -757,6 +770,7 @@ impl ElastiCacheService {
         let runtime = self.runtime.as_ref().ok_or_else(|| {
             self.state
                 .write()
+                .get_or_create(&request.account_id)
                 .cancel_cache_cluster_creation(&cache_cluster_id);
             AwsServiceError::aws_error(
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -771,6 +785,7 @@ impl ElastiCacheService {
             Err(e) => {
                 self.state
                     .write()
+                    .get_or_create(&request.account_id)
                     .cancel_cache_cluster_creation(&cache_cluster_id);
                 return Err(runtime_error_to_service_error(e));
             }
@@ -797,10 +812,11 @@ impl ElastiCacheService {
 
         let xml = cache_cluster_xml(&cluster, true);
         {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             state.finish_cache_cluster_creation(cluster.clone());
             if let Some(ref group_id) = cluster.replication_group_id {
-                add_cluster_to_replication_group(&mut state, group_id, &cluster.cache_cluster_id);
+                add_cluster_to_replication_group(state, group_id, &cluster.cache_cluster_id);
             }
         }
 
@@ -825,7 +841,9 @@ impl ElastiCacheService {
         let max_records = optional_usize_param(request, "MaxRecords")?;
         let marker = optional_param(request, "Marker");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let clusters: Vec<&CacheCluster> = if let Some(ref cluster_id) = cache_cluster_id {
             match state.cache_clusters.get(cluster_id) {
                 Some(cluster) => vec![cluster],
@@ -874,7 +892,8 @@ impl ElastiCacheService {
         let cache_cluster_id = required_param(request, "CacheClusterId")?;
 
         let cluster = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             let cluster = state
                 .cache_clusters
                 .remove(&cache_cluster_id)
@@ -886,11 +905,7 @@ impl ElastiCacheService {
                     )
                 })?;
             if let Some(ref group_id) = cluster.replication_group_id {
-                remove_cluster_from_replication_group(
-                    &mut state,
-                    group_id,
-                    &cluster.cache_cluster_id,
-                );
+                remove_cluster_from_replication_group(state, group_id, &cluster.cache_cluster_id);
             }
             state.tags.remove(&cluster.arn);
             cluster
@@ -956,7 +971,8 @@ impl ElastiCacheService {
                 .unwrap_or(false);
         // Reserve the ID under a write lock before starting the container.
         {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             if !state.begin_replication_group_creation(&replication_group_id) {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -969,6 +985,7 @@ impl ElastiCacheService {
         let runtime = self.runtime.as_ref().ok_or_else(|| {
             self.state
                 .write()
+                .get_or_create(&request.account_id)
                 .cancel_replication_group_creation(&replication_group_id);
             AwsServiceError::aws_error(
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -983,6 +1000,7 @@ impl ElastiCacheService {
             Err(e) => {
                 self.state
                     .write()
+                    .get_or_create(&request.account_id)
                     .cancel_replication_group_creation(&replication_group_id);
                 return Err(runtime_error_to_service_error(e));
             }
@@ -993,7 +1011,9 @@ impl ElastiCacheService {
             .collect();
 
         let (arn, region) = {
-            let state = self.state.read();
+            let accounts = self.state.read();
+            let empty = ElastiCacheState::new(&request.account_id, &request.region);
+            let state = accounts.get(&request.account_id).unwrap_or(&empty);
             let arn = format!(
                 "arn:aws:elasticache:{}:{}:replicationgroup:{}",
                 state.region, state.account_id, replication_group_id
@@ -1024,7 +1044,10 @@ impl ElastiCacheService {
         };
 
         let xml = replication_group_xml(&group, &region);
-        self.state.write().finish_replication_group_creation(group);
+        self.state
+            .write()
+            .get_or_create(&request.account_id)
+            .finish_replication_group_creation(group);
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -1045,7 +1068,8 @@ impl ElastiCacheService {
         let description =
             optional_param(request, "GlobalReplicationGroupDescription").unwrap_or_default();
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let region = state.region.clone();
         let account_id = state.account_id.clone();
         let global_replication_group_id = global_replication_group_id(&region, suffix.as_str());
@@ -1131,7 +1155,9 @@ impl ElastiCacheService {
             parse_optional_bool(optional_param(request, "ShowMemberInfo").as_deref())?
                 .unwrap_or(false);
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let groups: Vec<&GlobalReplicationGroup> = if let Some(ref global_replication_group_id) =
             global_replication_group_id
         {
@@ -1192,7 +1218,9 @@ impl ElastiCacheService {
         let max_records = optional_usize_param(request, "MaxRecords")?;
         let marker = optional_param(request, "Marker");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let region = state.region.clone();
 
         let groups: Vec<&ReplicationGroup> = if let Some(ref id) = group_id {
@@ -1244,7 +1272,8 @@ impl ElastiCacheService {
         let global_replication_group_id = required_param(request, "GlobalReplicationGroupId")?;
         let retain_primary = parse_required_bool(request, "RetainPrimaryReplicationGroup")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let mut group = state
             .global_replication_groups
             .remove(&global_replication_group_id)
@@ -1294,7 +1323,8 @@ impl ElastiCacheService {
         let replication_group_id = required_param(request, "ReplicationGroupId")?;
 
         let group = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             let g = state
                 .replication_groups
                 .remove(&replication_group_id)
@@ -1313,7 +1343,7 @@ impl ElastiCacheService {
             runtime.stop_container(&replication_group_id).await;
         }
 
-        let region = self.state.read().region.clone();
+        let region = self.state.read().region().to_string();
         let mut deleted_group = group;
         deleted_group.status = "deleting".to_string();
         let xml = replication_group_xml(&deleted_group, &region);
@@ -1352,7 +1382,8 @@ impl ElastiCacheService {
         let tags = parse_tags(request)?;
 
         let (arn, endpoint_address) = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             if !state.begin_serverless_cache_creation(&serverless_cache_name) {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -1393,6 +1424,7 @@ impl ElastiCacheService {
         let runtime = self.runtime.as_ref().ok_or_else(|| {
             self.state
                 .write()
+                .get_or_create(&request.account_id)
                 .cancel_serverless_cache_creation(&serverless_cache_name);
             AwsServiceError::aws_error(
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -1407,6 +1439,7 @@ impl ElastiCacheService {
             Err(e) => {
                 self.state
                     .write()
+                    .get_or_create(&request.account_id)
                     .cancel_serverless_cache_creation(&serverless_cache_name);
                 return Err(runtime_error_to_service_error(e));
             }
@@ -1444,7 +1477,8 @@ impl ElastiCacheService {
 
         let xml = serverless_cache_xml(&cache);
         {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             state.finish_serverless_cache_creation(cache.clone());
             if !tags.is_empty() {
                 merge_tags(state.tags.entry(arn).or_default(), &tags);
@@ -1469,7 +1503,9 @@ impl ElastiCacheService {
         let max_results = optional_usize_param(request, "MaxResults")?;
         let next_token = optional_param(request, "NextToken");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let caches: Vec<&ServerlessCache> = if let Some(ref name) = serverless_cache_name {
             match state.serverless_caches.get(name) {
                 Some(cache) => vec![cache],
@@ -1513,7 +1549,8 @@ impl ElastiCacheService {
         let serverless_cache_name = required_param(request, "ServerlessCacheName")?;
 
         let cache = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             let cache = state
                 .serverless_caches
                 .remove(&serverless_cache_name)
@@ -1560,7 +1597,8 @@ impl ElastiCacheService {
             optional_non_negative_i32_param(request, "SnapshotRetentionLimit")?;
         let daily_snapshot_time = optional_param(request, "DailySnapshotTime");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if let Some(ref group_id) = user_group_id {
             let user_group = state.user_groups.get(group_id).ok_or_else(|| {
@@ -1630,7 +1668,8 @@ impl ElastiCacheService {
         let kms_key_id = optional_param(request, "KmsKeyId");
         let tags = parse_tags(request)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         if state
             .serverless_cache_snapshots
             .contains_key(&serverless_cache_snapshot_name)
@@ -1700,7 +1739,9 @@ impl ElastiCacheService {
         let max_results = optional_usize_param(request, "MaxResults")?;
         let next_token = optional_param(request, "NextToken");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let snapshots: Vec<&ServerlessCacheSnapshot> =
             if let Some(ref snapshot_name) = serverless_cache_snapshot_name {
                 match state.serverless_cache_snapshots.get(snapshot_name) {
@@ -1778,7 +1819,8 @@ impl ElastiCacheService {
         let serverless_cache_snapshot_name =
             required_param(request, "ServerlessCacheSnapshotName")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let mut snapshot = state
             .serverless_cache_snapshots
             .remove(&serverless_cache_snapshot_name)
@@ -1818,7 +1860,8 @@ impl ElastiCacheService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if state.snapshots.contains_key(&snapshot_name) {
             return Err(AwsServiceError::aws_error(
@@ -1910,7 +1953,9 @@ impl ElastiCacheService {
         let max_records = optional_usize_param(request, "MaxRecords")?;
         let marker = optional_param(request, "Marker");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         let snapshots: Vec<&CacheSnapshot> = if let Some(ref name) = snapshot_name {
             match state.snapshots.get(name) {
@@ -1970,7 +2015,8 @@ impl ElastiCacheService {
     fn delete_snapshot(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let snapshot_name = required_param(request, "SnapshotName")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let mut snapshot = state.snapshots.remove(&snapshot_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -2029,7 +2075,8 @@ impl ElastiCacheService {
         let user_group_ids_to_remove =
             parse_member_list(&request.query_params, "UserGroupIdsToRemove", "member");
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         let group = state
             .replication_groups
@@ -2103,7 +2150,8 @@ impl ElastiCacheService {
         let new_automatic_failover =
             parse_optional_bool(optional_param(request, "AutomaticFailoverEnabled").as_deref())?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let primary_replication_group_id = state
             .global_replication_groups
             .get(&global_replication_group_id)
@@ -2218,7 +2266,8 @@ impl ElastiCacheService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         let group = state
             .replication_groups
@@ -2310,7 +2359,8 @@ impl ElastiCacheService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         let group = state
             .replication_groups
@@ -2365,7 +2415,9 @@ impl ElastiCacheService {
         let replication_group_id = required_param(request, "ReplicationGroupId")?;
         let node_group_id = required_param(request, "NodeGroupId")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         let group = state
             .replication_groups
@@ -2408,7 +2460,9 @@ impl ElastiCacheService {
         let replication_group_id = required_param(request, "ReplicationGroupId")?;
         let replication_group_region = required_param(request, "ReplicationGroupRegion")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let group = state
             .global_replication_groups
             .get(&global_replication_group_id)
@@ -2460,7 +2514,9 @@ impl ElastiCacheService {
         let primary_region = required_param(request, "PrimaryRegion")?;
         let primary_replication_group_id = required_param(request, "PrimaryReplicationGroupId")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let group = state
             .global_replication_groups
             .get(&global_replication_group_id)
@@ -2574,7 +2630,8 @@ impl ElastiCacheService {
             "6.0".to_string()
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if state.users.contains_key(&user_id) {
             return Err(AwsServiceError::aws_error(
@@ -2617,7 +2674,9 @@ impl ElastiCacheService {
         let max_records = optional_usize_param(request, "MaxRecords")?;
         let marker = optional_param(request, "Marker");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         let users: Vec<&ElastiCacheUser> = if let Some(ref id) = user_id {
             match state.users.get(id) {
@@ -2667,7 +2726,8 @@ impl ElastiCacheService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         let user = state.users.remove(&user_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -2708,7 +2768,8 @@ impl ElastiCacheService {
             "6.0".to_string()
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if state.user_groups.contains_key(&user_group_id) {
             return Err(AwsServiceError::aws_error(
@@ -2780,7 +2841,9 @@ impl ElastiCacheService {
         let max_records = optional_usize_param(request, "MaxRecords")?;
         let marker = optional_param(request, "Marker");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         let groups: Vec<&ElastiCacheUserGroup> = if let Some(ref id) = user_group_id {
             match state.user_groups.get(id) {
@@ -2822,7 +2885,8 @@ impl ElastiCacheService {
     fn delete_user_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let user_group_id = required_param(request, "UserGroupId")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         let group = state.user_groups.remove(&user_group_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -2855,7 +2919,8 @@ impl ElastiCacheService {
         let resource_name = required_param(request, "ResourceName")?;
         let tags = parse_tags(request)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let tag_list = state.tags.get_mut(&resource_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -2881,7 +2946,9 @@ impl ElastiCacheService {
     fn list_tags_for_resource(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let resource_name = required_param(request, "ResourceName")?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let tag_list = state.tags.get(&resource_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -2909,7 +2976,8 @@ impl ElastiCacheService {
         let resource_name = required_param(request, "ResourceName")?;
         let tag_keys = parse_tag_keys(request)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let tag_list = state.tags.get_mut(&resource_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -4390,8 +4458,9 @@ mod tests {
 
     #[test]
     fn create_user_returns_user_xml() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         let req = request(
@@ -4412,8 +4481,9 @@ mod tests {
 
     #[test]
     fn create_user_rejects_duplicate() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         let req = request(
@@ -4430,8 +4500,9 @@ mod tests {
 
     #[test]
     fn delete_user_rejects_default() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         let req = request("DeleteUser", &[("UserId", "default")]);
@@ -4440,8 +4511,9 @@ mod tests {
 
     #[test]
     fn describe_users_returns_default_user() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         let req = request("DescribeUsers", &[]);
@@ -4452,8 +4524,9 @@ mod tests {
 
     #[test]
     fn describe_reserved_cache_nodes_returns_empty_list_by_default() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         let resp = service
@@ -4465,11 +4538,13 @@ mod tests {
 
     #[test]
     fn describe_reserved_cache_nodes_filters_by_offering_id() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
         {
-            let mut state = service.state.write();
+            let mut __a = service.state.write();
+            let state = __a.default_mut();
             state.reserved_cache_nodes.insert(
                 "rcn-a".to_string(),
                 sample_reserved_cache_node("rcn-a", "offering-a"),
@@ -4493,8 +4568,9 @@ mod tests {
 
     #[test]
     fn describe_reserved_cache_nodes_not_found_by_id() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         assert!(service
@@ -4507,11 +4583,13 @@ mod tests {
 
     #[test]
     fn describe_reserved_cache_nodes_offerings_filters_and_paginates() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
         {
-            let mut state = service.state.write();
+            let mut __a = service.state.write();
+            let state = __a.default_mut();
             state.reserved_cache_nodes_offerings = vec![
                 sample_reserved_cache_node_offering("offering-a"),
                 ReservedCacheNodesOffering {
@@ -4564,8 +4642,9 @@ mod tests {
 
     #[test]
     fn describe_reserved_cache_nodes_offerings_not_found_by_id() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         assert!(service
@@ -4578,8 +4657,9 @@ mod tests {
 
     #[test]
     fn create_and_describe_user_group() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         let req = request(
@@ -4603,8 +4683,9 @@ mod tests {
 
     #[test]
     fn create_user_group_rejects_unknown_user() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         let req = request(
@@ -4620,8 +4701,9 @@ mod tests {
 
     #[test]
     fn delete_user_group_removes_from_state() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         let req = request(
@@ -4640,10 +4722,12 @@ mod tests {
     }
 
     fn service_with_cache_cluster(cluster_id: &str) -> ElastiCacheService {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared: SharedElastiCacheState = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         {
-            let mut s = shared.write();
+            let mut __a = shared.write();
+            let s = __a.default_mut();
             let arn = format!("arn:aws:elasticache:us-east-1:123456789012:cluster:{cluster_id}");
             s.tags.insert(arn.clone(), Vec::new());
             s.cache_clusters.insert(
@@ -4675,7 +4759,8 @@ mod tests {
     fn describe_cache_clusters_returns_all() {
         let service = service_with_cache_cluster("cluster-a");
         {
-            let mut state = service.state.write();
+            let mut __a = service.state.write();
+            let state = __a.default_mut();
             let arn = "arn:aws:elasticache:us-east-1:123456789012:cluster:cluster-b".to_string();
             state.tags.insert(arn.clone(), Vec::new());
             state.cache_clusters.insert(
@@ -4711,8 +4796,9 @@ mod tests {
 
     #[tokio::test]
     async fn create_cache_cluster_validates_engine_before_runtime() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
 
         let req = request(
@@ -4724,14 +4810,16 @@ mod tests {
 
     #[tokio::test]
     async fn create_cache_cluster_without_runtime_cancels_reservation() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared.clone());
 
         let req = request("CreateCacheCluster", &[("CacheClusterId", "no-runtime")]);
         assert!(service.create_cache_cluster(&req).await.is_err());
 
-        let mut state = shared.write();
+        let mut __a = shared.write();
+        let state = __a.default_mut();
         assert!(state.begin_cache_cluster_creation("no-runtime"));
     }
 
@@ -4773,9 +4861,10 @@ mod tests {
         assert!(!service
             .state
             .read()
+            .default_ref()
             .cache_clusters
             .contains_key("delete-me"));
-        assert!(!service.state.read().tags.contains_key(&arn));
+        assert!(!service.state.read().default_ref().tags.contains_key(&arn));
     }
 
     #[test]
@@ -4817,7 +4906,8 @@ mod tests {
     async fn delete_cache_cluster_removes_cluster_from_replication_group() {
         let service = service_with_cache_cluster("delete-rg-cluster");
         {
-            let mut state = service.state.write();
+            let mut __a = service.state.write();
+            let state = __a.default_mut();
             state
                 .cache_clusters
                 .get_mut("delete-rg-cluster")
@@ -4862,6 +4952,7 @@ mod tests {
         let group = service
             .state
             .read()
+            .default_ref()
             .replication_groups
             .get("delete-rg")
             .unwrap()
@@ -4884,10 +4975,12 @@ mod tests {
     }
 
     fn service_with_replication_group(group_id: &str, num_clusters: i32) -> ElastiCacheService {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared: SharedElastiCacheState = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         {
-            let mut s = shared.write();
+            let mut __a = shared.write();
+            let s = __a.default_mut();
             let member_clusters: Vec<String> = (1..=num_clusters)
                 .map(|i| format!("{group_id}-{i:03}"))
                 .collect();
@@ -4923,10 +5016,12 @@ mod tests {
     }
 
     fn service_with_serverless_cache(cache_name: &str) -> ElastiCacheService {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared: SharedElastiCacheState = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         {
-            let mut s = shared.write();
+            let mut __a = shared.write();
+            let s = __a.default_mut();
             let arn =
                 format!("arn:aws:elasticache:us-east-1:123456789012:serverlesscache:{cache_name}");
             s.tags.insert(arn.clone(), Vec::new());
@@ -4980,7 +5075,8 @@ mod tests {
     ) -> ElastiCacheService {
         let service = service_with_replication_group(replication_group_id, 1);
         {
-            let mut state = service.state.write();
+            let mut __a = service.state.write();
+            let state = __a.default_mut();
             state
                 .replication_groups
                 .get_mut(replication_group_id)
@@ -5037,7 +5133,8 @@ mod tests {
         assert!(body.contains("<ReplicationGroupId>primary-rg</ReplicationGroupId>"));
         assert!(body.contains("<Role>primary</Role>"));
 
-        let state = service.state.read();
+        let __a = service.state.read();
+        let state = __a.default_ref();
         let primary_group = state.replication_groups.get("primary-rg").unwrap();
         assert_eq!(
             primary_group.global_replication_group_id.as_deref(),
@@ -5095,7 +5192,8 @@ mod tests {
         assert!(body.contains("<CacheNodeType>cache.m5.large</CacheNodeType>"));
         assert!(body.contains("<EngineVersion>7.2</EngineVersion>"));
 
-        let state = service.state.read();
+        let __a = service.state.read();
+        let state = __a.default_ref();
         let primary_group = state.replication_groups.get("primary-rg").unwrap();
         assert_eq!(primary_group.cache_node_type, "cache.m5.large");
         assert_eq!(primary_group.engine_version, "7.2");
@@ -5117,7 +5215,8 @@ mod tests {
         let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<Status>deleting</Status>"));
 
-        let state = service.state.read();
+        let __a = service.state.read();
+        let state = __a.default_ref();
         assert!(!state
             .global_replication_groups
             .contains_key("fc-us-east-1-global-a"));
@@ -5220,8 +5319,9 @@ mod tests {
 
     #[test]
     fn modify_replication_group_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
         let req = request(
             "ModifyReplicationGroup",
@@ -5259,6 +5359,7 @@ mod tests {
         let cache = service_with_serverless_cache("cache-a")
             .state
             .read()
+            .default_ref()
             .serverless_caches["cache-a"]
             .clone();
 
@@ -5305,7 +5406,8 @@ mod tests {
     fn describe_serverless_caches_returns_all() {
         let service = service_with_serverless_cache("cache-a");
         {
-            let mut state = service.state.write();
+            let mut __a = service.state.write();
+            let state = __a.default_mut();
             state.serverless_caches.insert(
                 "cache-b".to_string(),
                 ServerlessCache {
@@ -5412,7 +5514,8 @@ mod tests {
     fn describe_serverless_cache_snapshots_filters_by_cache_name() {
         let service = service_with_serverless_cache("cache-a");
         {
-            let mut state = service.state.write();
+            let mut __a = service.state.write();
+            let state = __a.default_mut();
             state.serverless_cache_snapshots.insert(
                 "snap-a".to_string(),
                 ServerlessCacheSnapshot {
@@ -5446,7 +5549,8 @@ mod tests {
     fn delete_serverless_cache_snapshot_removes_tags() {
         let service = service_with_serverless_cache("cache-a");
         {
-            let mut state = service.state.write();
+            let mut __a = service.state.write();
+            let state = __a.default_mut();
             let arn =
                 "arn:aws:elasticache:us-east-1:123456789012:serverlesssnapshot:snap-a".to_string();
             state.tags.insert(arn.clone(), Vec::new());
@@ -5479,6 +5583,7 @@ mod tests {
         assert!(!service
             .state
             .read()
+            .default_ref()
             .tags
             .contains_key("arn:aws:elasticache:us-east-1:123456789012:serverlesssnapshot:snap-a"));
     }
@@ -5518,8 +5623,9 @@ mod tests {
 
     #[test]
     fn increase_replica_count_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
         let req = request(
             "IncreaseReplicaCount",
@@ -5605,8 +5711,9 @@ mod tests {
 
     #[test]
     fn test_failover_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
         let req = request(
             "TestFailover",
@@ -5678,8 +5785,9 @@ mod tests {
 
     #[test]
     fn create_snapshot_rejects_nonexistent_group() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
         let req = request(
             "CreateSnapshot",
@@ -5710,7 +5818,8 @@ mod tests {
         );
         service.create_snapshot(&req).unwrap();
 
-        let state = service.state.read();
+        let __a = service.state.read();
+        let state = __a.default_ref();
         let arn = "arn:aws:elasticache:us-east-1:123456789012:snapshot:tag-snap".to_string();
         assert!(state.tags.contains_key(&arn));
     }
@@ -5776,8 +5885,9 @@ mod tests {
 
     #[test]
     fn describe_snapshots_not_found_by_name() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
         let req = request("DescribeSnapshots", &[("SnapshotName", "nope")]);
         assert!(service.describe_snapshots(&req).is_err());
@@ -5802,7 +5912,12 @@ mod tests {
         assert!(body.contains("<DeleteSnapshotResponse"));
 
         // Verify it's gone
-        assert!(!service.state.read().snapshots.contains_key("del-snap"));
+        assert!(!service
+            .state
+            .read()
+            .default_ref()
+            .snapshots
+            .contains_key("del-snap"));
     }
 
     #[test]
@@ -5818,17 +5933,18 @@ mod tests {
         service.create_snapshot(&req).unwrap();
 
         let arn = "arn:aws:elasticache:us-east-1:123456789012:snapshot:tag-del-snap".to_string();
-        assert!(service.state.read().tags.contains_key(&arn));
+        assert!(service.state.read().default_ref().tags.contains_key(&arn));
 
         let req = request("DeleteSnapshot", &[("SnapshotName", "tag-del-snap")]);
         service.delete_snapshot(&req).unwrap();
-        assert!(!service.state.read().tags.contains_key(&arn));
+        assert!(!service.state.read().default_ref().tags.contains_key(&arn));
     }
 
     #[test]
     fn delete_snapshot_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let service = ElastiCacheService::new(shared);
         let req = request("DeleteSnapshot", &[("SnapshotName", "nope")]);
         assert!(service.delete_snapshot(&req).is_err());
@@ -5872,8 +5988,9 @@ mod tests {
 
     #[test]
     fn describe_cache_cluster_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.describe_cache_clusters(&request(
@@ -5886,8 +6003,9 @@ mod tests {
 
     #[tokio::test]
     async fn delete_cache_cluster_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.delete_cache_cluster(&request(
@@ -5901,8 +6019,9 @@ mod tests {
 
     #[test]
     fn describe_replication_group_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.describe_replication_groups(&request(
@@ -5915,8 +6034,9 @@ mod tests {
 
     #[tokio::test]
     async fn delete_replication_group_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.delete_replication_group(&request(
@@ -5930,8 +6050,9 @@ mod tests {
 
     #[test]
     fn describe_serverless_cache_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.describe_serverless_caches(&request(
@@ -5944,8 +6065,9 @@ mod tests {
 
     #[tokio::test]
     async fn delete_serverless_cache_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.delete_serverless_cache(&request(
@@ -5959,8 +6081,9 @@ mod tests {
 
     #[test]
     fn describe_user_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.describe_users(&request("DescribeUsers", &[("UserId", "nope")])),
@@ -5970,8 +6093,9 @@ mod tests {
 
     #[test]
     fn delete_user_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.delete_user(&request("DeleteUser", &[("UserId", "nope")])),
@@ -5981,8 +6105,9 @@ mod tests {
 
     #[test]
     fn describe_user_group_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.describe_user_groups(&request("DescribeUserGroups", &[("UserGroupId", "nope")])),
@@ -5992,8 +6117,9 @@ mod tests {
 
     #[test]
     fn delete_user_group_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.delete_user_group(&request("DeleteUserGroup", &[("UserGroupId", "nope")])),
@@ -6003,8 +6129,9 @@ mod tests {
 
     #[test]
     fn describe_cache_subnet_group_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.describe_cache_subnet_groups(&request(
@@ -6017,8 +6144,9 @@ mod tests {
 
     #[test]
     fn delete_cache_subnet_group_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.delete_cache_subnet_group(&request(
@@ -6031,8 +6159,9 @@ mod tests {
 
     #[test]
     fn describe_snapshot_not_found() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.describe_snapshots(&request("DescribeSnapshots", &[("SnapshotName", "nope")])),
@@ -6042,8 +6171,9 @@ mod tests {
 
     #[test]
     fn delete_snapshot_nonexistent() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         expect_ec_err(
             svc.delete_snapshot(&request("DeleteSnapshot", &[("SnapshotName", "nope")])),
@@ -6053,8 +6183,9 @@ mod tests {
 
     #[test]
     fn create_user_duplicate() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request(
             "CreateUser",
@@ -6073,8 +6204,9 @@ mod tests {
 
     #[test]
     fn describe_cache_engine_versions() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
 
         let resp = svc
@@ -6088,8 +6220,9 @@ mod tests {
 
     #[test]
     fn describe_reserved_cache_nodes_offerings_basic() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
 
         let resp = svc
@@ -6104,8 +6237,9 @@ mod tests {
 
     #[test]
     fn describe_reserved_cache_nodes_empty() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
 
         let resp = svc
@@ -6119,8 +6253,9 @@ mod tests {
 
     #[test]
     fn subnet_group_create_describe_delete() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
 
         svc.create_cache_subnet_group(&request(
@@ -6150,8 +6285,9 @@ mod tests {
 
     #[test]
     fn describe_global_replication_groups_empty() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
 
         let resp = svc
@@ -6165,8 +6301,9 @@ mod tests {
 
     #[test]
     fn create_user_missing_user_id_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("CreateUser", &[("UserName", "u"), ("Engine", "redis")]);
         assert!(svc.create_user(&req).is_err());
@@ -6174,8 +6311,9 @@ mod tests {
 
     #[test]
     fn create_user_missing_engine_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("CreateUser", &[("UserId", "u1"), ("UserName", "u")]);
         assert!(svc.create_user(&req).is_err());
@@ -6183,8 +6321,9 @@ mod tests {
 
     #[test]
     fn delete_user_group_not_found_is_error() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("DeleteUserGroup", &[("UserGroupId", "ghost")]);
         assert!(svc.delete_user_group(&req).is_err());
@@ -6194,8 +6333,9 @@ mod tests {
 
     #[test]
     fn describe_cache_clusters_invalid_marker_returns_error() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         // no clusters, marker for a nonexistent cluster - returns empty list
         let req = request("DescribeCacheClusters", &[]);
@@ -6206,8 +6346,9 @@ mod tests {
 
     #[tokio::test]
     async fn delete_cache_cluster_missing_id_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("DeleteCacheCluster", &[]);
         assert!(svc.delete_cache_cluster(&req).await.is_err());
@@ -6215,8 +6356,9 @@ mod tests {
 
     #[test]
     fn add_tags_missing_arn_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("AddTagsToResource", &[("Tags.Tag.1.Key", "k")]);
         assert!(svc.add_tags_to_resource(&req).is_err());
@@ -6224,8 +6366,9 @@ mod tests {
 
     #[test]
     fn list_tags_missing_arn_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("ListTagsForResource", &[]);
         assert!(svc.list_tags_for_resource(&req).is_err());
@@ -6233,8 +6376,9 @@ mod tests {
 
     #[test]
     fn remove_tags_missing_arn_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("RemoveTagsFromResource", &[("TagKeys.member.1", "k")]);
         assert!(svc.remove_tags_from_resource(&req).is_err());
@@ -6244,8 +6388,9 @@ mod tests {
 
     #[tokio::test]
     async fn create_replication_group_missing_id_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request(
             "CreateReplicationGroup",
@@ -6256,8 +6401,9 @@ mod tests {
 
     #[tokio::test]
     async fn create_replication_group_missing_description_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("CreateReplicationGroup", &[("ReplicationGroupId", "rg")]);
         assert!(svc.create_replication_group(&req).await.is_err());
@@ -6267,8 +6413,9 @@ mod tests {
 
     #[test]
     fn create_cache_subnet_group_missing_id_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request(
             "CreateCacheSubnetGroup",
@@ -6282,8 +6429,9 @@ mod tests {
 
     #[test]
     fn create_cache_subnet_group_duplicate_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let params = &[
             ("CacheSubnetGroupName", "sg"),
@@ -6300,8 +6448,9 @@ mod tests {
 
     #[test]
     fn describe_snapshots_empty_returns_ok() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("DescribeSnapshots", &[]);
         let resp = svc.describe_snapshots(&req).unwrap();
@@ -6313,8 +6462,9 @@ mod tests {
 
     #[tokio::test]
     async fn create_serverless_cache_missing_name_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("CreateServerlessCache", &[("Engine", "redis")]);
         assert!(svc.create_serverless_cache(&req).await.is_err());
@@ -6322,8 +6472,9 @@ mod tests {
 
     #[tokio::test]
     async fn delete_serverless_cache_missing_name_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("DeleteServerlessCache", &[]);
         assert!(svc.delete_serverless_cache(&req).await.is_err());
@@ -6333,8 +6484,9 @@ mod tests {
 
     #[test]
     fn create_global_replication_group_missing_id_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("CreateGlobalReplicationGroup", &[]);
         assert!(svc.create_global_replication_group(&req).is_err());
@@ -6342,8 +6494,9 @@ mod tests {
 
     #[test]
     fn describe_replication_groups_empty_ok() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("DescribeReplicationGroups", &[]);
         let resp = svc.describe_replication_groups(&req).unwrap();
@@ -6353,8 +6506,9 @@ mod tests {
 
     #[test]
     fn describe_cache_parameter_groups_has_defaults() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("DescribeCacheParameterGroups", &[]);
         let resp = svc.describe_cache_parameter_groups(&req).unwrap();
@@ -6364,8 +6518,9 @@ mod tests {
 
     #[test]
     fn describe_cache_subnet_groups_has_defaults() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("DescribeCacheSubnetGroups", &[]);
         let resp = svc.describe_cache_subnet_groups(&req).unwrap();
@@ -6375,8 +6530,9 @@ mod tests {
 
     #[test]
     fn describe_user_groups_empty_ok() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("DescribeUserGroups", &[]);
         let resp = svc.describe_user_groups(&req).unwrap();
@@ -6386,8 +6542,9 @@ mod tests {
 
     #[tokio::test]
     async fn create_cache_cluster_unsupported_engine_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request(
             "CreateCacheCluster",
@@ -6403,8 +6560,9 @@ mod tests {
 
     #[tokio::test]
     async fn delete_cache_cluster_unknown_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("DeleteCacheCluster", &[("CacheClusterId", "ghost")]);
         assert!(svc.delete_cache_cluster(&req).await.is_err());
@@ -6412,8 +6570,9 @@ mod tests {
 
     #[test]
     fn delete_user_unknown_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request("DeleteUser", &[("UserId", "ghost")]);
         assert!(svc.delete_user(&req).is_err());
@@ -6421,8 +6580,9 @@ mod tests {
 
     #[test]
     fn list_tags_unknown_arn_errors() {
-        let state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
-        let shared = std::sync::Arc::new(parking_lot::RwLock::new(state));
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
         let svc = ElastiCacheService::new(shared);
         let req = request(
             "ListTagsForResource",

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -4,7 +4,14 @@ use std::sync::Arc;
 use fakecloud_aws::arn::Arn;
 use parking_lot::RwLock;
 
-pub type SharedElastiCacheState = Arc<RwLock<ElastiCacheState>>;
+pub type SharedElastiCacheState =
+    Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<ElastiCacheState>>>;
+
+impl fakecloud_core::multi_account::AccountState for ElastiCacheState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CacheEngineVersion {
@@ -626,12 +633,15 @@ fn default_users(account_id: &str, region: &str) -> HashMap<String, ElastiCacheU
     map
 }
 
-pub const ELASTICACHE_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const ELASTICACHE_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ElastiCacheSnapshot {
     pub schema_version: u32,
-    pub state: ElastiCacheState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<ElastiCacheState>>,
+    #[serde(default)]
+    pub state: Option<ElastiCacheState>,
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -14,7 +14,7 @@ use fakecloud_persistence::SnapshotStore;
 use crate::runtime::{RdsRuntime, RuntimeError};
 use crate::state::{
     default_engine_versions, default_orderable_options, DbInstance, DbParameterGroup, DbSnapshot,
-    DbSubnetGroup, EngineVersionInfo, OrderableDbInstanceOption, RdsSnapshot, RdsTag,
+    DbSubnetGroup, EngineVersionInfo, OrderableDbInstanceOption, RdsSnapshot, RdsState, RdsTag,
     SharedRdsState, RDS_SNAPSHOT_SCHEMA_VERSION,
 };
 
@@ -101,7 +101,8 @@ impl RdsService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = RdsSnapshot {
             schema_version: RDS_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            state: None,
+            accounts: Some(self.state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -229,7 +230,8 @@ impl RdsService {
         )?;
 
         {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             if !state.begin_instance_creation(&db_instance_identifier) {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -268,11 +270,13 @@ impl RdsService {
             .map_err(|error| {
                 self.state
                     .write()
+                    .get_or_create(&request.account_id)
                     .cancel_instance_creation(&db_instance_identifier);
                 runtime_error_to_service_error(error)
             })?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let created_at = Utc::now();
         let instance = DbInstance {
             db_instance_identifier: db_instance_identifier.clone(),
@@ -351,7 +355,9 @@ impl RdsService {
 
         // Check deletion protection BEFORE creating snapshot or making any changes
         {
-            let state = self.state.read();
+            let accounts = self.state.read();
+            let empty = RdsState::new(&request.account_id, &request.region);
+            let state = accounts.get(&request.account_id).unwrap_or(&empty);
             if let Some(instance) = state.instances.get(&db_instance_identifier) {
                 if instance.deletion_protection {
                     return Err(AwsServiceError::aws_error(
@@ -369,12 +375,18 @@ impl RdsService {
         }
 
         if let Some(ref snapshot_id) = final_db_snapshot_identifier {
-            self.create_final_db_snapshot(&db_instance_identifier, snapshot_id)
-                .await?;
+            self.create_final_db_snapshot(
+                &db_instance_identifier,
+                snapshot_id,
+                &request.account_id,
+                &request.region,
+            )
+            .await?;
         }
 
         let instance = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             let instance = state
                 .instances
                 .remove(&db_instance_identifier)
@@ -423,6 +435,8 @@ impl RdsService {
         &self,
         db_instance_identifier: &str,
         snapshot_id: &str,
+        account_id: &str,
+        region: &str,
     ) -> Result<(), AwsServiceError> {
         let runtime = self.runtime.as_ref().ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -433,7 +447,9 @@ impl RdsService {
         })?;
 
         let (instance_for_snapshot, db_name) = {
-            let state = self.state.read();
+            let accounts = self.state.read();
+            let empty = RdsState::new(account_id, region);
+            let state = accounts.get(account_id).unwrap_or(&empty);
 
             if state.snapshots.contains_key(snapshot_id) {
                 return Err(AwsServiceError::aws_error(
@@ -470,7 +486,8 @@ impl RdsService {
             .await
             .map_err(runtime_error_to_service_error)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
 
         if state.snapshots.contains_key(snapshot_id) {
             return Err(AwsServiceError::aws_error(
@@ -544,7 +561,8 @@ impl RdsService {
             validate_db_instance_class(class)?;
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
         let instance = state
             .instances
             .get_mut(&db_instance_identifier)
@@ -608,7 +626,9 @@ impl RdsService {
         }
 
         let instance = {
-            let state = self.state.read();
+            let accounts = self.state.read();
+            let empty = RdsState::new(&request.account_id, &request.region);
+            let state = accounts.get(&request.account_id).unwrap_or(&empty);
             state
                 .instances
                 .get(&db_instance_identifier)
@@ -633,7 +653,8 @@ impl RdsService {
             .map_err(runtime_error_to_service_error)?;
 
         let instance = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             let instance = state
                 .instances
                 .get_mut(&db_instance_identifier)
@@ -717,7 +738,9 @@ impl RdsService {
         let marker = optional_param(request, "Marker");
         let max_records = optional_param(request, "MaxRecords");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = RdsState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         // If specific identifier requested, return just that one (no pagination)
         if let Some(identifier) = db_instance_identifier {
@@ -826,8 +849,9 @@ impl RdsService {
             ));
         }
 
-        let mut state = self.state.write();
-        let instance = find_instance_by_arn_mut(&mut state, &resource_name)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let instance = find_instance_by_arn_mut(state, &resource_name)?;
         merge_tags(&mut instance.tags, &tags);
 
         Ok(AwsResponse::xml(
@@ -846,8 +870,10 @@ impl RdsService {
             ));
         }
 
-        let state = self.state.read();
-        let instance = find_instance_by_arn(&state, &resource_name)?;
+        let accounts = self.state.read();
+        let empty = RdsState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
+        let instance = find_instance_by_arn(state, &resource_name)?;
         let tag_xml = instance.tags.iter().map(tag_xml).collect::<String>();
 
         Ok(AwsResponse::xml(
@@ -875,8 +901,9 @@ impl RdsService {
             ));
         }
 
-        let mut state = self.state.write();
-        let instance = find_instance_by_arn_mut(&mut state, &resource_name)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let instance = find_instance_by_arn_mut(state, &resource_name)?;
         instance
             .tags
             .retain(|tag| !tag_keys.iter().any(|key| key == &tag.key));
@@ -903,7 +930,9 @@ impl RdsService {
         })?;
 
         let (instance, db_name) = {
-            let state = self.state.write();
+            let accounts = self.state.read();
+            let empty = RdsState::new(&request.account_id, &request.region);
+            let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
             if state.snapshots.contains_key(&db_snapshot_identifier) {
                 return Err(AwsServiceError::aws_error(
@@ -940,7 +969,8 @@ impl RdsService {
             .await
             .map_err(runtime_error_to_service_error)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if state.snapshots.contains_key(&db_snapshot_identifier) {
             return Err(AwsServiceError::aws_error(
@@ -997,7 +1027,9 @@ impl RdsService {
             ));
         }
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = RdsState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         // If specific snapshot requested, return just that one (no pagination)
         if let Some(snapshot_id) = db_snapshot_identifier {
@@ -1074,7 +1106,8 @@ impl RdsService {
     fn delete_db_snapshot(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let db_snapshot_identifier = required_param(request, "DBSnapshotIdentifier")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         let snapshot = state
             .snapshots
@@ -1102,7 +1135,8 @@ impl RdsService {
         let runtime = self.require_runtime()?;
 
         let (snapshot, dbi_resource_id, db_instance_arn, created_at) = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
 
             if !state.begin_instance_creation(&db_instance_identifier) {
                 return Err(AwsServiceError::aws_error(
@@ -1146,6 +1180,7 @@ impl RdsService {
             Err(e) => {
                 self.state
                     .write()
+                    .get_or_create(&request.account_id)
                     .cancel_instance_creation(&db_instance_identifier);
                 return Err(runtime_error_to_service_error(e));
             }
@@ -1164,6 +1199,7 @@ impl RdsService {
         {
             self.state
                 .write()
+                .get_or_create(&request.account_id)
                 .cancel_instance_creation(&db_instance_identifier);
             runtime.stop_container(&db_instance_identifier).await;
             return Err(runtime_error_to_service_error(e));
@@ -1181,6 +1217,7 @@ impl RdsService {
 
         self.state
             .write()
+            .get_or_create(&request.account_id)
             .finish_instance_creation(instance.clone());
 
         Ok(AwsResponse::xml(
@@ -1212,7 +1249,8 @@ impl RdsService {
         })?;
 
         let (source_instance, db_name) = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
 
             if !state.begin_instance_creation(&db_instance_identifier) {
                 return Err(AwsServiceError::aws_error(
@@ -1255,13 +1293,21 @@ impl RdsService {
             Err(e) => {
                 self.state
                     .write()
+                    .get_or_create(&request.account_id)
                     .cancel_instance_creation(&db_instance_identifier);
                 return Err(runtime_error_to_service_error(e));
             }
         };
 
-        let dbi_resource_id = self.state.read().next_dbi_resource_id();
-        let db_instance_arn = self.state.read().db_instance_arn(&db_instance_identifier);
+        let (dbi_resource_id, db_instance_arn) = {
+            let accounts = self.state.read();
+            let empty = RdsState::new(&request.account_id, &request.region);
+            let s = accounts.get(&request.account_id).unwrap_or(&empty);
+            (
+                s.next_dbi_resource_id(),
+                s.db_instance_arn(&db_instance_identifier),
+            )
+        };
         let created_at = Utc::now();
 
         let running = match runtime
@@ -1279,6 +1325,7 @@ impl RdsService {
             Err(e) => {
                 self.state
                     .write()
+                    .get_or_create(&request.account_id)
                     .cancel_instance_creation(&db_instance_identifier);
                 return Err(runtime_error_to_service_error(e));
             }
@@ -1297,6 +1344,7 @@ impl RdsService {
         {
             self.state
                 .write()
+                .get_or_create(&request.account_id)
                 .cancel_instance_creation(&db_instance_identifier);
             runtime.stop_container(&db_instance_identifier).await;
             return Err(runtime_error_to_service_error(e));
@@ -1313,7 +1361,8 @@ impl RdsService {
         );
 
         let source_missing = {
-            let mut state = self.state.write();
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
             match state.instances.get_mut(&source_db_instance_identifier) {
                 Some(source) => {
                     source
@@ -1368,7 +1417,8 @@ impl RdsService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if state.subnet_groups.contains_key(&db_subnet_group_name) {
             return Err(AwsServiceError::aws_error(
@@ -1431,7 +1481,9 @@ impl RdsService {
         let marker = optional_param(request, "Marker");
         let max_records = optional_param(request, "MaxRecords");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = RdsState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         // If specific subnet group requested, return just that one (no pagination)
         if let Some(name) = db_subnet_group_name {
@@ -1491,7 +1543,8 @@ impl RdsService {
     fn delete_db_subnet_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let db_subnet_group_name = required_param(request, "DBSubnetGroupName")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if state.subnet_groups.remove(&db_subnet_group_name).is_none() {
             return Err(AwsServiceError::aws_error(
@@ -1527,7 +1580,8 @@ impl RdsService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         let region = state.region.clone();
 
@@ -1602,7 +1656,8 @@ impl RdsService {
             ));
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if state
             .parameter_groups
@@ -1652,7 +1707,9 @@ impl RdsService {
         let marker = optional_param(request, "Marker");
         let max_records = optional_param(request, "MaxRecords");
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = RdsState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
 
         // If specific parameter group requested, return just that one (no pagination)
         if let Some(name) = db_parameter_group_name {
@@ -1724,7 +1781,8 @@ impl RdsService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let db_parameter_group_name = required_param(request, "DBParameterGroupName")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         if db_parameter_group_name.starts_with("default.") {
             return Err(AwsServiceError::aws_error(
@@ -1758,7 +1816,8 @@ impl RdsService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let db_parameter_group_name = required_param(request, "DBParameterGroupName")?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
 
         let parameter_group = state
             .parameter_groups
@@ -2708,9 +2767,7 @@ mod tests {
         db_instance_xml, filter_engine_versions, filter_orderable_options, merge_tags,
         optional_i32_param, parse_tag_keys, parse_tags, validate_create_request, RdsService,
     };
-    use crate::state::{
-        default_engine_versions, default_orderable_options, DbInstance, RdsState, RdsTag,
-    };
+    use crate::state::{default_engine_versions, default_orderable_options, DbInstance, RdsTag};
     use fakecloud_core::service::{AwsRequest, AwsService, AwsServiceError};
 
     #[test]
@@ -2869,10 +2926,9 @@ mod tests {
 
     #[tokio::test]
     async fn describe_engine_versions_returns_xml_body() {
-        let service = RdsService::new(Arc::new(RwLock::new(RdsState::new(
-            "123456789012",
-            "us-east-1",
-        ))));
+        let service = RdsService::new(Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        )));
         let request = request("DescribeDBEngineVersions", &[("Engine", "postgres")]);
 
         let response = service.handle(request).await.expect("response");
@@ -2911,10 +2967,9 @@ mod tests {
     // ── Helpers for handler tests ────────────────────────────────────
 
     fn make_service() -> RdsService {
-        RdsService::new(Arc::new(RwLock::new(RdsState::new(
-            "123456789012",
-            "us-east-1",
-        ))))
+        RdsService::new(Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        )))
     }
 
     fn body_of(resp: fakecloud_core::service::AwsResponse) -> String {
@@ -2923,7 +2978,8 @@ mod tests {
 
     fn seed_instance(svc: &RdsService, identifier: &str) -> String {
         let arn = format!("arn:aws:rds:us-east-1:123456789012:db:{identifier}");
-        let mut state = svc.state.write();
+        let mut accounts = svc.state.write();
+        let state = accounts.default_mut();
         state.instances.insert(
             identifier.to_string(),
             DbInstance {
@@ -3037,7 +3093,8 @@ mod tests {
         let svc = make_service();
         let arn = seed_instance(&svc, "db1");
         {
-            let mut state = svc.state.write();
+            let mut __a = svc.state.write();
+            let state = __a.default_mut();
             let inst = state.instances.get_mut("db1").unwrap();
             inst.tags = vec![
                 RdsTag {
@@ -3056,7 +3113,8 @@ mod tests {
         );
         svc.remove_tags_from_resource(&req).unwrap();
 
-        let state = svc.state.read();
+        let __a = svc.state.read();
+        let state = __a.default_ref();
         let tags = &state.instances.get("db1").unwrap().tags;
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].key, "team");
@@ -3180,7 +3238,7 @@ mod tests {
         create_subnet_group(&svc, "sg1");
         let req = request("DeleteDBSubnetGroup", &[("DBSubnetGroupName", "sg1")]);
         svc.delete_db_subnet_group(&req).unwrap();
-        assert!(svc.state.read().subnet_groups.is_empty());
+        assert!(svc.state.read().default_ref().subnet_groups.is_empty());
     }
 
     #[test]
@@ -3197,7 +3255,8 @@ mod tests {
         );
         svc.modify_db_subnet_group(&req).unwrap();
 
-        let state = svc.state.read();
+        let __a = svc.state.read();
+        let state = __a.default_ref();
         let sg = state.subnet_groups.get("sg1").unwrap();
         assert_eq!(sg.subnet_ids, vec!["subnet-new1", "subnet-new2"]);
     }
@@ -3308,7 +3367,12 @@ mod tests {
         create_param_group(&svc, "pg1");
         let req = request("DeleteDBParameterGroup", &[("DBParameterGroupName", "pg1")]);
         svc.delete_db_parameter_group(&req).unwrap();
-        assert!(!svc.state.read().parameter_groups.contains_key("pg1"));
+        assert!(!svc
+            .state
+            .read()
+            .default_ref()
+            .parameter_groups
+            .contains_key("pg1"));
     }
 
     #[test]
@@ -3323,7 +3387,8 @@ mod tests {
             ],
         );
         svc.modify_db_parameter_group(&req).unwrap();
-        let state = svc.state.read();
+        let __a = svc.state.read();
+        let state = __a.default_ref();
         assert_eq!(
             state.parameter_groups.get("pg1").unwrap().description,
             "shiny new"
@@ -3414,7 +3479,8 @@ mod tests {
             ],
         );
         svc.modify_db_instance(&req).unwrap();
-        let state = svc.state.read();
+        let __a = svc.state.read();
+        let state = __a.default_ref();
         assert_eq!(
             state.instances.get("db1").unwrap().db_instance_class,
             "db.t3.small"
@@ -3434,7 +3500,8 @@ mod tests {
             ],
         );
         svc.modify_db_instance(&req).unwrap();
-        let state = svc.state.read();
+        let __a = svc.state.read();
+        let state = __a.default_ref();
         let inst = state.instances.get("db1").unwrap();
         assert_eq!(inst.db_instance_class, "db.t3.micro");
         assert_eq!(
@@ -3450,7 +3517,8 @@ mod tests {
     // ── Snapshots (sync ops only) ────────────────────────────────────
 
     fn seed_snapshot(svc: &RdsService, snapshot_id: &str, instance_id: &str) {
-        let mut state = svc.state.write();
+        let mut __a = svc.state.write();
+        let state = __a.default_mut();
         let arn = state.db_snapshot_arn(snapshot_id);
         state.snapshots.insert(
             snapshot_id.to_string(),
@@ -3481,7 +3549,7 @@ mod tests {
         seed_snapshot(&svc, "snap1", "db1");
         let req = request("DeleteDBSnapshot", &[("DBSnapshotIdentifier", "snap1")]);
         svc.delete_db_snapshot(&req).unwrap();
-        assert!(svc.state.read().snapshots.is_empty());
+        assert!(svc.state.read().default_ref().snapshots.is_empty());
     }
 
     #[test]

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -7,7 +7,13 @@ use fakecloud_aws::arn::Arn;
 use parking_lot::RwLock;
 use uuid::Uuid;
 
-pub type SharedRdsState = Arc<RwLock<RdsState>>;
+pub type SharedRdsState = Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<RdsState>>>;
+
+impl fakecloud_core::multi_account::AccountState for RdsState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
 
 /// Supported DB instance classes — single source of truth.
 pub const SUPPORTED_INSTANCE_CLASSES: &[&str] = &[
@@ -464,12 +470,15 @@ pub fn default_parameter_groups(
     groups
 }
 
-pub const RDS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const RDS_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RdsSnapshot {
     pub schema_version: u32,
-    pub state: RdsState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<RdsState>>,
+    #[serde(default)]
+    pub state: Option<RdsState>,
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -212,18 +212,34 @@ async fn main() {
         ),
     ));
     let rds_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_rds::state::RdsState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
     let elasticache_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_elasticache::state::ElastiCacheState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
 
     let stepfunctions_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_stepfunctions::state::StepFunctionsState::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
 
     let apigatewayv2_state = Arc::new(parking_lot::RwLock::new(
-        fakecloud_apigatewayv2::state::ApiGatewayV2State::new(&cli.account_id, &cli.region),
+        fakecloud_core::multi_account::MultiAccountState::new(
+            &cli.account_id,
+            &cli.region,
+            &endpoint_url,
+        ),
     ));
 
     let bedrock_state = Arc::new(parking_lot::RwLock::new(
@@ -1484,20 +1500,31 @@ async fn main() {
                     match serde_json::from_slice::<fakecloud_rds::state::RdsSnapshot>(&bytes) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_rds::state::RDS_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_rds::state::RDS_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "rds persistence schema mismatch: on-disk={}, expected={}",
+                                    "rds persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_rds::state::RDS_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let instance_count = snapshot.state.instances.len();
-                            *rds_state.write() = snapshot.state;
-                            tracing::info!(
-                                instances = instance_count,
-                                "loaded rds persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *rds_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded rds persistence snapshot (multi-account)",
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let instance_count = single_state.instances.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = rds_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    instances = instance_count,
+                                    "loaded rds persistence snapshot (migrated from v1)",
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse rds persistence snapshot: {err}"
@@ -1539,20 +1566,31 @@ async fn main() {
                     ) {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_elasticache::state::ELASTICACHE_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_elasticache::state::ELASTICACHE_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "elasticache persistence schema mismatch: on-disk={}, expected={}",
+                                    "elasticache persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_elasticache::state::ELASTICACHE_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let cluster_count = snapshot.state.cache_clusters.len();
-                            *elasticache_state.write() = snapshot.state;
-                            tracing::info!(
-                                clusters = cluster_count,
-                                "loaded elasticache persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *elasticache_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded elasticache persistence snapshot (multi-account)",
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let cluster_count = single_state.cache_clusters.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = elasticache_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    clusters = cluster_count,
+                                    "loaded elasticache persistence snapshot (migrated from v1)",
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse elasticache persistence snapshot: {err}"
@@ -1633,22 +1671,31 @@ async fn main() {
                     {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_stepfunctions::state::STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_stepfunctions::state::STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "stepfunctions persistence schema mismatch: on-disk={}, expected={}",
+                                    "stepfunctions persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_stepfunctions::state::STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let sm_count = snapshot.state.state_machines.len();
-                            let exec_count = snapshot.state.executions.len();
-                            *stepfunctions_state.write() = snapshot.state;
-                            tracing::info!(
-                                state_machines = sm_count,
-                                executions = exec_count,
-                                "loaded stepfunctions persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *stepfunctions_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded stepfunctions persistence snapshot (multi-account)",
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let sm_count = single_state.state_machines.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = stepfunctions_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    state_machines = sm_count,
+                                    "loaded stepfunctions persistence snapshot (migrated from v1)",
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse stepfunctions persistence snapshot: {err}"
@@ -1688,20 +1735,31 @@ async fn main() {
                     {
                         Ok(snapshot) => {
                             if snapshot.schema_version
-                                != fakecloud_apigatewayv2::state::APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION
+                                > fakecloud_apigatewayv2::state::APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION
                             {
                                 fatal_exit(format_args!(
-                                    "apigatewayv2 persistence schema mismatch: on-disk={}, expected={}",
+                                    "apigatewayv2 persistence schema too new: on-disk={}, max supported={}",
                                     snapshot.schema_version,
                                     fakecloud_apigatewayv2::state::APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
                                 ));
                             }
-                            let api_count = snapshot.state.apis.len();
-                            *apigatewayv2_state.write() = snapshot.state;
-                            tracing::info!(
-                                apis = api_count,
-                                "loaded apigatewayv2 persistence snapshot",
-                            );
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *apigatewayv2_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded apigatewayv2 persistence snapshot (multi-account)",
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let api_count = single_state.apis.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = apigatewayv2_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    apis = api_count,
+                                    "loaded apigatewayv2 persistence snapshot (migrated from v1)",
+                                );
+                            }
                         }
                         Err(err) => fatal_exit(format_args!(
                             "failed to parse apigatewayv2 persistence snapshot: {err}"
@@ -2632,7 +2690,8 @@ async fn main() {
                 move || {
                     let rs = rs.clone();
                     async move {
-                        let state = rs.read();
+                        let accounts = rs.read();
+                        let state = accounts.default_ref();
                         let mut instances: Vec<types::RdsInstance> = state
                             .instances
                             .values()
@@ -2653,7 +2712,8 @@ async fn main() {
                 move || {
                     let ec = ec.clone();
                     async move {
-                        let state = ec.read();
+                        let accounts = ec.read();
+                        let state = accounts.default_ref();
                         let mut clusters: Vec<types::ElastiCacheCluster> = state
                             .cache_clusters
                             .values()
@@ -2672,7 +2732,8 @@ async fn main() {
                 move || {
                     let ec = ec.clone();
                     async move {
-                        let state = ec.read();
+                        let accounts = ec.read();
+                        let state = accounts.default_ref();
                         let mut replication_groups: Vec<
                             types::ElastiCacheReplicationGroupIntrospection,
                         > = state
@@ -2696,7 +2757,8 @@ async fn main() {
                 move || {
                     let ec = ec.clone();
                     async move {
-                        let state = ec.read();
+                        let accounts = ec.read();
+                        let state = accounts.default_ref();
                         let mut serverless_caches: Vec<
                             types::ElastiCacheServerlessCacheIntrospection,
                         > = state
@@ -2718,7 +2780,8 @@ async fn main() {
                 move || {
                     let ss = ss.clone();
                     async move {
-                        let state = ss.read();
+                        let accounts = ss.read();
+                        let state = accounts.default_ref();
                         let mut executions: Vec<types::StepFunctionsExecution> = state
                             .executions
                             .values()
@@ -2746,7 +2809,8 @@ async fn main() {
                 move || {
                     let apigw_state = apigw_state.clone();
                     async move {
-                        let state = apigw_state.read();
+                        let accounts = apigw_state.read();
+                        let state = accounts.default_ref();
                         axum::Json(serde_json::json!({
                             "requests": state.request_history
                         }))

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -117,7 +117,7 @@ impl ResetState {
                 self.scheduler.write().reset();
             }
             "apigateway" | "apigatewayv2" => {
-                self.apigatewayv2.write().apis.clear();
+                self.apigatewayv2.write().reset();
             }
             "bedrock" | "bedrock-runtime" => {
                 self.bedrock.write().reset();
@@ -180,7 +180,7 @@ impl ResetState {
         }
         self.stepfunctions.write().reset();
         self.scheduler.write().reset();
-        self.apigatewayv2.write().apis.clear();
+        self.apigatewayv2.write().reset();
         self.bedrock.write().reset();
         tracing::info!("state reset via reset API");
         axum::Json(types::ResetResponse {
@@ -271,7 +271,9 @@ mod tests {
 
     #[test]
     fn reset_service_clears_rds_state() {
-        let mut rds = RdsState::new("123456789012", "us-east-1");
+        let mut rds_mas: fakecloud_core::multi_account::MultiAccountState<RdsState> =
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", "");
+        let rds = rds_mas.default_mut();
         let created_at = Utc::now();
         rds.instances.insert(
             "db-1".to_string(),
@@ -406,14 +408,19 @@ mod tests {
                     "http://localhost:4566",
                 ),
             )),
-            rds: Arc::new(parking_lot::RwLock::new(rds)),
+            rds: Arc::new(parking_lot::RwLock::new(rds_mas)),
             elasticache: Arc::new(parking_lot::RwLock::new(
-                fakecloud_elasticache::state::ElastiCacheState::new("123456789012", "us-east-1"),
-            )),
-            stepfunctions: Arc::new(parking_lot::RwLock::new(
-                fakecloud_stepfunctions::state::StepFunctionsState::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",
+                    "",
+                ),
+            )),
+            stepfunctions: Arc::new(parking_lot::RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
                 ),
             )),
             scheduler: Arc::new(parking_lot::RwLock::new(
@@ -424,7 +431,11 @@ mod tests {
                 ),
             )),
             apigatewayv2: Arc::new(parking_lot::RwLock::new(
-                fakecloud_apigatewayv2::state::ApiGatewayV2State::new("123456789012", "us-east-1"),
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
             )),
             bedrock: Arc::new(parking_lot::RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
@@ -440,7 +451,7 @@ mod tests {
 
         state.reset_service("rds").expect("reset rds");
 
-        assert!(state.rds.read().instances.is_empty());
+        assert!(state.rds.read().default_ref().instances.is_empty());
     }
 
     #[test]

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1588,6 +1588,11 @@ fn apply_state_catcher(
     Some((next, new_input))
 }
 
+/// Extract account ID from an execution ARN (`arn:aws:states:region:account_id:...`).
+fn account_id_from_arn(arn: &str) -> &str {
+    arn.split(':').nth(4).unwrap_or("000000000000")
+}
+
 fn add_event(
     state: &SharedStepFunctionsState,
     execution_arn: &str,
@@ -1595,7 +1600,9 @@ fn add_event(
     previous_event_id: i64,
     details: Value,
 ) -> i64 {
-    let mut s = state.write();
+    let account_id = account_id_from_arn(execution_arn).to_string();
+    let mut accounts = state.write();
+    let s = accounts.get_or_create(&account_id);
     if let Some(exec) = s.executions.get_mut(execution_arn) {
         let id = exec.history_events.len() as i64 + 1;
         exec.history_events.push(HistoryEvent {
@@ -1612,12 +1619,15 @@ fn add_event(
 }
 
 fn succeed_execution(state: &SharedStepFunctionsState, execution_arn: &str, output: &Value) {
+    let account_id = account_id_from_arn(execution_arn).to_string();
     // Check terminal status before recording events to avoid inconsistent history
     {
-        let s = state.read();
-        if let Some(exec) = s.executions.get(execution_arn) {
-            if exec.status != ExecutionStatus::Running {
-                return;
+        let accounts = state.read();
+        if let Some(s) = accounts.get(&account_id) {
+            if let Some(exec) = s.executions.get(execution_arn) {
+                if exec.status != ExecutionStatus::Running {
+                    return;
+                }
             }
         }
     }
@@ -1632,7 +1642,8 @@ fn succeed_execution(state: &SharedStepFunctionsState, execution_arn: &str, outp
         json!({ "output": output_str }),
     );
 
-    let mut s = state.write();
+    let mut accounts = state.write();
+    let s = accounts.get_or_create(&account_id);
     if let Some(exec) = s.executions.get_mut(execution_arn) {
         exec.status = ExecutionStatus::Succeeded;
         exec.output = Some(output_str);
@@ -1641,12 +1652,15 @@ fn succeed_execution(state: &SharedStepFunctionsState, execution_arn: &str, outp
 }
 
 fn fail_execution(state: &SharedStepFunctionsState, execution_arn: &str, error: &str, cause: &str) {
+    let account_id = account_id_from_arn(execution_arn).to_string();
     // Check terminal status before recording events to avoid inconsistent history
     {
-        let s = state.read();
-        if let Some(exec) = s.executions.get(execution_arn) {
-            if exec.status != ExecutionStatus::Running {
-                return;
+        let accounts = state.read();
+        if let Some(s) = accounts.get(&account_id) {
+            if let Some(exec) = s.executions.get(execution_arn) {
+                if exec.status != ExecutionStatus::Running {
+                    return;
+                }
             }
         }
     }
@@ -1659,7 +1673,8 @@ fn fail_execution(state: &SharedStepFunctionsState, execution_arn: &str, error: 
         json!({ "error": error, "cause": cause }),
     );
 
-    let mut s = state.write();
+    let mut accounts = state.write();
+    let s = accounts.get_or_create(&account_id);
     if let Some(exec) = s.executions.get_mut(execution_arn) {
         exec.status = ExecutionStatus::Failed;
         exec.error = Some(error.to_string());
@@ -1671,19 +1686,19 @@ fn fail_execution(state: &SharedStepFunctionsState, execution_arn: &str, error: 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{Execution, StepFunctionsState};
+    use crate::state::Execution;
     use parking_lot::RwLock;
     use std::sync::Arc;
 
     fn make_state() -> SharedStepFunctionsState {
-        Arc::new(RwLock::new(StepFunctionsState::new(
-            "123456789012",
-            "us-east-1",
-        )))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ))
     }
 
     fn create_execution(state: &SharedStepFunctionsState, arn: &str, input: Option<String>) {
-        let mut s = state.write();
+        let mut accounts = state.write();
+        let s = accounts.get_or_create("123456789012");
         s.executions.insert(
             arn.to_string(),
             Execution {
@@ -1732,7 +1747,8 @@ mod tests {
         )
         .await;
 
-        let s = state.read();
+        let __a = state.read();
+        let s = __a.default_ref();
         let exec = s.executions.get(arn).unwrap();
         assert_eq!(exec.status, ExecutionStatus::Succeeded);
         assert!(exec.output.is_some());
@@ -1775,7 +1791,8 @@ mod tests {
         )
         .await;
 
-        let s = state.read();
+        let __a = state.read();
+        let s = __a.default_ref();
         let exec = s.executions.get(arn).unwrap();
         assert_eq!(exec.status, ExecutionStatus::Succeeded);
         let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
@@ -1809,7 +1826,8 @@ mod tests {
         )
         .await;
 
-        let s = state.read();
+        let __a = state.read();
+        let s = __a.default_ref();
         let exec = s.executions.get(arn).unwrap();
         assert_eq!(exec.status, ExecutionStatus::Succeeded);
     }
@@ -1834,7 +1852,8 @@ mod tests {
 
         execute_state_machine(state.clone(), arn.to_string(), definition, None, None, None).await;
 
-        let s = state.read();
+        let __a = state.read();
+        let s = __a.default_ref();
         let exec = s.executions.get(arn).unwrap();
         assert_eq!(exec.status, ExecutionStatus::Failed);
         assert_eq!(exec.error.as_deref(), Some("CustomError"));
@@ -1868,7 +1887,8 @@ mod tests {
         )
         .await;
 
-        let s = state.read();
+        let __a = state.read();
+        let s = __a.default_ref();
         let exec = s.executions.get(arn).unwrap();
         let event_types: Vec<&str> = exec
             .history_events
@@ -1908,7 +1928,8 @@ mod tests {
         arn: &str,
         f: impl FnOnce(&Execution) -> R,
     ) -> R {
-        let s = state.read();
+        let __a = state.read();
+        let s = __a.default_ref();
         f(s.executions.get(arn).expect("execution missing"))
     }
 
@@ -2503,11 +2524,13 @@ mod tests {
         let arn = "arn:aws:states:us-east-1:123456789012:execution:test:already";
         create_execution(&state, arn, None);
         {
-            let mut s = state.write();
+            let mut __a = state.write();
+            let s = __a.default_mut();
             s.executions.get_mut(arn).unwrap().status = ExecutionStatus::Failed;
         }
         succeed_execution(&state, arn, &json!({"x":1}));
-        let s = state.read();
+        let __a = state.read();
+        let s = __a.default_ref();
         let exec = s.executions.get(arn).unwrap();
         assert_eq!(exec.status, ExecutionStatus::Failed);
         assert!(exec.output.is_none());
@@ -2519,11 +2542,13 @@ mod tests {
         let arn = "arn:aws:states:us-east-1:123456789012:execution:test:already2";
         create_execution(&state, arn, None);
         {
-            let mut s = state.write();
+            let mut __a = state.write();
+            let s = __a.default_mut();
             s.executions.get_mut(arn).unwrap().status = ExecutionStatus::Succeeded;
         }
         fail_execution(&state, arn, "Oops", "nope");
-        let s = state.read();
+        let __a = state.read();
+        let s = __a.default_ref();
         let exec = s.executions.get(arn).unwrap();
         assert_eq!(exec.status, ExecutionStatus::Succeeded);
         assert!(exec.error.is_none());

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -17,7 +17,8 @@ use fakecloud_persistence::SnapshotStore;
 use crate::interpreter;
 use crate::state::{
     Execution, ExecutionStatus, SharedStepFunctionsState, StateMachine, StateMachineStatus,
-    StateMachineType, StepFunctionsSnapshot, STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
+    StateMachineType, StepFunctionsSnapshot, StepFunctionsState,
+    STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const SUPPORTED: &[&str] = &[
@@ -78,7 +79,8 @@ impl StepFunctionsService {
         let _guard = self.snapshot_lock.lock().await;
         let snapshot = StepFunctionsSnapshot {
             schema_version: STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
-            state: self.state.read().clone(),
+            state: None,
+            accounts: Some(self.state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -181,7 +183,8 @@ impl StepFunctionsService {
             StateMachineType::Standard
         };
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let arn = state.state_machine_arn(name);
 
         // Check if name already exists
@@ -242,7 +245,9 @@ impl StepFunctionsService {
             .ok_or_else(|| missing("stateMachineArn"))?;
         validate_arn(arn)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = StepFunctionsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let sm = state
             .state_machines
             .get(arn)
@@ -257,7 +262,9 @@ impl StepFunctionsService {
         validate_range_i64("maxResults", max_results as i64, 1, 1000)?;
         let next_token = body["nextToken"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = StepFunctionsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let mut machines: Vec<&StateMachine> = state.state_machines.values().collect();
         machines.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -290,7 +297,8 @@ impl StepFunctionsService {
             .ok_or_else(|| missing("stateMachineArn"))?;
         validate_arn(arn)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         // AWS returns success even if it doesn't exist
         state.state_machines.remove(arn);
 
@@ -305,7 +313,8 @@ impl StepFunctionsService {
             .ok_or_else(|| missing("stateMachineArn"))?;
         validate_arn(arn)?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let sm = state
             .state_machines
             .get_mut(arn)
@@ -379,7 +388,8 @@ impl StepFunctionsService {
             validate_name(name)?;
         }
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let sm = state
             .state_machines
             .get(sm_arn)
@@ -415,7 +425,7 @@ impl StepFunctionsService {
         };
 
         state.executions.insert(exec_arn.clone(), execution);
-        drop(state);
+        drop(accounts);
 
         // Spawn async execution
         let shared_state = self.state.clone();
@@ -451,7 +461,8 @@ impl StepFunctionsService {
         let error = body["error"].as_str().map(|s| s.to_string());
         let cause = body["cause"].as_str().map(|s| s.to_string());
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let exec = state
             .executions
             .get_mut(exec_arn)
@@ -483,7 +494,9 @@ impl StepFunctionsService {
             .as_str()
             .ok_or_else(|| missing("executionArn"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = StepFunctionsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let exec = state
             .executions
             .get(exec_arn)
@@ -505,7 +518,9 @@ impl StepFunctionsService {
         let next_token = body["nextToken"].as_str();
         let status_filter = body["statusFilter"].as_str();
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = StepFunctionsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         // Verify state machine exists
         if !state.state_machines.contains_key(sm_arn) {
@@ -564,7 +579,9 @@ impl StepFunctionsService {
         let next_token = body["nextToken"].as_str();
         let reverse_order = body["reverseOrder"].as_bool().unwrap_or(false);
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = StepFunctionsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let exec = state
             .executions
             .get(exec_arn)
@@ -607,7 +624,9 @@ impl StepFunctionsService {
             .as_str()
             .ok_or_else(|| missing("executionArn"))?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = StepFunctionsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let exec = state
             .executions
             .get(exec_arn)
@@ -632,7 +651,8 @@ impl StepFunctionsService {
         validate_arn(arn)?;
         validate_required("tags", &body["tags"])?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let sm = state
             .state_machines
             .get_mut(arn)
@@ -660,7 +680,8 @@ impl StepFunctionsService {
         validate_arn(arn)?;
         validate_required("tagKeys", &body["tagKeys"])?;
 
-        let mut state = self.state.write();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let sm = state
             .state_machines
             .get_mut(arn)
@@ -685,7 +706,9 @@ impl StepFunctionsService {
             .ok_or_else(|| missing("resourceArn"))?;
         validate_arn(arn)?;
 
-        let state = self.state.read();
+        let accounts = self.state.read();
+        let empty = StepFunctionsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let sm = state
             .state_machines
             .get(arn)
@@ -919,7 +942,15 @@ pub fn start_execution_from_delivery(
 
     let execution_name = uuid::Uuid::new_v4().to_string();
 
-    let mut st = state.write();
+    // Extract account_id from the state machine ARN
+    let account_id = state_machine_arn
+        .split(':')
+        .nth(4)
+        .unwrap_or("000000000000")
+        .to_string();
+
+    let mut accounts = state.write();
+    let st = accounts.get_or_create(&account_id);
     let sm = match st.state_machines.get(state_machine_arn) {
         Some(sm) => sm,
         None => {
@@ -952,7 +983,7 @@ pub fn start_execution_from_delivery(
     };
 
     st.executions.insert(exec_arn.clone(), execution);
-    drop(st);
+    drop(accounts);
 
     let shared_state = state.clone();
     let delivery = delivery.clone();
@@ -974,17 +1005,15 @@ pub fn start_execution_from_delivery(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::StepFunctionsState;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
     use serde_json::Value;
     use std::sync::Arc;
 
     fn make_state() -> SharedStepFunctionsState {
-        Arc::new(RwLock::new(StepFunctionsState::new(
-            "123456789012",
-            "us-east-1",
-        )))
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ))
     }
 
     fn make_request(action: &str, body: &str) -> AwsRequest {

--- a/crates/fakecloud-stepfunctions/src/state.rs
+++ b/crates/fakecloud-stepfunctions/src/state.rs
@@ -6,14 +6,24 @@ use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-pub type SharedStepFunctionsState = Arc<RwLock<StepFunctionsState>>;
+pub type SharedStepFunctionsState =
+    Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<StepFunctionsState>>>;
 
-pub const STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+impl fakecloud_core::multi_account::AccountState for StepFunctionsState {
+    fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
+        Self::new(account_id, region)
+    }
+}
+
+pub const STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StepFunctionsSnapshot {
     pub schema_version: u32,
-    pub state: StepFunctionsState,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<StepFunctionsState>>,
+    #[serde(default)]
+    pub state: Option<StepFunctionsState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Batch 9 of #381. Last 4 services: RDS, ElastiCache, ApiGatewayV2, StepFunctions.

All 21 services now wrapped in MultiAccountState.

## Test plan

- [x] All workspace unit tests pass
- [x] Clippy clean
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-account state isolation for `fakecloud-rds`, `fakecloud-elasticache`, `fakecloud-apigatewayv2`, and `fakecloud-stepfunctions`, completing the migration to `MultiAccountState`. Snapshots move to v2 with backward-compatible loading.

- **New Features**
  - States for the four services are now stored per account/region via `MultiAccountState`.
  - `fakecloud-stepfunctions`: interpreter derives account ID from execution ARNs; events and executions are isolated per account.
  - `fakecloud-elasticache`: default resources (users, groups, etc.) are seeded per account.
  - `fakecloud-apigatewayv2`: request history tracking is per account.
  - Snapshot schema bumped to v2 for all four; snapshots now persist an accounts map and still load v1 snapshots.
  - Server init/reset updated to create and reset `MultiAccountState` across these services.

<sup>Written for commit 88774dc42995680da03545cf76a290e8617e6461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

