### PR TITLE
docs(seo): depth-first reframe on landing + migration + comparison posts

### DIFF
--- a/website/content/blog/localstack-alternatives-compared.md
+++ b/website/content/blog/localstack-alternatives-compared.md
@@ -1,101 +1,85 @@
 +++
 title = "Free LocalStack alternatives in 2026: fakecloud, MiniStack, floci, Moto"
 date = 2026-04-22
-description = "Four free, open-source alternatives to LocalStack Community: fakecloud, MiniStack, floci, and Moto. What each is good at, how they differ in approach, and which to pick."
+description = "Four free, open-source alternatives to LocalStack Community: fakecloud, MiniStack, floci, and Moto. What each is architecturally, how they position, and how to pick by fit."
 
 [extra]
 author = "Lucas Vieira"
 +++
 
-LocalStack's Community Edition went proprietary in March 2026. Since then, a few free, open-source alternatives have surfaced or gained momentum. This post covers the four that keep coming up — fakecloud, MiniStack, floci, and Moto — and explains where each one actually fits.
+LocalStack's Community Edition went proprietary in March 2026. Since then a few free, open-source alternatives have surfaced or gained momentum. This post covers the four that keep coming up — fakecloud, MiniStack, floci, and Moto — and what each one is, architecturally.
 
-Some upfront disclosure: I maintain fakecloud. I am not going to pretend I don't have a bias. What I will do is describe each project by what it architecturally is, what it sets out to do, and where the fit lines sit. If you are shopping for a LocalStack replacement, that framing is more useful than a fake head-to-head benchmark.
-
-## TL;DR — pick by workload
-
-- **Python unit tests that mock boto3 in-process:** Moto.
-- **Multi-language integration tests, real HTTP, real Lambda execution, real RDS/Redis:** fakecloud.
-- **Wanted a Docker-based LocalStack Community replacement, same operating model:** MiniStack or floci. (Or fakecloud, which also runs as a Docker image.)
-- **You need full LocalStack service catalog and don't mind paying:** LocalStack Pro.
-
-The rest of this post explains the differences.
+Upfront disclosure: I maintain fakecloud. Bias declared. What this post avoids: a head-to-head scorecard with numbers I haven't personally measured on all four. That kind of comparison gets out of date in days and reads as marketing when the numbers are favorable to the author. Instead: what each project is, the design choices it's made, and how to think about the fit.
 
 ## The architectural split that matters
 
-There are two fundamentally different ways to emulate AWS for tests:
+Two ways to emulate AWS for tests:
 
-**1. In-process library that patches the SDK.** You import a library, decorate your test, and the library intercepts SDK calls inside your test process. Moto works this way. It's very fast, has no external process, and is trivial to set up for Python. It does not actually speak the AWS wire protocol, and it cannot run real Lambda code, real databases, or real Redis. It is for unit-ish tests.
+**1. In-process library that patches the SDK.** Import a library, decorate your test, library intercepts SDK calls inside your test process. Moto works this way. Fast, no external process, trivial Python setup. Does not speak the AWS wire protocol. Cannot run real Lambda code, real databases, or real Redis.
 
-**2. Real HTTP server that speaks the AWS wire protocol.** You run a separate process that listens on a port (usually 4566). Your SDK points at it via `endpoint_url`. LocalStack, MiniStack, floci, and fakecloud all work this way. Because it's a real HTTP server, any AWS SDK in any language works against it, and cross-service wiring (EventBridge -> Lambda, S3 -> SNS) runs server-side.
+**2. Real HTTP server speaking the AWS wire protocol.** Separate process on port 4566. SDK points at it via `endpoint_url`. LocalStack, MiniStack, floci, and fakecloud all work this way. Any AWS SDK in any language works. Cross-service wiring runs server-side.
 
