### PR TITLE
feat(iam): SCP enforcement as top-of-chain ceiling

### DIFF
--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -337,16 +337,23 @@ pub trait IamPolicyEvaluator: Send + Sync {
     /// `principal`, using `context` for `Condition` block resolution.
     /// `session_policies` are the raw JSON session-policy documents
     /// from the STS call that minted the caller's credential (empty
-    /// for IAM user access keys).
+    /// for IAM user access keys). `scps` are the inherited SCP
+    /// documents (root-OU first, account-direct last) that form the
+    /// top-of-chain allow-list ceiling; `None` means no org exists
+    /// for this principal or the principal is exempt (management,
+    /// service-linked role) and the layer is a pass-through.
     fn evaluate(
         &self,
         principal: &Principal,
         action: &IamAction,
         context: &ConditionContext,
         session_policies: &[String],
+        scps: Option<&[String]>,
     ) -> IamDecision;
 
     /// Evaluate with resource-policy + session-policy intersection.
+    /// `scps` follows the same semantics as in [`Self::evaluate`].
+    #[allow(clippy::too_many_arguments)]
     fn evaluate_with_resource_policy(
         &self,
         principal: &Principal,
@@ -355,7 +362,26 @@ pub trait IamPolicyEvaluator: Send + Sync {
         resource_policy_json: Option<&str>,
         resource_account_id: &str,
         session_policies: &[String],
+        scps: Option<&[String]>,
     ) -> IamDecision;
+}
+
+/// Abstraction over "given a principal, return the inherited SCP
+/// documents that form the top-of-chain allow-list ceiling for the
+/// principal's account". Implemented by `fakecloud-organizations`.
+///
+/// Returning `None` means SCPs do not apply (no org exists for this
+/// fakecloud process, or the principal is the management account, or
+/// the principal is a service-linked role, or the account is not
+/// enrolled in the organization). Dispatch plumbs the returned slice
+/// straight into [`IamPolicyEvaluator`].
+///
+/// The ordered list puts root-OU-attached policies first, then each
+/// descendant OU down to the account's parent, and account-direct
+/// attachments last — the evaluator treats each entry as a separate
+/// gate that must allow (intersection), matching AWS SCP semantics.
+pub trait ScpResolver: Send + Sync {
+    fn scps_for(&self, principal: &Principal) -> Option<Vec<String>>;
 }
 
 /// Abstraction over "given a service + a fully-qualified resource ARN,

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -379,6 +379,16 @@ pub async fn dispatch(
                         // same-account by using the caller's account.
                         let resource_account_id = parse_account_from_arn(&iam_action.resource)
                             .unwrap_or_else(|| principal.account_id.clone());
+                        // SCP ceiling: resolve the inherited SCP chain
+                        // for this principal (management accounts and
+                        // service-linked roles come back as `None`, in
+                        // which case the evaluator treats the layer as
+                        // absent). Audit breadcrumbs emitted by the
+                        // resolver itself, not here.
+                        let scps = config
+                            .scp_resolver
+                            .as_ref()
+                            .and_then(|r| r.scps_for(principal));
                         let decision = evaluator.evaluate_with_resource_policy(
                             principal,
                             &iam_action,
@@ -386,6 +396,7 @@ pub async fn dispatch(
                             resource_policy_json.as_deref(),
                             &resource_account_id,
                             &caller_session_policies,
+                            scps.as_deref(),
                         );
                         if !decision.is_allow() {
                             tracing::warn!(
@@ -524,6 +535,13 @@ pub struct DispatchConfig {
     /// dispatch then behaves as if no resource policy is attached to
     /// any resource, identical to the Phase 1 behavior.
     pub resource_policy_provider: Option<Arc<dyn ResourcePolicyProvider>>,
+    /// Resolves the ordered SCP chain that applies to a principal's
+    /// account (root-OU first, account-direct last). `None` means no
+    /// organizations resolver has been registered — SCPs never gate
+    /// any request in that case. Off-by-default matches the Batch 4
+    /// contract: zero behavior change until a user calls
+    /// `CreateOrganization` and the resolver is wired.
+    pub scp_resolver: Option<Arc<dyn crate::auth::ScpResolver>>,
 }
 
 impl std::fmt::Debug for DispatchConfig {
@@ -554,6 +572,10 @@ impl std::fmt::Debug for DispatchConfig {
                     .as_ref()
                     .map(|_| "<ResourcePolicyProvider>"),
             )
+            .field(
+                "scp_resolver",
+                &self.scp_resolver.as_ref().map(|_| "<ScpResolver>"),
+            )
             .finish()
     }
 }
@@ -570,6 +592,7 @@ impl DispatchConfig {
             credential_resolver: None,
             policy_evaluator: None,
             resource_policy_provider: None,
+            scp_resolver: None,
         }
     }
 }
@@ -1040,9 +1063,11 @@ mod tests {
             credential_resolver: None,
             policy_evaluator: None,
             resource_policy_provider: None,
+            scp_resolver: None,
         };
         assert!(cfg.verify_sigv4);
         assert!(cfg.iam_mode.is_strict());
         assert!(cfg.resource_policy_provider.is_none());
+        assert!(cfg.scp_resolver.is_none());
     }
 }

