### PR TITLE
docs(seo): JSON-LD structured data + OpenGraph + canonical links

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -5,6 +5,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{% block title %}{{ config.title }}{% endblock %}</title>
 <meta name="description" content="{% block description %}{{ config.description }}{% endblock %}">
+<meta property="og:title" content="{% block og_title %}{{ config.title }}{% endblock %}">
+<meta property="og:description" content="{% block og_description %}{{ config.description }}{% endblock %}">
+<meta property="og:type" content="{% block og_type %}website{% endblock %}">
+<meta property="og:url" content="{% block og_url %}{{ current_url | default(value=config.base_url) }}{% endblock %}">
+<meta property="og:site_name" content="fakecloud">
+<meta name="twitter:card" content="summary">
+{% block canonical %}{% if current_url %}<link rel="canonical" href="{{ current_url }}">{% endif %}{% endblock %}
 <link rel="help" href="/llms.txt" type="text/markdown" title="LLM documentation">
 {% if config.generate_feeds %}
 <link rel="alternate" type="application/rss+xml" title="fakecloud blog" href="{{ get_url(path='rss.xml') }}">
@@ -12,6 +19,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" href="/favicon.ico">
 <link rel="stylesheet" href="/style.css">
+{% block structured_data %}{% endblock %}
 <script>
   (function() {
     var t = localStorage.getItem('theme');

--- a/website/templates/blog-page.html
+++ b/website/templates/blog-page.html
@@ -2,6 +2,39 @@
 
 {% block title %}{{ page.title }} - {{ config.title }}{% endblock %}
 {% block description %}{{ page.description }}{% endblock %}
+{% block og_title %}{{ page.title }}{% endblock %}
+{% block og_description %}{{ page.description }}{% endblock %}
+{% block og_type %}article{% endblock %}
+{% block og_url %}{{ page.permalink }}{% endblock %}
+{% block canonical %}<link rel="canonical" href="{{ page.permalink }}">{% endblock %}
+
+{% block structured_data %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ page.title | json_encode | safe }},
+  "description": {{ page.description | json_encode | safe }},
+  "datePublished": "{{ page.date | date(format='%Y-%m-%d') }}",
+  "dateModified": "{{ page.date | date(format='%Y-%m-%d') }}",
+  "author": {
+    "@type": "Person",
+    "name": "{{ page.extra.author | default(value='Lucas Vieira') }}",
+    "url": "https://github.com/vieiralucas"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "fakecloud",
+    "url": "https://fakecloud.dev"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ page.permalink }}"
+  },
+  "url": "{{ page.permalink }}"
+}
+</script>
+{% endblock %}
 
 {% block content %}
 <article class="blog-article">

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -3,6 +3,54 @@
 {% block title %}fakecloud - Local AWS Cloud Emulator{% endblock %}
 {% block description %}fakecloud is a free, open-source local AWS cloud emulator. Single binary, no auth required, no paid tier, plus first-party SDKs for test assertions.{% endblock %}
 
