### PR TITLE
docs(seo): 6 more vs-competitor peer landings

### DIFF
--- a/website/content/vs/aws-sdk-client-mock.md
+++ b/website/content/vs/aws-sdk-client-mock.md
@@ -1,0 +1,58 @@
++++
+title = "fakecloud vs aws-sdk-client-mock"
+description = "How fakecloud compares to aws-sdk-client-mock. In-process Node mocks vs a real HTTP AWS emulator; when each fits."
+template = "page.html"
++++
+
+[aws-sdk-client-mock](https://github.com/m-radzikowski/aws-sdk-client-mock) is an in-process mocking library for AWS SDK v3 in Node.js. You declare what responses each SDK call should return, and the library intercepts calls at the client level.
+
+fakecloud is a real HTTP server that your SDK talks to.
+
+## Architectural split
+
+**aws-sdk-client-mock** is in-process. Your test process imports it, sets expectations, and the library patches SDK behavior. Never touches the network. Returns the exact shapes you scripted.
+
+**fakecloud** is a separate process on port 4566, speaking the AWS wire protocol. Your SDK serializes a real HTTP request; fakecloud parses it, runs the emulated service behavior, and returns a real HTTP response. Cross-service wiring runs server-side.
+
+## When to pick aws-sdk-client-mock
+
+- **Pure unit tests** where you want the SDK to return specific, scripted responses.
+- **You're asserting the SDK was called correctly**, not that downstream behavior worked.
+- **No external process** in your CI — zero runtime dependencies.
+- **Failure-path testing.** Scripting a specific error response is trivial with mocks and hard with real AWS-shaped emulation.
+
+aws-sdk-client-mock excels at this. Don't drop it if it already works for your unit tests.
+
+## When to pick fakecloud
+
+- **Integration tests** that exercise cross-service flows (S3 -> Lambda, SQS -> Lambda, SNS fan-out).
+- **Multi-language tests** — aws-sdk-client-mock is Node-only; fakecloud's HTTP server works with any AWS SDK.
+- **Tests that need Lambda to actually run** — aws-sdk-client-mock stubs responses; fakecloud executes your function code.
+- **Tests against Terraform/CDK/Serverless Framework deploys** — IaC tools talk to an HTTP endpoint, not an in-process library.
+- **"Does my whole system actually work"** questions vs "does my SDK call look right."
+
+## Complementary
+
+Most Node teams use both:
+- **aws-sdk-client-mock** for unit tests against a specific file (mock SQS return shape, check behavior).
+- **fakecloud** for integration tests across files (put an object, expect the Lambda to run, expect the message to land in DynamoDB).
+
+Both tools, different tiers of the test pyramid.
+
+## Feature-level comparison
+
+| | fakecloud | aws-sdk-client-mock |
+|---|---|---|
+| Language | Any (HTTP) | Node.js only |
+| Runtime | External process | In-process |
+| Real Lambda execution | Yes | No (stubbed) |
+| Real cross-service wiring | Yes | No |
+| Works with Terraform/CDK | Yes | No |
+| Failure-path specificity | Medium (via normal AWS error codes) | High (script any response) |
+| Test isolation | `/_fakecloud/reset` or unique resource names | Per-test by default |
+
+## Links
+
+- [fakecloud GitHub](https://github.com/faiscadev/fakecloud)
+- [aws-sdk-client-mock GitHub](https://github.com/m-radzikowski/aws-sdk-client-mock)
+- [Moto equivalent for Go/Java/Node](/blog/moto-equivalent-go-java-node/)

--- a/website/content/vs/dynamodb-local.md
+++ b/website/content/vs/dynamodb-local.md
@@ -1,0 +1,57 @@
++++
+title = "fakecloud vs DynamoDB Local"
+description = "How fakecloud compares to DynamoDB Local. Same DynamoDB behavior, plus cross-service triggers, Lambda execution, and the 22 other AWS services around it."
+template = "page.html"
++++
+
+DynamoDB Local is AWS's official local DynamoDB: a downloadable JAR (or Docker image) that runs DynamoDB for offline development. Good at what it does.
+
+fakecloud is a broader tool that happens to include DynamoDB.
+
+## When to pick DynamoDB Local
+
+- You only need DynamoDB, nothing else.
+- Your app talks to DynamoDB and nothing else from AWS.
+- You're on a JVM-heavy stack and prefer AWS's official tooling.
+
+DynamoDB Local is focused and battle-tested. For pure DynamoDB tests, nothing wrong with it.
+
+## When to pick fakecloud
+
+- Your tests exercise **DynamoDB + something else** (Lambda reading via Streams, SNS publishing when items change, S3 notification triggering Lambda that writes to DynamoDB).
+- You want **DynamoDB Streams -> Lambda** to actually fire end-to-end (DynamoDB Local emits stream records; it doesn't have Lambda to consume them).
+- You want the same test harness to cover multiple services without running multiple emulators.
+- You want test-assertion SDKs for the wider AWS surface (what emails got sent, what SNS messages got published, what Lambda invocations fired).
+
+## Feature-level comparison
+
+| | fakecloud | DynamoDB Local |
+|---|---|---|
+| DynamoDB operations | 57 | Full (100%) |
+| DynamoDB Streams | Yes | Yes |
+| PartiQL | Yes | Yes |
+| Transactions | Yes | Yes |
+| Global tables | Yes | Yes (limited) |
+| Lambda consumes Streams (real) | **Yes** | **No** (no Lambda service) |
+| S3 writes trigger DynamoDB updates via Lambda | **Yes** | **No** |
+| Other AWS services available | 22 more | None |
+| Runtime | Single Rust binary (~19 MB) | Java JAR or Docker image |
+| Startup | ~500ms | ~2s |
+| Install size | ~19 MB | ~60 MB JAR + JVM |
+
+## Same DynamoDB call works against both
+
+```python
+import boto3
+ddb = boto3.client('dynamodb', endpoint_url='http://localhost:4566')  # fakecloud
+# OR
+ddb = boto3.client('dynamodb', endpoint_url='http://localhost:8000')  # DynamoDB Local
+```
+
+If you already test against DynamoDB Local and need nothing more, no reason to switch. If you're expanding tests to cover downstream services, fakecloud replaces DynamoDB Local without requiring a second emulator process.
+
+## Links
+
+- [fakecloud GitHub](https://github.com/faiscadev/fakecloud)
+- [DynamoDB Local docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)
+- [Mock DynamoDB for tests](/mock-dynamodb/)

--- a/website/content/vs/elasticmq.md
+++ b/website/content/vs/elasticmq.md
@@ -1,0 +1,55 @@
++++
+title = "fakecloud vs ElasticMQ"
+description = "How fakecloud compares to ElasticMQ. Both provide local SQS; fakecloud adds SNS fan-out, Lambda event source mappings, and 21 other AWS services."
+template = "page.html"
++++
+
+[ElasticMQ](https://github.com/softwaremill/elasticmq) is a message queue server with an Amazon SQS-compatible interface. Scala-based, focused, battle-tested. Good at what it does.
+
+fakecloud's SQS is one of 23 services and ties into the rest (SNS fan-out, Lambda event source mappings, DLQ to other services, IAM policy enforcement).
+
+## When to pick ElasticMQ
+
+- You need SQS and nothing else from AWS.
+- You're on a JVM-heavy stack and already run Scala or Java services.
+- You want production-grade message queue semantics at scale (ElasticMQ is deployable as real infrastructure).
+- You want a single, focused tool rather than a multi-service emulator.
+
+## When to pick fakecloud
+
+- Your tests exercise **SQS + Lambda** — ElasticMQ doesn't have Lambda; your Lambda event source mappings have nowhere to go.
+- Your tests exercise **SNS -> SQS fan-out** — ElasticMQ has no SNS service.
+- Your tests exercise **SQS DLQ + other services** — the DLQ receiver might be a Lambda or an SNS notification.
+- Multi-language codebase — any AWS SDK works against fakecloud's HTTP endpoint.
+
+## Feature-level comparison
+
+| | fakecloud | ElasticMQ |
+|---|---|---|
+| SQS operations | 23 | Full SQS API |
+| FIFO queues | Yes | Yes |
+| DLQ | Yes | Yes |
+| Long polling | Yes | Yes |
+| SNS -> SQS fan-out | **Yes** | **No** (no SNS service) |
+| SQS -> Lambda event source mapping | **Yes** (Lambda runs for real) | **No** (no Lambda service) |
+| IAM policy enforcement on SQS | Yes (opt-in `--iam strict`) | No |
+| Other AWS services | 22 more | None |
+| Runtime | Rust binary (~19 MB) | Scala/JVM |
+| Startup | ~500ms | ~2-3s (JVM) |
+
+## Same SQS call works against both
+
+```python
+sqs = boto3.client('sqs',
+    endpoint_url='http://localhost:4566',  # fakecloud
+    # OR 'http://localhost:9324' for ElasticMQ default port
+    ...)
+```
+
+Both implement the SQS wire protocol.
+
+## Links
+
+- [fakecloud GitHub](https://github.com/faiscadev/fakecloud)
+- [ElasticMQ GitHub](https://github.com/softwaremill/elasticmq)
+- [Mock SQS for tests](/mock-sqs/)

--- a/website/content/vs/minio.md
+++ b/website/content/vs/minio.md
@@ -1,0 +1,71 @@
++++
+title = "fakecloud vs MinIO"
+description = "How fakecloud compares to MinIO. MinIO is an S3-compatible object store; fakecloud is an AWS emulator with S3 plus 22 other services."
+template = "page.html"
++++
+
+MinIO is a high-performance S3-compatible object store. It's production-ready, scales, and is often deployed as real storage infrastructure.
+
+fakecloud is a local AWS emulator for testing. Different tool for a different job.
+
+## When to pick MinIO
+
+- You want a **production-grade S3-compatible object store** (self-hosted alternative to S3, for real workloads).
+- You need performance characteristics comparable to real S3 or better.
+- You're deploying to on-premises or bare-metal and need S3 semantics at scale.
+- Your need is S3, period — no other AWS services.
+
+MinIO is excellent for these. It's not primarily a testing tool; it's real infrastructure.
+
+## When to pick fakecloud
+
+- You want **integration tests against AWS**, not production object storage.
+- Your tests exercise S3 **plus** Lambda / SNS / SQS / DynamoDB / any other AWS service.
+- You need S3 notifications to actually fire Lambda end-to-end (MinIO emits events but has no Lambda service).
+- You want the full AWS API surface (S3 + IAM + STS + KMS + everything else) against one endpoint.
+- You want a lightweight local-dev experience (~500ms startup, ~10 MiB idle memory) rather than a production storage daemon.
+
+## Feature-level comparison
+
+| | fakecloud | MinIO |
+|---|---|---|
+| S3 operations | 107 | Full S3 API |
+| Production-grade storage | **No** (testing tool) | **Yes** |
+| Distributed / clustered | No | Yes |
+| S3 notifications | Yes | Yes |
+| Notifications fire Lambda | **Yes** (real Lambda runs) | **No** (no Lambda service) |
+| IAM + STS API | Yes | MinIO-specific IAM (not AWS IAM API) |
+| Other AWS services (Lambda, DynamoDB, SQS, etc.) | **22 more** | **None** |
+| Encryption via KMS | Yes (real AWS KMS emulation) | MinIO-specific KMS gateway |
+| Startup | ~500ms | ~1-2s |
+| Use case | Local integration testing | Real object storage |
+
+## Using both
+
+Some teams run MinIO as production storage **and** fakecloud for tests. This works:
+
+- MinIO = real object store at cdn.example.com
+- fakecloud = `http://localhost:4566` in tests, exercising S3 + Lambda + IAM + KMS together
+
+They don't compete for the same job.
+
+## Same S3 call works against both
+
+```python
+import boto3
+s3 = boto3.client('s3',
+    endpoint_url='http://localhost:4566',  # fakecloud for tests
+    # OR endpoint_url='https://minio.example.com' for MinIO in prod
+    aws_access_key_id='test',
+    aws_secret_access_key='test',
+    region_name='us-east-1')
+```
+
+Both are S3-compatible.
+
+## Links
+
+- [fakecloud GitHub](https://github.com/faiscadev/fakecloud)
+- [MinIO GitHub](https://github.com/minio/minio)
+- [Local S3 for integration tests](/local-s3-for-tests/)
+- [Fake AWS server for tests](/fake-aws-server/)

--- a/website/content/vs/s3mock.md
+++ b/website/content/vs/s3mock.md
@@ -1,0 +1,48 @@
++++
+title = "fakecloud vs S3Mock"
+description = "How fakecloud compares to adobe/S3Mock. Both local S3 emulators; fakecloud adds cross-service wiring and 22 other AWS services."
+template = "page.html"
++++
+
+[adobe/S3Mock](https://github.com/adobe/S3Mock) is a lightweight S3-only mock for integration tests, written in Java and distributed as a JAR or Docker image. Simple, focused, well-maintained.
+
+fakecloud does S3 (107 operations) plus 22 other AWS services end-to-end.
+
+## When to pick S3Mock
+
+- Pure S3 tests in JVM-heavy stacks (Java, Kotlin, Scala).
+- You want a minimal footprint and simple setup.
+- Your app talks to S3 and nothing else from AWS.
+- You prefer Adobe's testing ecosystem.
+
+## When to pick fakecloud
+
+- Your tests exercise **S3 + other AWS services** (S3 -> Lambda notifications, S3 -> SNS topic events, SES inbound -> S3).
+- Non-JVM language (Go, Python, Node, Rust, PHP) — fakecloud's HTTP server works with any SDK.
+- You want real Lambda execution on S3 notifications.
+- You want IAM + bucket policies enforced (`--iam strict`), not just stubbed.
+
+## Feature-level comparison
+
+| | fakecloud | S3Mock |
+|---|---|---|
+| S3 operations | 107 | Core S3 surface |
+| Versioning | Yes | Yes |
+| Multipart uploads | Yes | Yes |
+| Lifecycle | Yes | Partial |
+| S3 notifications fire subscribers (real) | **Yes** (SNS/SQS/Lambda) | **No** (no other services) |
+| Bucket policy enforcement | Yes (opt-in `--iam strict`) | No |
+| Non-JVM SDKs | Any | Any (S3 SDK only) |
+| Other AWS services | 22 more | None |
+| Startup | ~500ms | ~2s (JVM) |
+| Runtime | Rust binary (~19 MB) | JAR / Docker |
+
+## Using both
+
+Not typical — both are S3 emulators. Pick one.
+
+## Links
+
+- [fakecloud GitHub](https://github.com/faiscadev/fakecloud)
+- [adobe/S3Mock GitHub](https://github.com/adobe/S3Mock)
+- [Local S3 for integration tests](/local-s3-for-tests/)

--- a/website/content/vs/testcontainers.md
+++ b/website/content/vs/testcontainers.md
@@ -1,0 +1,71 @@
++++
+title = "fakecloud vs Testcontainers"
+description = "How fakecloud compares to Testcontainers. Testcontainers manages throwaway Docker containers for tests; fakecloud is an AWS emulator that Testcontainers can run."
+template = "page.html"
++++
+
+Testcontainers is not a direct competitor — it's a test-container orchestration library for spinning up throwaway Docker containers for integration tests (PostgreSQL, Redis, Kafka, LocalStack, etc.). It provides the plumbing for managing container lifecycles in tests.
+
+fakecloud is one of the AWS emulators Testcontainers can run. They're complementary.
+
+## How to use them together
+
+Testcontainers has modules for local AWS emulation — historically the LocalStack module. fakecloud has a Rust Testcontainers module in progress: [testcontainers-rs-modules-community PR #467](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/467).
+
+Without the dedicated module, any Testcontainers flavor (Java, Python, Go, Rust, Node) can run fakecloud as a generic container:
+
+```java
+// Java
+GenericContainer<?> fakecloud = new GenericContainer<>("ghcr.io/faiscadev/fakecloud:latest")
+    .withExposedPorts(4566)
+    .waitingFor(Wait.forHttp("/_fakecloud/health"));
+fakecloud.start();
+String endpoint = "http://" + fakecloud.getHost() + ":" + fakecloud.getMappedPort(4566);
+```
+
+```python
+# Python
+from testcontainers.core.container import DockerContainer
+fakecloud = DockerContainer("ghcr.io/faiscadev/fakecloud:latest") \
+    .with_exposed_ports(4566)
+fakecloud.start()
+endpoint = f"http://{fakecloud.get_container_host_ip()}:{fakecloud.get_exposed_port(4566)}"
+```
+
+```go
+// Go
+req := testcontainers.ContainerRequest{
+    Image:        "ghcr.io/faiscadev/fakecloud:latest",
+    ExposedPorts: []string{"4566/tcp"},
+    WaitingFor:   wait.ForHTTP("/_fakecloud/health"),
+}
+container, _ := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{ContainerRequest: req, Started: true})
+```
+
+## When to use fakecloud standalone (no Testcontainers)
+
+- Simple CI setup — install-and-run is ~500ms vs ~2-3s container boot.
+- Local dev where you don't need per-test container throwaway.
+- Single-service CI jobs.
+
+## When to use fakecloud via Testcontainers
+
+- Java / JVM codebases where Testcontainers is already the test-infra convention.
+- Per-test container isolation is a requirement.
+- You already use Testcontainers for Postgres / Redis / Kafka and want fakecloud in the same lifecycle pattern.
+- You need the container lifecycle to match the test class / method / session.
+
+## Testcontainers module status
+
+- **Java**: fakecloud runs as `GenericContainer` today; dedicated module is a future item.
+- **Python**: same (GenericContainer works now).
+- **Rust**: dedicated module [PR #467](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/467) open.
+- **Go**: generic container works.
+- **Node**: generic container works via [testcontainers-node](https://github.com/testcontainers/testcontainers-node).
+
+## Links
+
+- [fakecloud GitHub](https://github.com/faiscadev/fakecloud)
+- [Testcontainers homepage](https://testcontainers.com)
+- [testcontainers-rs-modules-community PR #467](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/467)
+- [Integration testing AWS in CI](/blog/integration-testing-aws-in-ci/)


### PR DESCRIPTION
Batch 4B. Six more /vs/ peer landing pages.

- [/vs/dynamodb-local/](https://fakecloud.dev/vs/dynamodb-local/) — AWS's official DynamoDB emulator; fakecloud adds Streams-to-Lambda + 22 other services
- [/vs/minio/](https://fakecloud.dev/vs/minio/) — MinIO is production S3-compatible storage; fakecloud is AWS-testing. Complementary, not competitive.
- [/vs/s3mock/](https://fakecloud.dev/vs/s3mock/) — adobe/S3Mock is JVM S3-only
- [/vs/aws-sdk-client-mock/](https://fakecloud.dev/vs/aws-sdk-client-mock/) — in-process Node mocks; complementary test-pyramid tiers
- [/vs/testcontainers/](https://fakecloud.dev/vs/testcontainers/) — not a competitor; includes usage snippets in 5 languages
- [/vs/elasticmq/](https://fakecloud.dev/vs/elasticmq/) — Scala SQS-only

Honest positioning. 'Pick by fit' framing. No fabricated benchmarks. Each page documents when to pick the competitor, when fakecloud, when both.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six SEO /vs competitor pages: /vs/dynamodb-local, /vs/minio, /vs/s3mock, /vs/aws-sdk-client-mock, /vs/testcontainers, and /vs/elasticmq. Each page explains when to choose the peer, when to use fakecloud, and when to use both, with clear guidance on cross-service flows, real Lambda triggers, and multi-language support.

<sup>Written for commit 8fb4a2782320bfc96af04ef772c67e91e2f9e9b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

