### PR TITLE
feat(routing): decode LocalStack-style Host headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 - **Single binary.** ~19 MB, ~10 MiB idle memory, ~500ms startup. No Docker required to run fakecloud itself (only to exercise the services that need real containers).
 - **First-party test SDKs** for TypeScript, Python, Go, PHP, Java, and Rust. Assert on what your code called without writing raw HTTP.
 - **Opt-in SigV4 verification and IAM enforcement.** Off by default so tests just work; turn on `--verify-sigv4` for real cryptographic signature checking and `--iam soft|strict` for identity-policy evaluation (Allow/Deny with Deny precedence, Action/Resource wildcards, user/group/role policies, `Condition` blocks with all 28 AWS operators against global keys like `aws:username` / `aws:SourceIp` / `aws:CurrentTime`, plus resource-based policies for S3 bucket, SNS topic, and Lambda function policies with AWS's cross-account combining semantics) across IAM, STS, SQS, SNS, and S3. See [the security docs](https://fakecloud.dev/docs/reference/security/).
+- **LocalStack URL compatibility.** `*.localhost.localstack.cloud` Host headers decode to service + region for routing, and `<bucket>.s3.<region>.localhost.localstack.cloud` hostnames are accepted as virtual-hosted-style S3. Persisted queue URLs, presigned URLs, and dev scripts from LocalStack replay against fakecloud unchanged.
 
 ## Supported services
 

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -111,8 +111,15 @@ pub async fn dispatch(
     };
     let sigv4_info = header_info.or(presigned_info);
     let access_key_id = sigv4_info.as_ref().map(|info| info.access_key.clone());
+
+    // LocalStack-style Host (`<svc>.<region>.localhost.localstack.cloud[:port]`,
+    // or `<bucket>.s3.<region>.…` for virtual-hosted S3) is a secondary
+    // region source and carries the bucket for virtual-hosted S3 path rewrite.
+    let host_info = protocol::parse_localstack_host_from_headers(&parts.headers);
+
     let region = sigv4_info
         .map(|info| info.region)
+        .or_else(|| host_info.as_ref().map(|h| h.region.clone()))
         .or_else(|| extract_region_from_user_agent(&parts.headers))
         .unwrap_or_else(|| config.region.clone());
 
@@ -226,8 +233,28 @@ pub async fn dispatch(
         }
     }
 
-    // Build path segments
-    let path = parts.uri.path().to_string();
+    // Build path segments. For S3 virtual-hosted-style requests the bucket
+    // lives in the Host header, not the path — prepend it so the S3 handler
+    // sees a uniform path-style request. SigV4 verification above already
+    // ran against the wire path, so this rewrite is signature-safe.
+    let wire_path = parts.uri.path();
+    let path = if detected.service == "s3" {
+        if let Some(bucket) = host_info.as_ref().and_then(|h| h.bucket.as_deref()) {
+            let prefix_with_slash = format!("/{bucket}/");
+            let is_bucket_root = wire_path.trim_end_matches('/') == format!("/{bucket}");
+            if wire_path.starts_with(&prefix_with_slash) || is_bucket_root {
+                wire_path.to_string()
+            } else if wire_path == "/" || wire_path.is_empty() {
+                format!("/{bucket}")
+            } else {
+                format!("/{bucket}{wire_path}")
+            }
+        } else {
+            wire_path.to_string()
+        }
+    } else {
+        wire_path.to_string()
+    };
     let raw_query = parts.uri.query().unwrap_or("").to_string();
     let path_segments: Vec<String> = path
         .split('/')

