### PR TITLE
test(bedrock): invocation job lifecycle

### DIFF
--- a/crates/fakecloud-bedrock/src/invocation_jobs.rs
+++ b/crates/fakecloud-bedrock/src/invocation_jobs.rs
@@ -194,3 +194,129 @@ fn find_job_key(
             )
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        let multi: MultiAccountState<BedrockState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        Arc::new(RwLock::new(multi))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "r".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn create(state: &SharedBedrockState, name: &str) -> String {
+        let body = json!({
+            "jobName": name,
+            "modelId": "anthropic.claude",
+            "roleArn": "arn:aws:iam::123:role/r",
+            "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://b/in"}},
+            "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://b/out"}}
+        });
+        let resp = create_model_invocation_job(state, &req(), &body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        v["jobArn"].as_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn create_stores_job() {
+        let s = shared();
+        let arn = create(&s, "j1");
+        let st = s.read();
+        let job = st.default_ref().model_invocation_jobs.get(&arn).unwrap();
+        assert_eq!(job.job_name, "j1");
+        assert_eq!(job.status, "InProgress");
+    }
+
+    #[test]
+    fn get_by_arn_name_or_id() {
+        let s = shared();
+        let arn = create(&s, "my-job");
+        let id = arn.rsplit('/').next().unwrap().to_string();
+        assert!(get_model_invocation_job(&s, &req(), &arn).is_ok());
+        assert!(get_model_invocation_job(&s, &req(), &id).is_ok());
+        assert!(get_model_invocation_job(&s, &req(), "my-job").is_ok());
+    }
+
+    #[test]
+    fn get_unknown_returns_not_found() {
+        let s = shared();
+        let err = get_model_invocation_job(&s, &req(), "missing")
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn list_paginates() {
+        let s = shared();
+        for i in 0..3 {
+            create(&s, &format!("j{i}"));
+        }
+        let mut r = req();
+        r.query_params
+            .insert("maxResults".to_string(), "2".to_string());
+        let resp = list_model_invocation_jobs(&s, &r).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["invocationJobSummaries"].as_array().unwrap().len(), 2);
+        assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn stop_sets_status_and_end_time() {
+        let s = shared();
+        let arn = create(&s, "j");
+        stop_model_invocation_job(&s, &req(), &arn).unwrap();
+        let st = s.read();
+        let job = st.default_ref().model_invocation_jobs.get(&arn).unwrap();
+        assert_eq!(job.status, "Stopped");
+        assert!(job.end_time.is_some());
+    }
+
+    #[test]
+    fn stop_rejects_non_in_progress() {
+        let s = shared();
+        let arn = create(&s, "j");
+        stop_model_invocation_job(&s, &req(), &arn).unwrap();
+        let err = stop_model_invocation_job(&s, &req(), &arn).err().unwrap();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn stop_unknown_returns_not_found() {
+        let s = shared();
+        let err = stop_model_invocation_job(&s, &req(), "missing")
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Covers create, get by ARN/name/id, list pagination, stop (success + conflict when not InProgress), plus not-found paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for the Bedrock model invocation job lifecycle in `crates/fakecloud-bedrock`. Tests cover create, get by ARN/name/id, paginated list, stop (success and 409 when not InProgress), and 404s for unknown jobs.

<sup>Written for commit 9787d9cba9ddc1baa8b0420e86c8c1795f33a81d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

