### PR TITLE
feat(organizations): OU tree + account membership + auto-enrollment

### DIFF
--- a/crates/fakecloud-e2e/tests/organizations.rs
+++ b/crates/fakecloud-e2e/tests/organizations.rs
@@ -121,3 +121,125 @@ async fn only_management_can_delete_organization() {
     let err = orgs_a.describe_organization().send().await.unwrap_err();
     assert!(format!("{err:?}").contains("AWSOrganizationsNotInUseException"));
 }
+
+#[tokio::test]
+async fn list_roots_after_create() {
+    let server = start().await;
+    let (akid, secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let cfg = config_with(&server, &akid, &secret).await;
+    let orgs = OrgsClient::new(&cfg);
+
+    orgs.create_organization().send().await.unwrap();
+    let roots = orgs.list_roots().send().await.unwrap();
+    let roots = roots.roots();
+    assert_eq!(roots.len(), 1);
+    assert!(roots[0].id().unwrap().starts_with("r-"));
+}
+
+#[tokio::test]
+async fn ou_tree_crud_and_move_account() {
+    let server = start().await;
+    let (a_akid, a_secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let a_cfg = config_with(&server, &a_akid, &a_secret).await;
+    let orgs = OrgsClient::new(&a_cfg);
+
+    orgs.create_organization().send().await.unwrap();
+    let root_id = orgs.list_roots().send().await.unwrap().roots()[0]
+        .id()
+        .unwrap()
+        .to_string();
+
+    // Create OU, account B auto-enrolls into root when admin created.
+    let (_b_akid, _b_secret) = server.create_admin(ACCOUNT_B, "admin-b").await;
+
+    let ou = orgs
+        .create_organizational_unit()
+        .parent_id(&root_id)
+        .name("engineering")
+        .send()
+        .await
+        .unwrap();
+    let ou_id = ou.organizational_unit().unwrap().id().unwrap().to_string();
+
+    // Duplicate name under same parent -> DuplicateOrganizationalUnitException.
+    let err = orgs
+        .create_organizational_unit()
+        .parent_id(&root_id)
+        .name("engineering")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("DuplicateOrganizationalUnitException"));
+
+    // Move account B from root to the new OU.
+    orgs.move_account()
+        .account_id(ACCOUNT_B)
+        .source_parent_id(&root_id)
+        .destination_parent_id(&ou_id)
+        .send()
+        .await
+        .unwrap();
+
+    let in_ou = orgs
+        .list_accounts_for_parent()
+        .parent_id(&ou_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(in_ou.accounts().len(), 1);
+    assert_eq!(in_ou.accounts()[0].id().unwrap(), ACCOUNT_B);
+
+    // Deleting the non-empty OU must fail.
+    let err = orgs
+        .delete_organizational_unit()
+        .organizational_unit_id(&ou_id)
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("OrganizationalUnitNotEmptyException"));
+
+    // Move back, then delete — should succeed.
+    orgs.move_account()
+        .account_id(ACCOUNT_B)
+        .source_parent_id(&ou_id)
+        .destination_parent_id(&root_id)
+        .send()
+        .await
+        .unwrap();
+    orgs.delete_organizational_unit()
+        .organizational_unit_id(&ou_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn non_management_member_cannot_create_ou() {
+    let server = start().await;
+    let (a_akid, a_secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let a_cfg = config_with(&server, &a_akid, &a_secret).await;
+    let orgs_a = OrgsClient::new(&a_cfg);
+
+    // Create the org before bootstrapping account B so B auto-enrolls
+    // into root as a member — otherwise B is a non-member and the
+    // attempt would return `AWSOrganizationsNotInUseException` instead
+    // of `AccessDeniedException`.
+    orgs_a.create_organization().send().await.unwrap();
+    let root_id = orgs_a.list_roots().send().await.unwrap().roots()[0]
+        .id()
+        .unwrap()
+        .to_string();
+
+    let (b_akid, b_secret) = server.create_admin(ACCOUNT_B, "admin-b").await;
+    let b_cfg = config_with(&server, &b_akid, &b_secret).await;
+    let orgs_b = OrgsClient::new(&b_cfg);
+
+    let err = orgs_b
+        .create_organizational_unit()
+        .parent_id(&root_id)
+        .name("forbidden")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("AccessDeniedException"));
+}

--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -611,4 +611,567 @@ mod tests {
         );
         assert_eq!(err.code(), "UnsupportedAPIEndpointException");
     }
+
+    /// Helper: create org with ACCOUNT_A as management, return shared
+    /// state + root id for subsequent assertions.
+    async fn create_org_with_root(svc: &Arc<OrganizationsService>) -> String {
+        svc.handle(req_with("111111111111", "CreateOrganization", json!({})))
+            .await
+            .unwrap();
+        let roots = svc
+            .handle(req_with("111111111111", "ListRoots", json!({})))
+            .await
+            .unwrap();
+        let v = body_json(&roots);
+        v["Roots"][0]["Id"].as_str().unwrap().to_string()
+    }
+
+    #[tokio::test]
+    async fn list_roots_returns_single_root() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        assert!(root_id.starts_with("r-"));
+    }
+
+    #[tokio::test]
+    async fn list_roots_non_member_hidden() {
+        let (svc, _state) = OrganizationsService::shared();
+        svc.handle(req_with("111111111111", "CreateOrganization", json!({})))
+            .await
+            .unwrap();
+        let err = expect_err(
+            svc.handle(req_with("999999999999", "ListRoots", json!({})))
+                .await,
+        );
+        assert_eq!(err.code(), "AWSOrganizationsNotInUseException");
+    }
+
+    #[tokio::test]
+    async fn create_ou_happy_path_and_describe() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let created = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": root_id, "Name": "eng"}),
+            ))
+            .await
+            .unwrap();
+        let ou = body_json(&created);
+        let ou_id = ou["OrganizationalUnit"]["Id"].as_str().unwrap().to_string();
+        assert!(ou_id.starts_with("ou-"));
+
+        let described = svc
+            .handle(req_with(
+                "111111111111",
+                "DescribeOrganizationalUnit",
+                json!({"OrganizationalUnitId": ou_id}),
+            ))
+            .await
+            .unwrap();
+        let v = body_json(&described);
+        assert_eq!(v["OrganizationalUnit"]["Name"], "eng");
+    }
+
+    #[tokio::test]
+    async fn create_ou_missing_parent_id_rejected() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"Name": "eng"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "InvalidInputException");
+    }
+
+    #[tokio::test]
+    async fn create_ou_duplicate_under_same_parent() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        svc.handle(req_with(
+            "111111111111",
+            "CreateOrganizationalUnit",
+            json!({"ParentId": root_id, "Name": "eng"}),
+        ))
+        .await
+        .unwrap();
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": root_id, "Name": "eng"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "DuplicateOrganizationalUnitException");
+    }
+
+    #[tokio::test]
+    async fn create_ou_unknown_parent_rejected() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": "ou-bogus", "Name": "eng"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "ParentNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn create_ou_non_management_rejected() {
+        let (svc, state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        // Enroll a non-management member directly.
+        {
+            let mut guard = state.write();
+            guard
+                .as_mut()
+                .unwrap()
+                .enroll_account_if_missing("222222222222");
+        }
+        let err = expect_err(
+            svc.handle(req_with(
+                "222222222222",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": root_id, "Name": "eng"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "AccessDeniedException");
+    }
+
+    #[tokio::test]
+    async fn create_ou_without_org_not_in_use() {
+        let (svc, _state) = OrganizationsService::shared();
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": "r-whatever", "Name": "eng"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "AWSOrganizationsNotInUseException");
+    }
+
+    #[tokio::test]
+    async fn update_ou_renames_and_rejects_dup() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let created = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": root_id, "Name": "eng"}),
+            ))
+            .await
+            .unwrap();
+        let ou_id = body_json(&created)["OrganizationalUnit"]["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        svc.handle(req_with(
+            "111111111111",
+            "CreateOrganizationalUnit",
+            json!({"ParentId": root_id, "Name": "ops"}),
+        ))
+        .await
+        .unwrap();
+
+        let renamed = svc
+            .handle(req_with(
+                "111111111111",
+                "UpdateOrganizationalUnit",
+                json!({"OrganizationalUnitId": ou_id, "Name": "platform"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            body_json(&renamed)["OrganizationalUnit"]["Name"],
+            "platform"
+        );
+
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "UpdateOrganizationalUnit",
+                json!({"OrganizationalUnitId": ou_id, "Name": "ops"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "DuplicateOrganizationalUnitException");
+    }
+
+    #[tokio::test]
+    async fn update_ou_unknown_id_rejected() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "UpdateOrganizationalUnit",
+                json!({"OrganizationalUnitId": "ou-unknown", "Name": "x"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "OrganizationalUnitNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn delete_ou_rejects_when_not_empty() {
+        let (svc, state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let created = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": root_id, "Name": "eng"}),
+            ))
+            .await
+            .unwrap();
+        let ou_id = body_json(&created)["OrganizationalUnit"]["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        {
+            let mut guard = state.write();
+            let org = guard.as_mut().unwrap();
+            org.enroll_account_if_missing("222222222222");
+            let root = org.root_id.clone();
+            org.move_account("222222222222", &root, &ou_id).unwrap();
+        }
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "DeleteOrganizationalUnit",
+                json!({"OrganizationalUnitId": ou_id}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "OrganizationalUnitNotEmptyException");
+    }
+
+    #[tokio::test]
+    async fn delete_ou_unknown_rejected() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "DeleteOrganizationalUnit",
+                json!({"OrganizationalUnitId": "ou-unknown"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "OrganizationalUnitNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn describe_ou_unknown_rejected() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "DescribeOrganizationalUnit",
+                json!({"OrganizationalUnitId": "ou-unknown"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "OrganizationalUnitNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn list_ous_for_parent_filters_by_parent() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let created = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": root_id, "Name": "top"}),
+            ))
+            .await
+            .unwrap();
+        let top_id = body_json(&created)["OrganizationalUnit"]["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        svc.handle(req_with(
+            "111111111111",
+            "CreateOrganizationalUnit",
+            json!({"ParentId": top_id, "Name": "child"}),
+        ))
+        .await
+        .unwrap();
+
+        let under_root = svc
+            .handle(req_with(
+                "111111111111",
+                "ListOrganizationalUnitsForParent",
+                json!({"ParentId": root_id}),
+            ))
+            .await
+            .unwrap();
+        let v = body_json(&under_root);
+        assert_eq!(v["OrganizationalUnits"].as_array().unwrap().len(), 1);
+        assert_eq!(v["OrganizationalUnits"][0]["Id"], top_id);
+
+        let under_top = svc
+            .handle(req_with(
+                "111111111111",
+                "ListOrganizationalUnitsForParent",
+                json!({"ParentId": top_id}),
+            ))
+            .await
+            .unwrap();
+        let v = body_json(&under_top);
+        assert_eq!(v["OrganizationalUnits"].as_array().unwrap().len(), 1);
+        assert_eq!(v["OrganizationalUnits"][0]["Name"], "child");
+    }
+
+    #[tokio::test]
+    async fn list_ous_for_parent_unknown_parent() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "ListOrganizationalUnitsForParent",
+                json!({"ParentId": "ou-unknown"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "ParentNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn list_accounts_returns_all_members() {
+        let (svc, state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        {
+            let mut guard = state.write();
+            guard
+                .as_mut()
+                .unwrap()
+                .enroll_account_if_missing("222222222222");
+        }
+        let resp = svc
+            .handle(req_with("111111111111", "ListAccounts", json!({})))
+            .await
+            .unwrap();
+        let v = body_json(&resp);
+        assert_eq!(v["Accounts"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn list_accounts_for_parent_scopes_to_parent() {
+        let (svc, state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let created = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": root_id, "Name": "team"}),
+            ))
+            .await
+            .unwrap();
+        let ou_id = body_json(&created)["OrganizationalUnit"]["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        {
+            let mut guard = state.write();
+            let org = guard.as_mut().unwrap();
+            org.enroll_account_if_missing("222222222222");
+            org.move_account("222222222222", &org.root_id.clone(), &ou_id)
+                .unwrap();
+        }
+        let in_ou = svc
+            .handle(req_with(
+                "111111111111",
+                "ListAccountsForParent",
+                json!({"ParentId": ou_id}),
+            ))
+            .await
+            .unwrap();
+        let v = body_json(&in_ou);
+        assert_eq!(v["Accounts"].as_array().unwrap().len(), 1);
+        assert_eq!(v["Accounts"][0]["Id"], "222222222222");
+    }
+
+    #[tokio::test]
+    async fn list_accounts_for_parent_unknown_rejected() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "ListAccountsForParent",
+                json!({"ParentId": "ou-unknown"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "ParentNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn describe_account_roundtrip_and_unknown() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "DescribeAccount",
+                json!({"AccountId": "111111111111"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(body_json(&resp)["Account"]["Id"], "111111111111");
+
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "DescribeAccount",
+                json!({"AccountId": "999999999999"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "AccountNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn move_account_happy_path() {
+        let (svc, state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let created = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": root_id, "Name": "team"}),
+            ))
+            .await
+            .unwrap();
+        let ou_id = body_json(&created)["OrganizationalUnit"]["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        {
+            let mut guard = state.write();
+            guard
+                .as_mut()
+                .unwrap()
+                .enroll_account_if_missing("222222222222");
+        }
+        svc.handle(req_with(
+            "111111111111",
+            "MoveAccount",
+            json!({
+                "AccountId": "222222222222",
+                "SourceParentId": root_id,
+                "DestinationParentId": ou_id,
+            }),
+        ))
+        .await
+        .unwrap();
+        let guard = state.read();
+        let org = guard.as_ref().unwrap();
+        assert_eq!(org.accounts.get("222222222222").unwrap().parent_id, ou_id);
+    }
+
+    #[tokio::test]
+    async fn move_account_unknown_account() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "MoveAccount",
+                json!({
+                    "AccountId": "777777777777",
+                    "SourceParentId": root_id,
+                    "DestinationParentId": root_id,
+                }),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "AccountNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn move_account_wrong_source_parent() {
+        let (svc, state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let created = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateOrganizationalUnit",
+                json!({"ParentId": root_id, "Name": "team"}),
+            ))
+            .await
+            .unwrap();
+        let ou_id = body_json(&created)["OrganizationalUnit"]["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        {
+            let mut guard = state.write();
+            guard
+                .as_mut()
+                .unwrap()
+                .enroll_account_if_missing("222222222222");
+        }
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "MoveAccount",
+                json!({
+                    "AccountId": "222222222222",
+                    "SourceParentId": ou_id,
+                    "DestinationParentId": root_id,
+                }),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "SourceParentNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn move_account_unknown_destination() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "MoveAccount",
+                json!({
+                    "AccountId": "111111111111",
+                    "SourceParentId": root_id,
+                    "DestinationParentId": "ou-bogus",
+                }),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "DestinationParentNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn unknown_action_returns_not_implemented() {
+        let (svc, _state) = OrganizationsService::shared();
+        let err = expect_err(
+            svc.handle(req_with("111111111111", "BogusAction", json!({})))
+                .await,
+        );
+        // ActionNotImplemented carries NOT_IMPLEMENTED status.
+        assert_eq!(err.status(), StatusCode::NOT_IMPLEMENTED);
+    }
 }

--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -6,14 +6,27 @@ use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
-use crate::state::{OrganizationState, SharedOrganizationsState, FEATURE_SET_ALL};
+use crate::state::{
+    MemberAccount, OrgError, OrganizationState, OrganizationalUnit, SharedOrganizationsState,
+    FEATURE_SET_ALL,
+};
 
 /// Single source of truth for supported Organizations actions. Expanded
-/// across subsequent batches (OUs, Policy CRUD, attachment ops).
+/// across subsequent batches (SCP CRUD + attachment ops).
 pub static ORGANIZATIONS_ACTIONS: &[&str] = &[
     "CreateOrganization",
     "DescribeOrganization",
     "DeleteOrganization",
+    "ListRoots",
+    "CreateOrganizationalUnit",
+    "UpdateOrganizationalUnit",
+    "DeleteOrganizationalUnit",
+    "DescribeOrganizationalUnit",
+    "ListOrganizationalUnitsForParent",
+    "ListAccounts",
+    "ListAccountsForParent",
+    "DescribeAccount",
+    "MoveAccount",
 ];
 
 pub struct OrganizationsService {
@@ -112,6 +125,186 @@ impl OrganizationsService {
         *guard = None;
         Ok(AwsResponse::ok_json(Value::Null))
     }
+
+    fn list_roots(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        let root = json!({
+            "Id": org.root_id,
+            "Arn": org.root_arn,
+            "Name": org.root_name,
+            "PolicyTypes": [
+                {"Type": "SERVICE_CONTROL_POLICY", "Status": "ENABLED"}
+            ],
+        });
+        Ok(AwsResponse::ok_json(json!({ "Roots": [root] })))
+    }
+
+    fn create_organizational_unit(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let parent_id = required_str(&body, "ParentId")?;
+        let name = required_str(&body, "Name")?;
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().unwrap();
+        let ou = org.create_ou(parent_id, name).map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(
+            json!({ "OrganizationalUnit": ou_payload(&ou) }),
+        ))
+    }
+
+    fn update_organizational_unit(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let ou_id = required_str(&body, "OrganizationalUnitId")?;
+        let new_name = required_str(&body, "Name")?;
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().unwrap();
+        let ou = org.rename_ou(ou_id, new_name).map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(
+            json!({ "OrganizationalUnit": ou_payload(&ou) }),
+        ))
+    }
+
+    fn delete_organizational_unit(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let ou_id = required_str(&body, "OrganizationalUnitId")?;
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().unwrap();
+        org.delete_ou(ou_id).map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(Value::Null))
+    }
+
+    fn describe_organizational_unit(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let ou_id = required_str(&body, "OrganizationalUnitId")?;
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        let ou = org.ous.get(ou_id).ok_or_else(|| {
+            org_error_to_aws(OrgError::OrganizationalUnitNotFound(ou_id.to_string()))
+        })?;
+        Ok(AwsResponse::ok_json(
+            json!({ "OrganizationalUnit": ou_payload(ou) }),
+        ))
+    }
+
+    fn list_organizational_units_for_parent(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let parent_id = required_str(&body, "ParentId")?;
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        if parent_id != org.root_id && !org.ous.contains_key(parent_id) {
+            return Err(org_error_to_aws(OrgError::ParentNotFound(
+                parent_id.to_string(),
+            )));
+        }
+        let children: Vec<Value> = org
+            .ous
+            .values()
+            .filter(|ou| ou.parent_id == parent_id)
+            .map(ou_payload)
+            .collect();
+        Ok(AwsResponse::ok_json(
+            json!({ "OrganizationalUnits": children }),
+        ))
+    }
+
+    fn list_accounts(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        let accounts: Vec<Value> = org.accounts.values().map(account_payload).collect();
+        Ok(AwsResponse::ok_json(json!({ "Accounts": accounts })))
+    }
+
+    fn list_accounts_for_parent(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let parent_id = required_str(&body, "ParentId")?;
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        if parent_id != org.root_id && !org.ous.contains_key(parent_id) {
+            return Err(org_error_to_aws(OrgError::ParentNotFound(
+                parent_id.to_string(),
+            )));
+        }
+        let accounts: Vec<Value> = org
+            .accounts
+            .values()
+            .filter(|a| a.parent_id == parent_id)
+            .map(account_payload)
+            .collect();
+        Ok(AwsResponse::ok_json(json!({ "Accounts": accounts })))
+    }
+
+    fn describe_account(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let account_id = required_str(&body, "AccountId")?;
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        let account = org
+            .accounts
+            .get(account_id)
+            .ok_or_else(|| org_error_to_aws(OrgError::AccountNotFound(account_id.to_string())))?;
+        Ok(AwsResponse::ok_json(
+            json!({ "Account": account_payload(account) }),
+        ))
+    }
+
+    fn move_account(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let account_id = required_str(&body, "AccountId")?;
+        let source = required_str(&body, "SourceParentId")?;
+        let dest = required_str(&body, "DestinationParentId")?;
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().unwrap();
+        org.move_account(account_id, source, dest)
+            .map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(Value::Null))
+    }
+
+    /// Read-side helper: enforce that an org exists and the caller is a
+    /// member. Returns the borrowed org on success.
+    fn require_member<'a>(
+        &self,
+        guard: &'a parking_lot::RwLockReadGuard<'_, Option<OrganizationState>>,
+        account_id: &str,
+    ) -> Result<&'a OrganizationState, AwsServiceError> {
+        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
+        if !org.accounts.contains_key(account_id) {
+            return Err(organizations_not_in_use());
+        }
+        Ok(org)
+    }
+
+    /// Write-side helper for mutating ops: caller must be the
+    /// management account of an existing organization. Returns the
+    /// management-only error rather than an Option, so the caller can
+    /// unwrap the guard safely right after.
+    fn require_member_management(
+        &self,
+        guard: &parking_lot::RwLockWriteGuard<'_, Option<OrganizationState>>,
+        account_id: &str,
+    ) -> Result<(), AwsServiceError> {
+        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
+        if !org.accounts.contains_key(account_id) {
+            return Err(organizations_not_in_use());
+        }
+        if !org.is_management(account_id) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::FORBIDDEN,
+                "AccessDeniedException",
+                "This operation can be called only from the organization's management account.",
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -125,6 +318,16 @@ impl AwsService for OrganizationsService {
             "CreateOrganization" => self.create_organization(&req),
             "DescribeOrganization" => self.describe_organization(&req),
             "DeleteOrganization" => self.delete_organization(&req),
+            "ListRoots" => self.list_roots(&req),
+            "CreateOrganizationalUnit" => self.create_organizational_unit(&req),
+            "UpdateOrganizationalUnit" => self.update_organizational_unit(&req),
+            "DeleteOrganizationalUnit" => self.delete_organizational_unit(&req),
+            "DescribeOrganizationalUnit" => self.describe_organizational_unit(&req),
+            "ListOrganizationalUnitsForParent" => self.list_organizational_units_for_parent(&req),
+            "ListAccounts" => self.list_accounts(&req),
+            "ListAccountsForParent" => self.list_accounts_for_parent(&req),
+            "DescribeAccount" => self.describe_account(&req),
+            "MoveAccount" => self.move_account(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "organizations",
                 &req.action,
@@ -143,6 +346,76 @@ fn organizations_not_in_use() -> AwsServiceError {
         "AWSOrganizationsNotInUseException",
         "Your account is not a member of an organization.",
     )
+}
+
+fn ou_payload(ou: &OrganizationalUnit) -> Value {
+    json!({
+        "Id": ou.id,
+        "Arn": ou.arn,
+        "Name": ou.name,
+    })
+}
+
+fn account_payload(account: &MemberAccount) -> Value {
+    json!({
+        "Id": account.id,
+        "Arn": account.arn,
+        "Email": account.email,
+        "Name": account.name,
+        "Status": account.status,
+        "JoinedMethod": account.joined_method,
+        "JoinedTimestamp": account.joined_timestamp.timestamp() as f64,
+    })
+}
+
+fn required_str<'a>(body: &'a Value, key: &str) -> Result<&'a str, AwsServiceError> {
+    body.get(key).and_then(|v| v.as_str()).ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidInputException",
+            format!("Missing required parameter: {key}"),
+        )
+    })
+}
+
+fn org_error_to_aws(err: OrgError) -> AwsServiceError {
+    match err {
+        OrgError::ParentNotFound(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ParentNotFoundException",
+            format!("The parent with id {id} was not found."),
+        ),
+        OrgError::DuplicateOrganizationalUnit(name) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "DuplicateOrganizationalUnitException",
+            format!("An organizational unit named {name} already exists under this parent."),
+        ),
+        OrgError::OrganizationalUnitNotFound(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "OrganizationalUnitNotFoundException",
+            format!("The organizational unit with id {id} was not found."),
+        ),
+        OrgError::OrganizationalUnitNotEmpty(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "OrganizationalUnitNotEmptyException",
+            format!("The organizational unit {id} still contains accounts or child OUs."),
+        ),
+        OrgError::AccountNotFound(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "AccountNotFoundException",
+            format!("The account with id {id} was not found."),
+        ),
+        OrgError::SourceParentNotFound(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "SourceParentNotFoundException",
+            format!("The source parent {id} does not contain this account."),
+        ),
+        OrgError::DestinationParentNotFound(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "DestinationParentNotFoundException",
+            format!("The destination parent {id} does not exist."),
+        ),
+    }
 }
 
 fn organization_payload(org: &OrganizationState) -> Value {

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -126,6 +126,157 @@ impl OrganizationState {
     pub fn is_management(&self, account_id: &str) -> bool {
         account_id == self.management_account_id
     }
+
+    /// Enroll `account_id` into the root OU as a member of the
+    /// organization if not already known. No-op when the account is
+    /// already enrolled anywhere in the tree. Used as the
+    /// auto-enrollment hook when a new IAM admin bootstraps via
+    /// `/_fakecloud/iam/create-admin` while an organization exists.
+    pub fn enroll_account_if_missing(&mut self, account_id: &str) {
+        if self.accounts.contains_key(account_id) {
+            return;
+        }
+        let arn = format!(
+            "arn:aws:organizations::{}:account/{}/{}",
+            self.management_account_id, self.org_id, account_id
+        );
+        self.accounts.insert(
+            account_id.to_string(),
+            MemberAccount {
+                id: account_id.to_string(),
+                arn,
+                email: format!("{}@example.com", account_id),
+                name: format!("Account {}", account_id),
+                status: "ACTIVE".to_string(),
+                joined_method: "INVITED".to_string(),
+                joined_timestamp: Utc::now(),
+                parent_id: self.root_id.clone(),
+            },
+        );
+    }
+
+    /// Create a new OU under `parent_id` (which must be the root or
+    /// another existing OU). Returns the created OU on success.
+    ///
+    /// Errors:
+    /// - `ParentNotFoundException` — `parent_id` does not exist in
+    ///   this org (neither root nor a known OU).
+    /// - `DuplicateOrganizationalUnitException` — another OU with the
+    ///   same name already lives directly under `parent_id`.
+    pub fn create_ou(
+        &mut self,
+        parent_id: &str,
+        name: &str,
+    ) -> Result<OrganizationalUnit, OrgError> {
+        if parent_id != self.root_id && !self.ous.contains_key(parent_id) {
+            return Err(OrgError::ParentNotFound(parent_id.to_string()));
+        }
+        let dup = self
+            .ous
+            .values()
+            .any(|ou| ou.parent_id == parent_id && ou.name == name);
+        if dup {
+            return Err(OrgError::DuplicateOrganizationalUnit(name.to_string()));
+        }
+        let root_suffix = self.root_id.strip_prefix("r-").unwrap_or(&self.root_id);
+        let id = format!("ou-{}-{}", root_suffix, random_id(8));
+        let arn = format!(
+            "arn:aws:organizations::{}:ou/{}/{}",
+            self.management_account_id, self.org_id, id
+        );
+        let ou = OrganizationalUnit {
+            id: id.clone(),
+            arn,
+            name: name.to_string(),
+            parent_id: parent_id.to_string(),
+        };
+        self.ous.insert(id, ou.clone());
+        Ok(ou)
+    }
+
+    /// Rename an existing OU.
+    pub fn rename_ou(
+        &mut self,
+        ou_id: &str,
+        new_name: &str,
+    ) -> Result<OrganizationalUnit, OrgError> {
+        let parent_id = self
+            .ous
+            .get(ou_id)
+            .ok_or_else(|| OrgError::OrganizationalUnitNotFound(ou_id.to_string()))?
+            .parent_id
+            .clone();
+        let dup = self
+            .ous
+            .values()
+            .any(|ou| ou.id != ou_id && ou.parent_id == parent_id && ou.name == new_name);
+        if dup {
+            return Err(OrgError::DuplicateOrganizationalUnit(new_name.to_string()));
+        }
+        let ou = self.ous.get_mut(ou_id).unwrap();
+        ou.name = new_name.to_string();
+        Ok(ou.clone())
+    }
+
+    /// Delete an OU. Fails with `OrganizationalUnitNotEmptyException`
+    /// if the OU contains any child OUs or member accounts.
+    pub fn delete_ou(&mut self, ou_id: &str) -> Result<(), OrgError> {
+        if !self.ous.contains_key(ou_id) {
+            return Err(OrgError::OrganizationalUnitNotFound(ou_id.to_string()));
+        }
+        let has_child_ou = self.ous.values().any(|ou| ou.parent_id == ou_id);
+        let has_account = self.accounts.values().any(|a| a.parent_id == ou_id);
+        if has_child_ou || has_account {
+            return Err(OrgError::OrganizationalUnitNotEmpty(ou_id.to_string()));
+        }
+        // Detach all policies from the deleted target so stale pointers
+        // don't survive.
+        self.attachments.remove(ou_id);
+        self.ous.remove(ou_id);
+        Ok(())
+    }
+
+    /// Move an account between OUs.
+    ///
+    /// Errors:
+    /// - `AccountNotFoundException`
+    /// - `SourceParentNotFoundException` when `source_parent` is not
+    ///   the account's current parent
+    /// - `DestinationParentNotFoundException` when `dest_parent` is
+    ///   not root or a known OU
+    pub fn move_account(
+        &mut self,
+        account_id: &str,
+        source_parent: &str,
+        dest_parent: &str,
+    ) -> Result<(), OrgError> {
+        let account = self
+            .accounts
+            .get_mut(account_id)
+            .ok_or_else(|| OrgError::AccountNotFound(account_id.to_string()))?;
+        if account.parent_id != source_parent {
+            return Err(OrgError::SourceParentNotFound(source_parent.to_string()));
+        }
+        let dest_exists = dest_parent == self.root_id || self.ous.contains_key(dest_parent);
+        if !dest_exists {
+            return Err(OrgError::DestinationParentNotFound(dest_parent.to_string()));
+        }
+        account.parent_id = dest_parent.to_string();
+        Ok(())
+    }
+}
+
+/// Typed errors used by organization state mutations so the service
+/// layer can translate each into the correct AWS exception code.
+#[derive(Debug)]
+pub enum OrgError {
+    ParentNotFound(String),
+    DuplicateOrganizationalUnit(String),
+    OrganizationalUnitNotFound(String),
+    OrganizationalUnitNotEmpty(String),
+    AccountNotFound(String),
+    SourceParentNotFound(String),
+    DestinationParentNotFound(String),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -220,5 +371,112 @@ mod tests {
             let id = random_id(len);
             assert_eq!(id.len(), len);
         }
+    }
+
+    #[test]
+    fn enroll_account_if_missing_adds_to_root() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enroll_account_if_missing("222222222222");
+        let member = org.accounts.get("222222222222").expect("enrolled");
+        assert_eq!(member.parent_id, org.root_id);
+    }
+
+    #[test]
+    fn enroll_account_if_missing_is_idempotent() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enroll_account_if_missing("111111111111");
+        assert_eq!(org.accounts.len(), 1);
+    }
+
+    #[test]
+    fn create_ou_rejects_unknown_parent() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let err = org.create_ou("ou-nope", "team").unwrap_err();
+        assert!(matches!(err, OrgError::ParentNotFound(_)));
+    }
+
+    #[test]
+    fn create_ou_rejects_duplicate_name_under_same_parent() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        org.create_ou(&root, "engineering").unwrap();
+        let err = org.create_ou(&root, "engineering").unwrap_err();
+        assert!(matches!(err, OrgError::DuplicateOrganizationalUnit(_)));
+    }
+
+    #[test]
+    fn create_ou_allows_same_name_under_different_parents() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let parent = org.create_ou(&root, "top").unwrap();
+        // Same leaf name under a different parent OU must succeed.
+        org.create_ou(&parent.id, "engineering").unwrap();
+        org.create_ou(&root, "engineering").unwrap();
+    }
+
+    #[test]
+    fn delete_ou_rejects_non_empty_with_accounts() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let ou = org.create_ou(&root, "team").unwrap();
+        org.enroll_account_if_missing("222222222222");
+        org.move_account("222222222222", &root, &ou.id).unwrap();
+        let err = org.delete_ou(&ou.id).unwrap_err();
+        assert!(matches!(err, OrgError::OrganizationalUnitNotEmpty(_)));
+    }
+
+    #[test]
+    fn delete_ou_rejects_non_empty_with_child_ou() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let parent = org.create_ou(&root, "parent").unwrap();
+        org.create_ou(&parent.id, "child").unwrap();
+        let err = org.delete_ou(&parent.id).unwrap_err();
+        assert!(matches!(err, OrgError::OrganizationalUnitNotEmpty(_)));
+    }
+
+    #[test]
+    fn delete_ou_clears_attachments() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let ou = org.create_ou(&root, "team").unwrap();
+        org.attachments
+            .entry(ou.id.clone())
+            .or_default()
+            .insert("p-custom".to_string());
+        org.delete_ou(&ou.id).unwrap();
+        assert!(!org.attachments.contains_key(&ou.id));
+    }
+
+    #[test]
+    fn move_account_enforces_source_parent() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let ou = org.create_ou(&root, "team").unwrap();
+        org.enroll_account_if_missing("222222222222");
+        let err = org.move_account("222222222222", &ou.id, &root).unwrap_err();
+        assert!(matches!(err, OrgError::SourceParentNotFound(_)));
+    }
+
+    #[test]
+    fn move_account_rejects_unknown_destination() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let err = org
+            .move_account("111111111111", &root, "ou-nope")
+            .unwrap_err();
+        assert!(matches!(err, OrgError::DestinationParentNotFound(_)));
+    }
+
+    #[test]
+    fn rename_ou_rejects_duplicate() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let a = org.create_ou(&root, "a").unwrap();
+        let b = org.create_ou(&root, "b").unwrap();
+        let err = org.rename_ou(&b.id, "a").unwrap_err();
+        assert!(matches!(err, OrgError::DuplicateOrganizationalUnit(_)));
+        // Renaming in place is fine.
+        org.rename_ou(&a.id, "a").unwrap();
     }
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3318,11 +3318,14 @@ async fn main() {
             "/_fakecloud/iam/create-admin",
             axum::routing::post({
                 let iam = iam_state.clone();
+                let orgs = organizations_state.clone();
                 move |axum::Json(body): axum::Json<types::CreateAdminRequest>| {
                     let iam = iam.clone();
+                    let orgs = orgs.clone();
                     async move {
                         axum::Json(reset::create_admin_in_account(
                             &iam,
+                            &orgs,
                             &body.account_id,
                             &body.user_name,
                         ))

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -349,9 +349,18 @@ impl ResetState {
 /// credentials for a non-default account via the normal AWS API.
 pub(crate) fn create_admin_in_account(
     iam: &fakecloud_iam::state::SharedIamState,
+    organizations: &fakecloud_organizations::state::SharedOrganizationsState,
     account_id: &str,
     user_name: &str,
 ) -> types::CreateAdminResponse {
+    // Auto-enroll the account into the organization's root OU if an
+    // org exists. Matches AWS's InviteAccount path in spirit: tests
+    // bootstrapping admin credentials for a second account expect
+    // that account to immediately participate in SCP evaluation.
+    if let Some(org) = organizations.write().as_mut() {
+        org.enroll_account_if_missing(account_id);
+    }
+
     let mut accounts = iam.write();
     let state = accounts.get_or_create(account_id);
 
@@ -618,7 +627,9 @@ mod tests {
         let iam: fakecloud_iam::state::SharedIamState = Arc::new(parking_lot::RwLock::new(
             fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
         ));
-        let resp = super::create_admin_in_account(&iam, "123456789012", "admin");
+        let orgs: fakecloud_organizations::state::SharedOrganizationsState =
+            Arc::new(parking_lot::RwLock::new(None));
+        let resp = super::create_admin_in_account(&iam, &orgs, "123456789012", "admin");
         assert_eq!(resp.account_id, "123456789012");
         assert!(resp.access_key_id.starts_with("FKIA"));
         assert!(resp.arn.contains("123456789012"));
@@ -637,7 +648,9 @@ mod tests {
         let iam: fakecloud_iam::state::SharedIamState = Arc::new(parking_lot::RwLock::new(
             fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
         ));
-        let resp = super::create_admin_in_account(&iam, "999999999999", "bob");
+        let orgs: fakecloud_organizations::state::SharedOrganizationsState =
+            Arc::new(parking_lot::RwLock::new(None));
+        let resp = super::create_admin_in_account(&iam, &orgs, "999999999999", "bob");
         assert_eq!(resp.account_id, "999999999999");
         assert!(resp.arn.contains("999999999999"));
 
@@ -660,7 +673,9 @@ mod tests {
         let iam: fakecloud_iam::state::SharedIamState = Arc::new(parking_lot::RwLock::new(
             fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
         ));
-        let resp = super::create_admin_in_account(&iam, "222222222222", "admin");
+        let orgs: fakecloud_organizations::state::SharedOrganizationsState =
+            Arc::new(parking_lot::RwLock::new(None));
+        let resp = super::create_admin_in_account(&iam, &orgs, "222222222222", "admin");
 
         let evaluator = fakecloud_iam::policy_evaluator::IamPolicyEvaluatorImpl::new(iam.clone());
         let principal = Principal {
@@ -689,7 +704,9 @@ mod tests {
         let iam: fakecloud_iam::state::SharedIamState = Arc::new(parking_lot::RwLock::new(
             fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
         ));
-        let resp = super::create_admin_in_account(&iam, "222222222222", "alice");
+        let orgs: fakecloud_organizations::state::SharedOrganizationsState =
+            Arc::new(parking_lot::RwLock::new(None));
+        let resp = super::create_admin_in_account(&iam, &orgs, "222222222222", "alice");
 
         // Verify the credential resolver can find this key
         let mut accounts = iam.write();

--- a/website/content/docs/reference/organizations.md
+++ b/website/content/docs/reference/organizations.md
@@ -1,12 +1,12 @@
 +++
 title = "AWS Organizations"
-description = "Minimal Organizations control plane: create an organization, describe it, delete it. SCP CRUD and enforcement ship in later batches."
+description = "Minimal Organizations control plane: organization, OU tree, account membership. SCP CRUD and enforcement ship in later batches."
 weight = 6
 +++
 
 fakecloud ships a minimal AWS Organizations implementation. Its purpose is to let you attach Service Control Policies (SCPs) to accounts and organizational units so your tests can exercise the full IAM evaluation hierarchy — SCP ceiling, permission boundary, session policy, identity policy, resource policy — end to end.
 
-The current surface is intentionally narrow: CreateOrganization, DescribeOrganization, and DeleteOrganization. OU ops, account membership ops, and SCP CRUD land in subsequent batches, and SCP enforcement through the IAM evaluator lands last.
+The current surface: organization lifecycle, OU tree, and member-account listing. SCP CRUD lands in Batch 3, and SCP enforcement through the IAM evaluator lands in Batch 4.
 
 ## Model
 
@@ -16,17 +16,28 @@ The current surface is intentionally narrow: CreateOrganization, DescribeOrganiz
   {"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}
   ```
 - Only the `ALL` feature set is supported. `CONSOLIDATED_BILLING` disables SCPs in AWS and is not useful in a test tool; requesting it returns `UnsupportedAPIEndpointException`.
-- Only the management account can delete the organization. Any other account calling `DeleteOrganization` gets `AccessDeniedException`.
+- Only the management account can run write ops (`CreateOrganizationalUnit`, `MoveAccount`, `DeleteOrganization`, etc.). A member but non-management caller gets `AccessDeniedException`. A non-member caller gets `AWSOrganizationsNotInUseException` so org existence itself does not leak.
+- Accounts auto-enroll into the root OU whenever a new admin bootstraps via `/_fakecloud/iam/create-admin` and an organization exists. This means tests can create the org first, then bootstrap admins for each member account, and the membership lands automatically.
 
 ## Supported operations
 
 | Operation | Status | Notes |
 |-----------|--------|-------|
 | `CreateOrganization` | ✅ | `FeatureSet=ALL` only; caller becomes management |
-| `DescribeOrganization` | ✅ | Returns `AWSOrganizationsNotInUseException` if no org exists |
+| `DescribeOrganization` | ✅ | Returns `AWSOrganizationsNotInUseException` to non-members |
 | `DeleteOrganization` | ✅ | Management only; fails if any non-management members remain |
+| `ListRoots` | ✅ | Returns the single root |
+| `CreateOrganizationalUnit` | ✅ | Management only; name must be unique under the parent |
+| `UpdateOrganizationalUnit` | ✅ | Rename; duplicate-name check |
+| `DeleteOrganizationalUnit` | ✅ | Fails with `OrganizationalUnitNotEmptyException` if children remain |
+| `DescribeOrganizationalUnit` | ✅ | |
+| `ListOrganizationalUnitsForParent` | ✅ | |
+| `ListAccounts` | ✅ | Returns all members |
+| `ListAccountsForParent` | ✅ | |
+| `DescribeAccount` | ✅ | |
+| `MoveAccount` | ✅ | Enforces exact source-parent match |
 
-OU ops, SCP CRUD, and SCP enforcement are in active development. See the security reference for the IAM evaluation hierarchy.
+SCP CRUD and enforcement are in active development. See the security reference for the IAM evaluation hierarchy.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Batch 2 of the SCP rollout. Fills out the Organizations control plane so tests can build an actual org tree and move accounts between OUs.

- **OU CRUD** — `CreateOrganizationalUnit`, `UpdateOrganizationalUnit`, `DeleteOrganizationalUnit`, `DescribeOrganizationalUnit`, `ListOrganizationalUnitsForParent`, `ListRoots`
- **Account membership** — `ListAccounts`, `ListAccountsForParent`, `DescribeAccount`, `MoveAccount`
- **Auto-enrollment** — `/_fakecloud/iam/create-admin` now enrolls the newly bootstrapped account into the root OU when an organization exists. Tests create the org once, then every subsequent `create_admin(account_id, user)` call just works as a member.

Mutating ops are management-only. Non-member callers see `AWSOrganizationsNotInUseException` (no leak of org existence); member-but-not-management callers see `AccessDeniedException`.

No evaluator behavior change yet — SCP CRUD lands in Batch 3, enforcement in Batch 4.

## Test plan

- [x] Unit tests for OU CRUD, duplicate-name checks across parents, non-empty delete, move-account source/dest validation, rename, auto-enrollment
- [x] E2E: `list_roots_after_create`, `ou_tree_crud_and_move_account`, `non_management_member_cannot_create_ou`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] Docs updated at `/docs/reference/organizations` with the new operation table and auto-enrollment semantics

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OU tree APIs, account membership, and auto-enrollment so tests can build org hierarchies and move accounts. Mutations are management-only; non-members get AWSOrganizationsNotInUseException and non-management members get AccessDeniedException; no SCP evaluator changes yet.

- **New Features**
  - OU CRUD: CreateOrganizationalUnit, UpdateOrganizationalUnit, DeleteOrganizationalUnit, DescribeOrganizationalUnit, ListOrganizationalUnitsForParent, ListRoots
  - Account membership: ListAccounts, ListAccountsForParent, DescribeAccount, MoveAccount
  - Auto-enrollment: `/_fakecloud/iam/create-admin` enrolls new admins’ accounts into the root OU when an org exists

<sup>Written for commit 4981ccf8fa366f1b9cf4f4ad2637975040b5ac5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

