### PR TITLE
test(bedrock): resource policy lifecycle

### DIFF
--- a/crates/fakecloud-bedrock/src/resource_policies.rs
+++ b/crates/fakecloud-bedrock/src/resource_policies.rs
@@ -102,3 +102,112 @@ pub fn delete_resource_policy(
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        let multi: MultiAccountState<BedrockState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        Arc::new(RwLock::new(multi))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "r".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    const ARN: &str = "arn:aws:bedrock:us-east-1:123:agent/my-agent";
+
+    fn put(state: &SharedBedrockState, arn: &str) {
+        put_resource_policy(
+            state,
+            &req(),
+            &json!({"resourceArn": arn, "resourcePolicy": "{\"Version\":\"2012-10-17\"}"}),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn put_missing_resource_arn_errors() {
+        let s = shared();
+        let err = put_resource_policy(&s, &req(), &json!({"resourcePolicy": "{}"}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn put_missing_policy_errors() {
+        let s = shared();
+        let err = put_resource_policy(&s, &req(), &json!({"resourceArn": ARN}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn get_by_full_arn() {
+        let s = shared();
+        put(&s, ARN);
+        let resp = get_resource_policy(&s, &req(), ARN).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["resourcePolicy"].is_string());
+        assert!(v["revisionId"].is_string());
+    }
+
+    #[test]
+    fn get_by_suffix_id() {
+        let s = shared();
+        put(&s, ARN);
+        assert!(get_resource_policy(&s, &req(), "my-agent").is_ok());
+    }
+
+    #[test]
+    fn get_unknown_returns_not_found() {
+        let s = shared();
+        let err = get_resource_policy(&s, &req(), "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn delete_by_full_arn_then_by_suffix() {
+        let s = shared();
+        put(&s, ARN);
+        delete_resource_policy(&s, &req(), ARN).unwrap();
+        put(&s, ARN);
+        delete_resource_policy(&s, &req(), "my-agent").unwrap();
+        assert!(s.read().default_ref().resource_policies.is_empty());
+    }
+
+    #[test]
+    fn delete_unknown_returns_not_found() {
+        let s = shared();
+        let err = delete_resource_policy(&s, &req(), "missing").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Covers put validation, get by full ARN and suffix, delete by both forms, plus not-found on get and delete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for the Bedrock resource policy lifecycle to verify validation and lookups. Tests cover PUT requiring both resourceArn and resourcePolicy, GET by full ARN and suffix, DELETE by both forms, and 404s for unknown GET/DELETE.

<sup>Written for commit e3b110f3cc702057b49d5b30c7ddf884db53331e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

