### PR TITLE
docs(seo): upstream-query landing page + migration guide + comparison post

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 Per-service docs and feature matrices: [fakecloud.dev/docs/services](https://fakecloud.dev/docs/services).
 
+## Common use cases
+
+| What you want to do                        | Command                                                                        |
+| ------------------------------------------ | ------------------------------------------------------------------------------ |
+| **Test Lambda locally**                    | `fakecloud` then `aws --endpoint-url http://localhost:4566 lambda invoke …`    |
+| **Mock DynamoDB in tests**                 | `fakecloud` then point boto3/aws-sdk at `http://localhost:4566`                |
+| **Local S3 for integration tests**         | `fakecloud` then use any S3 SDK with `endpoint_url=http://localhost:4566`      |
+| **Fake AWS server for tests**              | `fakecloud` — single binary on port 4566, any AWS SDK works                    |
+| **Replace LocalStack in CI**               | `curl … install.sh`, then `fakecloud &` as a background step                   |
+| **Terraform local dev**                    | Point the `aws` provider `endpoints` block at `http://localhost:4566`          |
+| **CDK local testing**                      | `cdklocal deploy --endpoint-url http://localhost:4566`                         |
+| **Moto equivalent for Go/Java/Node**       | `fakecloud` — real HTTP server, every AWS SDK works, no language lock-in       |
+| **Integration test AWS in GitHub Actions** | Install or pull `ghcr.io/faiscadev/fakecloud`, run as service container        |
+
+Full guides: [fakecloud.dev/docs/guides](https://fakecloud.dev/docs/guides).
+
 ## Compared to LocalStack Community
 
 | Feature             | fakecloud                                          | LocalStack Community (post-March 2026)                                         |

--- a/website/content/blog/localstack-alternatives-compared.md
+++ b/website/content/blog/localstack-alternatives-compared.md
@@ -1,0 +1,106 @@
++++
+title = "Free LocalStack alternatives in 2026: fakecloud, MiniStack, floci, Moto"
+date = 2026-04-22
+description = "Four free, open-source alternatives to LocalStack Community: fakecloud, MiniStack, floci, and Moto. What each is good at, how they differ in approach, and which to pick."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+LocalStack's Community Edition went proprietary in March 2026. Since then, a few free, open-source alternatives have surfaced or gained momentum. This post covers the four that keep coming up — fakecloud, MiniStack, floci, and Moto — and explains where each one actually fits.
+
+Some upfront disclosure: I maintain fakecloud. I am not going to pretend I don't have a bias. What I will do is describe each project by what it architecturally is, what it sets out to do, and where the fit lines sit. If you are shopping for a LocalStack replacement, that framing is more useful than a fake head-to-head benchmark.
+
+## TL;DR — pick by workload
+
+- **Python unit tests that mock boto3 in-process:** Moto.
+- **Multi-language integration tests, real HTTP, real Lambda execution, real RDS/Redis:** fakecloud.
+- **Wanted a Docker-based LocalStack Community replacement, same operating model:** MiniStack or floci. (Or fakecloud, which also runs as a Docker image.)
+- **You need full LocalStack service catalog and don't mind paying:** LocalStack Pro.
+
+The rest of this post explains the differences.
+
+## The architectural split that matters
+
+There are two fundamentally different ways to emulate AWS for tests:
+
+**1. In-process library that patches the SDK.** You import a library, decorate your test, and the library intercepts SDK calls inside your test process. Moto works this way. It's very fast, has no external process, and is trivial to set up for Python. It does not actually speak the AWS wire protocol, and it cannot run real Lambda code, real databases, or real Redis. It is for unit-ish tests.
+
+**2. Real HTTP server that speaks the AWS wire protocol.** You run a separate process that listens on a port (usually 4566). Your SDK points at it via `endpoint_url`. LocalStack, MiniStack, floci, and fakecloud all work this way. Because it's a real HTTP server, any AWS SDK in any language works against it, and cross-service wiring (EventBridge -> Lambda, S3 -> SNS) runs server-side.
+
+If your tests are "does my Python function call boto3 correctly," Moto is probably what you want. If your tests are "does my whole system actually work end-to-end against AWS-shaped infrastructure," you want an HTTP server.
+
+## fakecloud
+
+**What it is:** single static binary written in Rust, ships as ~19 MB. Speaks the AWS wire protocol on port 4566. No account, no token, no paid tier. AGPL-3.0.
+
+**What it covers:** 23 services, 1,680 operations, 100% conformance per implemented service, validated on every commit against AWS's own Smithy models (54,000+ generated test variants). Full list: S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, KMS, Secrets Manager, SSM, CloudWatch Logs, CloudFormation, EventBridge, EventBridge Scheduler, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime.
+
+**Distinctive choices:**
+- Real Lambda execution across 13 runtimes in Docker containers. Not a stub — your function code runs.
+- Real stateful services. RDS runs real PostgreSQL/MySQL/MariaDB via Docker. ElastiCache runs real Redis/Valkey.
+- Cross-service wiring is wired end-to-end. EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> S3/SNS/Lambda, 15+ more integrations that actually fire.
+- Multi-account, SCPs, ABAC, permission boundaries, session policies, KMS key policies, bucket policies — all with the Allow/Deny/NotPrincipal semantics AWS uses.
+- First-party test-assertion SDKs in TypeScript, Python, Go, PHP, Java, Rust. Assert that an email was sent, an SNS was published, a Lambda was invoked, without raw HTTP.
+- CI runs upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud to catch provider-level drift.
+
+**Where it fits:** integration tests and local development in any language. If you used LocalStack Community with Lambda, Cognito, SES v2, RDS, or ElastiCache and hit the paywall, fakecloud covers those.
+
+**Where it doesn't fit:** EC2, ECS, ECR, CloudFront, AppSync, Athena, Glue, SageMaker — not implemented yet. If you need any of those, it's not the tool for you today.
+
+**Source:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+
+## MiniStack
+
+**What it is:** a newer project that surfaced during the March 2026 LocalStack paywall window. Positions itself as a free LocalStack alternative. Check the repo for current service coverage and architecture details — the project is moving quickly and anything I write here will be outdated fast.
+
+**Where it fits:** if you want the LocalStack operating model — a Docker image you pull and run — and are looking for a free alternative, MiniStack is one of the options worth evaluating against fakecloud on your specific service mix. If your test suite leans heavily on services MiniStack supports, it may be the easier drop-in for your team.
+
+**Where to check fit:** compare the supported-services list in their README to your actual SDK calls. That's the only comparison that matters for your codebase.
+
+**Source:** check GitHub for the current repo and README.
+
+## floci
+
+**What it is:** another newer free LocalStack alternative that appeared in the same window. The landing page publishes performance claims (startup time, memory, SDK-test pass rate); verify them against the version you'd actually run before relying on the numbers.
+
+**Where it fits:** same category as MiniStack. If you want a free Docker-image-based LocalStack replacement, floci is on the shortlist. Evaluate against your service mix.
+
+**Source:** check GitHub / floci.io for the current repo.
+
+## Moto
+
+**What it is:** the longest-lived open-source AWS mocking project. Python library, in-process, patches `boto3` inside your test. 100+ services covered at varying depth.
+
+**Where it fits:** Python unit tests where you want to assert that your code calls boto3 the right way and handles boto3 responses the right way. Moto is great at this and has years of maturity.
+
+**Where it doesn't fit:** any language other than Python. Any integration test that needs real cross-service wiring. Any test that needs Lambda to actually execute your code. Any test against Terraform or CDK deploys — Moto is in-process, so external tooling can't talk to it.
+
+**Source:** [github.com/getmoto/moto](https://github.com/getmoto/moto)
+
+## LocalStack Pro (for completeness)
+
+**What it is:** the paid tier of the project that dropped Community Edition. Has the most mature service catalog, commercial support, and a track record.
+
+**Where it fits:** teams that need the full LocalStack service catalog, are comfortable with a proprietary license, and are OK paying per-seat pricing.
+
+**Where it doesn't fit:** teams who want an open-source license, who don't want an account/token gate, or who need a service like Bedrock that LocalStack doesn't implement.
+
+## The non-dodge honest recommendation
+
+If you were on LocalStack Community for integration testing, the likely fit order is:
+
+1. **Try fakecloud first** if your service mix includes Lambda, Cognito, SES v2, RDS, ElastiCache, API Gateway v2, or Bedrock — these are where fakecloud does the most that LocalStack Community no longer does (or never did).
+2. **Try MiniStack or floci** if fakecloud doesn't have a service you depend on. Their catalogs may overlap differently with yours.
+3. **Add Moto** if you have Python unit tests that are happy with in-process mocking — Moto and fakecloud are complementary, not competitive, for different test tiers.
+4. **Pay for LocalStack Pro** if none of the above cover what you need and you're OK with the commercial terms.
+
+The honest test for any of these: run your actual test suite against each. Every team's mix of services, SDKs, and test patterns is different, and the only benchmark that matters is whether your tests pass.
+
+## Links
+
+- fakecloud: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- Moto: [github.com/getmoto/moto](https://github.com/getmoto/moto)
+- LocalStack: [localstack.cloud](https://localstack.cloud)
+- fakecloud install: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- fakecloud migration guide: [Migrating from LocalStack to fakecloud](/blog/migrate-from-localstack/)

--- a/website/content/blog/localstack-alternatives-compared.md
+++ b/website/content/blog/localstack-alternatives-compared.md
@@ -102,5 +102,5 @@ The honest test for any of these: run your actual test suite against each. Every
 - fakecloud: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 - Moto: [github.com/getmoto/moto](https://github.com/getmoto/moto)
 - LocalStack: [localstack.cloud](https://localstack.cloud)
-- fakecloud install: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- fakecloud install options: [fakecloud.dev/docs/getting-started](/docs/getting-started/)
 - fakecloud migration guide: [Migrating from LocalStack to fakecloud](/blog/migrate-from-localstack/)

--- a/website/content/blog/migrate-from-localstack.md
+++ b/website/content/blog/migrate-from-localstack.md
@@ -1,0 +1,301 @@
++++
+title = "Migrating from LocalStack to fakecloud in 10 minutes"
+date = 2026-04-22
+description = "Step-by-step migration from LocalStack Community to fakecloud: docker-compose, CI, Terraform, CDK, Serverless Framework. Copy-paste configs for every common setup."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+In March 2026, LocalStack replaced its open-source Community Edition with a proprietary image that requires an account and an auth token. If your build broke last month, this guide is for you. If you are still on a pinned older tag and worried about the next pull, this is also for you.
+
+fakecloud is a free, open-source AWS emulator — single binary, no account, no token, no paid tier — that covers the services most teams relied on LocalStack Community for, plus several that moved to LocalStack Pro (RDS, ElastiCache, Cognito User Pools, SES v2, API Gateway v2).
+
+This guide is step-by-step. Copy, paste, done.
+
+## The one-line summary
+
+Change the image or the install command. Keep `http://localhost:4566` and your dummy credentials. Everything else stays the same.
+
+## Step 1: Stop LocalStack
+
+```sh
+docker compose down
+# or: docker kill $(docker ps -q --filter ancestor=localstack/localstack)
+```
+
+## Step 2: Install fakecloud
+
+Pick one:
+
+```sh
+# Option A: single binary, no Docker
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+
+# Option B: Docker
+docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud
+
+# Option C: cargo
+cargo install fakecloud
+```
+
+fakecloud listens on `http://localhost:4566` — same as LocalStack.
+
+## Step 3: Keep your SDK wiring
+
+Your application code does not change. The endpoint URL and dummy credentials stay identical:
+
+```ts
+// TypeScript
+import { S3Client } from "@aws-sdk/client-s3";
+const s3 = new S3Client({
+  endpoint: "http://localhost:4566",
+  region: "us-east-1",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+  forcePathStyle: true,
+});
+```
+
+```python
+# Python (boto3)
+import boto3
+s3 = boto3.client(
+    "s3",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+    region_name="us-east-1",
+)
+```
+
+```go
+// Go
+cfg, _ := config.LoadDefaultConfig(ctx,
+    config.WithRegion("us-east-1"),
+    config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+    config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
+        func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+            return aws.Endpoint{URL: "http://localhost:4566"}, nil
+        },
+    )),
+)
+```
+
+## Step 4: Update docker-compose.yml
+
+**Before:**
+
+```yaml
+services:
+  localstack:
+    image: localstack/localstack:latest
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=s3,sqs,sns,dynamodb,lambda
+      - DEBUG=1
+```
+
+**After:**
+
+```yaml
+services:
+  fakecloud:
+    image: ghcr.io/faiscadev/fakecloud:latest
+    ports:
+      - "4566:4566"
+```
+
+fakecloud starts all services by default (they are lazy and cheap — no `SERVICES` env var needed). If you want to pass flags:
+
+```yaml
+services:
+  fakecloud:
+    image: ghcr.io/faiscadev/fakecloud:latest
+    ports:
+      - "4566:4566"
+    command: ["fakecloud", "--host", "0.0.0.0", "--port", "4566"]
+```
+
+For Lambda execution you will need Docker-in-Docker or a mounted Docker socket (same as LocalStack Pro required):
+
+```yaml
+services:
+  fakecloud:
+    image: ghcr.io/faiscadev/fakecloud:latest
+    ports:
+      - "4566:4566"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+## Step 5: Update GitHub Actions
+
+**Before:**
+
+```yaml
+services:
+  localstack:
+    image: localstack/localstack
+    ports:
+      - 4566:4566
+    env:
+      LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_TOKEN }}  # now required
+```
+
+**After (service container):**
+
+```yaml
+services:
+  fakecloud:
+    image: ghcr.io/faiscadev/fakecloud:latest
+    ports:
+      - 4566:4566
+```
+
+**After (install-and-run, no Docker):**
+
+```yaml
+steps:
+  - run: curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+  - run: fakecloud &
+  - run: |
+      for i in $(seq 1 30); do
+        curl -sf http://localhost:4566/_fakecloud/health && exit 0
+        sleep 1
+      done
+      exit 1
+```
+
+The install-and-run pattern is ~500ms vs ~3s for LocalStack container boot. On a cold CI runner the difference is noticeable over hundreds of test runs.
+
+## Step 6: Terraform / OpenTofu
+
+No change needed. The provider block stays the same — only the running emulator changes.
+
+```hcl
+provider "aws" {
+  access_key                  = "test"
+  secret_key                  = "test"
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    s3       = "http://localhost:4566"
+    sqs      = "http://localhost:4566"
+    sns      = "http://localhost:4566"
+    dynamodb = "http://localhost:4566"
+    lambda   = "http://localhost:4566"
+    # ...
+  }
+}
+```
+
+fakecloud's CI runs the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites against itself, so Terraform flows that worked against LocalStack Community should work against fakecloud. If you hit a mismatch, it is a bug — open an issue.
+
+## Step 7: CDK — cdklocal
+
+CDK users with `cdklocal` change the endpoint override:
+
+```sh
+cdklocal bootstrap --endpoint-url http://localhost:4566
+cdklocal deploy --endpoint-url http://localhost:4566
+```
+
+Or set `AWS_ENDPOINT_URL=http://localhost:4566` in your shell and use plain `cdk`.
+
+## Step 8: Serverless Framework — serverless-offline
+
+If you used `serverless-localstack`, the simplest migration is to drop it and rely on the AWS SDK endpoint override instead. fakecloud's API Gateway v2 + Lambda integration handles the flow directly:
+
+```yaml
+# serverless.yml
+custom:
+  endpoints:
+    - aws:
+        endpoint: http://localhost:4566
+```
+
+## Things that may need attention
+
+**SERVICES env var.** LocalStack used `SERVICES=s3,sqs,...` to scope which services booted. fakecloud starts all services by default and they are cheap. Drop the env var.
+
+**LOCALSTACK_AUTH_TOKEN.** Drop it. fakecloud does not use auth tokens.
+
+**Gateway / edge URL.** LocalStack had historical URLs like `http://localhost:4566` and older per-service ports (4572, 4576, etc). fakecloud uses only `4566` — same as modern LocalStack. If you still have old per-service URLs pinned, consolidate them.
+
+**Regions.** fakecloud respects the region from your SDK call. Default `us-east-1` works everywhere.
+
+**Persisted state.** LocalStack Pro has `PERSISTENCE=1`. fakecloud has `--persist /path/to/dir` for the same effect.
+
+## Services that moved from LocalStack Community to Pro (and what fakecloud does)
+
+| Service | LocalStack Community (pre-Mar 2026) | LocalStack Community (now) | fakecloud |
+|---|---|---|---|
+| RDS | [Paid only](https://docs.localstack.cloud/references/licensing/) — always was | Paid only | 163 ops, real PostgreSQL/MySQL/MariaDB via Docker |
+| ElastiCache | Paid only | Paid only | 75 ops, real Redis/Valkey via Docker |
+| Cognito User Pools | Free | [Paid only](https://docs.localstack.cloud/references/licensing/) | 122 ops, full auth flows + MFA |
+| SES v2 | Free (limited) | [Paid only](https://docs.localstack.cloud/references/licensing/) | 110 ops, full send + templates + DKIM |
+| API Gateway v2 | Free | [Paid only](https://docs.localstack.cloud/references/licensing/) | 28 ops, HTTP APIs + JWT/Lambda authorizers |
+| Bedrock | Not available | Not available | 111 ops (control plane + runtime) |
+
+## Assertion helpers (optional)
+
+This is new capability LocalStack never had: fakecloud ships test-assertion SDKs that let you inspect side effects from tests without raw HTTP.
+
+```ts
+import { FakeCloud } from "fakecloud";
+const fc = new FakeCloud();
+
+// Your app code sends an email through the normal AWS SDK.
+// Your test asserts the side effect directly.
+const { emails } = await fc.ses.getEmails();
+expect(emails).toHaveLength(1);
+expect(emails[0].destination.toAddresses).toContain("alice@example.com");
+
+// Reset between tests.
+await fc.reset();
+```
+
+SDKs for TypeScript, Python, Go, PHP, Java, Rust. See [the SDK docs](https://fakecloud.dev/docs/sdks).
+
+## Verify the migration
+
+One-shot smoke test that exercises a cross-service flow:
+
+```sh
+# Create a bucket, upload, confirm, teardown
+aws --endpoint-url http://localhost:4566 s3 mb s3://test-bucket
+echo hello | aws --endpoint-url http://localhost:4566 s3 cp - s3://test-bucket/hello.txt
+aws --endpoint-url http://localhost:4566 s3 ls s3://test-bucket/
+aws --endpoint-url http://localhost:4566 s3 rb s3://test-bucket --force
+
+# Lambda round-trip
+echo 'exports.handler = async () => ({ ok: true })' > index.js
+zip fn.zip index.js
+aws --endpoint-url http://localhost:4566 lambda create-function \
+  --function-name smoke --runtime nodejs20.x \
+  --role arn:aws:iam::000000000000:role/lambda-role \
+  --handler index.handler --zip-file fileb://fn.zip
+aws --endpoint-url http://localhost:4566 lambda invoke \
+  --function-name smoke out.json && cat out.json
+```
+
+If both print what you expect, migration is done.
+
+## When fakecloud is not the right choice
+
+- You need EC2, ECS, ECR, CloudFront, AppSync, Athena, Glue, or SageMaker. Those are not implemented yet. Vote with an issue.
+- You need 100% production parity for mission-critical pre-prod validation. No emulator replaces real AWS for that.
+- Your team is already paying for LocalStack Pro and happy with it. Migration is not urgent.
+
+## Links
+
+- Install: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- Repo: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- Site: [fakecloud.dev](https://fakecloud.dev)
+- Comparison: [fakecloud vs LocalStack, MiniStack, floci, Moto](/blog/localstack-alternatives-compared/)
+- Issues: [github.com/faiscadev/fakecloud/issues](https://github.com/faiscadev/fakecloud/issues)

--- a/website/content/blog/migrate-from-localstack.md
+++ b/website/content/blog/migrate-from-localstack.md
@@ -207,17 +207,19 @@ cdklocal deploy --endpoint-url http://localhost:4566
 
 Or set `AWS_ENDPOINT_URL=http://localhost:4566` in your shell and use plain `cdk`.
 
-## Step 8: Serverless Framework — serverless-offline
+## Step 8: Serverless Framework
 
-If you used `serverless-localstack`, the simplest migration is to drop it and rely on the AWS SDK endpoint override instead. fakecloud's API Gateway v2 + Lambda integration handles the flow directly:
+If you used `serverless-localstack`, the simplest migration is to drop the plugin and set `AWS_ENDPOINT_URL` before running `serverless`:
 
-```yaml
-# serverless.yml
-custom:
-  endpoints:
-    - aws:
-        endpoint: http://localhost:4566
+```sh
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=us-east-1
+serverless deploy
 ```
+
+AWS SDK v3 (which Serverless Framework uses internally on recent versions) respects `AWS_ENDPOINT_URL` automatically — no plugin or custom config required. If you're on an older version that doesn't, configure the endpoint through whatever per-service override your current plugin exposes.
 
 ## Things that may need attention
 

--- a/website/content/localstack-alternative.md
+++ b/website/content/localstack-alternative.md
@@ -1,0 +1,127 @@
++++
+title = "Free, open-source LocalStack alternative"
+description = "fakecloud is a free, open-source local AWS emulator: 23 services, 1,680 operations, 100% conformance, 6 test-assertion SDKs. No account, no token, no paid tier. Drop-in replacement for LocalStack Community."
+template = "page.html"
++++
+
+LocalStack replaced its open-source Community Edition with a proprietary image in March 2026. Running `localstack:latest` now requires an account and an auth token, and several previously-free services (RDS, ElastiCache, Cognito User Pools, SES v2, API Gateway v2, ECS/ECR) moved behind a paywall.
+
+**fakecloud is a free, open-source replacement.** Single static binary, no account, no token, no paid tier, AGPL-3.0.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point any AWS SDK or CLI at `http://localhost:4566` with dummy credentials. That is the whole setup.
+
+## What fakecloud gives you
+
+- **23 AWS services.** S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, KMS, Secrets Manager, SSM, CloudWatch Logs, CloudFormation, EventBridge, EventBridge Scheduler, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime.
+- **1,680 API operations. 100% conformance** per implemented service, validated against AWS's own Smithy models on every commit (54,000+ generated test variants).
+- **Tested against upstream Terraform acceptance tests.** CI runs `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud, catching waiter and field-presence drift that pure SDK tests miss.
+- **Real Lambda execution.** 13 runtimes in Docker containers. Not a mock, not a stub. Node, Python, Java, Go, .NET, Ruby, custom runtimes.
+- **Real stateful services.** RDS runs real PostgreSQL/MySQL/MariaDB. ElastiCache runs real Redis/Valkey. Your Lambda talking to RDS is talking to a real Postgres.
+- **Real cross-service wiring.** EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> S3/SNS/Lambda, 15+ more end-to-end integrations.
+- **Fast.** ~500ms startup. ~10 MiB idle memory. ~19 MB binary. No Docker required to run fakecloud itself.
+- **Test-assertion SDKs** for TypeScript, Python, Go, PHP, Java, and Rust. Assert that an email was sent, an SNS message published, a Lambda invoked, without writing raw HTTP.
+- **Multi-account, SCPs, ABAC.** Cross-account delivery on SQS/SNS/Lambda/S3/EventBridge/Step Functions. STS trust policies with `sts:ExternalId`, session tags, permission boundaries, and session policies all enforced.
+- **IAM, KMS key policies, bucket policies, SCPs.** Opt-in strict enforcement with the full Allow/Deny/NotPrincipal semantics AWS uses.
+
+## fakecloud vs LocalStack Community (post-March 2026)
+
+| Feature | fakecloud | LocalStack Community |
+|---|---|---|
+| License | AGPL-3.0 (open source) | Proprietary |
+| Account / auth token | Not required | Required |
+| Free for commercial use | Yes | No |
+| Docker required | No (single binary) | Yes |
+| Startup | ~500ms | ~3s |
+| Idle memory | ~10 MiB | ~150 MiB |
+| Install size | ~19 MB binary | ~1 GB image |
+| Conformance methodology | Smithy-model-validated, 54k+ test variants | Not published |
+| Test-assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust | Python, Java |
+| Cognito User Pools | 122 operations | [Paid only](https://docs.localstack.cloud/references/licensing/) |
+| SES v2 | 110 operations, full send + templates + DKIM | [Paid only](https://docs.localstack.cloud/references/licensing/) |
+| SES inbound email | Real receipt rule action execution | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) |
+| RDS | 163 ops, real PostgreSQL/MySQL/MariaDB via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/) |
+| ElastiCache | 75 ops, real Redis/Valkey via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/) |
+| API Gateway v2 | 28 ops, HTTP APIs + JWT/Lambda authorizers | [Paid only](https://docs.localstack.cloud/references/licensing/) |
+| Bedrock | 111 ops (control plane + runtime) | Not available |
+
+Performance numbers measured on Apple M1 via `time fakecloud`, `ps -o rss`, `ls -lh`. LocalStack numbers from a fresh `localstack start` on the same hardware.
+
+## Migrating from LocalStack
+
+Most projects can migrate by changing one thing: the container image (or the install command), plus the port if it differs. The endpoint URL, dummy credentials, and SDK wiring all stay the same.
+
+```yaml
+# docker-compose.yml — before (LocalStack Community)
+services:
+  localstack:
+    image: localstack/localstack:latest  # now requires auth token
+    ports:
+      - "4566:4566"
+
+# docker-compose.yml — after (fakecloud)
+services:
+  fakecloud:
+    image: ghcr.io/faiscadev/fakecloud:latest
+    ports:
+      - "4566:4566"
+```
+
+For CI without Docker:
+
+```yaml
+- run: curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+- run: fakecloud &
+- run: sleep 1 && aws --endpoint-url http://localhost:4566 s3 ls  # verify
+```
+
+Full migration guide: [Migrating from LocalStack to fakecloud](/blog/migrate-from-localstack/).
+
+## FAQ
+
+**Is fakecloud a drop-in replacement for LocalStack Community?**
+
+For integration testing and local development against the services fakecloud supports, yes. Your AWS SDK code, CLI commands, Terraform configs, and CDK apps work unchanged — you only switch the endpoint URL (already `http://localhost:4566`) and the process you run.
+
+**Is fakecloud free for commercial use?**
+
+Yes. AGPL-3.0. Using fakecloud as a dev/test dependency has zero AGPL implications for your application or your production code. The copyleft clause only kicks in if you modify fakecloud itself and redistribute it as a network service.
+
+**How is fakecloud different from Moto?**
+
+Moto is a Python library that patches boto3 inside a test process. fakecloud is a real HTTP server that listens on port 4566 and speaks the AWS wire protocol. That means fakecloud works with any language and any SDK (Go, Java, Node, Rust, PHP), and it exercises real cross-service wiring (EventBridge -> Lambda, S3 -> SNS, etc) because the services are running in the same process. Moto doesn't execute Lambda code; fakecloud runs Lambda in real Docker containers across 13 runtimes.
+
+**How is fakecloud different from SAM Local / serverless-offline?**
+
+SAM Local and serverless-offline only run Lambda (and a limited HTTP/API Gateway surface in front of it). fakecloud runs Lambda plus 22 other services, with real cross-service integrations. If your function calls SQS, fans out over SNS, or reads from DynamoDB, fakecloud has those services wired up.
+
+**Does fakecloud run on CI?**
+
+Yes. Single binary, ~19 MB, ~500ms startup. Common patterns: install-and-run as a background step in GitHub Actions / GitLab CI / CircleCI, or pull `ghcr.io/faiscadev/fakecloud:latest` as a service container. See [integration testing AWS in CI](/blog/integration-testing-aws-in-ci/) for copy-paste configs.
+
+**Which services are implemented at 100% conformance?**
+
+Every service listed above. Conformance means: for every operation exposed by AWS's Smithy model, fakecloud accepts every documented input shape and returns the documented output shape, with every field AWS returns. Validated on every commit against 54,000+ generated test variants.
+
+**What's not implemented?**
+
+EC2, ECS, ECR, CloudFront, SQS extended client encryption, AppSync, Athena, Glue, SageMaker. If you need one of these, open an issue — the roadmap is driven by real-project demand.
+
+**Is this a fork of LocalStack?**
+
+No. fakecloud is written from scratch in Rust. No LocalStack code was used. LocalStack is written in Python; fakecloud is written in Rust and ships as a single binary.
+
+## Get started
+
+- **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Docker:** `docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud`
+- **Cargo:** `cargo install fakecloud`
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Docs:** [fakecloud.dev/docs](/docs/)
+- **Issues:** [github.com/faiscadev/fakecloud/issues](https://github.com/faiscadev/fakecloud/issues)
+
+If fakecloud behaves differently from real AWS, that's a bug — open an issue and it gets fixed.

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -8,7 +8,7 @@
   <div class="container">
     <h1>fake<span>cloud</span></h1>
     <p class="tagline">Local AWS cloud emulator for integration tests. Run your app with normal AWS clients, stay fully local, and use fakecloud SDKs when your tests need deeper visibility.</p>
-    <p class="hero-proof">22 services. 1155 operations. 100% conformance across implemented APIs.</p>
+    <p class="hero-proof">23 services. 1,680 operations. 100% conformance across implemented APIs.</p>
     <div class="btn-group">
       <a href="#quickstart" class="btn">Get Started</a>
       <a href="#compare" class="btn btn-outline">Why fakecloud</a>
@@ -47,13 +47,13 @@
       </div>
       <div class="feature">
         <div class="label">Coverage</div>
-        <h3>22 AWS services</h3>
-        <p>S3, SQS, SNS, EventBridge, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES, Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, and Bedrock Runtime.</p>
+        <h3>23 AWS services</h3>
+        <p>S3, SQS, SNS, EventBridge, EventBridge Scheduler, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES, Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, and Bedrock Runtime.</p>
       </div>
       <div class="feature">
         <div class="label">Tested</div>
         <h3>Conformance tested</h3>
-        <p>100% conformance across all 1155 implemented API operations, backed by model-driven conformance coverage plus end-to-end tests against the official AWS SDKs.</p>
+        <p>100% conformance across all 1,680 implemented API operations, backed by 54,000+ Smithy-model-generated test variants plus end-to-end tests against the official AWS SDKs.</p>
       </div>
       <div class="feature">
         <div class="label">Real behavior</div>
@@ -142,13 +142,15 @@
           <tr><td>Startup time</td><td class="check">~500ms</td><td class="cross">~3s</td></tr>
           <tr><td>Idle memory</td><td class="check">~10 MiB</td><td class="cross">~150 MiB</td></tr>
           <tr><td>Install size</td><td class="check">~19 MB binary</td><td class="cross">~1 GB Docker image</td></tr>
-          <tr><td>AWS services</td><td>22</td><td>30+</td></tr>
+          <tr><td>AWS services</td><td>23</td><td>30+</td></tr>
           <tr><td>Test assertion SDKs</td><td class="check">TypeScript, Python, Go, PHP, Java, Rust</td><td>Python, Java</td></tr>
-          <tr><td>Cognito User Pools</td><td class="check">80 operations</td><td class="cross">Paid only</td></tr>
-          <tr><td>SES v2</td><td class="check">97 operations</td><td class="cross">Paid only</td></tr>
+          <tr><td>Cognito User Pools</td><td class="check">122 operations</td><td class="cross">Paid only</td></tr>
+          <tr><td>SES v2</td><td class="check">110 operations</td><td class="cross">Paid only</td></tr>
           <tr><td>SES inbound email</td><td class="check">Real receipt rule actions</td><td class="cross">Stored but never executed</td></tr>
-          <tr><td>RDS</td><td class="check">22 operations, PostgreSQL/MySQL/MariaDB via Docker</td><td class="cross">Paid only</td></tr>
-          <tr><td>ElastiCache</td><td class="check">44 operations, Redis and Valkey via Docker</td><td class="cross">Paid only</td></tr>
+          <tr><td>RDS</td><td class="check">163 operations, PostgreSQL/MySQL/MariaDB via Docker</td><td class="cross">Paid only</td></tr>
+          <tr><td>ElastiCache</td><td class="check">75 operations, Redis and Valkey via Docker</td><td class="cross">Paid only</td></tr>
+          <tr><td>API Gateway v2</td><td class="check">28 operations, HTTP APIs + JWT/Lambda authorizers</td><td class="cross">Paid only</td></tr>
+          <tr><td>Bedrock</td><td class="check">111 operations (control plane + runtime)</td><td class="cross">Not available</td></tr>
         </tbody>
       </table>
     </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -166,6 +166,7 @@
       <div class="service"><div class="name">SQS</div><div class="proto">Query protocol &middot; XML</div></div>
       <div class="service"><div class="name">SNS</div><div class="proto">Query protocol &middot; XML</div></div>
       <div class="service"><div class="name">EventBridge</div><div class="proto">JSON protocol</div></div>
+      <div class="service"><div class="name">EventBridge Scheduler</div><div class="proto">JSON protocol</div></div>
       <div class="service"><div class="name">SSM Parameter Store</div><div class="proto">JSON protocol</div></div>
       <div class="service"><div class="name">DynamoDB</div><div class="proto">JSON protocol</div></div>
       <div class="service"><div class="name">IAM / STS</div><div class="proto">Query protocol</div></div>

--- a/website/templates/page.html
+++ b/website/templates/page.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} - {{ config.title }}{% endblock %}
+{% block description %}{{ page.description | default(value=config.description) }}{% endblock %}
+
+{% block content %}
+<article class="blog-article">
+  <h1>{{ page.title }}</h1>
+  {% if page.description %}<p class="section-sub">{{ page.description }}</p>{% endif %}
+  {{ page.content | safe }}
+</article>
+{% endblock %}


### PR DESCRIPTION
## Summary

Batch 1 of the upstream-query SEO/LLM visibility push. Targets the \`localstack free alternative\` / \`replace localstack\` / \`localstack not free anymore\` query cluster that is spiking post-paywall with no dominant canonical winner yet.

- **New landing page** [/localstack-alternative/](https://fakecloud.dev/localstack-alternative/) — non-dated, keeps current. Hero + FAQ block seeded with quotable numbers (23 services, 1,680 ops, 54k Smithy test variants, 6 SDK languages) for LLM citation density.
- **New blog post** [/blog/migrate-from-localstack/](https://fakecloud.dev/blog/migrate-from-localstack/) — step-by-step migration w/ copy-paste configs for docker-compose, GitHub Actions, Terraform, CDK, Serverless Framework.
- **New blog post** [/blog/localstack-alternatives-compared/](https://fakecloud.dev/blog/localstack-alternatives-compared/) — honest fit-based comparison across fakecloud, MiniStack, floci, Moto, LocalStack Pro. No fabricated benchmarks; positioning and architecture only.
- **README** — added "Common use cases" table mapping upstream queries (test Lambda locally, mock DynamoDB, fake AWS server, Moto equivalent for Go/Java/Node, integration test AWS in GitHub Actions, etc) to copy-paste commands.
- **Homepage** — stats refreshed to current numbers (23 services / 1,680 ops / 6 SDKs, Bedrock and API Gateway v2 rows added to compare table).
- **New template** \`page.html\` for non-dated landing pages (no author/date chrome, unlike blog posts).

Existing \`/blog/localstack-alternative/\` post left untouched per the "blog posts are point-in-time" rule. The new \`/localstack-alternative/\` page is a living landing page at a different URL.

Dev.to cross-posts and awesome-list PR bodies are staged locally in \`marketing/\` (gitignored as usual) for manual publication.

## Test plan

- [x] \`zola build\` succeeds locally (52 pages, 0 orphan)
- [x] New pages render at expected paths: \`/localstack-alternative/\`, \`/blog/migrate-from-localstack/\`, \`/blog/localstack-alternatives-compared/\`
- [ ] CI green
- [ ] Merge and wait for fakecloud.dev to deploy; then spot-check the three URLs live
- [ ] Dev.to cross-posts published under Lucas's account (manual)
- [ ] Awesome-list PRs opened (manual, bodies drafted in \`marketing/awesome-list-prs.md\`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new LocalStack-alternative landing page and two guides to capture “localstack free alternative/replace localstack” traffic. Also refreshes homepage stats, expands the README with common use cases, and adds a template for evergreen landing pages.

- **New Features**
  - New landing page: /localstack-alternative/ with current stats and FAQ.
  - New guide: /blog/migrate-from-localstack/ with copy-paste configs for docker-compose, GitHub Actions, Terraform, CDK, and Serverless Framework.
  - New comparison post: /blog/localstack-alternatives-compared/ (fakecloud, MiniStack, floci, Moto, LocalStack Pro).

- **Site Updates**
  - Homepage numbers and compare table updated (23 services, 1,680 ops; added Bedrock and API Gateway v2 rows; added EventBridge Scheduler tile).
  - README gains a “Common use cases” table with commands and links to guides.
  - New `page.html` template for non-dated landing pages.
  - Docs polish: fixed Serverless Framework example to use AWS_ENDPOINT_URL in the migration guide; removed curl|bash install snippet from the comparison post links in favor of install docs.

<sup>Written for commit 6ffb2c09b946ff639a1eb92f549042a404e6f783. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

