### PR TITLE
refactor(testkit): harden stdout port handshake

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,4 +49,19 @@ jobs:
       # rustls 0.21 -> aws-smithy-http-client. Our own rustls-webpki 0.103.x
       # is already on the patched release; we can't drop the 0.101 pull chain
       # until the AWS Rust SDK moves off rustls 0.21.
-      - run: cargo audit --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099
+      #
+      # RUSTSEC-2026-0002 (lru 0.12.5 IterMut Stacked Borrows) is pulled in
+      # transitively by aws-sdk-s3 and mysql_async. We never construct or
+      # iterate those crates' internal LRU instances, so the unsoundness is
+      # unreachable from our code.
+      #
+      # RUSTSEC-2026-0097 (rand 0.8.5 unsound with custom logger) reaches us
+      # via mysql_async / twox-hash / rust_decimal / mysql_common. The advisory
+      # requires a user-installed custom logger that calls `rand::rng()` during
+      # logging — fakecloud does not install such a logger.
+      - run: |
+          cargo audit \
+            --ignore RUSTSEC-2026-0098 \
+            --ignore RUSTSEC-2026-0099 \
+            --ignore RUSTSEC-2026-0002 \
+            --ignore RUSTSEC-2026-0097

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,10 +45,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo install cargo-audit
-      # RUSTSEC-2026-0098/0099 (rustls-webpki 0.101.x) reach us only through
-      # rustls 0.21 -> aws-smithy-http-client. Our own rustls-webpki 0.103.x
-      # is already on the patched release; we can't drop the 0.101 pull chain
-      # until the AWS Rust SDK moves off rustls 0.21.
+      # RUSTSEC-2026-0098/0099/0104 (rustls-webpki 0.101.x) reach us only
+      # through rustls 0.21 -> aws-smithy-http-client. Our own rustls-webpki
+      # 0.103.x is already on the patched release (0.103.13+); we can't drop
+      # the 0.101 pull chain until the AWS Rust SDK moves off rustls 0.21.
       #
       # RUSTSEC-2026-0002 (lru 0.12.5 IterMut Stacked Borrows) is pulled in
       # transitively by aws-sdk-s3 and mysql_async. We never construct or
@@ -63,5 +63,6 @@ jobs:
           cargo audit \
             --ignore RUSTSEC-2026-0098 \
             --ignore RUSTSEC-2026-0099 \
