### PR TITLE
test(bedrock): converse branches + estimate_tokens

### DIFF
--- a/crates/fakecloud-bedrock/src/converse.rs
+++ b/crates/fakecloud-bedrock/src/converse.rs
@@ -150,3 +150,165 @@ fn estimate_tokens(input: &Value) -> u64 {
     // Rough approximation: 1 token ~= 4 characters, minimum 1
     (text_len / 4).max(1) as u64
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        let multi: MultiAccountState<BedrockState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        Arc::new(RwLock::new(multi))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "Converse".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "r".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn estimate_tokens_empty_returns_min_one() {
+        let v = json!({});
+        assert_eq!(estimate_tokens(&v), 1);
+    }
+
+    #[test]
+    fn estimate_tokens_counts_system_and_messages() {
+        let v = json!({
+            "system": [{"text": "12345678"}],
+            "messages": [{"content": [{"text": "abcdefgh"}]}]
+        });
+        assert_eq!(estimate_tokens(&v), 4); // 16 chars / 4
+    }
+
+    #[test]
+    fn converse_default_response_no_fault_no_override() {
+        let s = shared();
+        let body = br#"{"messages":[{"content":[{"text":"hi"}]}]}"#;
+        let resp = converse(&s, &req(), "anthropic.claude-v2", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["output"]["message"]["role"], "assistant");
+        assert_eq!(v["stopReason"], "end_turn");
+        assert!(v["usage"]["totalTokens"].is_u64());
+    }
+
+    #[test]
+    fn converse_truncates_via_max_tokens() {
+        let s = shared();
+        let body = br#"{"messages":[], "inferenceConfig": {"maxTokens": 2}}"#;
+        let resp = converse(&s, &req(), "m", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        let text = v["output"]["message"]["content"][0]["text"]
+            .as_str()
+            .unwrap();
+        // 2 tokens * 4 chars = 8-char cap
+        assert!(text.len() <= 8);
+    }
+
+    #[test]
+    fn converse_tool_config_adds_tool_use_block_and_stop_reason() {
+        let s = shared();
+        let body = br#"{
+            "messages": [],
+            "toolConfig": {"tools": [{"toolSpec": {"name": "calculator"}}]}
+        }"#;
+        let resp = converse(&s, &req(), "m", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["stopReason"], "tool_use");
+        let content = v["output"]["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[1]["toolUse"]["name"], "calculator");
+    }
+
+    #[test]
+    fn converse_records_invocation() {
+        let s = shared();
+        let body = br#"{"messages":[]}"#;
+        converse(&s, &req(), "model-x", body).unwrap();
+        let state = s.read();
+        let acct = state.default_ref();
+        assert_eq!(acct.invocations.len(), 1);
+        assert_eq!(acct.invocations[0].model_id, "model-x");
+        assert!(acct.invocations[0].error.is_none());
+    }
+
+    #[test]
+    fn converse_uses_response_rule_override() {
+        let s = shared();
+        s.write()
+            .default_mut()
+            .custom_responses
+            .insert("model-y".to_string(), "override-output".to_string());
+        let body = br#"{"messages":[]}"#;
+        let resp = converse(&s, &req(), "model-y", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(
+            v["output"]["message"]["content"][0]["text"],
+            "override-output"
+        );
+    }
+
+    #[test]
+    fn converse_override_with_nested_text_extracts_from_json() {
+        let s = shared();
+        let payload = r#"{"output":{"message":{"content":[{"text":"nested-hello"}]}}}"#;
+        s.write()
+            .default_mut()
+            .custom_responses
+            .insert("model-z".to_string(), payload.to_string());
+        let body = br#"{"messages":[]}"#;
+        let resp = converse(&s, &req(), "model-z", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["output"]["message"]["content"][0]["text"], "nested-hello");
+    }
+
+    #[test]
+    fn converse_returns_fault_when_matched_and_records_error_invocation() {
+        let s = shared();
+        s.write()
+            .default_mut()
+            .fault_rules
+            .push(crate::state::FaultRule {
+                error_type: "Throttled".to_string(),
+                message: "slow".to_string(),
+                http_status: 429,
+                remaining: 1,
+                model_id: None,
+                operation: None,
+            });
+        let body = br#"{"messages":[]}"#;
+        let err = converse(&s, &req(), "m", body).err().unwrap();
+        assert_eq!(err.status(), StatusCode::TOO_MANY_REQUESTS);
+        let state = s.read();
+        let acct = state.default_ref();
+        assert_eq!(acct.invocations.len(), 1);
+        assert!(acct.invocations[0].error.is_some());
+    }
+}


### PR DESCRIPTION
Covers default response, maxTokens truncation, toolConfig toolUse block + stop_reason, response rule override (raw + nested JSON extract), fault injection path. Plus estimate_tokens empty/system+messages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for Bedrock Converse covering default response, truncation via `inferenceConfig.maxTokens`, tool-use blocks with `stopReason`, response overrides (raw and nested JSON), invocation recording, and fault-rule errors. Also tests `estimate_tokens` for minimum 1 and counting across `system` and `messages`.

<sup>Written for commit 18c86eae07eaa5533613bde41ebdfd8b35ce6cda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