--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -46,8 +46,9 @@ pub fn detect_service(
 
     // 2. Check for Query protocol (Action parameter in query string or form body)
     if let Some(action) = query_params.get("Action") {
-        let service =
-            extract_service_from_auth(headers).or_else(|| infer_service_from_action(action));
+        let service = extract_service_from_auth(headers)
+            .or_else(|| infer_service_from_action(action))
+            .or_else(|| parse_localstack_host_from_headers(headers).map(|h| h.service));
         if let Some(service) = service {
             return Some(DetectedRequest {
                 service,
@@ -62,8 +63,9 @@ pub fn detect_service(
         let form_params = decode_form_urlencoded(body);
 
         if let Some(action) = form_params.get("Action") {
-            let service =
-                extract_service_from_auth(headers).or_else(|| infer_service_from_action(action));
+            let service = extract_service_from_auth(headers)
+                .or_else(|| infer_service_from_action(action))
+                .or_else(|| parse_localstack_host_from_headers(headers).map(|h| h.service));
             if let Some(service) = service {
                 return Some(DetectedRequest {
                     service,
@@ -115,7 +117,75 @@ pub fn detect_service(
         });
     }
 
+    // 7. Fallback: unsigned REST-style request carrying a LocalStack-shaped
+    //    Host header. Lets fixtures and curl-style probes reach the right
+    //    service without SigV4; signed requests were already handled in step 4.
+    if let Some(host_info) = parse_localstack_host_from_headers(headers) {
+        if let Some(protocol) = rest_protocol_for(&host_info.service) {
+            return Some(DetectedRequest {
+                service: host_info.service,
+                action: String::new(),
+                protocol,
+            });
+        }
+    }
+
     None
+}
+
+/// Service + region (and optional bucket) decoded from a LocalStack-style
+/// Host header: `<service>.<region>.localhost.localstack.cloud[:port]`, or
+/// `<bucket>.s3.<region>.localhost.localstack.cloud[:port]` for
+/// virtual-hosted-style S3.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalStackHost {
+    pub service: String,
+    pub region: String,
+    /// Set only for virtual-hosted-style S3 hostnames.
+    pub bucket: Option<String>,
+}
+
+const LOCALSTACK_SUFFIX: &str = ".localhost.localstack.cloud";
+
+/// Parse a `Host` header value for the LocalStack hostname convention.
+/// Returns `None` for anything that doesn't match — callers fall through
+/// to their existing detection path.
+pub fn parse_localstack_host(host: &str) -> Option<LocalStackHost> {
+    let hostname = host.split(':').next()?;
+    if hostname.is_empty() {
+        return None;
+    }
+    let hostname = hostname.to_ascii_lowercase();
+    let prefix = hostname.strip_suffix(LOCALSTACK_SUFFIX)?;
+    if prefix.is_empty() {
+        return None;
+    }
+    let labels: Vec<&str> = prefix.split('.').collect();
+    if labels.iter().any(|l| l.is_empty()) {
+        return None;
+    }
+    match labels.len() {
+        2 => Some(LocalStackHost {
+            service: labels[0].to_string(),
+            region: labels[1].to_string(),
+            bucket: None,
+        }),
+        n if n >= 3 && labels[n - 2] == "s3" => {
+            let bucket = labels[..n - 2].join(".");
+            Some(LocalStackHost {
+                service: "s3".to_string(),
+                region: labels[n - 1].to_string(),
+                bucket: Some(bucket),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Pull the `Host` header and parse it with [`parse_localstack_host`].
+pub fn parse_localstack_host_from_headers(headers: &HeaderMap) -> Option<LocalStackHost> {
+    let host = headers.get("host")?.to_str().ok()?;
+    parse_localstack_host(host)
 }
 
 /// Parse `X-Amz-Target: AWSEvents.PutEvents` -> service=events, action=PutEvents
@@ -536,5 +606,156 @@ mod tests {
         let query = HashMap::new();
         let body = Bytes::new();
         assert!(detect_service(&headers, &query, &body).is_none());
+    }
+
+    #[test]
+    fn parse_localstack_host_basic() {
+        let h = parse_localstack_host("sqs.us-east-1.localhost.localstack.cloud").unwrap();
+        assert_eq!(h.service, "sqs");
+        assert_eq!(h.region, "us-east-1");
+        assert!(h.bucket.is_none());
+    }
+
+    #[test]
+    fn parse_localstack_host_with_port() {
+        let h = parse_localstack_host("lambda.eu-west-1.localhost.localstack.cloud:4566").unwrap();
+        assert_eq!(h.service, "lambda");
+        assert_eq!(h.region, "eu-west-1");
+        assert!(h.bucket.is_none());
+    }
+
+    #[test]
+    fn parse_localstack_host_case_insensitive() {
+        let h = parse_localstack_host("SQS.US-EAST-1.LOCALHOST.LOCALSTACK.CLOUD:4566").unwrap();
+        assert_eq!(h.service, "sqs");
+        assert_eq!(h.region, "us-east-1");
+    }
+
+    #[test]
+    fn parse_localstack_host_s3_virtual_hosted() {
+        let h = parse_localstack_host("my-bucket.s3.us-east-1.localhost.localstack.cloud:4566")
+            .unwrap();
+        assert_eq!(h.service, "s3");
+        assert_eq!(h.region, "us-east-1");
+        assert_eq!(h.bucket.as_deref(), Some("my-bucket"));
+    }
+
+    #[test]
+    fn parse_localstack_host_s3_vhost_bucket_with_dots() {
+        let h = parse_localstack_host("a.b.c.s3.us-east-1.localhost.localstack.cloud").unwrap();
+        assert_eq!(h.service, "s3");
+        assert_eq!(h.region, "us-east-1");
+        assert_eq!(h.bucket.as_deref(), Some("a.b.c"));
+    }
+
+    #[test]
+    fn parse_localstack_host_rejects_amazonaws_com() {
+        assert!(parse_localstack_host("s3.us-east-1.amazonaws.com").is_none());
+        assert!(parse_localstack_host("my-bucket.s3.us-east-1.amazonaws.com").is_none());
+    }
+
+    #[test]
+    fn parse_localstack_host_rejects_plain_localhost() {
+        assert!(parse_localstack_host("localhost:4566").is_none());
+        assert!(parse_localstack_host("127.0.0.1:4566").is_none());
+    }
+
+    #[test]
+    fn parse_localstack_host_empty_and_malformed_rejected() {
+        assert!(parse_localstack_host("").is_none());
+        assert!(parse_localstack_host(".localhost.localstack.cloud").is_none());
+        assert!(parse_localstack_host("..localhost.localstack.cloud").is_none());
+        assert!(parse_localstack_host("sqs.localhost.localstack.cloud").is_none());
+        assert!(parse_localstack_host("foo.bar.baz.localhost.localstack.cloud").is_none());
+    }
+
+    #[test]
+    fn detect_service_via_host_for_rest_service() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "host",
+            "s3.us-east-1.localhost.localstack.cloud:4566"
+                .parse()
+                .unwrap(),
+        );
+        let query = HashMap::new();
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "s3");
+        assert_eq!(detected.protocol, AwsProtocol::Rest);
+    }
+
+    #[test]
+    fn detect_service_via_host_for_rest_json_service() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "host",
+            "lambda.us-east-1.localhost.localstack.cloud:4566"
+                .parse()
+                .unwrap(),
+        );
+        let query = HashMap::new();
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "lambda");
+        assert_eq!(detected.protocol, AwsProtocol::RestJson);
+    }
+
+    #[test]
+    fn detect_service_via_host_plus_query_action() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "host",
+            "sqs.us-east-1.localhost.localstack.cloud:4566"
+                .parse()
+                .unwrap(),
+        );
+        let mut query = HashMap::new();
+        query.insert("Action".to_string(), "ListQueues".to_string());
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "sqs");
+        assert_eq!(detected.action, "ListQueues");
+        assert_eq!(detected.protocol, AwsProtocol::Query);
+    }
+
+    #[test]
+    fn detect_service_sigv4_wins_over_host() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/s3/aws4_request, \
+             SignedHeaders=host, Signature=abc"
+                .parse()
+                .unwrap(),
+        );
+        headers.insert(
+            "host",
+            "lambda.us-east-1.localhost.localstack.cloud:4566"
+                .parse()
+                .unwrap(),
+        );
+        let query = HashMap::new();
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        // SigV4 credential scope says s3; Host header says lambda. SigV4 wins.
+        assert_eq!(detected.service, "s3");
+        assert_eq!(detected.protocol, AwsProtocol::Rest);
+    }
+
+    #[test]
+    fn detect_service_host_for_virtual_hosted_s3() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "host",
+            "my-bucket.s3.us-east-1.localhost.localstack.cloud:4566"
+                .parse()
+                .unwrap(),
+        );
+        let query = HashMap::new();
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "s3");
+        assert_eq!(detected.protocol, AwsProtocol::Rest);
     }
 }

