### PR TITLE
docs(seo): Terraform + CDK tutorials + slug-exact mock-X landings

### DIFF
--- a/website/content/blog/cdk-local-testing.md
+++ b/website/content/blog/cdk-local-testing.md
@@ -1,0 +1,185 @@
++++
+title = "CDK local testing: full flow with fakecloud and cdklocal"
+date = 2026-04-22
+description = "Deploy and test AWS CDK apps locally with fakecloud. Full cdklocal flow, plain cdk with AWS_ENDPOINT_URL, CI setup. Free, open-source, no account required."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+AWS CDK writes CloudFormation under the hood and ships it through the AWS SDK. That means "CDK local testing" boils down to one question: where does the SDK send its CreateStack / UpdateStack calls?
+
+Pointed at real AWS, you pay per resource, wait minutes per deploy, and have to remember to destroy. Pointed at a local emulator, you iterate fast and don't pay anything. This guide covers both flows (`cdklocal` wrapper and plain `cdk` with endpoint overrides) against [fakecloud](https://github.com/faiscadev/fakecloud), a free, open-source AWS emulator with real CloudFormation support (90 operations, template parsing, resource provisioning, custom resources, drift detection).
+
+## Install fakecloud
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Listens on `http://localhost:4566`. ~500ms startup.
+
+## Option 1: plain `cdk` with `AWS_ENDPOINT_URL`
+
+Simplest and works with any CDK version that uses AWS SDK v3 (CDK 2.67+).
+
+```sh
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=us-east-1
+export CDK_DEFAULT_ACCOUNT=000000000000
+export CDK_DEFAULT_REGION=us-east-1
+
+cdk bootstrap
+cdk deploy
+```
+
+That's it. Same `cdk` binary you use for prod, pointed at fakecloud for dev.
+
+## Option 2: `cdklocal` wrapper
+
+If your team is already using `cdklocal` (from the LocalStack ecosystem), it works the same way against fakecloud:
+
+```sh
+cdklocal bootstrap --endpoint-url http://localhost:4566
+cdklocal deploy --endpoint-url http://localhost:4566
+```
+
+## A minimal stack
+
+```ts
+// lib/my-stack.ts
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Function, Runtime, Code } from 'aws-cdk-lib/aws-lambda';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
+import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { Construct } from 'constructs';
+
+export class MyStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const bucket = new Bucket(this, 'Uploads');
+    const queue = new Queue(this, 'Jobs');
+
+    const processor = new Function(this, 'Processor', {
+      runtime: Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: Code.fromInline(
+        `exports.handler = async (event) => ({ ok: true, received: event })`
+      ),
+    });
+
+    processor.addEventSource(new SqsEventSource(queue));
+    bucket.grantRead(processor);
+  }
+}
+```
+
+Deploy:
+
+```sh
+cdk deploy
+```
+
+Verify:
+
+```sh
+aws --endpoint-url http://localhost:4566 cloudformation describe-stacks
+aws --endpoint-url http://localhost:4566 lambda list-functions
+aws --endpoint-url http://localhost:4566 s3 ls
+```
+
+Trigger the flow:
+
+```sh
+echo "hi" | aws --endpoint-url http://localhost:4566 s3 cp - s3://$(aws --endpoint-url http://localhost:4566 s3api list-buckets --query 'Buckets[0].Name' --output text)/file.txt
+aws --endpoint-url http://localhost:4566 logs tail /aws/lambda/MyStack-Processor --since 1m
+```
+
+Your Lambda code actually runs (fakecloud pulls the real Node 20 runtime container). The SQS -> Lambda event source mapping actually fires. CloudFormation actually provisioned the resources from the template CDK generated.
+
+## CI integration
+
+```yaml
+jobs:
+  cdk:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ENDPOINT_URL: http://localhost:4566
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      CDK_DEFAULT_ACCOUNT: '000000000000'
+      CDK_DEFAULT_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+
+      - name: Start fakecloud
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+          fakecloud &
+          for i in $(seq 1 30); do curl -sf http://localhost:4566/_fakecloud/health && break; sleep 1; done
+
+      - run: npm ci
+      - run: npx cdk bootstrap
+      - run: npx cdk deploy --require-approval never
+      - run: npm test
+```
+
+## Assertions from tests
+
+CDK integration tests usually fall into two shapes:
+
+**1. Synth assertions** — what CloudFormation does your CDK emit. These don't need fakecloud; use CDK's `@aws-cdk/assert` or `aws-cdk-lib/assertions`.
+
+**2. Deployed-stack behavior** — does the stack actually work when deployed. For these, deploy to fakecloud and assert on real side effects:
+
+```ts
+import { FakeCloud } from 'fakecloud';
+const fc = new FakeCloud();
+
+test('upload triggers lambda', async () => {
+  await uploadToBucket('uploads', 'test.txt', 'hello');
+
+  const { invocations } = await fc.lambda.getInvocations({ functionName: 'Processor' });
+  expect(invocations).toHaveLength(1);
+});
+
+afterEach(() => fc.reset());
+```
+
+fakecloud SDKs available in TypeScript, Python, Go, PHP, Java, Rust.
+
+## Destroy between tests
+
+CloudFormation state persists across tests unless you destroy or reset:
+
+```sh
+# Full stack teardown
+cdk destroy --force
+
+# OR reset fakecloud's entire state (faster)
+curl -X POST http://localhost:4566/_fakecloud/reset
+```
+
+Reset is ~instant and covers every service. `cdk destroy` only unwinds one stack at a time.
+
+## Why this works
+
+fakecloud targets 100% behavioral conformance per implemented service. CloudFormation (90 operations), Lambda (85 ops, real code execution in 13 runtimes), SQS (23 ops), S3 (107 ops) — all in. Cross-service wiring like S3 -> Lambda event sources and SQS -> Lambda event source mappings actually execute server-side, not as stubs.
+
+The depth-first goal: 100% of AWS services, each at 100% conformance, with 100% cross-service integrations. 23 services shipped today; more land one-at-a-time as they pass the conformance bar.
+
+## Links
+
+- Install: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- Repo: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- Terraform local dev guide: [Terraform local development for AWS](/blog/terraform-local-development-aws/)
+- LocalStack migration guide: [Migrating from LocalStack to fakecloud](/blog/migrate-from-localstack/)
+- Issues: [github.com/faiscadev/fakecloud/issues](https://github.com/faiscadev/fakecloud/issues)

--- a/website/content/blog/terraform-local-development-aws.md
+++ b/website/content/blog/terraform-local-development-aws.md
@@ -1,0 +1,251 @@
++++
+title = "Terraform local development for AWS: full flow with fakecloud"
+date = 2026-04-22
+description = "Run Terraform against AWS locally with fakecloud. Provider endpoints config, tflocal, CI setup. Free, open-source, no account required. Works with the upstream terraform-provider-aws TestAcc suites."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+Writing Terraform for AWS means iterating against AWS. Every `terraform apply` costs money, takes minutes, and leaves resources behind that you have to remember to destroy. For local dev and CI, you want the same AWS provider running against something that behaves like AWS but isn't.
+
+This guide walks through local Terraform development for AWS with [fakecloud](https://github.com/faiscadev/fakecloud) — a free, open-source AWS emulator that targets 100% behavioral conformance, depth-first. fakecloud's CI runs the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites against itself on every commit, so Terraform flows that work against real AWS should work against fakecloud.
+
+## Install fakecloud
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Listens on `http://localhost:4566`. ~500ms startup. No account, no token.
+
+## Option 1: provider `endpoints` block (explicit)
+
+Most explicit and portable. Works with any Terraform/OpenTofu version.
+
+```hcl
+# main.tf
+provider "aws" {
+  access_key                  = "test"
+  secret_key                  = "test"
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  s3_use_path_style           = true
+
+  endpoints {
+    s3             = "http://localhost:4566"
+    sqs            = "http://localhost:4566"
+    sns            = "http://localhost:4566"
+    dynamodb       = "http://localhost:4566"
+    lambda         = "http://localhost:4566"
+    iam            = "http://localhost:4566"
+    sts            = "http://localhost:4566"
+    kms            = "http://localhost:4566"
+    secretsmanager = "http://localhost:4566"
+    ssm            = "http://localhost:4566"
+    logs           = "http://localhost:4566"
+    cloudformation = "http://localhost:4566"
+    events         = "http://localhost:4566"
+    scheduler      = "http://localhost:4566"
+    ses            = "http://localhost:4566"
+    sesv2          = "http://localhost:4566"
+    cognitoidp     = "http://localhost:4566"
+    kinesis        = "http://localhost:4566"
+    rds            = "http://localhost:4566"
+    elasticache    = "http://localhost:4566"
+    sfn            = "http://localhost:4566"
+    apigatewayv2   = "http://localhost:4566"
+    bedrock        = "http://localhost:4566"
+    bedrockruntime = "http://localhost:4566"
+  }
+}
+```
+
+Now `terraform init && terraform apply` talks to fakecloud.
+
+## Option 2: `AWS_ENDPOINT_URL` (minimal config)
+
+Cleaner. AWS provider v5.63+ respects `AWS_ENDPOINT_URL` from environment. No `endpoints` block needed.
+
+```sh
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=us-east-1
+
+terraform init
+terraform apply
+```
+
+The provider block collapses to just auth scaffolding:
+
+```hcl
+provider "aws" {
+  access_key                  = "test"
+  secret_key                  = "test"
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  s3_use_path_style           = true
+}
+```
+
+## Option 3: `tflocal` wrapper
+
+If you're coming from LocalStack and have a `tflocal` setup, the endpoint override works the same way — just point at fakecloud instead.
+
+```sh
+AWS_ENDPOINT_URL=http://localhost:4566 tflocal apply
+```
+
+## End-to-end example: S3 + Lambda + SQS
+
+```hcl
+# main.tf
+resource "aws_s3_bucket" "uploads" {
+  bucket = "uploads-${random_id.suffix.hex}"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+resource "aws_sqs_queue" "jobs" {
+  name = "jobs"
+}
+
+resource "aws_iam_role" "lambda" {
+  name = "lambda-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_lambda_function" "processor" {
+  filename      = data.archive_file.fn.output_path
+  function_name = "processor"
+  role          = aws_iam_role.lambda.arn
+  handler       = "index.handler"
+  runtime       = "nodejs20.x"
+  source_code_hash = data.archive_file.fn.output_base64sha256
+}
+
+data "archive_file" "fn" {
+  type        = "zip"
+  output_path = "fn.zip"
+  source {
+    filename = "index.js"
+    content  = "exports.handler = async (event) => ({ ok: true, received: event })"
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "sqs_to_lambda" {
+  event_source_arn = aws_sqs_queue.jobs.arn
+  function_name    = aws_lambda_function.processor.function_name
+  batch_size       = 1
+}
+
+resource "aws_s3_bucket_notification" "uploads_to_sqs" {
+  bucket = aws_s3_bucket.uploads.id
+  queue {
+    queue_arn = aws_sqs_queue.jobs.arn
+    events    = ["s3:ObjectCreated:*"]
+  }
+}
+```
+
+Apply it against fakecloud:
+
+```sh
+terraform apply -auto-approve
+```
+
+Upload an object and watch the Lambda fire:
+
+```sh
+echo "hello" | aws --endpoint-url http://localhost:4566 s3 cp - s3://$(terraform output -raw bucket_id)/file.txt
+aws --endpoint-url http://localhost:4566 logs tail /aws/lambda/processor
+```
+
+That's S3 notification -> SQS queue -> Lambda event source mapping -> real Node runtime executing your handler. End-to-end, no stubs. Same flow as real AWS.
+
+## CI: Terraform plan/apply in GitHub Actions
+
+```yaml
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ENDPOINT_URL: http://localhost:4566
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Start fakecloud
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+          fakecloud &
+          for i in $(seq 1 30); do curl -sf http://localhost:4566/_fakecloud/health && break; sleep 1; done
+
+      - name: terraform init
+        run: terraform init
+
+      - name: terraform plan
+        run: terraform plan -out=tfplan
+
+      - name: terraform apply
+        run: terraform apply -auto-approve tfplan
+```
+
+~500ms startup means this adds negligible time to the job.
+
+## State backend
+
+For local dev, default `local` backend is fine. If your real config uses `s3` backend, you can point that at fakecloud too:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket                      = "tf-state"
+    key                         = "terraform.tfstate"
+    region                      = "us-east-1"
+    endpoint                    = "http://localhost:4566"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    force_path_style            = true
+  }
+}
+```
+
+Pre-create the bucket:
+
+```sh
+aws --endpoint-url http://localhost:4566 s3 mb s3://tf-state
+```
+
+## Why this works at parity
+
+fakecloud targets 100% behavioral conformance per implemented service, validated on every commit against AWS's own Smithy models. On top of that, CI runs the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites — the same acceptance tests HashiCorp runs against real AWS — so provider-level behavior (waiters, retries, field presence, ARN formats) matches.
+
+If a Terraform flow that works against real AWS doesn't work against fakecloud, that's a bug. [Open an issue](https://github.com/faiscadev/fakecloud/issues) and it gets fixed.
+
+## Links
+
+- Install: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- Repo: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- LocalStack migration guide: [Migrating from LocalStack to fakecloud](/blog/migrate-from-localstack/)
+- CI guide: [Integration testing AWS in GitHub Actions](/blog/integration-testing-aws-in-ci/)
+- Issues: [github.com/faiscadev/fakecloud/issues](https://github.com/faiscadev/fakecloud/issues)

--- a/website/content/local-s3-for-tests.md
+++ b/website/content/local-s3-for-tests.md
@@ -1,0 +1,144 @@
++++
+title = "Local S3 for integration tests"
+description = "Run S3 locally for integration tests with fakecloud. 107 S3 operations, versioning, lifecycle, notifications, multipart, replication. Any AWS SDK, no Docker required, free."
+template = "page.html"
++++
+
+Need a local S3 for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point your AWS SDK at `http://localhost:4566`.
+
+## Why fakecloud for S3
+
+- **107 S3 operations** at 100% conformance — buckets, objects, multipart uploads, versioning, lifecycle, CORS, notifications, object lock, replication, website hosting.
+- **Real cross-service triggers.** S3 notifications fire SNS, SQS, and Lambda for real. `PutObject` -> Lambda invocation happens end-to-end.
+- **Any AWS SDK in any language.** Real HTTP server on port 4566 — Python boto3, Node aws-sdk, Go aws-sdk-go-v2, Java, Kotlin, Rust, PHP, AWS CLI all work.
+- **No Docker required** for S3 itself (binary runs the storage engine in-process).
+- **Validated against AWS's own Smithy models** on every commit. CI also runs upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud.
+- **No account, no auth token, no paid tier.** AGPL-3.0.
+
+## Quick examples
+
+### Python (boto3)
+
+```python
+import boto3
+s3 = boto3.client('s3',
+    endpoint_url='http://localhost:4566',
+    aws_access_key_id='test',
+    aws_secret_access_key='test',
+    region_name='us-east-1')
+
+s3.create_bucket(Bucket='uploads')
+s3.put_object(Bucket='uploads', Key='hello.txt', Body=b'hello world')
+obj = s3.get_object(Bucket='uploads', Key='hello.txt')
+print(obj['Body'].read())
+```
+
+### Node.js (AWS SDK v3)
+
+```ts
+process.env.AWS_ENDPOINT_URL = 'http://localhost:4566';
+process.env.AWS_ACCESS_KEY_ID = 'test';
+process.env.AWS_SECRET_ACCESS_KEY = 'test';
+process.env.AWS_REGION = 'us-east-1';
+
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+const s3 = new S3Client({ forcePathStyle: true });
+
+await s3.send(new PutObjectCommand({
+  Bucket: 'uploads',
+  Key: 'hello.txt',
+  Body: 'hello world',
+}));
+```
+
+### Go
+
+```go
+cfg, _ := config.LoadDefaultConfig(ctx,
+    config.WithRegion("us-east-1"),
+    config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+    config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
+        func(s, r string, o ...interface{}) (aws.Endpoint, error) {
+            return aws.Endpoint{URL: "http://localhost:4566"}, nil
+        },
+    )),
+)
+s3 := s3.NewFromConfig(cfg, func(o *s3.Options) { o.UsePathStyle = true })
+```
+
+### AWS CLI
+
+```sh
+aws --endpoint-url http://localhost:4566 s3 mb s3://uploads
+echo "hello" | aws --endpoint-url http://localhost:4566 s3 cp - s3://uploads/hello.txt
+aws --endpoint-url http://localhost:4566 s3 ls s3://uploads/
+```
+
+## Versioning + lifecycle
+
+```sh
+aws --endpoint-url http://localhost:4566 s3api put-bucket-versioning \
+  --bucket uploads --versioning-configuration Status=Enabled
+
+aws --endpoint-url http://localhost:4566 s3api put-bucket-lifecycle-configuration \
+  --bucket uploads --lifecycle-configuration file://lifecycle.json
+```
+
+Versioning returns VersionIds on puts. Lifecycle transitions run on fakecloud's schedule.
+
+## Multipart uploads
+
+```python
+mpu = s3.create_multipart_upload(Bucket='uploads', Key='large.bin')
+parts = []
+for i, chunk in enumerate(chunks, start=1):
+    resp = s3.upload_part(Bucket='uploads', Key='large.bin', UploadId=mpu['UploadId'],
+                          PartNumber=i, Body=chunk)
+    parts.append({'PartNumber': i, 'ETag': resp['ETag']})
+s3.complete_multipart_upload(Bucket='uploads', Key='large.bin', UploadId=mpu['UploadId'],
+                             MultipartUpload={'Parts': parts})
+```
+
+Full multipart API. ETags match AWS.
+
+## Notifications: S3 -> Lambda end-to-end
+
+```sh
+aws --endpoint-url http://localhost:4566 s3api put-bucket-notification-configuration \
+  --bucket uploads \
+  --notification-configuration '{
+    "LambdaFunctionConfigurations": [{
+      "LambdaFunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:on-upload",
+      "Events": ["s3:ObjectCreated:*"]
+    }]
+  }'
+```
+
+Now `PutObject` fires the Lambda for real — not a stub. fakecloud runs Lambda code in real runtime containers across 13 runtimes.
+
+## How it differs from alternatives
+
+| Tool | Multi-language | Versioning | Notifications | Real Lambda triggers | Lifecycle |
+|---|---|---|---|---|---|
+| fakecloud | Any | Yes | Yes | Yes (real code runs) | Yes |
+| adobe/S3Mock | Any | Yes | No | No (no Lambda service) | Partial |
+| MinIO | Any | Yes | Yes | N/A (no AWS Lambda service) | Yes |
+| gofakes3 | Any | Limited | No | No | No |
+| Moto (mock_s3) | Python only | Yes | Stubbed | Stubbed | Partial |
+| DynamoDB Local | N/A | N/A | N/A | N/A | N/A (wrong service) |
+
+If you need S3 + cross-service wiring (S3 -> SNS/SQS/Lambda actually fires), pick fakecloud.
+
+## Links
+
+- **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **S3 docs:** [fakecloud.dev/docs/services](/docs/services/)
+- **Related:** [Fake AWS server for tests](/fake-aws-server/), [Mock DynamoDB for tests](/mock-dynamodb/), [Test Lambda locally](/test-lambda-locally/)