+{% block structured_data %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "fakecloud",
+  "applicationCategory": "DeveloperApplication",
+  "applicationSubCategory": "CloudTestingTool",
+  "operatingSystem": "Linux, macOS, Windows",
+  "description": "Free, open-source local AWS cloud emulator. 23 services, 1,680 operations, 100% conformance per implemented service. Single binary, no account, no auth token.",
+  "url": "https://fakecloud.dev",
+  "downloadUrl": "https://github.com/faiscadev/fakecloud/releases",
+  "codeRepository": "https://github.com/faiscadev/fakecloud",
+  "programmingLanguage": "Rust",
+  "license": "https://www.gnu.org/licenses/agpl-3.0.html",
+  "isAccessibleForFree": true,
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "author": {
+    "@type": "Person",
+    "name": "Lucas Vieira",
+    "url": "https://github.com/vieiralucas"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "faisca",
+    "url": "https://faisca.dev"
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "fakecloud",
+  "url": "https://fakecloud.dev",
+  "description": "Free, open-source local AWS cloud emulator written in Rust.",
+  "publisher": {
+    "@type": "Organization",
+    "name": "faisca"
+  }
+}
+</script>
+{% endblock %}
+
 {% block content %}
 <section class="hero">
   <div class="container">

--- a/website/templates/page.html
+++ b/website/templates/page.html
@@ -2,6 +2,42 @@
 
 {% block title %}{{ page.title }} - {{ config.title }}{% endblock %}
 {% block description %}{{ page.description | default(value=config.description) }}{% endblock %}
+{% block og_title %}{{ page.title }}{% endblock %}
+{% block og_description %}{{ page.description | default(value=config.description) }}{% endblock %}
+{% block og_url %}{{ page.permalink }}{% endblock %}
+{% block canonical %}<link rel="canonical" href="{{ page.permalink }}">{% endblock %}
+
+{% block structured_data %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": {{ page.title | json_encode | safe }},
+  "description": {{ page.description | default(value=config.description) | json_encode | safe }},
+  "author": {
+    "@type": "Person",
+    "name": "Lucas Vieira",
+    "url": "https://github.com/vieiralucas"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "fakecloud",
+    "url": "https://fakecloud.dev"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ page.permalink }}"
+  },
+  "url": "{{ page.permalink }}",
+  "about": {
+    "@type": "SoftwareApplication",
+    "name": "fakecloud",
+    "applicationCategory": "DeveloperApplication",
+    "url": "https://fakecloud.dev"
+  }
+}
+</script>
+{% endblock %}
 
 {% block content %}
 <article class="blog-article">


### PR DESCRIPTION
## Summary

Batch 3C. Adds structured data to the site templates so search engines produce rich snippets and LLMs can parse key facts from schema.org fields instead of free-text description.

**Changes to templates:**
- \`base.html\`: OpenGraph + twitter:card meta tags (social previews), canonical link block, \`structured_data\` block hook for child templates.
- \`index.html\`: \`SoftwareApplication\` + \`WebSite\` JSON-LD on homepage. Marks fakecloud as a free developer tool with license=AGPL-3.0, price=0, codeRepository, downloadUrl.
- \`blog-page.html\`: \`BlogPosting\` JSON-LD per post (date, author, publisher).
- \`page.html\`: \`TechArticle\` JSON-LD per landing page with \`about: SoftwareApplication\` pointing back at fakecloud. Canonical link explicit — important because Dev.to cross-posts set \`canonical_url\` pointing here.

**Why it matters:** when Dev.to posts go up with canonical_url -> fakecloud.dev, Google needs to see a matching canonical link on the fakecloud.dev side to fully honor the de-duplication. Structured data also surfaces in AI Overview panels, Claude/ChatGPT citation extractions, and Google Knowledge Graph.

## Test plan

- [x] \`zola build\` succeeds (57 pages, 0 orphan)
- [x] Grep'd rendered output, JSON-LD present on \`/\`, \`/localstack-alternative/\`, \`/blog/migrate-from-localstack/\`
- [ ] CI green + Cubic approves
- [ ] After merge: validate with Google Rich Results Test (https://search.google.com/test/rich-results) on a few URLs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add JSON-LD structured data, OpenGraph/Twitter meta tags, and canonical links across site templates. Improves rich results, social previews, and Dev.to canonical de-duplication.

- **New Features**
  - `base.html`: Add OpenGraph + `twitter:card` tags, canonical link block, and a `structured_data` block hook.
  - `index.html`: Add `SoftwareApplication` + `WebSite` JSON-LD (AGPL-3.0 license, price 0, repo, download URL, OS).
  - `blog-page.html`: Add `BlogPosting` JSON-LD (headline, description, dates, author, publisher) and set canonical to the post permalink.
  - `page.html`: Add `TechArticle` JSON-LD with `about: SoftwareApplication` pointing to fakecloud and set canonical to the page permalink.

<sup>Written for commit e14b4ccb54b748f25a6fcef016a45b6416ec7a6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