--- a/crates/fakecloud-e2e/tests/host_routing.rs
+++ b/crates/fakecloud-e2e/tests/host_routing.rs
@@ -1,0 +1,253 @@
+//! LocalStack-style Host header decoding.
+//!
+//! Fakecloud treats `<service>.<region>.localhost.localstack.cloud[:port]`
+//! and `<bucket>.s3.<region>.localhost.localstack.cloud[:port]` as valid
+//! routing signals so that fixtures, presigned URLs, and dev scripts
+//! persisted against LocalStack can be replayed unchanged against
+//! fakecloud.
+
+mod helpers;
+
+use aws_sdk_s3::primitives::ByteStream;
+use helpers::TestServer;
+
+fn localstack_host(sub: &str, port: u16) -> String {
+    format!("{sub}.localhost.localstack.cloud:{port}")
+}
+
+#[tokio::test]
+async fn unsigned_sqs_list_queues_via_host_header() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+
+    let resp = http
+        .post(format!("{}/", server.endpoint()))
+        .header("Host", localstack_host("sqs.us-east-1", server.port()))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body("Action=ListQueues&Version=2012-11-05")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("ListQueuesResponse") || body.contains("ListQueuesResult"),
+        "expected SQS XML response, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn unsigned_s3_list_buckets_via_host_header() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+
+    let resp = http
+        .get(format!("{}/", server.endpoint()))
+        .header("Host", localstack_host("s3.us-east-1", server.port()))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("ListAllMyBucketsResult"),
+        "expected S3 ListAllMyBuckets XML, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn unsigned_lambda_list_functions_via_host_header() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+
+    let resp = http
+        .get(format!("{}/2015-03-31/functions/", server.endpoint()))
+        .header("Host", localstack_host("lambda.us-east-1", server.port()))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    // Lambda returns JSON with a Functions array.
+    assert!(
+        body.contains("Functions"),
+        "expected Lambda ListFunctions JSON, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn s3_virtual_hosted_put_get_delete() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+
+    // Create the bucket path-style via the SDK.
+    s3.create_bucket()
+        .bucket("vhost-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let vhost_host = localstack_host("vhost-bucket.s3.us-east-1", server.port());
+
+    // PUT object via virtual-hosted-style: URL path is `/key` (no bucket),
+    // bucket lives in the Host header.
+    let put = http
+        .put(format!("{}/hello.txt", server.endpoint()))
+        .header("Host", &vhost_host)
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=test/20240101/us-east-1/s3/aws4_request, \
+             SignedHeaders=host, Signature=fake",
+        )
+        .body("hello world")
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        put.status().is_success(),
+        "PUT failed: {} — {}",
+        put.status(),
+        put.text().await.unwrap_or_default()
+    );
+
+    // GET it back virtual-hosted.
+    let get = http
+        .get(format!("{}/hello.txt", server.endpoint()))
+        .header("Host", &vhost_host)
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=test/20240101/us-east-1/s3/aws4_request, \
+             SignedHeaders=host, Signature=fake",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.status(), 200);
+    assert_eq!(get.text().await.unwrap(), "hello world");
+
+    // DELETE virtual-hosted.
+    let del = http
+        .delete(format!("{}/hello.txt", server.endpoint()))
+        .header("Host", &vhost_host)
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=test/20240101/us-east-1/s3/aws4_request, \
+             SignedHeaders=host, Signature=fake",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(del.status().is_success());
+
+    // Confirm through the SDK (path-style) that the object is gone.
+    let list = s3
+        .list_objects_v2()
+        .bucket("vhost-bucket")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(list.contents().len(), 0);
+}
+
+#[tokio::test]
+async fn s3_virtual_hosted_bucket_with_dots() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket().bucket("a.b.c").send().await.unwrap();
+    s3.put_object()
+        .bucket("a.b.c")
+        .key("obj")
+        .body(ByteStream::from_static(b"dotted"))
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!("{}/obj", server.endpoint()))
+        .header("Host", localstack_host("a.b.c.s3.us-east-1", server.port()))
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=test/20240101/us-east-1/s3/aws4_request, \
+             SignedHeaders=host, Signature=fake",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "dotted");
+}
+
+#[tokio::test]
+async fn s3_virtual_hosted_list_objects_on_bucket_root() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket()
+        .bucket("root-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    // GET / against the vhost hostname = ListObjectsV1 on the bucket.
+    let resp = http
+        .get(format!("{}/", server.endpoint()))
+        .header(
+            "Host",
+            localstack_host("root-bucket.s3.us-east-1", server.port()),
+        )
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=test/20240101/us-east-1/s3/aws4_request, \
+             SignedHeaders=host, Signature=fake",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("ListBucketResult"),
+        "expected ListBucketResult XML, got: {body}"
+    );
+    assert!(body.contains("<Name>root-bucket</Name>"));
+}
+
+#[tokio::test]
+async fn sigv4_credential_scope_wins_over_host_header() {
+    // A signed S3 request whose Host header is shaped like a Lambda
+    // hostname must still be dispatched to S3 — the SigV4 scope is
+    // the canonical truth, otherwise CDN-style proxies mutating the
+    // Host header could redirect signed traffic to the wrong service.
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket()
+        .bucket("sigv4-wins")
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!("{}/sigv4-wins/", server.endpoint()))
+        .header("Host", localstack_host("lambda.us-east-1", server.port()))
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=test/20240101/us-east-1/s3/aws4_request, \
+             SignedHeaders=host, Signature=fake",
+        )
+        .send()
+        .await
+        .unwrap();
+    // S3 ListObjectsV1: status 200 with ListBucketResult XML.
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("ListBucketResult"),
+        "expected S3 response despite Lambda-shaped Host, got: {body}"
+    );
+}

