### PR TITLE
docs(seo): address Cubic findings on SEO landings

### DIFF
--- a/website/content/blog/cdk-local-testing.md
+++ b/website/content/blog/cdk-local-testing.md
@@ -125,6 +125,7 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
           fakecloud &
           for i in $(seq 1 30); do curl -sf http://localhost:4566/_fakecloud/health && break; sleep 1; done
+          curl -sf http://localhost:4566/_fakecloud/health
 
       - run: npm ci
       - run: npx cdk bootstrap

--- a/website/content/blog/terraform-local-development-aws.md
+++ b/website/content/blog/terraform-local-development-aws.md
@@ -161,6 +161,10 @@ resource "aws_s3_bucket_notification" "uploads_to_sqs" {
     events    = ["s3:ObjectCreated:*"]
   }
 }
+
+output "bucket_id" {
+  value = aws_s3_bucket.uploads.id
+}
 ```
 
 Apply it against fakecloud:
@@ -198,6 +202,7 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
           fakecloud &
           for i in $(seq 1 30); do curl -sf http://localhost:4566/_fakecloud/health && break; sleep 1; done
+          curl -sf http://localhost:4566/_fakecloud/health
 
       - name: terraform init
         run: terraform init

--- a/website/content/mock-dynamodb.md
+++ b/website/content/mock-dynamodb.md
@@ -130,5 +130,5 @@ If you need multi-language, free, real Lambda triggers, depth-first conformance:
 
 - **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
 - **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
-- **DynamoDB docs:** [fakecloud.dev/docs/services/dynamodb](/docs/services/)
+- **DynamoDB docs:** [fakecloud.dev/docs/services/dynamodb](/docs/services/dynamodb/)
 - **Related:** [Fake AWS server for tests](/fake-aws-server/), [Test Lambda locally](/test-lambda-locally/), [Integration testing AWS in CI](/blog/integration-testing-aws-in-ci/)

--- a/website/content/test-lambda-locally.md
+++ b/website/content/test-lambda-locally.md
@@ -13,7 +13,7 @@ fakecloud
 
 ## What you get
 
-- **All 13 AWS Lambda runtimes** — Node 18/20/22, Python 3.9-3.12, Java 11/17/21, .NET 6/8, Ruby 3.2, Go, custom (`provided.al2`, `provided.al2023`).
+- **All 13 AWS Lambda runtimes** — Node 18/20/22, Python 3.11/3.12/3.13, Java 17/21, .NET 8, Ruby 3.3/3.4, custom (`provided.al2`, `provided.al2023`).
 - **Real code execution.** fakecloud pulls the AWS Lambda runtime container and runs your handler. Not a stub, not a simulated response.
 - **Real event triggers.** S3 -> Lambda, SQS -> Lambda, SNS -> Lambda, EventBridge -> Lambda, DynamoDB Streams -> Lambda, API Gateway v2 -> Lambda. All wired end-to-end.
 - **Real event source mappings.** fakecloud polls SQS/Kinesis, batches events, invokes your Lambda, handles success/failure/DLQ the way AWS does.


### PR DESCRIPTION
## Summary

Fixes 5 Cubic review findings across the recent SEO batch:

- **#676 `test-lambda-locally.md`:** the "All 13 AWS Lambda runtimes" bullet listed 15+ entries that didn't match what fakecloud actually ships. Replaced with the real supported set (Node 18/20/22, Python 3.11/3.12/3.13, Java 17/21, .NET 8, Ruby 3.3/3.4, `provided.al2`/`provided.al2023`) — 13 total, matching `crates/fakecloud-lambda/src/runtime.rs`.
- **#679 `mock-dynamodb.md`:** "DynamoDB docs" link pointed to the services index (`/docs/services/`) instead of the DynamoDB page (`/docs/services/dynamodb/`).
- **#679 `blog/cdk-local-testing.md` + `blog/terraform-local-development-aws.md` (2x):** the `for i in \$(seq 1 30); do curl -sf … && break; sleep 1; done` health-wait loop exits 0 even when fakecloud never becomes ready (the final `sleep 1` is the loop's exit status). Added a trailing `curl -sf` so the CI step fails explicitly on timeout.
- **#679 `blog/terraform-local-development-aws.md`:** the sample command used `\$(terraform output -raw bucket_id)` but no `output "bucket_id"` block was defined. Added the missing output so the documented flow works as copy-pasted.

## Test plan

- [x] Diff reviewed — 4 files, 8 insertions, 2 deletions.
- [x] Runtime count verified against `crates/fakecloud-lambda/src/runtime.rs` (13 entries match).
- [x] `/docs/services/dynamodb/` confirmed to exist (`website/content/docs/services/dynamodb.md`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five SEO-related doc issues found by Cubic across four pages. Updates the Lambda runtime list, corrects a DynamoDB link, hardens CI health checks, and adds a missing Terraform output.

- **Bug Fixes**
  - `test-lambda-locally.md`: Replace runtime list with the actual 13 supported runtimes — Node 18/20/22; Python 3.11/3.12/3.13; Java 17/21; .NET 8; Ruby 3.3/3.4; `provided.al2`/`provided.al2023`.
  - `mock-dynamodb.md`: Point “DynamoDB docs” to `/docs/services/dynamodb/`.
  - `blog/cdk-local-testing.md` and `blog/terraform-local-development-aws.md`: Add a trailing `curl -sf` after the wait loop so CI fails if fakecloud never becomes ready.
  - `blog/terraform-local-development-aws.md`: Add `output "bucket_id"` to match the documented `terraform output -raw bucket_id`.

<sup>Written for commit 9b75eae35e0cf66346a46454173cbbec014dd0e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

