### PR TITLE
fix(ci): disable persist-credentials in packagist job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          # Don't persist the default GITHUB_TOKEN as a git credential helper,
+          # otherwise `git push` to the mirror repo ignores our PAT and uses
+          # the default token (which can't push to faiscadev/fakecloud-php).
+          persist-credentials: false
 
       - name: Verify tag matches composer.json version
         working-directory: sdks/php


### PR DESCRIPTION
## Why

v0.10.0 release Packagist job failed with:

> remote: Permission to faiscadev/fakecloud-php.git denied to github-actions[bot].
> fatal: unable to access 'https://github.com/faiscadev/fakecloud-php.git/': The requested URL returned error: 403

Even after refreshing PHP_MIRROR_TOKEN with write on the mirror.

Root cause: \`actions/checkout@v4\` default \`persist-credentials: true\` installs a git config extraheader that authenticates all github.com pushes as the built-in GITHUB_TOKEN (github-actions[bot]). That bot has no write on faiscadev/fakecloud-php, so git ignores the \`x-access-token:\${MIRROR_TOKEN}\` in the remote URL and uses the bot token instead.

Fix: \`persist-credentials: false\` on this job's checkout. The PAT embedded in the remote URL is then used.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, re-run \`Publish Packagist\` on v0.10.0 run (id 24781286793) — expect success and \`faiscadev/fakecloud-php\` tagged \`v0.10.0\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable persisted GitHub credentials in the Packagist publish job so mirror pushes use the PAT instead of the default `GITHUB_TOKEN`, fixing 403 failures on `faiscadev/fakecloud-php`.
This restores the v0.10.0 Packagist release flow.

- **Bug Fixes**
  - In the Packagist job, set `actions/checkout@v4` `persist-credentials: false` so git uses the PAT in the remote URL, resolving 403 on mirror pushes.

<sup>Written for commit 0f01b5914b1352982ca50419daa5b6a810b42756. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