--- a/website/content/docs/reference/configuration.md
+++ b/website/content/docs/reference/configuration.md
@@ -41,3 +41,28 @@ FAKECLOUD_REGION=eu-central-1 fakecloud
 ```
 
 See also [Persistence](/docs/reference/persistence/) for details on persistent storage mode.
+
+## LocalStack URL compatibility
+
+fakecloud decodes LocalStack's `*.localhost.localstack.cloud` hostname convention so persisted URLs from a LocalStack setup — queue URLs baked into dev scripts, presigned URLs in fixtures, webhook targets in response mocks — replay against fakecloud without rewriting. Two patterns are recognized on the `Host` header:
+
+| Host pattern                                                | Routed as                             |
+| ----------------------------------------------------------- | ------------------------------------- |
+| `<service>.<region>.localhost.localstack.cloud[:port]`      | `<service>` in `<region>`             |
+| `<bucket>.s3.<region>.localhost.localstack.cloud[:port]`    | S3 virtual-hosted-style on `<bucket>` |
+
+The DNS wildcard `*.localhost.localstack.cloud` resolves to `127.0.0.1`, so TCP reaches fakecloud unchanged; fakecloud then parses the hostname to recover service, region, and (for S3) bucket. SigV4-signed requests still route by credential scope first — the hostname is a secondary signal that takes over when the request is unsigned, uses a non-standard `Authorization` header, or is being probed with `curl`.
+
+```bash
+# Unsigned SQS request — routed to SQS purely by Host header
+curl -X POST \
+     -H 'Host: sqs.us-east-1.localhost.localstack.cloud:4566' \
+     -d 'Action=ListQueues&Version=2012-11-05' \
+     http://127.0.0.1:4566/
+
+# Virtual-hosted-style S3 GetObject — bucket recovered from Host header
+curl -H 'Host: my-bucket.s3.us-east-1.localhost.localstack.cloud:4566' \
+     http://127.0.0.1:4566/key
+```
+
+Bucket names with dots (e.g. `a.b.c`) are supported; fakecloud recognizes the `.s3.<region>.localhost.localstack.cloud` suffix and treats everything before it as the bucket label.


### PR DESCRIPTION
## Summary

Teams migrating from LocalStack carry persisted URLs like `http://sqs.us-east-1.localhost.localstack.cloud:4566/<account>/<queue>` and `http://<bucket>.s3.us-east-1.localhost.localstack.cloud:4566/key` baked into dev scripts, fixtures, presigned URLs, and webhooks. The DNS wildcard `*.localhost.localstack.cloud` already resolves to `127.0.0.1`, so TCP reaches fakecloud — but until now fakecloud ignored the Host header for routing.

