### PR TITLE
test(bedrock): event-stream encoding + response text

### DIFF
--- a/crates/fakecloud-bedrock/src/streaming.rs
+++ b/crates/fakecloud-bedrock/src/streaming.rs
@@ -215,3 +215,179 @@ pub fn get_response_text(
     }
     custom
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BedrockState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use fakecloud_core::service::AwsRequest;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> crate::state::SharedBedrockState {
+        let multi: MultiAccountState<BedrockState> =
+            MultiAccountState::new("123456789012", "us-east-1", "http://x");
+        Arc::new(RwLock::new(multi))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "a".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "r".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    /// Parse prelude to verify framing and sizes.
+    fn parse_prelude(buf: &[u8]) -> (u32, u32) {
+        let total = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+        let headers = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]);
+        (total, headers)
+    }
+
+    #[test]
+    fn encode_event_produces_well_formed_frame() {
+        let payload = b"{\"x\":1}";
+        let buf = encode_event("chunk", "application/json", payload);
+        let (total, headers_len) = parse_prelude(&buf);
+        assert_eq!(total as usize, buf.len());
+        let expected_headers = 1 + ":event-type".len()
+            + 1
+            + 2
+            + "chunk".len()
+            + 1
+            + ":content-type".len()
+            + 1
+            + 2
+            + "application/json".len()
+            + 1
+            + ":message-type".len()
+            + 1
+            + 2
+            + "event".len();
+        assert_eq!(headers_len as usize, expected_headers);
+        let start = 12 + headers_len as usize;
+        assert_eq!(&buf[start..start + payload.len()], payload);
+    }
+
+    fn decode_inner_chunk(frame: &[u8]) -> Value {
+        use base64::Engine;
+        let s = String::from_utf8_lossy(frame);
+        let bytes_start = s.find("\"bytes\":").unwrap() + "\"bytes\":".len();
+        let after = &s[bytes_start..];
+        let quote = after.find('"').unwrap();
+        let end = after[quote + 1..].find('"').unwrap();
+        let b64 = &after[quote + 1..quote + 1 + end];
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .unwrap();
+        serde_json::from_slice(&raw).unwrap()
+    }
+
+    #[test]
+    fn build_invoke_stream_response_anthropic_uses_content_block_delta() {
+        let out = build_invoke_stream_response("anthropic.claude-3", "hello");
+        let inner = decode_inner_chunk(&out);
+        assert_eq!(inner["type"], "content_block_delta");
+        assert_eq!(inner["delta"]["text"], "hello");
+    }
+
+    #[test]
+    fn build_invoke_stream_response_generic_uses_output_text() {
+        let out = build_invoke_stream_response("amazon.titan-text-lite", "hi");
+        let inner = decode_inner_chunk(&out);
+        assert_eq!(inner["outputText"], "hi");
+    }
+
+    #[test]
+    fn build_converse_stream_emits_all_events() {
+        let out = build_converse_stream_response("hello world");
+        let s = String::from_utf8_lossy(&out);
+        for marker in [
+            "messageStart",
+            "contentBlockStart",
+            "contentBlockDelta",
+            "contentBlockStop",
+            "messageStop",
+            "metadata",
+            "end_turn",
+        ] {
+            assert!(s.contains(marker), "missing marker {marker}");
+        }
+    }
+
+    #[test]
+    fn default_stream_text_is_non_empty() {
+        assert!(!default_stream_text().is_empty());
+    }
+
+    #[test]
+    fn get_response_text_returns_default_without_override() {
+        let s = shared();
+        let out = get_response_text(&s, &req(), "anthropic.claude", b"{}");
+        assert_eq!(out, default_stream_text());
+    }
+
+    fn install_rule(state: &crate::state::SharedBedrockState, model: &str, response: &str) {
+        let mut st = state.write();
+        let acct = st.get_or_create("123456789012");
+        acct.response_rules.insert(
+            model.to_string(),
+            vec![crate::state::ResponseRule {
+                prompt_contains: None,
+                response: response.to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn get_response_text_extracts_anthropic_content_when_override_present() {
+        let s = shared();
+        install_rule(
+            &s,
+            "anthropic.claude",
+            &json!({ "content": [{"text": "FROM-RULE"}] }).to_string(),
+        );
+        let out = get_response_text(&s, &req(), "anthropic.claude", b"{}");
+        assert_eq!(out, "FROM-RULE");
+    }
+
+    #[test]
+    fn get_response_text_extracts_converse_output_when_override_present() {
+        let s = shared();
+        install_rule(
+            &s,
+            "anthropic.claude",
+            &json!({
+                "output": {"message": {"content": [{"text": "CONV-TEXT"}]}}
+            })
+            .to_string(),
+        );
+        let out = get_response_text(&s, &req(), "anthropic.claude", b"{}");
+        assert_eq!(out, "CONV-TEXT");
+    }
+
+    #[test]
+    fn get_response_text_returns_raw_string_when_not_parseable() {
+        let s = shared();
+        install_rule(&s, "anthropic.claude", "plain raw");
+        let out = get_response_text(&s, &req(), "anthropic.claude", b"{}");
+        assert_eq!(out, "plain raw");
+    }
+}

--- a/crates/fakecloud-bedrock/src/streaming.rs
+++ b/crates/fakecloud-bedrock/src/streaming.rs
@@ -267,7 +267,8 @@ mod tests {
         let buf = encode_event("chunk", "application/json", payload);
         let (total, headers_len) = parse_prelude(&buf);
         assert_eq!(total as usize, buf.len());
-        let expected_headers = 1 + ":event-type".len()
+        let expected_headers = 1
+            + ":event-type".len()
             + 1
             + 2
             + "chunk".len()


### PR DESCRIPTION
Covers prelude framing, invoke-stream chunk payloads (Anthropic vs generic) with base64 decode, converse-stream event set, get_response_text default/rule-based/converse/raw branches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests in `fakecloud-bedrock` for AWS event-stream framing (prelude, header size, payload), base64-decoded invoke-stream chunks for Anthropic (`content_block_delta`) vs generic (`outputText`), full converse-stream event set, and `get_response_text` defaults, rule overrides (Anthropic content and converse output), and raw passthrough. Includes a formatting-only `cargo fmt` pass.

<sup>Written for commit 6bd4ebe7cf6da2af75730a4eb524144b7171ca3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

