### PR TITLE
docs(seo): vs-competitor slug-exact landing pages

### DIFF
--- a/website/content/vs/_index.md
+++ b/website/content/vs/_index.md
@@ -1,0 +1,8 @@
++++
+title = "fakecloud vs other AWS testing tools"
+description = "Honest positioning comparisons between fakecloud and other AWS local emulators and mocking libraries."
+template = "vs-index.html"
+sort_by = "title"
++++
+
+Fit-based comparisons between fakecloud and other AWS testing tools. No fabricated benchmarks — honest positioning on architecture and approach.

--- a/website/content/vs/floci.md
+++ b/website/content/vs/floci.md
@@ -1,0 +1,55 @@
++++
+title = "fakecloud vs floci"
+description = "How fakecloud compares to floci. Both free, open-source AWS emulators positioned as LocalStack replacements."
+template = "page.html"
++++
+
+floci is a free, open-source AWS emulator that appeared after LocalStack replaced its Community Edition with a proprietary image in March 2026. fakecloud is another option in the same space.
+
+This page is honest positioning. I maintain fakecloud. What follows is architectural — what each project *is* — rather than side-by-side benchmarks I haven't personally measured across both.
+
+## Shared fundamentals
+
+Both are free, open-source, local AWS emulators. Real HTTP server speaking the AWS wire protocol. Any AWS SDK in any language works. Both are replacements for LocalStack Community for the services each covers.
+
+## The positioning difference
+
+**floci's approach** (check their site for the current details — the project publishes performance claims like startup time, memory, and SDK-test pass rate): a free LocalStack replacement. Verify their numbers against the version you'd actually run.
+
+**fakecloud's approach:** depth-first, explicit goal. 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. A service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in. 23 services shipped today. Built around real Lambda execution (13 runtimes in Docker), real stateful backends (Postgres/MySQL/MariaDB/Redis/Valkey via Docker), real cross-service wiring, and validation on every commit against AWS's own Smithy models (54,000+ generated test variants) plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
+
+Breadth-first and depth-first are both valid tradeoffs. Pick by whether your tests need real downstream execution and cross-service flows, or surface-level plausibility across more services.
+
+## How to pick
+
+Run your actual test suite against both. Numbers published on landing pages are marketing; numbers your tests produce against your services are signal.
+
+## fakecloud specifics
+
+| Feature | fakecloud |
+|---|---|
+| Language | Rust |
+| Distribution | Single static binary (~19 MB) + Docker image |
+| Startup | ~500ms |
+| Idle memory | ~10 MiB |
+| Services covered today | 23 (1,680 ops) at 100% conformance |
+| Lambda execution | Real code in 13 Docker runtime containers |
+| RDS | Real PostgreSQL/MySQL/MariaDB via Docker |
+| ElastiCache | Real Redis/Valkey via Docker |
+| Cross-service wiring | S3 -> Lambda, SNS fan-out, EventBridge -> Step Functions, SES inbound -> S3/SNS/Lambda, 15+ more fire end-to-end |
+| Conformance methodology | Smithy-validated, 54k+ test variants per commit |
+| Terraform TestAcc CI | Yes (upstream suites run against fakecloud) |
+| Test-assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust |
+| Multi-account, SCPs, ABAC | Yes |
+| License | AGPL-3.0 |
+
+## Install fakecloud
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **LocalStack alternative landing:** [/localstack-alternative/](/localstack-alternative/)
+- **Four-way comparison:** [/blog/localstack-alternatives-compared/](/blog/localstack-alternatives-compared/)

