### PR TITLE
docs(seo): 6 more slug-exact mock-X/local-X landings

### DIFF
--- a/website/content/local-elasticache.md
+++ b/website/content/local-elasticache.md
@@ -1,0 +1,125 @@
++++
+title = "Local ElastiCache for integration tests"
+description = "Run local ElastiCache for integration tests with fakecloud. 75 operations, real Redis/Valkey via Docker, replication groups, serverless caches. Free, no account required."
+template = "page.html"
++++
+
+Need local ElastiCache for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point your AWS SDK at `http://localhost:4566`. Docker required because fakecloud runs **real** Redis / Valkey.
+
+## Why fakecloud for ElastiCache
+
+- **75 ElastiCache operations** at 100% conformance — cache clusters, replication groups, global replication groups, serverless caches and snapshots, subnet groups, users / user groups, failover, tagging.
+- **Real Redis and real Valkey.** fakecloud pulls real Redis / Valkey Docker images and runs them as the ElastiCache node. Your `LPUSH`, `ZADD`, `XADD`, streams, pub/sub, Lua scripts — all work because the engine is real.
+- **Endpoint works.** `DescribeCacheClusters` returns a real connectable host. Your application connects with a regular Redis client (redis-py, ioredis, lettuce, go-redis).
+- **Paid on LocalStack; free here.** ElastiCache has always been LocalStack Pro-only.
+- **No account, no auth token, no paid tier.** AGPL-3.0.
+
+## Create a Redis cluster
+
+```sh
+aws --endpoint-url http://localhost:4566 elasticache create-cache-cluster \
+  --cache-cluster-id mycache \
+  --engine redis \
+  --cache-node-type cache.t3.micro \
+  --num-cache-nodes 1
+```
+
+Get the endpoint:
+
+```sh
+aws --endpoint-url http://localhost:4566 elasticache describe-cache-clusters \
+  --cache-cluster-id mycache \
+  --show-cache-node-info \
+  --query 'CacheClusters[0].CacheNodes[0].Endpoint'
+```
+
+Connect:
+
+```sh
+redis-cli -h <endpoint> -p 6379
+```
+
+Real Redis — all commands work, including `CLIENT LIST`, `INFO`, `CONFIG GET`, modules.
+
+## Valkey
+
+```sh
+aws --endpoint-url http://localhost:4566 elasticache create-cache-cluster \
+  --cache-cluster-id mycache \
+  --engine valkey \
+  --cache-node-type cache.t3.micro \
+  --num-cache-nodes 1
+```
+
+Valkey is API-compatible with Redis.
+
+## Replication groups
+
+```sh
+aws --endpoint-url http://localhost:4566 elasticache create-replication-group \
+  --replication-group-id my-rg \
+  --replication-group-description "test rg" \
+  --engine redis \
+  --cache-node-type cache.t3.micro \
+  --num-node-groups 1 \
+  --replicas-per-node-group 1
+```
+
+Real primary + replica nodes via Redis replication.
+
+## Serverless caches
+
+```sh
+aws --endpoint-url http://localhost:4566 elasticache create-serverless-cache \
+  --serverless-cache-name myserverless \
+  --engine redis
+```
+
+## In tests
+
+```ts
+import { ElastiCacheClient, CreateCacheClusterCommand, DescribeCacheClustersCommand } from '@aws-sdk/client-elasticache';
+import { createClient } from 'redis';
+
+const ec = new ElastiCacheClient({ endpoint: 'http://localhost:4566' });
+
+beforeAll(async () => {
+  await ec.send(new CreateCacheClusterCommand({
+    CacheClusterId: 'test',
+    Engine: 'redis',
+    CacheNodeType: 'cache.t3.micro',
+    NumCacheNodes: 1,
+  }));
+  // ... poll for "available" ...
+});
+
+test('app caches via real redis behind ElastiCache emulation', async () => {
+  const redis = createClient({ url: 'redis://localhost:6379' });
+  await redis.connect();
+  await redis.set('key', 'value');
+  expect(await redis.get('key')).toBe('value');
+});
+```
+
+## How it differs from alternatives
+
+| Tool | Real Redis | Real Valkey | Replication groups | Serverless caches | Price |
+|---|---|---|---|---|---|
+| fakecloud | Yes (Docker) | Yes (Docker) | Yes | Yes | Free |
+| LocalStack Pro | Yes | Yes | Yes | Partial | Paid |
+| LocalStack Community | **No** | **No** | — | — | — (not available) |
+| Plain `docker run redis` | Yes | N/A | Manual | N/A | Free, but no ElastiCache API |
+| Moto | Stubbed | Stubbed | Stubbed | Stubbed | Free |
+
+## Links
+
+- **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Related:** [Local RDS for tests](/local-rds/), [Fake AWS server for tests](/fake-aws-server/)