--- a/website/content/mock-dynamodb.md
+++ b/website/content/mock-dynamodb.md
@@ -1,0 +1,134 @@
++++
+title = "Mock DynamoDB for tests"
+description = "Mock DynamoDB locally for integration tests with fakecloud. 57 operations, transactions, PartiQL, streams, global tables. Any language, no Docker required, free."
+template = "page.html"
++++
+
+Need to mock DynamoDB for tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point your AWS SDK at `http://localhost:4566`. That's the whole setup.
+
+## Why fakecloud for DynamoDB
+
+- **57 DynamoDB operations** at 100% conformance — tables, items, transactions (`TransactWriteItems`, `TransactGetItems`), PartiQL (`ExecuteStatement`, `BatchExecuteStatement`), backups, global tables, streams, secondary indexes.
+- **Validated against AWS's own Smithy models** on every commit (54,000+ generated test variants).
+- **Any AWS SDK in any language.** Real HTTP server on port 4566 — Python boto3, Node aws-sdk, Go aws-sdk-go-v2, Java, Kotlin, Rust, PHP all work identically.
+- **No account, no auth token, no paid tier.** AGPL-3.0.
+- **No Docker required** for DynamoDB (binary runs the storage engine in-process). Fastest local DynamoDB you can run.
+
+## Quick examples
+
+### Python (boto3)
+
+```python
+import boto3
+ddb = boto3.client('dynamodb',
+    endpoint_url='http://localhost:4566',
+    aws_access_key_id='test',
+    aws_secret_access_key='test',
+    region_name='us-east-1')
+
+ddb.create_table(
+    TableName='users',
+    KeySchema=[{'AttributeName': 'id', 'KeyType': 'HASH'}],
+    AttributeDefinitions=[{'AttributeName': 'id', 'AttributeType': 'S'}],
+    BillingMode='PAY_PER_REQUEST')
+
+ddb.put_item(TableName='users', Item={'id': {'S': 'u1'}, 'name': {'S': 'Alice'}})
+resp = ddb.get_item(TableName='users', Key={'id': {'S': 'u1'}})
+print(resp['Item'])
+```
+
+### Node.js (AWS SDK v3)
+
+```ts
+process.env.AWS_ENDPOINT_URL = 'http://localhost:4566';
+process.env.AWS_ACCESS_KEY_ID = 'test';
+process.env.AWS_SECRET_ACCESS_KEY = 'test';
+process.env.AWS_REGION = 'us-east-1';
+
+import { DynamoDBClient, CreateTableCommand, PutItemCommand, GetItemCommand } from '@aws-sdk/client-dynamodb';
+const ddb = new DynamoDBClient({});
+
+await ddb.send(new CreateTableCommand({
+  TableName: 'users',
+  KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],
+  AttributeDefinitions: [{ AttributeName: 'id', AttributeType: 'S' }],
+  BillingMode: 'PAY_PER_REQUEST',
+}));
+```
+
+### Go
+
+```go
+cfg, _ := config.LoadDefaultConfig(ctx,
+    config.WithRegion("us-east-1"),
+    config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+    config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
+        func(s, r string, o ...interface{}) (aws.Endpoint, error) {
+            return aws.Endpoint{URL: "http://localhost:4566"}, nil
+        },
+    )),
+)
+ddb := dynamodb.NewFromConfig(cfg)
+```
+
+### AWS CLI
+
+```sh
+aws --endpoint-url http://localhost:4566 dynamodb create-table \
+  --table-name users \
+  --key-schema AttributeName=id,KeyType=HASH \
+  --attribute-definitions AttributeName=id,AttributeType=S \
+  --billing-mode PAY_PER_REQUEST
+```
+
+## Transactions
+
+```python
+ddb.transact_write_items(TransactItems=[
+    {'Put': {'TableName': 'orders', 'Item': {'id': {'S': 'o1'}, 'total': {'N': '100'}}}},
+    {'Update': {'TableName': 'accounts', 'Key': {'id': {'S': 'a1'}},
+                'UpdateExpression': 'ADD balance :delta',
+                'ExpressionAttributeValues': {':delta': {'N': '-100'}}}},
+])
+```
+
+Real transaction semantics: all-or-nothing, condition check failures roll back the whole batch.
+
+## Streams
+
+```python
+ddb.create_table(
+    TableName='events',
+    KeySchema=[{'AttributeName': 'id', 'KeyType': 'HASH'}],
+    AttributeDefinitions=[{'AttributeName': 'id', 'AttributeType': 'S'}],
+    BillingMode='PAY_PER_REQUEST',
+    StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'NEW_AND_OLD_IMAGES'})
+```
+
+Stream records get published. Lambda event source mappings consume them.
+
+## How it differs from alternatives
+
+| Tool | Multi-language | Transactions | Streams | PartiQL | Real Lambda triggers |
+|---|---|---|---|---|---|
+| fakecloud | Any | Yes | Yes | Yes | Yes (real runtime code) |
+| DynamoDB Local (AWS official) | Any (JVM required) | Yes | Yes | Yes | No (no cross-service) |
+| Moto | Python only | Yes | Yes | Partial | Stubbed |
+| aws-sdk-client-mock | Node only | Stubbed | Stubbed | Stubbed | N/A |
+| LocalStack Community | Any | Yes | Yes | Yes | Yes (post-paywall, requires auth) |
+
+If you need multi-language, free, real Lambda triggers, depth-first conformance: fakecloud.
+
+## Links
+
+- **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **DynamoDB docs:** [fakecloud.dev/docs/services/dynamodb](/docs/services/)
+- **Related:** [Fake AWS server for tests](/fake-aws-server/), [Test Lambda locally](/test-lambda-locally/), [Integration testing AWS in CI](/blog/integration-testing-aws-in-ci/)

