### PR TITLE
feat(organizations): SCP CRUD + attach/detach + target listings

### DIFF
--- a/crates/fakecloud-e2e/tests/organizations.rs
+++ b/crates/fakecloud-e2e/tests/organizations.rs
@@ -243,3 +243,133 @@ async fn non_management_member_cannot_create_ou() {
         .unwrap_err();
     assert!(format!("{err:?}").contains("AccessDeniedException"));
 }
+
+const SCP_ALLOW_ALL: &str =
+    r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+
+#[tokio::test]
+async fn scp_create_attach_detach_delete_roundtrip() {
+    let server = start().await;
+    let (akid, secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let cfg = config_with(&server, &akid, &secret).await;
+    let orgs = OrgsClient::new(&cfg);
+
+    orgs.create_organization().send().await.unwrap();
+    let root_id = orgs.list_roots().send().await.unwrap().roots()[0]
+        .id()
+        .unwrap()
+        .to_string();
+
+    // CreatePolicy -> returned id starts with p-.
+    let created = orgs
+        .create_policy()
+        .name("CustomGuardrail")
+        .description("test SCP")
+        .r#type(aws_sdk_organizations::types::PolicyType::ServiceControlPolicy)
+        .content(SCP_ALLOW_ALL)
+        .send()
+        .await
+        .unwrap();
+    let policy_id = created
+        .policy()
+        .unwrap()
+        .policy_summary()
+        .unwrap()
+        .id()
+        .unwrap()
+        .to_string();
+    assert!(policy_id.starts_with("p-"));
+
+    // Attach to root.
+    orgs.attach_policy()
+        .policy_id(&policy_id)
+        .target_id(&root_id)
+        .send()
+        .await
+        .unwrap();
+
+    // Delete attached -> fails.
+    let err = orgs
+        .delete_policy()
+        .policy_id(&policy_id)
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("PolicyInUseException"));
+
+    // ListPoliciesForTarget sees Custom + FullAWSAccess.
+    let list = orgs
+        .list_policies_for_target()
+        .target_id(&root_id)
+        .filter(aws_sdk_organizations::types::PolicyType::ServiceControlPolicy)
+        .send()
+        .await
+        .unwrap();
+    let names: Vec<String> = list
+        .policies()
+        .iter()
+        .map(|p| p.name().unwrap().to_string())
+        .collect();
+    assert!(names.contains(&"CustomGuardrail".to_string()));
+    assert!(names.contains(&"FullAWSAccess".to_string()));
+
+    // ListTargetsForPolicy sees the root.
+    let targets = orgs
+        .list_targets_for_policy()
+        .policy_id(&policy_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(targets.targets().len(), 1);
+    assert_eq!(targets.targets()[0].target_id().unwrap(), root_id);
+
+    // Detach + delete succeed.
+    orgs.detach_policy()
+        .policy_id(&policy_id)
+        .target_id(&root_id)
+        .send()
+        .await
+        .unwrap();
+    orgs.delete_policy()
+        .policy_id(&policy_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn scp_full_aws_access_is_immutable() {
+    let server = start().await;
+    let (akid, secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let cfg = config_with(&server, &akid, &secret).await;
+    let orgs = OrgsClient::new(&cfg);
+
+    orgs.create_organization().send().await.unwrap();
+    let err = orgs
+        .delete_policy()
+        .policy_id("p-FullAWSAccess")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("PolicyChangesNotAllowedException"));
+}
+
+#[tokio::test]
+async fn scp_reject_non_scp_policy_type() {
+    let server = start().await;
+    let (akid, secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let cfg = config_with(&server, &akid, &secret).await;
+    let orgs = OrgsClient::new(&cfg);
+
+    orgs.create_organization().send().await.unwrap();
+    let err = orgs
+        .create_policy()
+        .name("TagGuard")
+        .description("won't work")
+        .r#type(aws_sdk_organizations::types::PolicyType::TagPolicy)
+        .content("{}")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("PolicyTypeNotSupportedException"));
+}

--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -7,12 +7,12 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
 use crate::state::{
-    MemberAccount, OrgError, OrganizationState, OrganizationalUnit, SharedOrganizationsState,
-    FEATURE_SET_ALL,
+    MemberAccount, OrgError, OrganizationState, OrganizationalUnit, Policy,
+    SharedOrganizationsState, FEATURE_SET_ALL, POLICY_TYPE_SCP,
 };
 
-/// Single source of truth for supported Organizations actions. Expanded
-/// across subsequent batches (SCP CRUD + attachment ops).
+/// Single source of truth for supported Organizations actions.
+/// Enforcement of attached SCPs ships in Batch 4.
 pub static ORGANIZATIONS_ACTIONS: &[&str] = &[
     "CreateOrganization",
     "DescribeOrganization",
@@ -27,6 +27,15 @@ pub static ORGANIZATIONS_ACTIONS: &[&str] = &[
     "ListAccountsForParent",
     "DescribeAccount",
     "MoveAccount",
+    "CreatePolicy",
+    "UpdatePolicy",
+    "DeletePolicy",
+    "DescribePolicy",
+    "ListPolicies",
+    "AttachPolicy",
+    "DetachPolicy",
+    "ListPoliciesForTarget",
+    "ListTargetsForPolicy",
 ];
 
 pub struct OrganizationsService {
@@ -269,6 +278,155 @@ impl OrganizationsService {
         Ok(AwsResponse::ok_json(Value::Null))
     }
 
+    fn create_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let name = required_str(&body, "Name")?;
+        let policy_type = required_str(&body, "Type")?;
+        let content = required_str(&body, "Content")?;
+        let description = body
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().unwrap();
+        let policy = org
+            .create_policy(name, description, content, policy_type)
+            .map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(
+            json!({ "Policy": policy_with_content(&policy) }),
+        ))
+    }
+
+    fn update_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let policy_id = required_str(&body, "PolicyId")?;
+        let name = body.get("Name").and_then(|v| v.as_str());
+        let description = body.get("Description").and_then(|v| v.as_str());
+        let content = body.get("Content").and_then(|v| v.as_str());
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().unwrap();
+        let policy = org
+            .update_policy(policy_id, name, description, content)
+            .map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(
+            json!({ "Policy": policy_with_content(&policy) }),
+        ))
+    }
+
+    fn delete_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let policy_id = required_str(&body, "PolicyId")?;
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().unwrap();
+        org.delete_policy(policy_id).map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(Value::Null))
+    }
+
+    fn describe_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let policy_id = required_str(&body, "PolicyId")?;
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        let policy = org
+            .policies
+            .get(policy_id)
+            .ok_or_else(|| org_error_to_aws(OrgError::PolicyNotFound(policy_id.to_string())))?;
+        Ok(AwsResponse::ok_json(
+            json!({ "Policy": policy_with_content(policy) }),
+        ))
+    }
+
+    fn list_policies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        // Filter is a required parameter on the AWS API. Reject missing
+        // filter so the SDK wire format matches and callers learn about
+        // their typo rather than getting an implicit SCP default.
+        let filter = required_str(&body, "Filter")?;
+        if filter != POLICY_TYPE_SCP {
+            return Err(org_error_to_aws(OrgError::PolicyTypeNotSupported(
+                filter.to_string(),
+            )));
+        }
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        let mut policies: Vec<&Policy> = org
+            .policies
+            .values()
+            .filter(|p| p.policy_type == filter)
+            .collect();
+        policies.sort_by(|a, b| a.name.cmp(&b.name));
+        let summaries: Vec<Value> = policies.iter().map(|p| policy_summary(p)).collect();
+        Ok(AwsResponse::ok_json(json!({ "Policies": summaries })))
+    }
+
+    fn attach_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let policy_id = required_str(&body, "PolicyId")?;
+        let target_id = required_str(&body, "TargetId")?;
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().unwrap();
+        org.attach_policy(policy_id, target_id)
+            .map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(Value::Null))
+    }
+
+    fn detach_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let policy_id = required_str(&body, "PolicyId")?;
+        let target_id = required_str(&body, "TargetId")?;
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().unwrap();
+        org.detach_policy(policy_id, target_id)
+            .map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(Value::Null))
+    }
+
+    fn list_policies_for_target(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let target_id = required_str(&body, "TargetId")?;
+        let filter = required_str(&body, "Filter")?;
+        if filter != POLICY_TYPE_SCP {
+            return Err(org_error_to_aws(OrgError::PolicyTypeNotSupported(
+                filter.to_string(),
+            )));
+        }
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        let mut policies = org
+            .policies_for_target(target_id)
+            .map_err(org_error_to_aws)?;
+        policies.sort_by(|a, b| a.name.cmp(&b.name));
+        let summaries: Vec<Value> = policies.iter().map(|p| policy_summary(p)).collect();
+        Ok(AwsResponse::ok_json(json!({ "Policies": summaries })))
+    }
+
+    fn list_targets_for_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let policy_id = required_str(&body, "PolicyId")?;
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        let targets = org
+            .targets_for_policy(policy_id)
+            .map_err(org_error_to_aws)?;
+        let payload: Vec<Value> = targets
+            .iter()
+            .map(|(id, name, ttype)| {
+                json!({
+                    "TargetId": id,
+                    "Name": name,
+                    "Type": ttype,
+                    "Arn": target_arn(org, id, ttype),
+                })
+            })
+            .collect();
+        Ok(AwsResponse::ok_json(json!({ "Targets": payload })))
+    }
+
     /// Read-side helper: enforce that an org exists and the caller is a
     /// member. Returns the borrowed org on success.
     fn require_member<'a>(