--- a/website/content/local-rds.md
+++ b/website/content/local-rds.md
@@ -1,0 +1,153 @@
++++
+title = "Local RDS for integration tests"
+description = "Run local RDS for integration tests with fakecloud. 163 RDS operations, real PostgreSQL/MySQL/MariaDB engines via Docker, snapshots, read replicas. Free, AGPL-3.0."
+template = "page.html"
++++
+
+Need local RDS for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point your AWS SDK at `http://localhost:4566`. Docker required because fakecloud runs **real** PostgreSQL/MySQL/MariaDB engines.
+
+## Why fakecloud for RDS
+
+- **163 RDS operations** at 100% conformance — DB instances, snapshots, read replicas, parameter groups, subnet groups, engine/version discovery, tagging, upgrades.
+- **Real database engines.** fakecloud pulls real PostgreSQL / MySQL / MariaDB Docker images and runs them as the RDS instance. Your SQL schema, indexes, triggers, and extensions all work because they are real Postgres/MySQL/MariaDB.
+- **Endpoint works.** `DescribeDBInstances` returns a real connectable host. Your application connects with the usual PostgreSQL / MySQL / MariaDB driver.
+- **Paid on LocalStack; free here.** RDS has always been LocalStack Pro-only.
+- **No account, no auth token, no paid tier.** AGPL-3.0.
+
+## Create a PostgreSQL instance
+
+```sh
+aws --endpoint-url http://localhost:4566 rds create-db-instance \
+  --db-instance-identifier mydb \
+  --engine postgres \
+  --engine-version 16 \
+  --db-instance-class db.t3.micro \
+  --allocated-storage 20 \
+  --master-username admin \
+  --master-user-password password \
+  --publicly-accessible
+
+aws --endpoint-url http://localhost:4566 rds wait db-instance-available \
+  --db-instance-identifier mydb
+```
+
+Get the endpoint:
+
+```sh
+aws --endpoint-url http://localhost:4566 rds describe-db-instances \
+  --db-instance-identifier mydb \
+  --query 'DBInstances[0].Endpoint'
+```
+
+Connect with psql (or any Postgres driver):
+
+```sh
+PGPASSWORD=password psql -h <endpoint> -p 5432 -U admin -d postgres
+```
+
+It's a real Postgres 16. `\l`, `CREATE EXTENSION pg_trgm`, `CREATE TRIGGER`, JSONB — all work.
+
+## MySQL / MariaDB
+
+```sh
+aws --endpoint-url http://localhost:4566 rds create-db-instance \
+  --db-instance-identifier mydb \
+  --engine mysql \
+  --engine-version 8.0 \
+  --db-instance-class db.t3.micro \
+  --allocated-storage 20 \
+  --master-username admin \
+  --master-user-password password
+```
+
+`--engine mariadb` for MariaDB.
+
+## Snapshots
+
+```sh
+aws --endpoint-url http://localhost:4566 rds create-db-snapshot \
+  --db-instance-identifier mydb \
+  --db-snapshot-identifier before-migration
+
+# ... do stuff that might break ...
+
+aws --endpoint-url http://localhost:4566 rds restore-db-instance-from-db-snapshot \
+  --db-instance-identifier mydb-restored \
+  --db-snapshot-identifier before-migration
+```
+
+Real snapshot — pg_dump / mysqldump of the running instance.
+
+## Read replicas
+
+```sh
+aws --endpoint-url http://localhost:4566 rds create-db-instance-read-replica \
+  --db-instance-identifier mydb-replica \
+  --source-db-instance-identifier mydb
+```
+
+Real streaming replication on the Postgres side; binlog replication on MySQL/MariaDB.
+
+## In tests
+
+```ts
+import { RDSClient, CreateDBInstanceCommand, waitUntilDBInstanceAvailable } from '@aws-sdk/client-rds';
+import { Client } from 'pg';
+
+const rds = new RDSClient({ endpoint: 'http://localhost:4566' });
+
+beforeAll(async () => {
+  await rds.send(new CreateDBInstanceCommand({
+    DBInstanceIdentifier: 'test-db',
+    Engine: 'postgres',
+    EngineVersion: '16',
+    DBInstanceClass: 'db.t3.micro',
+    AllocatedStorage: 20,
+    MasterUsername: 'admin',
+    MasterUserPassword: 'password',
+  }));
+  await waitUntilDBInstanceAvailable(
+    { client: rds, maxWaitTime: 60 },
+    { DBInstanceIdentifier: 'test-db' }
+  );
+});
+
+test('app writes to real postgres via RDS emulation', async () => {
+  const pg = new Client({
+    host: 'localhost', port: 5432,
+    user: 'admin', password: 'password', database: 'postgres',
+  });
+  await pg.connect();
+  await pg.query('CREATE TABLE t (id int)');
+  await pg.query('INSERT INTO t VALUES (1)');
+  const r = await pg.query('SELECT * FROM t');
+  expect(r.rows).toEqual([{ id: 1 }]);
+});
+```
+
+Your Postgres integration tests run against a real Postgres that RDS manages. No compromises.
+
+## How it differs from alternatives
+
+| Tool | Real Postgres | Real MySQL | Snapshots | Read replicas | Price |
+|---|---|---|---|---|---|
+| fakecloud | Yes (Docker) | Yes (Docker) | Yes | Yes | Free |
+| LocalStack Pro | Yes | Yes | Yes | Yes | Paid |
+| LocalStack Community | **No** | No | No | No | — (not available) |
+| Plain `docker run postgres` | Yes (DB only) | Yes | Manual | Manual | Free, but no RDS API |
+| Moto | Stubbed | Stubbed | Stubbed | Stubbed | Free |
+
+If you want the RDS API + real engines without paying LocalStack Pro, fakecloud is the option.
+
+## Links
+
+- **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Related:** [Local ElastiCache for tests](/local-elasticache/), [Fake AWS server for tests](/fake-aws-server/)