- Parse `<service>.<region>.localhost.localstack.cloud[:port]` as a routing fallback, equivalent to inspecting the SigV4 credential scope. Kicks in for unsigned/curl-style/non-standard-Auth requests; SigV4-signed requests still route by credential scope.
- Accept `<bucket>.s3.<region>.localhost.localstack.cloud[:port]` as virtual-hosted-style S3 and rewrite to path-style before the S3 handler sees it. Bucket names with dots (e.g. `a.b.c`) work.
- Use the Host-derived region as an extra region fallback in dispatch.

Closes the gap for dropping fakecloud into an existing LocalStack-shaped test setup without rewriting a single fixture.

## Test plan

- [x] Unit tests for `parse_localstack_host` (port stripping, case, vhost, bucket-with-dots, rejection cases) and `detect_service` integration (host for REST, host + Action param, SigV4 precedence).
- [x] E2E tests in `host_routing.rs`: unsigned SQS ListQueues via Host header, unsigned S3 ListBuckets via Host header, unsigned Lambda ListFunctions via Host header, virtual-hosted S3 PUT/GET/DELETE, virtual-hosted S3 with dots in bucket name, virtual-hosted S3 ListObjectsV1 on bucket root, SigV4 scope wins over Host header.
- [x] Regression: full `fakecloud-e2e --test s3` (64 tests), `sigv4_verification` (6), `multi_account` (6) green locally.
- [x] `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LocalStack URL compatibility so existing `*.localhost.localstack.cloud` URLs route correctly without changes. This enables unsigned and curl-style requests to reach the right service and supports S3 virtual-hosted-style buckets.

- **New Features**
  - Decode Host headers `<service>.<region>.localhost.localstack.cloud[:port]` and `<bucket>.s3.<region>.localhost.localstack.cloud[:port]` to route requests; buckets with dots are supported.
  - Rewrite S3 virtual-hosted requests to path-style before handling to keep S3 logic uniform.
  - Use Host-derived region as a fallback; SigV4 credential scope still takes precedence for signed requests.

<sup>Written for commit 054e28a878bfa514615a6f8d3d58f40ac81328b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

