### PR TITLE
test(bedrock): invocation logging config

### DIFF
--- a/crates/fakecloud-bedrock/src/logging.rs
+++ b/crates/fakecloud-bedrock/src/logging.rs
@@ -76,3 +76,122 @@ pub fn delete_model_invocation_logging_configuration(
     s.logging_config = None;
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        let multi: MultiAccountState<BedrockState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        Arc::new(RwLock::new(multi))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "r".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn put_requires_logging_config() {
+        let s = shared();
+        let err = put_model_invocation_logging_configuration(&s, &req(), &json!({}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn put_stores_cloudwatch_and_s3_and_defaults_flags_true() {
+        let s = shared();
+        let body = json!({
+            "loggingConfig": {
+                "cloudWatchConfig": {"logGroupName": "lg"},
+                "s3Config": {"bucketName": "b"}
+            }
+        });
+        put_model_invocation_logging_configuration(&s, &req(), &body).unwrap();
+        let st = s.read();
+        let c = st.default_ref().logging_config.as_ref().unwrap();
+        assert!(c.text_data_delivery_enabled);
+        assert!(c.image_data_delivery_enabled);
+        assert!(c.embedding_data_delivery_enabled);
+        assert!(c.cloud_watch_config.is_some());
+        assert!(c.s3_config.is_some());
+    }
+
+    #[test]
+    fn put_honors_explicit_flags() {
+        let s = shared();
+        let body = json!({
+            "loggingConfig": {
+                "textDataDeliveryEnabled": false,
+                "imageDataDeliveryEnabled": false,
+                "embeddingDataDeliveryEnabled": false
+            }
+        });
+        put_model_invocation_logging_configuration(&s, &req(), &body).unwrap();
+        let st = s.read();
+        let c = st.default_ref().logging_config.as_ref().unwrap();
+        assert!(!c.text_data_delivery_enabled);
+        assert!(!c.image_data_delivery_enabled);
+        assert!(!c.embedding_data_delivery_enabled);
+    }
+
+    #[test]
+    fn get_returns_empty_when_not_configured() {
+        let s = shared();
+        let resp = get_model_invocation_logging_configuration(&s, &req()).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert!(v["loggingConfig"].is_null());
+    }
+
+    #[test]
+    fn get_returns_stored_config() {
+        let s = shared();
+        let body = json!({
+            "loggingConfig": {
+                "cloudWatchConfig": {"logGroupName": "lg"},
+                "s3Config": {"bucketName": "b"}
+            }
+        });
+        put_model_invocation_logging_configuration(&s, &req(), &body).unwrap();
+        let resp = get_model_invocation_logging_configuration(&s, &req()).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["loggingConfig"]["cloudWatchConfig"]["logGroupName"], "lg");
+        assert_eq!(v["loggingConfig"]["s3Config"]["bucketName"], "b");
+    }
+
+    #[test]
+    fn delete_clears_config() {
+        let s = shared();
+        let body = json!({"loggingConfig": {}});
+        put_model_invocation_logging_configuration(&s, &req(), &body).unwrap();
+        delete_model_invocation_logging_configuration(&s, &req()).unwrap();
+        assert!(s.read().default_ref().logging_config.is_none());
+    }
+}


### PR DESCRIPTION
Covers put validation + flag defaults + explicit flags, get empty + stored, delete clears state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for Bedrock model invocation logging configuration in `crates/fakecloud-bedrock` to lock in expected API behavior and prevent regressions.

- Validates that `loggingConfig` is required on PUT.
- Ensures default flags are true when omitted and honors explicit false flags.
- Verifies GET returns null when not configured and returns stored CloudWatch/S3 config when set.
- Confirms DELETE clears the stored configuration.

<sup>Written for commit b56d9fb436df2859868695cd1fb3ec18e81c39f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