+            --ignore RUSTSEC-2026-0104 \
             --ignore RUSTSEC-2026-0002 \
             --ignore RUSTSEC-2026-0097

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4619,7 +4619,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -4660,7 +4660,7 @@ dependencies = [
  "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -4685,9 +4685,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/fakecloud-server/src/cli.rs
+++ b/crates/fakecloud-server/src/cli.rs
@@ -111,26 +111,6 @@ pub(crate) struct Cli {
 }
 
 impl Cli {
-    /// Derive the public-facing endpoint URL from the configured bind address.
-    /// Wildcard hosts (``0.0.0.0`` / ``[::]``) are rewritten to ``localhost`` so
-    /// the URL is meaningful when handed back to clients.
-    ///
-    /// **Note:** when ``--addr`` uses port ``0`` the OS assigns the real port at
-    /// bind time; in that case ``main`` computes the URL directly from the
-    /// bound ``SocketAddr`` rather than calling this method.
-    #[cfg(test)]
-    pub fn endpoint_url(&self) -> String {
-        let addr = &self.addr;
-        let port = addr.rsplit(':').next().unwrap_or("4566");
-        let host = addr.rsplit_once(':').map(|(h, _)| h).unwrap_or("0.0.0.0");
-        let host = if host == "0.0.0.0" || host == "[::]" {
-            "localhost"
-        } else {
-            host
-        };
-        format!("http://{host}:{port}")
-    }
-
     /// Resolve the IAM mode as the cross-crate [`IamMode`] type.
     pub fn iam_mode(&self) -> IamMode {
         self.iam_mode.into()
@@ -179,24 +159,6 @@ mod tests {
     #[test]
     fn iam_flag_rejects_garbage() {
         assert!(Cli::try_parse_from(["fakecloud", "--iam", "allow"]).is_err());
-    }
-
-    #[test]
-    fn endpoint_url_rewrites_wildcard_v4() {
-        let cli = Cli::try_parse_from(["fakecloud", "--addr", "0.0.0.0:4566"]).unwrap();
-        assert_eq!(cli.endpoint_url(), "http://localhost:4566");
-    }
-
-    #[test]
-    fn endpoint_url_rewrites_wildcard_v6() {
-        let cli = Cli::try_parse_from(["fakecloud", "--addr", "[::]:4566"]).unwrap();
-        assert_eq!(cli.endpoint_url(), "http://localhost:4566");
-    }
-
-    #[test]
-    fn endpoint_url_preserves_explicit_host() {
-        let cli = Cli::try_parse_from(["fakecloud", "--addr", "127.0.0.1:9999"]).unwrap();
-        assert_eq!(cli.endpoint_url(), "http://127.0.0.1:9999");
     }
 
     #[test]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -99,20 +99,23 @@ async fn main() {
     // When the caller passes `--addr 0.0.0.0:0` the OS assigns a free port
     // atomically, eliminating the race between find-a-free-port and bind that
     // previously caused sporadic "Connection refused" in parallel tests.
-    // LCOV_EXCL_START
-    let listener = TcpListener::bind(&cli.addr)
+    let (listener, bound_addr) = bind_listener(&cli.addr)
         .await
         .unwrap_or_else(|e| fatal_exit(format_args!("failed to bind {}: {e}", cli.addr)));
-    let bound_addr = listener.local_addr().unwrap();
-    // Print the actual port to stdout so test harnesses can discover it.
-    println!("{}", bound_addr.port());
+
+    // Announce the bound port to stdout so test harnesses (fakecloud-testkit)
+    // can discover the OS-assigned port when `--addr :0` is used. The prefix
+    // makes the line self-identifying: if anything ever prints to stdout
+    // before this line, the parser on the other side still finds the port.
+    if let Err(e) = announce_bound_port(bound_addr.port(), &mut std::io::stdout().lock()) {
+        fatal_exit(format_args!("failed to announce bound port: {e}"));
+    }
     tracing::info!(addr = %bound_addr, "fakecloud is ready");
 
     // Build the endpoint URL from the *actual* bound address so that port 0
     // resolves to the real OS-assigned port in all internal resource URLs
     // (SQS queue URLs, SNS ARNs, etc.).
     let endpoint_url = endpoint_url_from_addr(bound_addr);
-    // LCOV_EXCL_STOP
 
     // Shared state
     let iam_state = Arc::new(parking_lot::RwLock::new(
@@ -3438,6 +3441,26 @@ fn install_panic_hook() {
     }));
 }
 
+/// Prefix used to announce the bound port on stdout. `fakecloud-testkit`
+/// scans stdout for the first line starting with this prefix to discover
+/// the OS-assigned port when the server was launched with `--addr :0`.
+const PORT_HANDSHAKE_PREFIX: &str = "FAKECLOUD_PORT=";
+
+/// Bind a `TcpListener` and return the listener together with the address
+/// the OS actually chose. Separated from `main` so the happy/error paths
+/// are reachable from unit tests.
+async fn bind_listener(addr: &str) -> std::io::Result<(TcpListener, std::net::SocketAddr)> {
+    let listener = TcpListener::bind(addr).await?;
+    let bound = listener.local_addr()?;
+    Ok((listener, bound))
+}
+
+/// Emit the port-handshake line used by test harnesses. Taking a generic
+/// writer keeps this testable without capturing process stdout.
+fn announce_bound_port<W: std::io::Write>(port: u16, writer: &mut W) -> std::io::Result<()> {
+    writeln!(writer, "{PORT_HANDSHAKE_PREFIX}{port}")
+}
+
 /// Build a public-facing endpoint URL from the address the server actually
 /// bound to. Wildcard hosts (``0.0.0.0`` / ``[::]``) are rewritten to
 /// ``localhost`` so the URL is useful when embedded in resource identifiers
@@ -3495,5 +3518,36 @@ mod endpoint_url_tests {
         let port_str = url.trim_start_matches("http://127.0.0.1:");
         let port: u16 = port_str.parse().unwrap();
         assert!(port > 0);
+    }
+}
+
+#[cfg(test)]
+mod startup_tests {
+    use super::*;
+
+    #[test]
+    fn announce_bound_port_uses_tagged_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        announce_bound_port(4566, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "FAKECLOUD_PORT=4566\n",);
+    }
+
+    #[test]
+    fn announce_bound_port_prefix_matches_constant() {
+        // Guard against accidental drift between the constant and the
+        // literal parser in fakecloud-testkit.
+        assert_eq!(PORT_HANDSHAKE_PREFIX, "FAKECLOUD_PORT=");
+    }
+
+    #[tokio::test]
+    async fn bind_listener_reports_os_assigned_port() {
+        let (_listener, bound) = bind_listener("127.0.0.1:0").await.unwrap();
+        assert!(bound.port() > 0);
+        assert_eq!(bound.ip().to_string(), "127.0.0.1");
+    }
+
+    #[tokio::test]
+    async fn bind_listener_errors_on_invalid_addr() {
+        assert!(bind_listener("not-a-socket-addr").await.is_err());
     }
 }

--- a/crates/fakecloud-testkit/src/lib.rs
+++ b/crates/fakecloud-testkit/src/lib.rs
@@ -451,22 +451,53 @@ fn cli_available(cli: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Prefix that `fakecloud-server` prints before the bound port on stdout.
+/// Must stay in sync with `PORT_HANDSHAKE_PREFIX` in
+/// `crates/fakecloud-server/src/main.rs`.
+const PORT_HANDSHAKE_PREFIX: &str = "FAKECLOUD_PORT=";
+
+/// Scan a reader for the `FAKECLOUD_PORT=<n>` handshake line, skipping any
+/// non-handshake lines. Returns `None` on EOF or I/O error before a valid
+/// line is seen. Extracted from `read_bound_port` so it can be unit tested
+/// without spawning a real fakecloud process.
+fn scan_for_handshake<R: std::io::BufRead>(reader: &mut R) -> Option<u16> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => return None,
+            Ok(_) => {
+                if let Some(rest) = line.trim().strip_prefix(PORT_HANDSHAKE_PREFIX) {
+                    if let Ok(port) = rest.parse::<u16>() {
+                        return Some(port);
+                    }
+                }
+                // Non-handshake line — ignore and keep reading.
+            }
+        }
+    }
+}
+
 /// Read the port that fakecloud printed to stdout after binding.
 ///