@@ -328,6 +486,15 @@ impl AwsService for OrganizationsService {
             "ListAccountsForParent" => self.list_accounts_for_parent(&req),
             "DescribeAccount" => self.describe_account(&req),
             "MoveAccount" => self.move_account(&req),
+            "CreatePolicy" => self.create_policy(&req),
+            "UpdatePolicy" => self.update_policy(&req),
+            "DeletePolicy" => self.delete_policy(&req),
+            "DescribePolicy" => self.describe_policy(&req),
+            "ListPolicies" => self.list_policies(&req),
+            "AttachPolicy" => self.attach_policy(&req),
+            "DetachPolicy" => self.detach_policy(&req),
+            "ListPoliciesForTarget" => self.list_policies_for_target(&req),
+            "ListTargetsForPolicy" => self.list_targets_for_policy(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "organizations",
                 &req.action,
@@ -346,6 +513,41 @@ fn organizations_not_in_use() -> AwsServiceError {
         "AWSOrganizationsNotInUseException",
         "Your account is not a member of an organization.",
     )
+}
+
+fn policy_summary(policy: &Policy) -> Value {
+    json!({
+        "Id": policy.id,
+        "Arn": policy.arn,
+        "Name": policy.name,
+        "Description": policy.description,
+        "Type": policy.policy_type,
+        "AwsManaged": policy.aws_managed,
+    })
+}
+
+fn policy_with_content(policy: &Policy) -> Value {
+    json!({
+        "PolicySummary": policy_summary(policy),
+        "Content": policy.content,
+    })
+}
+
+fn target_arn(org: &OrganizationState, target_id: &str, target_type: &str) -> String {
+    match target_type {
+        "ROOT" => org.root_arn.clone(),
+        "ORGANIZATIONAL_UNIT" => org
+            .ous
+            .get(target_id)
+            .map(|ou| ou.arn.clone())
+            .unwrap_or_default(),
+        "ACCOUNT" => org
+            .accounts
+            .get(target_id)
+            .map(|a| a.arn.clone())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
 }
 
 fn ou_payload(ou: &OrganizationalUnit) -> Value {
@@ -414,6 +616,46 @@ fn org_error_to_aws(err: OrgError) -> AwsServiceError {
             StatusCode::BAD_REQUEST,
             "DestinationParentNotFoundException",
             format!("The destination parent {id} does not exist."),
+        ),
+        OrgError::PolicyNotFound(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "PolicyNotFoundException",
+            format!("The policy with id {id} was not found."),
+        ),
+        OrgError::DuplicatePolicy(name) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "DuplicatePolicyException",
+            format!("A policy named {name} already exists for this policy type."),
+        ),
+        OrgError::MalformedPolicyDocument => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "MalformedPolicyDocumentException",
+            "The policy document is not valid JSON.",
+        ),
+        OrgError::PolicyTypeNotSupported(t) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "PolicyTypeNotSupportedException",
+            format!("fakecloud only supports SERVICE_CONTROL_POLICY; got {t}."),
+        ),
+        OrgError::PolicyChangesNotAllowed(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "PolicyChangesNotAllowedException",
+            format!("Policy {id} is AWS-managed and cannot be modified or deleted."),
+        ),
+        OrgError::PolicyInUse(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "PolicyInUseException",
+            format!("Policy {id} is attached to one or more targets; detach before deleting."),
+        ),
+        OrgError::PolicyNotAttached(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "PolicyNotAttachedException",
+            format!("Policy {id} is not attached to this target."),
+        ),
+        OrgError::TargetNotFound(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "TargetNotFoundException",
+            format!("The target with id {id} was not found."),
         ),
     }
 }