--- a/website/content/mock-sqs.md
+++ b/website/content/mock-sqs.md
@@ -1,0 +1,154 @@
++++
+title = "Mock SQS for tests"
+description = "Mock SQS locally for integration tests with fakecloud. 23 SQS operations, FIFO, DLQs, long polling, real Lambda event source mappings. Any AWS SDK, free."
+template = "page.html"
++++
+
+Need to mock SQS for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point your AWS SDK at `http://localhost:4566`.
+
+## Why fakecloud for SQS
+
+- **23 SQS operations** at 100% conformance — queues, messages, long polling, FIFO queues with message group IDs and deduplication, dead-letter queues, batch operations, message attributes.
+- **Real SQS -> Lambda event source mappings.** Your Lambda actually runs when messages arrive. `CreateEventSourceMapping` polls the queue, batches messages, invokes your function with the SQS event shape, deletes on success, routes failures to DLQ — same contract as real AWS.
+- **Real SNS -> SQS fan-out.** Topic subscriptions deliver to queues for real.
+- **Any AWS SDK in any language.** Real HTTP server on port 4566.
+- **No account, no auth token, no paid tier.** AGPL-3.0.
+
+## Quick examples
+
+### Python (boto3)
+
+```python
+import boto3
+sqs = boto3.client('sqs',
+    endpoint_url='http://localhost:4566',
+    aws_access_key_id='test',
+    aws_secret_access_key='test',
+    region_name='us-east-1')
+
+q = sqs.create_queue(QueueName='jobs')
+sqs.send_message(QueueUrl=q['QueueUrl'], MessageBody='{"job": "resize", "id": 42}')
+resp = sqs.receive_message(QueueUrl=q['QueueUrl'], WaitTimeSeconds=1)
+print(resp.get('Messages', []))
+```
+
+### Node.js (AWS SDK v3)
+
+```ts
+process.env.AWS_ENDPOINT_URL = 'http://localhost:4566';
+process.env.AWS_ACCESS_KEY_ID = 'test';
+process.env.AWS_SECRET_ACCESS_KEY = 'test';
+process.env.AWS_REGION = 'us-east-1';
+
+import { SQSClient, CreateQueueCommand, SendMessageCommand } from '@aws-sdk/client-sqs';
+const sqs = new SQSClient({});
+
+const { QueueUrl } = await sqs.send(new CreateQueueCommand({ QueueName: 'jobs' }));
+await sqs.send(new SendMessageCommand({ QueueUrl, MessageBody: JSON.stringify({ job: 'resize' }) }));
+```
+
+### Go
+
+```go
+cfg, _ := config.LoadDefaultConfig(ctx,
+    config.WithRegion("us-east-1"),
+    config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+    config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
+        func(s, r string, o ...interface{}) (aws.Endpoint, error) {
+            return aws.Endpoint{URL: "http://localhost:4566"}, nil
+        },
+    )),
+)
+sqs := sqs.NewFromConfig(cfg)
+```
+
+### AWS CLI
+
+```sh
+aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name jobs
+aws --endpoint-url http://localhost:4566 sqs send-message \
+  --queue-url http://localhost:4566/000000000000/jobs \
+  --message-body '{"job":"resize","id":42}'
+```
+
+## FIFO queues
+
+```sh
+aws --endpoint-url http://localhost:4566 sqs create-queue \
+  --queue-name orders.fifo \
+  --attributes FifoQueue=true,ContentBasedDeduplication=true
+
+aws --endpoint-url http://localhost:4566 sqs send-message \
+  --queue-url http://localhost:4566/000000000000/orders.fifo \
+  --message-body '{"order":"o1"}' \
+  --message-group-id orders
+```
+
+Real FIFO semantics: within a message group, messages are processed in order. Deduplication works.
+
+## Dead-letter queues
+
+```sh
+aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name jobs-dlq
+
+# Link primary queue to DLQ via RedrivePolicy
+aws --endpoint-url http://localhost:4566 sqs set-queue-attributes \
+  --queue-url http://localhost:4566/000000000000/jobs \
+  --attributes '{"RedrivePolicy":"{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:000000000000:jobs-dlq\",\"maxReceiveCount\":\"3\"}"}'
+```
+
+After `maxReceiveCount` failed deliveries, messages route to the DLQ automatically. Same contract as real AWS.
+
+## SQS -> Lambda event source mapping
+
+```sh
+aws --endpoint-url http://localhost:4566 lambda create-event-source-mapping \
+  --function-name processor \
+  --event-source-arn arn:aws:sqs:us-east-1:000000000000:jobs \
+  --batch-size 10
+```
+
+fakecloud polls the queue, batches messages, invokes your Lambda with the SQS event shape, deletes messages on success, routes to DLQ on failure. Your function code actually runs (fakecloud pulls the Lambda runtime container).
+
+## Assertions from tests
+
+```ts
+import { FakeCloud } from 'fakecloud';
+const fc = new FakeCloud();
+
+test('enqueue and process', async () => {
+  await enqueue({ job: 'resize', id: 42 });
+
+  const { invocations } = await fc.lambda.getInvocations({ functionName: 'processor' });
+  expect(invocations).toHaveLength(1);
+});
+
+afterEach(() => fc.reset());
+```
+
+SDKs available in TypeScript, Python, Go, PHP, Java, Rust.
+
+## How it differs from alternatives
+
+| Tool | Multi-language | FIFO | DLQ | Real Lambda trigger | Real SNS fan-out |
+|---|---|---|---|---|---|
+| fakecloud | Any | Yes | Yes | Yes (real code runs) | Yes |
+| ElasticMQ | Any | Yes | Yes | No (no Lambda service) | N/A |
+| Moto (mock_sqs) | Python only | Yes | Yes | Stubbed | Stubbed |
+| LocalStack Community | Any | Yes | Yes | Yes (post-paywall auth required) | Yes (paywall) |
+| aws-sdk-client-mock | Node only | Stubbed | Stubbed | N/A | N/A |
+
+If you need SQS + cross-service (SNS -> SQS, SQS -> Lambda actually firing), pick fakecloud.
+
+## Links
+
+- **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Related:** [Fake AWS server for tests](/fake-aws-server/), [Test Lambda locally](/test-lambda-locally/), [Integration testing AWS in CI](/blog/integration-testing-aws-in-ci/)