--- a/website/content/vs/localstack.md
+++ b/website/content/vs/localstack.md
@@ -1,0 +1,71 @@
++++
+title = "fakecloud vs LocalStack"
+description = "How fakecloud compares to LocalStack Community (post-March 2026) and LocalStack Pro. Honest positioning, feature table, migration path."
+template = "page.html"
++++
+
+Since LocalStack replaced its open-source Community Edition with a proprietary image in March 2026, `localstack:latest` now requires an account + auth token, and several previously-free services (Cognito, SES v2, RDS, ElastiCache, API Gateway v2, ECS/ECR) moved to the paid LocalStack Pro tier.
+
+**fakecloud is a free, open-source replacement.** Single binary, no account, no token, AGPL-3.0.
+
+## At a glance
+
+| | fakecloud | LocalStack Community (post-Mar 2026) | LocalStack Pro |
+|---|---|---|---|
+| License | AGPL-3.0 | Proprietary | Proprietary, paid |
+| Account / auth token | No | **Required** | Required |
+| Commercial use | Free | **Not allowed** | Paid plans only |
+| Docker required | No (single binary) | Yes | Yes |
+| Startup | ~500ms | ~3s | ~3s |
+| Idle memory | ~10 MiB | ~150 MiB | ~150 MiB |
+| Install size | ~19 MB | ~1 GB Docker image | ~1 GB Docker image |
+| Conformance methodology | Smithy-validated, 54k+ test variants on every commit | Not published | Not published |
+| Terraform TestAcc CI | Yes (upstream suites run against fakecloud) | Not published | Not published |
+| Test-assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust | Python, Java | Python, Java |
+| Cognito User Pools | 122 ops, full auth flows | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
+| SES v2 | 110 ops, send + templates + DKIM | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
+| SES inbound email | Real receipt rule action execution | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) | Stored but never executed |
+| RDS | 163 ops, real PostgreSQL/MySQL/MariaDB | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
+| ElastiCache | 75 ops, real Redis/Valkey | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
+| API Gateway v2 | 28 ops | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
+| Bedrock | 111 ops (control plane + runtime) | Not available | Not available |
+| SCPs / multi-account | Yes (Organizations control plane + ceiling enforcement) | No | Partial |
+| Lambda real code execution | Yes (13 runtimes) | Paywall required | Yes |
+
+## Approach difference
+
+**LocalStack's approach** is breadth-first — a very large catalog of AWS services at varying depth. Good for "tests need the call to resolve plausibly."
+
+**fakecloud's approach** is depth-first — fewer services today (23), each at 100% behavioral conformance with 100% of cross-service integrations. Good for "tests need the downstream actually to happen."
+
+Both are valid. Pick by whether your tests need real cross-service wiring, real Lambda execution, and real stateful backends, or whether you need surface-level plausibility across more services.
+
+## Migrating from LocalStack
+
+Most projects migrate in under 10 minutes. Full guide: [Migrating from LocalStack to fakecloud](/blog/migrate-from-localstack/).
+
+One-liner version:
+
+```diff
+# docker-compose.yml
+ services:
+   fakecloud:
+-    image: localstack/localstack:latest
++    image: ghcr.io/faiscadev/fakecloud:latest
+     ports:
+       - "4566:4566"
+```
+
+Endpoint URL, dummy credentials, all SDK wiring unchanged.
+
+## Install
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Docs:** [fakecloud.dev/docs/](/docs/)
+- **Migration guide:** [/blog/migrate-from-localstack/](/blog/migrate-from-localstack/)
+- **LocalStack alternative landing:** [/localstack-alternative/](/localstack-alternative/)

--- a/website/content/vs/ministack.md
+++ b/website/content/vs/ministack.md
@@ -1,0 +1,56 @@
++++
+title = "fakecloud vs MiniStack"
+description = "How fakecloud compares to MiniStack. Both free, open-source AWS emulators that surfaced after LocalStack's March 2026 proprietary transition."
+template = "page.html"
++++
+
+MiniStack is one of the free, open-source AWS emulators that gained momentum after LocalStack replaced its Community Edition with a proprietary image in March 2026. fakecloud is another.
+
+This page is honest positioning. I maintain fakecloud, so the bias is declared. What follows is architectural — what each project *is* — rather than fabricated side-by-side benchmarks (the surest way to get out of date in days).
+
+## Both solve the same general problem
+
+Free, open-source, local AWS emulation. Real HTTP server speaking the AWS wire protocol on port 4566. Any AWS SDK in any language works. Both are drop-in replacements for LocalStack Community for the services each covers.
+
+## The positioning difference
+
+**MiniStack's approach** (check their repo for current details — it's moving fast): positions as a free LocalStack replacement. Evaluate their service coverage and architecture directly against your test suite.
+
+**fakecloud's approach:** depth-first, explicit goal. 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. Services land one at a time; a service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in. 23 services shipped today; more progressively. Built around real Lambda execution, real stateful backends (Postgres/MySQL/MariaDB/Redis/Valkey via Docker), and real cross-service wiring, validated on every commit against AWS's own Smithy models (54,000+ generated test variants) plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
+
+These are philosophies, not rankings. Breadth-first and depth-first are different tradeoffs. A team whose tests lean lightly on many services will prefer breadth. A team whose tests exercise real cross-service flows or need real code execution will prefer depth.
+
+## How to pick
+
+1. **Open your test suite.** Count the AWS services it actually calls.
+2. **Check each tool's current supported-services list** against that set.
+3. **For the services you use, check depth:** does the tool actually execute Lambda code? Actually run Postgres? Actually fire S3 -> Lambda notifications end-to-end?
+4. **Run your actual tests against each option you're considering.** That's the only benchmark that matters for your codebase.
+
+## fakecloud specifics
+
+| Feature | fakecloud |
+|---|---|
+| Language | Rust |
+| Distribution | Single static binary (~19 MB) + Docker image |
+| Startup | ~500ms |
+| Idle memory | ~10 MiB |
+| Services covered today | 23 (1,680 ops) at 100% conformance |
+| Lambda execution | Real, 13 runtimes in Docker |
+| RDS | Real PostgreSQL/MySQL/MariaDB via Docker |
+| ElastiCache | Real Redis/Valkey via Docker |
+| Conformance methodology | Smithy-validated, 54k+ test variants on every commit |
+| Terraform TestAcc CI | Yes (upstream suites run against fakecloud) |
+| Test-assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust |
+| License | AGPL-3.0 |
+
+## Install fakecloud
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **LocalStack alternative landing:** [/localstack-alternative/](/localstack-alternative/)
+- **Four-way comparison:** [/blog/localstack-alternatives-compared/](/blog/localstack-alternatives-compared/)