--- a/website/content/mock-cognito.md
+++ b/website/content/mock-cognito.md
@@ -1,0 +1,144 @@
++++
+title = "Mock Cognito for tests"
+description = "Mock AWS Cognito User Pools locally for integration tests with fakecloud. 122 operations, full auth flows (USER_PASSWORD_AUTH, USER_SRP_AUTH, CUSTOM_AUTH), MFA, identity providers, triggers."
+template = "page.html"
++++
+
+Need to mock AWS Cognito for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point your AWS SDK at `http://localhost:4566`.
+
+## Why fakecloud for Cognito
+
+- **122 Cognito User Pools operations** at 100% conformance — user pools, app clients, users, groups, MFA (SMS, TOTP, WebAuthn), identity providers (Google, Facebook, SAML, OIDC), resource servers, domains, devices.
+- **Full authentication flows** — `USER_PASSWORD_AUTH`, `USER_SRP_AUTH`, `REFRESH_TOKEN_AUTH`, `CUSTOM_AUTH`, `ADMIN_USER_PASSWORD_AUTH`. Real SRP crypto, real JWTs signed with per-pool keys.
+- **Triggers fire.** Pre-sign-up, post-confirmation, pre-token-generation, custom-message, custom-auth triggers all invoke your Lambda for real.
+- **Confirmation code introspection.** Tests read codes via `/_fakecloud/cognito/confirmation-codes` without checking email.
+- **Cognito as an SNS/SES consumer.** Verification emails/SMS flow through the real SES/SNS emulation — test assertions work on those too.
+- **Paid on LocalStack; free here.** Cognito moved to LocalStack Pro in March 2026.
+- **No account, no auth token, no paid tier.** AGPL-3.0.
+
+## Create a user pool
+
+```python
+import boto3
+cog = boto3.client('cognito-idp',
+    endpoint_url='http://localhost:4566',
+    aws_access_key_id='test',
+    aws_secret_access_key='test',
+    region_name='us-east-1')
+
+pool = cog.create_user_pool(PoolName='my-pool', AutoVerifiedAttributes=['email'])
+client = cog.create_user_pool_client(
+    UserPoolId=pool['UserPool']['Id'],
+    ClientName='web',
+    ExplicitAuthFlows=['ALLOW_USER_PASSWORD_AUTH', 'ALLOW_REFRESH_TOKEN_AUTH'])
+```
+
+## Sign up + confirm + authenticate
+
+```python
+# Sign up
+cog.sign_up(
+    ClientId=client['UserPoolClient']['ClientId'],
+    Username='alice@example.com',
+    Password='Str0ng!Passw0rd',
+    UserAttributes=[{'Name': 'email', 'Value': 'alice@example.com'}])
+
+# Fetch the confirmation code from the test introspection endpoint
+import requests
+codes = requests.get('http://localhost:4566/_fakecloud/cognito/confirmation-codes').json()
+code = codes['codes'][0]['code']
+
+cog.confirm_sign_up(
+    ClientId=client['UserPoolClient']['ClientId'],
+    Username='alice@example.com',
+    ConfirmationCode=code)
+
+# Authenticate
+auth = cog.initiate_auth(
+    ClientId=client['UserPoolClient']['ClientId'],
+    AuthFlow='USER_PASSWORD_AUTH',
+    AuthParameters={'USERNAME': 'alice@example.com', 'PASSWORD': 'Str0ng!Passw0rd'})
+
+# auth['AuthenticationResult'] has real AccessToken, IdToken, RefreshToken
+```
+
+The tokens are real signed JWTs — your application's JWT verification (with jwks_uri pointing at the fakecloud public key endpoint) works unchanged.
+
+## SRP authentication
+
+```python
+# USER_SRP_AUTH — real SRP handshake, same as AWS
+auth = cog.initiate_auth(
+    ClientId=client['UserPoolClient']['ClientId'],
+    AuthFlow='USER_SRP_AUTH',
+    AuthParameters={'USERNAME': 'alice@example.com', 'SRP_A': '<srp-A value>'})
+
+# Returns SRP_B + challenge params
+# Client responds with PASSWORD_VERIFIER challenge
+auth2 = cog.respond_to_auth_challenge(
+    ClientId=client['UserPoolClient']['ClientId'],
+    ChallengeName='PASSWORD_VERIFIER',
+    ChallengeResponses={
+        'USERNAME': 'alice@example.com',
+        'PASSWORD_CLAIM_SIGNATURE': '<signature>',
+        'PASSWORD_CLAIM_SECRET_BLOCK': auth['ChallengeParameters']['SECRET_BLOCK'],
+        'TIMESTAMP': '<timestamp>',
+    })
+```
+
+Real crypto — same SRP-6a parameters AWS uses.
+
+## MFA
+
+TOTP and SMS MFA. Verification codes readable from `/_fakecloud/cognito/confirmation-codes` with type filter.
+
+## Triggers (Lambda)
+
+```python
+cog.update_user_pool(
+    UserPoolId=pool['UserPool']['Id'],
+    LambdaConfig={
+        'PreSignUp': 'arn:aws:lambda:us-east-1:000000000000:function:pre-signup',
+        'PostConfirmation': 'arn:aws:lambda:us-east-1:000000000000:function:post-confirmation',
+        'PreTokenGeneration': 'arn:aws:lambda:us-east-1:000000000000:function:pre-token',
+    })
+```
+
+Triggers invoke your Lambda with the Cognito event shape. Not stubbed — the function runs in a real runtime container.
+
+## Assertions
+
+```ts
+import { FakeCloud } from 'fakecloud';
+const fc = new FakeCloud();
+
+// Alice just signed up
+const { codes } = await fc.cognito.getConfirmationCodes({ username: 'alice@example.com' });
+expect(codes).toHaveLength(1);
+
+// Your app should have called the pre-signup Lambda
+const { invocations } = await fc.lambda.getInvocations({ functionName: 'pre-signup' });
+expect(invocations).toHaveLength(1);
+```
+
+## How it differs from alternatives
+
+| Tool | Multi-language | Full SRP | Real JWT signing | Triggers execute | Price |
+|---|---|---|---|---|---|
+| fakecloud | Any | Yes | Yes | Yes (real Lambda runs) | Free |
+| LocalStack Community | Any | — | — | — | **Paid only** (post Mar 2026) |
+| cognito-local | Node only | Partial | Yes | No | Free |
+| Moto (mock_cognitoidp) | Python only | Stubbed | Stubbed | Stubbed | Free |
+
+## Links
+
+- **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Related:** [Fake AWS server for tests](/fake-aws-server/), [Test Lambda locally](/test-lambda-locally/)

