### PR TITLE
chore: release 0.10.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,7 @@ jobs:
           publish fakecloud-sqs
           publish fakecloud-sns
           publish fakecloud-iam
+          publish fakecloud-organizations  # depends on core only
           publish fakecloud-lambda
           publish fakecloud-secretsmanager
           publish fakecloud-logs
@@ -174,6 +175,7 @@ jobs:
           publish fakecloud-rds
           publish fakecloud-elasticache
           publish fakecloud-kinesis
+          publish fakecloud-scheduler      # depends on aws + core + persistence
           publish fakecloud-apigatewayv2   # depends on core only
           publish fakecloud-bedrock        # depends on aws + core
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.9.2"
+version = "0.10.0"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
@@ -80,29 +80,29 @@ regex = "1"
 tokio-postgres = "0.7"
 
 # Internal crates
-fakecloud-core = { path = "crates/fakecloud-core", version = "0.9.2" }
-fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.9.2" }
-fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.9.2" }
-fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.9.2" }
-fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.9.2" }
-fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.9.2" }
-fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.9.2" }
-fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.9.2" }
-fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.9.2" }
-fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.9.2" }
-fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.9.2" }
-fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.9.2" }
-fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.9.2" }
-fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.9.2" }
-fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.9.2" }
-fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.9.2" }
-fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.9.2" }
-fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.9.2" }
-fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.9.2" }
-fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.9.2" }
-fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.9.2" }
-fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.9.2" }
-fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.9.2" }
-fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.9.2" }
-fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.9.2" }
-fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.9.2" }
+fakecloud-core = { path = "crates/fakecloud-core", version = "0.10.0" }
+fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.10.0" }
+fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.10.0" }
+fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.10.0" }
+fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.10.0" }
+fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.10.0" }
+fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.10.0" }
+fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.10.0" }
+fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.10.0" }
+fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.10.0" }
+fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.10.0" }
+fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.10.0" }
+fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.10.0" }
+fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.10.0" }
+fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.10.0" }
+fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.10.0" }
+fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.10.0" }
+fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.10.0" }
+fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.10.0" }
+fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.10.0" }
+fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.10.0" }
+fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.10.0" }
+fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.10.0" }
+fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.10.0" }
+fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.10.0" }
+fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.10.0" }

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.9.2")
+    testImplementation("dev.fakecloud:fakecloud:0.10.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.9.2</version>
+    <version>0.10.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.9.2"
+version = "0.10.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.9.2"
+version = "0.10.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakecloud",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/website/content/docs/getting-started/sdk-setup.md
+++ b/website/content/docs/getting-started/sdk-setup.md
@@ -81,7 +81,7 @@ $emails = $fc->ses()->getEmails()->emails;
 
 ```kotlin
 // build.gradle.kts
-testImplementation("dev.fakecloud:fakecloud:0.9.2")
+testImplementation("dev.fakecloud:fakecloud:0.10.0")
 ```
 
 ```java

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -19,7 +19,7 @@ curl http://localhost:4566/_fakecloud/health
 ```json
 {
   "status": "ok",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "services": [
     "apigatewayv2", "bedrock", "cloudformation", "cognito-idp",
     "dynamodb", "elasticache", "events", "iam", "kinesis", "kms",

--- a/website/content/docs/sdks/_index.md
+++ b/website/content/docs/sdks/_index.md
@@ -19,7 +19,7 @@ These SDKs are **not** the AWS SDK. Your application code still talks to fakeclo
 | Python     | `pip install fakecloud`                         | [Python SDK](/docs/sdks/python/) |
 | Go         | `go get github.com/faiscadev/fakecloud/sdks/go` | [Go SDK](/docs/sdks/go/) |
 | PHP        | `composer require fakecloud/fakecloud`          | [PHP SDK](/docs/sdks/php/) |
-| Java       | `dev.fakecloud:fakecloud:0.9.2`                 | [Java SDK](/docs/sdks/java/) |
+| Java       | `dev.fakecloud:fakecloud:0.10.0`                 | [Java SDK](/docs/sdks/java/) |
 | Rust       | `cargo add fakecloud-sdk`                       | [Rust SDK](/docs/sdks/rust/) |
 
 ## Common surface

--- a/website/content/docs/sdks/java.md
+++ b/website/content/docs/sdks/java.md
@@ -10,7 +10,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.9.2")
+    testImplementation("dev.fakecloud:fakecloud:0.10.0")
 }
 ```
 
@@ -20,7 +20,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.9.2</version>
+    <version>0.10.0</version>
     <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
Release 0.10.0. Bumps workspace + SDK versions and Java install docs.

See [RELEASE_NOTES_0.10.0.md](https://github.com/faiscadev/fakecloud/blob/chore/release-0.10.0/RELEASE_NOTES_0.10.0.md) on the branch for the curated notes (file is not committed; will be used as `--notes-file` when creating the GH release after tag).

## Highlights

- Multi-account state isolation across all stateful services, cross-account delivery, `/_fakecloud/iam/create-admin` bootstrap.
- **AWS Organizations + SCPs** (new service) — OU tree, SCP CRUD + top-of-chain ceiling enforcement.
- **EventBridge Scheduler** (new service) — firing loop with SQS/SNS/Lambda/SF/EB targets, DLQ, persistence, IAM.
- IAM Phases 2–6: conditions, resource policies, permission boundaries, session policies, ABAC, NotPrincipal, KMS key policies, cross-account semantics.
- Opt-in disk persistence wired for every service.
- PHP SDK (5th first-party SDK) published to Packagist.
- AWS + LocalStack-style Host header routing.

## Test plan

- [ ] CI green
- [ ] Tag `v0.10.0` after merge to trigger release workflow
- [ ] Overwrite auto-generated release notes with curated notes via `gh release edit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 0.10.0 release by bumping all workspace crate and SDK versions, updating docs, and updating the release workflow to publish new crates. Aligns versions across the repo for publishing.

- **Dependencies**
  - Rust workspace and internal crates set to `0.10.0`; `Cargo.lock` updated.
  - Java SDK set to `0.10.0`; install snippets updated (`dev.fakecloud:fakecloud:0.10.0`).
  - Python SDK version bumped to `0.10.0`.
  - TypeScript SDK version bumped to `0.10.0`; lockfile updated.
  - Docs updated to reference `0.10.0` (SDK setup, Java page, introspection, SDK index).
  - Release workflow now publishes `fakecloud-organizations` and `fakecloud-scheduler`.

<sup>Written for commit f5fb0a8e178df966d183df8d63c47592d012d130. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