--- a/website/content/vs/moto.md
+++ b/website/content/vs/moto.md
@@ -1,0 +1,98 @@
++++
+title = "fakecloud vs Moto"
+description = "How fakecloud differs from Moto. Architectural split (HTTP server vs in-process Python library), language support, cross-service wiring, Lambda execution."
+template = "page.html"
++++
+
+Moto is the longest-lived open-source AWS mocking project. Python library that patches `boto3` inside a test process. Great at what it does.
+
+fakecloud is a different tool for a different problem.
+
+## The architectural split
+
+**Moto** is an **in-process Python library**. You import it, decorate your test, it monkey-patches `boto3` SDK calls inside your test process. Very fast, zero external dependencies, trivial setup for Python. Does not speak the AWS wire protocol — it intercepts SDK method calls directly.
+
+**fakecloud** is a **real HTTP server** speaking the AWS wire protocol on port 4566. Your code uses the regular AWS SDK with `endpoint_url` set to `http://localhost:4566`. Any AWS SDK in any language works. Cross-service wiring runs server-side.
+
+## What that means practically
+
+| | fakecloud | Moto |
+|---|---|---|
+| Languages | Any (Python, Node, Go, Java, Kotlin, Rust, PHP, more) | Python only |
+| Works with Terraform | Yes | **No** (Moto is in-process, Terraform runs as a separate binary) |
+| Works with CDK | Yes | **No** (same reason) |
+| Works with AWS CLI | Yes | **No** |
+| Real Lambda execution | Yes (13 runtimes, real containers) | **No** (stubbed responses) |
+| Real RDS databases | Yes (PostgreSQL/MySQL/MariaDB via Docker) | **No** (in-memory stubs) |
+| Real ElastiCache | Yes (Redis/Valkey via Docker) | **No** |
+| Real cross-service wiring | Yes (S3 -> Lambda, SNS fan-out, etc fire end-to-end) | Partial (Moto simulates some events, not real execution) |
+| Setup for Python unit tests | HTTP endpoint override + fakecloud running | `@mock_aws` decorator |
+| Service count | 23 at 100% conformance (depth-first) | 100+ at varying depth (breadth-first) |
+| Conformance methodology | Smithy-validated, 54k+ test variants on every commit | Not published |
+| License | AGPL-3.0 | Apache-2.0 |
+
+## When Moto is the right pick
+
+- **Python-only codebase.**
+- **Unit tests** where you just need boto3 to respond with plausible shapes.
+- **Very fast test suite** where per-test process-isolated mocking is a feature.
+- **You don't exercise cross-service flows** (no Lambda execution, no real DB).
+
+Moto is excellent at this. Years of maturity, huge contributor base.
+
+## When fakecloud is the right pick
+
+- **Non-Python codebase** (Go, Node, Java, Kotlin, Rust, PHP).
+- **Integration tests** that exercise real cross-service wiring (S3 -> Lambda, EventBridge -> Step Functions, SES inbound -> S3/SNS/Lambda).
+- **Tests against Terraform, CDK, or IaC tooling** — these need a real HTTP endpoint.
+- **Tests that need Lambda to actually execute** your function code.
+- **Tests that need real stateful backends** (Postgres schema, Redis data structures).
+
+## Complementary, not competitive
+
+Lots of Python teams use both: Moto for fast-iterating unit tests inside Python, fakecloud for integration tests that span services or involve Terraform/CDK/other-language components.
+
+## Example: the same test, both ways
+
+**With Moto (Python-only):**
+
+```python
+from moto import mock_aws
+import boto3
+
+@mock_aws
+def test_put_and_get():
+    s3 = boto3.client('s3')
+    s3.create_bucket(Bucket='test')
+    s3.put_object(Bucket='test', Key='k', Body=b'v')
+    assert s3.get_object(Bucket='test', Key='k')['Body'].read() == b'v'
+```
+
+**With fakecloud (any language):**
+
+```python
+import boto3
+import os
+os.environ['AWS_ENDPOINT_URL'] = 'http://localhost:4566'
+os.environ['AWS_ACCESS_KEY_ID'] = 'test'
+os.environ['AWS_SECRET_ACCESS_KEY'] = 'test'
+
+def test_put_and_get():
+    s3 = boto3.client('s3')
+    s3.create_bucket(Bucket='test')
+    s3.put_object(Bucket='test', Key='k', Body=b'v')
+    assert s3.get_object(Bucket='test', Key='k')['Body'].read() == b'v'
+```
+
+Same test. Moto needs Python + the decorator. fakecloud needs the emulator running; the test itself is just plain boto3.
+
+## Install fakecloud
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Moto equivalent for Go/Java/Node:** [/blog/moto-equivalent-go-java-node/](/blog/moto-equivalent-go-java-node/)
+- **Moto:** [github.com/getmoto/moto](https://github.com/getmoto/moto)

--- a/website/content/vs/sam-local.md
+++ b/website/content/vs/sam-local.md
@@ -1,0 +1,64 @@
++++
+title = "fakecloud vs SAM Local"
+description = "How fakecloud compares to AWS SAM Local. Scope difference: SAM Local runs Lambda + limited API Gateway; fakecloud runs 23 services with real cross-service wiring."
+template = "page.html"
++++
+
+AWS SAM Local is AWS's official tool for running Lambda functions locally. It invokes Lambda inside a Docker container with the real AWS runtime image, and provides a limited HTTP / API Gateway surface in front.
+
+fakecloud runs Lambda the same way — real runtime containers, 13 runtimes supported — and also runs 22 other AWS services end-to-end.
+
+## Scope difference
+
+| | fakecloud | SAM Local |
+|---|---|---|
+| Lambda real code execution | Yes (13 runtimes in Docker) | Yes (13 runtimes in Docker) |
+| API Gateway v2 | 28 ops, HTTP APIs, JWT/Lambda authorizers | Limited (REST API emulation) |
+| API Gateway v1 | Not yet | Yes (SAM focuses here) |
+| S3 | 107 ops, real storage + notifications | **No** |
+| SQS | 23 ops, real queues + event source mappings | **No** |
+| SNS | 42 ops, real fan-out | **No** |
+| DynamoDB | 57 ops, transactions, PartiQL, streams | **No** |
+| EventBridge | 57 ops + Scheduler (12 ops) | **No** |
+| Step Functions | 37 ops, full ASL interpreter | **No** |
+| RDS | 163 ops, real PostgreSQL/MySQL/MariaDB | **No** |
+| Cognito | 122 ops, full auth flows | **No** |
+| Cross-service triggers | S3 -> Lambda, SQS -> Lambda, SNS -> Lambda, EventBridge -> Lambda all fire | Synthetic events only (you generate JSON and hand it to your handler) |
+
+## The difference in practice
+
+**SAM Local's model:** run your Lambda. If your Lambda reads from DynamoDB, you run your Lambda against fake event JSON you generate. The DynamoDB side is not emulated — you mock or point at real AWS.
+
+**fakecloud's model:** run your Lambda *and* the services it talks to. If your Lambda reads from DynamoDB, fakecloud runs the DynamoDB. If it's triggered by S3 upload, fakecloud fires the trigger for real when the upload happens. If it publishes to SNS, the topic actually fans out to subscribers.
+
+## When SAM Local is the right pick
+
+- **You're only building a Lambda function** (nothing else to emulate).
+- **Your Lambda reads from fixed data** or pointed at a shared/staging AWS.
+- **You're heavy on SAM templates / CloudFormation** and want AWS's own SAM tooling.
+- **You need API Gateway v1** specifically (fakecloud supports v2; v1 is on the roadmap).
+
+## When fakecloud is the right pick
+
+- **Your Lambda talks to other AWS services** (DynamoDB, SQS, SNS, S3, Cognito, etc) — fakecloud runs them.
+- **Your Lambda is triggered by other services** (S3 PutObject, SQS message, EventBridge rule) — fakecloud fires the trigger end-to-end.
+- **You want to test the whole system locally**, not just the function handler.
+- **You're not on SAM templates** — fakecloud supports CDK, Terraform, serverless-framework, or no IaC at all.
+
+## Using both
+
+Some teams run SAM Local for Lambda synthesis + local invoke, and fakecloud for the rest of AWS behind the function. This works — they don't conflict.
+
+## Install fakecloud
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Lambda in fakecloud works the same way SAM Local does: pull the runtime container, mount your code, invoke the handler. The difference is everything else in the system also runs.
+
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Test Lambda locally:** [/test-lambda-locally/](/test-lambda-locally/)
+- **Full Lambda tutorial:** [/blog/test-lambda-locally/](/blog/test-lambda-locally/)
+- **CDK local testing:** [/blog/cdk-local-testing/](/blog/cdk-local-testing/)

--- a/website/templates/vs-index.html
+++ b/website/templates/vs-index.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}{{ section.title }} - {{ config.title }}{% endblock %}
+{% block description %}{{ section.description | default(value=config.description) }}{% endblock %}
+
+{% block content %}
+<article class="blog-article">
+  <h1>{{ section.title }}</h1>
+  {% if section.description %}<p class="section-sub">{{ section.description }}</p>{% endif %}
+  {{ section.content | safe }}
+  <ul>
+    {% for page in section.pages %}
+    <li><a href="{{ page.permalink }}">{{ page.title }}</a>{% if page.description %} — {{ page.description }}{% endif %}</li>
+    {% endfor %}
+  </ul>
+</article>
+{% endblock %}