--- a/website/content/mock-kms.md
+++ b/website/content/mock-kms.md
@@ -1,0 +1,105 @@
++++
+title = "Mock KMS for tests"
+description = "Mock AWS KMS locally for integration tests with fakecloud. 53 KMS operations, real ECDH, encryption/decryption, aliases, grants, key import, multi-region keys. Any AWS SDK, free."
+template = "page.html"
++++
+
+Need to mock AWS KMS for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point your AWS SDK at `http://localhost:4566`.
+
+## Why fakecloud for KMS
+
+- **53 KMS operations** at 100% conformance — symmetric and asymmetric keys, encrypt/decrypt, aliases, grants, data key generation, real ECDH, key import, multi-region keys, key policies.
+- **Real cryptography.** Encrypt/decrypt operations use real AES-GCM / RSA / ECDSA / ECDH primitives. Output ciphertexts are cryptographically meaningful, not opaque stubs.
+- **Any AWS SDK in any language.** Real HTTP server on port 4566.
+- **KMS key policies enforced.** Opt-in `--iam strict` mode validates key-policy Principal/Condition semantics with AWS's cross-account combining rules.
+- **No account, no auth token, no paid tier.** AGPL-3.0.
+
+## Quick examples
+
+### Python (boto3)
+
+```python
+import boto3
+kms = boto3.client('kms',
+    endpoint_url='http://localhost:4566',
+    aws_access_key_id='test',
+    aws_secret_access_key='test',
+    region_name='us-east-1')
+
+key = kms.create_key(Description='test-key')
+key_id = key['KeyMetadata']['KeyId']
+
+ct = kms.encrypt(KeyId=key_id, Plaintext=b'secret data')
+pt = kms.decrypt(KeyId=key_id, CiphertextBlob=ct['CiphertextBlob'])
+assert pt['Plaintext'] == b'secret data'
+```
+
+### AWS CLI
+
+```sh
+aws --endpoint-url http://localhost:4566 kms create-key --description "test-key"
+aws --endpoint-url http://localhost:4566 kms encrypt \
+  --key-id <key-id> --plaintext "hello world" --query CiphertextBlob --output text
+```
+
+## Aliases
+
+```sh
+aws --endpoint-url http://localhost:4566 kms create-alias \
+  --alias-name alias/my-key --target-key-id <key-id>
+
+aws --endpoint-url http://localhost:4566 kms encrypt \
+  --key-id alias/my-key --plaintext "hello"
+```
+
+## Data keys
+
+```python
+dk = kms.generate_data_key(KeyId=key_id, KeySpec='AES_256')
+# dk['Plaintext']      -> raw 32-byte key for local encryption
+# dk['CiphertextBlob'] -> encrypted version to store with data
+```
+
+Used in envelope-encryption flows. Real AES-GCM throughout.
+
+## Asymmetric + ECDH
+
+```python
+asym = kms.create_key(KeySpec='ECC_NIST_P256', KeyUsage='KEY_AGREEMENT')
+# Real ECDH key agreement for end-to-end tests
+```
+
+## SSE-KMS on S3
+
+```sh
+aws --endpoint-url http://localhost:4566 s3 cp file.txt s3://bucket/file.txt \
+  --sse aws:kms --sse-kms-key-id alias/my-key
+```
+
+Object encrypted at rest with the specified KMS key. Retrieval decrypts transparently.
+
+## Secrets Manager + KMS
+
+Secrets Manager secrets are encrypted with KMS by default. Rotation via Lambda works end-to-end (Lambda runs real code, calls KMS to re-encrypt).
+
+## How it differs from alternatives
+
+| Tool | Multi-language | Real crypto | SSE-KMS on S3 | Key policies |
+|---|---|---|---|---|
+| fakecloud | Any | Yes (AES-GCM, RSA, ECDSA, ECDH) | Yes | Yes (Principal/Condition) |
+| LocalStack Community | Any (auth required) | Partial | Yes | Partial |
+| Moto (mock_kms) | Python only | Partial | Stubbed | Partial |
+| aws-encryption-sdk | N/A | N/A | N/A (client-side only) | N/A |
+
+## Links
+
+- **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Related:** [Fake AWS server for tests](/fake-aws-server/), [Local S3 for integration tests](/local-s3-for-tests/)

