### PR TITLE
test(bedrock): enforced_guardrails put/list/delete

### DIFF
--- a/crates/fakecloud-bedrock/src/enforced_guardrails.rs
+++ b/crates/fakecloud-bedrock/src/enforced_guardrails.rs
@@ -91,3 +91,109 @@ pub fn delete_enforced_guardrail_configuration(
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        let multi: MultiAccountState<BedrockState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        Arc::new(RwLock::new(multi))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "r".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn put_stores_config_with_id() {
+        let s = shared();
+        let resp =
+            put_enforced_guardrail_configuration(&s, &req(), &json!({"policy": "p"})).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["configId"].is_string());
+        assert_eq!(s.read().default_ref().enforced_guardrail_configs.len(), 1);
+    }
+
+    #[test]
+    fn list_returns_configs_with_ids() {
+        let s = shared();
+        put_enforced_guardrail_configuration(&s, &req(), &json!({"k": "a"})).unwrap();
+        put_enforced_guardrail_configuration(&s, &req(), &json!({"k": "b"})).unwrap();
+        let resp = list_enforced_guardrails_configuration(&s, &req()).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        let arr = v["enforcedGuardrailsConfigurations"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        for item in arr {
+            assert!(item["configId"].is_string());
+        }
+    }
+
+    #[test]
+    fn list_paginates() {
+        let s = shared();
+        for i in 0..3 {
+            put_enforced_guardrail_configuration(&s, &req(), &json!({"idx": i})).unwrap();
+        }
+        let mut r = req();
+        r.query_params
+            .insert("maxResults".to_string(), "2".to_string());
+        let resp = list_enforced_guardrails_configuration(&s, &r).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(
+            v["enforcedGuardrailsConfigurations"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn delete_removes_entry() {
+        let s = shared();
+        let resp = put_enforced_guardrail_configuration(&s, &req(), &json!({"k": "v"})).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        let id = v["configId"].as_str().unwrap().to_string();
+        delete_enforced_guardrail_configuration(&s, &req(), &id).unwrap();
+        assert!(s.read().default_ref().enforced_guardrail_configs.is_empty());
+    }
+
+    #[test]
+    fn delete_unknown_returns_not_found() {
+        let s = shared();
+        let err = delete_enforced_guardrail_configuration(&s, &req(), "missing")
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Covers put stores config with id, list returns configs with ids + pagination, delete removes + not-found error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for Bedrock enforced guardrail configurations to validate core behaviors and error handling.
Tests cover: PUT stores a config and returns a `configId`, LIST returns configs with ids and paginates (`maxResults`/`nextToken`), and DELETE removes the config and returns 404 for unknown ids.

<sup>Written for commit 82e77c7235c0d743ac8bd428658d03a6dddedbd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