-/// fakecloud prints one line — the port number — to stdout immediately after
-/// `TcpListener::bind` succeeds. Reading this line tells us both that the TCP
-/// port is bound (no racy "find port, release, rebind" window) and what the
-/// actual OS-assigned port is when `--addr 0.0.0.0:0` is used.
+/// fakecloud prints a tagged handshake line — `FAKECLOUD_PORT=<n>` —
+/// immediately after `TcpListener::bind` succeeds. Scanning for the
+/// prefix (rather than parsing the first line blindly) means a future
+/// startup log line on stdout won't break this handshake.
+///
+/// Once the port is found, the remaining stdout is drained on a
+/// background thread. Without that, a later `println!` in the server
+/// would eventually fill the OS pipe buffer and block the server.
 async fn read_bound_port(child: &mut Child) -> Option<u16> {
-    use std::io::BufRead;
     let stdout = child.stdout.take()?;
     let result = tokio::task::spawn_blocking(move || {
         let mut reader = std::io::BufReader::new(stdout);
-        let mut line = String::new();
-        match reader.read_line(&mut line) {
-            Ok(0) | Err(_) => None,
-            Ok(_) => line.trim().parse::<u16>().ok(),
-        }
+        let port = scan_for_handshake(&mut reader)?;
+        std::thread::spawn(move || {
+            let mut sink = std::io::sink();
+            let _ = std::io::copy(&mut reader, &mut sink);
+        });
+        Some(port)
     });
     match tokio::time::timeout(Duration::from_secs(30), result).await {
         Ok(Ok(Some(port))) => Some(port),
@@ -601,5 +632,60 @@ impl TestServer {
             .force_path_style(true)
             .build();
         aws_sdk_s3::Client::from_conf(s3_config)
+    }
+}
+
+#[cfg(test)]
+mod handshake_tests {
+    use super::*;
+    use std::io::BufReader;
+
+    #[test]
+    fn handshake_on_first_line() {
+        let input = b"FAKECLOUD_PORT=4566\n";
+        let mut reader = BufReader::new(&input[..]);
+        assert_eq!(scan_for_handshake(&mut reader), Some(4566));
+    }
+
+    #[test]
+    fn handshake_after_unrelated_lines() {
+        // Simulate a future scenario where something prints to stdout
+        // before the handshake — scanner must skip and keep reading.
+        let input = b"startup banner\n\
+                     some other log\n\
+                     FAKECLOUD_PORT=38291\n";
+        let mut reader = BufReader::new(&input[..]);
+        assert_eq!(scan_for_handshake(&mut reader), Some(38291));
+    }
+
+    #[test]
+    fn returns_none_on_eof_without_handshake() {
+        let input = b"no port here\nnope\n";
+        let mut reader = BufReader::new(&input[..]);
+        assert_eq!(scan_for_handshake(&mut reader), None);
+    }
+
+    #[test]
+    fn returns_none_on_empty_stream() {
+        let input: &[u8] = b"";
+        let mut reader = BufReader::new(input);
+        assert_eq!(scan_for_handshake(&mut reader), None);
+    }
+
+    #[test]
+    fn ignores_malformed_port_value() {
+        // A line with the prefix but an invalid port is skipped rather
+        // than accepted — prefix is necessary but not sufficient.
+        let input = b"FAKECLOUD_PORT=not-a-number\n\
+                     FAKECLOUD_PORT=70000\n\
+                     FAKECLOUD_PORT=5000\n";
+        let mut reader = BufReader::new(&input[..]);
+        assert_eq!(scan_for_handshake(&mut reader), Some(5000));
+    }
+
+    #[test]
+    fn prefix_matches_server_contract() {
+        // Guards against accidental drift from the server-side constant.
+        assert_eq!(PORT_HANDSHAKE_PREFIX, "FAKECLOUD_PORT=");
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #659 addressing self-review nits:

- **Tag handshake with prefix** — server now emits `FAKECLOUD_PORT=<n>` instead of a bare number. Testkit scans for the prefix and skips other stdout lines, so adding any future `println!` to the server startup path won't silently break port discovery.
- **Drain child stdout** — after finding the handshake, testkit spawns a background thread that sinks remaining stdout. Without it, a future stdout write in the server would eventually fill the OS pipe buffer (~64 KB) and block.
- **Testable bind block** — extracted `bind_listener` and `announce_bound_port` out of `main`, dropped the `LCOV_EXCL_START/STOP` markers, added unit tests.
- **Scanner unit tests** — `scan_for_handshake` pulled out of the async wrapper and covered with 5 cases: happy path, delayed handshake, EOF, empty stream, malformed port value.
- **Delete dead `Cli::endpoint_url`** — the method was `#[cfg(test)]`-gated and only used by its own tests; `endpoint_url_from_addr` in `main.rs` is the real code path.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p fakecloud -p fakecloud-testkit --all-targets -- -D warnings`
- [x] `cargo test -p fakecloud --bins` (29 passed, incl. new `startup_tests` and updated cli tests)
- [x] `cargo test -p fakecloud-testkit --lib` (6 passed, all new handshake tests)
- [x] Manual smoke: spawning the binary prints `FAKECLOUD_PORT=<n>` on first stdout line
- [ ] Full CI + e2e

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the server–testkit startup handshake for reliable port discovery and non-blocking stdout. Also bumps `rustls-webpki` to 0.103.13 and updates `cargo audit` ignores for transitive advisories we don't use.

- **Refactors**
  - Tagged handshake: server prints `FAKECLOUD_PORT=<n>`; testkit scans the prefix and ignores other stdout.
  - Drain remaining stdout on a background thread after the handshake.
  - Extracted `bind_listener` and `announce_bound_port` with unit tests; removed `LCOV_EXCL_*`.
  - Moved handshake parsing to `scan_for_handshake` with focused tests; deleted dead `Cli::endpoint_url` in favor of `endpoint_url_from_addr`.

- **Dependencies**
  - Bumped `rustls-webpki` to 0.103.13 (patches RUSTSEC-2026-0104); CI ignores 0.101.x advisories 0098/0099/0104 pulled via the AWS SDK chain.
  - Extended `cargo audit` ignores for `RUSTSEC-2026-0002` (`lru`) and `RUSTSEC-2026-0097` (`rand`); not reachable in our usage.

<sup>Written for commit 881a639a86084fc4b8130a3cf6f07d3e1406c04d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

