### PR TITLE
test(bedrock): invoke_model provider-specific responses + count_tokens

### DIFF
--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -249,3 +249,208 @@ fn generic_response(_input: &Value) -> String {
     }))
     .unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        let multi: MultiAccountState<BedrockState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        Arc::new(RwLock::new(multi))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "InvokeModel".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "r".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn invoke_empty_model_id_errors() {
+        let s = shared();
+        let err = invoke_model(&s, &req(), "", b"{}").err().unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invoke_anthropic_returns_message_format() {
+        let s = shared();
+        let resp = invoke_model(&s, &req(), "anthropic.claude-3", b"{}").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["role"], "assistant");
+        assert_eq!(v["model"], "anthropic.claude-3");
+    }
+
+    #[test]
+    fn invoke_amazon_titan_text_returns_results() {
+        let s = shared();
+        let resp = invoke_model(&s, &req(), "amazon.titan-text-express-v1", b"{}").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["results"].is_array());
+    }
+
+    #[test]
+    fn invoke_amazon_titan_embed_returns_vector() {
+        let s = shared();
+        let resp = invoke_model(&s, &req(), "amazon.titan-embed-text-v1", b"{}").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["embedding"].is_array());
+    }
+
+    #[test]
+    fn invoke_meta_returns_generation() {
+        let s = shared();
+        let resp = invoke_model(&s, &req(), "meta.llama3", b"{}").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["generation"].is_string());
+    }
+
+    #[test]
+    fn invoke_cohere_returns_generations() {
+        let s = shared();
+        let resp = invoke_model(&s, &req(), "cohere.command", b"{}").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["generations"].is_array());
+    }
+
+    #[test]
+    fn invoke_mistral_returns_outputs() {
+        let s = shared();
+        let resp = invoke_model(&s, &req(), "mistral.7b", b"{}").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["outputs"].is_array());
+    }
+
+    #[test]
+    fn invoke_unknown_provider_returns_generic() {
+        let s = shared();
+        let resp = invoke_model(&s, &req(), "stability.diffusion", b"{}").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(
+            v["output"],
+            "This is a test response from the emulated model."
+        );
+    }
+
+    #[test]
+    fn invoke_records_invocation_entry() {
+        let s = shared();
+        invoke_model(&s, &req(), "anthropic.claude", b"{}").unwrap();
+        let state = s.read();
+        assert_eq!(state.default_ref().invocations.len(), 1);
+    }
+
+    #[test]
+    fn invoke_returns_bedrock_headers() {
+        let s = shared();
+        let resp = invoke_model(&s, &req(), "anthropic.claude", b"{}").unwrap();
+        assert!(resp
+            .headers
+            .get("x-amzn-bedrock-input-token-count")
+            .is_some());
+        assert!(resp
+            .headers
+            .get("x-amzn-bedrock-output-token-count")
+            .is_some());
+    }
+
+    #[test]
+    fn invoke_fault_injected_records_error() {
+        let s = shared();
+        s.write()
+            .default_mut()
+            .fault_rules
+            .push(crate::state::FaultRule {
+                error_type: "Throttle".to_string(),
+                message: "slow".to_string(),
+                http_status: 429,
+                remaining: 1,
+                model_id: None,
+                operation: None,
+            });
+        let err = invoke_model(&s, &req(), "m", b"{}").err().unwrap();
+        assert_eq!(err.status(), StatusCode::TOO_MANY_REQUESTS);
+        let state = s.read();
+        let acct = state.default_ref();
+        assert_eq!(acct.invocations.len(), 1);
+        assert!(acct.invocations[0].error.is_some());
+    }
+
+    #[test]
+    fn count_tokens_empty_model_id_errors() {
+        let s = shared();
+        let err = count_tokens(&s, &req(), "", b"{}").err().unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn count_tokens_invoke_model_body_docs() {
+        let s = shared();
+        let body = br#"{"input":{"invokeModel":{"body":{"prompt":"hello world foo bar"}}}}"#;
+        let resp = count_tokens(&s, &req(), "m", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["inputTokens"].as_u64().unwrap() > 0);
+    }
+
+    #[test]
+    fn count_tokens_converse_format() {
+        let s = shared();
+        let body = br#"{"input":{"converse":{"system":[{"text":"sys prompt"}],"messages":[{"content":[{"text":"hello world"}]}]}}}"#;
+        let resp = count_tokens(&s, &req(), "m", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["inputTokens"].as_u64().unwrap(), 4);
+    }
+
+    #[test]
+    fn count_tokens_unknown_input_falls_back_to_raw_json_count() {
+        let s = shared();
+        let body = br#"{"other":"field"}"#;
+        let resp = count_tokens(&s, &req(), "m", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["inputTokens"].as_u64().unwrap() >= 1);
+    }
+
+    #[test]
+    fn count_tokens_empty_body_parses_cleanly() {
+        let s = shared();
+        let body = b"";
+        let resp = count_tokens(&s, &req(), "m", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        // Empty body produces Null JSON serialized to "null" (4 chars, 1 token)
+        assert!(v["inputTokens"].is_u64());
+    }
+}


### PR DESCRIPTION
Covers anthropic/amazon (text+embed)/meta/cohere/mistral/generic responses, fault injection error path, bedrock response headers. count_tokens invoke_model + converse + unknown + empty body + missing model id.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for Bedrock InvokeModel and CountTokens to validate provider-specific response shapes, fault injection behavior, Bedrock input/output token headers, and error handling.

Covers Anthropic, Amazon Titan (text + embedding), Meta, Cohere, Mistral, and a generic fallback; verifies invocation recording, empty/missing model ID errors, and CountTokens for invokeModel, converse, unknown input, and empty bodies.

<sup>Written for commit 2d41a6b08923530b83b423868b732b7f3333118a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

