### PR TITLE
test(bedrock): model import + imported model lifecycle

### DIFF
--- a/crates/fakecloud-bedrock/src/model_import.rs
+++ b/crates/fakecloud-bedrock/src/model_import.rs
@@ -273,3 +273,158 @@ pub fn delete_imported_model(
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        let multi: MultiAccountState<BedrockState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        Arc::new(RwLock::new(multi))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "r".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn create_import(state: &SharedBedrockState, job_name: &str) -> (String, String) {
+        let resp = create_model_import_job(
+            state,
+            &req(),
+            &json!({"jobName": job_name, "importedModelName": job_name, "roleArn": "role"}),
+        )
+        .unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        let job_arn = v["jobArn"].as_str().unwrap().to_string();
+        let accts = state.read();
+        let s = accts.default_ref();
+        let model_arn = s.model_import_jobs[&job_arn].imported_model_arn.clone();
+        (job_arn, model_arn)
+    }
+
+    #[test]
+    fn create_import_defaults_name_and_role() {
+        let s = shared();
+        let resp = create_model_import_job(&s, &req(), &json!({})).unwrap();
+        assert_eq!(resp.status, StatusCode::CREATED);
+        let state = s.read();
+        let acct = state.default_ref();
+        assert_eq!(acct.model_import_jobs.len(), 1);
+        assert_eq!(acct.imported_models.len(), 1);
+    }
+
+    #[test]
+    fn get_import_job_by_arn_or_name_or_id() {
+        let s = shared();
+        let (arn, _) = create_import(&s, "my-import");
+        let id = arn.rsplit('/').next().unwrap().to_string();
+        assert!(get_model_import_job(&s, &req(), &arn).is_ok());
+        assert!(get_model_import_job(&s, &req(), &id).is_ok());
+        assert!(get_model_import_job(&s, &req(), "my-import").is_ok());
+    }
+
+    #[test]
+    fn get_import_job_unknown_not_found() {
+        let s = shared();
+        let err = get_model_import_job(&s, &req(), "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn list_import_jobs_paginates() {
+        let s = shared();
+        for i in 0..3 {
+            create_import(&s, &format!("j{i}"));
+        }
+        let mut r = req();
+        r.query_params
+            .insert("maxResults".to_string(), "2".to_string());
+        let resp = list_model_import_jobs(&s, &r).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["modelImportJobSummaries"].as_array().unwrap().len(), 2);
+        assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn get_imported_model_by_arn_or_name_or_id() {
+        let s = shared();
+        let (_, model_arn) = create_import(&s, "my-model");
+        let id = model_arn.rsplit('/').next().unwrap().to_string();
+        assert!(get_imported_model(&s, &req(), &model_arn).is_ok());
+        assert!(get_imported_model(&s, &req(), &id).is_ok());
+        assert!(get_imported_model(&s, &req(), "my-model").is_ok());
+    }
+
+    #[test]
+    fn get_imported_model_unknown_not_found() {
+        let s = shared();
+        let err = get_imported_model(&s, &req(), "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn list_imported_models_paginates() {
+        let s = shared();
+        for i in 0..3 {
+            create_import(&s, &format!("m{i}"));
+        }
+        let mut r = req();
+        r.query_params
+            .insert("maxResults".to_string(), "2".to_string());
+        let resp = list_imported_models(&s, &r).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["modelSummaries"].as_array().unwrap().len(), 2);
+        assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn delete_imported_model_removes_entry() {
+        let s = shared();
+        let (_, model_arn) = create_import(&s, "del");
+        delete_imported_model(&s, &req(), &model_arn).unwrap();
+        assert!(s.read().default_ref().imported_models.is_empty());
+    }
+
+    #[test]
+    fn delete_imported_model_unknown_not_found() {
+        let s = shared();
+        let err = delete_imported_model(&s, &req(), "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn delete_imported_model_no_account_not_found() {
+        let s = shared();
+        let mut r = req();
+        r.account_id = "999999999999".to_string();
+        let err = delete_imported_model(&s, &r, "any").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Covers create (default name/role), get/delete by ARN/name/id, list pagination, not-found paths including missing account.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for Bedrock model import and imported model lifecycle in `fakecloud-bedrock`. Covers create with default name/role, get by ARN/name/id, pagination for list endpoints, and delete with not-found cases (including missing account).

<sup>Written for commit 72ab11df1a1e2de0815bfd7ac0cff644d14a17b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

