### PR TITLE
feat: multi-account quality gaps — bucket uniqueness, introspection, background tasks, account reset

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -59,6 +59,16 @@ impl ApiGatewayV2State {
             request_history: Vec::new(),
         }
     }
+
+    pub fn reset(&mut self) {
+        self.apis.clear();
+        self.routes.clear();
+        self.integrations.clear();
+        self.stages.clear();
+        self.deployments.clear();
+        self.authorizers.clear();
+        self.request_history.clear();
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-s3/src/inventory.rs
+++ b/crates/fakecloud-s3/src/inventory.rs
@@ -37,14 +37,24 @@ fn bucket_name_from_arn(arn: &str) -> Option<&str> {
 ///
 /// The report is a CSV with columns: Bucket, Key, Size, LastModifiedDate, ETag, StorageClass.
 pub fn generate_inventory_report(state: &SharedS3State, source_bucket: &str, config_id: &str) {
-    // Read the inventory config
-    let config_xml = {
+    // Read the inventory config (search all accounts)
+    let (config_xml, source_account_id) = {
         let mas = state.read();
-        let _empty_s3 = crate::state::S3State::new("", "");
-        let st = mas.default_ref();
-        st.buckets
-            .get(source_bucket)
-            .and_then(|b| b.inventory_configs.get(config_id).cloned())
+        let mut found = None;
+        for (acct_id, st) in mas.iter() {
+            if let Some(cfg) = st
+                .buckets
+                .get(source_bucket)
+                .and_then(|b| b.inventory_configs.get(config_id).cloned())
+            {
+                found = Some((cfg, acct_id.to_string()));
+                break;
+            }
+        }
+        match found {
+            Some((cfg, acct)) => (Some(cfg), acct),
+            None => (None, String::new()),
+        }
     };
 
     let config_xml = match config_xml {
@@ -65,8 +75,10 @@ pub fn generate_inventory_report(state: &SharedS3State, source_bucket: &str, con
     // Collect object data from source bucket
     let rows: Vec<String> = {
         let mas = state.read();
-        let _empty_s3 = crate::state::S3State::new("", "");
-        let st = mas.default_ref();
+        let st = match mas.get(&source_account_id) {
+            Some(s) => s,
+            None => return,
+        };
         let bucket = match st.buckets.get(source_bucket) {
             Some(b) => b,
             None => return,
@@ -125,9 +137,16 @@ pub fn generate_inventory_report(state: &SharedS3State, source_bucket: &str, con
     };
 
     let mut mas = state.write();
-    let st = mas.default_mut();
-    if let Some(target) = st.buckets.get_mut(&dest_bucket_name) {
-        target.objects.insert(report_key, report_object);
+    // Find the account that owns the destination bucket
+    let dest_acct = mas
+        .find_account(|s| s.buckets.contains_key(&dest_bucket_name))
+        .map(|a| a.to_string());
+    if let Some(acct) = dest_acct {
+        if let Some(st) = mas.get_mut(&acct) {
+            if let Some(target) = st.buckets.get_mut(&dest_bucket_name) {
+                target.objects.insert(report_key, report_object);
+            }
+        }
     }
 }
 

--- a/crates/fakecloud-s3/src/lifecycle.rs
+++ b/crates/fakecloud-s3/src/lifecycle.rs
@@ -33,22 +33,22 @@ impl LifecycleProcessor {
         let now = Utc::now();
         let today = now.date_naive();
 
-        // Collect bucket names and their lifecycle configs (to avoid holding lock during processing)
-        let bucket_configs: Vec<(String, String)> = {
+        // Collect bucket names, their lifecycle configs, and owning account id
+        let bucket_configs: Vec<(String, String, String)> = {
             let __mas = self.state.read();
-            let state = __mas.default_ref();
-            state
-                .buckets
-                .values()
-                .filter_map(|b| {
-                    b.lifecycle_config
-                        .as_ref()
-                        .map(|cfg| (b.name.clone(), cfg.clone()))
+            __mas
+                .iter()
+                .flat_map(|(acct_id, state)| {
+                    state.buckets.values().filter_map(move |b| {
+                        b.lifecycle_config
+                            .as_ref()
+                            .map(|cfg| (b.name.clone(), cfg.clone(), acct_id.to_string()))
+                    })
                 })
                 .collect()
         };
 
-        for (bucket_name, config_xml) in bucket_configs {
+        for (bucket_name, config_xml, account_id) in bucket_configs {
             let rules = match parse_lifecycle_rules(&config_xml) {
                 Some(r) => r,
                 None => continue,
@@ -59,14 +59,23 @@ impl LifecycleProcessor {
                     continue;
                 }
 
-                self.process_rule(&bucket_name, rule, today);
+                self.process_rule(&account_id, &bucket_name, rule, today);
             }
         }
     }
 
-    fn process_rule(&self, bucket_name: &str, rule: &LifecycleRule, today: NaiveDate) {
+    fn process_rule(
+        &self,
+        account_id: &str,
+        bucket_name: &str,
+        rule: &LifecycleRule,
+        today: NaiveDate,
+    ) {
         let mut __mas = self.state.write();
-        let state = __mas.default_mut();
+        let state = match __mas.get_mut(account_id) {
+            Some(s) => s,
+            None => return,
+        };
         let bucket = match state.buckets.get_mut(bucket_name) {
             Some(b) => b,
             None => return,

--- a/crates/fakecloud-s3/src/service/buckets.rs
+++ b/crates/fakecloud-s3/src/service/buckets.rs
@@ -129,6 +129,20 @@ impl S3Service {
             .unwrap_or("private");
 
         let mut accts = self.state.write();
+        // Check global uniqueness across all accounts before creating
+        for (other_account_id, acct_state) in accts.iter() {
+            if acct_state.buckets.contains_key(bucket) {
+                if other_account_id == account_id {
+                    // Same account owns it — fall through to idempotency / BucketAlreadyOwnedByYou logic below
+                    break;
+                }
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::CONFLICT,
+                    "BucketAlreadyExists",
+                    "The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.",
+                ));
+            }
+        }
         let state = accts.get_or_create(account_id);
         if let Some(existing) = state.buckets.get(bucket) {
             // In us-east-1, re-creating same bucket in same region is idempotent (returns 200)

--- a/crates/fakecloud-s3/src/simulation.rs
+++ b/crates/fakecloud-s3/src/simulation.rs
@@ -17,25 +17,26 @@ struct BucketSnapshot {
 
 /// Run one tick of the S3 lifecycle processor and return statistics.
 pub fn tick_lifecycle(state: &SharedS3State) -> LifecycleTickResult {
-    // Snapshot object counts and storage classes before processing
+    // Snapshot object counts and storage classes before processing (all accounts)
     let (buckets_with_lifecycle, before_snapshot) = {
         let __mas = state.read();
-        let s = __mas.default_ref();
         let mut count = 0u64;
         let mut snapshot: Vec<BucketSnapshot> = Vec::new();
-        for bucket in s.buckets.values() {
-            let classes: Vec<(String, String)> = bucket
-                .objects
-                .iter()
-                .map(|(k, o)| (k.clone(), o.storage_class.clone()))
-                .collect();
-            snapshot.push(BucketSnapshot {
-                name: bucket.name.clone(),
-                object_count: bucket.objects.len(),
-                storage_classes: classes,
-            });
-            if bucket.lifecycle_config.is_some() {
-                count += 1;
+        for (_, s) in __mas.iter() {
+            for bucket in s.buckets.values() {
+                let classes: Vec<(String, String)> = bucket
+                    .objects
+                    .iter()
+                    .map(|(k, o)| (k.clone(), o.storage_class.clone()))
+                    .collect();
+                snapshot.push(BucketSnapshot {
+                    name: bucket.name.clone(),
+                    object_count: bucket.objects.len(),
+                    storage_classes: classes,
+                });
+                if bucket.lifecycle_config.is_some() {
+                    count += 1;
+                }
             }
         }
         (count, snapshot)
@@ -50,9 +51,10 @@ pub fn tick_lifecycle(state: &SharedS3State) -> LifecycleTickResult {
     let mut transitioned_objects = 0u64;
 
     let __mas = state.read();
-    let s = __mas.default_ref();
     for snap in &before_snapshot {
-        let bucket = match s.buckets.get(&snap.name) {
+        // Find the bucket across all accounts
+        let bucket = __mas.iter().find_map(|(_, s)| s.buckets.get(&snap.name));
+        let bucket = match bucket {
             Some(b) => b,
             None => continue,
         };

--- a/crates/fakecloud-sdk/src/client.rs
+++ b/crates/fakecloud-sdk/src/client.rs
@@ -69,6 +69,23 @@ impl FakeCloud {
         Self::parse(resp).await
     }
 
+    /// Reset a single service's state for a specific account only.
+    pub async fn reset_service_for_account(
+        &self,
+        service: &str,
+        account_id: &str,
+    ) -> Result<ResetServiceResponse, Error> {
+        let resp = self
+            .client
+            .post(format!(
+                "{}/_fakecloud/reset/{}/{}",
+                self.base_url, service, account_id
+            ))
+            .send()
+            .await?;
+        Self::parse(resp).await
+    }
+
     // ── Sub-clients ─────────────────────────────────────────────────
 
     pub fn lambda(&self) -> LambdaClient<'_> {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2069,10 +2069,9 @@ async fn main() {
                 let ls = lambda_invocations_state.clone();
                 move || async move {
                     let accounts = ls.read();
-                    let state = accounts.default_ref();
-                    let invocations = state
-                        .invocations
+                    let invocations = accounts
                         .iter()
+                        .flat_map(|(_, state)| state.invocations.iter())
                         .map(|inv| types::LambdaInvocation {
                             function_arn: inv.function_arn.clone(),
                             payload: inv.payload.clone(),
@@ -2330,10 +2329,9 @@ async fn main() {
                 let ss = sns_introspection_state;
                 move || async move {
                     let mas = ss.read();
-                    let state = mas.default_ref();
-                    let messages = state
-                        .published
+                    let messages = mas
                         .iter()
+                        .flat_map(|(_, state)| state.published.iter())
                         .map(|msg| types::SnsMessage {
                             message_id: msg.message_id.clone(),
                             topic_arn: msg.topic_arn.clone(),
@@ -2352,10 +2350,9 @@ async fn main() {
                 let ss = sqs_introspection_state;
                 move || async move {
                     let mas = ss.read();
-                    let state = mas.default_ref();
-                    let queues = state
-                        .queues
-                        .values()
+                    let queues = mas
+                        .iter()
+                        .flat_map(|(_, state)| state.queues.values())
                         .map(|queue| {
                             let mut messages: Vec<types::SqsMessageInfo> = queue
                                 .messages
@@ -2397,10 +2394,9 @@ async fn main() {
                 let es = eb_introspection_state;
                 move || async move {
                     let accounts = es.read();
-                    let state = accounts.default_ref();
-                    let events = state
-                        .events
+                    let events = accounts
                         .iter()
+                        .flat_map(|(_, state)| state.events.iter())
                         .map(|evt| types::EventBridgeEvent {
                             event_id: evt.event_id.clone(),
                             source: evt.source.clone(),
@@ -2410,18 +2406,18 @@ async fn main() {
                             timestamp: evt.time.to_rfc3339(),
                         })
                         .collect();
-                    let lambda = state
-                        .lambda_invocations
+                    let lambda = accounts
                         .iter()
+                        .flat_map(|(_, state)| state.lambda_invocations.iter())
                         .map(|inv| types::EventBridgeLambdaDelivery {
                             function_arn: inv.function_arn.clone(),
                             payload: inv.payload.clone(),
                             timestamp: inv.timestamp.to_rfc3339(),
                         })
                         .collect();
-                    let logs = state
-                        .log_deliveries
+                    let logs = accounts
                         .iter()
+                        .flat_map(|(_, state)| state.log_deliveries.iter())
                         .map(|ld| types::EventBridgeLogDelivery {
                             log_group_arn: ld.log_group_arn.clone(),
                             payload: ld.payload.clone(),
@@ -2511,10 +2507,9 @@ async fn main() {
                 let ss = s3_introspection_state;
                 move || async move {
                     let mas = ss.read();
-                    let state = mas.default_ref();
-                    let notifications = state
-                        .notification_events
+                    let notifications = mas
                         .iter()
+                        .flat_map(|(_, state)| state.notification_events.iter())
                         .map(|evt| types::S3Notification {
                             bucket: evt.bucket.clone(),
                             key: evt.key.clone(),
@@ -2984,6 +2979,26 @@ async fn main() {
                             axum::http::StatusCode::OK,
                             axum::Json(serde_json::json!(types::ResetServiceResponse {
                                 reset: service
+                            })),
+                        ),
+                        Err(msg) => (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({ "error": msg })),
+                        ),
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/reset/{service}/{account_id}",
+            axum::routing::post({
+                let s = reset_state.clone();
+                move |axum::extract::Path((service, account_id)): axum::extract::Path<(String, String)>| async move {
+                    match s.reset_service_for_account(&service, &account_id) {
+                        Ok(()) => (
+                            axum::http::StatusCode::OK,
+                            axum::Json(serde_json::json!(types::ResetServiceResponse {
+                                reset: format!("{service}/{account_id}")
                             })),
                         ),
                         Err(msg) => (

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -130,6 +130,148 @@ impl ResetState {
         Ok(())
     }
 
+    /// Reset a single service's state for a specific account only.
+    pub(crate) fn reset_service_for_account(
+        &self,
+        service: &str,
+        account_id: &str,
+    ) -> Result<(), String> {
+        match service {
+            "iam" | "sts" => {
+                let mut mas = self.iam.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "sqs" => {
+                let mut mas = self.sqs.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "sns" => {
+                let mut mas = self.sns.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                    state.seed_default_opted_out();
+                }
+            }
+            "events" | "eventbridge" => {
+                let mut mas = self.eb.write();
+                if let Some(eb) = mas.get_mut(account_id) {
+                    eb.reset();
+                }
+            }
+            "ssm" => {
+                let mut mas = self.ssm.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "dynamodb" => {
+                let mut mas = self.dynamodb.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "lambda" => {
+                let mut mas = self.lambda.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "secretsmanager" => {
+                let mut mas = self.secretsmanager.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "s3" => {
+                let mut mas = self.s3.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "logs" => {
+                let mut mas = self.logs.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "kms" => {
+                let mut mas = self.kms.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "cloudformation" => {
+                let mut mas = self.cloudformation.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "ses" => {
+                let mut mas = self.ses.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "cognito" => {
+                let mut mas = self.cognito.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "kinesis" => {
+                let mut mas = self.kinesis.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "rds" => {
+                let mut mas = self.rds.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "elasticache" => {
+                let mut mas = self.elasticache.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "states" | "stepfunctions" => {
+                let mut mas = self.stepfunctions.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "scheduler" => {
+                let mut mas = self.scheduler.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "apigateway" | "apigatewayv2" => {
+                let mut mas = self.apigatewayv2.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            "bedrock" | "bedrock-runtime" => {
+                let mut mas = self.bedrock.write();
+                if let Some(state) = mas.get_mut(account_id) {
+                    state.reset();
+                }
+            }
+            _ => {
+                return Err(format!("Unknown service: {service}"));
+            }
+        }
+        tracing::info!(service = %service, account_id = %account_id, "service state reset for account via per-account reset API");
+        Ok(())
+    }
+
     pub(crate) fn reset(&self) -> axum::Json<types::ResetResponse> {
         self.iam.write().reset();
         self.sqs.write().reset();


### PR DESCRIPTION
## Summary

Batch 10 of #381. Final quality improvements completing 100% multi-account support.

1. **S3 global bucket uniqueness**: `create_bucket` checks all accounts before creating
2. **Introspection aggregation**: 5 endpoints now show data from all accounts
3. **Background tasks**: S3 lifecycle/inventory/simulation iterate all accounts
4. **Account-scoped reset**: `POST /_fakecloud/reset/{service}/{account_id}`

## Test plan

- [x] All 3,437 workspace unit tests pass
- [x] Clippy clean
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes multi-account support: enforces global S3 bucket-name uniqueness, aggregates introspection across accounts, and updates S3 background jobs to process all accounts. Adds a per‑account reset API and a `fakecloud-sdk` client method.

- **New Features**
  - S3 bucket creation checks all accounts; if another account owns the name, returns BucketAlreadyExists (409).
  - Introspection aggregates across all accounts for Lambda invocations, SNS messages, SQS queues, EventBridge events/deliveries, and S3 notifications.
  - S3 background jobs (lifecycle, inventory, simulation) iterate and search across all accounts.
  - New API: POST `/_fakecloud/reset/{service}/{account_id}` to reset a single account; added `FakeCloud::reset_service_for_account` in `fakecloud-sdk`.

<sup>Written for commit 9df9f3b65b8e6e190a576054da9602f13abb4267. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