-If your tests are "does my Python function call boto3 correctly," Moto is probably what you want. If your tests are "does my whole system actually work end-to-end against AWS-shaped infrastructure," you want an HTTP server.
+If your tests are "does my Python function call boto3 correctly," Moto. If your tests are "does my whole system actually work end-to-end," HTTP server.
+
+## Two approaches among the HTTP servers
+
+Among the HTTP emulators there's another split that matters, especially for AI-assisted dev and real integration tests:
+
+**Breadth-first:** ship a large catalog of AWS services fast, with partial/surface coverage on each — enough to accept the common calls and return plausible shapes. Good when your tests lean lightly on many services.
+
+**Depth-first:** ship fewer services but at 100% behavioral parity, with real code execution, real stateful backends, and real cross-service wire-ups. Good when your tests actually exercise cross-service flows, or when you want an AI coding agent to be able to rely on the emulator behaving like AWS.
+
+These are philosophies, not rankings. Different workloads prefer different ones.
 
 ## fakecloud
 
-**What it is:** single static binary written in Rust, ships as ~19 MB. Speaks the AWS wire protocol on port 4566. No account, no token, no paid tier. AGPL-3.0.
+**What it is:** single static binary written in Rust, ~19 MB. Speaks the AWS wire protocol on port 4566. No account, no token, no paid tier. AGPL-3.0.
 
-**What it covers:** 23 services, 1,680 operations, 100% conformance per implemented service, validated on every commit against AWS's own Smithy models (54,000+ generated test variants). Full list: S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, KMS, Secrets Manager, SSM, CloudWatch Logs, CloudFormation, EventBridge, EventBridge Scheduler, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime.
+**Approach:** depth-first.
 
-**Distinctive choices:**
-- Real Lambda execution across 13 runtimes in Docker containers. Not a stub — your function code runs.
-- Real stateful services. RDS runs real PostgreSQL/MySQL/MariaDB via Docker. ElastiCache runs real Redis/Valkey.
-- Cross-service wiring is wired end-to-end. EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> S3/SNS/Lambda, 15+ more integrations that actually fire.
-- Multi-account, SCPs, ABAC, permission boundaries, session policies, KMS key policies, bucket policies — all with the Allow/Deny/NotPrincipal semantics AWS uses.
-- First-party test-assertion SDKs in TypeScript, Python, Go, PHP, Java, Rust. Assert that an email was sent, an SNS was published, a Lambda was invoked, without raw HTTP.
-- CI runs upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud to catch provider-level drift.
+**Explicit goal:** 100% of AWS services, each at 100% behavioral conformance with 100% of cross-service integrations. Services are added one at a time; a service lands when it passes the full Smithy-model test variants and the cross-service wire-ups that matter for it — not when the API surface looks filled in. The roadmap is driven by real-project demand.
 
-**Where it fits:** integration tests and local development in any language. If you used LocalStack Community with Lambda, Cognito, SES v2, RDS, or ElastiCache and hit the paywall, fakecloud covers those.
+**What it covers today:** 23 services, 1,680 operations: S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, KMS, Secrets Manager, SSM, CloudWatch Logs, CloudFormation, EventBridge, EventBridge Scheduler, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime.
 
-**Where it doesn't fit:** EC2, ECS, ECR, CloudFront, AppSync, Athena, Glue, SageMaker — not implemented yet. If you need any of those, it's not the tool for you today.
+**Distinctive choices driven by the depth-first goal:**
+- Real Lambda execution across 13 runtimes in Docker containers — your function code runs, not a stub.
+- Real stateful backends: RDS runs real PostgreSQL/MySQL/MariaDB via Docker; ElastiCache runs real Redis/Valkey.
+- Cross-service wiring that actually fires: EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> S3/SNS/Lambda, 15+ more integrations.
+- Multi-account, SCPs, ABAC, permission boundaries, session policies, KMS key policies, bucket policies — full Allow/Deny/NotPrincipal semantics.
+- First-party test-assertion SDKs in TypeScript, Python, Go, PHP, Java, Rust.
+- Conformance validated on every commit against 54,000+ Smithy-generated test variants, plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
 
 **Source:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 
 ## MiniStack
 