--- a/website/content/mock-ses.md
+++ b/website/content/mock-ses.md
@@ -1,0 +1,169 @@
++++
+title = "Mock SES for tests"
+description = "Mock AWS SES locally for integration tests with fakecloud. 110 SES operations, v2 send + templates + DKIM, real receipt rule execution for inbound email. Free, no account required."
+template = "page.html"
++++
+
+Need to mock AWS SES for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point your AWS SDK at `http://localhost:4566`.
+
+## Why fakecloud for SES
+
+- **110 SES operations** at 100% conformance — v2 API for send, templates, configuration sets, event destinations, DKIM, suppression list. Plus v1 inbound (receipt rules, receipt filters).
+- **Real receipt rule action execution.** When a test email arrives at a configured recipient, fakecloud actually runs the S3, SNS, and Lambda actions in the receipt rule. LocalStack Community stores inbound email but never fires the actions; fakecloud fires them.
+- **Test-assertion SDK.** `fc.ses.getEmails()` returns the sent-email log so tests can assert recipients, subject, body, destinations, bounces.
+- **Real DKIM signing.** Configure a domain identity, fakecloud signs outbound mail with the computed DKIM-Signature header.
+- **Configuration sets + event destinations.** Sending, delivery, bounce, complaint, click, open events published to SNS / Kinesis / CloudWatch destinations.
+- **No account, no auth token, no paid tier.** AGPL-3.0.
+
+## Send an email
+
+### Python (boto3)
+
+```python
+import boto3
+ses = boto3.client('sesv2',
+    endpoint_url='http://localhost:4566',
+    aws_access_key_id='test',
+    aws_secret_access_key='test',
+    region_name='us-east-1')
+
+ses.send_email(
+    FromEmailAddress='sender@example.com',
+    Destination={'ToAddresses': ['alice@example.com']},
+    Content={'Simple': {
+        'Subject': {'Data': 'Hello'},
+        'Body': {'Text': {'Data': 'World'}}
+    }})
+```
+
+### Node.js (AWS SDK v3)
+
+```ts
+import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
+const ses = new SESv2Client({});
+
+await ses.send(new SendEmailCommand({
+  FromEmailAddress: 'sender@example.com',
+  Destination: { ToAddresses: ['alice@example.com'] },
+  Content: { Simple: {
+    Subject: { Data: 'Hello' },
+    Body: { Text: { Data: 'World' } },
+  }},
+}));
+```
+
+## Assert what was sent
+
+```ts
+import { FakeCloud } from 'fakecloud';
+const fc = new FakeCloud();
+
+const { emails } = await fc.ses.getEmails();
+expect(emails).toHaveLength(1);
+expect(emails[0].destination.toAddresses).toContain('alice@example.com');
+expect(emails[0].content.simple.subject.data).toBe('Hello');
+
+await fc.reset();
+```
+
+SDKs for TypeScript, Python, Go, PHP, Java, Rust.
+
+## Templates
+
+```python
+ses.create_email_template(
+    TemplateName='welcome',
+    TemplateContent={
+        'Subject': 'Hi {{name}}',
+        'Text': 'Welcome, {{name}}!',
+    })
+
+ses.send_email(
+    FromEmailAddress='sender@example.com',
+    Destination={'ToAddresses': ['alice@example.com']},
+    Content={'Template': {
+        'TemplateName': 'welcome',
+        'TemplateData': '{"name":"Alice"}',
+    }})
+```
+
+## Inbound email with receipt rules
+
+```sh
+aws --endpoint-url http://localhost:4566 ses create-receipt-rule-set --rule-set-name default
+aws --endpoint-url http://localhost:4566 ses set-active-receipt-rule-set --rule-set-name default
+
+aws --endpoint-url http://localhost:4566 ses create-receipt-rule \
+  --rule-set-name default \
+  --rule '{
+    "Name": "save-to-s3",
+    "Enabled": true,
+    "Recipients": ["support@example.com"],
+    "Actions": [{
+      "S3Action": {"BucketName": "inbound-mail"}
+    }, {
+      "LambdaAction": {"FunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:on-inbound"}
+    }]
+  }'
+```
+
+Simulate an inbound email:
+
+```sh
+curl -X POST http://localhost:4566/_fakecloud/ses/simulate-inbound \
+  -H 'Content-Type: application/json' \
+  -d '{"to": "support@example.com", "from": "buyer@example.com", "subject": "Question", "body": "Help?"}'
+```
+
+The receipt rule fires: the email lands in S3, the Lambda runs with the SES event shape. End-to-end.
+
+## Configuration sets + event destinations
+
+```python
+ses.create_configuration_set(ConfigurationSetName='default')
+ses.create_configuration_set_event_destination(
+    ConfigurationSetName='default',
+    EventDestinationName='sns-events',
+    EventDestination={
+        'Enabled': True,
+        'MatchingEventTypes': ['SEND', 'DELIVERY', 'BOUNCE', 'COMPLAINT'],
+        'SnsDestination': {'TopicArn': 'arn:aws:sns:us-east-1:000000000000:ses-events'},
+    })
+```
+
+Sending through this configuration set publishes send/delivery/bounce events to SNS for real.
+
+## Bounce / complaint simulation
+
+Use AWS's [mailbox simulator](https://docs.aws.amazon.com/ses/latest/dg/send-email-simulator.html) addresses for test-path bounces:
+
+- `bounce@simulator.amazonses.com` -> synthetic hard bounce
+- `complaint@simulator.amazonses.com` -> synthetic complaint
+- `suppressionlist@simulator.amazonses.com` -> suppression
+- `success@simulator.amazonses.com` -> successful delivery
+
+fakecloud emits the corresponding events via configured destinations.
+
+## How it differs from alternatives
+
+| Tool | Multi-language | Inbound receipt rules execute | DKIM | Templates |
+|---|---|---|---|---|
+| fakecloud | Any | Yes (real actions fire) | Yes | Yes |
+| LocalStack Community (post-paywall) | Any (auth required) | No (stored but never executed) | Paid | Paid |
+| Moto (mock_ses) | Python only | Stubbed | Partial | Partial |
+| maildev / MailHog | Any (SMTP, not AWS SES API) | N/A | N/A | N/A |
+
+Real inbound receipt rule execution is the big differentiator — critical if your app does SES-inbound -> S3/Lambda pipelines.
+
+## Links
+
+- **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Related:** [Fake AWS server for tests](/fake-aws-server/), [Test Lambda locally](/test-lambda-locally/)

