### PR TITLE
fix(dynamodb): align size() type semantics with AWS

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/expression_corpus_tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/expression_corpus_tests.rs
@@ -320,16 +320,19 @@ fn filter_sdk_compound_shapes() {
 }
 
 #[test]
-#[ignore = "known gap: `size(X)` (no space) inside a comparison isn't matched by the size-function branch"]
 fn filter_functions_with_sdk_space_before_paren() {
-    // aws-sdk-go-v2 emits a space before the open-paren for these 5 functions:
+    // aws-sdk-go-v2 emits a space before the open-paren for these 6 functions:
     //   attribute_exists (X), attribute_not_exists (X), attribute_type (X, Y),
     //   begins_with (X, Y), contains (X, Y), size (X).
     // Hand-crafted callers usually omit the space. Both must work.
+    //
+    // `count` is a length-10 string so size() returns 10; size() on an N-type
+    // attribute is invalid per AWS and must evaluate to false (see
+    // filter_size_on_numeric_is_invalid).
     let it = item(&[
         ("name", s("widget-42")),
         ("tags", ss(&["red", "blue"])),
-        ("count", n("10")),
+        ("count", s("1234567890")),
     ]);
     let names = HashMap::new();
     let values = values(&[
@@ -360,6 +363,30 @@ fn filter_functions_with_sdk_space_before_paren() {
             evaluate_filter_expression(expr, &it, &names, &values),
             expected,
             "filter fn-shape '{label}' failed for `{expr}`"
+        );
+    }
+}
+
+#[test]
+fn filter_size_on_numeric_is_invalid() {
+    // size() is defined for S, B, SS, NS, BS, L, M per AWS docs; calling it on
+    // N, BOOL, or NULL is a type error that evaluates to false (matching AWS's
+    // silent filter-out semantics in FilterExpression context).
+    let it = item(&[("count", n("10")), ("active", b(true))]);
+    let names = HashMap::new();
+    let values = values(&[(":ten", n("10")), (":one", n("1"))]);
+
+    let cases = [
+        ("size-on-n-eq", "size(count) = :ten", false),
+        ("size-on-n-gt", "size(count) > :one", false),
+        ("size-on-bool", "size(active) = :one", false),
+        ("size-on-missing", "size(ghost) = :one", false),
+    ];
+    for (label, expr, expected) in cases {
+        assert_eq!(
+            evaluate_filter_expression(expr, &it, &names, &values),
+            expected,
+            "size-invalid '{label}' failed for `{expr}`"
         );
     }
 }

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -1171,9 +1171,15 @@ fn key_cond_simple_comparison(
 }
 
 /// Returns the "size" of a DynamoDB attribute value per AWS docs:
-/// S → character count, N → always 0 (AWS returns size of internal representation, we approximate),
-/// B → byte count, SS/NS/BS → element count, L → element count, M → element count,
-/// BOOL/NULL → 1.
+/// - S → character count
+/// - B → decoded byte count
+/// - SS/NS/BS → element count
+/// - L → element count
+/// - M → element count
+///
+/// `size()` is not valid on N, BOOL, or NULL per AWS; returns None for those so
+/// the enclosing comparison evaluates to false (matching AWS's behavior of
+/// silently filtering type-mismatched rows in FilterExpression context).
 fn attribute_size(val: &Value) -> Option<usize> {
     if let Some(s) = val.get("S").and_then(|v| v.as_str()) {
         return Some(s.len());
@@ -1200,13 +1206,6 @@ fn attribute_size(val: &Value) -> Option<usize> {
     }
     if let Some(obj) = val.get("M").and_then(|v| v.as_object()) {
         return Some(obj.len());
-    }
-    if val.get("N").is_some() {
-        // AWS returns numeric representation size; approximate with string length
-        return val.get("N").and_then(|v| v.as_str()).map(|s| s.len());
-    }
-    if val.get("BOOL").is_some() || val.get("NULL").is_some() {
-        return Some(1);
     }
     None
 }


### PR DESCRIPTION
## Summary

- `attribute_size` returned string-length for N-type attributes, so `size(count) = :ten` with `count = N("10")` and `:ten = N("10")` evaluated to false (`"10".len() == 2`, not 10). That isn't AWS behavior: `size()` is defined only for S, B, SS, NS, BS, L, and M; on N, BOOL, or NULL it's a type mismatch that silently filters the row out in FilterExpression context.
- Drop the N and BOOL/NULL branches of `attribute_size` so size() returns `None` on those types, which flows to `false` in the filter evaluator.
- Unignore `filter_functions_with_sdk_space_before_paren`: switch `count` from `N("10")` to `S("1234567890")` so size() still returns 10 and exercises both the `size(X)` and `size (X)` spacings.
- Add `filter_size_on_numeric_is_invalid` locking the new semantics (size on N, BOOL, and a missing attribute all evaluate to false).

## Test plan

- [x] `cargo test -p fakecloud-dynamodb --lib`
- [x] `cargo test -p fakecloud-e2e --test dynamodb`
- [x] `cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB `size()` evaluation to match AWS: it’s only valid for S, B, SS, NS, BS, L, and M. On N, BOOL, or NULL it now evaluates to false in filters, avoiding incorrect matches.

- **Bug Fixes**
  - Removed N/BOOL/NULL handling in `attribute_size` so `size()` returns `None` for those types.
  - Unignored `filter_functions_with_sdk_space_before_paren`; switched `count` to `S("1234567890")` to keep `size()` = 10 for both `size(X)` and `size (X)`.
  - Added `filter_size_on_numeric_is_invalid` to assert false for `size()` on N, BOOL, and missing attributes.

<sup>Written for commit 3fef3f64ddaa51de67044d2b48cb754b1015f4cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

