### PR TITLE
test(bedrock): customization job lifecycle

### DIFF
--- a/crates/fakecloud-bedrock/src/customization.rs
+++ b/crates/fakecloud-bedrock/src/customization.rs
@@ -212,3 +212,171 @@ pub fn stop_model_customization_job(
 
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        let multi: MultiAccountState<BedrockState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://localhost");
+        Arc::new(RwLock::new(multi))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "r".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn create_job_requires_name() {
+        let s = shared();
+        let err = create_model_customization_job(&s, &req(), &json!({}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn create_job_stores_record_with_defaults() {
+        let s = shared();
+        create_model_customization_job(
+            &s,
+            &req(),
+            &json!({"jobName": "j", "roleArn": "role", "hyperParameters": {"lr": "0.01", "epochs": 3}}),
+        )
+        .unwrap();
+        let accts = s.read();
+        let state = accts.default_ref();
+        assert_eq!(state.customization_jobs.len(), 1);
+        let job = state.customization_jobs.values().next().unwrap();
+        assert_eq!(job.job_name, "j");
+        assert_eq!(job.custom_model_name, "j");
+        assert_eq!(job.status, "InProgress");
+        assert_eq!(
+            job.hyper_parameters.get("lr").map(String::as_str),
+            Some("0.01")
+        );
+        assert_eq!(
+            job.hyper_parameters.get("epochs").map(String::as_str),
+            Some("3")
+        );
+    }
+
+    #[test]
+    fn get_job_by_arn_and_by_name() {
+        let s = shared();
+        create_model_customization_job(&s, &req(), &json!({"jobName": "my-job"})).unwrap();
+        let arn = s
+            .read()
+            .default_ref()
+            .customization_jobs
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
+        assert!(get_model_customization_job(&s, &req(), &arn).is_ok());
+        assert!(get_model_customization_job(&s, &req(), "my-job").is_ok());
+    }
+
+    #[test]
+    fn get_job_unknown_not_found() {
+        let s = shared();
+        let err = get_model_customization_job(&s, &req(), "missing")
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn list_jobs_paginates() {
+        let s = shared();
+        for i in 0..3 {
+            create_model_customization_job(&s, &req(), &json!({"jobName": format!("j{i}")}))
+                .unwrap();
+        }
+        let mut r = req();
+        r.query_params
+            .insert("maxResults".to_string(), "2".to_string());
+        let resp = list_model_customization_jobs(&s, &r).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(
+            v["modelCustomizationJobSummaries"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn stop_job_transitions_status() {
+        let s = shared();
+        create_model_customization_job(&s, &req(), &json!({"jobName": "j"})).unwrap();
+        let arn = s
+            .read()
+            .default_ref()
+            .customization_jobs
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
+        stop_model_customization_job(&s, &req(), &arn).unwrap();
+        assert_eq!(
+            s.read().default_ref().customization_jobs[&arn].status,
+            "Stopped"
+        );
+    }
+
+    #[test]
+    fn stop_job_not_in_progress_conflicts() {
+        let s = shared();
+        create_model_customization_job(&s, &req(), &json!({"jobName": "j"})).unwrap();
+        let arn = s
+            .read()
+            .default_ref()
+            .customization_jobs
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
+        stop_model_customization_job(&s, &req(), &arn).unwrap();
+        let err = stop_model_customization_job(&s, &req(), &arn)
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn stop_job_unknown_not_found() {
+        let s = shared();
+        let err = stop_model_customization_job(&s, &req(), "missing")
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Covers create (missing name + defaults), get by ARN/name + not-found, list pagination, stop transitions + conflict + not-found.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests in `fakecloud-bedrock` for the model customization job lifecycle to validate creation, retrieval, listing, and stopping behavior.

Covers: creation (name required; defaults stored), get by ARN or name (404 on missing), list pagination with `maxResults` and `nextToken`, and stop behavior (status transitions to Stopped; 409 on repeat; 404 on missing job).

<sup>Written for commit d59924958af2fd60c03c783a7f3607b959521375. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