### PR DESCRIPTION
## Summary

Batch 3B. 5 vs-competitor landing pages with slug-exact URLs that match \`fakecloud vs X\` queries. Honest positioning, no fabricated benchmarks.

- [/vs/localstack/](https://fakecloud.dev/vs/localstack/) — full feature table, one-line migration diff
- [/vs/moto/](https://fakecloud.dev/vs/moto/) — architectural split, side-by-side test code
- [/vs/ministack/](https://fakecloud.dev/vs/ministack/) — depth-first positioning, no measured numbers across competitor
- [/vs/floci/](https://fakecloud.dev/vs/floci/) — same treatment
- [/vs/sam-local/](https://fakecloud.dev/vs/sam-local/) — scope difference (Lambda-only vs 23-service)

All reframed depth-first per #678. fakecloud's goal is 100% AWS / 100% conformance / 100% cross-service integrations, progressively.

New template \`vs-index.html\` for the section landing at \`/vs/\` — existing \`page.html\` uses \`page.title\` which doesn't resolve for section indexes.

## Test plan

- [x] \`zola build\` succeeds (62 pages, 9 sections)
- [ ] CI green + Cubic approves

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five SEO-focused competitor pages under /vs/ with slug-exact URLs for “fakecloud vs X” searches, plus a `/vs/` section index using a new template. Improves discoverability and gives honest positioning and migration guidance.

- **New Features**
  - Added pages: `/vs/localstack/`, `/vs/moto/`, `/vs/ministack/`, `/vs/floci/`, `/vs/sam-local/`.
  - Page focus: LocalStack (feature table + one-line migration diff), Moto (HTTP server vs in-process; side-by-side test), MiniStack & floci (depth-first positioning; no fabricated benchmarks), SAM Local (Lambda-only vs 23-service scope).
  - New `/vs/` section landing using `vs-index.html` (supports `section.title`/description and lists comparison pages).

<sup>Written for commit 046309712924fbae9f3d49ac4c17a395461b53b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