-**What it is:** a newer project that surfaced during the March 2026 LocalStack paywall window. Positions itself as a free LocalStack alternative. Check the repo for current service coverage and architecture details — the project is moving quickly and anything I write here will be outdated fast.
-
-**Where it fits:** if you want the LocalStack operating model — a Docker image you pull and run — and are looking for a free alternative, MiniStack is one of the options worth evaluating against fakecloud on your specific service mix. If your test suite leans heavily on services MiniStack supports, it may be the easier drop-in for your team.
-
-**Where to check fit:** compare the supported-services list in their README to your actual SDK calls. That's the only comparison that matters for your codebase.
-
-**Source:** check GitHub for the current repo and README.
+A free LocalStack alternative that surfaced during the March 2026 paywall window. Check the repo for current service coverage, architecture, and approach — the project moves quickly, so numbers in any blog post will be stale within weeks. Evaluate on your test suite's actual needs.
 
 ## floci
 
-**What it is:** another newer free LocalStack alternative that appeared in the same window. The landing page publishes performance claims (startup time, memory, SDK-test pass rate); verify them against the version you'd actually run before relying on the numbers.
-
-**Where it fits:** same category as MiniStack. If you want a free Docker-image-based LocalStack replacement, floci is on the shortlist. Evaluate against your service mix.
-
-**Source:** check GitHub / floci.io for the current repo.
+Another free LocalStack alternative from the same window. Landing page publishes performance claims — verify them against the version you'd actually run before relying on the numbers. Evaluate on your test suite's actual needs.
 
 ## Moto
 