--- a/website/content/mock-sns.md
+++ b/website/content/mock-sns.md
@@ -1,0 +1,127 @@
++++
+title = "Mock SNS for tests"
+description = "Mock SNS locally for integration tests with fakecloud. 42 SNS operations, fan-out to SQS/Lambda/HTTP, filter policies, real cross-service delivery. Any AWS SDK, free, no account required."
+template = "page.html"
++++
+
+Need to mock SNS for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point your AWS SDK at `http://localhost:4566`.
+
+## Why fakecloud for SNS
+
+- **42 SNS operations** at 100% conformance — topics, subscriptions, publishing, filter policies (exact, prefix, anything-but, numeric, exists), message attributes.
+- **Real fan-out delivery.** SNS -> SQS, SNS -> Lambda, SNS -> HTTP/HTTPS endpoints all execute end-to-end. Your subscriber Lambda actually runs when a message is published.
+- **Filter policies are real.** Messages match filter policies before delivery, same semantics as AWS.
+- **Any AWS SDK in any language.** Real HTTP server on port 4566.
+- **No account, no auth token, no paid tier.** AGPL-3.0.
+
+## Quick examples
+
+### Python (boto3)
+
+```python
+import boto3
+sns = boto3.client('sns',
+    endpoint_url='http://localhost:4566',
+    aws_access_key_id='test',
+    aws_secret_access_key='test',
+    region_name='us-east-1')
+
+topic = sns.create_topic(Name='orders')
+sns.publish(TopicArn=topic['TopicArn'], Message='{"order": "o1"}')
+```
+
+### Node.js (AWS SDK v3)
+
+```ts
+process.env.AWS_ENDPOINT_URL = 'http://localhost:4566';
+process.env.AWS_ACCESS_KEY_ID = 'test';
+process.env.AWS_SECRET_ACCESS_KEY = 'test';
+process.env.AWS_REGION = 'us-east-1';
+
+import { SNSClient, CreateTopicCommand, PublishCommand } from '@aws-sdk/client-sns';
+const sns = new SNSClient({});
+
+const { TopicArn } = await sns.send(new CreateTopicCommand({ Name: 'orders' }));
+await sns.send(new PublishCommand({ TopicArn, Message: JSON.stringify({ order: 'o1' }) }));
+```
+
+### AWS CLI
+
+```sh
+aws --endpoint-url http://localhost:4566 sns create-topic --name orders
+aws --endpoint-url http://localhost:4566 sns publish \
+  --topic-arn arn:aws:sns:us-east-1:000000000000:orders \
+  --message '{"order":"o1"}'
+```
+
+## SNS -> SQS fan-out
+
+```sh
+aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name orders-queue
+
+aws --endpoint-url http://localhost:4566 sns subscribe \
+  --topic-arn arn:aws:sns:us-east-1:000000000000:orders \
+  --protocol sqs \
+  --notification-endpoint arn:aws:sqs:us-east-1:000000000000:orders-queue
+```
+
+Publishing to the topic delivers to the queue for real. `ReceiveMessage` returns the SNS-wrapped envelope.
+
+## SNS -> Lambda
+
+```sh
+aws --endpoint-url http://localhost:4566 sns subscribe \
+  --topic-arn arn:aws:sns:us-east-1:000000000000:orders \
+  --protocol lambda \
+  --notification-endpoint arn:aws:lambda:us-east-1:000000000000:function:on-order
+```
+
+Your Lambda fires with the SNS event shape when messages are published. Not a stub — the Lambda code runs in a real runtime container.
+
+## Filter policies
+
+```sh
+aws --endpoint-url http://localhost:4566 sns set-subscription-attributes \
+  --subscription-arn <arn> \
+  --attribute-name FilterPolicy \
+  --attribute-value '{"eventType":["orderPlaced","orderShipped"]}'
+```
+
+Real filter matching — messages published without matching attributes do not deliver.
+
+## Assertions
+
+```ts
+import { FakeCloud } from 'fakecloud';
+const fc = new FakeCloud();
+
+const { messages } = await fc.sns.getPublishedMessages({ topicName: 'orders' });
+expect(messages).toHaveLength(1);
+expect(JSON.parse(messages[0].message).order).toBe('o1');
+
+await fc.reset();
+```
+
+SDKs for TypeScript, Python, Go, PHP, Java, Rust.
+
+## How it differs from alternatives
+
+| Tool | Multi-language | Fan-out to SQS | Fan-out to Lambda (real) | Filter policies |
+|---|---|---|---|---|
+| fakecloud | Any | Yes | Yes (real code runs) | Yes |
+| LocalStack Community | Any (auth required post-paywall) | Yes | Yes | Yes |
+| Moto (mock_sns) | Python only | Yes | Stubbed | Partial |
+| aws-sdk-client-mock | Node only | Stubbed | N/A | Stubbed |
+
+## Links
+
+- **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Related:** [Mock SQS for tests](/mock-sqs/), [Test Lambda locally](/test-lambda-locally/), [Fake AWS server for tests](/fake-aws-server/)