@@ -1173,5 +1415,382 @@ mod tests {
         );
         // ActionNotImplemented carries NOT_IMPLEMENTED status.
         assert_eq!(err.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    const SCP_ALLOW_ALL: &str =
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+
+    async fn create_scp(svc: &Arc<OrganizationsService>, name: &str) -> String {
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "CreatePolicy",
+                json!({
+                    "Name": name,
+                    "Description": "",
+                    "Type": "SERVICE_CONTROL_POLICY",
+                    "Content": SCP_ALLOW_ALL,
+                }),
+            ))
+            .await
+            .unwrap();
+        body_json(&resp)["Policy"]["PolicySummary"]["Id"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn create_policy_happy_path() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let id = create_scp(&svc, "Custom").await;
+        assert!(id.starts_with("p-"));
+    }
+
+    #[tokio::test]
+    async fn create_policy_rejects_non_scp_type() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "CreatePolicy",
+                json!({
+                    "Name": "T",
+                    "Description": "",
+                    "Type": "TAG_POLICY",
+                    "Content": SCP_ALLOW_ALL,
+                }),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "PolicyTypeNotSupportedException");
+    }
+
+    #[tokio::test]
+    async fn create_policy_malformed_content_rejected() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "CreatePolicy",
+                json!({
+                    "Name": "X",
+                    "Description": "",
+                    "Type": "SERVICE_CONTROL_POLICY",
+                    "Content": "not json",
+                }),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "MalformedPolicyDocumentException");
+    }
+
+    #[tokio::test]
+    async fn create_policy_missing_required_fields() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "CreatePolicy",
+                json!({"Name": "X", "Type": "SERVICE_CONTROL_POLICY"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "InvalidInputException");
+    }
+
+    #[tokio::test]
+    async fn create_policy_non_management_rejected() {
+        let (svc, state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        {
+            let mut guard = state.write();
+            guard
+                .as_mut()
+                .unwrap()
+                .enroll_account_if_missing("222222222222");
+        }
+        let err = expect_err(
+            svc.handle(req_with(
+                "222222222222",
+                "CreatePolicy",
+                json!({
+                    "Name": "X",
+                    "Description": "",
+                    "Type": "SERVICE_CONTROL_POLICY",
+                    "Content": SCP_ALLOW_ALL,
+                }),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "AccessDeniedException");
+    }
+
+    #[tokio::test]
+    async fn update_policy_roundtrip_and_blocks_aws_managed() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let id = create_scp(&svc, "Original").await;
+        let renamed = svc
+            .handle(req_with(
+                "111111111111",
+                "UpdatePolicy",
+                json!({"PolicyId": id, "Name": "Renamed"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            body_json(&renamed)["Policy"]["PolicySummary"]["Name"],
+            "Renamed"
+        );
+        // FullAWSAccess is AWS-managed -> blocked.
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "UpdatePolicy",
+                json!({"PolicyId": "p-FullAWSAccess", "Name": "Hacked"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "PolicyChangesNotAllowedException");
+    }
+
+    #[tokio::test]
+    async fn delete_policy_blocked_when_attached_and_aws_managed() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let id = create_scp(&svc, "InUse").await;
+        svc.handle(req_with(
+            "111111111111",
+            "AttachPolicy",
+            json!({"PolicyId": id, "TargetId": root_id}),
+        ))
+        .await
+        .unwrap();
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "DeletePolicy",
+                json!({"PolicyId": id}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "PolicyInUseException");
+        // AWS-managed cannot be deleted either.
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "DeletePolicy",
+                json!({"PolicyId": "p-FullAWSAccess"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "PolicyChangesNotAllowedException");
+    }
+
+    #[tokio::test]
+    async fn describe_policy_unknown_and_known() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let id = create_scp(&svc, "X").await;
+        let ok = svc
+            .handle(req_with(
+                "111111111111",
+                "DescribePolicy",
+                json!({"PolicyId": id}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(body_json(&ok)["Policy"]["PolicySummary"]["Id"], id);
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "DescribePolicy",
+                json!({"PolicyId": "p-none"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "PolicyNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn list_policies_rejects_unsupported_filter() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "ListPolicies",
+                json!({"Filter": "TAG_POLICY"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "PolicyTypeNotSupportedException");
+    }
+
+    #[tokio::test]
+    async fn list_policies_includes_full_aws_access() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "ListPolicies",
+                json!({"Filter": "SERVICE_CONTROL_POLICY"}),
+            ))
+            .await
+            .unwrap();
+        let v = body_json(&resp);
+        assert!(v["Policies"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|p| p["Id"] == "p-FullAWSAccess"));
+    }
+
+    #[tokio::test]
+    async fn attach_detach_lifecycle_and_errors() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let id = create_scp(&svc, "X").await;
+
+        // Attach then detach.
+        svc.handle(req_with(
+            "111111111111",
+            "AttachPolicy",
+            json!({"PolicyId": id, "TargetId": root_id}),
+        ))
+        .await
+        .unwrap();
+        // Re-attach is idempotent.
+        svc.handle(req_with(
+            "111111111111",
+            "AttachPolicy",
+            json!({"PolicyId": id, "TargetId": root_id}),
+        ))
+        .await
+        .unwrap();
+
+        // Unknown target.
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "AttachPolicy",
+                json!({"PolicyId": id, "TargetId": "ou-bogus"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "TargetNotFoundException");
+
+        // Unknown policy.
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "AttachPolicy",
+                json!({"PolicyId": "p-none", "TargetId": root_id}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "PolicyNotFoundException");
+
+        // Detach unattached policy.
+        let id2 = create_scp(&svc, "Y").await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "DetachPolicy",
+                json!({"PolicyId": id2, "TargetId": root_id}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "PolicyNotAttachedException");
+
+        // Happy-path detach of the first policy.
+        svc.handle(req_with(
+            "111111111111",
+            "DetachPolicy",
+            json!({"PolicyId": id, "TargetId": root_id}),
+        ))
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_policies_for_target_and_targets_for_policy() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let id = create_scp(&svc, "Custom").await;
+        svc.handle(req_with(
+            "111111111111",
+            "AttachPolicy",
+            json!({"PolicyId": id, "TargetId": root_id}),
+        ))
+        .await
+        .unwrap();
+
+        let list = svc
+            .handle(req_with(
+                "111111111111",
+                "ListPoliciesForTarget",
+                json!({"TargetId": root_id, "Filter": "SERVICE_CONTROL_POLICY"}),
+            ))
+            .await
+            .unwrap();
+        let v = body_json(&list);
+        let names: Vec<_> = v["Policies"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["Name"].as_str().unwrap().to_string())
+            .collect();
+        assert!(names.contains(&"Custom".to_string()));
+        assert!(names.contains(&"FullAWSAccess".to_string()));
+
+        let targets = svc
+            .handle(req_with(
+                "111111111111",
+                "ListTargetsForPolicy",
+                json!({"PolicyId": id}),
+            ))
+            .await
+            .unwrap();
+        let v = body_json(&targets);
+        assert_eq!(v["Targets"].as_array().unwrap().len(), 1);
+        assert_eq!(v["Targets"][0]["TargetId"], root_id);
+        assert_eq!(v["Targets"][0]["Type"], "ROOT");
+    }
+
+    #[tokio::test]
+    async fn list_policies_for_target_rejects_bad_filter() {
+        let (svc, _state) = OrganizationsService::shared();
+        let root_id = create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "ListPoliciesForTarget",
+                json!({"TargetId": root_id, "Filter": "TAG_POLICY"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "PolicyTypeNotSupportedException");
+    }
+
+    #[tokio::test]
+    async fn list_targets_for_unknown_policy() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "ListTargetsForPolicy",
+                json!({"PolicyId": "p-none"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "PolicyNotFoundException");
     }
 }

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -264,6 +264,227 @@ impl OrganizationState {
         account.parent_id = dest_parent.to_string();
         Ok(())
     }
+
+    /// Create a customer-managed SCP. Returns the created policy on
+    /// success.
+    ///
+    /// Errors:
+    /// - `PolicyTypeNotSupportedException` — `policy_type` isn't SCP.
+    /// - `MalformedPolicyDocumentException` — `content` doesn't parse
+    ///   as JSON.
+    /// - `DuplicatePolicyException` — another SCP with the same name.
+    pub fn create_policy(
+        &mut self,
+        name: &str,
+        description: &str,
+        content: &str,
+        policy_type: &str,
+    ) -> Result<Policy, OrgError> {
+        if policy_type != POLICY_TYPE_SCP {
+            return Err(OrgError::PolicyTypeNotSupported(policy_type.to_string()));
+        }
+        if serde_json::from_str::<serde_json::Value>(content).is_err() {
+            return Err(OrgError::MalformedPolicyDocument);
+        }
+        let dup = self
+            .policies
+            .values()
+            .any(|p| p.policy_type == POLICY_TYPE_SCP && p.name == name);
+        if dup {
+            return Err(OrgError::DuplicatePolicy(name.to_string()));
+        }
+        let id = format!("p-{}", random_id(8));
+        let arn = format!(
+            "arn:aws:organizations::{}:policy/{}/service_control_policy/{}",
+            self.management_account_id, self.org_id, id
+        );
+        let policy = Policy {
+            id: id.clone(),
+            arn,
+            name: name.to_string(),
+            description: description.to_string(),
+            policy_type: POLICY_TYPE_SCP.to_string(),
+            aws_managed: false,
+            content: content.to_string(),
+        };
+        self.policies.insert(id, policy.clone());
+        Ok(policy)
+    }
+
+    /// Update an existing customer-managed SCP. Any `Option::Some`
+    /// field overrides the stored value; `None` leaves it untouched.
+    /// AWS-managed policies (e.g. `FullAWSAccess`) are immutable.
+    pub fn update_policy(
+        &mut self,
+        id: &str,
+        name: Option<&str>,
+        description: Option<&str>,
+        content: Option<&str>,
+    ) -> Result<Policy, OrgError> {
+        let policy = self
+            .policies
+            .get(id)
+            .ok_or_else(|| OrgError::PolicyNotFound(id.to_string()))?;
+        if policy.aws_managed {
+            return Err(OrgError::PolicyChangesNotAllowed(id.to_string()));
+        }
+        if let Some(new_name) = name {
+            let dup = self
+                .policies
+                .values()
+                .any(|p| p.id != id && p.policy_type == POLICY_TYPE_SCP && p.name == new_name);
+            if dup {
+                return Err(OrgError::DuplicatePolicy(new_name.to_string()));
+            }
+        }
+        if let Some(c) = content {
+            if serde_json::from_str::<serde_json::Value>(c).is_err() {
+                return Err(OrgError::MalformedPolicyDocument);
+            }
+        }
+        let policy = self.policies.get_mut(id).unwrap();
+        if let Some(n) = name {
+            policy.name = n.to_string();
+        }
+        if let Some(d) = description {
+            policy.description = d.to_string();
+        }
+        if let Some(c) = content {
+            policy.content = c.to_string();
+        }
+        Ok(policy.clone())
+    }
+
+    /// Delete a customer-managed SCP. Fails with `PolicyInUseException`
+    /// if the policy is still attached to any target.
+    pub fn delete_policy(&mut self, id: &str) -> Result<(), OrgError> {
+        let policy = self
+            .policies
+            .get(id)
+            .ok_or_else(|| OrgError::PolicyNotFound(id.to_string()))?;
+        if policy.aws_managed {
+            return Err(OrgError::PolicyChangesNotAllowed(id.to_string()));
+        }
+        let attached = self.attachments.values().any(|set| set.contains(id));
+        if attached {
+            return Err(OrgError::PolicyInUse(id.to_string()));
+        }
+        self.policies.remove(id);
+        Ok(())
+    }
+
+    /// Verify `target_id` is one of root, an OU, or a member account.
+    pub fn target_exists(&self, target_id: &str) -> bool {
+        target_id == self.root_id
+            || self.ous.contains_key(target_id)
+            || self.accounts.contains_key(target_id)
+    }
+
+    /// Type tag for target listings (`ROOT`, `ORGANIZATIONAL_UNIT`,
+    /// `ACCOUNT`). Returns `None` when the target is unknown.
+    pub fn target_type(&self, target_id: &str) -> Option<&'static str> {
+        if target_id == self.root_id {
+            Some("ROOT")
+        } else if self.ous.contains_key(target_id) {
+            Some("ORGANIZATIONAL_UNIT")
+        } else if self.accounts.contains_key(target_id) {
+            Some("ACCOUNT")
+        } else {
+            None
+        }
+    }
+
+    /// Attach a policy to a target. No-op if already attached (AWS
+    /// treats re-attach as success; matches the documented idempotent
+    /// behaviour).
+    pub fn attach_policy(&mut self, policy_id: &str, target_id: &str) -> Result<(), OrgError> {
+        if !self.policies.contains_key(policy_id) {
+            return Err(OrgError::PolicyNotFound(policy_id.to_string()));
+        }
+        if !self.target_exists(target_id) {
+            return Err(OrgError::TargetNotFound(target_id.to_string()));
+        }
+        self.attachments
+            .entry(target_id.to_string())
+            .or_default()
+            .insert(policy_id.to_string());
+        Ok(())
+    }
+
+    /// Detach a policy from a target.
+    ///
+    /// Errors:
+    /// - `PolicyNotFoundException`
+    /// - `TargetNotFoundException`
+    /// - `PolicyNotAttachedException` — policy is known but not
+    ///   attached to `target_id`.
+    pub fn detach_policy(&mut self, policy_id: &str, target_id: &str) -> Result<(), OrgError> {
+        if !self.policies.contains_key(policy_id) {
+            return Err(OrgError::PolicyNotFound(policy_id.to_string()));
+        }
+        if !self.target_exists(target_id) {
+            return Err(OrgError::TargetNotFound(target_id.to_string()));
+        }
+        let set = self
+            .attachments
+            .get_mut(target_id)
+            .ok_or_else(|| OrgError::PolicyNotAttached(policy_id.to_string()))?;
+        if !set.remove(policy_id) {
+            return Err(OrgError::PolicyNotAttached(policy_id.to_string()));
+        }
+        if set.is_empty() {
+            self.attachments.remove(target_id);
+        }
+        Ok(())
+    }
+
+    /// All SCPs attached directly to `target_id` (no inheritance).
+    pub fn policies_for_target(&self, target_id: &str) -> Result<Vec<&Policy>, OrgError> {
+        if !self.target_exists(target_id) {
+            return Err(OrgError::TargetNotFound(target_id.to_string()));
+        }
+        let ids = match self.attachments.get(target_id) {
+            Some(s) => s,
+            None => return Ok(Vec::new()),
+        };
+        Ok(ids.iter().filter_map(|id| self.policies.get(id)).collect())
+    }
+
+    /// All targets that carry a direct attachment of `policy_id`. Each
+    /// entry pairs the target id with its type tag so callers can
+    /// render the full AWS response shape.
+    pub fn targets_for_policy(
+        &self,
+        policy_id: &str,
+    ) -> Result<Vec<(&str, &str, &'static str)>, OrgError> {
+        if !self.policies.contains_key(policy_id) {
+            return Err(OrgError::PolicyNotFound(policy_id.to_string()));
+        }
+        let mut out = Vec::new();
+        for (target_id, set) in &self.attachments {
+            if set.contains(policy_id) {
+                let ttype = self
+                    .target_type(target_id)
+                    .expect("attachment target must still exist");
+                let name = match ttype {
+                    "ROOT" => self.root_name.as_str(),
+                    "ORGANIZATIONAL_UNIT" => self
+                        .ous
+                        .get(target_id)
+                        .map(|o| o.name.as_str())
+                        .unwrap_or(""),
+                    "ACCOUNT" => self
+                        .accounts
+                        .get(target_id)
+                        .map(|a| a.name.as_str())
+                        .unwrap_or(""),
+                    _ => "",
+                };
+                out.push((target_id.as_str(), name, ttype));
+            }
+        }
+        Ok(out)
+    }
 }
 
 /// Typed errors used by organization state mutations so the service
@@ -277,6 +498,14 @@ pub enum OrgError {
     AccountNotFound(String),
     SourceParentNotFound(String),
     DestinationParentNotFound(String),
+    PolicyNotFound(String),
+    DuplicatePolicy(String),
+    MalformedPolicyDocument,
+    PolicyTypeNotSupported(String),
+    PolicyChangesNotAllowed(String),
+    PolicyInUse(String),
+    PolicyNotAttached(String),
+    TargetNotFound(String),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -478,5 +707,214 @@ mod tests {
         assert!(matches!(err, OrgError::DuplicateOrganizationalUnit(_)));
         // Renaming in place is fine.
         org.rename_ou(&a.id, "a").unwrap();
+    }
+
+    const CONTENT_ALL: &str =
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+
+    #[test]
+    fn create_policy_assigns_id_and_arn() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let p = org
+            .create_policy("AllowAll", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        assert!(p.id.starts_with("p-"));
+        assert!(p.arn.contains("service_control_policy"));
+        assert_eq!(p.policy_type, POLICY_TYPE_SCP);
+        assert!(!p.aws_managed);
+    }
+
+    #[test]
+    fn create_policy_rejects_non_scp_type() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let err = org
+            .create_policy("x", "d", CONTENT_ALL, "TAG_POLICY")
+            .unwrap_err();
+        assert!(matches!(err, OrgError::PolicyTypeNotSupported(_)));
+    }
+
+    #[test]
+    fn create_policy_rejects_malformed_json() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let err = org
+            .create_policy("x", "d", "not-json", POLICY_TYPE_SCP)
+            .unwrap_err();
+        assert!(matches!(err, OrgError::MalformedPolicyDocument));
+    }
+
+    #[test]
+    fn create_policy_duplicate_name_rejected() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.create_policy("AllowAll", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        let err = org
+            .create_policy("AllowAll", "other", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap_err();
+        assert!(matches!(err, OrgError::DuplicatePolicy(_)));
+    }
+
+    #[test]
+    fn update_policy_overrides_fields() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let p = org
+            .create_policy("a", "old", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        let updated = org
+            .update_policy(&p.id, Some("b"), Some("new"), None)
+            .unwrap();
+        assert_eq!(updated.name, "b");
+        assert_eq!(updated.description, "new");
+        assert_eq!(updated.content, CONTENT_ALL);
+    }
+
+    #[test]
+    fn update_policy_rejects_aws_managed() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let err = org
+            .update_policy(FULL_AWS_ACCESS_POLICY_ID, Some("x"), None, None)
+            .unwrap_err();
+        assert!(matches!(err, OrgError::PolicyChangesNotAllowed(_)));
+    }
+
+    #[test]
+    fn update_policy_rejects_malformed_content() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let p = org
+            .create_policy("a", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        let err = org
+            .update_policy(&p.id, None, None, Some("{bad"))
+            .unwrap_err();
+        assert!(matches!(err, OrgError::MalformedPolicyDocument));
+    }
+
+    #[test]
+    fn update_policy_duplicate_name_rejected() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let a = org
+            .create_policy("a", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        let b = org
+            .create_policy("b", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        let err = org.update_policy(&b.id, Some("a"), None, None).unwrap_err();
+        assert!(matches!(err, OrgError::DuplicatePolicy(_)));
+        // Rename to its own name is fine (idempotent).
+        org.update_policy(&a.id, Some("a"), None, None).unwrap();
+    }
+
+    #[test]
+    fn delete_policy_rejects_in_use() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let p = org
+            .create_policy("p", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        org.attach_policy(&p.id, &root).unwrap();
+        let err = org.delete_policy(&p.id).unwrap_err();
+        assert!(matches!(err, OrgError::PolicyInUse(_)));
+    }
+
+    #[test]
+    fn delete_policy_rejects_aws_managed() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let err = org.delete_policy(FULL_AWS_ACCESS_POLICY_ID).unwrap_err();
+        assert!(matches!(err, OrgError::PolicyChangesNotAllowed(_)));
+    }
+
+    #[test]
+    fn attach_detach_roundtrip() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let p = org
+            .create_policy("p", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        let ou = org.create_ou(&root, "team").unwrap();
+        org.attach_policy(&p.id, &ou.id).unwrap();
+        let targets = org.targets_for_policy(&p.id).unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].0, ou.id);
+        assert_eq!(targets[0].2, "ORGANIZATIONAL_UNIT");
+        org.detach_policy(&p.id, &ou.id).unwrap();
+        assert!(org.targets_for_policy(&p.id).unwrap().is_empty());
+    }
+
+    #[test]
+    fn attach_rejects_unknown_target_and_policy() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let p = org
+            .create_policy("p", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        let err = org.attach_policy(&p.id, "ou-bogus").unwrap_err();
+        assert!(matches!(err, OrgError::TargetNotFound(_)));
+        let root = org.root_id.clone();
+        let err = org.attach_policy("p-bogus", &root).unwrap_err();
+        assert!(matches!(err, OrgError::PolicyNotFound(_)));
+    }
+
+    #[test]
+    fn detach_unattached_policy_fails() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let p = org
+            .create_policy("p", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        let err = org.detach_policy(&p.id, &root).unwrap_err();
+        assert!(matches!(err, OrgError::PolicyNotAttached(_)));
+    }
+
+    #[test]
+    fn policies_for_target_returns_attached_only() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let p = org
+            .create_policy("p", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        org.attach_policy(&p.id, &root).unwrap();
+        // Root starts with FullAWSAccess + new p attached.
+        let list = org.policies_for_target(&root).unwrap();
+        assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn policies_for_target_unknown_target() {
+        let org = OrganizationState::bootstrap("111111111111");
+        let err = org.policies_for_target("ou-bogus").unwrap_err();
+        assert!(matches!(err, OrgError::TargetNotFound(_)));
+    }
+
+    #[test]
+    fn targets_for_policy_identifies_target_types() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let ou = org.create_ou(&root, "team").unwrap();
+        let p = org
+            .create_policy("p", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        org.enroll_account_if_missing("222222222222");
+        org.attach_policy(&p.id, &root).unwrap();
+        org.attach_policy(&p.id, &ou.id).unwrap();
+        org.attach_policy(&p.id, "222222222222").unwrap();
+        let mut types: Vec<_> = org
+            .targets_for_policy(&p.id)
+            .unwrap()
+            .into_iter()
+            .map(|(_, _, t)| t)
+            .collect();
+        types.sort();
+        assert_eq!(types, vec!["ACCOUNT", "ORGANIZATIONAL_UNIT", "ROOT"]);
+    }
+
+    #[test]
+    fn attach_is_idempotent() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let p = org
+            .create_policy("p", "d", CONTENT_ALL, POLICY_TYPE_SCP)
+            .unwrap();
+        org.attach_policy(&p.id, &root).unwrap();
+        org.attach_policy(&p.id, &root).unwrap();
+        let targets = org.targets_for_policy(&p.id).unwrap();
+        assert_eq!(targets.len(), 1);
     }
 }

--- a/website/content/docs/reference/organizations.md
+++ b/website/content/docs/reference/organizations.md
@@ -1,12 +1,12 @@
 +++
 title = "AWS Organizations"
-description = "Minimal Organizations control plane: organization, OU tree, account membership. SCP CRUD and enforcement ship in later batches."
+description = "Organizations control plane: organization, OU tree, account membership, SCP CRUD. Enforcement ships in Batch 4."
 weight = 6
 +++
 
 fakecloud ships a minimal AWS Organizations implementation. Its purpose is to let you attach Service Control Policies (SCPs) to accounts and organizational units so your tests can exercise the full IAM evaluation hierarchy — SCP ceiling, permission boundary, session policy, identity policy, resource policy — end to end.
 
-The current surface: organization lifecycle, OU tree, and member-account listing. SCP CRUD lands in Batch 3, and SCP enforcement through the IAM evaluator lands in Batch 4.
+The current surface: organization lifecycle, OU tree, member-account listing, and SCP CRUD + attachment. SCP enforcement through the IAM evaluator lands in Batch 4.
 
 ## Model
 
@@ -36,8 +36,23 @@ The current surface: organization lifecycle, OU tree, and member-account listing
 | `ListAccountsForParent` | ✅ | |
 | `DescribeAccount` | ✅ | |
 | `MoveAccount` | ✅ | Enforces exact source-parent match |
+| `CreatePolicy` | ✅ | `Type=SERVICE_CONTROL_POLICY` only; structural JSON validation |
+| `UpdatePolicy` | ✅ | Blocks mutation of AWS-managed policies (`FullAWSAccess`) |
+| `DeletePolicy` | ✅ | Blocks deletion when attached or AWS-managed |
+| `DescribePolicy` | ✅ | |
+| `ListPolicies` | ✅ | `Filter` required and must be `SERVICE_CONTROL_POLICY` |
+| `AttachPolicy` | ✅ | Idempotent re-attach; targets = root / OU / account |
+| `DetachPolicy` | ✅ | Returns `PolicyNotAttachedException` on missing attachment |
+| `ListPoliciesForTarget` | ✅ | |
+| `ListTargetsForPolicy` | ✅ | |
 
-SCP CRUD and enforcement are in active development. See the security reference for the IAM evaluation hierarchy.
+## SCP semantics
+
+Policies are JSON documents of the same shape as identity policies. In Batch 3 the control plane validates that the document is parseable JSON; deeper semantic validation happens alongside enforcement in Batch 4, so there is no divergence between what the control plane accepts and what the evaluator actually enforces.
+
+`FullAWSAccess` (`p-FullAWSAccess`) is created and attached to the root OU on `CreateOrganization` and is immutable: `UpdatePolicy` and `DeletePolicy` return `PolicyChangesNotAllowedException` for it. You can still `DetachPolicy` it from the root — AWS permits this, and tests that want to exercise a restrictive SCP posture rely on being able to drop the AWS-managed allow-all.
+
+SCP enforcement in the IAM evaluator is in active development. See the security reference for where SCPs sit in the full evaluation hierarchy.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Batch 3 of the SCP rollout. Ships the customer-managed SCP CRUD surface so tests can create policies and attach them to targets. No evaluator changes — enforcement ships in Batch 4.

- **Policy CRUD** — `CreatePolicy`, `UpdatePolicy`, `DeletePolicy`, `DescribePolicy`, `ListPolicies`
- **Attachment** — `AttachPolicy`, `DetachPolicy`, `ListPoliciesForTarget`, `ListTargetsForPolicy`
- **SCP-only type** — any other `Type` returns `PolicyTypeNotSupportedException`; matches the plan's SCP-only scope.
- **Validation** — structural JSON parse for policy documents. Deeper semantic validation lands with enforcement in Batch 4 (avoids accept-but-don't-enforce drift).
- **FullAWSAccess is immutable** — `UpdatePolicy` / `DeletePolicy` return `PolicyChangesNotAllowedException`. `DetachPolicy` from the root still works, so tests can adopt a restrictive SCP posture by dropping the AWS-managed allow-all.
- **Delete while attached** fails with `PolicyInUseException`; **detach without attachment** fails with `PolicyNotAttachedException`.
- **Idempotent attach** — re-attaching the same policy to the same target is a no-op success.

## Test plan

- [x] 65+ unit tests covering every state mutation and every service dispatcher (happy + error paths)
- [x] E2E: `scp_create_attach_detach_delete_roundtrip`, `scp_full_aws_access_is_immutable`, `scp_reject_non_scp_policy_type`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] Docs updated at `/docs/reference/organizations` — new ops table, SCP semantics section explaining validation + FullAWSAccess immutability

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SCP policy CRUD and attachment APIs to Organizations so tests can create policies and attach them to roots, OUs, and accounts. No enforcement changes yet; that ships in Batch 4.

- **New Features**
  - Implemented `CreatePolicy`, `UpdatePolicy`, `DeletePolicy`, `DescribePolicy`, `ListPolicies`, `AttachPolicy`, `DetachPolicy`, `ListPoliciesForTarget`, `ListTargetsForPolicy`.
  - SCP-only: non-`SERVICE_CONTROL_POLICY` types return `PolicyTypeNotSupportedException`.
  - Policy content is validated as JSON; deeper validation lands with enforcement in Batch 4.
  - `p-FullAWSAccess` is immutable (`PolicyChangesNotAllowedException` on update/delete); can still detach from the root.
  - Guardrails: delete while attached -> `PolicyInUseException`; detach when not attached -> `PolicyNotAttachedException`; re-attach is a no-op success.
  - Listings: `ListPolicies` requires `Filter=SERVICE_CONTROL_POLICY`; target listings cover `ROOT`/`ORGANIZATIONAL_UNIT`/`ACCOUNT` and include ARNs.

<sup>Written for commit 275c800e1bf7d14bb856933b378c7b3e9a5d1af5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