--- a/crates/fakecloud-e2e/tests/organizations_scp_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/organizations_scp_enforcement.rs
@@ -1,0 +1,291 @@
+//! End-to-end SCP enforcement tests.
+//!
+//! Drives real `aws-sdk-s3` + `aws-sdk-sqs` against fakecloud running
+//! in `FAKECLOUD_IAM=strict`, with an organization and SCPs attached.
+//! Covers the Batch 4 behavior contract:
+//!
+//! - Off by default (no org, `FAKECLOUD_IAM=strict`): no behavior change.
+//! - Management account is always exempt from SCP enforcement.
+//! - A custom SCP denying a service blocks member accounts.
+//! - Detaching `FullAWSAccess` from root + attaching a restrictive
+//!   SCP demonstrates allow-list ceiling semantics.
+
+mod helpers;
+
+use aws_credential_types::Credentials;
+use aws_sdk_organizations::Client as OrgsClient;
+use aws_sdk_s3::Client as S3Client;
+use aws_sdk_sqs::Client as SqsClient;
+use helpers::TestServer;
+
+const ACCOUNT_A: &str = "111111111111"; // management
+const ACCOUNT_B: &str = "222222222222"; // member
+
+async fn start() -> TestServer {
+    TestServer::start_with_env(&[
+        ("FAKECLOUD_IAM", "strict"),
+        ("FAKECLOUD_VERIFY_SIGV4", "true"),
+        ("FAKECLOUD_CONTAINER_CLI", "false"),
+    ])
+    .await
+}
+
+async fn config_with(server: &TestServer, akid: &str, secret: &str) -> aws_config::SdkConfig {
+    aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(akid, secret, None, None, "scp-e2e"))
+        .load()
+        .await
+}
+
+const SCP_ALLOW_ALL: &str =
+    r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+
+const SCP_DENY_SQS: &str = r#"{"Version":"2012-10-17","Statement":[
+        {"Effect":"Allow","Action":"*","Resource":"*"},
+        {"Effect":"Deny","Action":"sqs:*","Resource":"*"}
+    ]}"#;
+
+#[tokio::test]
+async fn member_account_blocked_by_explicit_deny_scp() {
+    let server = start().await;
+    let (a_akid, a_secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let a_cfg = config_with(&server, &a_akid, &a_secret).await;
+    let orgs = OrgsClient::new(&a_cfg);
+
+    // Management = A. Org must exist before B auto-enrolls.
+    orgs.create_organization().send().await.unwrap();
+    let root_id = orgs.list_roots().send().await.unwrap().roots()[0]
+        .id()
+        .unwrap()
+        .to_string();
+
+    // Account B auto-enrolls on admin bootstrap.
+    let (b_akid, b_secret) = server.create_admin(ACCOUNT_B, "admin-b").await;
+    let b_cfg = config_with(&server, &b_akid, &b_secret).await;
+
+    // Baseline: before SCP attached, B can use SQS.
+    let sqs_b = SqsClient::new(&b_cfg);
+    sqs_b
+        .create_queue()
+        .queue_name("pre-scp-queue")
+        .send()
+        .await
+        .unwrap();
+
+    // Attach custom SCP that denies sqs:* to root.
+    let policy = orgs
+        .create_policy()
+        .name("DenySqs")
+        .description("")
+        .r#type(aws_sdk_organizations::types::PolicyType::ServiceControlPolicy)
+        .content(SCP_DENY_SQS)
+        .send()
+        .await
+        .unwrap();
+    let policy_id = policy
+        .policy()
+        .unwrap()
+        .policy_summary()
+        .unwrap()
+        .id()
+        .unwrap()
+        .to_string();
+    orgs.attach_policy()
+        .policy_id(&policy_id)
+        .target_id(&root_id)
+        .send()
+        .await
+        .unwrap();
+
+    // Member B is now blocked from SQS.
+    let err = sqs_b
+        .create_queue()
+        .queue_name("post-scp-queue")
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDenied") || msg.contains("403"),
+        "expected AccessDenied, got: {msg}"
+    );
+
+    // S3 still works for B — SCP only denies sqs:*.
+    let s3_b = S3Client::new(&b_cfg);
+    s3_b.create_bucket()
+        .bucket("scp-allowed-bucket")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn management_account_exempt_from_scp() {
+    let server = start().await;
+    let (a_akid, a_secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let a_cfg = config_with(&server, &a_akid, &a_secret).await;
+    let orgs = OrgsClient::new(&a_cfg);
+
+    orgs.create_organization().send().await.unwrap();
+    let root_id = orgs.list_roots().send().await.unwrap().roots()[0]
+        .id()
+        .unwrap()
+        .to_string();
+
+    // Deny-all SCP attached to root.
+    let policy = orgs
+        .create_policy()
+        .name("DenyEverything")
+        .description("")
+        .r#type(aws_sdk_organizations::types::PolicyType::ServiceControlPolicy)
+        .content(
+            r#"{"Version":"2012-10-17","Statement":[
+                {"Effect":"Deny","Action":"*","Resource":"*"}
+            ]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+    let policy_id = policy
+        .policy()
+        .unwrap()
+        .policy_summary()
+        .unwrap()
+        .id()
+        .unwrap()
+        .to_string();
+    orgs.attach_policy()
+        .policy_id(&policy_id)
+        .target_id(&root_id)
+        .send()
+        .await
+        .unwrap();
+
+    // Management account A can still use SQS even with DenyAll SCP
+    // attached to root — AWS always exempts the management account.
+    let sqs_a = SqsClient::new(&a_cfg);
+    sqs_a
+        .create_queue()
+        .queue_name("management-immune")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn detach_full_aws_access_then_custom_scp_controls_ceiling() {
+    let server = start().await;
+    let (a_akid, a_secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let a_cfg = config_with(&server, &a_akid, &a_secret).await;
+    let orgs = OrgsClient::new(&a_cfg);
+
+    orgs.create_organization().send().await.unwrap();
+    let root_id = orgs.list_roots().send().await.unwrap().roots()[0]
+        .id()
+        .unwrap()
+        .to_string();
+
+    let (b_akid, b_secret) = server.create_admin(ACCOUNT_B, "admin-b").await;
+    let b_cfg = config_with(&server, &b_akid, &b_secret).await;
+    let sqs_b = SqsClient::new(&b_cfg);
+    let s3_b = S3Client::new(&b_cfg);
+
+    // Detach FullAWSAccess from root. Now no SCP allow-all reaches B.
+    orgs.detach_policy()
+        .policy_id("p-FullAWSAccess")
+        .target_id(&root_id)
+        .send()
+        .await
+        .unwrap();
+
+    // B cannot do anything that flows through an SCP-enforced service.
+    let err = s3_b
+        .create_bucket()
+        .bucket("should-be-denied")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("AccessDenied") || format!("{err:?}").contains("403"));
+
+    // Attach an SCP that allows only SQS. S3 stays denied; SQS works.
+    let policy = orgs
+        .create_policy()
+        .name("AllowSqsOnly")
+        .description("")
+        .r#type(aws_sdk_organizations::types::PolicyType::ServiceControlPolicy)
+        .content(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sqs:*","Resource":"*"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+    let policy_id = policy
+        .policy()
+        .unwrap()
+        .policy_summary()
+        .unwrap()
+        .id()
+        .unwrap()
+        .to_string();
+    orgs.attach_policy()
+        .policy_id(&policy_id)
+        .target_id(&root_id)
+        .send()
+        .await
+        .unwrap();
+
+    sqs_b
+        .create_queue()
+        .queue_name("sqs-allowed")
+        .send()
+        .await
+        .unwrap();
+    let err = s3_b
+        .create_bucket()
+        .bucket("still-denied")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("AccessDenied") || format!("{err:?}").contains("403"));
+
+    // Re-attach FullAWSAccess and detach the restrictive SCP — B's
+    // ceiling is now allow-all again. AWS intersects SCPs across the
+    // chain: with both `FullAWSAccess` (allow *) and `AllowSqsOnly`
+    // attached, the intersection still caps at sqs only, so S3 stays
+    // denied until the narrow SCP comes off.
+    orgs.attach_policy()
+        .policy_id("p-FullAWSAccess")
+        .target_id(&root_id)
+        .send()
+        .await
+        .unwrap();
+    orgs.detach_policy()
+        .policy_id(&policy_id)
+        .target_id(&root_id)
+        .send()
+        .await
+        .unwrap();
+    s3_b.create_bucket()
+        .bucket("open-again")
+        .send()
+        .await
+        .unwrap();
+    let _ = SCP_ALLOW_ALL; // constant kept for readability in the module
+}
+
+#[tokio::test]
+async fn no_organization_is_zero_behavior_change() {
+    let server = start().await;
+    let (akid, secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let cfg = config_with(&server, &akid, &secret).await;
+    let sqs = SqsClient::new(&cfg);
+    // No CreateOrganization call — resolver returns None, evaluator
+    // behaves exactly as before SCPs shipped.
+    sqs.create_queue()
+        .queue_name("pre-org-world")
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -386,42 +386,80 @@ pub fn evaluate(policies: &[PolicyDocument], request: &EvalRequest<'_>) -> Decis
 }
 
 /// Evaluate `request` against a principal's identity policies plus
-/// optional permission-boundary and session-policy layers.
+/// optional permission-boundary, session-policy, and SCP layers.
 ///
-/// Phase 3 intersection semantics:
+/// Intersection semantics (applies identically to every gate):
 ///
-/// - `boundary = None` / `session = None` → the layer is absent and does
-///   not gate the decision (pass-through).
-/// - `boundary = Some(&[])` / `session = Some(&[])` → the layer is
-///   present but empty, which evaluates to `ImplicitDeny` and therefore
-///   denies the request. This is how dangling boundary ARNs and empty
-///   session policies are represented.
+/// - `boundary = None` / `session = None` / `scps = None` → the layer
+///   is absent and does not gate the decision (pass-through).
+/// - `Some(&[])` → the layer is present but empty, which evaluates to
+///   `ImplicitDeny` and therefore denies the request. This is how
+///   dangling boundary ARNs, empty session policies, and empty SCP
+///   sets (e.g. every policy detached from a target) are represented.
 /// - Any layer returning `ExplicitDeny` wins immediately (Deny
 ///   precedence applies across layers, not just within one).
 /// - Otherwise the request is allowed iff **every present layer**
 ///   evaluates to `Allow`. A layer with `ImplicitDeny` caps the
 ///   intersection to `ImplicitDeny`.
+///
+/// When `scps` is `Some`, each document in the slice is treated as a
+/// separate gate that must allow — the caller already assembled the
+/// ordered list (root OU first, account-direct last) via
+/// [`crate::scp_resolver`] or equivalent.
 pub fn evaluate_with_gates(
     identity: &[PolicyDocument],
     boundary: Option<&[PolicyDocument]>,
     session: Option<&[PolicyDocument]>,
     request: &EvalRequest<'_>,
 ) -> Decision {
+    evaluate_with_gates_and_scps(identity, boundary, session, None, request)
+}
+
+/// Full-chain variant of [`evaluate_with_gates`] that also applies an
+/// SCP ceiling. See the top-of-module docs for the intersection
+/// semantics. Batch 4 added this alongside the 4-arg form so existing
+/// callers (and tests) don't have to thread an extra `None` through
+/// every evaluation site.
+pub fn evaluate_with_gates_and_scps(
+    identity: &[PolicyDocument],
+    boundary: Option<&[PolicyDocument]>,
+    session: Option<&[PolicyDocument]>,
+    scps: Option<&[PolicyDocument]>,
+    request: &EvalRequest<'_>,
+) -> Decision {
     let identity_decision = evaluate_inner(identity, request, false);
-    intersect_layers(identity_decision, boundary, session, request)
+    intersect_layers(identity_decision, boundary, session, scps, request)
 }
 
 /// Combine an already-computed identity-side decision with the optional
-/// boundary and session-policy layers. Factored out so the
+/// boundary, session-policy, and SCP layers. Factored out so the
 /// resource-policy variant can apply the same intersection to the
 /// identity side before OR/ANDing with the resource-policy side.
 fn intersect_layers(
     identity_decision: Decision,
     boundary: Option<&[PolicyDocument]>,
     session: Option<&[PolicyDocument]>,
+    scps: Option<&[PolicyDocument]>,
     request: &EvalRequest<'_>,
 ) -> Decision {
     if matches!(identity_decision, Decision::ExplicitDeny) {
+        return Decision::ExplicitDeny;
+    }
+    // SCP gate sits at the top of the ceiling stack. Each SCP
+    // document is a separate layer that must allow (AWS intersects
+    // SCPs across the OU path). A single explicit Deny in any SCP
+    // short-circuits the evaluation.
+    let scp_decision = scps.map(|docs| evaluate_scp_chain(docs, request));
+    if matches!(scp_decision, Some(Decision::ExplicitDeny)) {
+        if let Some(scps_slice) = scps {
+            tracing::debug!(
+                target: "fakecloud::iam::audit",
+                action = %request.action,
+                principal_arn = %request.principal.arn,
+                scp_count = scps_slice.len(),
+                "SCP ceiling produced ExplicitDeny"
+            );
+        }
         return Decision::ExplicitDeny;
     }
     let boundary_decision = boundary.map(|policies| evaluate_inner(policies, request, false));
@@ -440,7 +478,44 @@ fn intersect_layers(
     let session_allows = session_decision
         .map(|d| matches!(d, Decision::Allow))
         .unwrap_or(true);
-    if identity_allows && boundary_allows && session_allows {
+    let scp_allows = scp_decision
+        .map(|d| matches!(d, Decision::Allow))
+        .unwrap_or(true);
+    if identity_allows && boundary_allows && session_allows && scp_allows {
+        Decision::Allow
+    } else {
+        if scps.is_some() && !scp_allows {
+            tracing::debug!(
+                target: "fakecloud::iam::audit",
+                action = %request.action,
+                principal_arn = %request.principal.arn,
+                "SCP ceiling did not allow action; capped to ImplicitDeny"
+            );
+        }
+        Decision::ImplicitDeny
+    }
+}
+
+/// Walk an ordered SCP chain (root OU -> descendant OUs -> account)
+/// and intersect the per-document decisions. Each document is its own
+/// gate: an explicit Deny anywhere wins, otherwise every document
+/// must evaluate to Allow for the chain to allow.
+fn evaluate_scp_chain(scps: &[PolicyDocument], request: &EvalRequest<'_>) -> Decision {
+    if scps.is_empty() {
+        // `Some(&[])` means the org exists and applies but no SCPs
+        // are attached up the chain. Preserve AWS's deny-by-default
+        // ceiling semantics: nothing allowed.
+        return Decision::ImplicitDeny;
+    }
+    let mut all_allow = true;
+    for doc in scps {
+        match evaluate_inner(std::slice::from_ref(doc), request, false) {
+            Decision::ExplicitDeny => return Decision::ExplicitDeny,
+            Decision::Allow => {}
+            Decision::ImplicitDeny => all_allow = false,
+        }
+    }
+    if all_allow {
         Decision::Allow
     } else {
         Decision::ImplicitDeny
@@ -504,13 +579,40 @@ pub fn evaluate_with_resource_policy_and_gates(
     request: &EvalRequest<'_>,
     resource_account_id: &str,
 ) -> Decision {
+    evaluate_with_resource_policy_and_gates_and_scps(
+        identity_policies,
+        boundary,
+        session,
+        None,
+        resource_policy,
+        request,
+        resource_account_id,
+    )
+}
+
+/// Full-chain variant of
+/// [`evaluate_with_resource_policy_and_gates`] that also applies an
+/// SCP ceiling on the identity side. SCPs never apply to the
+/// resource-policy branch — AWS evaluates the resource policy in the
+/// resource's account, and the caller's SCPs have no authority there.
+pub fn evaluate_with_resource_policy_and_gates_and_scps(
+    identity_policies: &[PolicyDocument],
+    boundary: Option<&[PolicyDocument]>,
+    session: Option<&[PolicyDocument]>,
+    scps: Option<&[PolicyDocument]>,
+    resource_policy: Option<&PolicyDocument>,
+    request: &EvalRequest<'_>,
+    resource_account_id: &str,
+) -> Decision {
     let identity_raw = evaluate_inner(identity_policies, request, false);
     if matches!(identity_raw, Decision::ExplicitDeny) {
         return Decision::ExplicitDeny;
     }
-    // Apply boundary and session gates to the identity side. An
-    // ExplicitDeny from either layer short-circuits the whole call.
-    let identity_gated = intersect_layers(identity_raw, boundary, session, request);
+    // Apply boundary, session, and SCP gates to the identity side.
+    // SCPs only apply to the identity side (never to the resource
+    // policy branch) — they are the caller-account ceiling, and AWS
+    // evaluates the resource policy in the resource's account.
+    let identity_gated = intersect_layers(identity_raw, boundary, session, scps, request);
     if matches!(identity_gated, Decision::ExplicitDeny) {
         return Decision::ExplicitDeny;
     }
@@ -2610,6 +2712,184 @@ mod tests {
                 "123456789012"
             ),
             Decision::ExplicitDeny
+        );
+    }
+
+    // --- Batch 4: SCP ceiling layer -------------------------------------
+
+    #[test]
+    fn scp_caps_identity_allow_all() {
+        let p = principal_user("arn:aws:iam::123456789012:user/alice");
+        let identity = [allow_all()];
+        let scps = [allow_get_object()];
+        assert_eq!(
+            evaluate_with_gates_and_scps(
+                &identity,
+                None,
+                None,
+                Some(&scps),
+                &req(&p, "s3:GetObject", "arn:aws:s3:::bucket/key"),
+            ),
+            Decision::Allow
+        );
+        assert_eq!(
+            evaluate_with_gates_and_scps(
+                &identity,
+                None,
+                None,
+                Some(&scps),
+                &req(&p, "s3:PutObject", "arn:aws:s3:::bucket/key"),
+            ),
+            Decision::ImplicitDeny
+        );
+    }
+
+    #[test]
+    fn scp_explicit_deny_wins() {
+        let p = principal_user("arn:aws:iam::123456789012:user/alice");
+        let identity = [allow_all()];
+        let scps = [deny_put_object()];
+        assert_eq!(
+            evaluate_with_gates_and_scps(
+                &identity,
+                None,
+                None,
+                Some(&scps),
+                &req(&p, "s3:PutObject", "arn:aws:s3:::bucket/key"),
+            ),
+            Decision::ExplicitDeny
+        );
+    }
+
+    #[test]
+    fn scp_empty_chain_denies_everything() {
+        let p = principal_user("arn:aws:iam::123456789012:user/alice");
+        let identity = [allow_all()];
+        let scps: [PolicyDocument; 0] = [];
+        // Some(&[]) means the org applies but no SCP allow-all reaches
+        // the account path (e.g. FullAWSAccess detached and nothing
+        // else attached). Deny-by-default.
+        assert_eq!(
+            evaluate_with_gates_and_scps(
+                &identity,
+                None,
+                None,
+                Some(&scps),
+                &req(&p, "s3:GetObject", "arn:aws:s3:::bucket/key"),
+            ),
+            Decision::ImplicitDeny
+        );
+    }
+
+    #[test]
+    fn scp_none_preserves_identity_only_decision() {
+        // None = off-by-default. Evaluation must match the no-SCP
+        // path bit-for-bit, preserving the zero-behavior-change
+        // contract when no organization exists.
+        let p = principal_user("arn:aws:iam::123456789012:user/alice");
+        let identity = [allow_all()];
+        let with_scps = evaluate_with_gates_and_scps(
+            &identity,
+            None,
+            None,
+            None,
+            &req(&p, "s3:GetObject", "arn:aws:s3:::bucket/key"),
+        );
+        let without = evaluate_with_gates(
+            &identity,
+            None,
+            None,
+            &req(&p, "s3:GetObject", "arn:aws:s3:::bucket/key"),
+        );
+        assert_eq!(with_scps, without);
+        assert_eq!(with_scps, Decision::Allow);
+    }
+
+    #[test]
+    fn scp_chain_intersects_across_ancestors() {
+        // Two SCPs up the path: outer Allow *, inner Allow only
+        // s3:GetObject. AWS intersects — action must be in every one.
+        let p = principal_user("arn:aws:iam::123456789012:user/alice");
+        let identity = [allow_all()];
+        let scps = [allow_all(), allow_get_object()];
+        assert_eq!(
+            evaluate_with_gates_and_scps(
+                &identity,
+                None,
+                None,
+                Some(&scps),
+                &req(&p, "s3:GetObject", "arn:aws:s3:::bucket/key"),
+            ),
+            Decision::Allow
+        );
+        assert_eq!(
+            evaluate_with_gates_and_scps(
+                &identity,
+                None,
+                None,
+                Some(&scps),
+                &req(&p, "s3:PutObject", "arn:aws:s3:::bucket/key"),
+            ),
+            Decision::ImplicitDeny
+        );
+    }
+
+    #[test]
+    fn scp_intersects_with_boundary_and_session() {
+        let p = principal_user("arn:aws:iam::123456789012:user/alice");
+        let identity = [allow_all()];
+        let boundary = [allow_all()];
+        let session = [allow_all()];
+        let scps = [allow_get_object()];
+        assert_eq!(
+            evaluate_with_gates_and_scps(
+                &identity,
+                Some(&boundary),
+                Some(&session),
+                Some(&scps),
+                &req(&p, "s3:PutObject", "arn:aws:s3:::bucket/key"),
+            ),
+            Decision::ImplicitDeny
+        );
+        assert_eq!(
+            evaluate_with_gates_and_scps(
+                &identity,
+                Some(&boundary),
+                Some(&session),
+                Some(&scps),
+                &req(&p, "s3:GetObject", "arn:aws:s3:::bucket/key"),
+            ),
+            Decision::Allow
+        );
+    }
+
+    #[test]
+    fn scp_caps_identity_side_of_resource_policy() {
+        // Cross-account resource policy grants PutObject; caller's SCP
+        // allows only GetObject. Identity side is gated by SCP →
+        // cross-account AND means the whole thing denies.
+        let p = principal_user("arn:aws:iam::111111111111:user/alice");
+        let identity = [allow_all()];
+        let resource = doc(serde_json::json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:PutObject",
+                "Resource": "arn:aws:s3:::bucket/*"
+            }]
+        }));
+        let scps = [allow_get_object()];
+        assert_eq!(
+            evaluate_with_resource_policy_and_gates_and_scps(
+                &identity,
+                None,
+                None,
+                Some(&scps),
+                Some(&resource),
+                &req(&p, "s3:PutObject", "arn:aws:s3:::bucket/key"),
+                "222222222222",
+            ),
+            Decision::ImplicitDeny
         );
     }
 }

--- a/crates/fakecloud-iam/src/policy_evaluator.rs
+++ b/crates/fakecloud-iam/src/policy_evaluator.rs
@@ -37,6 +37,7 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
         action: &IamAction,
         context: &ConditionContext,
         session_policies: &[String],
+        scps: Option<&[String]>,
     ) -> IamDecision {
         let states = self.state.read();
         let Some(state) = states.get(&principal.account_id) else {
@@ -45,16 +46,18 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
         let identity_policies = evaluator::collect_identity_policies(state, principal);
         let boundary = evaluator::collect_boundary_policies(state, principal);
         let session = parse_session_policies(session_policies);
+        let scp_docs = parse_scp_policies(scps, principal);
         let request = EvalRequest {
             principal,
             action: action.action_string(),
             resource: action.resource.clone(),
             context: context.clone(),
         };
-        decision_to_core(evaluator::evaluate_with_gates(
+        decision_to_core(evaluator::evaluate_with_gates_and_scps(
             &identity_policies,
             boundary.as_deref(),
             session.as_deref(),
+            scp_docs.as_deref(),
             &request,
         ))
     }
@@ -67,6 +70,7 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
         resource_policy_json: Option<&str>,
         resource_account_id: &str,
         session_policies: &[String],
+        scps: Option<&[String]>,
     ) -> IamDecision {
         let states = self.state.read();
         let Some(state) = states.get(&principal.account_id) else {
@@ -75,6 +79,7 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
         let identity_policies = evaluator::collect_identity_policies(state, principal);
         let boundary = evaluator::collect_boundary_policies(state, principal);
         let session = parse_session_policies(session_policies);
+        let scp_docs = parse_scp_policies(scps, principal);
         let request = EvalRequest {
             principal,
             action: action.action_string(),
@@ -82,10 +87,11 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
             context: context.clone(),
         };
         let resource_policy = resource_policy_json.map(evaluator::PolicyDocument::parse);
-        decision_to_core(evaluator::evaluate_with_resource_policy_and_gates(
+        decision_to_core(evaluator::evaluate_with_resource_policy_and_gates_and_scps(
             &identity_policies,
             boundary.as_deref(),
             session.as_deref(),
+            scp_docs.as_deref(),
             resource_policy.as_ref(),
             &request,
             resource_account_id,
@@ -102,6 +108,44 @@ fn parse_session_policies(raw: &[String]) -> Option<Vec<evaluator::PolicyDocumen
             .map(|doc| evaluator::PolicyDocument::parse(doc))
             .collect(),
     )
+}
+
+/// Parse the ordered SCP documents returned by the resolver into the
+/// evaluator's `PolicyDocument` shape.
+///
+/// Returns `None` when the resolver indicated that SCPs don't apply
+/// to this principal (no organization, management account, SLR, or
+/// account not enrolled). Returns `Some(vec![])` when the resolver
+/// returned an empty chain — the evaluator treats that as deny-all,
+/// matching AWS's default when every SCP has been detached from every
+/// target up the chain.
+///
+/// Individual JSON parse failures are skipped with a debug log on
+/// `fakecloud::iam::audit` — the "no gaming" rule from the task brief
+/// says we must never silently treat a broken SCP as "matches".
+fn parse_scp_policies(
+    raw: Option<&[String]>,
+    principal: &Principal,
+) -> Option<Vec<evaluator::PolicyDocument>> {
+    let raw = raw?;
+    let mut docs = Vec::with_capacity(raw.len());
+    for (i, json) in raw.iter().enumerate() {
+        // PolicyDocument::parse already logs a warn on malformed JSON
+        // and returns an empty (implicit-deny) document. That makes
+        // the evaluator deny the action rather than silently allow —
+        // the safer direction for an SCP ceiling. Emit an audit
+        // breadcrumb so operators can see which attachment is bad.
+        if serde_json::from_str::<serde_json::Value>(json).is_err() {
+            tracing::debug!(
+                target: "fakecloud::iam::audit",
+                principal_arn = %principal.arn,
+                scp_index = i,
+                "SCP JSON failed to parse; treating as implicit-deny document"
+            );
+        }
+        docs.push(evaluator::PolicyDocument::parse(json));
+    }
+    Some(docs)
 }
 
 fn decision_to_core(decision: Decision) -> IamDecision {
@@ -182,7 +226,13 @@ mod tests {
             resource: "arn:aws:s3:::bucket/key".into(),
         };
         assert_eq!(
-            eval.evaluate(&principal(), &action, &ConditionContext::default(), &[]),
+            eval.evaluate(
+                &principal(),
+                &action,
+                &ConditionContext::default(),
+                &[],
+                None
+            ),
             IamDecision::Allow
         );
     }
@@ -211,7 +261,13 @@ mod tests {
             resource: "arn:aws:s3:::bucket/key".into(),
         };
         assert_eq!(
-            eval.evaluate(&principal(), &action, &ConditionContext::default(), &[]),
+            eval.evaluate(
+                &principal(),
+                &action,
+                &ConditionContext::default(),
+                &[],
+                None
+            ),
             IamDecision::ExplicitDeny
         );
     }
@@ -285,7 +341,8 @@ mod tests {
                 &principal(),
                 &s3_get_object_action(),
                 &ConditionContext::default(),
-                &[]
+                &[],
+                None,
             ),
             IamDecision::Allow
         );
@@ -294,7 +351,8 @@ mod tests {
                 &principal(),
                 &s3_put_object_action(),
                 &ConditionContext::default(),
-                &[]
+                &[],
+                None,
             ),
             IamDecision::ImplicitDeny
         );
@@ -327,7 +385,8 @@ mod tests {
                 &principal(),
                 &s3_put_object_action(),
                 &ConditionContext::default(),
-                &[]
+                &[],
+                None,
             ),
             IamDecision::ExplicitDeny
         );
@@ -357,7 +416,8 @@ mod tests {
                 &principal(),
                 &s3_get_object_action(),
                 &ConditionContext::default(),
-                &[]
+                &[],
+                None,
             ),
             IamDecision::ImplicitDeny
         );
@@ -412,7 +472,8 @@ mod tests {
                 &principal,
                 &s3_get_object_action(),
                 &ConditionContext::default(),
-                &[]
+                &[],
+                None,
             ),
             IamDecision::Allow
         );
@@ -428,7 +489,13 @@ mod tests {
             resource: "arn:aws:s3:::bucket/key".into(),
         };
         assert_eq!(
-            eval.evaluate(&principal(), &action, &ConditionContext::default(), &[]),
+            eval.evaluate(
+                &principal(),
+                &action,
+                &ConditionContext::default(),
+                &[],
+                None
+            ),
             IamDecision::ImplicitDeny
         );
     }

--- a/crates/fakecloud-organizations/src/lib.rs
+++ b/crates/fakecloud-organizations/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod resolver;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-organizations/src/resolver.rs
+++ b/crates/fakecloud-organizations/src/resolver.rs
@@ -114,15 +114,61 @@ impl ScpResolver for OrganizationsScpResolver {
         // Account-direct attachments come last.
         path.push(principal.account_id.clone());
 
+        // AWS semantics: SCPs attached to the **same** target are
+        // unioned (OR across the policies' statements), and the union
+        // documents across **different** ancestor levels are then
+        // intersected (AND). Our evaluator models each slice entry as
+        // an intersection gate, so emit one entry per target level
+        // with its per-level union already merged. Identified by cubic.
         let mut docs: Vec<String> = Vec::new();
         for target_id in &path {
-            if let Some(policy_ids) = org.attachments.get(target_id) {
-                for pid in policy_ids {
-                    if let Some(policy) = org.policies.get(pid) {
-                        docs.push(policy.content.clone());
+            let Some(policy_ids) = org.attachments.get(target_id) else {
+                continue;
+            };
+            if policy_ids.is_empty() {
+                continue;
+            }
+            let mut statements: Vec<serde_json::Value> = Vec::new();
+            for pid in policy_ids {
+                let Some(policy) = org.policies.get(pid) else {
+                    continue;
+                };
+                let parsed: serde_json::Value = match serde_json::from_str(&policy.content) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::debug!(
+                            target: "fakecloud::iam::audit",
+                            policy_id = %pid,
+                            error = %e,
+                            "SCP content failed to parse at resolve time; skipping policy"
+                        );
+                        continue;
+                    }
+                };
+                match parsed.get("Statement") {
+                    Some(serde_json::Value::Array(arr)) => {
+                        statements.extend(arr.iter().cloned());
+                    }
+                    Some(single @ serde_json::Value::Object(_)) => {
+                        statements.push(single.clone());
+                    }
+                    _ => {
+                        tracing::debug!(
+                            target: "fakecloud::iam::audit",
+                            policy_id = %pid,
+                            "SCP has no Statement array; skipping"
+                        );
                     }
                 }
             }
+            if statements.is_empty() {
+                continue;
+            }
+            let merged = serde_json::json!({
+                "Version": "2012-10-17",
+                "Statement": statements,
+            });
+            docs.push(merged.to_string());
         }
         Some(docs)
     }
@@ -255,8 +301,50 @@ mod tests {
 
         let resolver = OrganizationsScpResolver::new(shared(org));
         let docs = resolver.scps_for(&user_principal("222222222222")).unwrap();
-        // Chain: FullAWSAccess@root + P_Root + P_Parent + P_Child + P_Account.
-        assert_eq!(docs.len(), 5);
+        // One merged document per level: root (FullAWSAccess + P_Root),
+        // parent OU (P_Parent), child OU (P_Child), account (P_Account).
+        assert_eq!(docs.len(), 4);
+    }
+
+    #[test]
+    fn same_target_scps_are_unioned_into_one_document() {
+        // Two SCPs attached to the same target must fold their
+        // statements into a single document so the evaluator sees one
+        // entry for that level. AWS semantics: same-target = OR,
+        // across-levels = AND. (Identified by cubic.)
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        org.detach_policy(crate::state::FULL_AWS_ACCESS_POLICY_ID, &root)
+            .unwrap();
+        let a = org
+            .create_policy(
+                "A",
+                "",
+                r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#,
+                crate::state::POLICY_TYPE_SCP,
+            )
+            .unwrap();
+        let b = org
+            .create_policy(
+                "B",
+                "",
+                r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:PutObject","Resource":"*"}]}"#,
+                crate::state::POLICY_TYPE_SCP,
+            )
+            .unwrap();
+        org.attach_policy(&a.id, &root).unwrap();
+        org.attach_policy(&b.id, &root).unwrap();
+        org.enroll_account_if_missing("222222222222");
+        let resolver = OrganizationsScpResolver::new(shared(org));
+        let docs = resolver.scps_for(&user_principal("222222222222")).unwrap();
+        assert_eq!(
+            docs.len(),
+            1,
+            "same-target SCPs must merge into one document"
+        );
+        let merged: serde_json::Value = serde_json::from_str(&docs[0]).unwrap();
+        let stmts = merged["Statement"].as_array().unwrap();
+        assert_eq!(stmts.len(), 2);
     }
 
     #[test]

--- a/crates/fakecloud-organizations/src/resolver.rs
+++ b/crates/fakecloud-organizations/src/resolver.rs
@@ -1,0 +1,276 @@
+//! Implementation of [`fakecloud_core::auth::ScpResolver`] over the
+//! shared organizations state.
+//!
+//! Walks the OU tree from root down to the account's parent, collecting
+//! attachments at every node plus account-direct attachments. The
+//! evaluator treats each returned document as a separate gate that
+//! must allow, matching AWS's intersect-across-ancestors semantics.
+//!
+//! Exemptions that return `None` (layer absent, pass-through):
+//!
+//! - No organization exists for this fakecloud process.
+//! - Principal is the management account (AWS never enforces SCPs
+//!   against the management account).
+//! - Principal is a service-linked role (AWS SLR exemption, same as
+//!   permission boundaries).
+//! - Principal's account is not enrolled in the organization (stale
+//!   credentials from before the org was created, for example).
+
+use std::sync::Arc;
+
+use fakecloud_core::auth::{Principal, PrincipalType, ScpResolver};
+
+use crate::state::SharedOrganizationsState;
+
+pub struct OrganizationsScpResolver {
+    state: SharedOrganizationsState,
+}
+
+impl OrganizationsScpResolver {
+    pub fn new(state: SharedOrganizationsState) -> Self {
+        Self { state }
+    }
+
+    pub fn shared(state: SharedOrganizationsState) -> Arc<dyn ScpResolver> {
+        Arc::new(Self::new(state))
+    }
+}
+
+impl ScpResolver for OrganizationsScpResolver {
+    fn scps_for(&self, principal: &Principal) -> Option<Vec<String>> {
+        let guard = self.state.read();
+        let org = guard.as_ref()?;
+
+        // Management account: always exempt.
+        if org.is_management(&principal.account_id) {
+            tracing::debug!(
+                target: "fakecloud::iam::audit",
+                principal_arn = %principal.arn,
+                "SCP resolver: management account exempt"
+            );
+            return None;
+        }
+
+        // Service-linked role exemption mirrors the permission-boundary
+        // rule: an assumed role whose role name starts with
+        // `AWSServiceRoleFor` is exempt from SCP enforcement. AWS
+        // rejects attaching SCPs to SLRs at the control plane, so this
+        // is defense-in-depth.
+        if matches!(principal.principal_type, PrincipalType::AssumedRole)
+            && slr_role_name(&principal.arn)
+                .map(|n| n.starts_with("AWSServiceRoleFor"))
+                .unwrap_or(false)
+        {
+            tracing::debug!(
+                target: "fakecloud::iam::audit",
+                principal_arn = %principal.arn,
+                "SCP resolver: service-linked role exempt"
+            );
+            return None;
+        }
+
+        let account = match org.accounts.get(&principal.account_id) {
+            Some(a) => a,
+            None => {
+                tracing::debug!(
+                    target: "fakecloud::iam::audit",
+                    principal_arn = %principal.arn,
+                    account = %principal.account_id,
+                    "SCP resolver: account not enrolled in organization; SCPs don't apply"
+                );
+                return None;
+            }
+        };
+
+        // Walk the OU tree from the account's direct parent up to the
+        // root, then reverse so the output is root-OU-first. Collect
+        // each target's SCPs into the final ordered chain.
+        let mut path: Vec<String> = Vec::new();
+        let mut cursor = account.parent_id.clone();
+        let mut seen_root = false;
+        loop {
+            path.push(cursor.clone());
+            if cursor == org.root_id {
+                seen_root = true;
+                break;
+            }
+            match org.ous.get(&cursor) {
+                Some(ou) => cursor = ou.parent_id.clone(),
+                None => break,
+            }
+        }
+        if !seen_root {
+            // Defensive: if an OU chain doesn't lead to root (shouldn't
+            // happen given how we build the tree), skip SCP enforcement
+            // with an audit log rather than enforcing a partial chain.
+            tracing::debug!(
+                target: "fakecloud::iam::audit",
+                principal_arn = %principal.arn,
+                "SCP resolver: OU path did not reach root; bailing out"
+            );
+            return None;
+        }
+        path.reverse();
+        // Account-direct attachments come last.
+        path.push(principal.account_id.clone());
+
+        let mut docs: Vec<String> = Vec::new();
+        for target_id in &path {
+            if let Some(policy_ids) = org.attachments.get(target_id) {
+                for pid in policy_ids {
+                    if let Some(policy) = org.policies.get(pid) {
+                        docs.push(policy.content.clone());
+                    }
+                }
+            }
+        }
+        Some(docs)
+    }
+}
+
+/// Extract the bare role name from an `arn:aws:sts::<account>:assumed-role/<name>/<session>` ARN.
+fn slr_role_name(arn: &str) -> Option<&str> {
+    let rest = arn.splitn(6, ':').nth(5)?;
+    let after_prefix = rest.strip_prefix("assumed-role/")?;
+    after_prefix.split('/').next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::OrganizationState;
+    use parking_lot::RwLock;
+
+    fn shared(org: OrganizationState) -> SharedOrganizationsState {
+        Arc::new(RwLock::new(Some(org)))
+    }
+
+    fn user_principal(account: &str) -> Principal {
+        Principal {
+            arn: format!("arn:aws:iam::{}:user/alice", account),
+            user_id: "AIDATEST".to_string(),
+            account_id: account.to_string(),
+            principal_type: PrincipalType::User,
+            source_identity: None,
+            tags: None,
+        }
+    }
+
+    #[test]
+    fn no_org_returns_none() {
+        let state: SharedOrganizationsState = Arc::new(RwLock::new(None));
+        let resolver = OrganizationsScpResolver::new(state);
+        assert!(resolver.scps_for(&user_principal("111111111111")).is_none());
+    }
+
+    #[test]
+    fn management_account_is_exempt() {
+        let org = OrganizationState::bootstrap("111111111111");
+        let resolver = OrganizationsScpResolver::new(shared(org));
+        assert!(resolver.scps_for(&user_principal("111111111111")).is_none());
+    }
+
+    #[test]
+    fn non_member_returns_none() {
+        let org = OrganizationState::bootstrap("111111111111");
+        let resolver = OrganizationsScpResolver::new(shared(org));
+        assert!(resolver.scps_for(&user_principal("999999999999")).is_none());
+    }
+
+    #[test]
+    fn slr_is_exempt() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enroll_account_if_missing("222222222222");
+        let resolver = OrganizationsScpResolver::new(shared(org));
+        let slr = Principal {
+            arn: "arn:aws:sts::222222222222:assumed-role/AWSServiceRoleForLambda/session1"
+                .to_string(),
+            user_id: "AROATEST".to_string(),
+            account_id: "222222222222".to_string(),
+            principal_type: PrincipalType::AssumedRole,
+            source_identity: None,
+            tags: None,
+        };
+        assert!(resolver.scps_for(&slr).is_none());
+    }
+
+    #[test]
+    fn member_account_gets_root_scps() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enroll_account_if_missing("222222222222");
+        let resolver = OrganizationsScpResolver::new(shared(org));
+        let docs = resolver.scps_for(&user_principal("222222222222")).unwrap();
+        // Root auto-attaches FullAWSAccess.
+        assert_eq!(docs.len(), 1);
+        assert!(docs[0].contains("\"Action\":\"*\""));
+    }
+
+    #[test]
+    fn account_in_nested_ou_gets_full_chain() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let parent_ou = org.create_ou(&root, "top").unwrap();
+        let child_ou = org.create_ou(&parent_ou.id, "child").unwrap();
+        org.enroll_account_if_missing("222222222222");
+        org.move_account("222222222222", &root, &child_ou.id)
+            .unwrap();
+
+        // Attach custom policies at each level.
+        let p_root = org
+            .create_policy(
+                "P_Root",
+                "",
+                r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+                crate::state::POLICY_TYPE_SCP,
+            )
+            .unwrap();
+        let p_parent = org
+            .create_policy(
+                "P_Parent",
+                "",
+                r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+                crate::state::POLICY_TYPE_SCP,
+            )
+            .unwrap();
+        let p_child = org
+            .create_policy(
+                "P_Child",
+                "",
+                r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+                crate::state::POLICY_TYPE_SCP,
+            )
+            .unwrap();
+        let p_account = org
+            .create_policy(
+                "P_Account",
+                "",
+                r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+                crate::state::POLICY_TYPE_SCP,
+            )
+            .unwrap();
+        org.attach_policy(&p_root.id, &root).unwrap();
+        org.attach_policy(&p_parent.id, &parent_ou.id).unwrap();
+        org.attach_policy(&p_child.id, &child_ou.id).unwrap();
+        org.attach_policy(&p_account.id, "222222222222").unwrap();
+
+        let resolver = OrganizationsScpResolver::new(shared(org));
+        let docs = resolver.scps_for(&user_principal("222222222222")).unwrap();
+        // Chain: FullAWSAccess@root + P_Root + P_Parent + P_Child + P_Account.
+        assert_eq!(docs.len(), 5);
+    }
+
+    #[test]
+    fn account_with_no_attachments_returns_empty_chain_if_full_aws_access_detached() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        org.detach_policy(crate::state::FULL_AWS_ACCESS_POLICY_ID, &root)
+            .unwrap();
+        org.enroll_account_if_missing("222222222222");
+        let resolver = OrganizationsScpResolver::new(shared(org));
+        let docs = resolver.scps_for(&user_principal("222222222222")).unwrap();
+        // No SCPs attached anywhere on the path — evaluator will treat
+        // this as deny-all (matches AWS when the last allow-all is
+        // detached and nothing else is attached).
+        assert!(docs.is_empty());
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2078,6 +2078,11 @@ async fn main() {
                 ),
             ],
         )),