### PR DESCRIPTION
Batch 4A. Six more slug-exact landing pages covering underserved upstream queries.

- [/mock-sns/](https://fakecloud.dev/mock-sns/) -- `mock sns for tests`, `fake sns`
- [/mock-kms/](https://fakecloud.dev/mock-kms/) -- `mock kms`, `aws kms local`
- [/mock-ses/](https://fakecloud.dev/mock-ses/) -- `mock ses`, `local ses email testing`, highlights the real-receipt-rule-execution differentiator (LocalStack Community stores inbound but does not execute)
- [/mock-cognito/](https://fakecloud.dev/mock-cognito/) -- `mock cognito`, Cognito is LocalStack-paid-only post Mar 2026
- [/local-rds/](https://fakecloud.dev/local-rds/) -- `local rds postgres`, RDS is LocalStack-paid
- [/local-elasticache/](https://fakecloud.dev/local-elasticache/) -- `local elasticache redis`, ElastiCache is LocalStack-paid

Each follows the established page.html template and depth-first framing. Comparison tables highlight real engine execution vs stubs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six slug-exact SEO landing pages for SNS, KMS, SES, Cognito, RDS, and ElastiCache to capture upstream queries and highlight fakecloud’s real engine execution vs stubs. Each page uses the existing page.html template with concise how-tos and comparison tables.

- **New Features**
  - /mock-sns — mock SNS; real fan-out to SQS/Lambda/HTTP; filter policies.
  - /mock-kms — mock KMS; real AES/RSA/ECDH; aliases, data keys, SSE-KMS.
  - /mock-ses — mock SES; v2 send/templates; real receipt rule execution.
  - /mock-cognito — mock Cognito; full auth flows and triggers; LocalStack paywalled.
  - /local-rds — local Postgres/MySQL/MariaDB; snapshots/replicas; upstream Pro-only.
  - /local-elasticache — local Redis/Valkey; replication groups/serverless; upstream Pro-only.

<sup>Written for commit 6500d193aceee67719016789399be90637842c8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

