### PR TITLE
fix(server): remove flaky reaper env-based tests

### DIFF
--- a/crates/fakecloud-server/src/reaper.rs
+++ b/crates/fakecloud-server/src/reaper.rs
@@ -123,7 +123,7 @@ pub fn pid_alive(_pid: u32) -> bool {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::{cli_works, detect_cli, pid_alive, reap_stale_containers};
+    use super::{cli_works, pid_alive};
 
     #[test]
     fn self_is_alive() {
@@ -144,44 +144,5 @@ mod tests {
     #[test]
     fn cli_works_false_for_unknown_binary() {
         assert!(!cli_works("definitely-not-a-real-cli-name-xyz123"));
-    }
-
-    #[test]
-    fn detect_cli_respects_env_var_pointing_to_missing_bin() {
-        let _g = EnvGuard::set("FAKECLOUD_CONTAINER_CLI", "nonexistent-cli-binary-abc-123");
-        // Env says use this specific CLI; it doesn't exist so returns None
-        // regardless of docker/podman availability on the host.
-        assert!(detect_cli().is_none());
-    }
-
-    #[test]
-    fn reap_runs_without_panicking() {
-        // Point env at a nonexistent CLI so the reap body never executes any
-        // real docker command. Ensures the startup hook is safe on boxes
-        // without any container CLI.
-        let _g = EnvGuard::set("FAKECLOUD_CONTAINER_CLI", "nonexistent-cli-binary-abc-123");
-        reap_stale_containers();
-    }
-
-    struct EnvGuard {
-        key: &'static str,
-        prev: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let prev = std::env::var(key).ok();
-            std::env::set_var(key, value);
-            Self { key, prev }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.prev {
-                Some(v) => std::env::set_var(self.key, v),
-                None => std::env::remove_var(self.key),
-            }
-        }
     }
 }


### PR DESCRIPTION
reap_runs_without_panicking and detect_cli_respects_env_var_pointing_to_missing_bin hang CI. Env var is shared process-wide; parallel test runs race on FAKECLOUD_CONTAINER_CLI and these tests end up invoking the real docker CLI. Remove both; pid_alive + cli_works still covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove two flaky env-based reaper tests that caused CI hangs due to races on the `FAKECLOUD_CONTAINER_CLI` env var. Keeps core liveness and CLI checks, and avoids calling the real Docker CLI during parallel tests.

- **Bug Fixes**
  - Deleted tests: detect_cli_respects_env_var_pointing_to_missing_bin and reap_runs_without_panicking.
  - Removed test-only EnvGuard and references to detect_cli/reap_stale_containers in tests.
  - Root cause: process-wide env var races triggered the host Docker CLI in CI.

<sup>Written for commit 0d28a8706de6e42270e3ecc51cae5fffcb70bfc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