### PR DESCRIPTION
## Summary

Batch 3A of upstream-query SEO push. Targets underserved queries where top-10 today is outdated Medium posts or single-service tools.

**Blog tutorials (dated, Dev.to cross-posts to follow):**
- [/blog/terraform-local-development-aws/](https://fakecloud.dev/blog/terraform-local-development-aws/) -- \`terraform local development aws\`, \`terraform local dev\`. Full provider config + tflocal + CI YAML.
- [/blog/cdk-local-testing/](https://fakecloud.dev/blog/cdk-local-testing/) -- \`cdk local testing\`, \`cdklocal\`. Full CDK flow + CI + test assertions.

**Slug-exact living landings:**
- [/mock-dynamodb/](https://fakecloud.dev/mock-dynamodb/) -- \`mock dynamodb\`, \`mock dynamodb for integration tests\`
- [/local-s3-for-tests/](https://fakecloud.dev/local-s3-for-tests/) -- \`local s3 for integration tests\`, \`mock s3\`, \`fake s3 server\`
- [/mock-sqs/](https://fakecloud.dev/mock-sqs/) -- \`mock sqs for unit tests\`, \`fake sqs\`

All framed depth-first per the reframe in #678: 100% AWS / 100% conformance / 100% cross-service integrations goal; 23 services is the shipped-today snapshot, not a ceiling.

## Test plan

- [x] \`zola build\` succeeds (62 pages, 0 orphan)
- [ ] CI green + Cubic approves

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two in-depth tutorials for Terraform and CDK local AWS workflows with fakecloud, plus three keyword-targeted landing pages for S3, DynamoDB, and SQS testing. Improves SEO for upstream queries and provides copy-paste configs for local dev and CI.

- **New Features**
  - /blog/terraform-local-development-aws/: provider endpoints block, `AWS_ENDPOINT_URL`, `tflocal`, S3 backend config, and GitHub Actions CI.
  - /blog/cdk-local-testing/: plain `cdk` with `AWS_ENDPOINT_URL`, `cdklocal`, CI setup, and synth vs deployed assertions.
  - Slug-exact landings: /mock-dynamodb/, /local-s3-for-tests/, /mock-sqs/ with short intros, multi-language SDK snippets, and real cross-service triggers (e.g., S3 -> Lambda, SQS -> Lambda). Targets queries like “mock dynamodb”, “local s3 for tests”, and “mock sqs”.

<sup>Written for commit a64e9e543bce5443fda3363f5d60616728dee9c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