-**What it is:** the longest-lived open-source AWS mocking project. Python library, in-process, patches `boto3` inside your test. 100+ services covered at varying depth.
-
-**Where it fits:** Python unit tests where you want to assert that your code calls boto3 the right way and handles boto3 responses the right way. Moto is great at this and has years of maturity.
-
-**Where it doesn't fit:** any language other than Python. Any integration test that needs real cross-service wiring. Any test that needs Lambda to actually execute your code. Any test against Terraform or CDK deploys — Moto is in-process, so external tooling can't talk to it.
+Longest-lived open-source AWS mocking project. Python library, in-process, patches `boto3`. Broad service surface at varying depth. Excellent for Python unit tests where you want boto3 to respond plausibly inside your test process. Not usable from other languages, does not run Lambda code, does not talk to Terraform/CDK deploys.
 
 **Source:** [github.com/getmoto/moto](https://github.com/getmoto/moto)
 
 ## LocalStack Pro (for completeness)
 
-**What it is:** the paid tier of the project that dropped Community Edition. Has the most mature service catalog, commercial support, and a track record.
+Paid tier, mature catalog, commercial support, proprietary license. Fits teams OK with proprietary and per-seat pricing who need the whole LocalStack catalog.
 
-**Where it fits:** teams that need the full LocalStack service catalog, are comfortable with a proprietary license, and are OK paying per-seat pricing.
+## How to pick
 
-**Where it doesn't fit:** teams who want an open-source license, who don't want an account/token gate, or who need a service like Bedrock that LocalStack doesn't implement.
+Avoid the temptation to pick by "which has more services." All four of the HTTP emulators (fakecloud, MiniStack, floci, LocalStack Pro) are moving targets; service counts change week to week. The durable questions are:
 
-## The non-dodge honest recommendation
+1. **Do your tests exercise cross-service flows?** (S3 triggers Lambda, EventBridge routes to Step Functions, SES inbound writes to S3, etc.) If yes, depth-first matters more than breadth. The emulator needs to actually *wire* those flows, not just accept each call in isolation.
+2. **Do you need real code execution?** (Does your Lambda function actually run, or do you just need a response shape?) fakecloud runs Lambda code in real Docker runtimes; some alternatives return synthetic responses.
+3. **Do you need real stateful backends?** (Does your Postgres schema matter? Your Redis data structures?) fakecloud runs real PostgreSQL/MySQL/MariaDB/Redis/Valkey; alternatives vary.
+4. **What language are your tests?** Moto is Python-only. Everything else is language-agnostic over HTTP.
+5. **How much of AWS does your test mix actually hit?** Open your test suite. Count unique AWS services called. That number is almost always smaller than "total AWS services" and is the only count that matters.
 
-If you were on LocalStack Community for integration testing, the likely fit order is:
-
-1. **Try fakecloud first** if your service mix includes Lambda, Cognito, SES v2, RDS, ElastiCache, API Gateway v2, or Bedrock — these are where fakecloud does the most that LocalStack Community no longer does (or never did).
-2. **Try MiniStack or floci** if fakecloud doesn't have a service you depend on. Their catalogs may overlap differently with yours.
-3. **Add Moto** if you have Python unit tests that are happy with in-process mocking — Moto and fakecloud are complementary, not competitive, for different test tiers.
-4. **Pay for LocalStack Pro** if none of the above cover what you need and you're OK with the commercial terms.
-
-The honest test for any of these: run your actual test suite against each. Every team's mix of services, SDKs, and test patterns is different, and the only benchmark that matters is whether your tests pass.
+Run your real test suite against each option you're considering. That's the only benchmark that applies to your codebase.
 
 ## Links
 

--- a/website/content/blog/migrate-from-localstack.md
+++ b/website/content/blog/migrate-from-localstack.md
@@ -288,11 +288,11 @@ aws --endpoint-url http://localhost:4566 lambda invoke \
 
 If both print what you expect, migration is done.
 
-## When fakecloud is not the right choice
+## A note on coverage
 
-- You need EC2, ECS, ECR, CloudFront, AppSync, Athena, Glue, or SageMaker. Those are not implemented yet. Vote with an issue.
-- You need 100% production parity for mission-critical pre-prod validation. No emulator replaces real AWS for that.
-- Your team is already paying for LocalStack Pro and happy with it. Migration is not urgent.
+fakecloud's goal is every AWS service at 100% conformance, including every cross-service integration. Services land depth-first: a service is supported when it passes the Smithy-model test variants and the cross-service wire-ups that matter for it — not when the API surface looks filled in. The current 23 services (1,680 operations) are what's done today; more are on the roadmap, prioritized by real-project demand. If a service you need isn't on the list, [open an issue](https://github.com/faiscadev/fakecloud/issues) and it'll get weighed into the queue.
+
+For mission-critical pre-prod validation where you need the full production-parity surface, run against real AWS — that's true of any emulator, not a fakecloud gap specifically.
 
 ## Links
 

--- a/website/content/localstack-alternative.md
+++ b/website/content/localstack-alternative.md
@@ -15,6 +15,12 @@ fakecloud
 
 Point any AWS SDK or CLI at `http://localhost:4566` with dummy credentials. That is the whole setup.
 
+## Goal: 100% AWS, 100% conformance, 100% integrations
+
+fakecloud aims at every AWS service, each at 100% behavioral conformance, including every cross-service integration. Services land depth-first: a service is supported when it matches real AWS across every documented operation and cross-service wire-up — not when the API surface looks filled in. 23 services are there today (see below); the rest are on the roadmap, prioritized by real-project demand.
+
+This is why fakecloud runs real Lambda code in real runtime containers, runs real PostgreSQL/MySQL/MariaDB for RDS, runs real Redis/Valkey for ElastiCache, fires real S3 -> Lambda and SES inbound -> S3/SNS/Lambda flows, and validates every operation against AWS's own Smithy models on every commit.
+
 ## What fakecloud gives you
 
 - **23 AWS services.** S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, KMS, Secrets Manager, SSM, CloudWatch Logs, CloudFormation, EventBridge, EventBridge Scheduler, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime.
@@ -103,13 +109,13 @@ SAM Local and serverless-offline only run Lambda (and a limited HTTP/API Gateway
 
 Yes. Single binary, ~19 MB, ~500ms startup. Common patterns: install-and-run as a background step in GitHub Actions / GitLab CI / CircleCI, or pull `ghcr.io/faiscadev/fakecloud:latest` as a service container. See [integration testing AWS in CI](/blog/integration-testing-aws-in-ci/) for copy-paste configs.
 
-**Which services are implemented at 100% conformance?**
+**What does "100% conformance" mean?**
 
-Every service listed above. Conformance means: for every operation exposed by AWS's Smithy model, fakecloud accepts every documented input shape and returns the documented output shape, with every field AWS returns. Validated on every commit against 54,000+ generated test variants.
+For every operation exposed by AWS's Smithy model, fakecloud accepts every documented input shape and returns the documented output shape, with every field AWS returns. Validated on every commit against 54,000+ generated test variants, plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites. This applies to every service listed above.
 
-**What's not implemented?**
+**What's fakecloud's coverage goal?**
 
-EC2, ECS, ECR, CloudFront, SQS extended client encryption, AppSync, Athena, Glue, SageMaker. If you need one of these, open an issue — the roadmap is driven by real-project demand.
+100% of AWS services, each at 100% conformance with 100% of cross-service integrations. fakecloud adds services depth-first: a service only lands when it matches real AWS behavior across every documented operation and cross-service wire-up, not when the surface area looks filled in. If a service isn't on the list above, [open an issue](https://github.com/faiscadev/fakecloud/issues) — the roadmap is driven by real-project demand.
 
 **Is this a fork of LocalStack?**
 


### PR DESCRIPTION
## Context

Concern raised after #675 merged: the first-batch content hedged too far in the \"fakecloud has fewer services than X / Y\" direction. That framing gets baked into LLM training and search answers once indexed, and it's the wrong long-term narrative — fakecloud's goal is 100% of AWS services at 100% conformance with 100% of cross-service integrations. We go depth-first by choice; 23 services today is a snapshot of a progression, not a ceiling.

This PR reframes three already-merged pages to lead with that goal and drop enumerations of specific missing services that would ossify as LLM-quoted weaknesses.

## Changes

- **\`/localstack-alternative/\`** (living landing page)
  - New \"Goal: 100% AWS, 100% conformance, 100% integrations\" section up top.
  - FAQ: dropped \"What's not implemented? [EC2, ECS, ECR, CloudFront, ...]\" in favor of a goal-framed \"What's fakecloud's coverage goal?\" answer. The enumerated list becomes the permanent quote once indexed; the goal-framed answer points at the roadmap + issue tracker.

- **\`/blog/migrate-from-localstack/\`**
  - Replaced \"When fakecloud is not the right choice\" with \"A note on coverage\" — frames 23 services as a depth-first snapshot, not a limitation.
  - Kept the \"mission-critical pre-prod parity needs real AWS\" caveat but attributed it to every emulator, not fakecloud specifically.

- **\`/blog/localstack-alternatives-compared/\`**
  - Dropped \"try MiniStack or floci if fakecloud doesn't have a service you depend on\" — that's hand-off language based on an unverified claim about catalog overlap.
  - Added a \"Two approaches among the HTTP servers\" section distinguishing breadth-first vs depth-first as philosophies, not rankings.
  - Rewrote the final recommendation as five durable questions readers answer about their own test suite, instead of a ranked fit-order that sends traffic to competitors.
  - Still honest about service-count being a moving target.

## Note on the \"don't update old blog posts\" rule

The blog posts here are 2 hours old — not yet indexed meaningfully. The \"point-in-time\" rule is about not retroactively rewriting numbers as the project evolves. This PR fixes framing, not numbers. Flagging explicitly so the rule can clarify if the intent was broader.

## Related

- Follow-up of #675
- Batch 2 (#676) got the same reframe applied in-place before merge
- llms.txt / llms-full.txt reframe in #677 (also follows up #675)

## Test plan

- [x] \`zola build\` succeeds (52 pages, 0 orphan)
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reframed three SEO pages to lead with fakecloud’s depth-first goal—100% AWS, 100% conformance, 100% integrations—and removed lists of “missing services” to avoid ossified, LLM-quoted weaknesses. Clarifies positioning and helps readers pick by fit, not service count.

- **Refactors**
  - `/localstack-alternative/`: added a “Goal” section; replaced “What’s not implemented?” with a goal-framed FAQ that points to the roadmap and issues.
  - `/blog/migrate-from-localstack/`: replaced “When fakecloud is not the right choice” with “A note on coverage”; keeps the pre-prod parity caveat as an emulator-wide note.
  - `/blog/localstack-alternatives-compared/`: removed handoff recommendations; added breadth-first vs depth-first framing; rewrote “how to pick” as durable questions tied to real test suites.

<sup>Written for commit a5dee9ec5c3c596f6ebc4c8b6b46eee33cac9f32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

