### PR TITLE
chore: release 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "fakecloud-testkit",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.10.0"
+version = "0.10.1"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
@@ -80,29 +80,29 @@ regex = "1"
 tokio-postgres = "0.7"
 
 # Internal crates
-fakecloud-core = { path = "crates/fakecloud-core", version = "0.10.0" }
-fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.10.0" }
-fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.10.0" }
-fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.10.0" }
-fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.10.0" }
-fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.10.0" }
-fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.10.0" }
-fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.10.0" }
-fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.10.0" }
-fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.10.0" }
-fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.10.0" }
-fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.10.0" }
-fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.10.0" }
-fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.10.0" }
-fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.10.0" }
-fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.10.0" }
-fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.10.0" }
-fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.10.0" }
-fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.10.0" }
-fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.10.0" }
-fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.10.0" }
-fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.10.0" }
-fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.10.0" }
-fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.10.0" }
-fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.10.0" }
-fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.10.0" }
+fakecloud-core = { path = "crates/fakecloud-core", version = "0.10.1" }
+fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.10.1" }
+fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.10.1" }
+fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.10.1" }
+fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.10.1" }
+fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.10.1" }
+fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.10.1" }
+fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.10.1" }
+fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.10.1" }
+fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.10.1" }
+fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.10.1" }
+fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.10.1" }
+fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.10.1" }
+fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.10.1" }
+fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.10.1" }
+fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.10.1" }
+fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.10.1" }
+fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.10.1" }
+fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.10.1" }
+fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.10.1" }
+fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.10.1" }
+fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.10.1" }
+fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.10.1" }
+fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.10.1" }
+fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.10.1" }
+fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.10.1" }

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.10.0")
+    testImplementation("dev.fakecloud:fakecloud:0.10.1")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.10.0"
+version = "0.10.1"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.10.0"
+version = "0.10.1"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakecloud",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/website/content/docs/getting-started/sdk-setup.md
+++ b/website/content/docs/getting-started/sdk-setup.md
@@ -81,7 +81,7 @@ $emails = $fc->ses()->getEmails()->emails;
 
 ```kotlin
 // build.gradle.kts
-testImplementation("dev.fakecloud:fakecloud:0.10.0")
+testImplementation("dev.fakecloud:fakecloud:0.10.1")
 ```
 
 ```java

--- a/website/content/docs/sdks/_index.md
+++ b/website/content/docs/sdks/_index.md
@@ -19,7 +19,7 @@ These SDKs are **not** the AWS SDK. Your application code still talks to fakeclo
 | Python     | `pip install fakecloud`                         | [Python SDK](/docs/sdks/python/) |
 | Go         | `go get github.com/faiscadev/fakecloud/sdks/go` | [Go SDK](/docs/sdks/go/) |
 | PHP        | `composer require fakecloud/fakecloud`          | [PHP SDK](/docs/sdks/php/) |
-| Java       | `dev.fakecloud:fakecloud:0.10.0`                 | [Java SDK](/docs/sdks/java/) |
+| Java       | `dev.fakecloud:fakecloud:0.10.1`                 | [Java SDK](/docs/sdks/java/) |
 | Rust       | `cargo add fakecloud-sdk`                       | [Rust SDK](/docs/sdks/rust/) |
 
 ## Common surface

--- a/website/content/docs/sdks/java.md
+++ b/website/content/docs/sdks/java.md
@@ -10,7 +10,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.10.0")
+    testImplementation("dev.fakecloud:fakecloud:0.10.1")
 }
 ```
 
@@ -20,7 +20,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
## Summary

Patch release. Bumps workspace version 0.10.0 -> 0.10.1 across `Cargo.toml`, `Cargo.lock`, all SDK manifests (Java Gradle + README, Python pyproject, TypeScript package.json + lock), and the website doc references.

Changes shipped since 0.10.0 (all DynamoDB expression-parser fixes):

- #670 BETWEEN-aware + whitespace-tolerant AND/OR tokenizer.
- #671 Dotted-path resolution in filter LHS and function args (`attribute_exists`, `begins_with`, `contains`, `attribute_type`, `size`).
- #672 `size()` type semantics aligned with AWS (invalid on N/BOOL/NULL).
- #673 SET complex RHS (`if_not_exists`, `list_append`, arithmetic) into nested paths.

All 6 previously-ignored tests in `expression_corpus_tests.rs` now run and pass; the file has zero `#[ignore]`.

## Test plan

- [x] `cargo check --workspace` (Cargo.lock regenerated cleanly)
- [x] `cargo test --workspace --exclude fakecloud-e2e --exclude fakecloud-conformance --exclude fakecloud-tfacc --exclude fakecloud-parity` (matches release.yml check job)
- [x] Tag-triggered `v0.10.1` release workflow will build + publish after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the 0.10.1 patch release. Bumps workspace and SDK versions to 0.10.1 in `Cargo.toml`, `Cargo.lock`, Java/Python/TypeScript SDK manifests, and updates website docs.

- **Bug Fixes**
  - AND/OR tokenizer now BETWEEN-aware and whitespace-tolerant.
  - Support dotted-paths in filters and function args (`attribute_exists`, `begins_with`, `contains`, `attribute_type`, `size`); `size()` semantics aligned with AWS.
  - Allow complex RHS in `SET` into nested paths (`if_not_exists`, `list_append`, arithmetic). All previously ignored expression corpus tests now pass.

<sup>Written for commit ed01e613c13bc29632ca4e8a476cfd033f253f8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

