### PR TITLE
fix(dynamodb): resolve dotted paths in filter LHS and function args

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/expression_corpus_tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/expression_corpus_tests.rs
@@ -473,28 +473,56 @@ fn filter_deep_nested_parentheses() {
 }
 
 #[test]
-#[ignore = "known gap: Filter comparison LHS does not resolve dot-notation paths"]
 fn filter_nested_map_path() {
-    // Projection-style nested paths inside filter — dot notation.
+    // Projection-style nested paths inside filter — dot notation, including
+    // multi-level traversal, missing intermediates, placeholder segments, and
+    // dotted paths inside function arguments.
     let it = item(&[(
         "profile",
-        m(&[("email", s("a@b.com")), ("verified", b(true))]),
+        m(&[
+            ("email", s("a@b.com")),
+            ("verified", b(true)),
+            ("address", m(&[("city", s("Lisbon")), ("zip", s("1000"))])),
+        ]),
     )]);
-    let names = HashMap::new();
-    let values = values(&[(":e", s("a@b.com"))]);
+    let names = names(&[("#p", "profile"), ("#e", "email")]);
+    let values = values(&[
+        (":e", s("a@b.com")),
+        (":wrong", s("x@y.com")),
+        (":city", s("Lisbon")),
+    ]);
 
     let cases = [
         ("dot-equal", "profile.email = :e", true),
+        ("dot-equal-miss", "profile.email = :wrong", false),
         (
             "dot-attribute-exists",
             "attribute_exists(profile.email)",
             true,
         ),
         (
-            "dot-attribute-not-exists",
+            "dot-attribute-not-exists-leaf",
             "attribute_not_exists(profile.missing)",
             true,
         ),
+        (
+            "dot-attribute-exists-missing-parent",
+            "attribute_exists(ghost.email)",
+            false,
+        ),
+        ("three-level-equal", "profile.address.city = :city", true),
+        (
+            "three-level-attribute-exists",
+            "attribute_exists(profile.address.city)",
+            true,
+        ),
+        (
+            "three-level-attribute-not-exists",
+            "attribute_not_exists(profile.address.country)",
+            true,
+        ),
+        ("placeholder-dotted", "#p.#e = :e", true),
+        ("begins-with-nested", "begins_with(profile.email, :e)", true),
     ];
     for (label, expr, expected) in cases {
         assert_eq!(

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -641,6 +641,20 @@ fn resolve_attr_name(name: &str, expr_attr_names: &HashMap<String, String>) -> S
     }
 }
 
+/// Resolve a (possibly dotted, possibly `#name`-containing) document path to
+/// the leaf `AttributeValue` inside `item`. Single-segment paths (`foo`,
+/// `#foo`) resolve to a top-level attribute. Dotted paths (`profile.email`,
+/// `#p.#e`, `items[0].sku`) walk into `M`/`L` containers. Returns `None` if
+/// any segment is missing or the intermediate value isn't a map/list.
+fn resolve_path(
+    path: &str,
+    item: &HashMap<String, AttributeValue>,
+    expr_attr_names: &HashMap<String, String>,
+) -> Option<Value> {
+    let resolved = resolve_projection_path(path, expr_attr_names);
+    resolve_nested_path(item, &resolved)
+}
+
 fn extract_key(
     table: &DynamoTable,
     item: &HashMap<String, AttributeValue>,
@@ -1147,9 +1161,9 @@ fn key_cond_simple_comparison(
         };
         let left = part[..pos].trim();
         let right = part[pos + op.len()..].trim();
-        let attr_name = resolve_attr_name(left, expr_attr_names);
+        let actual_owned = resolve_path(left, item, expr_attr_names);
+        let actual = actual_owned.as_ref();
         let expected = expr_attr_values.get(right);
-        let actual = item.get(&attr_name);
 
         return match *op {
             "=" => actual == expected,
@@ -1241,9 +1255,8 @@ fn evaluate_size_comparison(
         return None;
     };
 
-    let attr_name = resolve_attr_name(path, expr_attr_names);
-    let actual = item.get(&attr_name)?;
-    let size = attribute_size(actual)? as f64;
+    let actual_owned = resolve_path(path, item, expr_attr_names)?;
+    let size = attribute_size(&actual_owned)? as f64;
 
     let expected = extract_number(&expr_attr_values.get(val_ref).cloned())?;
 
@@ -1363,13 +1376,11 @@ fn evaluate_single_filter_condition(
     expr_attr_values: &HashMap<String, Value>,
 ) -> bool {
     if let Some(inner) = extract_function_arg(part, "attribute_exists") {
-        let attr = resolve_attr_name(inner, expr_attr_names);
-        return item.contains_key(&attr);
+        return resolve_path(inner, item, expr_attr_names).is_some();
     }
 
     if let Some(inner) = extract_function_arg(part, "attribute_not_exists") {
-        let attr = resolve_attr_name(inner, expr_attr_names);
-        return !item.contains_key(&attr);
+        return resolve_path(inner, item, expr_attr_names).is_none();
     }
 
     if let Some(rest) = part
@@ -1426,10 +1437,9 @@ fn eval_begins_with(
     let (Some(attr_ref), Some(val_ref)) = (split.next(), split.next()) else {
         return false;
     };
-    let attr_name = resolve_attr_name(attr_ref.trim(), expr_attr_names);
+    let actual = resolve_path(attr_ref.trim(), item, expr_attr_names);
     let expected = expr_attr_values.get(val_ref.trim());
-    let actual = item.get(&attr_name);
-    match (actual, expected) {
+    match (actual.as_ref(), expected) {
         (Some(a), Some(e)) => {
             let a_str = a.get("S").and_then(|v| v.as_str());
             let e_str = e.get("S").and_then(|v| v.as_str());
@@ -1455,10 +1465,9 @@ fn eval_contains(
     let (Some(attr_ref), Some(val_ref)) = (split.next(), split.next()) else {
         return false;
     };
-    let attr_name = resolve_attr_name(attr_ref.trim(), expr_attr_names);
+    let actual = resolve_path(attr_ref.trim(), item, expr_attr_names);
     let expected = expr_attr_values.get(val_ref.trim());
-    let actual = item.get(&attr_name);
-    let (Some(a), Some(e)) = (actual, expected) else {
+    let (Some(a), Some(e)) = (actual.as_ref(), expected) else {
         return false;
     };
 
@@ -1505,13 +1514,12 @@ fn eval_attribute_type(
     let (Some(attr_ref), Some(val_ref)) = (split.next(), split.next()) else {
         return false;
     };
-    let attr_name = resolve_attr_name(attr_ref.trim(), expr_attr_names);
+    let actual = resolve_path(attr_ref.trim(), item, expr_attr_names);
     let expected_type = expr_attr_values
         .get(val_ref.trim())
         .and_then(|v| v.get("S"))
         .and_then(|v| v.as_str());
-    let actual = item.get(&attr_name);
-    let (Some(val), Some(t)) = (actual, expected_type) else {
+    let (Some(val), Some(t)) = (actual.as_ref(), expected_type) else {
         return false;
     };
     match t {


### PR DESCRIPTION
## Summary

- The filter-expression evaluator looked up every LHS via `item.get(&attr_name)`, which only hits top-level attributes. Any dotted path (``profile.email``) silently missed, so filters, `attribute_exists`, `begins_with`, `contains`, `attribute_type`, and `size` on nested maps all returned false.
- Add a `resolve_path` helper that chains the existing `resolve_projection_path` (per-segment `#name` resolution) with `resolve_nested_path` (M/L traversal). Single-segment paths still resolve to the top-level attribute, so this is strictly more permissive than before.
- Swap `item.get(&attr_name)` for `resolve_path` in every filter-side evaluator.
- Unignore `filter_nested_map_path` and expand its case matrix: multi-level (`profile.address.city`), missing parent, placeholder path (`#p.#e`), nested `begins_with`.

## Test plan

- [x] `cargo test -p fakecloud-dynamodb --lib` (206 pass, 5 ignored remaining)
- [x] `cargo test -p fakecloud-e2e --test dynamodb` (46 pass)
- [x] `cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB filter expressions to resolve dotted/placeholder paths on the left-hand side and in function args, so nested map/list fields evaluate correctly. This restores expected behavior for filters and functions on nested attributes.

- **Bug Fixes**
  - Added `resolve_path` to combine `resolve_projection_path` and `resolve_nested_path`, handling `#names` and multi-segment traversal.
  - Replaced `item.get(...)` with `resolve_path` in comparisons and functions: `attribute_exists`, `attribute_not_exists`, `begins_with`, `contains`, `attribute_type`, and `size`.
  - Unignored and expanded `filter_nested_map_path` tests to cover multi-level paths, missing parents, placeholder segments, and nested paths inside function args.

<sup>Written for commit 76d7297295ab9ed4bfff4ca28b8fe1ffb97bab07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

