### PR TITLE
docs(seo): refresh llms.txt and llms-full.txt to current numbers

### DIFF
--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -4,12 +4,14 @@
 
 ## Overview
 
-fakecloud emulates 22 AWS services locally for integration testing and development. It is a single Rust binary — no Docker required, no signup, starts in under 100ms. Point any AWS SDK or the AWS CLI at `http://localhost:4566` with dummy credentials.
+fakecloud emulates 23 AWS services (1,680 operations) locally for integration testing and development. It is a single Rust binary (~19 MB, ~500ms startup, ~10 MiB idle memory) — no Docker required to run fakecloud itself, no signup. Point any AWS SDK or the AWS CLI at `http://localhost:4566` with dummy credentials.
 
 Key design principles:
-- **Correctness over coverage**: Every implemented service targets 100% behavioral parity with real AWS, verified by automated conformance tests against AWS Smithy models
+- **Correctness over coverage**: Every implemented service targets 100% conformance with real AWS, validated on every commit against AWS's own Smithy models (54,000+ generated test variants). CI also runs upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud.
 - **Zero friction**: No auth tokens, no accounts, no config files needed
-- **Cross-service integration**: 30+ service-to-service integrations — S3 notifications, SNS fanout, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, API Gateway → Lambda, Step Functions task integrations, and more
+- **Cross-service integration**: 30+ service-to-service integrations — S3 notifications, SNS fan-out, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, API Gateway -> Lambda, Step Functions task integrations, SES inbound -> S3/SNS/Lambda, and more
+- **Real execution for stateful services**: Lambda runs function code in Docker across 13 runtimes. RDS runs real PostgreSQL/MySQL/MariaDB. ElastiCache runs real Redis/Valkey.
+- **Test-assertion SDKs** for TypeScript, Python, Go, PHP, Java, Rust, wrapping `/_fakecloud/*` introspection endpoints
 
 fakecloud is NOT a production-ready cloud replacement. It is for integration testing and local development.
 
@@ -160,7 +162,7 @@ client := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
 
 ## Supported Services — Full Reference
 
-### SQS (20 actions)
+### SQS (23 actions)
 
 CreateQueue, DeleteQueue, ListQueues, GetQueueUrl, GetQueueAttributes, SetQueueAttributes, SendMessage, SendMessageBatch, ReceiveMessage, DeleteMessage, DeleteMessageBatch, PurgeQueue, ChangeMessageVisibility, ChangeMessageVisibilityBatch, ListQueueTags, TagQueue, UntagQueue, AddPermission, RemovePermission, ListDeadLetterSourceQueues
 
@@ -168,7 +170,7 @@ Features: real MD5 hashing, long polling (WaitTimeSeconds), FIFO queues with mes
 
 Protocol: Query (form-encoded body, `Action` parameter, XML responses)
 
-### SNS (34 actions)
+### SNS (42 actions)
 
 **Topics:** CreateTopic, DeleteTopic, ListTopics, GetTopicAttributes, SetTopicAttributes
 **Subscriptions:** Subscribe, ConfirmSubscription, Unsubscribe, ListSubscriptions, ListSubscriptionsByTopic, GetSubscriptionAttributes, SetSubscriptionAttributes