+        scp_resolver: Some(
+            fakecloud_organizations::resolver::OrganizationsScpResolver::shared(
+                organizations_state.clone(),
+            ),
+        ),
     };
 
     let service_names: Vec<String> = registry

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -691,7 +691,8 @@ mod tests {
             action: "ListBuckets",
             resource: "*".to_string(),
         };
-        let decision = evaluator.evaluate(&principal, &action, &ConditionContext::default(), &[]);
+        let decision =
+            evaluator.evaluate(&principal, &action, &ConditionContext::default(), &[], None);
         assert_eq!(
             decision,
             IamDecision::Allow,

--- a/website/content/docs/reference/organizations.md
+++ b/website/content/docs/reference/organizations.md
@@ -1,12 +1,12 @@
 +++
 title = "AWS Organizations"
-description = "Organizations control plane: organization, OU tree, account membership, SCP CRUD. Enforcement ships in Batch 4."
+description = "Organizations control plane + SCP enforcement as the top-of-chain IAM evaluator layer."
 weight = 6
 +++
 
 fakecloud ships a minimal AWS Organizations implementation. Its purpose is to let you attach Service Control Policies (SCPs) to accounts and organizational units so your tests can exercise the full IAM evaluation hierarchy — SCP ceiling, permission boundary, session policy, identity policy, resource policy — end to end.
 
-The current surface: organization lifecycle, OU tree, member-account listing, and SCP CRUD + attachment. SCP enforcement through the IAM evaluator lands in Batch 4.
+Both the control plane and SCP enforcement are live. SCPs act as the top-of-chain allow-list ceiling: see the [security reference](/docs/reference/security#phase-6-service-control-policies-scps) for the full evaluation order and the management-account and service-linked-role exemptions.
 
 ## Model
 
@@ -48,11 +48,11 @@ The current surface: organization lifecycle, OU tree, member-account listing, an
 
 ## SCP semantics
 
-Policies are JSON documents of the same shape as identity policies. In Batch 3 the control plane validates that the document is parseable JSON; deeper semantic validation happens alongside enforcement in Batch 4, so there is no divergence between what the control plane accepts and what the evaluator actually enforces.
+Policies are JSON documents of the same shape as identity policies. The control plane validates structural parseability; the evaluator applies the same document at request time, so there is no divergence between what the control plane accepts and what actually gates traffic.
 
 `FullAWSAccess` (`p-FullAWSAccess`) is created and attached to the root OU on `CreateOrganization` and is immutable: `UpdatePolicy` and `DeletePolicy` return `PolicyChangesNotAllowedException` for it. You can still `DetachPolicy` it from the root — AWS permits this, and tests that want to exercise a restrictive SCP posture rely on being able to drop the AWS-managed allow-all.
 
-SCP enforcement in the IAM evaluator is in active development. See the security reference for where SCPs sit in the full evaluation hierarchy.
+SCPs are enforced through the IAM evaluator when `FAKECLOUD_IAM` is `soft` or `strict`. Off by default when no organization exists or the resolver returns a non-member / management / service-linked-role principal. See the [security reference](/docs/reference/security#phase-6-service-control-policies-scps) for the full evaluation chain.
 
 ## Usage
 
@@ -67,4 +67,4 @@ println!("{} managed by {}", org.id().unwrap(), org.master_account_id().unwrap()
 
 ## Behavior under `FAKECLOUD_IAM=off`
 
-Organizations control plane works identically regardless of the `FAKECLOUD_IAM` setting. SCP enforcement — once it ships — is gated on IAM being enabled, so creating an organization with `FAKECLOUD_IAM=off` is allowed but has no effect on evaluation.
+Organizations control plane works identically regardless of the `FAKECLOUD_IAM` setting. SCP enforcement is gated on IAM being enabled, so creating an organization with `FAKECLOUD_IAM=off` is allowed but has no effect on evaluation — the resolver is still wired, but the evaluator it feeds is never called.

--- a/website/content/docs/reference/security.md
+++ b/website/content/docs/reference/security.md
@@ -210,11 +210,27 @@ Key semantics:
 - Services that don't implement ABAC yet (Lambda, Step Functions, etc.) gracefully skip tag evaluation with a `fakecloud::iam::audit` debug log. No fake tag values are ever returned.
 - Adding ABAC support to a new service requires implementing two trait methods: `resource_tags_for()` and `request_tags_from()`.
 
-**Will not ship.**
+## Phase 6 — Service Control Policies (SCPs)
 
-- **Service control policies (SCPs).** An AWS Organizations construct that gates permissions across accounts in an org. fakecloud is a single-account model, so there is no org boundary for an SCP to attach to.
+fakecloud enforces SCPs as the top-of-chain allow-list ceiling above permission boundaries, session policies, and identity policies. SCPs only apply when an AWS Organizations organization exists in the process (see the [Organizations reference](/docs/reference/organizations)) — without one, nothing changes.
 
-If you need any of these for your test scenarios, **use real AWS**. fakecloud is a test tool, not a full IAM simulator.
+The evaluation chain, outermost to innermost:
+
+```
+SCP ceiling  ->  permission boundary  ->  session policy  ->  identity policy  (union resource policy)
+```
+
+Each layer is an intersection gate with AWS's standard semantics: if the layer is present it must evaluate to `Allow` for the request to survive. An explicit `Deny` in any layer wins immediately.
+
+SCP-specific rules:
+
+- **Inherited intersection.** When a member account lives under `root -> OU_A -> OU_B -> account`, every SCP attached along that path must allow the action. AWS intersects across ancestors; fakecloud mirrors it.
+- **Management-account exemption.** The account that called `CreateOrganization` is never constrained by SCPs, matching AWS.
+- **Service-linked role exemption.** Assumed roles whose name begins with `AWSServiceRoleFor` bypass SCP evaluation, same as permission boundaries.
+- **Empty chain denies.** If `FullAWSAccess` is detached from the root and no other SCP grants the action up the path, the principal is denied. This matches AWS's allow-list ceiling semantics — SCPs are not deny lists.
+- **Resource-policy branch untouched.** SCPs gate the identity side only. A resource policy in the resource's account has its own authority; the caller's SCPs have no reach there.
+
+Audit logs emit on `fakecloud::iam::audit` when an SCP layer produces an `ExplicitDeny` or caps the intersection to `ImplicitDeny`, so tests can inspect the decision path.
 
 ## Practical example
 


### PR DESCRIPTION
## Summary

Batch 4 (final batch of the SCP rollout). Service Control Policies now act as a real allow-list ceiling over the IAM evaluation chain. This is the last gap that kept fakecloud from covering every AWS identity primitive end-to-end.

The evaluation chain is now:

```
SCP ceiling  ->  permission boundary  ->  session policy  ->  identity policy  (union resource policy)
```

## Mechanics

- **`fakecloud-core`**
  - New `ScpResolver` trait next to `IamPolicyEvaluator`.
  - `IamPolicyEvaluator` gains `scps: Option<&[String]>` on both evaluate methods.
  - `DispatchConfig` carries `scp_resolver: Option<Arc<dyn ScpResolver>>`.
  - Dispatch resolves the principal's SCP chain before each enforced call and threads it through.

- **`fakecloud-iam/evaluator.rs`**
  - New `evaluate_with_gates_and_scps` + `evaluate_with_resource_policy_and_gates_and_scps`. The existing 4-arg public entry points stay as wrappers, so existing callers compile unchanged.
  - `intersect_layers` treats SCPs as an intersection gate with identical semantics to boundary/session: explicit `Deny` wins, every present `Some` must `Allow`.
  - `evaluate_scp_chain` walks the ordered chain (root-first). Empty chain -> `ImplicitDeny`, matching AWS when every allow-all has been detached.
  - Audit logs on `fakecloud::iam::audit` whenever SCPs explicitly deny or cap.

- **`fakecloud-iam/policy_evaluator.rs`**
  - Parses SCP JSON. Malformed docs log on `fakecloud::iam::audit` and parse as implicit-deny — safer than silently allow.

- **`fakecloud-organizations/resolver.rs`**
  - Implements `ScpResolver`. Management account, service-linked roles, and non-member accounts all return `None` (pass-through).
  - Member accounts get the ordered chain `root -> OU ancestors -> account-direct`.

- **Docs** — `security.md` removes the ``Will not ship: SCPs`` note and adds a Phase 6 section describing the new ceiling layer + exemptions. `organizations.md` no longer says enforcement is ``in progress``.

## Test plan

- [x] Unit tests in `evaluator.rs` for the SCP layer: caps identity, explicit Deny precedence, empty chain deny-all, `None`-as-pass-through, ancestor intersection, combined with boundary+session, resource-policy cross-account behavior.
- [x] Unit tests for `OrganizationsScpResolver`: no-org, management exempt, non-member, SLR exempt, root-OU chain, nested OU chain, empty-chain after FullAWSAccess detach.
- [x] E2E in `tests/organizations_scp_enforcement.rs` driving real `aws-sdk-s3` / `aws-sdk-sqs` against `FAKECLOUD_IAM=strict`:
      - `member_account_blocked_by_explicit_deny_scp`
      - `management_account_exempt_from_scp`
      - `detach_full_aws_access_then_custom_scp_controls_ceiling`
      - `no_organization_is_zero_behavior_change`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Service Control Policies (SCPs) as a top-of-chain allow-list ceiling in IAM evaluation, with same-target attachments unioned per level and intersection across the OU path. Dispatch now resolves inherited SCPs and the evaluator applies them above boundaries, session policies, and identity policies; behavior is off until an organization exists.

- New Features
  - `fakecloud-core`: added `ScpResolver` trait; `IamPolicyEvaluator::evaluate` methods accept `scps: Option<&[String]>`; `DispatchConfig` gains `scp_resolver` and threads resolved SCPs per request.
  - `fakecloud-iam`: evaluator treats SCPs as an intersection gate; explicit Deny wins; empty chain denies-all; resource-policy branch unchanged. Adds `evaluate_with_gates_and_scps` and resource-policy variant. Emits `fakecloud::iam::audit` logs on SCP deny/cap.
  - `fakecloud-organizations`: `OrganizationsScpResolver` returns the ordered chain (root -> OU ancestors -> account), unions same-target attachments into one document per target, and exempts management accounts, service-linked roles, and non-members. Server wires it by default.
  - Tests + docs: unit/E2E cover deny, exemptions, detach `FullAWSAccess`, chain intersection, union-per-level, and no-org = no behavior change. Docs updated with Phase 6.

- Migration
  - If you implement `IamPolicyEvaluator` or embed `fakecloud-core`, update method signatures to include `scps: Option<&[String]>` and set `DispatchConfig.scp_resolver` (e.g., `OrganizationsScpResolver`) when you want SCPs to gate.
  - No behavior change unless an organization is created; management and service-linked roles remain exempt.

<sup>Written for commit 11b1497682624387fac80b0522257b2c4a35782d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

