### PR TITLE
fix(conformance): address Cubic findings from PR #688

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -1114,6 +1114,13 @@ async fn rds_modify_db_parameter_group() {
     let response = client
         .modify_db_parameter_group()
         .db_parameter_group_name("conf-modify-pg")
+        .parameters(
+            aws_sdk_rds::types::Parameter::builder()
+                .parameter_name("max_connections")
+                .parameter_value("100")
+                .apply_method(aws_sdk_rds::types::ApplyMethod::PendingReboot)
+                .build(),
+        )
         .send()
         .await
         .unwrap();

--- a/website/content/vs/floci.md
+++ b/website/content/vs/floci.md
@@ -37,7 +37,7 @@ Run your actual test suite against both. Numbers published on landing pages are 
 | RDS | Real PostgreSQL/MySQL/MariaDB via Docker |
 | ElastiCache | Real Redis/Valkey via Docker |
 | Cross-service wiring | S3 -> Lambda, SNS fan-out, EventBridge -> Step Functions, SES inbound -> S3/SNS/Lambda, 15+ more fire end-to-end |
-| Conformance methodology | Smithy-validated, 54k+ test variants per commit |
+| Conformance methodology | Smithy-validated, 57k+ test variants per commit |
 | Terraform TestAcc CI | Yes (upstream suites run against fakecloud) |
 | Test-assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust |
 | Multi-account, SCPs, ABAC | Yes |

--- a/website/content/vs/ministack.md
+++ b/website/content/vs/ministack.md
@@ -39,7 +39,7 @@ These are philosophies, not rankings. Breadth-first and depth-first are differen
 | Lambda execution | Real, 13 runtimes in Docker |
 | RDS | Real PostgreSQL/MySQL/MariaDB via Docker |
 | ElastiCache | Real Redis/Valkey via Docker |
-| Conformance methodology | Smithy-validated, 54k+ test variants on every commit |
+| Conformance methodology | Smithy-validated, 57k+ test variants on every commit |
 | Terraform TestAcc CI | Yes (upstream suites run against fakecloud) |
 | Test-assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust |
 | License | AGPL-3.0 |


### PR DESCRIPTION
## Summary

PR #688 merged before its Cubic review comments were read (check conclusion was SUCCESS, which only means the reviewer finished — it does not mean zero findings). Three valid P3 issues:

- `crates/fakecloud-conformance/tests/rds.rs`: `ModifyDBParameterGroup` Smithy input requires `Parameters`; the test was omitting it. Send a realistic Parameter.
- `website/content/vs/floci.md` + `vs/ministack.md`: comparison tables still said "Smithy-validated, 54k+ test variants" while the surrounding prose moved to 57k+.

## Test plan

- [x] `cargo check --tests -p fakecloud-conformance`
- [x] `cargo fmt --check`
- [x] `grep -r "54k\|54,000" website/content/vs/` returns nothing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses Cubic findings from PR #688. Fixes the RDS ModifyDBParameterGroup conformance test to include the required `Parameters` (sets `max_connections=100`, `apply_method=pending-reboot`) and updates comparison tables in `website/content/vs/floci.md` and `website/content/vs/ministack.md` to 57k+ test variants.

<sup>Written for commit a552ed0f52d0a232b5634f39870c03e32213742f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

