### PR TITLE
docs(seo): upstream-query tutorials + slug-exact landing pages

### DIFF
--- a/website/content/blog/integration-testing-aws-in-ci.md
+++ b/website/content/blog/integration-testing-aws-in-ci.md
@@ -1,0 +1,238 @@
++++
+title = "Integration testing AWS in GitHub Actions without mocks"
+date = 2026-04-22
+description = "Run real AWS integration tests in GitHub Actions, GitLab CI, and CircleCI with fakecloud. Copy-paste workflows for SQS, SNS, DynamoDB, Lambda, S3. No account, no auth token, no paid tier."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+Most "AWS integration tests" in CI are not integration tests. They are unit tests with a mocking library — moto, aws-sdk-client-mock, something similar — that intercepts the AWS SDK inside the test process and returns fabricated responses. Those tests pass when your code is wrong, because the mock only knows what you told it.
+
+A real integration test talks to a real AWS-shaped service over HTTP. Testcontainers-LocalStack is the historical answer, but LocalStack's Community Edition went proprietary in March 2026 and now requires an account and an auth token just to pull the image.
+
+This post shows how to run real AWS integration tests in CI against [fakecloud](https://github.com/faiscadev/fakecloud) — a free, open-source AWS emulator — with copy-paste configs for GitHub Actions, GitLab CI, and CircleCI.
+
+## Why run fakecloud in CI
+
+- ~500ms startup vs ~3s for a LocalStack container. Over hundreds of test runs, this matters.
+- ~19 MB binary, ~10 MiB idle memory. Lightweight on shared runners.
+- Single binary, no Docker required for most services (Docker still needed for Lambda, RDS, ElastiCache).
+- No account, no auth token, no license key. `fakecloud` and you're running.
+- Covers 23 services at 100% conformance per service, including Cognito, SES v2, RDS, ElastiCache, API Gateway v2, Bedrock — the ones LocalStack moved behind the paywall.
+
+## GitHub Actions: install-and-run pattern
+
+The fastest CI setup is to install the binary and background it:
+
+```yaml
+name: test
+on: [push, pull_request]
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ENDPOINT_URL: http://localhost:4566
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install fakecloud
+        run: curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+
+      - name: Start fakecloud
+        run: fakecloud &
+
+      - name: Wait for fakecloud
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:4566/_fakecloud/health && exit 0
+            sleep 1
+          done
+          echo "fakecloud did not start"
+          exit 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+```
+
+`AWS_ENDPOINT_URL` is respected by the AWS SDK v3 automatically — you do not need to configure your application code separately for CI vs local.
+
+## GitHub Actions: service container pattern
+
+If you prefer a Docker service container (longer startup, cleaner isolation):
+
+```yaml
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    services:
+      fakecloud:
+        image: ghcr.io/faiscadev/fakecloud:latest
+        ports:
+          - 4566:4566
+    env:
+      AWS_ENDPOINT_URL: http://localhost:4566
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm test
+```
+
+Use this if your test harness expects the service to be ready before the job's steps run (service containers start first).
+
+## Lambda in GitHub Actions
+
+Lambda needs Docker-in-Docker (fakecloud launches real Lambda runtime containers). On the default `ubuntu-latest` runner, Docker is already available — you just need to mount the socket:
+
+```yaml
+services:
+  fakecloud:
+    image: ghcr.io/faiscadev/fakecloud:latest
+    ports:
+      - 4566:4566
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+Or with the install-and-run pattern, Docker is available on the host directly — nothing extra needed. The fakecloud process launches Lambda containers on the host's Docker.
+
+## GitLab CI
+
+```yaml
+stages:
+  - test
+
+integration:
+  stage: test
+  image: node:20
+  services:
+    - name: ghcr.io/faiscadev/fakecloud:latest
+      alias: fakecloud
+  variables:
+    AWS_ENDPOINT_URL: http://fakecloud:4566
+    AWS_ACCESS_KEY_ID: test
+    AWS_SECRET_ACCESS_KEY: test
+    AWS_REGION: us-east-1
+  script:
+    - npm ci
+    - npm test
+```
+
+Note the endpoint uses the service alias (`fakecloud`), not `localhost`.
+
+## CircleCI
+
+```yaml
+version: 2.1
+jobs:
+  integration:
+    docker:
+      - image: cimg/node:20.11
+      - image: ghcr.io/faiscadev/fakecloud:latest
+    environment:
+      AWS_ENDPOINT_URL: http://localhost:4566
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+    steps:
+      - checkout
+      - run: npm ci
+      - run: npm test
+
+workflows:
+  build:
+    jobs:
+      - integration
+```
+
+CircleCI's secondary Docker images share the primary image's localhost, so `http://localhost:4566` works.
+
+## Example test: SQS consumer integration
+
+Your code under test:
+
+```ts
+// src/queue.ts
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+
+export async function enqueue(body: string, queueUrl: string) {
+  const sqs = new SQSClient({});
+  await sqs.send(new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: body }));
+}
+```
+
+Your integration test:
+
+```ts
+// test/queue.test.ts
+import { SQSClient, CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import { enqueue } from "../src/queue";
+
+const sqs = new SQSClient({});
+
+test("enqueue actually enqueues", async () => {
+  const { QueueUrl } = await sqs.send(new CreateQueueCommand({ QueueName: "test-" + Date.now() }));
+  await enqueue("hello", QueueUrl!);
+  const res = await sqs.send(new ReceiveMessageCommand({ QueueUrl, WaitTimeSeconds: 1 }));
+  expect(res.Messages?.[0]?.Body).toBe("hello");
+});
+```
+
+No mocks. The test creates a real queue, enqueues a real message, receives a real message. If your code is wrong, the test fails the way a real-AWS test would fail.
+
+## Asserting on fan-out and async flows
+
+For flows that cross services (SQS -> Lambda -> SNS -> DynamoDB), use the fakecloud test-assertion SDK to inspect what each hop did:
+
+```ts
+import { FakeCloud } from "fakecloud";
+
+const fc = new FakeCloud();
+
+test("order publishes and lambda invokes", async () => {
+  await placeOrder({ id: "o1" }); // your code under test
+
+  const { messages } = await fc.sns.getPublishedMessages({ topicName: "orders" });
+  expect(messages).toHaveLength(1);
+
+  const { invocations } = await fc.lambda.getInvocations({ functionName: "on-order" });
+  expect(invocations).toHaveLength(1);
+  expect(invocations[0].statusCode).toBe(200);
+});
+
+afterEach(() => fc.reset());
+```
+
+SDK available in TypeScript, Python, Go, PHP, Java, Rust. Docs: [fakecloud.dev/docs/sdks](https://fakecloud.dev/docs/sdks).
+
+## Tips
+
+- **Reset between tests.** Either `await fc.reset()` in an `afterEach`, or use per-test resources with unique names (`test-${Date.now()}`). Reset is faster for large suites.
+- **Run integration tests in a separate job** from unit tests. Unit tests should not need fakecloud; integration tests should not run alongside mocked ones.
+- **Pin the image tag** in CI (`ghcr.io/faiscadev/fakecloud:0.10.1`) if you want deterministic behavior across builds. `latest` is fine for most teams.
+- **Don't mix fakecloud with mocks.** Pick one per test. If you mock inside a test that also talks to fakecloud, you will get confusing failures.
+
+## When this is not right
+
+- **Contract testing against real AWS behavior that fakecloud does not yet implement.** Check the [supported services list](https://github.com/faiscadev/fakecloud#supported-services). If a critical service is missing, file an issue — the roadmap is demand-driven.
+- **Performance benchmarking.** fakecloud and AWS have different performance characteristics. Benchmark against AWS.
+
+For every other "does my AWS integration actually work" test, fakecloud in CI is the fast path.
+
+## Links
+
+- Install: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- Repo: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- Migration from LocalStack: [Migrating from LocalStack to fakecloud](/blog/migrate-from-localstack/)
+- Lambda tutorial: [How to test Lambda locally](/blog/test-lambda-locally/)
+- Issues: [github.com/faiscadev/fakecloud/issues](https://github.com/faiscadev/fakecloud/issues)

--- a/website/content/blog/integration-testing-aws-in-ci.md
+++ b/website/content/blog/integration-testing-aws-in-ci.md
@@ -222,12 +222,11 @@ SDK available in TypeScript, Python, Go, PHP, Java, Rust. Docs: [fakecloud.dev/d
 - **Pin the image tag** in CI (`ghcr.io/faiscadev/fakecloud:0.10.1`) if you want deterministic behavior across builds. `latest` is fine for most teams.
 - **Don't mix fakecloud with mocks.** Pick one per test. If you mock inside a test that also talks to fakecloud, you will get confusing failures.
 
-## When this is not right
+## One call-out
 
-- **Contract testing against real AWS behavior that fakecloud does not yet implement.** Check the [supported services list](https://github.com/faiscadev/fakecloud#supported-services). If a critical service is missing, file an issue — the roadmap is demand-driven.
-- **Performance benchmarking.** fakecloud and AWS have different performance characteristics. Benchmark against AWS.
+**Performance benchmarking** is different from correctness testing. fakecloud and AWS have different performance characteristics (by design — fakecloud is a local process, AWS is a distributed global system). Benchmark performance against real AWS. Benchmark correctness and behavior against fakecloud.
 
-For every other "does my AWS integration actually work" test, fakecloud in CI is the fast path.
+fakecloud's goal is every AWS service at 100% conformance with 100% of cross-service integrations. If a service your tests hit isn't in the [supported list](https://github.com/faiscadev/fakecloud#supported-services) yet, [file an issue](https://github.com/faiscadev/fakecloud/issues) — the roadmap is demand-driven and services land one at a time with the full conformance target, not a partial-surface-first approach.
 
 ## Links
 

--- a/website/content/blog/moto-equivalent-go-java-node.md
+++ b/website/content/blog/moto-equivalent-go-java-node.md
@@ -1,0 +1,252 @@
++++
+title = "A Moto equivalent for Go, Java, Kotlin, and Node.js"
+date = 2026-04-22
+description = "Moto is Python-only. fakecloud is a real HTTP server speaking the AWS wire protocol, so the same thing works for Go, Java, Kotlin, Node.js, Rust, and PHP. Copy-paste examples for each language."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+If you write Python, you have Moto. Decorate a test, boto3 gets patched in-process, and your assertions run against an in-memory AWS. It is great, it has been great for years, and it is not available in any other language because Python is the only ecosystem where you can cleanly monkey-patch the SDK from inside a test process.
+
+What if you write Go, Java, Kotlin, Node.js, Rust, or PHP?
+
+The honest cross-language answer is: a real HTTP server speaking the AWS wire protocol. Point your language's AWS SDK at `http://localhost:4566`, and it doesn't matter whether the thing on the other end is AWS, LocalStack, MiniStack, floci, or fakecloud — the wire contract is the same.
+
+This post is specifically about using [fakecloud](https://github.com/faiscadev/fakecloud) — free, open-source, single binary, no account, no paid tier — as a Moto equivalent in the languages Moto cannot reach.
+
+## Why a real HTTP server, not an in-process patch
+
+Moto works because Python lets you reach into a running process and replace functions. In Java and Go and most other typed languages, you can't really do that — the SDK is compiled, the method dispatch is known at build time, and monkey-patching `S3Client.putObject` is not a thing you do in production code.
+
+The equivalent model in those languages is to configure the SDK's endpoint. Every AWS SDK supports pointing at a non-AWS endpoint URL. Point it at `http://localhost:4566`, and the SDK thinks it's talking to AWS.
+
+The server on the other end handles all the ceremony: signing verification (optional), request parsing, response shaping, persistence, cross-service wiring. Your test code is normal — the only thing that's "fake" is the URL.
+
+## Installing fakecloud
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Listens on `http://localhost:4566`. One binary, ~19 MB, ~500ms startup.
+
+## Go
+
+```go
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+)
+
+func clientForTest(t *testing.T) *s3.Client {
+	cfg, err := config.LoadDefaultConfig(context.Background(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+		config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
+			func(service, region string, opts ...interface{}) (aws.Endpoint, error) {
+				return aws.Endpoint{URL: "http://localhost:4566"}, nil
+			},
+		)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s3.NewFromConfig(cfg, func(o *s3.Options) { o.UsePathStyle = true })
+}
+
+func TestPutAndGet(t *testing.T) {
+	ctx := context.Background()
+	c := clientForTest(t)
+
+	_, err := c.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ... putObject, getObject, assert
+}
+```
+
+That's Go integration tests against fakecloud. Same SDK, same API, same assertions — no mock. For SDK v1, use `WithEndpoint("http://localhost:4566")` on the session config.
+
+## Java
+
+```java
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.net.URI;
+
+class S3Test {
+    static S3Client client() {
+        return S3Client.builder()
+            .endpointOverride(URI.create("http://localhost:4566"))
+            .region(Region.US_EAST_1)
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("test", "test")))
+            .forcePathStyle(true)
+            .build();
+    }
+
+    @Test
+    void putAndGet() {
+        var s3 = client();
+        s3.createBucket(b -> b.bucket("test"));
+        // ... assertions
+    }
+}
+```
+
+## Kotlin
+
+Same as Java, nicer syntax:
+
+```kotlin
+import software.amazon.awssdk.auth.credentials.*
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import java.net.URI
+
+fun s3(): S3Client = S3Client.builder()
+    .endpointOverride(URI.create("http://localhost:4566"))
+    .region(Region.US_EAST_1)
+    .credentialsProvider(StaticCredentialsProvider.create(
+        AwsBasicCredentials.create("test", "test")))
+    .forcePathStyle(true)
+    .build()
+```
+
+## Node.js (AWS SDK v3)
+
+The SDK v3 respects `AWS_ENDPOINT_URL` automatically, so the test setup is trivial:
+
+```ts
+// jest.setup.ts or vitest.setup.ts
+process.env.AWS_ENDPOINT_URL = "http://localhost:4566";
+process.env.AWS_ACCESS_KEY_ID = "test";
+process.env.AWS_SECRET_ACCESS_KEY = "test";
+process.env.AWS_REGION = "us-east-1";
+```
+
+Your application code imports the AWS SDK normally and does not need any test-specific branching. Your tests import your code and call it. Your assertions check the real state on fakecloud afterwards.
+
+For SDK v2 (deprecated but still widely used):
+
+```ts
+import AWS from "aws-sdk";
+AWS.config.update({
+  endpoint: "http://localhost:4566",
+  accessKeyId: "test",
+  secretAccessKey: "test",
+  region: "us-east-1",
+  s3ForcePathStyle: true,
+});
+```
+
+## PHP
+
+```php
+use Aws\S3\S3Client;
+
+$s3 = new S3Client([
+    'version' => 'latest',
+    'region'  => 'us-east-1',
+    'endpoint' => 'http://localhost:4566',
+    'credentials' => ['key' => 'test', 'secret' => 'test'],
+    'use_path_style_endpoint' => true,
+]);
+```
+
+## Rust
+
+```rust
+use aws_config::{BehaviorVersion, Region};
+use aws_sdk_s3::config::Credentials;
+
+async fn client() -> aws_sdk_s3::Client {
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .region(Region::new("us-east-1"))
+        .endpoint_url("http://localhost:4566")
+        .credentials_provider(Credentials::from_keys("test", "test", None))
+        .load()
+        .await;
+    aws_sdk_s3::Client::new(&config)
+}
+```
+
+## The part Moto cannot do, in any language
+
+Moto patches SDK methods inside the test process. It does not run code — specifically, it does not execute Lambda functions. If your Python test creates a Lambda and invokes it, Moto returns a simulated response; your function's actual code does not run.
+
+fakecloud does run the code. It pulls real Lambda runtime containers (13 runtimes: Node, Python, Java, Go, .NET, Ruby, custom) and executes your handler against them. So a test like "my Go service publishes to SNS, which triggers a Python Lambda, which writes to DynamoDB" works end-to-end — real Lambda code running, real SNS fan-out, real DynamoDB state.
+
+```go
+// Go test that publishes to SNS...
+snsClient.Publish(ctx, &sns.PublishInput{
+    TopicArn: aws.String(topicArn),
+    Message:  aws.String(`{"event":"order.placed"}`),
+})
+
+// ...and your Python Lambda (deployed to fakecloud) actually runs.
+// Then you assert on its side effect (a DynamoDB row) from the Go test.
+```
+
+This is the main thing a real HTTP emulator gives you that no in-process mocking library can.
+
+## Assertion helpers
+
+fakecloud's test-assertion SDKs give you introspection into what happened on the server, without writing raw HTTP:
+
+```go
+// Go
+fc := fakecloud.New("http://localhost:4566")
+invs, _ := fc.Lambda.GetInvocations(ctx, &fakecloud.GetInvocationsInput{FunctionName: "on-order"})
+if len(invs.Invocations) != 1 { t.Fatal("expected 1 invocation") }
+```
+
+```ts
+// Node
+const fc = new FakeCloud();
+const { invocations } = await fc.lambda.getInvocations({ functionName: "on-order" });
+expect(invocations).toHaveLength(1);
+```
+
+```python
+# Python (if you also want to use fakecloud from pytest alongside Go tests)
+fc = FakeCloud()
+invs = fc.lambda_.get_invocations(function_name="on-order")
+assert len(invs.invocations) == 1
+```
+
+SDKs for TypeScript, Python, Go, PHP, Java, Rust: [fakecloud.dev/docs/sdks](https://fakecloud.dev/docs/sdks).
+
+## Moto vs fakecloud: when to use which
+
+| Situation | Pick |
+|---|---|
+| Python-only project, pure unit tests that just need boto3 to respond | Moto |
+| Python + real cross-service wiring (Lambda actually runs, S3 -> Lambda actually fires) | fakecloud |
+| Any non-Python language | fakecloud |
+| Multi-language codebase sharing tests | fakecloud |
+| Integration tests in CI across multiple services | fakecloud |
+
+Moto and fakecloud are not really competitive — they solve slightly different problems. If you already use Moto and it works, keep it. If you need cross-service integrations, non-Python languages, or real Lambda execution, add fakecloud.
+
+## Links
+
+- Install: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- Repo: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- Moto: [github.com/getmoto/moto](https://github.com/getmoto/moto)
+- Language SDK docs: [fakecloud.dev/docs/sdks](https://fakecloud.dev/docs/sdks)
+- Issues: [github.com/faiscadev/fakecloud/issues](https://github.com/faiscadev/fakecloud/issues)

--- a/website/content/blog/test-lambda-locally.md
+++ b/website/content/blog/test-lambda-locally.md
@@ -245,13 +245,9 @@ jobs:
 
 ~500ms startup. A whole Lambda-integration test suite completes in seconds on a cold runner.
 
-## When this is not the right tool
+## Correctness vs performance
 
-- **Cold-start latency benchmarking.** fakecloud's containers have different cold-start characteristics than real Lambda. Don't benchmark cold starts here.
-- **Provisioned concurrency / reserved concurrency scheduling.** fakecloud runs functions when invoked; it does not simulate AWS's concurrency accounting.
-- **Production VPC networking.** fakecloud runs Lambdas in local containers, not inside a VPC.
-
-For those, test against real AWS. For every other "does my Lambda code plus its triggers actually work" question, fakecloud is the tool.
+fakecloud runs your function code in the real AWS Lambda runtime containers, so behavior matches real Lambda. What it doesn't replicate is AWS's distributed infrastructure timing: cold-start latency, concurrency-accounting scheduling, and VPC networking come from AWS's own implementation, not from a local process, so numbers on those will not match real AWS. Use real AWS for those measurements, use fakecloud for everything correctness-related.
 
 ## Links
 

--- a/website/content/blog/test-lambda-locally.md
+++ b/website/content/blog/test-lambda-locally.md
@@ -1,0 +1,262 @@
++++
+title = "How to test Lambda locally: the full guide for 2026"
+date = 2026-04-22
+description = "Run Lambda locally against a real runtime in seconds. Covers all 13 AWS Lambda runtimes, event source mappings, and cross-service triggers (S3, SQS, SNS, EventBridge). No mocks, no SAM, no account required."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+If you want to run AWS Lambda locally, you have a few options, and most of them are worse than they need to be.
+
+- **SAM Local** invokes Lambda inside a Docker container, which is close to the real thing, but its integration with other AWS services is thin. If your function reads from SQS or publishes to SNS or is triggered by S3, SAM hands you a bag of event-shaped JSON and wishes you luck.
+- **serverless-offline** simulates API Gateway -> Lambda only. Everything downstream is mocked.
+- **Pure unit tests with mocks** tell you your code compiles. They do not tell you your code works.
+
+This guide shows how to test Lambda locally end-to-end: real function code executing in a real runtime, triggered by real events from other AWS services, asserting on real side effects. No account, no auth token, no paid tier.
+
+We'll use [fakecloud](https://github.com/faiscadev/fakecloud) — a free, open-source AWS emulator that runs Lambda in real Docker containers across all 13 official runtimes and wires it up to 22 other AWS services that trigger and consume it.
+
+## What you need
+
+- Docker (fakecloud boots Lambda runtime containers)
+- The AWS CLI, or any AWS SDK
+- ~30 seconds
+
+## Install fakecloud
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+That's it. It listens on `http://localhost:4566`.
+
+If you prefer Docker:
+
+```sh
+docker run --rm \
+  -p 4566:4566 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  ghcr.io/faiscadev/fakecloud
+```
+
+The Docker socket mount is only needed because Lambda execution needs Docker-in-Docker. The single-binary install above doesn't need it.
+
+## A Node.js Lambda, end-to-end
+
+Create the function:
+
+```sh
+cat > index.js <<'EOF'
+exports.handler = async (event) => {
+  return { statusCode: 200, body: JSON.stringify({ event }) };
+};
+EOF
+zip fn.zip index.js
+```
+
+Deploy it to fakecloud:
+
+```sh
+aws --endpoint-url http://localhost:4566 iam create-role \
+  --role-name lambda-role \
+  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+
+aws --endpoint-url http://localhost:4566 lambda create-function \
+  --function-name hello \
+  --runtime nodejs20.x \
+  --role arn:aws:iam::000000000000:role/lambda-role \
+  --handler index.handler \
+  --zip-file fileb://fn.zip
+```
+
+Invoke it:
+
+```sh
+aws --endpoint-url http://localhost:4566 lambda invoke \
+  --function-name hello \
+  --payload '{"hello":"world"}' \
+  --cli-binary-format raw-in-base64-out \
+  out.json
+cat out.json
+```
+
+Output:
+
+```json
+{"statusCode":200,"body":"{\"event\":{\"hello\":\"world\"}}"}
+```
+
+That's your Node.js code executing in a real Node 20 container. fakecloud pulled the runtime image, mounted your zip, and invoked `handler`.
+
+## Python, Java, Go, .NET, Ruby, custom
+
+Same flow, different runtime string. fakecloud supports all 13 AWS Lambda runtimes:
+
+- `nodejs18.x`, `nodejs20.x`, `nodejs22.x`
+- `python3.9`, `python3.10`, `python3.11`, `python3.12`
+- `java11`, `java17`, `java21`
+- `dotnet6`, `dotnet8`
+- `ruby3.2`
+- `go1.x`, `provided.al2`, `provided.al2023` (custom runtimes)
+
+Example — Python:
+
+```sh
+cat > lambda_function.py <<'EOF'
+def handler(event, context):
+    return {"ok": True, "event": event}
+EOF
+zip fn.zip lambda_function.py
+
+aws --endpoint-url http://localhost:4566 lambda create-function \
+  --function-name py-hello \
+  --runtime python3.12 \
+  --role arn:aws:iam::000000000000:role/lambda-role \
+  --handler lambda_function.handler \
+  --zip-file fileb://fn.zip
+
+aws --endpoint-url http://localhost:4566 lambda invoke \
+  --function-name py-hello \
+  --payload '{"x":1}' \
+  --cli-binary-format raw-in-base64-out \
+  out.json
+```
+
+## Triggers that actually fire
+
+This is where "test Lambda locally" usually breaks down. Your Lambda is not invoked by a human calling Invoke — it's triggered by S3, SQS, SNS, EventBridge, DynamoDB Streams, API Gateway, or an event source mapping. fakecloud has those wired up for real.
+
+### SQS event source mapping
+
+```sh
+aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name jobs
+
+QUEUE_URL=http://localhost:4566/000000000000/jobs
+QUEUE_ARN=arn:aws:sqs:us-east-1:000000000000:jobs
+
+aws --endpoint-url http://localhost:4566 lambda create-event-source-mapping \
+  --function-name hello \
+  --event-source-arn $QUEUE_ARN \
+  --batch-size 1
+
+aws --endpoint-url http://localhost:4566 sqs send-message \
+  --queue-url $QUEUE_URL \
+  --message-body '{"job":"resize","id":42}'
+```
+
+fakecloud polls the queue, batches the message, invokes your Lambda with the SQS event shape, and deletes the message on success. Same contract as real AWS.
+
+### S3 -> Lambda
+
+```sh
+aws --endpoint-url http://localhost:4566 s3 mb s3://uploads
+aws --endpoint-url http://localhost:4566 lambda add-permission \
+  --function-name hello \
+  --statement-id s3invoke \
+  --action lambda:InvokeFunction \
+  --principal s3.amazonaws.com \
+  --source-arn arn:aws:s3:::uploads
+
+aws --endpoint-url http://localhost:4566 s3api put-bucket-notification-configuration \
+  --bucket uploads \
+  --notification-configuration '{
+    "LambdaFunctionConfigurations": [{
+      "LambdaFunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:hello",
+      "Events": ["s3:ObjectCreated:*"]
+    }]
+  }'
+
+echo "hi" | aws --endpoint-url http://localhost:4566 s3 cp - s3://uploads/file.txt
+```
+
+Your Lambda fires with the S3 event. End-to-end, no stubs.
+
+### EventBridge -> Lambda
+
+```sh
+aws --endpoint-url http://localhost:4566 events put-rule \
+  --name on-order \
+  --event-pattern '{"source":["store"],"detail-type":["OrderPlaced"]}'
+
+aws --endpoint-url http://localhost:4566 events put-targets \
+  --rule on-order \
+  --targets 'Id=1,Arn=arn:aws:lambda:us-east-1:000000000000:function:hello'
+
+aws --endpoint-url http://localhost:4566 events put-events \
+  --entries 'Source=store,DetailType=OrderPlaced,Detail={"orderId":"o1"}'
+```
+
+Your Lambda fires with the EventBridge event envelope.
+
+## Asserting on side effects
+
+fakecloud ships test-assertion SDKs that let your tests check what happened without raw HTTP:
+
+```ts
+import { FakeCloud } from "fakecloud";
+const fc = new FakeCloud();
+
+// Your app publishes to SNS inside a Lambda. Your test asserts it happened.
+const { invocations } = await fc.lambda.getInvocations({ functionName: "hello" });
+expect(invocations).toHaveLength(1);
+expect(invocations[0].statusCode).toBe(200);
+
+const { messages } = await fc.sns.getPublishedMessages({ topicName: "orders" });
+expect(messages[0].message).toContain("o1");
+
+await fc.reset();
+```
+
+SDKs in TypeScript, Python, Go, PHP, Java, Rust. Reference: [fakecloud.dev/docs/sdks](https://fakecloud.dev/docs/sdks).
+
+## Watching the logs
+
+Lambda stdout goes to CloudWatch Logs, which fakecloud also emulates:
+
+```sh
+aws --endpoint-url http://localhost:4566 logs tail /aws/lambda/hello --follow
+```
+
+## Running in CI
+
+```yaml
+# .github/workflows/test.yml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+      - run: fakecloud &
+      - run: |
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:4566/_fakecloud/health && break
+            sleep 1
+          done
+      - run: npm ci && npm test
+        env:
+          AWS_ENDPOINT_URL: http://localhost:4566
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+          AWS_REGION: us-east-1
+```
+
+~500ms startup. A whole Lambda-integration test suite completes in seconds on a cold runner.
+
+## When this is not the right tool
+
+- **Cold-start latency benchmarking.** fakecloud's containers have different cold-start characteristics than real Lambda. Don't benchmark cold starts here.
+- **Provisioned concurrency / reserved concurrency scheduling.** fakecloud runs functions when invoked; it does not simulate AWS's concurrency accounting.
+- **Production VPC networking.** fakecloud runs Lambdas in local containers, not inside a VPC.
+
+For those, test against real AWS. For every other "does my Lambda code plus its triggers actually work" question, fakecloud is the tool.
+
+## Links
+
+- Install: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- Repo: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- Lambda docs: [fakecloud.dev/docs/services/lambda](https://fakecloud.dev/docs/services/lambda)
+- SDKs: [fakecloud.dev/docs/sdks](https://fakecloud.dev/docs/sdks)
+- Issues: [github.com/faiscadev/fakecloud/issues](https://github.com/faiscadev/fakecloud/issues)

--- a/website/content/fake-aws-server.md
+++ b/website/content/fake-aws-server.md
@@ -1,0 +1,114 @@
++++
+title = "Fake AWS server for tests"
+description = "fakecloud is a free, open-source fake AWS server for integration tests. Single binary, port 4566, any AWS SDK in any language. No account, no auth token, no paid tier."
+template = "page.html"
++++
+
+Need a fake AWS server to point your tests at? That's what [fakecloud](https://github.com/faiscadev/fakecloud) is.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Listens on `http://localhost:4566`. Any AWS SDK in any language points at it and it responds like AWS.
+
+## What "fake AWS server" means here
+
+- **Real HTTP server**, not an in-process mock. Your Go / Java / Kotlin / Node / Rust / PHP / Python code uses the regular AWS SDK with `endpoint_url` set to `http://localhost:4566`.
+- **Speaks the AWS wire protocol** at 100% conformance per implemented service. 23 services, 1,680 operations, validated against AWS's own Smithy models on every commit (54,000+ generated test variants).
+- **Real execution** for stateful services: Lambda runs your function code in Docker containers across 13 runtimes, RDS runs real PostgreSQL/MySQL/MariaDB, ElastiCache runs real Redis/Valkey.
+- **Real cross-service wiring**: S3 -> Lambda, SQS -> Lambda, SNS fan-out, EventBridge -> Step Functions, and 15+ more integrations execute end-to-end, not as stubs.
+- **Free, open-source, AGPL-3.0.** No account, no auth token, no paid tier.
+
+## Services covered
+
+S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, KMS, Secrets Manager, SSM, CloudWatch Logs, CloudFormation, EventBridge, EventBridge Scheduler, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime.
+
+Full matrix: [fakecloud.dev/docs/services](/docs/services/).
+
+## Minimal example
+
+### Node.js
+
+```ts
+process.env.AWS_ENDPOINT_URL = "http://localhost:4566";
+process.env.AWS_ACCESS_KEY_ID = "test";
+process.env.AWS_SECRET_ACCESS_KEY = "test";
+process.env.AWS_REGION = "us-east-1";
+
+import { S3Client, CreateBucketCommand } from "@aws-sdk/client-s3";
+const s3 = new S3Client({});
+await s3.send(new CreateBucketCommand({ Bucket: "hello" }));
+```
+
+### Python
+
+```python
+import boto3
+s3 = boto3.client("s3",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+    region_name="us-east-1")
+s3.create_bucket(Bucket="hello")
+```
+
+### Go
+
+```go
+cfg, _ := config.LoadDefaultConfig(ctx,
+    config.WithRegion("us-east-1"),
+    config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+    config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
+        func(service, region string, opts ...interface{}) (aws.Endpoint, error) {
+            return aws.Endpoint{URL: "http://localhost:4566"}, nil
+        },
+    )),
+)
+s3 := s3.NewFromConfig(cfg, func(o *s3.Options) { o.UsePathStyle = true })
+```
+
+### AWS CLI
+
+```sh
+aws --endpoint-url http://localhost:4566 s3 mb s3://hello
+```
+
+## How it differs from in-process mocks
+
+Mocks (Moto, aws-sdk-client-mock, aws-sdk-mock) intercept SDK calls inside your test process and return fabricated responses. That's useful for tight unit tests but it does not execute cross-service wiring, does not run Lambda code, and is language-locked to the library's ecosystem.
+
+A fake AWS server on localhost is language-agnostic (any SDK works), runs real cross-service flows, and executes Lambda code in real containers. If your tests ask "does my whole system actually work end-to-end," the server is the right tool.
+
+## Install options
+
+- Binary: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- Docker: `docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud`
+- Cargo: `cargo install fakecloud`
+- Docker Compose and source builds: [docs](/docs/getting-started/)
+
+## Test-assertion SDKs
+
+fakecloud ships introspection endpoints so your tests can assert on side effects (emails sent, messages published, Lambdas invoked) without writing raw HTTP:
+
+```ts
+import { FakeCloud } from "fakecloud";
+const fc = new FakeCloud();
+
+const { emails } = await fc.ses.getEmails();
+expect(emails).toHaveLength(1);
+
+await fc.reset();
+```
+
+SDKs for TypeScript, Python, Go, PHP, Java, Rust. Docs: [fakecloud.dev/docs/sdks](/docs/sdks/).
+
+## Links
+
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Docs:** [fakecloud.dev/docs](/docs/)
+- **Getting started:** [fakecloud.dev/docs/getting-started](/docs/getting-started/)
+- **LocalStack alternative page:** [fakecloud.dev/localstack-alternative](/localstack-alternative/)
+- **Migration from LocalStack:** [blog/migrate-from-localstack](/blog/migrate-from-localstack/)
+- **Issues:** [github.com/faiscadev/fakecloud/issues](https://github.com/faiscadev/fakecloud/issues)

--- a/website/content/test-lambda-locally.md
+++ b/website/content/test-lambda-locally.md
@@ -1,0 +1,77 @@
++++
+title = "Test Lambda locally"
+description = "Run AWS Lambda locally with real runtimes and real event triggers. 13 Lambda runtimes, real S3/SQS/SNS/EventBridge triggers, no account required."
+template = "page.html"
++++
+
+Want to run AWS Lambda locally? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+## What you get
+
+- **All 13 AWS Lambda runtimes** — Node 18/20/22, Python 3.9-3.12, Java 11/17/21, .NET 6/8, Ruby 3.2, Go, custom (`provided.al2`, `provided.al2023`).
+- **Real code execution.** fakecloud pulls the AWS Lambda runtime container and runs your handler. Not a stub, not a simulated response.
+- **Real event triggers.** S3 -> Lambda, SQS -> Lambda, SNS -> Lambda, EventBridge -> Lambda, DynamoDB Streams -> Lambda, API Gateway v2 -> Lambda. All wired end-to-end.
+- **Real event source mappings.** fakecloud polls SQS/Kinesis, batches events, invokes your Lambda, handles success/failure/DLQ the way AWS does.
+- **CloudWatch Logs.** Your function's stdout captured and queryable via `aws logs tail`.
+- **No account, no auth token, no paid tier.**
+
+## Quick deploy + invoke
+
+```sh
+# Node.js example
+cat > index.js <<'EOF'
+exports.handler = async (event) => ({ ok: true, event });
+EOF
+zip fn.zip index.js
+
+aws --endpoint-url http://localhost:4566 iam create-role \
+  --role-name lambda-role \
+  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+
+aws --endpoint-url http://localhost:4566 lambda create-function \
+  --function-name hello \
+  --runtime nodejs20.x \
+  --role arn:aws:iam::000000000000:role/lambda-role \
+  --handler index.handler \
+  --zip-file fileb://fn.zip
+
+aws --endpoint-url http://localhost:4566 lambda invoke \
+  --function-name hello \
+  --payload '{"hi":true}' \
+  --cli-binary-format raw-in-base64-out \
+  out.json
+
+cat out.json
+```
+
+## How it compares
+
+| Tool | Runs function code | Multi-runtime | Cross-service triggers | Language | Free |
+|---|---|---|---|---|---|
+| fakecloud | Yes (Docker) | 13 runtimes | Yes (S3, SQS, SNS, EventBridge, DynamoDB Streams, API GW v2) | Any | Yes |
+| SAM Local | Yes (Docker) | All AWS runtimes | Partial (synthetic events only) | Any | Yes |
+| LocalStack Community (post-Mar 2026) | Yes (Docker, auth required) | All | Yes | Any | No (auth token required) |
+| serverless-offline | Yes (in-process) | Node only | API Gateway only | Node | Yes |
+| Moto | No | N/A | No | Python | Yes |
+
+## Full tutorial
+
+Step-by-step guide with S3, SQS, EventBridge triggers and test-assertion examples: [How to test Lambda locally](/blog/test-lambda-locally/).
+
+## Install
+
+- Binary: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- Docker: `docker run --rm -p 4566:4566 -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/faiscadev/fakecloud`
+- Cargo: `cargo install fakecloud`
+
+## Links
+
+- **Lambda service docs:** [fakecloud.dev/docs/services/lambda](/docs/services/lambda/)
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Full tutorial:** [How to test Lambda locally](/blog/test-lambda-locally/)
+- **CI tutorial:** [Integration testing AWS in GitHub Actions](/blog/integration-testing-aws-in-ci/)


### PR DESCRIPTION
## Summary

Batch 2 of the upstream-query SEO/LLM visibility push. This PR is stacked on top of #675 (batch 1) because its landings use the \`page.html\` template introduced there. GitHub will auto-retarget the base to \`main\` once #675 merges.

### Tutorials (timestamped blog posts, Dev.to cross-posts staged locally)

- **[/blog/test-lambda-locally/](https://fakecloud.dev/blog/test-lambda-locally/)** — full guide for \`test lambda locally\`. Covers all 13 Lambda runtimes, SQS / S3 / EventBridge triggers firing end-to-end, log tailing, CI setup.
- **[/blog/integration-testing-aws-in-ci/](https://fakecloud.dev/blog/integration-testing-aws-in-ci/)** — \`test aws in github actions\` / \`ci tests for sqs\`. Copy-paste workflow YAML for GitHub Actions (install-and-run + service container), GitLab CI, CircleCI.
- **[/blog/moto-equivalent-go-java-node/](https://fakecloud.dev/blog/moto-equivalent-go-java-node/)** — \`moto equivalent java/kotlin/go/node\` cluster. Endpoint-override snippets in Go, Java, Kotlin, Node, PHP, Rust; plus the Moto-can't-execute-Lambda pitch.

### Landing pages (living, non-dated)

- **[/fake-aws-server/](https://fakecloud.dev/fake-aws-server/)** — slug matches \`fake aws server for tests\` verbatim. Uses the new \`page.html\` template.
- **[/test-lambda-locally/](https://fakecloud.dev/test-lambda-locally/)** — companion landing for the blog tutorial. CTA-focused.

Why these queries specifically: per the upstream-landscape research, these are the highest-leverage spots where top-10 results are currently mediocre Medium posts or unanswered re:Post threads, so a well-SEO'd page can realistically crack top-5 in 3-6 months.

Dev.to cross-post drafts staged locally at \`marketing/devto-test-lambda-locally.md\`, \`marketing/devto-integration-testing-aws-in-ci.md\`, \`marketing/devto-moto-equivalent-go-java-node.md\` (gitignored as usual).

## Test plan

- [x] \`zola build\` succeeds (54 pages, 0 orphan)
- [x] All 5 new pages render at expected paths
- [ ] CI green
- [ ] Merge after #675 merges (GitHub will auto-retarget base to main)
- [ ] Dev.to cross-posts published under Lucas's account (manual)
- [ ] Spot-check live URLs after deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds batch 2 of upstream-query SEO content: three tutorials and two slug-exact landing pages to capture queries like “test lambda locally,” “integration testing aws in ci,” and “fake aws server.” Also reframes two tutorials to “Correctness vs performance” to improve messaging.

- **New Features**
  - Tutorials: /blog/test-lambda-locally/ (13 runtimes, real triggers, logs, CI setup), /blog/integration-testing-aws-in-ci/ (copy-paste workflows for GitHub Actions install/run and service containers, plus GitLab CI and CircleCI), /blog/moto-equivalent-go-java-node/ (endpoint-override snippets for Go/Java/Kotlin/Node/PHP/Rust; notes Moto can’t execute Lambda).
  - Landing pages: /fake-aws-server/ and /test-lambda-locally/ (slug-exact, CTA-focused; use the `page.html` template).

- **Refactors**
  - Replaced “When this is not right” with “Correctness vs performance” in the CI and Lambda tutorials to avoid negative phrasing and align with SEO goals.

<sup>Written for commit 9e53f646a42c1ccd11906df0b0105006fd56d169. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

