### PR TITLE
test(bedrock): prompt router lifecycle

### DIFF
--- a/crates/fakecloud-bedrock/src/prompt_routers.rs
+++ b/crates/fakecloud-bedrock/src/prompt_routers.rs
@@ -169,3 +169,112 @@ pub fn delete_prompt_router(
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        let multi: MultiAccountState<BedrockState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        Arc::new(RwLock::new(multi))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "r".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn create(state: &SharedBedrockState, name: &str) -> String {
+        let body = json!({
+            "promptRouterName": name,
+            "description": "d",
+            "models": [{"modelArn": "m1"}],
+            "routingCriteria": {"responseQualityDifference": 0.2},
+            "fallbackModel": {"modelArn": "fallback"}
+        });
+        let resp = create_prompt_router(state, &req(), &body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        v["promptRouterArn"].as_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn create_with_default_name_when_omitted() {
+        let s = shared();
+        create_prompt_router(&s, &req(), &json!({})).unwrap();
+        let state = s.read();
+        let acct = state.default_ref();
+        assert_eq!(acct.prompt_routers.len(), 1);
+    }
+
+    #[test]
+    fn get_by_arn_or_name_or_id() {
+        let s = shared();
+        let arn = create(&s, "my-router");
+        let id = arn.rsplit('/').next().unwrap().to_string();
+        assert!(get_prompt_router(&s, &req(), &arn).is_ok());
+        assert!(get_prompt_router(&s, &req(), &id).is_ok());
+        assert!(get_prompt_router(&s, &req(), "my-router").is_ok());
+    }
+
+    #[test]
+    fn get_unknown_returns_not_found() {
+        let s = shared();
+        let err = get_prompt_router(&s, &req(), "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn list_paginates() {
+        let s = shared();
+        for i in 0..3 {
+            create(&s, &format!("r{i}"));
+        }
+        let mut r = req();
+        r.query_params
+            .insert("maxResults".to_string(), "2".to_string());
+        let resp = list_prompt_routers(&s, &r).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["promptRouterSummaries"].as_array().unwrap().len(), 2);
+        assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn delete_removes_entry() {
+        let s = shared();
+        let arn = create(&s, "del");
+        delete_prompt_router(&s, &req(), &arn).unwrap();
+        assert!(s.read().default_ref().prompt_routers.is_empty());
+    }
+
+    #[test]
+    fn delete_unknown_returns_not_found() {
+        let s = shared();
+        let err = delete_prompt_router(&s, &req(), "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Covers create default name, get by ARN/name/id, list pagination, delete + not-found.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for the Bedrock prompt router lifecycle to validate CRUD and pagination. Ensures default name creation, lookup by ARN/name/id, paginated listing (maxResults, nextToken), and delete behavior including 404 on unknown IDs.

<sup>Written for commit 84a3010dc3f05e4442e4feb0c2b60c2deb53ae6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