@@ -200,7 +202,15 @@ Features: pattern-based rules (nested fields, numeric comparisons, prefix, exist
 
 Protocol: JSON (JSON body, `X-Amz-Target` header, JSON responses)
 
-### IAM / STS (135 actions)
+### EventBridge Scheduler (12 actions)
+
+CreateSchedule, GetSchedule, UpdateSchedule, DeleteSchedule, ListSchedules, CreateScheduleGroup, GetScheduleGroup, DeleteScheduleGroup, ListScheduleGroups, TagResource, UntagResource, ListTagsForResource.
+
+Features: `at`, `rate`, and `cron` expressions; SQS targets; DLQ routing; one-shot schedules with self-delete.
+
+Protocol: REST + JSON
+
+### IAM (176 actions) + STS (11 actions)
 
 **Users:** CreateUser, GetUser, DeleteUser, ListUsers, UpdateUser, TagUser, UntagUser, ListUserTags, CreateAccessKey, DeleteAccessKey, ListAccessKeys, UpdateAccessKey, GetAccessKeyLastUsed, CreateLoginProfile, GetLoginProfile, UpdateLoginProfile, DeleteLoginProfile, AttachUserPolicy, DetachUserPolicy, ListAttachedUserPolicies, PutUserPolicy, GetUserPolicy, DeleteUserPolicy, ListUserPolicies
 **Roles:** CreateRole, GetRole, DeleteRole, ListRoles, UpdateRole, UpdateRoleDescription, UpdateAssumeRolePolicy, TagRole, UntagRole, ListRoleTags, PutRolePermissionsBoundary, DeleteRolePermissionsBoundary, AttachRolePolicy, DetachRolePolicy, ListAttachedRolePolicies, PutRolePolicy, GetRolePolicy, DeleteRolePolicy, ListRolePolicies, CreateServiceLinkedRole, DeleteServiceLinkedRole, GetServiceLinkedRoleDeletionStatus
@@ -229,7 +239,7 @@ Features: String/StringList/SecureString types, automatic versioning, parameter 
 
 Protocol: JSON (JSON body, `X-Amz-Target` header, JSON responses)
 
-### S3 (74 actions)
+### S3 (107 actions)
 
 **Buckets:** ListBuckets, CreateBucket, DeleteBucket, HeadBucket, GetBucketLocation
 **Objects:** PutObject, GetObject, DeleteObject, HeadObject, CopyObject, DeleteObjects, ListObjectsV2, ListObjects, ListObjectVersions, GetObjectAttributes, RestoreObject
@@ -241,13 +251,13 @@ Features: path-style addressing, prefix/delimiter listing, pagination, user meta
 
 Protocol: REST (HTTP method + path-based routing, XML responses)
 
-### DynamoDB
+### DynamoDB (57 actions)
 
-Table and item operations with support for key schemas, secondary indexes, and standard DynamoDB JSON wire format.
+Tables, items, transactions (TransactWriteItems, TransactGetItems), PartiQL (ExecuteStatement, BatchExecuteStatement), backups, global tables, streams, secondary indexes. Standard DynamoDB JSON wire format.
 
 Protocol: JSON (JSON body, `X-Amz-Target` header, JSON responses)
 
-### Lambda (10 actions)
+### Lambda (85 actions)
 
 CreateFunction, GetFunction, DeleteFunction, ListFunctions, Invoke, PublishVersion, CreateEventSourceMapping, ListEventSourceMappings, GetEventSourceMapping, DeleteEventSourceMapping
 
@@ -279,7 +289,7 @@ Features: real envelope encryption, key enable/disable/deletion scheduling, alia
 
 Protocol: JSON (JSON body, `X-Amz-Target` header, JSON responses)
 
-### CloudFormation (8 actions)
+### CloudFormation (90 actions)
 
 CreateStack, DeleteStack, DescribeStacks, ListStacks, ListStackResources, DescribeStackResources, UpdateStack, GetTemplate
 
@@ -289,7 +299,7 @@ Supported resource types: AWS::SQS::Queue, AWS::SNS::Topic, AWS::SNS::Subscripti
 
 Protocol: Query (form-encoded body, `Action` parameter, XML responses)
 
-### SES (111 actions)
+### SES (110 actions)
 
 **SES v2** (97 actions, REST protocol): identities, templates, configuration sets, contact lists, contacts, send email, tagging, suppression list, event destinations, identity policies, DKIM/feedback/mail-from attributes, config set options, custom verification email templates, template rendering, dedicated IP pools and IPs, multi-region endpoints, account settings, import/export jobs.
 
@@ -297,7 +307,7 @@ Protocol: Query (form-encoded body, `Action` parameter, XML responses)
 
 Features: email event fanout to SNS topics and EventBridge buses via configured event destinations, mailbox simulator (bounce@simulator.amazonses.com, complaint@, suppressionlist@), inbound email pipeline via /_fakecloud/ses/inbound endpoint that evaluates receipt rules and executes S3/SNS/Lambda actions.
 
-### Cognito User Pools (80 actions)
+### Cognito User Pools (122 actions)
 
 User pool management, app clients, user management, groups, authentication flows, password and session management, MFA/software tokens, identity providers, resource servers, domains, device management, tags, and import jobs.
 
@@ -305,7 +315,7 @@ Features: user pools with configurable policies, app client CRUD, user signup/co
 
 Protocol: JSON (JSON body, `X-Amz-Target` header, JSON responses)
 
-### Kinesis (14 actions)
+### Kinesis (39 actions)
 
 CreateStream, DescribeStream, DescribeStreamSummary, ListStreams, DeleteStream, GetRecords, GetShardIterator, PutRecord, PutRecords, AddTagsToStream, ListTagsForStream, RemoveTagsFromStream, IncreaseStreamRetentionPeriod, DecreaseStreamRetentionPeriod
 
@@ -313,7 +323,7 @@ Features: stream creation and deletion, shard iterators and record reads, batche
 
 Protocol: JSON (JSON body, `X-Amz-Target` header, JSON responses)
 
-### RDS (22 actions)
+### RDS (163 actions)
 
 AddTagsToResource, CreateDBInstance, CreateDBInstanceReadReplica, CreateDBParameterGroup, CreateDBSnapshot, CreateDBSubnetGroup, DeleteDBInstance, DeleteDBParameterGroup, DeleteDBSnapshot, DeleteDBSubnetGroup, DescribeDBEngineVersions, DescribeDBInstances, DescribeDBParameterGroups, DescribeDBSnapshots, DescribeDBSubnetGroups, DescribeOrderableDBInstanceOptions, ListTagsForResource, ModifyDBInstance, ModifyDBParameterGroup, RebootDBInstance, RemoveTagsFromResource, RestoreDBInstanceFromDBSnapshot
 
@@ -321,7 +331,7 @@ Features: DB instance lifecycle (PostgreSQL, MySQL, MariaDB via Docker), read re
 
 Protocol: Query (form-encoded body, `Action` parameter, XML responses)
 
-### ElastiCache (44 actions)
+### ElastiCache (75 actions)
 
 AddTagsToResource, CreateCacheCluster, CreateGlobalReplicationGroup, CreateCacheSubnetGroup, CreateReplicationGroup, CreateServerlessCache, CreateServerlessCacheSnapshot, CreateSnapshot, CreateUser, CreateUserGroup, DecreaseReplicaCount, DeleteCacheCluster, DeleteGlobalReplicationGroup, DeleteCacheSubnetGroup, DeleteReplicationGroup, DeleteServerlessCache, DeleteServerlessCacheSnapshot, DeleteSnapshot, DeleteUser, DeleteUserGroup, DescribeCacheClusters, DescribeCacheEngineVersions, DescribeGlobalReplicationGroups, DescribeCacheParameterGroups, DescribeReservedCacheNodes, DescribeReservedCacheNodesOfferings, DescribeCacheSubnetGroups, DescribeEngineDefaultParameters, DescribeReplicationGroups, DescribeServerlessCaches, DescribeServerlessCacheSnapshots, DescribeSnapshots, DescribeUserGroups, DescribeUsers, DisassociateGlobalReplicationGroup, FailoverGlobalReplicationGroup, IncreaseReplicaCount, ListTagsForResource, ModifyCacheSubnetGroup, ModifyGlobalReplicationGroup, ModifyReplicationGroup, ModifyServerlessCache, RemoveTagsFromResource, TestFailover
 
@@ -329,7 +339,7 @@ Features: cache clusters, replication groups, global replication groups, serverl
 
 Protocol: Query (form-encoded body, `Action` parameter, XML responses)
 
-### Step Functions (14 actions)
+### Step Functions (37 actions)
 
 CreateStateMachine, DeleteStateMachine, DescribeStateMachine, DescribeStateMachineForExecution, ListStateMachines, UpdateStateMachine, TagResource, UntagResource, ListTagsForResource, StartExecution, DescribeExecution, GetExecutionHistory, ListExecutions, StopExecution
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1,16 +1,18 @@
 # fakecloud — Full Documentation
 
-> fakecloud is a free, open-source local AWS cloud emulator written in Rust. It runs on a single port (4566), requires no account or auth token, and aims for 100% behavioral parity with real AWS on every service it implements. It is an open-source alternative to LocalStack, which went proprietary in March 2026.
+> fakecloud is a free, open-source local AWS cloud emulator written in Rust. It runs on a single port (4566), requires no account or auth token, and aims for 100% behavioral parity with real AWS across every service, every operation, and every cross-service integration. It is an open-source alternative to LocalStack, which went proprietary in March 2026.
 
 ## Overview
 
-fakecloud emulates 23 AWS services (1,680 operations) locally for integration testing and development. It is a single Rust binary (~19 MB, ~500ms startup, ~10 MiB idle memory) — no Docker required to run fakecloud itself, no signup. Point any AWS SDK or the AWS CLI at `http://localhost:4566` with dummy credentials.
+fakecloud emulates AWS locally for integration testing and development. It is a single Rust binary (~19 MB, ~500ms startup, ~10 MiB idle memory) — no Docker required to run fakecloud itself, no signup. Point any AWS SDK or the AWS CLI at `http://localhost:4566` with dummy credentials.
+
+**Coverage goal:** 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. Approach is depth-first — a service lands when it passes the full Smithy-model test variants and the cross-service wire-ups that matter for it, not when the API surface looks filled in. 23 services (1,680 operations) are shipped today; more land progressively as they hit the bar.
 
 Key design principles:
-- **Correctness over coverage**: Every implemented service targets 100% conformance with real AWS, validated on every commit against AWS's own Smithy models (54,000+ generated test variants). CI also runs upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud.
-- **Zero friction**: No auth tokens, no accounts, no config files needed
-- **Cross-service integration**: 30+ service-to-service integrations — S3 notifications, SNS fan-out, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, API Gateway -> Lambda, Step Functions task integrations, SES inbound -> S3/SNS/Lambda, and more
-- **Real execution for stateful services**: Lambda runs function code in Docker across 13 runtimes. RDS runs real PostgreSQL/MySQL/MariaDB. ElastiCache runs real Redis/Valkey.
+- **Depth-first coverage**: every implemented service targets 100% conformance with real AWS, validated on every commit against AWS's own Smithy models (54,000+ generated test variants). CI also runs upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud.
+- **Real cross-service integrations**: 30+ service-to-service integrations wire up end-to-end — S3 notifications, SNS fan-out, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, API Gateway -> Lambda, Step Functions task integrations, SES inbound -> S3/SNS/Lambda, and more. Not stubs — the downstream service actually executes.
+- **Real execution for stateful services**: Lambda runs function code in real Lambda runtime containers across 13 runtimes. RDS runs real PostgreSQL/MySQL/MariaDB. ElastiCache runs real Redis/Valkey.
+- **Zero friction**: no auth tokens, no accounts, no config files needed
 - **Test-assertion SDKs** for TypeScript, Python, Go, PHP, Java, Rust, wrapping `/_fakecloud/*` introspection endpoints
 
 fakecloud is NOT a production-ready cloud replacement. It is for integration testing and local development.

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -1,9 +1,10 @@
 # fakecloud
 
-> fakecloud is a free, open-source local AWS cloud emulator written in Rust. It runs on a single port (4566), requires no account or auth token, and aims for 100% behavioral parity with real AWS on every service it implements. It is an open-source alternative to LocalStack, which went proprietary in March 2026.
+> fakecloud is a free, open-source local AWS cloud emulator written in Rust. It runs on a single port (4566), requires no account or auth token, and aims for 100% behavioral parity with real AWS across every service, every operation, and every cross-service integration. It is an open-source alternative to LocalStack, which went proprietary in March 2026.
 
+- **Goal:** 100% of AWS services, each at 100% conformance, with 100% of cross-service integrations. Approach is depth-first — a service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in.
 - Single static binary (~19 MB), ~500ms startup, ~10 MiB idle memory, no Docker required to run fakecloud itself
-- **23 AWS services, 1,680 operations, 100% conformance per implemented service** — validated against AWS's own Smithy models on every commit (54,000+ generated test variants)
+- **23 AWS services shipped today, 1,680 operations, 100% conformance per implemented service** — validated against AWS's own Smithy models on every commit (54,000+ generated test variants). More services land as they hit the conformance bar; roadmap is driven by real-project demand.
 - Services: S3, SQS, SNS, EventBridge, EventBridge Scheduler, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime
 - 30+ cross-service integrations: S3 notifications, SNS fan-out, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, API Gateway -> Lambda, Step Functions task integrations, SES inbound -> S3/SNS/Lambda, and more
 - Real Lambda execution via Docker across 13 runtimes (Node.js 18/20/22, Python 3.9-3.12, Java 11/17/21, .NET 6/8, Ruby 3.2, Go, custom `provided.al2` / `provided.al2023`)

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -2,53 +2,77 @@
 
 > fakecloud is a free, open-source local AWS cloud emulator written in Rust. It runs on a single port (4566), requires no account or auth token, and aims for 100% behavioral parity with real AWS on every service it implements. It is an open-source alternative to LocalStack, which went proprietary in March 2026.
 
-- Single binary, no Docker required, starts in under 100ms
-- 22 AWS services (1155 operations): S3, SQS, SNS, EventBridge, IAM/STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES, Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime
-- 30+ cross-service integrations: S3 notifications, SNS fanout, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, API Gateway → Lambda, Step Functions task integrations, and more
-- Scheduled EventBridge rules (cron and rate) that actually fire
-- Conformance tested against real AWS behavior
-- AGPL-3.0 licensed, free for commercial use
+- Single static binary (~19 MB), ~500ms startup, ~10 MiB idle memory, no Docker required to run fakecloud itself
+- **23 AWS services, 1,680 operations, 100% conformance per implemented service** — validated against AWS's own Smithy models on every commit (54,000+ generated test variants)
+- Services: S3, SQS, SNS, EventBridge, EventBridge Scheduler, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime
+- 30+ cross-service integrations: S3 notifications, SNS fan-out, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, API Gateway -> Lambda, Step Functions task integrations, SES inbound -> S3/SNS/Lambda, and more
+- Real Lambda execution via Docker across 13 runtimes (Node.js 18/20/22, Python 3.9-3.12, Java 11/17/21, .NET 6/8, Ruby 3.2, Go, custom `provided.al2` / `provided.al2023`)
+- Real stateful services: RDS runs real PostgreSQL/MySQL/MariaDB via Docker; ElastiCache runs real Redis/Valkey via Docker
+- First-party test-assertion SDKs for TypeScript, Python, Go, PHP, Java, and Rust — assert on emails sent, SNS messages published, Lambda invocations, Cognito confirmation codes, etc. without raw HTTP
+- Multi-account, SCPs, ABAC (tag-based conditions), permission boundaries, session policies, KMS key policies, bucket policies — full Allow/Deny/NotPrincipal semantics
+- CI runs upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud to catch provider-level drift
+- AGPL-3.0 licensed, free for commercial use, no account or auth token required
 
 ## Install
 
 - [Install script](https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh): `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
 - [Cargo install](https://crates.io/crates/fakecloud): `cargo install fakecloud`
-- [Docker](https://github.com/faiscadev/fakecloud/pkgs/container/fakecloud): `docker run -p 4566:4566 ghcr.io/faiscadev/fakecloud`
+- [Docker](https://github.com/faiscadev/fakecloud/pkgs/container/fakecloud): `docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud`
 
 ## Usage
 
-- [Quick start](https://fakecloud.dev#quickstart): Run `fakecloud` then point any AWS SDK at `http://localhost:4566`
-- [Configuration](https://github.com/faiscadev/fakecloud#configuration): CLI flags and environment variables (--addr, --region, --account-id, --log-level, --storage-mode, --data-path, --s3-cache-size)
-- [Persistence](https://github.com/faiscadev/fakecloud#persistence): opt-in disk persistence for S3 via --storage-mode=persistent
-- [Health check](https://github.com/faiscadev/fakecloud#health-check): `curl http://localhost:4566/_fakecloud/health`
+- [Quick start](https://fakecloud.dev#quickstart): Run `fakecloud` then point any AWS SDK at `http://localhost:4566` with dummy credentials (access_key=test, secret_key=test)
+- [Configuration](https://github.com/faiscadev/fakecloud#configuration): CLI flags and environment variables (`--addr`, `--region`, `--account-id`, `--log-level`, `--persist`, `--verify-sigv4`, `--iam soft|strict`)
+- [Health check](https://fakecloud.dev/docs/reference): `curl http://localhost:4566/_fakecloud/health`
+- [LocalStack migration guide](https://fakecloud.dev/blog/migrate-from-localstack/): step-by-step migration from LocalStack Community with copy-paste configs for docker-compose, GitHub Actions, Terraform, CDK, Serverless Framework
+- [Integration testing AWS in CI](https://fakecloud.dev/blog/integration-testing-aws-in-ci/): GitHub Actions, GitLab CI, CircleCI workflow examples
+- [Test Lambda locally](https://fakecloud.dev/blog/test-lambda-locally/): full Lambda tutorial with SQS/S3/EventBridge triggers
+- [Moto equivalent for Go/Java/Node](https://fakecloud.dev/blog/moto-equivalent-go-java-node/): using fakecloud from non-Python languages
 
 ## Supported Services
 
-- [S3](https://github.com/faiscadev/fakecloud#s3-74-actions): 74 actions — buckets, objects, multipart uploads, versioning, lifecycle, CORS, notifications, object lock
-- [SQS](https://github.com/faiscadev/fakecloud#sqs-20-actions): 20 actions — queues, messages, long polling, FIFO, dead-letter queues, batch operations
-- [SNS](https://github.com/faiscadev/fakecloud#sns-34-actions): 34 actions — topics, subscriptions, publishing, filter policies, SQS fan-out, HTTP delivery
-- [EventBridge](https://github.com/faiscadev/fakecloud#eventbridge-41-actions): 41 actions — event buses, rules, targets, archives, replays, connections, API destinations
-- [IAM/STS](https://github.com/faiscadev/fakecloud#iam--sts-135-actions): 135 actions — users, roles, groups, policies, instance profiles, identity providers, MFA, STS
-- [SSM](https://github.com/faiscadev/fakecloud#ssm-46-actions): 46 actions — parameters, documents, commands, maintenance windows, patch baselines
-- [DynamoDB](https://github.com/faiscadev/fakecloud#supported-services): Table and item operations
-- [Lambda](https://github.com/faiscadev/fakecloud#lambda-10-actions): 10 actions — function CRUD, real code execution via Docker (13 runtimes: Python, Node.js, Ruby, Java, .NET, Go, provided.al2/al2023)
-- [Secrets Manager](https://github.com/faiscadev/fakecloud#secrets-manager-11-actions): 11 actions — secret CRUD, versioning, soft delete, restore
-- [CloudWatch Logs](https://github.com/faiscadev/fakecloud#cloudwatch-logs-14-actions): 14 actions — log groups, streams, events, filtering, retention
-- [KMS](https://github.com/faiscadev/fakecloud#kms-16-actions): 16 actions — keys, encryption/decryption, aliases, data key generation
-- [CloudFormation](https://github.com/faiscadev/fakecloud#cloudformation-8-actions): 8 actions — stacks, resource provisioning, template parsing, intrinsic functions
-- [SES](https://github.com/faiscadev/fakecloud#supported-services): 111 actions — v2 (97 ops): identities, templates, configuration sets, send email, event fanout, mailbox simulator. v1 inbound (14 ops): receipt rules, receipt filters, inbound email pipeline with S3/SNS/Lambda actions
-- [Cognito User Pools](https://github.com/faiscadev/fakecloud#supported-services): 80 actions — user pools, app clients, users, groups, MFA, identity providers, resource servers, domains, devices, authentication flows
-- [Kinesis](https://github.com/faiscadev/fakecloud#supported-services): 14 actions — streams, records, shard iterators, retention changes, tagging
-- [RDS](https://github.com/faiscadev/fakecloud#supported-services): 22 actions — DB instances (PostgreSQL, MySQL, MariaDB via Docker), snapshots, read replicas, parameter groups, subnet groups, engine/version discovery, tagging
-- [ElastiCache](https://github.com/faiscadev/fakecloud#supported-services): 44 actions — cache clusters, replication groups, global replication groups, serverless caches and snapshots, subnet groups, users/user groups, failover, tagging (Redis and Valkey via Docker)
-- [Step Functions](https://github.com/faiscadev/fakecloud#supported-services): 14 actions — state machines, executions, ASL interpreter (Pass, Task, Choice, Wait, Parallel, Map, Succeed, Fail), Retry/Catch, Lambda/SQS/SNS/EventBridge/DynamoDB task integrations
-- [API Gateway v2](https://github.com/faiscadev/fakecloud#supported-services): 28 actions — HTTP APIs, routes with path parameters and wildcards, Lambda proxy integration v2.0, HTTP proxy, Mock integrations, stages, deployments, authorizers (JWT and Lambda), CORS
-- [Bedrock](https://github.com/faiscadev/fakecloud#supported-services): 101 actions — foundation models, guardrails, custom models/deployments, import/copy/invocation/evaluation jobs, inference profiles, prompt routers, marketplace endpoints, automated reasoning policies
-- [Bedrock Runtime](https://github.com/faiscadev/fakecloud#supported-services): 10 actions — InvokeModel (Anthropic, Titan, Meta, Cohere, Mistral), Converse, streaming, ApplyGuardrail, CountTokens, async invoke
+- **S3** (107 ops): buckets, objects, multipart uploads, versioning, lifecycle, CORS, notifications, object lock, replication, website hosting
+- **SQS** (23 ops): queues, messages, long polling, FIFO, dead-letter queues, batch operations
+- **SNS** (42 ops): topics, subscriptions, publishing, filter policies, SQS/Lambda/HTTP fan-out
+- **EventBridge** (57 ops): event buses, rules, targets, archives, replays, connections, API destinations, pattern matching
+- **EventBridge Scheduler** (12 ops): at/rate/cron schedules, SQS targets, DLQ routing, one-shot self-delete
+- **Lambda** (85 ops): function CRUD, real code execution via Docker across 13 runtimes, event source mappings (SQS, Kinesis, DynamoDB Streams), layers, versions, aliases, URL endpoints
+- **DynamoDB** (57 ops): tables, items, transactions, PartiQL, backups, global tables, streams
+- **IAM** (176 ops): users, roles, groups, policies, instance profiles, OIDC/SAML providers, MFA, permission boundaries, session policies, ABAC tag conditions
+- **STS** (11 ops): AssumeRole, AssumeRoleWithWebIdentity, GetSessionToken, GetCallerIdentity, session tags, external IDs, federation
+- **SSM** (146 ops): Parameter Store (hierarchical parameters with KMS), documents, commands, maintenance windows, patch baselines
+- **Secrets Manager** (23 ops): secret CRUD, versioning, rotation via Lambda, replication, soft delete/restore
+- **CloudWatch Logs** (113 ops): log groups, streams, events, filtering, subscription filters, query language, metric filters, retention
+- **KMS** (53 ops): symmetric/asymmetric keys, encrypt/decrypt, aliases, grants, data keys, real ECDH, key import, multi-region keys
+- **CloudFormation** (90 ops): stacks, resource provisioning, template parsing, intrinsic functions, custom resources, drift detection, change sets
+- **SES** (110 ops): v2 API (send email, templates, configuration sets, event destinations, DKIM, suppression list) + v1 inbound (receipt rules with real S3/SNS/Lambda action execution, receipt filters)
+- **Cognito User Pools** (122 ops): user pools, app clients, users, groups, MFA (SMS, TOTP, WebAuthn), identity providers (Google, Facebook, SAML, OIDC), resource servers, domains, devices, full authentication flows (USER_PASSWORD_AUTH, USER_SRP_AUTH, REFRESH_TOKEN_AUTH, CUSTOM_AUTH), triggers
+- **Kinesis** (39 ops): data streams, records, shard iterators, retention changes, enhanced fan-out consumers, tagging
+- **RDS** (163 ops): DB instances with real PostgreSQL/MySQL/MariaDB engines via Docker, snapshots, read replicas, parameter groups, subnet groups, engine/version discovery, tagging
+- **ElastiCache** (75 ops): cache clusters with real Redis/Valkey via Docker, replication groups, global replication groups, serverless caches and snapshots, subnet groups, users/user groups, failover, tagging
+- **Step Functions** (37 ops): state machines, executions, full ASL interpreter (Pass, Task, Choice, Wait, Parallel, Map, Succeed, Fail), Retry/Catch, Lambda/SQS/SNS/EventBridge/DynamoDB task integrations
+- **API Gateway v2** (28 ops): HTTP APIs, routes with path parameters and wildcards, Lambda proxy integration v2.0, HTTP proxy, mock integrations, stages, deployments, JWT and Lambda authorizers, CORS
+- **Bedrock** (101 ops): foundation models, guardrails, custom models, import/copy/invocation/evaluation jobs, inference profiles, prompt routers, marketplace endpoints, automated reasoning policies
+- **Bedrock Runtime** (10 ops): InvokeModel (Anthropic, Titan, Meta, Cohere, Mistral), Converse, streaming, ApplyGuardrail, CountTokens, async invoke, configurable responses, fault injection
+
+## Introspection endpoints (for tests)
+
+fakecloud exposes `/_fakecloud/*` endpoints your tests can use to assert on side effects and reset state between tests. Wrapped by first-party SDKs in TypeScript, Python, Go, PHP, Java, Rust.
+
+- `GET /_fakecloud/health`: liveness check
+- `POST /_fakecloud/reset`: wipe all state (use between tests)
+- `GET /_fakecloud/ses/emails`: list emails that were sent
+- `GET /_fakecloud/sns/messages`: list SNS messages that were published
+- `GET /_fakecloud/lambda/invocations`: list Lambda invocations and their results
+- `GET /_fakecloud/cognito/confirmation-codes`: list Cognito confirmation codes (for testing signup flows)
+- `POST /_fakecloud/iam/create-admin`: bootstrap an admin user in a specific account (for multi-account tests)
+- See [SDK docs](https://fakecloud.dev/docs/sdks/) for the full endpoint list
 
 ## Optional
 
 - [Source code](https://github.com/faiscadev/fakecloud): GitHub repository
+- [Issues](https://github.com/faiscadev/fakecloud/issues): bug reports and feature requests — fakecloud's roadmap is demand-driven
 - [Architecture](https://github.com/faiscadev/fakecloud#architecture): Cargo workspace structure and protocol details
-- [Contributing](https://github.com/faiscadev/fakecloud#contributing): Contribution guidelines
-- [Comparison](https://github.com/faiscadev/fakecloud#comparison): Feature comparison with LocalStack
+- [Contributing](https://github.com/faiscadev/fakecloud/blob/main/CONTRIBUTING.md): contribution guidelines
+- [LocalStack alternative page](https://fakecloud.dev/localstack-alternative/): detailed feature comparison with LocalStack Community (post-March 2026)
+- [Four-way comparison](https://fakecloud.dev/blog/localstack-alternatives-compared/): fakecloud vs MiniStack vs floci vs Moto vs LocalStack Pro


### PR DESCRIPTION
## Summary

Follow-up to #675. While refreshing the homepage stats for that PR I noticed \`llms.txt\` and \`llms-full.txt\` were still on the old release's numbers. These two files are the primary surface LLM crawlers ingest for fakecloud, so stale numbers there directly degrade every AI-assistant answer that cites us.

- Header numbers: 22 services -> 23, 1,155 ops -> 1,680
- Startup line: \"under 100ms\" -> \"~500ms\" to match the README measurement (README ~500ms is the ready-to-serve time; 100ms was the pure process-start time). Using the same number everywhere avoids LLMs emitting a contradiction.
- Per-service action counts refreshed against the current README table: S3 107, SQS 23, SNS 42, EventBridge 57, IAM 176 + STS 11 (split out), Lambda 85, DynamoDB 57, RDS 163, ElastiCache 75, Step Functions 37, Cognito 122, SES 110, Secrets Manager 23, CloudWatch Logs 113, KMS 53, CloudFormation 90, Kinesis 39.
- Added EventBridge Scheduler (12 ops) section that was missing entirely.
- Added mentions of: first-party test-assertion SDKs, Terraform TestAcc CI validation, 54k+ Smithy-generated test variants, real RDS/ElastiCache Docker engines.
- Added links section pointing at /localstack-alternative/, /blog/migrate-from-localstack/, /blog/integration-testing-aws-in-ci/, /blog/test-lambda-locally/, /blog/moto-equivalent-go-java-node/ so LLMs have explicit anchors to cite.
- Replaced remaining unicode arrows with ASCII per the repo convention.

## Test plan

- [x] \`zola build\` succeeds
- [x] \`curl https://fakecloud.dev/llms.txt\` will return current numbers once deployed
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes `llms.txt` and `llms-full.txt` with current coverage, metrics, and messaging so crawlers return accurate, consistent info. Leads with the 100% coverage goal and depth‑first approach so “23 services” is read as a snapshot, not a ceiling.

- **Refactors**
  - Header counts updated: 23 services, 1,680 operations; startup "~500ms" with binary/memory notes.
  - Per‑service action counts synced to README (e.g., S3 107, EventBridge 57, IAM 176 + STS 11, Lambda 85, DynamoDB 57, RDS 163, ElastiCache 75, Step Functions 37, Cognito 122, SES 110, SSM 146, CloudWatch Logs 113, KMS 53, CloudFormation 90, Kinesis 39).
  - Added EventBridge Scheduler (12 ops).
  - Clarified real Lambda execution across 13 runtimes and real RDS/ElastiCache engines.
  - Documented `/_fakecloud/*` introspection endpoints and linked first‑party test‑assertion SDKs; noted Terraform `TestAcc*` validation.
  - Expanded install/usage and config flags (dummy creds, `--persist`, `--verify-sigv4`, `--iam soft|strict`); `docker run --rm`.
  - Added links to migration/comparison pages and core guides for citation anchors.
  - Replaced Unicode arrows with ASCII.

<sup>Written for commit e1aef8d20b5249a1fef89900d92cb0779559764f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

